### PR TITLE
Reshape Qdrant usage: REST, generations, hybrid search, decay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       qdrant:
-        image: qdrant/qdrant:v1.18.2
+        image: qdrant/qdrant:v1.19.0
         ports:
           - 6333:6333
-          - 6334:6334
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -72,7 +71,7 @@ jobs:
           exit 1
       - run: cargo test --locked --test integration_qdrant -- --ignored
         env:
-          ENGRAM_TEST_QDRANT: http://localhost:6334
+          ENGRAM_TEST_QDRANT: http://localhost:6333
 
   audit:
     name: security advisories

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,15 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,7 +1146,6 @@ dependencies = [
  "mime_guess",
  "openidconnect",
  "pulldown-cmark",
- "qdrant-client",
  "reqwest 0.13.4",
  "rmcp",
  "rust-embed",
@@ -1263,16 +1247,6 @@ name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flume"
@@ -1698,19 +1672,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -2161,16 +2122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,26 +2529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,38 +2610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,29 +2627,6 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "qdrant-client"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dddc19df129bad7346ebd027288621ab1ac7e52678371f906b9a8622d7aaf87e"
-dependencies = [
- "anyhow",
- "derive_builder",
- "futures",
- "futures-util",
- "parking_lot",
- "prost",
- "prost-types",
- "reqwest 0.13.4",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
- "tokio",
- "tonic",
- "tonic-prost",
-]
 
 [[package]]
 name = "quinn"
@@ -3051,7 +2927,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3072,14 +2947,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -3265,7 +3138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3668,12 +3540,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -4310,49 +4176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "flate2",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "rustls-native-certs",
- "socket2",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,12 +4183,9 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4709,19 +4529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ anyhow = "1"
 async-trait = "0.1.92"
 tokenizers = { version = "0.23.1", default-features = false, features = ["onig"] }
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "http2"] }
-qdrant-client = "1.19.0"
 pulldown-cmark = "0.13.4"
 ammonia = "4.1.4"
 argon2 = { version = "0.5.3", features = ["std", "password-hash"] }
@@ -48,3 +47,4 @@ schemars = "1.2.2"
 tempfile = "3"
 temp-env = "0.3"
 wiremock = "0.6.5"
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "http2"] }

--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ Tokenisation keeps `-`, `_`, `.` and `/` inside terms and also emits the pieces,
 so `--dry-run` matches `dry-run`, `dry` or `run`. Qdrant supplies the inverse
 document frequency. A query with no indexable term skips the lexical branch.
 
-**One source contributes at most three chunks** to a result list, so a
-forty-chunk document cannot crowd out the rest of the corpus. `ask` opts out —
-an answer often lives in one document.
+**One source leads with at most three chunks**, so a forty-chunk document
+cannot take the top of the list from the rest of the corpus. What that displaces
+goes back on the end in rank order, so the cap reorders a result list rather
+than shortening it — a base holding a single document still answers with as much
+as it has. `ask` opts out of the reordering entirely: an answer often lives in
+one document, and it reads better in rank order.
 
 **Recency and pinning** are applied as a final scoring pass. The weights let
 recency break a near-tie but never overturn a clearly better match. Pinning is a
@@ -107,8 +110,19 @@ tag: `PATCH /api/v1/chunks/{id}` with `{"tags": ["pinned"]}`.
 that have not appeared in results since. Every search records what it showed, so
 surfacing something counts as remembering it.
 
+Result **scores are ranking scores, not similarities**. A hybrid query returns a
+fused rank, a query with no indexable term returns a cosine, and both then carry
+the recency term. They order one result list and mean nothing between two, which
+is why the UI shows a position rather than a number.
+
 Editing a chunk's `tags` or `category` rewrites the Qdrant payload in place.
 Editing `text` or `title` queues a re-embed — those are what the model was shown.
+An absent field in a `PATCH` is left alone; an explicit `null` clears it.
+
+An edit that lands while a chunk is being embedded wins: chunks carry a revision
+that vector-invalidating edits bump, and the in-flight job's "indexed" mark only
+applies while the revision still matches. A losing job leaves the chunk pending,
+which is what gets it embedded again from the text that is actually there.
 
 ## Collection generations
 
@@ -160,6 +174,27 @@ every account your provider knows.
 
 **Local mode** is a single hardcoded credential for development. It refuses a
 non-loopback bind without `--i-know-this-is-insecure`.
+
+## Security posture
+
+- Chunk text is model output rendered into an authenticated session, so it is
+  treated as untrusted: rendered markdown is sanitized with `ammonia` and the
+  URL scheme allowlist is explicit. The one `|safe` interpolation in the
+  templates is the already-sanitized output.
+- API tokens are argon2id hashed and shown exactly once. Sessions are
+  server-side rows, so signing out actually revokes.
+- Local auth mode refuses a non-loopback bind without an explicit override
+  flag.
+- Internal errors (SQL, prompt fragments) never reach clients; they go to the
+  log and the client sees a generic message. Qdrant error bodies are reduced to
+  their message and truncated before they reach a log line.
+- Chunk metadata is bounded on the way in: a chunk carries at most 32 tags of
+  64 characters, because tags become payload on every point and a keyword index
+  in Qdrant.
+- CI runs `cargo audit` on every push. Advisories are ignored one id at a time
+  in `.cargo/audit.toml`, each with a written reachability argument — currently
+  one entry, RUSTSEC-2023-0071 in `rsa` via `openidconnect`, which concerns
+  private-key operations that engram never performs.
 
 ## Backup
 

--- a/README.md
+++ b/README.md
@@ -2,181 +2,182 @@
 
 **A trace of everything worth keeping.**
 
-An *engram* is the physical trace a memory leaves in neural tissue — the
-hypothesised substrate of recall. This is one you own: a self-hosted store for
-discrete, reusable knowledge, retrieved by meaning rather than by keyword.
-
-Retrieval is a search problem, not a chat problem. The default path embeds your
-query, searches vectors, and returns ranked markdown chunks. No generation step,
-no waiting on a model to finish thinking. Synthesis is available when you
-actually want it, on a separate page, never by accident.
+A self-hosted knowledge base you search by meaning. Capture text, and engram
+splits it into self-contained markdown chunks, embeds them, and answers queries
+with ranked excerpts — no generation step in the way. Synthesis is a separate
+endpoint you ask for explicitly.
 
 Three front doors over one backend: a web UI, a REST API, and an MCP server, so
-Claude Code or Claude Desktop can read and write your knowledge base mid-session
-— turning "I just explained this to an AI" into something permanent.
+Claude Code or Claude Desktop can read and write it mid-session.
 
-See [the design](docs/superpowers/specs/2026-08-09-engram-design.md) for why it
-is built this way.
-
-## The mark
-
-The logo is the mechanism, drawn to scale: a query point in latent space, bound
-to its nearest neighbours, with more distant points present in the space but
-absent from the answer. Read another way, it is a neuron — soma, dendrites, and
-the field it listens to.
+Design notes: [docs/superpowers/specs/2026-08-09-engram-design.md](docs/superpowers/specs/2026-08-09-engram-design.md).
+Planned work: [ROADMAP.md](ROADMAP.md).
 
 ## Requirements
 
-- Rust 1.94 or newer. The floor comes from sqlx 0.9; our own code needs
-  only 1.88 for let-chains.
-- Qdrant, reachable over **gRPC** (port 6334, not just the REST port 6333).
-- An OpenAI-compatible inference endpoint providing chat completions and
-  embeddings. One server can fill all roles, or you can point each role
-  somewhere different.
+- Rust 1.94+ (the floor comes from sqlx 0.9).
+- Qdrant over its REST API — 6333 locally, or whatever a proxy serves it on.
+  No gRPC port needed.
+- An OpenAI-compatible endpoint for chat completions and embeddings. One server
+  can fill all roles, or point each role somewhere different.
 
 ## Quick start
 
 ```bash
-docker compose up -d                  # starts Qdrant on 6333 (REST) and 6334 (gRPC)
+docker compose up -d                             # Qdrant on 6333
 cp config.example.toml config.toml
-cargo run -- --hash-password 'your password'   # paste the hash into config.toml
+cargo run -- --hash-password 'your password'     # paste the hash into config.toml
 cargo run
 ```
 
-Then open <http://127.0.0.1:8080/auth/login>.
-
-Capture something, and watch it move through `raw → segmenting → embedding →
-ready` on the Browse screen. A source whose chunks partly failed to embed shows
-as `partial`; the Ops screen lists the failed jobs with their errors and a retry
-button.
+Open <http://127.0.0.1:8080/auth/login>, capture something, and watch it move
+through `raw → segmenting → embedding → ready` on Browse. `partial` means some
+chunks failed to embed; the Ops screen lists the failures with a retry button.
 
 ## Configuration
 
-Every key can be overridden by an environment variable using the `ENGRAM__`
-prefix and `__` as the nesting separator, e.g. `ENGRAM__INFER__EMBED__DIM=768`.
-Secrets belong in the environment; the loader warns at startup if it finds one
-in the file. `cargo run -- --print-config` prints the effective configuration
-with secrets redacted.
+Any key can be set by environment variable: prefix `ENGRAM__`, `__` between
+levels, e.g. `ENGRAM__INFER__EMBED__DIM=768`. Put secrets there rather than in
+the file — the loader warns if it finds one. `--print-config` prints the
+effective config with secrets redacted.
 
 | Key | Meaning |
 |---|---|
 | `server.bind` | Listen address. Default `127.0.0.1:8080`. |
-| `server.workers` | Background worker tasks draining the job queue. Default 2. |
-| `store.path` | SQLite file. Created on first run. **Back this up.** |
-| `vector.url` | Qdrant gRPC endpoint, e.g. `http://localhost:6334`. |
-| `vector.collection` | Collection name. |
-| `vector.api_key` | Optional; prefer `ENGRAM__VECTOR__API_KEY`. |
+| `server.workers` | Background job workers. Default 2. |
+| `store.path` | SQLite file. **Back this up.** |
+| `vector.url` | Qdrant base URL, e.g. `http://localhost:6333`. |
+| `vector.collection` | Alias name. Data lives in `{name}_v1`, `_v2`, … |
+| `vector.api_key` | Prefer `ENGRAM__VECTOR__API_KEY`. |
+| `vector.recency_weight` | How much age counts against a result. `0.0` disables. Default 0.05. |
+| `vector.recency_half_life_days` | Age at which half that boost is gone. Default 180. |
+| `vector.pinned_boost` | Extra score for a chunk tagged `pinned`. Default 0.15. |
 | `infer.chunk.*` | Segmentation model: `base_url`, `model`, `context_tokens`, `max_output_tokens`, `output_ratio`, optional `tokenizer_path`. |
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`. |
-| `infer.ask.*` | Completion model used only by `ask`. |
-| `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Disabled by default. |
+| `infer.ask.*` | Completion model, used only by `ask`. |
+| `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
 | `auth.mode` | `oidc` or `local`. |
-| `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, and **`allowed_subs` / `allowed_emails`**. |
+| `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails`. |
 | `auth.local.*` | `username` and an argon2id `password_hash`. Development only. |
 
-Two settings deserve attention.
+Two worth knowing:
 
-**`infer.chunk.output_ratio`** exists because the segmenter rewrites chunks to
-be self-contained rather than merely splitting them, so its output can be larger
-than its input. The ratio tells engram how much larger to assume when sizing input
-windows. Raise it if segmentation responses are being truncated.
+- **`infer.embed.dim`** must match the collection. If it does not, engram refuses
+  to start and names both numbers. Mismatched vectors corrupt search in a way you
+  would not notice for weeks.
+- **`infer.chunk.output_ratio`** — the segmenter rewrites chunks to be
+  self-contained, so its output can be larger than its input. Raise this if
+  segmentation responses get truncated.
 
-**`infer.embed.dim`** must match the Qdrant collection. If it does not, engram
-refuses to start and names both numbers, because writing mismatched vectors
-corrupts search results in a way you would not notice for weeks.
+## Inference roles
 
-## The three inference roles
-
-`chunk`, `embed` and `ask` are configured independently and can point at
-different servers. Swapping one does not affect the others. There is no
-OpenAI-standard rerank endpoint, so reranking is opt-in and its wire format is
-configured explicitly rather than guessed.
+`chunk`, `embed` and `ask` are configured separately and can point at different
+servers. Reranking is opt-in because there is no OpenAI-standard rerank endpoint,
+so its wire format is configured rather than guessed.
 
 Ingest never calls inference. Capture writes the text and returns; segmentation
-and embedding happen in the background and retry with exponential backoff. A
-dead inference endpoint slows processing but never loses a capture.
+and embedding run in the background with retries. A dead endpoint slows
+processing but never loses a capture.
+
+## How search works
+
+One embedding call, one hybrid query, and one rerank call if a reranker is
+configured. Never a completion.
+
+**Hybrid** = two branches fused inside Qdrant in a single round trip: the dense
+vector from the embedding model, and a BM25 sparse vector computed locally from
+the same text. Dense embeddings blur exact tokens, and this kind of knowledge
+base is full of `E01`, `--dry-run`, `/etc/fstab` and error strings. The two
+rankings are merged with reciprocal rank fusion, which needs no score
+calibration between a cosine similarity and a term weight.
+
+Tokenisation keeps `-`, `_`, `.` and `/` inside terms and also emits the pieces,
+so `--dry-run` matches `dry-run`, `dry` or `run`. Qdrant supplies the inverse
+document frequency. A query with no indexable term skips the lexical branch.
+
+**One source contributes at most three chunks** to a result list, so a
+forty-chunk document cannot crowd out the rest of the corpus. `ask` opts out —
+an answer often lives in one document.
+
+**Recency and pinning** are applied as a final scoring pass. The weights let
+recency break a near-tie but never overturn a clearly better match. Pinning is a
+tag: `PATCH /api/v1/chunks/{id}` with `{"tags": ["pinned"]}`.
+
+**`GET /api/v1/resurface`** returns a random handful of chunks older than a month
+that have not appeared in results since. Every search records what it showed, so
+surfacing something counts as remembering it.
+
+Editing a chunk's `tags` or `category` rewrites the Qdrant payload in place.
+Editing `text` or `title` queues a re-embed — those are what the model was shown.
+
+## Collection generations
+
+`vector.collection` is a Qdrant **alias**. The vectors live in `chunks_v1`,
+`chunks_v2`, … and the alias points at the current one, so a schema change is a
+background rebuild plus an atomic swap instead of an outage:
+
+```bash
+cargo run -- --reindex
+```
+
+Points are copied into the next generation and the alias moves onto it. Dense
+vectors are copied as-is, so this costs no embedding calls. The previous
+generation is left in place — it is the only rollback there is.
+
+A collection created before this layout shares its name with the alias, and
+Qdrant will not allow both. Freeing the name means deleting the source after its
+points are copied and counted, so that case needs `--reindex --replace-legacy`.
+
+A rebuild cannot change vector width. See below for that.
+
+## Changing the embedding model
+
+1. Update `infer.embed.model` and `infer.embed.dim`.
+2. Point `vector.collection` at a new alias name, or delete the existing
+   generations.
+3. Start engram; it creates a fresh generation at the new dimension.
+4. Re-embed: `POST /api/v1/sources/{id}/reprocess` with `{"stage":"embed"}`.
+
+Skipping step 2 is refused at startup rather than silently accepted.
 
 ## Connecting Claude Code
 
-Mint a token on the Ops screen (shown once, stored only as an argon2id hash),
-then:
+Mint a token on the Ops screen (shown once, stored as an argon2id hash), then:
 
 ```bash
 claude mcp add --transport http engram http://127.0.0.1:8080/mcp \
   --header "Authorization: Bearer engram_..."
 ```
 
-Three tools appear: `ingest`, `search` and `ask`. They return markdown, which is
-what an agent wants to read.
+Three tools appear: `ingest`, `search` and `ask`. They return markdown.
 
 ## Auth
 
-**OIDC** is the production mode: authorization code flow with PKCE, server-side
-sessions in SQLite so revocation works, and an allowlist. The allowlist is
-mandatory — leaving both `allowed_subs` and `allowed_emails` empty denies
-everyone rather than admitting every account your identity provider knows about.
+**OIDC** for production: authorization code flow with PKCE, server-side sessions
+in SQLite so sign-out actually revokes, and a mandatory allowlist — leaving both
+`allowed_subs` and `allowed_emails` empty denies everyone rather than admitting
+every account your provider knows.
 
-**Local mode** is a development shortcut with a single hardcoded credential. It
-refuses to bind to a non-loopback address unless you pass
-`--i-know-this-is-insecure`, because a dev shortcut reachable from the network
-is production auth by accident.
+**Local mode** is a single hardcoded credential for development. It refuses a
+non-loopback bind without `--i-know-this-is-insecure`.
 
 ## Backup
 
-The SQLite file is the source of truth: it holds every raw capture verbatim.
-Copy it and you can rebuild everything else.
+SQLite is the source of truth; it holds every raw capture verbatim.
 
-- **Full backup:** copy `engram.db` (plus `-wal`/`-shm` if present) and the Qdrant
-  volume.
-- **Minimal backup:** copy `engram.db` alone. Vectors can be regenerated by
+- **Full:** copy `engram.db` (plus `-wal`/`-shm`) and the Qdrant volume.
+- **Minimal:** copy `engram.db` alone. Vectors can be regenerated by
   reprocessing, at the cost of re-running embeddings.
-
-## Changing the embedding model
-
-Vector dimensions are model-specific, so old vectors become meaningless.
-
-1. Update `infer.embed.model` and `infer.embed.dim`.
-2. Delete the Qdrant collection (it is a cache, not the source of truth).
-3. Start engram; it recreates the collection at the new dimension.
-4. Re-embed every source:
-   `POST /api/v1/sources/{id}/reprocess` with `{"stage":"embed"}`.
-
-Skipping step 2 is refused at startup rather than silently accepted.
 
 ## Development
 
 ```bash
-cargo test                                       # unit and HTTP tests, no containers
+cargo test                                         # no containers needed
 cargo test --test integration_qdrant -- --ignored  # needs a running Qdrant
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 ```
 
-Set `ENGRAM_TEST_QDRANT` if Qdrant is not on `localhost:6334`.
-
-Everything except the Qdrant suite runs without infrastructure: the inference
-roles and the vector store sit behind traits, and the tests inject deterministic
-fakes plus an in-memory brute-force vector store.
-
-## Security posture
-
-- Chunk text is model output rendered into an authenticated session, so it is
-  treated as untrusted: rendered markdown is sanitized with `ammonia` and the
-  URL scheme allowlist is explicit. The one `|safe` interpolation in the
-  templates is the already-sanitized output.
-- API tokens are argon2id hashed and shown exactly once. Sessions are
-  server-side rows, so signing out actually revokes.
-- Local auth mode refuses a non-loopback bind without an explicit override
-  flag.
-- Internal errors (SQL, prompt fragments) never reach clients; they go to the
-  log and the client sees a generic message.
-- CI runs `cargo audit` on every push. Advisories are ignored one id at a time
-  in `.cargo/audit.toml`, each with a written reachability argument — currently
-  one entry, RUSTSEC-2023-0071 in `rsa` via `openidconnect`, which concerns
-  private-key operations that engram never performs.
-
-## Not built (yet)
-
-Hybrid keyword + vector search (the FTS5 index and its triggers exist and are
-tested, but the retrieval path does not use them), reranking on by default, a
-CLI, retrieval-quality evaluation, OAuth 2.1 for `/mcp`, and file upload.
+Set `ENGRAM_TEST_QDRANT` if Qdrant is not on `localhost:6333`. Everything except
+the Qdrant suite runs without infrastructure: inference and the vector store sit
+behind traits, and the tests inject fakes plus an in-memory vector store.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,46 @@
+# Roadmap
+
+Not built yet, roughly in the order it would be worth building.
+
+## Retrieval
+
+- **Evaluation on a real corpus.** Ranking now has several knobs — fusion,
+  per-source cap, recency weight, pinned boost — and no way to measure whether a
+  change helped. A fixed set of query/expected-chunk pairs would make that
+  falsifiable. Everything below this line is guesswork until it exists.
+- **Reranking on by default**, once there is a default endpoint worth assuming.
+- **Late-interaction reranking** (ColBERT-style multivectors) as a prefetch stage
+  inside Qdrant, replacing the external reranker hop. Needs a model dependency.
+- **Server-side grouping.** The per-source cap is applied client-side, so a
+  source whose chunks fill the entire candidate pool still crowds others out.
+  Qdrant's `query/groups` fixes that properly.
+
+## Features
+
+- **Related chunks.** Qdrant's `recommend` takes a point id and returns its
+  neighbours — a "more like this" panel for free, no embedding call.
+- **Corpus map.** The distance-matrix API gives pairwise distances over a
+  filtered subset: near-duplicate detection on ingest, and a real rendering of
+  the neighbour graph the logo depicts.
+- **Facets.** Tag and category counts for the Browse sidebar, straight from the
+  payload index instead of a SQL scan.
+- **File upload** and a **CLI**.
+
+## Operations
+
+- **Quantization and on-disk payload** for small hosts. The chunk text is stored
+  in both SQLite and the Qdrant payload; dropping the second copy and hydrating
+  from SQLite would cut memory noticeably.
+- **Snapshots** as part of the backup story, so restoring does not mean paying
+  for every embedding again.
+- **Multi-user**, via payload-partitioned tenancy (`is_tenant`) rather than a
+  collection per user. Cheap to design in now, expensive to retrofit.
+- **OAuth 2.1 for `/mcp`.**
+
+## Loose ends
+
+- The SQLite FTS5 index and its triggers exist and are tested, but nothing reads
+  them. Hybrid search happens in Qdrant instead, where fusion is one round trip
+  and the lexical index cannot drift from the vectors. Either wire FTS5 up as a
+  fallback or delete it.
+- `clippy` is not run locally in every environment; CI is the only gate.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,9 +67,11 @@ it is a flat list of whole chunks.
 - **Reranking on by default**, once there is a default endpoint worth assuming.
 - **Late-interaction reranking** (ColBERT-style multivectors) as a prefetch stage
   inside Qdrant, replacing the external reranker hop. Needs a model dependency.
-- **Server-side grouping.** The per-source cap is applied client-side, so a
-  source whose chunks fill the entire candidate pool still crowds others out.
-  Qdrant's `query/groups` fixes that properly.
+- **Server-side grouping.** The per-source cap is applied client-side, over a
+  candidate pool three times the limit. It reorders rather than truncates — what
+  it displaces refills the tail — but a source whose chunks fill the entire
+  candidate pool still leaves nothing to promote ahead of it. Qdrant's
+  `query/groups` fixes that at the source, by retrieving per group.
 
 ## Segmentation fidelity
 
@@ -123,7 +125,14 @@ verbatim. Nothing checks that it did.
 - The SQLite FTS5 index and its triggers exist and are tested, but nothing reads
   them. Hybrid search happens in Qdrant instead, where fusion is one round trip
   and the lexical index cannot drift from the vectors. Either wire FTS5 up as a
-  fallback or delete it.
+  fallback or delete it. Its triggers are now scoped to `text`, `title` and
+  `tags`, so at least it no longer pays for every job-status write.
+- **Term-id collisions.** Sparse dimensions are `u32` and terms are hashed into
+  them, so a large enough vocabulary conflates two terms into one dimension and
+  a document matches a word it does not contain. `sparse::term_id` is the only
+  place ids are derived, so replacing it with a vocabulary table is a contained
+  change plus a `--reindex`. Nothing measures the effect yet, which is the
+  evaluation gap above.
 - Ingest is bounded by axum's default 2MB body limit rather than a deliberate
   one. Fine for pasted prose, wrong the moment file upload lands; set the limit
   explicitly and reject oversize captures with a message rather than a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,12 +2,68 @@
 
 Not built yet, roughly in the order it would be worth building.
 
+The ordering assumes the shape of use engram is for: paste a long reference
+document once, and a year later find the one paragraph in it that answers the
+situation you are in — while typing the situation, not after formulating a
+query. The pipeline from capture to ranked chunk is built. Most of what follows
+is the last hop, from a ranked chunk to the command the reader actually runs,
+plus the means to tell whether the ranking was any good.
+
+## Recall surface
+
+The result list is where a year-old capture either pays off or does not. Today
+it is a flat list of whole chunks.
+
+- **Chunk detail view.** A result card links to `/ui/sources/{id}`, which
+  renders the raw document and every chunk it produced. Clicking a hit should
+  land on the hit: a `/ui/chunks/{id}` route showing the chunk, its title,
+  category, tags, its span in the source, and a link back to the surrounding
+  raw text. Without it, "open the details" means scrolling a chapter to find
+  the paragraph search already found.
+- **Snippet and expand.** `_results.html` renders the whole chunk body. A
+  self-contained chunk is small by design, but the segmenter's size limit is a
+  prompt hint, not a guarantee, and one oversize chunk pushes every other
+  result off the screen. Clamp the card to a few lines with an expand control,
+  keeping fenced code blocks intact when clamping.
+- **Query term highlighting.** The sparse branch already knows which terms
+  matched; the reader gets no mark. In a chunk that is half prose and half
+  shell, highlighting the terms that hit is the difference between reading a
+  card and scanning one.
+- **Copy the command.** A copy button per fenced code block. The point of
+  keeping literals verbatim is that they get run.
+- **Tag and category controls.** `UiSearchParams` accepts `tags` and
+  `category`, and the search page renders no input for either, so narrowing to
+  `category=procedure` is API-only. Chips beside the search box, ideally
+  populated from facet counts (see below).
+
+## Search-as-you-type
+
+`keyup changed delay:250ms` is the whole of the incremental behaviour.
+
+- **Query embedding cache.** Every burst of typing costs one embedding call
+  before Qdrant is touched at all. Prefixes repeat constantly within a single
+  search, and identical queries repeat across sessions. A small bounded cache
+  keyed on the trimmed query removes the dominant latency term for a local
+  embedder and makes a remote one usable.
+- **Do not mark partial queries as seen.** `Core::search` calls `mark_seen` on
+  every request, so typing `d`, `dd`, `dd if` stamps `last_seen_at` on whatever
+  each prefix happened to match. That is the same field `resurface` reads, so
+  incremental search quietly drains the forgotten-chunk feature. Mark on an
+  explicit action — submit, expand, open — or debounce the stamp well behind
+  the query.
+- **Latency budget in the response.** `search` already logs `embed_ms` and
+  `total_ms`. Surfacing them in the UI, even faintly, makes it obvious whether
+  a sluggish box is the embedder, the vector store or the reranker.
+
 ## Retrieval
 
 - **Evaluation on a real corpus.** Ranking now has several knobs — fusion,
   per-source cap, recency weight, pinned boost — and no way to measure whether a
   change helped. A fixed set of query/expected-chunk pairs would make that
-  falsifiable. Everything below this line is guesswork until it exists.
+  falsifiable. Everything below this line is guesswork until it exists. The
+  pairs worth writing first are the hard case: a query phrased as a situation
+  in prose, against a chunk that is mostly commands and shares few of its
+  words.
 - **Reranking on by default**, once there is a default endpoint worth assuming.
 - **Late-interaction reranking** (ColBERT-style multivectors) as a prefetch stage
   inside Qdrant, replacing the external reranker hop. Needs a model dependency.
@@ -15,15 +71,40 @@ Not built yet, roughly in the order it would be worth building.
   source whose chunks fill the entire candidate pool still crowds others out.
   Qdrant's `query/groups` fixes that properly.
 
+## Segmentation fidelity
+
+The chunker is instructed to reproduce commands, paths and error strings
+verbatim. Nothing checks that it did.
+
+- **Literal verification.** After segmentation, extract fenced code, inline
+  code and path-like tokens from each chunk and confirm each appears in the
+  window it came from. A mismatch means the model paraphrased something that
+  will later be pasted into a root shell. Flag the chunk, and prefer retrying
+  the window over storing it silently.
+- **Span verification.** `source_lines` comes back from the model and is
+  trusted after the window offset is applied. Checking that the chunk's text
+  plausibly overlaps the lines it claims would catch a whole class of confident
+  nonsense, and the chunk detail view depends on the span being right.
+- **Coverage report.** Windowing is tested to lose no line, but nothing tracks
+  how much of a source ended up inside some chunk. A source where the segmenter
+  quietly dropped half the chapter currently looks identical to one where it
+  did not.
+
 ## Features
 
+- **Near-duplicate detection on ingest.** Sources are deduplicated by an exact
+  hash of the raw text, so re-pasting the same chapter a year later with one
+  changed byte stores it twice and the two copies then compete for the same
+  queries. The distance-matrix API below is the cheap way to catch this at
+  capture time and offer to replace rather than add.
 - **Related chunks.** Qdrant's `recommend` takes a point id and returns its
   neighbours — a "more like this" panel for free, no embedding call.
 - **Corpus map.** The distance-matrix API gives pairwise distances over a
   filtered subset: near-duplicate detection on ingest, and a real rendering of
   the neighbour graph the logo depicts.
 - **Facets.** Tag and category counts for the Browse sidebar, straight from the
-  payload index instead of a SQL scan.
+  payload index instead of a SQL scan. Also what the search page's filter chips
+  should be built from.
 - **File upload** and a **CLI**.
 
 ## Operations
@@ -43,4 +124,8 @@ Not built yet, roughly in the order it would be worth building.
   them. Hybrid search happens in Qdrant instead, where fusion is one round trip
   and the lexical index cannot drift from the vectors. Either wire FTS5 up as a
   fallback or delete it.
+- Ingest is bounded by axum's default 2MB body limit rather than a deliberate
+  one. Fine for pasted prose, wrong the moment file upload lands; set the limit
+  explicitly and reject oversize captures with a message rather than a
+  truncated form error.
 - `clippy` is not run locally in every environment; CI is the only gate.

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,9 +17,21 @@ workers = 2
 path = "engram.db"
 
 [vector]
-url = "http://localhost:6334"
+# Qdrant base URL. Its REST API, not the gRPC port: 6333 locally, or whatever
+# a reverse proxy serves it on (commonly plain https:// with no port).
+url = "http://localhost:6333"
+# Alias name. The vectors live in chunks_v1, chunks_v2, … behind it.
 collection = "chunks"
 # api_key = "..."   # prefer ENGRAM__VECTOR__API_KEY
+
+# How much age counts against a result. Fused ranks land between roughly 0.1
+# and 1.0, so this breaks near-ties in favour of the newer note without
+# overturning a clearly better match. Set to 0.0 to turn recency off.
+recency_weight = 0.05
+recency_half_life_days = 180
+# Extra score for a chunk tagged `pinned`, so a decision you made beats the
+# decay curve.
+pinned_boost = 0.15
 
 # ── Inference roles ─────────────────────────────────────────────────────────
 # Three independent roles. They may all point at one server, or at three

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 services:
   qdrant:
-    image: qdrant/qdrant:v1.18.2
+    image: qdrant/qdrant:v1.19.0
     container_name: engram-qdrant
     ports:
-      - "127.0.0.1:6333:6333"   # REST
-      - "127.0.0.1:6334:6334"   # gRPC — the client uses this one
+      - "127.0.0.1:6333:6333"   # REST — the only port engram uses
     volumes:
       - qdrant_data:/qdrant/storage
 volumes:

--- a/migrations/0004_chunk_embed_rev.sql
+++ b/migrations/0004_chunk_embed_rev.sql
@@ -1,0 +1,26 @@
+-- A chunk's vector revision.
+--
+-- Embedding reads a chunk, calls a slow remote endpoint, and only then writes
+-- back "this is indexed". Anything that edits the text or the title in that
+-- window — a PATCH, a reprocess — leaves the job about to mark a chunk
+-- embedded on the strength of a vector computed from text that no longer
+-- exists. Nothing in the row said so, because the edit set the same
+-- `embed_state = 'pending'` the job was about to clear.
+--
+-- So every vector-invalidating edit bumps this, the embed job carries the
+-- revision it read, and marking a chunk embedded only lands while the two
+-- still match. A losing job leaves the chunk pending, which is exactly the
+-- state that gets it embedded again.
+ALTER TABLE chunks ADD COLUMN embed_rev INTEGER NOT NULL DEFAULT 0;
+
+-- The FTS index only mirrors text, title and tags, but this trigger fired on
+-- every column — so each `embed_state` write, and now each revision bump,
+-- deleted and reinserted three FTS rows for no change in what they hold.
+-- Scoping it makes the index cost track edits rather than job traffic.
+DROP TRIGGER chunks_au;
+CREATE TRIGGER chunks_au AFTER UPDATE OF text, title, tags ON chunks BEGIN
+  INSERT INTO chunks_fts(chunks_fts, rowid, text, title, tags)
+  VALUES ('delete', old.rowid, old.text, old.title, old.tags);
+  INSERT INTO chunks_fts(rowid, text, title, tags)
+  VALUES (new.rowid, new.text, new.title, new.tags);
+END;

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,28 @@ pub struct VectorConfig {
     pub collection: String,
     #[serde(default)]
     pub api_key: Option<String>,
+    /// How much a result's age counts against it. Fused ranks land between
+    /// roughly 0.1 and 1.0, so the default breaks near-ties in favour of the
+    /// newer note without ever overturning a clearly better match. `0.0` turns
+    /// recency off entirely.
+    #[serde(default = "default_recency_weight")]
+    pub recency_weight: f32,
+    /// Age at which a chunk has lost half of that boost.
+    #[serde(default = "default_recency_half_life_days")]
+    pub recency_half_life_days: u32,
+    /// Extra score for a chunk carrying the `pinned` tag, so something you
+    /// decided matters can outrank the decay curve.
+    #[serde(default = "default_pinned_boost")]
+    pub pinned_boost: f32,
+}
+fn default_recency_weight() -> f32 {
+    0.05
+}
+fn default_recency_half_life_days() -> u32 {
+    180
+}
+fn default_pinned_boost() -> f32 {
+    0.15
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/core/ask.rs
+++ b/src/core/ask.rs
@@ -37,13 +37,19 @@ impl Core {
             return Err(Error::Validation("question is empty".into()));
         }
 
+        // No per-source cap: an answer often lives in one document, and
+        // withholding its paragraphs to keep the citation list varied would
+        // make the answer worse, not fairer.
         let hits = self
-            .search(&SearchQuery {
-                q: req.q.clone(),
-                limit: req.limit.unwrap_or(8),
-                tags: req.tags.clone(),
-                category: req.category.clone(),
-            })
+            .search_capped(
+                &SearchQuery {
+                    q: req.q.clone(),
+                    limit: req.limit.unwrap_or(8),
+                    tags: req.tags.clone(),
+                    category: req.category.clone(),
+                },
+                None,
+            )
             .await?;
 
         if hits.is_empty() {

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -1,0 +1,151 @@
+//! Detached writes that still have to finish.
+//!
+//! Some work must not sit on the request path but must not be lost either.
+//! Recording which chunks a search showed is the case that exists today: a
+//! search must not get slower, or fail, because a bookkeeping write did — and
+//! yet a stamp dropped at shutdown is a chunk that looks forgotten when it is
+//! not.
+//!
+//! `tokio::spawn` alone gives the first half and not the second: the runtime
+//! drops outstanding tasks when `main` returns. This counts them, so shutdown
+//! can wait, and so tests can await the effect instead of sleeping and hoping.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Notify;
+
+#[derive(Default)]
+pub struct Background {
+    inflight: AtomicUsize,
+    idle: Notify,
+}
+
+/// Decrements on drop rather than after the await, so a task that panics or is
+/// cancelled releases its slot. Decrementing at the end of the future body
+/// would wedge every later shutdown behind a task that is already gone.
+struct Slot(Arc<Background>);
+
+impl Drop for Slot {
+    fn drop(&mut self) {
+        if self.0.inflight.fetch_sub(1, Ordering::SeqCst) == 1 {
+            self.0.idle.notify_waiters();
+        }
+    }
+}
+
+impl Background {
+    /// Run `task` detached, counted until it finishes.
+    ///
+    /// The count is incremented here rather than inside the spawned future, so
+    /// a `wait_idle` racing a `spawn` cannot observe zero for work that has
+    /// already been handed over.
+    pub fn spawn<F>(self: &Arc<Self>, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.inflight.fetch_add(1, Ordering::SeqCst);
+        let slot = Slot(self.clone());
+        tokio::spawn(async move {
+            let _slot = slot;
+            task.await;
+        });
+    }
+
+    pub fn inflight(&self) -> usize {
+        self.inflight.load(Ordering::SeqCst)
+    }
+
+    /// Resolve once nothing is outstanding.
+    ///
+    /// Waiting for work spawned *after* this returns is not the contract:
+    /// callers stop accepting requests first, then drain.
+    pub async fn wait_idle(&self) {
+        loop {
+            // Registered before the count is read, because `notify_waiters`
+            // wakes only what is already waiting. Checking first would lose a
+            // task that finished in between and wait for a wake-up that has
+            // already happened.
+            let notified = self.idle.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self.inflight() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn waiting_resolves_after_the_task_has_actually_run() {
+        let bg = Arc::new(Background::default());
+        let done = Arc::new(AtomicBool::new(false));
+
+        let flag = done.clone();
+        bg.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            flag.store(true, Ordering::SeqCst);
+        });
+
+        bg.wait_idle().await;
+        assert!(
+            done.load(Ordering::SeqCst),
+            "shutdown returned while the write was still in flight"
+        );
+    }
+
+    #[tokio::test]
+    async fn waiting_on_nothing_returns_immediately() {
+        let bg = Arc::new(Background::default());
+        bg.wait_idle().await;
+        assert_eq!(bg.inflight(), 0);
+    }
+
+    #[tokio::test]
+    async fn every_spawned_task_is_waited_for() {
+        let bg = Arc::new(Background::default());
+        let count = Arc::new(AtomicUsize::new(0));
+        for i in 0..50 {
+            let c = count.clone();
+            bg.spawn(async move {
+                // Staggered, so a wait that resolves early is caught rather
+                // than passing because everything happened to finish at once.
+                tokio::time::sleep(Duration::from_millis(i % 7)).await;
+                c.fetch_add(1, Ordering::SeqCst);
+            });
+        }
+        bg.wait_idle().await;
+        assert_eq!(count.load(Ordering::SeqCst), 50);
+    }
+
+    #[tokio::test]
+    async fn a_panicking_task_does_not_wedge_shutdown() {
+        // A background write that panics must still release its slot, or every
+        // later shutdown hangs waiting for a task that is already gone.
+        let bg = Arc::new(Background::default());
+        bg.spawn(async { panic!("the write failed") });
+
+        tokio::time::timeout(Duration::from_secs(5), bg.wait_idle())
+            .await
+            .expect("wait_idle hung after a task panicked");
+        assert_eq!(bg.inflight(), 0);
+    }
+
+    #[tokio::test]
+    async fn waiting_twice_is_allowed() {
+        let bg = Arc::new(Background::default());
+        bg.spawn(async {});
+        bg.wait_idle().await;
+        bg.spawn(async {});
+        bg.wait_idle().await;
+        assert_eq!(bg.inflight(), 0);
+    }
+}

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -73,9 +73,8 @@ impl Core {
                     .await?;
             }
             Stage::Embed => {
-                for c in self.store.chunks_for_source(&src.id).await? {
-                    self.store.enqueue(Stage::Embed, "chunk", &c.id).await?;
-                }
+                self.store.reset_embed_state(&src.id).await?;
+                self.store.enqueue(Stage::Embed, "source", &src.id).await?;
                 self.store
                     .set_source_status(&src.id, SourceStatus::Embedding)
                     .await?;
@@ -158,6 +157,7 @@ mod tests {
             .unwrap();
         core.vectors
             .upsert(vec![crate::vector::VectorPoint {
+                sparse: Default::default(),
                 vector: vec![0.1; 8],
                 payload: crate::vector::VectorPayload {
                     chunk_id: chunks[0].id.clone(),
@@ -167,6 +167,7 @@ mod tests {
                     category: None,
                     tags: vec![],
                     created_at: 0,
+                    last_seen_at: None,
                 },
             }])
             .await

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -43,6 +43,15 @@ pub mod test_support {
         .await
     }
 
+    /// A core plus a handle on its embedder, for asserting how many times the
+    /// endpoint was called rather than only what came back.
+    pub async fn test_core_counting_embed_calls() -> (Core, Arc<FakeEmbedder>) {
+        let embedder = Arc::new(FakeEmbedder::new(TEST_DIM));
+        let mut core = build(Arc::new(FakeChunker::default()), None).await;
+        core.embedder = embedder.clone();
+        (core, embedder)
+    }
+
     async fn build(chunker: Arc<dyn Chunker>, reranker: Option<Arc<dyn Reranker>>) -> Core {
         let store = Store::memory().await.unwrap();
         Core {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod ask;
+pub mod background;
 pub mod ingest;
 pub mod search;
 
@@ -6,6 +7,7 @@ use crate::infer::budget::TokenCounter;
 use crate::infer::{Chunker, Completer, Embedder, Reranker};
 use crate::store::Store;
 use crate::vector::VectorStore;
+use background::Background;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -17,6 +19,9 @@ pub struct Core {
     pub reranker: Option<Arc<dyn Reranker>>,
     pub completer: Arc<dyn Completer>,
     pub counter: Arc<TokenCounter>,
+    /// Writes that run off the request path. Shared by every clone of `Core`,
+    /// so draining one drains them all.
+    pub background: Arc<Background>,
 }
 
 #[cfg(test)]
@@ -62,6 +67,7 @@ pub mod test_support {
             reranker,
             completer: Arc::new(FakeCompleter::default()),
             counter: Arc::new(TokenCounter::Estimate),
+            background: Arc::new(Background::default()),
         }
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -4,9 +4,12 @@ use crate::vector::SearchFilter;
 
 pub const DEFAULT_LIMIT: usize = 10;
 pub const MAX_LIMIT: usize = 50;
-/// Over-fetch before reranking. Reranking only reorders what it is given, so
-/// the candidate pool has to be wider than the answer.
+/// Over-fetch before reranking and grouping. Both only narrow what they are
+/// given, so the candidate pool has to be wider than the answer.
 pub const CANDIDATE_MULTIPLIER: usize = 3;
+/// Chunks one source may contribute to a result list. A forty-chunk document
+/// otherwise fills the whole answer and hides everything else in the corpus.
+pub const MAX_PER_SOURCE: usize = 3;
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct SearchQuery {
@@ -30,10 +33,100 @@ pub struct SearchResult {
     pub score: f32,
 }
 
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Keep at most `max` hits per source, preserving the order they arrived in.
+///
+/// Applied to a ranked list, this keeps each source's strongest chunks and
+/// drops the tail, which is what stops one long document from filling an answer
+/// with near-identical paragraphs.
+fn cap_per_source(
+    hits: Vec<crate::vector::SearchHit>,
+    max: usize,
+) -> Vec<crate::vector::SearchHit> {
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    hits.into_iter()
+        .filter(|h| {
+            let n = seen.entry(h.payload.source_id.clone()).or_insert(0);
+            *n += 1;
+            *n <= max
+        })
+        .collect()
+}
+
+/// Chunks older than this are candidates for resurfacing, and a chunk shown
+/// within this window counts as still remembered.
+pub const FORGOTTEN_AFTER_DAYS: i64 = 30;
+const SECONDS_PER_DAY: i64 = 86_400;
+
 impl Core {
+    /// Record that these results were shown, without making the caller wait.
+    ///
+    /// One request for the whole list, off the request path: a search must not
+    /// get slower, or fail, because a bookkeeping write did.
+    fn mark_seen(&self, results: &[SearchResult]) {
+        if results.is_empty() {
+            return;
+        }
+        let ids: Vec<String> = results.iter().map(|r| r.chunk_id.clone()).collect();
+        let vectors = self.vectors.clone();
+        let now = now_secs();
+        tokio::spawn(async move {
+            if let Err(e) = vectors.touch(&ids, now).await {
+                tracing::warn!(error = %e, "could not record which chunks were shown");
+            }
+        });
+    }
+
+    /// A random handful of chunks that have not surfaced in a month.
+    ///
+    /// Random rather than ranked, because there is no query: the question is
+    /// what has been forgotten, and ranking would keep returning the same
+    /// answer to it.
+    pub async fn resurface(&self, limit: usize) -> Result<Vec<SearchResult>> {
+        let cutoff = now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY;
+        let hits = self
+            .vectors
+            .resurface(limit.clamp(1, MAX_LIMIT), cutoff, cutoff)
+            .await?;
+        let results: Vec<SearchResult> = hits
+            .into_iter()
+            .map(|h| SearchResult {
+                chunk_id: h.payload.chunk_id,
+                source_id: h.payload.source_id,
+                title: h.payload.title,
+                text: h.payload.text,
+                category: h.payload.category,
+                tags: h.payload.tags,
+                score: h.score,
+            })
+            .collect();
+        // Surfacing counts as seeing, or the same chunks come back tomorrow.
+        self.mark_seen(&results);
+        Ok(results)
+    }
+
     /// The hot path. One embedding call, one vector search, and optionally one
     /// rerank call. No completion, ever.
+    ///
+    /// Results are capped per source so one long document cannot fill the list.
     pub async fn search(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
+        self.search_capped(query, Some(MAX_PER_SOURCE)).await
+    }
+
+    /// `cap` of `None` lets a single source supply every result. `ask` wants
+    /// that: a question is often answered by one document, and starving it of
+    /// its own paragraphs to make the list look varied helps nobody.
+    pub async fn search_capped(
+        &self,
+        query: &SearchQuery,
+        cap: Option<usize>,
+    ) -> Result<Vec<SearchResult>> {
         if query.q.trim().is_empty() {
             return Err(Error::Validation("query is empty".into()));
         }
@@ -50,15 +143,27 @@ impl Core {
             tags: query.tags.clone(),
             category: query.category.clone(),
         };
-        let candidates = if self.reranker.is_some() {
+        // Over-fetch whenever something downstream narrows the list: both the
+        // per-source cap and the reranker can only discard what they are given.
+        let candidates = if cap.is_some() || self.reranker.is_some() {
             limit * CANDIDATE_MULTIPLIER
         } else {
             limit
         };
+        // The lexical half of the query. Computed locally and for free, so it
+        // costs nothing when the store ignores it.
+        let sparse = crate::vector::sparse::encode_query(query.q.trim());
         let hits = self
             .vectors
-            .search(&vectors[0], candidates, &filter)
+            .search(&vectors[0], &sparse, candidates, &filter)
             .await?;
+
+        // Cap before reranking, in vector order, so what survives per source is
+        // that source's best.
+        let hits = match cap {
+            Some(max) => cap_per_source(hits, max),
+            None => hits,
+        };
 
         let mut results: Vec<SearchResult> = hits
             .into_iter()
@@ -95,6 +200,7 @@ impl Core {
         }
 
         results.truncate(limit);
+        self.mark_seen(&results);
         tracing::info!(
             q = %query.q,
             results = results.len(),
@@ -113,7 +219,16 @@ mod tests {
     use crate::store::chunks::NewChunk;
 
     async fn seed(core: &crate::core::Core, texts: &[(&str, &str, &[&str])]) -> String {
-        let src = core.store.insert_source("raw", "web", None).await.unwrap();
+        seed_from(core, "raw", texts).await
+    }
+
+    /// `raw` has to differ per source: sources are deduplicated by a hash of it.
+    async fn seed_from(
+        core: &crate::core::Core,
+        raw: &str,
+        texts: &[(&str, &str, &[&str])],
+    ) -> String {
+        let src = core.store.insert_source(raw, "web", None).await.unwrap();
         let new: Vec<NewChunk> = texts
             .iter()
             .enumerate()
@@ -131,6 +246,15 @@ mod tests {
             crate::jobs::embed::run(core, &c.id).await.unwrap();
         }
         src.id
+    }
+
+    /// Rewrite every vector payload from the current chunk rows.
+    async fn reembed_all(core: &crate::core::Core) {
+        for src in core.store.list_sources(100, 0).await.unwrap() {
+            for c in core.store.chunks_for_source(&src.id).await.unwrap() {
+                crate::jobs::embed::run(core, &c.id).await.unwrap();
+            }
+        }
     }
 
     fn q(text: &str) -> SearchQuery {
@@ -255,18 +379,154 @@ mod tests {
         // were not wider than the limit, a better match ranked 11th by vector
         // similarity could never be promoted into a top-10 answer.
         let core = test_core_with_rerank().await;
-        let many: Vec<(String, &str, Vec<&str>)> =
-            (0..30).map(|i| (format!("doc {i}"), "c", vec![])).collect();
-        let refs: Vec<(&str, &str, &[&str])> = many
-            .iter()
-            .map(|(t, c, g)| (t.as_str(), *c, g.as_slice()))
-            .collect();
-        seed(&core, &refs).await;
+        // Spread across sources so the per-source cap is not what narrows the
+        // list; this test is about the candidate pool, not about grouping.
+        for batch in 0..10 {
+            let texts: Vec<String> = (0..3).map(|i| format!("doc {batch}-{i}")).collect();
+            let refs: Vec<(&str, &str, &[&str])> =
+                texts.iter().map(|t| (t.as_str(), "c", &[][..])).collect();
+            seed_from(&core, &format!("raw {batch}"), &refs).await;
+        }
 
         let mut query = q("anything");
         query.limit = 5;
         let hits = core.search(&query).await.unwrap();
         assert_eq!(hits.len(), 5, "result count must still honour the limit");
+    }
+
+    #[tokio::test]
+    async fn one_source_cannot_fill_the_whole_result_list() {
+        // A forty-chunk document otherwise crowds out every other source and
+        // the answer becomes forty near-identical paragraphs.
+        let core = test_core().await;
+        let hog: Vec<String> = (0..12).map(|i| format!("alpha {i}")).collect();
+        let refs: Vec<(&str, &str, &[&str])> =
+            hog.iter().map(|t| (t.as_str(), "c", &[][..])).collect();
+        let big = seed_from(&core, "big", &refs).await;
+        let small = seed_from(&core, "small", &[("alpha other", "c", &[])]).await;
+
+        let hits = core.search(&q("t0\nalpha 0")).await.unwrap();
+        let from_big = hits.iter().filter(|h| h.source_id == big).count();
+        assert!(
+            from_big <= MAX_PER_SOURCE,
+            "one source contributed {from_big} of {} results",
+            hits.len()
+        );
+        assert!(
+            hits.iter().any(|h| h.source_id == small),
+            "the crowded-out source never appeared"
+        );
+    }
+
+    #[tokio::test]
+    async fn ask_may_draw_every_excerpt_from_one_source() {
+        // The cap exists to keep a browsable list varied. An answer is often
+        // found in a single document, and rationing its paragraphs would make
+        // the answer worse rather than the list fairer.
+        let core = test_core().await;
+        let texts: Vec<String> = (0..8).map(|i| format!("alpha {i}")).collect();
+        let refs: Vec<(&str, &str, &[&str])> =
+            texts.iter().map(|t| (t.as_str(), "c", &[][..])).collect();
+        seed_from(&core, "only", &refs).await;
+
+        let capped = core.search(&q("t0\nalpha 0")).await.unwrap();
+        let uncapped = core.search_capped(&q("t0\nalpha 0"), None).await.unwrap();
+        assert_eq!(capped.len(), MAX_PER_SOURCE);
+        assert!(
+            uncapped.len() > MAX_PER_SOURCE,
+            "an uncapped search returned {} results",
+            uncapped.len()
+        );
+    }
+
+    #[test]
+    fn the_cap_keeps_the_highest_ranked_chunk_of_each_source() {
+        // Applied to a ranked list, what survives per source must be its best,
+        // not whichever chunk happened to be enumerated first.
+        use crate::vector::{SearchHit, VectorPayload};
+        let hit = |chunk: &str, src: &str, score: f32| SearchHit {
+            payload: VectorPayload {
+                chunk_id: chunk.into(),
+                source_id: src.into(),
+                text: String::new(),
+                title: None,
+                category: None,
+                tags: vec![],
+                created_at: 0,
+                last_seen_at: None,
+            },
+            score,
+        };
+        let kept = cap_per_source(
+            vec![
+                hit("a1", "a", 0.9),
+                hit("a2", "a", 0.8),
+                hit("b1", "b", 0.7),
+                hit("a3", "a", 0.6),
+            ],
+            2,
+        );
+        let ids: Vec<&str> = kept.iter().map(|h| h.payload.chunk_id.as_str()).collect();
+        assert_eq!(ids, vec!["a1", "a2", "b1"]);
+    }
+
+    #[tokio::test]
+    async fn resurface_returns_only_what_has_been_forgotten() {
+        let core = test_core().await;
+        seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
+        seed_from(&core, "new", &[("captured just now", "c", &[])]).await;
+
+        // `created_at` is set by the store, so age the one that should surface.
+        let cutoff = now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1;
+        sqlx::query("UPDATE chunks SET created_at = ? WHERE text = ?")
+            .bind(cutoff)
+            .bind("long forgotten")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        // The vector payload carries its own copy, so re-embed to pick it up.
+        reembed_all(&core).await;
+
+        let out = core.resurface(10).await.unwrap();
+        assert_eq!(
+            out.len(),
+            1,
+            "got: {:?}",
+            out.iter().map(|r| &r.text).collect::<Vec<_>>()
+        );
+        assert_eq!(out[0].text, "long forgotten");
+    }
+
+    #[tokio::test]
+    async fn a_resurfaced_chunk_does_not_come_straight_back() {
+        // Showing something counts as seeing it, or the same handful returns
+        // every day and the feature is noise.
+        let core = test_core().await;
+        seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
+        let old = now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1;
+        sqlx::query("UPDATE chunks SET created_at = ?")
+            .bind(old)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        reembed_all(&core).await;
+
+        assert_eq!(core.resurface(10).await.unwrap().len(), 1);
+        // mark_seen runs off the request path; let it land.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            core.resurface(10).await.unwrap().is_empty(),
+            "a chunk shown a moment ago is not forgotten"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_result_list_is_not_marked_seen() {
+        // Nothing was shown, so nothing should be recorded — and the empty
+        // case must not produce a pointless write.
+        let core = test_core().await;
+        assert!(core.search(&q("nothing here")).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -40,23 +40,37 @@ fn now_secs() -> i64 {
         .unwrap_or(0)
 }
 
-/// Keep at most `max` hits per source, preserving the order they arrived in.
+/// Promote at most `max` hits per source to the front of the list, then refill
+/// from what that displaced until `limit` is reached.
 ///
-/// Applied to a ranked list, this keeps each source's strongest chunks and
-/// drops the tail, which is what stops one long document from filling an answer
-/// with near-identical paragraphs.
+/// The cap is a diversity rule, not a ceiling. Capping alone would mean a base
+/// holding two sources could never answer with more than `2 * max` results
+/// however many good matches it contains — which is the common case for a young
+/// knowledge base, and the case where throwing matches away hurts most. So the
+/// displaced hits go back on the end in rank order: one long document no longer
+/// leads the list, but it still fills it when nothing else can.
 fn cap_per_source(
     hits: Vec<crate::vector::SearchHit>,
     max: usize,
+    limit: usize,
 ) -> Vec<crate::vector::SearchHit> {
     let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    hits.into_iter()
-        .filter(|h| {
-            let n = seen.entry(h.payload.source_id.clone()).or_insert(0);
-            *n += 1;
-            *n <= max
-        })
-        .collect()
+    let mut kept = Vec::with_capacity(hits.len());
+    let mut displaced = Vec::new();
+    for h in hits {
+        let n = seen.entry(h.payload.source_id.clone()).or_insert(0);
+        *n += 1;
+        if *n <= max {
+            kept.push(h);
+        } else {
+            displaced.push(h);
+        }
+    }
+    if kept.len() < limit {
+        let room = limit - kept.len();
+        kept.extend(displaced.into_iter().take(room));
+    }
+    kept
 }
 
 /// Chunks older than this are candidates for resurfacing, and a chunk shown
@@ -68,7 +82,9 @@ impl Core {
     /// Record that these results were shown, without making the caller wait.
     ///
     /// One request for the whole list, off the request path: a search must not
-    /// get slower, or fail, because a bookkeeping write did.
+    /// get slower, or fail, because a bookkeeping write did. Tracked rather
+    /// than merely spawned, so shutdown drains it instead of dropping it — a
+    /// lost stamp makes a chunk look forgotten when it is not.
     fn mark_seen(&self, results: &[SearchResult]) {
         if results.is_empty() {
             return;
@@ -76,7 +92,7 @@ impl Core {
         let ids: Vec<String> = results.iter().map(|r| r.chunk_id.clone()).collect();
         let vectors = self.vectors.clone();
         let now = now_secs();
-        tokio::spawn(async move {
+        self.background.spawn(async move {
             if let Err(e) = vectors.touch(&ids, now).await {
                 tracing::warn!(error = %e, "could not record which chunks were shown");
             }
@@ -158,10 +174,10 @@ impl Core {
             .search(&vectors[0], &sparse, candidates, &filter)
             .await?;
 
-        // Cap before reranking, in vector order, so what survives per source is
+        // Cap before reranking, in vector order, so what leads per source is
         // that source's best.
         let hits = match cap {
-            Some(max) => cap_per_source(hits, max),
+            Some(max) => cap_per_source(hits, max, limit),
             None => hits,
         };
 
@@ -395,9 +411,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn one_source_cannot_fill_the_whole_result_list() {
+    async fn one_source_cannot_lead_the_whole_result_list() {
         // A forty-chunk document otherwise crowds out every other source and
-        // the answer becomes forty near-identical paragraphs.
+        // the top of the list becomes forty near-identical paragraphs.
         let core = test_core().await;
         let hog: Vec<String> = (0..12).map(|i| format!("alpha {i}")).collect();
         let refs: Vec<(&str, &str, &[&str])> =
@@ -406,42 +422,70 @@ mod tests {
         let small = seed_from(&core, "small", &[("alpha other", "c", &[])]).await;
 
         let hits = core.search(&q("t0\nalpha 0")).await.unwrap();
-        let from_big = hits.iter().filter(|h| h.source_id == big).count();
+        let leading = &hits[..hits.len().min(MAX_PER_SOURCE + 1)];
+        let from_big = leading.iter().filter(|h| h.source_id == big).count();
         assert!(
             from_big <= MAX_PER_SOURCE,
-            "one source contributed {from_big} of {} results",
-            hits.len()
+            "one source took {from_big} of the leading {} results",
+            leading.len()
         );
         assert!(
-            hits.iter().any(|h| h.source_id == small),
-            "the crowded-out source never appeared"
+            leading.iter().any(|h| h.source_id == small),
+            "the crowded-out source never reached the top of the list"
         );
     }
 
     #[tokio::test]
-    async fn ask_may_draw_every_excerpt_from_one_source() {
-        // The cap exists to keep a browsable list varied. An answer is often
-        // found in a single document, and rationing its paragraphs would make
-        // the answer worse rather than the list fairer.
+    async fn a_single_source_base_still_fills_the_limit() {
+        // The cap orders the list, it does not shorten it. A base holding one
+        // document must not answer every query with three results.
         let core = test_core().await;
         let texts: Vec<String> = (0..8).map(|i| format!("alpha {i}")).collect();
         let refs: Vec<(&str, &str, &[&str])> =
             texts.iter().map(|t| (t.as_str(), "c", &[][..])).collect();
         seed_from(&core, "only", &refs).await;
 
+        let hits = core.search(&q("t0\nalpha 0")).await.unwrap();
+        assert_eq!(
+            hits.len(),
+            8,
+            "the per-source cap swallowed matches nothing else could replace"
+        );
+        // And still no duplicates: refilling must not re-add a kept hit.
+        let ids: std::collections::HashSet<&str> =
+            hits.iter().map(|h| h.chunk_id.as_str()).collect();
+        assert_eq!(ids.len(), hits.len(), "a hit appeared twice");
+    }
+
+    #[tokio::test]
+    async fn ask_reads_in_rank_order_rather_than_diversity_order() {
+        // An answer is often found in one document. `ask` takes the ranked
+        // list as it is, rather than the reordering that makes a browsable
+        // list varied.
+        let core = test_core().await;
+        let hog: Vec<String> = (0..6).map(|i| format!("alpha {i}")).collect();
+        let refs: Vec<(&str, &str, &[&str])> =
+            hog.iter().map(|t| (t.as_str(), "c", &[][..])).collect();
+        seed_from(&core, "big", &refs).await;
+        seed_from(&core, "small", &[("alpha other", "c", &[])]).await;
+
         let capped = core.search(&q("t0\nalpha 0")).await.unwrap();
         let uncapped = core.search_capped(&q("t0\nalpha 0"), None).await.unwrap();
-        assert_eq!(capped.len(), MAX_PER_SOURCE);
         assert!(
-            uncapped.len() > MAX_PER_SOURCE,
-            "an uncapped search returned {} results",
-            uncapped.len()
+            uncapped.windows(2).all(|w| w[0].score >= w[1].score),
+            "ask was handed a reordered list: {:?}",
+            uncapped.iter().map(|h| h.score).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            capped.len(),
+            uncapped.len(),
+            "the two paths must differ in order, not in how much they return"
         );
     }
 
     #[test]
-    fn the_cap_keeps_the_highest_ranked_chunk_of_each_source() {
-        // Applied to a ranked list, what survives per source must be its best,
+    fn the_cap_leads_with_the_highest_ranked_chunk_of_each_source() {
+        // Applied to a ranked list, what leads per source must be its best,
         // not whichever chunk happened to be enumerated first.
         use crate::vector::{SearchHit, VectorPayload};
         let hit = |chunk: &str, src: &str, score: f32| SearchHit {
@@ -457,17 +501,26 @@ mod tests {
             },
             score,
         };
-        let kept = cap_per_source(
+        let ranked = || {
             vec![
                 hit("a1", "a", 0.9),
                 hit("a2", "a", 0.8),
                 hit("b1", "b", 0.7),
                 hit("a3", "a", 0.6),
-            ],
-            2,
+            ]
+        };
+        let ids = |hits: Vec<SearchHit>| -> Vec<String> {
+            hits.iter().map(|h| h.payload.chunk_id.clone()).collect()
+        };
+
+        // Room for three: the cap holds and `a3` stays out.
+        assert_eq!(ids(cap_per_source(ranked(), 2, 3)), vec!["a1", "a2", "b1"]);
+        // Room for four and nothing else to offer: `a3` comes back, last.
+        assert_eq!(
+            ids(cap_per_source(ranked(), 2, 4)),
+            vec!["a1", "a2", "b1", "a3"],
+            "a displaced hit must refill an otherwise short list"
         );
-        let ids: Vec<&str> = kept.iter().map(|h| h.payload.chunk_id.as_str()).collect();
-        assert_eq!(ids, vec!["a1", "a2", "b1"]);
     }
 
     #[tokio::test]
@@ -512,9 +565,9 @@ mod tests {
         reembed_all(&core).await;
 
         assert_eq!(core.resurface(10).await.unwrap().len(), 1);
-        // mark_seen runs off the request path; let it land.
-        tokio::task::yield_now().await;
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // mark_seen runs off the request path; wait for it rather than sleeping
+        // and hoping, or this test fails on a loaded machine and nowhere else.
+        core.background.wait_idle().await;
         assert!(
             core.resurface(10).await.unwrap().is_empty(),
             "a chunk shown a moment ago is not forgotten"

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -8,17 +8,29 @@ use sha2::{Digest, Sha256};
 /// retrieval tests need from an embedding model.
 pub struct FakeEmbedder {
     dim: usize,
+    /// How many times the endpoint was called. Batching is invisible in the
+    /// output — only the call count shows whether it happened.
+    calls: std::sync::atomic::AtomicUsize,
 }
 
 impl FakeEmbedder {
     pub fn new(dim: usize) -> Self {
-        Self { dim }
+        Self {
+            dim,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    pub fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
 #[async_trait]
 impl Embedder for FakeEmbedder {
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(texts
             .iter()
             .map(|t| {

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -109,9 +109,26 @@ async fn embed_batch(core: &Core, chunks: &[Chunk], texts: Vec<String>) -> Resul
     core.vectors.upsert(points).await?;
 
     for c in chunks {
-        core.store
-            .mark_embedded(&c.id, core.embedder.model())
-            .await?;
+        mark_indexed(core, c).await?;
+    }
+    Ok(())
+}
+
+/// Report a chunk indexed, unless it was edited while it was being embedded.
+///
+/// The revision is the one read before the inference call, so an edit that
+/// landed in between wins: the mark does not apply, the chunk stays pending,
+/// and the job the editor queued embeds the text that is actually there.
+async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
+    let landed = core
+        .store
+        .mark_embedded(&chunk.id, core.embedder.model(), chunk.embed_rev)
+        .await?;
+    if !landed {
+        tracing::info!(
+            chunk_id = %chunk.id,
+            "chunk was edited while it was being embedded; leaving it pending"
+        );
     }
     Ok(())
 }
@@ -155,9 +172,7 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> 
                 payload: payload_of(chunk),
             }])
             .await?;
-        core.store
-            .mark_embedded(&chunk.id, core.embedder.model())
-            .await?;
+        mark_indexed(core, chunk).await?;
         return settle_source(core, &chunk.source_id).await;
     }
 
@@ -453,6 +468,69 @@ mod tests {
         let (_src, ids) = seed(&core, &[&big]).await;
         run_with_limit(&core, &ids[0], 200).await.unwrap();
         assert_eq!(core.vectors.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_chunk_edited_mid_embed_is_not_reported_as_indexed() {
+        // The job read the chunk, called a slow endpoint, and is about to write
+        // back "indexed". An edit that landed in that window must win, or the
+        // vector describes text that no longer exists and nothing says so.
+        let core = test_core().await;
+        let (_src, ids) = seed(&core, &["one"]).await;
+        let stale = core.store.get_chunk(&ids[0]).await.unwrap();
+
+        core.store
+            .update_chunk_text(&ids[0], "edited while embedding")
+            .await
+            .unwrap();
+
+        // What the in-flight job would have done, with the revision it read.
+        assert!(
+            !core
+                .store
+                .mark_embedded(&stale.id, "fake-embed", stale.embed_rev)
+                .await
+                .unwrap(),
+            "a stale job overwrote a newer edit"
+        );
+        assert_eq!(
+            core.store.get_chunk(&ids[0]).await.unwrap().embed_state,
+            EmbedState::Pending,
+            "the chunk must stay queued for the text that is actually there"
+        );
+
+        // And the retry, reading the current row, does land.
+        run(&core, &ids[0]).await.unwrap();
+        assert_eq!(
+            core.store.get_chunk(&ids[0]).await.unwrap().embed_state,
+            EmbedState::Embedded
+        );
+    }
+
+    #[tokio::test]
+    async fn reprocessing_a_source_outlives_a_worker_already_embedding_it() {
+        // `reset_embed_state` and an in-flight batch race by construction: both
+        // write the same chunk, and only the revision says which is current.
+        let core = test_core().await;
+        let (src_id, ids) = seed(&core, &["one", "two"]).await;
+        let inflight: Vec<_> = core.store.pending_chunks_for_source(&src_id).await.unwrap();
+
+        core.store.reset_embed_state(&src_id).await.unwrap();
+        for c in &inflight {
+            assert!(
+                !core
+                    .store
+                    .mark_embedded(&c.id, "fake-embed", c.embed_rev)
+                    .await
+                    .unwrap()
+            );
+        }
+
+        assert_eq!(
+            core.store.pending_embed_count(&src_id).await.unwrap(),
+            ids.len() as i64,
+            "the reprocess was silently cancelled by the job it interrupted"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -1,5 +1,5 @@
 use crate::core::Core;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::store::chunks::{Chunk, NewChunk};
 use crate::store::jobs::Stage;
 use crate::store::sources::SourceStatus;
@@ -9,37 +9,127 @@ use crate::vector::{VectorPayload, VectorPoint};
 /// remaining headroom absorbs tokenizer estimation error.
 const SAFETY: f32 = 0.8;
 
+/// Chunks sent to the embedder in one request. Bounded because a long source
+/// can hold hundreds of chunks and endpoints cap how many inputs they accept.
+const BATCH: usize = 32;
+
+/// Text for the embedding carries the title: it holds topical signal the body
+/// often leaves implicit.
+fn embed_text(chunk: &Chunk) -> String {
+    match &chunk.title {
+        Some(t) => format!("{t}\n{}", chunk.text),
+        None => chunk.text.clone(),
+    }
+}
+
 pub async fn run(core: &Core, chunk_id: &str) -> Result<()> {
-    let limit = (core.embedder.max_input_tokens() as f32 * SAFETY) as usize;
-    run_with_limit(core, chunk_id, limit).await
+    run_with_limit(core, chunk_id, default_limit(core)).await
+}
+
+fn default_limit(core: &Core) -> usize {
+    (core.embedder.max_input_tokens() as f32 * SAFETY) as usize
 }
 
 pub async fn run_with_limit(core: &Core, chunk_id: &str, limit: usize) -> Result<()> {
     let chunk = core.store.get_chunk(chunk_id).await?;
+    let text = embed_text(&chunk);
 
-    // Text for the embedding carries the title: it holds topical signal the
-    // body often leaves implicit.
-    let embed_text = match &chunk.title {
-        Some(t) => format!("{t}\n{}", chunk.text),
-        None => chunk.text.clone(),
-    };
-
-    if core.counter.count(&embed_text) > limit {
+    if core.counter.count(&text) > limit {
         return split_oversize(core, &chunk, limit).await;
     }
 
-    let vectors = core.embedder.embed(&[embed_text]).await?;
-    core.vectors
-        .upsert(vec![VectorPoint {
-            vector: vectors.into_iter().next().unwrap(),
-            payload: payload_of(&chunk),
-        }])
-        .await?;
-
-    core.store
-        .mark_embedded(&chunk.id, core.embedder.model())
-        .await?;
+    embed_batch(core, std::slice::from_ref(&chunk), vec![text]).await?;
     settle_source(core, &chunk.source_id).await
+}
+
+/// Embed every chunk of a source that is still waiting, in as few inference
+/// calls as the batch size allows.
+///
+/// One call per source rather than per chunk is the whole point: the embedding
+/// endpoint is the slow, rate-limited, and often paid part of ingest.
+pub async fn run_source(core: &Core, source_id: &str) -> Result<()> {
+    run_source_with_limit(core, source_id, default_limit(core)).await
+}
+
+pub async fn run_source_with_limit(core: &Core, source_id: &str, limit: usize) -> Result<()> {
+    let pending = core.store.pending_chunks_for_source(source_id).await?;
+
+    // An oversize chunk becomes siblings instead of a vector, so it cannot ride
+    // along in a batch. It leaves behind its own per-chunk jobs.
+    let mut batch: Vec<Chunk> = Vec::with_capacity(pending.len());
+    let mut texts: Vec<String> = Vec::with_capacity(pending.len());
+    for chunk in pending {
+        let text = embed_text(&chunk);
+        if core.counter.count(&text) > limit {
+            split_oversize(core, &chunk, limit).await?;
+        } else {
+            texts.push(text);
+            batch.push(chunk);
+        }
+    }
+
+    for (chunks, texts) in batch.chunks(BATCH).zip(texts.chunks(BATCH)) {
+        embed_batch(core, chunks, texts.to_vec()).await?;
+    }
+    settle_source(core, source_id).await
+}
+
+/// One inference call and one upsert for the whole slice. Chunks are marked
+/// embedded only once Qdrant has durably accepted their vectors, so a crash
+/// leaves work to redo rather than a chunk that claims to be searchable.
+async fn embed_batch(core: &Core, chunks: &[Chunk], texts: Vec<String>) -> Result<()> {
+    if chunks.is_empty() {
+        return Ok(());
+    }
+    let vectors = core.embedder.embed(&texts).await?;
+    if vectors.len() != chunks.len() {
+        return Err(Error::Inference {
+            role: "embed",
+            detail: format!(
+                "asked for {} embeddings and got {}; pairing them would attach vectors \
+                 to the wrong chunks",
+                chunks.len(),
+                vectors.len()
+            ),
+        });
+    }
+
+    let points = chunks
+        .iter()
+        .zip(texts.iter())
+        .zip(vectors)
+        .map(|((c, text), vector)| VectorPoint {
+            vector,
+            // The same text the embedder saw, so the lexical and the semantic
+            // half of a hit always describe the same thing.
+            sparse: crate::vector::sparse::encode_document(text),
+            payload: payload_of(c),
+        })
+        .collect();
+    core.vectors.upsert(points).await?;
+
+    for c in chunks {
+        core.store
+            .mark_embedded(&c.id, core.embedder.model())
+            .await?;
+    }
+    Ok(())
+}
+
+/// Fall back from one job per source to one job per chunk. A batch that has
+/// exhausted its retries may be failing on a single chunk the embedder rejects,
+/// and one bad chunk must not keep its siblings out of search.
+pub async fn split_into_chunk_jobs(core: &Core, source_id: &str) -> Result<()> {
+    let pending = core.store.pending_chunks_for_source(source_id).await?;
+    for c in &pending {
+        core.store.enqueue(Stage::Embed, "chunk", &c.id).await?;
+    }
+    tracing::info!(
+        source_id,
+        chunks = pending.len(),
+        "split batch into per-chunk embed jobs"
+    );
+    Ok(())
 }
 
 /// A chunk larger than the embedder accepts becomes several sibling chunks
@@ -61,6 +151,7 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> 
         core.vectors
             .upsert(vec![VectorPoint {
                 vector: vectors.into_iter().next().unwrap(),
+                sparse: crate::vector::sparse::encode_document(&chunk.text),
                 payload: payload_of(chunk),
             }])
             .await?;
@@ -128,6 +219,8 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         category: chunk.category.clone(),
         tags: chunk.tags.clone(),
         created_at: chunk.created_at,
+        // Left unset so re-embedding does not make a chunk look forgotten.
+        last_seen_at: None,
     }
 }
 
@@ -138,6 +231,11 @@ pub async fn settle_source(core: &Core, source_id: &str) -> Result<()> {
         return Ok(());
     }
     let status = if core.store.failed_embed_count(source_id).await? > 0 {
+        SourceStatus::Partial
+    } else if core.store.get_source(source_id).await?.status == SourceStatus::Partial {
+        // A source segmented by the structural fallback is already partial.
+        // Its chunks embedding cleanly does not undo that degradation, and
+        // reporting `ready` would hide it.
         SourceStatus::Partial
     } else {
         SourceStatus::Ready
@@ -195,7 +293,7 @@ mod tests {
             .unwrap();
         let hits = core
             .vectors
-            .search(&q[0], 5, &Default::default())
+            .search(&q[0], &Default::default(), 5, &Default::default())
             .await
             .unwrap();
         assert_eq!(hits[0].payload.source_id, src_id);
@@ -228,6 +326,99 @@ mod tests {
         run(&core, &ids[0]).await.unwrap();
         core.store.mark_embed_failed(&ids[1]).await.unwrap();
         settle_source(&core, &src_id).await.unwrap();
+        assert_eq!(
+            core.store.get_source(&src_id).await.unwrap().status,
+            SourceStatus::Partial
+        );
+    }
+
+    #[tokio::test]
+    async fn a_whole_source_is_embedded_in_one_inference_call() {
+        // The embedding endpoint is the slow, rate-limited part of ingest.
+        // Five chunks must cost one call, not five.
+        let (core, embedder) = crate::core::test_support::test_core_counting_embed_calls().await;
+        let (src_id, ids) = seed(&core, &["one", "two", "three", "four", "five"]).await;
+
+        run_source(&core, &src_id).await.unwrap();
+
+        assert_eq!(embedder.calls(), 1, "chunks were embedded one at a time");
+        assert_eq!(core.vectors.count().await.unwrap(), 5);
+        for id in &ids {
+            assert_eq!(
+                core.store.get_chunk(id).await.unwrap().embed_state,
+                EmbedState::Embedded
+            );
+        }
+        assert_eq!(
+            core.store.get_source(&src_id).await.unwrap().status,
+            SourceStatus::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn a_batch_larger_than_the_request_limit_is_split_across_calls() {
+        // Endpoints cap how many inputs they accept, so the batch is bounded.
+        let (core, embedder) = crate::core::test_support::test_core_counting_embed_calls().await;
+        let texts: Vec<String> = (0..BATCH + 5).map(|i| format!("chunk {i}")).collect();
+        let refs: Vec<&str> = texts.iter().map(String::as_str).collect();
+        let (src_id, _) = seed(&core, &refs).await;
+
+        run_source(&core, &src_id).await.unwrap();
+
+        assert_eq!(embedder.calls(), 2, "the batch was not bounded");
+        assert_eq!(core.vectors.count().await.unwrap(), (BATCH + 5) as u64);
+    }
+
+    #[tokio::test]
+    async fn a_source_with_nothing_pending_still_settles() {
+        // Re-running a finished job must not leave the source stuck in
+        // `embedding` forever.
+        let core = test_core().await;
+        let (src_id, _) = seed(&core, &["one"]).await;
+        run_source(&core, &src_id).await.unwrap();
+        run_source(&core, &src_id).await.unwrap();
+        assert_eq!(
+            core.store.get_source(&src_id).await.unwrap().status,
+            SourceStatus::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn an_oversize_chunk_does_not_block_its_siblings() {
+        // It becomes siblings rather than a vector, so it cannot ride along in
+        // the batch. The rest of the source must still be embedded.
+        let core = test_core().await;
+        let big = format!("{}\n\n{}", "alpha ".repeat(400), "beta ".repeat(400));
+        let (src_id, _) = seed(&core, &["small one", &big, "small two"]).await;
+
+        run_source_with_limit(&core, &src_id, 200).await.unwrap();
+
+        assert_eq!(
+            core.vectors.count().await.unwrap(),
+            2,
+            "the two small chunks should be embedded"
+        );
+        let chunks = core.store.chunks_for_source(&src_id).await.unwrap();
+        assert!(
+            chunks.len() > 3,
+            "the oversize chunk should have become siblings"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_fallback_segmented_source_is_not_promoted_to_ready() {
+        // `partial` records that segmentation was degraded. Every chunk
+        // embedding cleanly does not undo that, and reporting `ready` would
+        // hide it.
+        let core = test_core().await;
+        let (src_id, _) = seed(&core, &["one", "two"]).await;
+        core.store
+            .set_source_status(&src_id, SourceStatus::Partial)
+            .await
+            .unwrap();
+
+        run_source(&core, &src_id).await.unwrap();
+
         assert_eq!(
             core.store.get_source(&src_id).await.unwrap().status,
             SourceStatus::Partial

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -26,9 +26,12 @@ pub async fn run_one(core: &Core) -> Result<bool> {
     );
     let _guard = span.enter();
 
-    let result = match job.stage {
-        Stage::Segment | Stage::Enrich => segment::run(core, &job.target_id).await,
-        Stage::Embed => embed::run(core, &job.target_id).await,
+    let result = match (job.stage, job.target_kind.as_str()) {
+        (Stage::Segment | Stage::Enrich, _) => segment::run(core, &job.target_id).await,
+        // Embedding is batched per source; the per-chunk path is for edits,
+        // for oversize splits, and for isolating a chunk the batch chokes on.
+        (Stage::Embed, "source") => embed::run_source(core, &job.target_id).await,
+        (Stage::Embed, _) => embed::run(core, &job.target_id).await,
     };
 
     match result {
@@ -44,29 +47,49 @@ pub async fn run_one(core: &Core) -> Result<bool> {
             Ok(true)
         }
         Err(e) if e.retryable() => {
-            if job.attempts >= MAX_ATTEMPTS && job.stage == Stage::Segment {
+            let exhausted = job.attempts >= MAX_ATTEMPTS;
+            match (job.stage, job.target_kind.as_str()) {
                 // Out of attempts against the chunker. A structural split is
                 // worse than an LLM split, and far better than losing the source.
-                tracing::warn!(error = %e, "segmentation exhausted retries; using structural fallback");
-                match segment::run_with_fallback(core, &job.target_id).await {
-                    Ok(()) => {
-                        core.store.complete_job(job.id).await?;
-                    }
-                    Err(fe) => {
-                        core.store
-                            .fail_job(job.id, job.attempts, &fe.to_string())
-                            .await?;
+                (Stage::Segment, _) if exhausted => {
+                    tracing::warn!(error = %e, "segmentation exhausted retries; using structural fallback");
+                    match segment::run_with_fallback(core, &job.target_id).await {
+                        Ok(()) => {
+                            core.store.complete_job(job.id).await?;
+                        }
+                        Err(fe) => {
+                            core.store
+                                .fail_job(job.id, job.attempts, &fe.to_string())
+                                .await?;
+                        }
                     }
                 }
-            } else {
-                tracing::warn!(error = %e, "job failed; will retry");
-                core.store
-                    .fail_job(job.id, job.attempts, &e.to_string())
-                    .await?;
-                if job.stage == Stage::Embed && job.attempts >= MAX_ATTEMPTS {
-                    core.store.mark_embed_failed(&job.target_id).await?;
-                    if let Ok(c) = core.store.get_chunk(&job.target_id).await {
-                        embed::settle_source(core, &c.source_id).await?;
+                // A whole source failing together usually means the endpoint is
+                // down, but it can also be one chunk the embedder rejects.
+                // Retrying chunk by chunk isolates the culprit either way.
+                (Stage::Embed, "source") if exhausted => {
+                    tracing::warn!(error = %e, "batch embedding exhausted retries; retrying chunk by chunk");
+                    match embed::split_into_chunk_jobs(core, &job.target_id).await {
+                        Ok(()) => {
+                            core.store.complete_job(job.id).await?;
+                        }
+                        Err(fe) => {
+                            core.store
+                                .fail_job(job.id, job.attempts, &fe.to_string())
+                                .await?;
+                        }
+                    }
+                }
+                _ => {
+                    tracing::warn!(error = %e, "job failed; will retry");
+                    core.store
+                        .fail_job(job.id, job.attempts, &e.to_string())
+                        .await?;
+                    if job.stage == Stage::Embed && exhausted {
+                        core.store.mark_embed_failed(&job.target_id).await?;
+                        if let Ok(c) = core.store.get_chunk(&job.target_id).await {
+                            embed::settle_source(core, &c.source_id).await?;
+                        }
                     }
                 }
             }

--- a/src/jobs/segment.rs
+++ b/src/jobs/segment.rs
@@ -122,9 +122,11 @@ async fn write_chunks(
     }
 
     let inserted = core.store.insert_chunks(source_id, &new).await?;
-    for c in &inserted {
-        core.store.enqueue(Stage::Embed, "chunk", &c.id).await?;
-    }
+    // One job for the whole source: every chunk was just written, and embedding
+    // them together is one inference call instead of `inserted.len()`.
+    core.store
+        .enqueue(Stage::Embed, "source", source_id)
+        .await?;
     core.store.set_source_status(source_id, status).await?;
     tracing::info!(source_id, chunks = inserted.len(), "segmented");
     Ok(())
@@ -173,14 +175,18 @@ mod tests {
             SourceStatus::Embedding
         );
 
+        // One embed job for the whole source, not one per chunk: the point of
+        // batching is a single inference call.
         core.store.claim_job().await.unwrap(); // segment
-        let mut embed_jobs = 0;
+        let mut embed_jobs = Vec::new();
         while let Some(j) = core.store.claim_job().await.unwrap() {
             if j.stage == Stage::Embed {
-                embed_jobs += 1;
+                embed_jobs.push(j);
             }
         }
-        assert_eq!(embed_jobs, 2);
+        assert_eq!(embed_jobs.len(), 1, "expected one batched embed job");
+        assert_eq!(embed_jobs[0].target_kind, "source");
+        assert_eq!(embed_jobs[0].target_id, out.id);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,16 @@ struct Args {
     /// Print an argon2id hash for a password, for auth.local.password_hash.
     #[arg(long)]
     hash_password: Option<String>,
+    /// Copy every vector into a fresh collection generation and swap the alias
+    /// onto it, then exit. Costs no embedding calls and leaves the previous
+    /// generation in place.
+    #[arg(long)]
+    reindex: bool,
+    /// With --reindex, permit deleting a pre-alias collection once its points
+    /// have been copied and counted. Needed only for a collection created
+    /// before engram addressed vectors through an alias.
+    #[arg(long)]
+    replace_legacy: bool,
 }
 
 fn validate_auth(cfg: &Config, insecure_ok: bool) -> Result<()> {
@@ -135,6 +145,15 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if args.reindex {
+        let vectors = engram::vector::qdrant::QdrantVectors::connect(&cfg.vector).await?;
+        let target = vectors
+            .reindex(cfg.infer.embed.dim, args.replace_legacy)
+            .await?;
+        println!("{} now serves `{}`", cfg.vector.collection, target);
+        return Ok(());
+    }
+
     validate_auth(&cfg, args.i_know_this_is_insecure)?;
 
     let store = engram::store::Store::connect(&cfg.store).await?;
@@ -203,9 +222,12 @@ mod startup_tests {
                 path: "engram.db".into(),
             },
             vector: VectorConfig {
-                url: "http://localhost:6334".into(),
+                url: "http://localhost:6333".into(),
                 collection: "chunks".into(),
                 api_key: None,
+                recency_weight: 0.05,
+                recency_half_life_days: 180,
+                pinned_boost: 0.15,
             },
             infer: InferConfig {
                 chunk: ChunkRole {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ fn build_core(
         counter: Arc::new(TokenCounter::load(
             cfg.infer.chunk.tokenizer_path.as_deref(),
         )),
+        background: Arc::new(engram::core::background::Background::default()),
     }
 }
 
@@ -187,6 +188,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let background = core.background.clone();
     let handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
 
     let listener = tokio::net::TcpListener::bind(&cfg.server.bind).await?;
@@ -203,6 +205,24 @@ async fn main() -> anyhow::Result<()> {
     let _ = shutdown_tx.send(true);
     for h in handles {
         let _ = h.await;
+    }
+    // The last searches served each left a write behind. The listener is
+    // already closed, so this drains a bounded set rather than chasing new
+    // work; bounded further in case one of them is stuck on a wedged Qdrant.
+    if background.inflight() > 0 {
+        tracing::info!(
+            inflight = background.inflight(),
+            "draining background writes"
+        );
+        if tokio::time::timeout(std::time::Duration::from_secs(10), background.wait_idle())
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                inflight = background.inflight(),
+                "gave up waiting for background writes"
+            );
+        }
     }
     Ok(())
 }

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -133,6 +133,69 @@ impl Store {
         Ok(rows.iter().map(row_to_chunk).collect())
     }
 
+    /// Chunks of a source still waiting for a vector. The embed job batches
+    /// these into one inference call, so it needs them as rows, not a count.
+    pub async fn pending_chunks_for_source(&self, source_id: &str) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM chunks WHERE source_id = ? AND embed_state = 'pending' ORDER BY ordinal",
+        )
+        .bind(source_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_chunk).collect())
+    }
+
+    /// Put every chunk of a source back in the embed queue's path. Re-embedding
+    /// only happens for rows that say they still need it, so asking for it has
+    /// to say so first.
+    pub async fn reset_embed_state(&self, source_id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE chunks SET embed_state = 'pending', embed_model = NULL WHERE source_id = ?",
+        )
+        .bind(source_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Update the fields the embedding model never sees. Deliberately does not
+    /// touch `embed_state`: the stored vector is still correct.
+    pub async fn update_chunk_meta(
+        &self,
+        id: &str,
+        category: Option<&str>,
+        tags: Option<&[String]>,
+    ) -> Result<()> {
+        if let Some(c) = category {
+            sqlx::query("UPDATE chunks SET category = ? WHERE id = ?")
+                .bind(c)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        if let Some(t) = tags {
+            sqlx::query("UPDATE chunks SET tags = ? WHERE id = ?")
+                .bind(serde_json::to_string(t).unwrap_or_else(|_| "[]".into()))
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// The title is part of the text handed to the embedder, so changing it
+    /// invalidates the vector the same way changing the body does.
+    pub async fn update_chunk_title(&self, id: &str, title: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE chunks SET title = ?, embed_state = 'pending', embed_model = NULL WHERE id = ?",
+        )
+        .bind(title)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn update_chunk_text(&self, id: &str, text: &str) -> Result<()> {
         let res = sqlx::query(
             "UPDATE chunks SET text = ?, embed_state = 'pending', embed_model = NULL WHERE id = ?",

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -46,6 +46,11 @@ pub struct Chunk {
     pub embed_state: EmbedState,
     pub embed_model: Option<String>,
     pub created_at: i64,
+    /// Bumped by every edit that invalidates the stored vector. Internal
+    /// bookkeeping between the editor and the embed job, so it is not part of
+    /// what the API hands out.
+    #[serde(skip)]
+    pub embed_rev: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -73,6 +78,7 @@ fn row_to_chunk(r: &sqlx::sqlite::SqliteRow) -> Chunk {
         embed_state: EmbedState::parse(r.get::<String, _>("embed_state").as_str()),
         embed_model: r.get("embed_model"),
         created_at: r.get("created_at"),
+        embed_rev: r.get("embed_rev"),
     }
 }
 
@@ -93,6 +99,7 @@ impl Store {
                 embed_state: EmbedState::Pending,
                 embed_model: None,
                 created_at: now(),
+                embed_rev: 0,
             };
             sqlx::query(
                 "INSERT INTO chunks (id, source_id, ordinal, text, source_span, title, category, tags, embed_state, embed_model, created_at)
@@ -148,9 +155,15 @@ impl Store {
     /// Put every chunk of a source back in the embed queue's path. Re-embedding
     /// only happens for rows that say they still need it, so asking for it has
     /// to say so first.
+    ///
+    /// The revision bump is what makes this safe to run while a worker is
+    /// mid-batch on the same source: that worker's `mark_embedded` no longer
+    /// matches, so it cannot clear the pending state this just set.
     pub async fn reset_embed_state(&self, source_id: &str) -> Result<()> {
         sqlx::query(
-            "UPDATE chunks SET embed_state = 'pending', embed_model = NULL WHERE source_id = ?",
+            "UPDATE chunks
+             SET embed_state = 'pending', embed_model = NULL, embed_rev = embed_rev + 1
+             WHERE source_id = ?",
         )
         .bind(source_id)
         .execute(&self.pool)
@@ -158,65 +171,91 @@ impl Store {
         Ok(())
     }
 
-    /// Update the fields the embedding model never sees. Deliberately does not
-    /// touch `embed_state`: the stored vector is still correct.
-    pub async fn update_chunk_meta(
-        &self,
-        id: &str,
-        category: Option<&str>,
-        tags: Option<&[String]>,
-    ) -> Result<()> {
-        if let Some(c) = category {
+    /// Set or clear the category. Deliberately does not touch `embed_state`:
+    /// the embedding model is never shown a category, so the stored vector is
+    /// still correct.
+    pub async fn update_chunk_category(&self, id: &str, category: Option<&str>) -> Result<()> {
+        self.expect_updated(
             sqlx::query("UPDATE chunks SET category = ? WHERE id = ?")
-                .bind(c)
+                .bind(category)
                 .bind(id)
                 .execute(&self.pool)
-                .await?;
-        }
-        if let Some(t) = tags {
-            sqlx::query("UPDATE chunks SET tags = ? WHERE id = ?")
-                .bind(serde_json::to_string(t).unwrap_or_else(|_| "[]".into()))
-                .bind(id)
-                .execute(&self.pool)
-                .await?;
-        }
-        Ok(())
+                .await?,
+        )
     }
 
-    /// The title is part of the text handed to the embedder, so changing it
-    /// invalidates the vector the same way changing the body does.
-    pub async fn update_chunk_title(&self, id: &str, title: &str) -> Result<()> {
-        sqlx::query(
-            "UPDATE chunks SET title = ?, embed_state = 'pending', embed_model = NULL WHERE id = ?",
+    /// Replace the tag list. An empty list is a clear, not a no-op.
+    pub async fn update_chunk_tags(&self, id: &str, tags: &[String]) -> Result<()> {
+        self.expect_updated(
+            sqlx::query("UPDATE chunks SET tags = ? WHERE id = ?")
+                .bind(serde_json::to_string(tags).unwrap_or_else(|_| "[]".into()))
+                .bind(id)
+                .execute(&self.pool)
+                .await?,
         )
-        .bind(title)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
+    }
+
+    /// The title is part of the text handed to the embedder, so setting or
+    /// clearing it invalidates the vector the same way changing the body does.
+    pub async fn update_chunk_title(&self, id: &str, title: Option<&str>) -> Result<()> {
+        self.expect_updated(
+            sqlx::query(
+                "UPDATE chunks
+                 SET title = ?, embed_state = 'pending', embed_model = NULL,
+                     embed_rev = embed_rev + 1
+                 WHERE id = ?",
+            )
+            .bind(title)
+            .bind(id)
+            .execute(&self.pool)
+            .await?,
+        )
     }
 
     pub async fn update_chunk_text(&self, id: &str, text: &str) -> Result<()> {
-        let res = sqlx::query(
-            "UPDATE chunks SET text = ?, embed_state = 'pending', embed_model = NULL WHERE id = ?",
+        self.expect_updated(
+            sqlx::query(
+                "UPDATE chunks
+                 SET text = ?, embed_state = 'pending', embed_model = NULL,
+                     embed_rev = embed_rev + 1
+                 WHERE id = ?",
+            )
+            .bind(text)
+            .bind(id)
+            .execute(&self.pool)
+            .await?,
         )
-        .bind(text)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
+    }
+
+    fn expect_updated(&self, res: sqlx::sqlite::SqliteQueryResult) -> Result<()> {
         if res.rows_affected() == 0 {
             return Err(Error::NotFound);
         }
         Ok(())
     }
 
-    pub async fn mark_embedded(&self, id: &str, model: &str) -> Result<()> {
-        sqlx::query("UPDATE chunks SET embed_state = 'embedded', embed_model = ? WHERE id = ?")
-            .bind(model)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+    /// Report a chunk indexed, but only if it has not been edited since the
+    /// embed job read it.
+    ///
+    /// Returns whether the mark landed. `false` means a newer revision exists
+    /// and the vector just written describes text that is already stale; the
+    /// chunk stays pending, so it will be embedded again from the current row.
+    ///
+    /// That relies on an invariant worth keeping: whoever bumps the revision
+    /// also queues the work. `update_chunk_text`, `update_chunk_title` and
+    /// `reset_embed_state` are only ever called alongside an `enqueue`, so a
+    /// chunk left pending here always has a job coming for it.
+    pub async fn mark_embedded(&self, id: &str, model: &str, rev: i64) -> Result<bool> {
+        let res = sqlx::query(
+            "UPDATE chunks SET embed_state = 'embedded', embed_model = ?
+             WHERE id = ? AND embed_rev = ?",
+        )
+        .bind(model)
+        .bind(id)
+        .bind(rev)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
     }
 
     pub async fn mark_embed_failed(&self, id: &str) -> Result<()> {
@@ -349,7 +388,7 @@ mod tests {
             .await
             .unwrap()
             .remove(0);
-        s.mark_embedded(&c.id, "bge-m3").await.unwrap();
+        assert!(s.mark_embedded(&c.id, "bge-m3", c.embed_rev).await.unwrap());
         assert_eq!(
             s.get_chunk(&c.id).await.unwrap().embed_state,
             EmbedState::Embedded
@@ -375,7 +414,9 @@ mod tests {
             .unwrap();
         assert_eq!(s.pending_embed_count(&src.id).await.unwrap(), 2);
 
-        s.mark_embedded(&made[0].id, "m").await.unwrap();
+        s.mark_embedded(&made[0].id, "m", made[0].embed_rev)
+            .await
+            .unwrap();
         s.mark_embed_failed(&made[1].id).await.unwrap();
         assert_eq!(s.pending_embed_count(&src.id).await.unwrap(), 0);
         assert_eq!(s.failed_embed_count(&src.id).await.unwrap(), 1);

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -38,9 +38,55 @@ impl VectorStore for MemoryVectors {
         Ok(())
     }
 
+    async fn set_payload(&self, payload: &super::VectorPayload) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        if let Some(p) = w.get_mut(&payload.chunk_id) {
+            // A merge, matching Qdrant: an absent stamp means "unchanged", so
+            // a tag edit must not erase when the chunk was last shown.
+            let seen = payload.last_seen_at.or(p.payload.last_seen_at);
+            p.payload = payload.clone();
+            p.payload.last_seen_at = seen;
+        }
+        Ok(())
+    }
+
+    async fn touch(&self, chunk_ids: &[String], seen_at: i64) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        for id in chunk_ids {
+            if let Some(p) = w.get_mut(id) {
+                p.payload.last_seen_at = Some(seen_at);
+            }
+        }
+        Ok(())
+    }
+
+    async fn resurface(
+        &self,
+        limit: usize,
+        older_than: i64,
+        unseen_since: i64,
+    ) -> Result<Vec<SearchHit>> {
+        let r = self.points.read().unwrap();
+        Ok(r.values()
+            .filter(|p| {
+                p.payload.created_at < older_than
+                    && p.payload.last_seen_at.is_none_or(|s| s < unseen_since)
+            })
+            .take(limit)
+            .map(|p| SearchHit {
+                payload: p.payload.clone(),
+                score: 0.0,
+            })
+            .collect())
+    }
+
+    /// Dense only. Hybrid fusion is a Qdrant feature; reimplementing BM25
+    /// scoring here would test this file rather than the real retrieval path,
+    /// which the integration suite covers instead.
     async fn search(
         &self,
         vector: &[f32],
+        _sparse: &super::sparse::SparseVector,
         limit: usize,
         filter: &SearchFilter,
     ) -> Result<Vec<SearchHit>> {
@@ -97,6 +143,7 @@ mod tests {
     fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPoint {
         VectorPoint {
             vector: v,
+            sparse: Default::default(),
             payload: VectorPayload {
                 chunk_id: id.into(),
                 source_id: src.into(),
@@ -105,6 +152,7 @@ mod tests {
                 category: Some(cat.into()),
                 tags: tags.iter().map(|s| s.to_string()).collect(),
                 created_at: 0,
+                last_seen_at: None,
             },
         }
     }
@@ -121,7 +169,12 @@ mod tests {
         .unwrap();
 
         let hits = v
-            .search(&[1.0, 0.0, 0.0], 10, &SearchFilter::default())
+            .search(
+                &[1.0, 0.0, 0.0],
+                &Default::default(),
+                10,
+                &SearchFilter::default(),
+            )
             .await
             .unwrap();
         assert_eq!(hits[0].payload.chunk_id, "near");
@@ -140,10 +193,15 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            v.search(&[1.0, 0.0, 0.0], 2, &SearchFilter::default())
-                .await
-                .unwrap()
-                .len(),
+            v.search(
+                &[1.0, 0.0, 0.0],
+                &Default::default(),
+                2,
+                &SearchFilter::default()
+            )
+            .await
+            .unwrap()
+            .len(),
             2
         );
     }
@@ -169,7 +227,10 @@ mod tests {
             tags: vec!["linux".into(), "forensics".into()],
             category: None,
         };
-        let hits = v.search(&[1.0, 0.0, 0.0], 10, &f).await.unwrap();
+        let hits = v
+            .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &f)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].payload.chunk_id, "both");
     }
@@ -188,7 +249,10 @@ mod tests {
             tags: vec![],
             category: Some("concept".into()),
         };
-        let hits = v.search(&[1.0, 0.0, 0.0], 10, &f).await.unwrap();
+        let hits = v
+            .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &f)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].payload.chunk_id, "c");
     }
@@ -209,7 +273,12 @@ mod tests {
             "re-embedding must not duplicate the point"
         );
         let hits = v
-            .search(&[0.0, 1.0, 0.0], 1, &SearchFilter::default())
+            .search(
+                &[0.0, 1.0, 0.0],
+                &Default::default(),
+                1,
+                &SearchFilter::default(),
+            )
             .await
             .unwrap();
         assert!(hits[0].score > 0.99);
@@ -238,7 +307,12 @@ mod tests {
             .await
             .unwrap();
         let hits = v
-            .search(&[1.0, 0.0, 0.0], 10, &SearchFilter::default())
+            .search(
+                &[1.0, 0.0, 0.0],
+                &Default::default(),
+                10,
+                &SearchFilter::default(),
+            )
             .await
             .unwrap();
         assert!(hits[0].score.is_finite());
@@ -259,12 +333,22 @@ mod tests {
         .unwrap();
 
         let first = v
-            .search(&[1.0, 0.0, 0.0], 5, &SearchFilter::default())
+            .search(
+                &[1.0, 0.0, 0.0],
+                &Default::default(),
+                5,
+                &SearchFilter::default(),
+            )
             .await
             .unwrap();
         for _ in 0..5 {
             let again = v
-                .search(&[1.0, 0.0, 0.0], 5, &SearchFilter::default())
+                .search(
+                    &[1.0, 0.0, 0.0],
+                    &Default::default(),
+                    5,
+                    &SearchFilter::default(),
+                )
                 .await
                 .unwrap();
             assert_eq!(

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,5 +1,6 @@
 pub mod memory;
 pub mod qdrant;
+pub mod sparse;
 
 use crate::error::Result;
 use async_trait::async_trait;
@@ -13,11 +14,19 @@ pub struct VectorPayload {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub created_at: i64,
+    /// When this chunk last appeared in results. Optional and omitted when
+    /// unset, because Qdrant merges a payload write: a writer that does not
+    /// know the stamp must leave the stored one alone rather than clear it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_seen_at: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
 pub struct VectorPoint {
     pub vector: Vec<f32>,
+    /// BM25 terms for the same text. Empty when the store does not do hybrid
+    /// retrieval, which is why it is a plain value rather than an option.
+    pub sparse: sparse::SparseVector,
     pub payload: VectorPayload,
 }
 
@@ -45,11 +54,31 @@ pub struct SearchHit {
 pub trait VectorStore: Send + Sync {
     async fn ensure_collection(&self, dim: usize) -> Result<()>;
     async fn upsert(&self, points: Vec<VectorPoint>) -> Result<()>;
+    /// Replace a point's payload, leaving its vector alone. Editing tags or a
+    /// category changes nothing the embedding model saw, so re-embedding for it
+    /// would spend an inference call to arrive at the same vector.
+    async fn set_payload(&self, payload: &VectorPayload) -> Result<()>;
+    /// `sparse` carries the query's BM25 terms. An empty one means the query
+    /// held no indexable token, and the lexical half is skipped rather than
+    /// asked to match nothing.
     async fn search(
         &self,
         vector: &[f32],
+        sparse: &sparse::SparseVector,
         limit: usize,
         filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>>;
+    /// Record that these chunks were just shown. Merged into the stored
+    /// payload, never written as a whole one.
+    async fn touch(&self, chunk_ids: &[String], seen_at: i64) -> Result<()>;
+    /// A random sample of chunks captured before `older_than` and not shown
+    /// since `unseen_since`. Random rather than ranked: there is no query here,
+    /// only the question of what has been forgotten.
+    async fn resurface(
+        &self,
+        limit: usize,
+        older_than: i64,
+        unseen_since: i64,
     ) -> Result<Vec<SearchHit>>;
     async fn delete_chunks(&self, chunk_ids: &[String]) -> Result<()>;
     async fn delete_by_source(&self, source_id: &str) -> Result<()>;

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1,25 +1,84 @@
+//! Qdrant backend, spoken over its REST API.
+//!
+//! REST rather than gRPC because REST is the port operators actually expose —
+//! typically behind a TLS reverse proxy on 443 — and because the feature set is
+//! identical. `reqwest` was already a dependency, so this costs no new crates
+//! and saves the whole `tonic`/`prost` tree.
+//!
+//! `vector.collection` names an *alias*, never a collection. The data lives in
+//! `{alias}_v1`, `_v2`, … and the alias points at whichever generation is
+//! current. Changing the embedding model or the index schema is then a
+//! background rebuild followed by an atomic swap, rather than an outage.
+
+use super::sparse::SparseVector;
 use super::{SearchFilter, SearchHit, VectorPayload, VectorPoint, VectorStore};
 use crate::config::VectorConfig;
 use crate::error::{Error, Result};
 use async_trait::async_trait;
-use qdrant_client::Qdrant;
-use qdrant_client::qdrant::{
-    Condition, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, DeletePointsBuilder,
-    Distance, FieldType, Filter, PointStruct, QueryPointsBuilder, UpsertPointsBuilder,
-    VectorParamsBuilder,
-};
+use reqwest::{Client, Method, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+/// Generous enough for a cold HNSW segment load, short enough that a wedged
+/// server surfaces as a retryable job failure rather than a hung worker.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The named dense vector. Named rather than default because a collection
+/// cannot gain named vectors later without being rebuilt, and the sparse half
+/// of hybrid search needs the namespace.
+pub const DENSE: &str = "dense";
+
+/// The sparse (BM25) vector slot. Declared from the first generation onwards so
+/// that turning hybrid search on is a code change, not a migration.
+pub const SPARSE: &str = "text";
+
+/// Points copied per scroll page during a rebuild.
+const REINDEX_BATCH: usize = 256;
+
+/// A chunk carrying this tag is boosted past the decay curve. A tag rather than
+/// a column: `PATCH /api/v1/chunks/{id}` already edits tags without
+/// re-embedding, and the payload index that makes it filterable already exists.
+pub const PINNED_TAG: &str = "pinned";
+
+const SECONDS_PER_DAY: u64 = 86_400;
 
 pub struct QdrantVectors {
-    client: Qdrant,
-    collection: String,
+    http: Client,
+    base: String,
+    /// The alias clients read and write through, from `vector.collection`.
+    alias: String,
+    api_key: Option<String>,
+    recency_weight: f32,
+    recency_half_life_days: u32,
+    pinned_boost: f32,
 }
 
 pub fn dimension_mismatch(collection: &str, configured: usize, existing: usize) -> Error {
     Error::Vector(format!(
         "collection `{collection}` has vector dimension {existing}, but config says {configured}. \
          Refusing to start: writing mismatched vectors would corrupt search results. \
-         Either restore the original embedding model, or delete the collection and re-embed \
-         every chunk."
+         A rebuild cannot fix this — `--reindex` copies vectors and cannot change their width. \
+         Either restore the embedding model that produced {existing}-wide vectors, or point \
+         `vector.collection` at a new alias name and let every chunk embed again under the \
+         new model."
+    ))
+}
+
+/// A collection named exactly like the alias predates the aliased layout. It
+/// still holds every vector, so the fix is a rebuild, never a bare delete.
+///
+/// Qdrant refuses an alias whose name collides with an existing collection, so
+/// unlike a generational rebuild this one cannot keep its source. That makes it
+/// destructive, and destructive steps are opt-in.
+fn legacy_layout(alias: &str) -> Error {
+    Error::Vector(format!(
+        "`{alias}` is a plain collection, but engram now addresses vectors through an alias of \
+         that name, and Qdrant will not let the two share it. Run \
+         `engram --reindex --replace-legacy` to copy every point into `{alias}_v1`, check that \
+         nothing was lost, and only then delete `{alias}` and create the alias. No re-embedding \
+         is needed. Take a Qdrant snapshot first if you want a way back."
     ))
 }
 
@@ -38,89 +97,581 @@ pub fn point_uuid(chunk_id: &str) -> String {
     }
 }
 
+/// Strip trailing slashes so path joining never produces a double slash, which
+/// some proxies answer with a redirect instead of the resource.
+fn normalize_base(url: &str) -> String {
+    url.trim_end_matches('/').to_string()
+}
+
+/// The physical collection backing generation `n` of an alias.
+fn generation_name(alias: &str, n: u32) -> String {
+    format!("{alias}_v{n}")
+}
+
+/// Read the generation number back out of a physical collection name. A name
+/// that does not carry one is treated as generation 0, so the next rebuild
+/// lands on `_v1`.
+fn generation_of(alias: &str, collection: &str) -> u32 {
+    collection
+        .strip_prefix(&format!("{alias}_v"))
+        .and_then(|n| n.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Qdrant answers `{"must": [...]}` with an implicit AND. An empty condition
+/// list would match nothing, so callers must skip the filter entirely instead.
+fn build_filter(filter: &SearchFilter) -> Option<Value> {
+    if filter.is_empty() {
+        return None;
+    }
+    let mut must: Vec<Value> = Vec::new();
+    for t in &filter.tags {
+        must.push(json!({ "key": "tags", "match": { "value": t } }));
+    }
+    if let Some(c) = &filter.category {
+        must.push(json!({ "key": "category", "match": { "value": c } }));
+    }
+    Some(json!({ "must": must }))
+}
+
+/// The schema every generation is created with.
+fn collection_body(dim: usize) -> Value {
+    json!({
+        "vectors": { DENSE: { "size": dim, "distance": "Cosine" } },
+        "sparse_vectors": { SPARSE: { "modifier": "idf" } },
+    })
+}
+
+/// The sparse half of a stored point, as Qdrant wants it. Skipped entirely when
+/// the text held no indexable term, because a sparse vector with no dimensions
+/// is not the same as no sparse vector.
+fn sparse_body(sparse: &SparseVector) -> Option<Value> {
+    if sparse.is_empty() {
+        return None;
+    }
+    Some(json!({ "indices": sparse.indices, "values": sparse.values }))
+}
+
+/// Rebuild a point's terms from its payload. A rebuild has the text but not the
+/// chunk row, and this must match what the embed job indexed: title then body.
+fn sparse_of_payload(payload: &Value) -> SparseVector {
+    let text = payload.get("text").and_then(Value::as_str).unwrap_or("");
+    match payload.get("title").and_then(Value::as_str) {
+        Some(t) if !t.is_empty() => super::sparse::encode_document(&format!("{t}\n{text}")),
+        _ => super::sparse::encode_document(text),
+    }
+}
+
+/// The score adjustment applied on top of retrieval: newer wins ties, and a
+/// pinned chunk wins outright.
+///
+/// `$score` here is the fused rank from the prefetch below it, which lands
+/// between roughly 0.1 and 1.0. `exp_decay` returns 1.0 for something captured
+/// now and 0.5 at one half-life old, so the recency term is a small nudge
+/// rather than a second ranking.
+fn scoring_formula(now: i64, half_life_secs: u64, recency: f32, pinned: f32) -> Value {
+    let mut terms = vec![json!("$score")];
+    if recency > 0.0 {
+        terms.push(json!({
+            "mult": [recency, {
+                "exp_decay": { "x": "created_at", "target": now, "scale": half_life_secs, "midpoint": 0.5 }
+            }]
+        }));
+    }
+    if pinned > 0.0 {
+        // A filter condition evaluates to 1.0 for a point that matches it.
+        terms.push(json!({
+            "mult": [pinned, { "key": "tags", "match": { "value": PINNED_TAG } }]
+        }));
+    }
+    json!({ "formula": { "sum": terms } })
+}
+
+/// A stored point's dense vector, whether the collection uses named vectors or
+/// is a pre-alias collection with a single default one.
+fn dense_of(vector: &Value) -> Option<&Value> {
+    match vector {
+        Value::Array(_) => Some(vector),
+        Value::Object(m) => m.get(DENSE),
+        _ => None,
+    }
+}
+
+/// Every Qdrant response is wrapped in this. `result` is absent on failures,
+/// which is why it is optional rather than required.
+#[derive(Deserialize)]
+struct Envelope<T> {
+    result: Option<T>,
+}
+
+#[derive(Deserialize)]
+struct Exists {
+    exists: bool,
+}
+
+#[derive(Deserialize)]
+struct CountResult {
+    count: u64,
+}
+
+#[derive(Deserialize)]
+struct QueryResult {
+    #[serde(default)]
+    points: Vec<ScoredPoint>,
+}
+
+#[derive(Deserialize)]
+struct ScoredPoint {
+    score: f32,
+    #[serde(default)]
+    payload: Value,
+}
+
+#[derive(Deserialize)]
+struct AliasList {
+    #[serde(default)]
+    aliases: Vec<AliasEntry>,
+}
+
+#[derive(Deserialize)]
+struct AliasEntry {
+    alias_name: String,
+    collection_name: String,
+}
+
+#[derive(Deserialize)]
+struct CollectionList {
+    #[serde(default)]
+    collections: Vec<CollectionEntry>,
+}
+
+#[derive(Deserialize)]
+struct CollectionEntry {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct ScrollResult {
+    #[serde(default)]
+    points: Vec<ScrolledPoint>,
+    #[serde(default)]
+    next_page_offset: Value,
+}
+
+#[derive(Deserialize)]
+struct ScrolledPoint {
+    id: Value,
+    #[serde(default)]
+    payload: Value,
+    #[serde(default)]
+    vector: Value,
+}
+
 impl QdrantVectors {
     pub async fn connect(cfg: &VectorConfig) -> Result<QdrantVectors> {
-        let mut builder = Qdrant::from_url(&cfg.url);
-        if let Some(k) = &cfg.api_key {
-            builder = builder.api_key(k.clone());
+        // 6334 is the gRPC port. Pointing the REST client at it fails in a way
+        // that reads like a network problem, so name the real cause up front.
+        if cfg.url.trim_end_matches('/').ends_with(":6334") {
+            tracing::warn!(
+                url = %cfg.url,
+                "vector.url points at 6334, Qdrant's gRPC port; the REST API is usually on 6333"
+            );
         }
-        let client = builder.build().map_err(|e| Error::Vector(e.to_string()))?;
+
+        let http = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| Error::Vector(e.to_string()))?;
+
         Ok(QdrantVectors {
-            client,
-            collection: cfg.collection.clone(),
+            http,
+            base: normalize_base(&cfg.url),
+            alias: cfg.collection.clone(),
+            api_key: cfg.api_key.clone(),
+            recency_weight: cfg.recency_weight,
+            recency_half_life_days: cfg.recency_half_life_days.max(1),
+            pinned_boost: cfg.pinned_boost,
         })
     }
 
-    /// Drop the collection. Used by the integration suite to start clean.
+    /// Drop the alias and every generation behind it. Used by the integration
+    /// suite to start clean.
     pub async fn drop_collection(&self) -> Result<()> {
-        let _ = self.client.delete_collection(&self.collection).await;
+        if self.resolve_alias().await?.is_some() {
+            let _: Result<Value> = self
+                .call(
+                    Method::POST,
+                    "/collections/aliases",
+                    Some(json!({
+                        "actions": [ { "delete_alias": { "alias_name": self.alias } } ]
+                    })),
+                )
+                .await;
+        }
+        for name in self.generations().await? {
+            let _: Result<Value> = self
+                .call(Method::DELETE, &format!("/collections/{name}"), None)
+                .await;
+        }
         Ok(())
+    }
+
+    /// The physical collection the alias currently points at, if the alias
+    /// exists at all.
+    pub async fn resolve_alias(&self) -> Result<Option<String>> {
+        // Listing is `/aliases`; only the update action lives under
+        // `/collections/aliases`, which otherwise reads as a collection name.
+        let list: AliasList = self.call(Method::GET, "/aliases", None).await?;
+        Ok(list
+            .aliases
+            .into_iter()
+            .find(|a| a.alias_name == self.alias)
+            .map(|a| a.collection_name))
+    }
+
+    /// Every collection belonging to this alias: the generations, plus a
+    /// pre-alias collection named exactly like it if one is still around.
+    async fn generations(&self) -> Result<Vec<String>> {
+        let list: CollectionList = self.call(Method::GET, "/collections", None).await?;
+        let prefix = format!("{}_v", self.alias);
+        Ok(list
+            .collections
+            .into_iter()
+            .map(|c| c.name)
+            .filter(|n| *n == self.alias || n.starts_with(&prefix))
+            .collect())
+    }
+
+    /// The highest-numbered generation that exists, ignoring any pre-alias
+    /// collection sharing the alias name.
+    async fn newest_generation(&self) -> Result<Option<String>> {
+        Ok(self
+            .generations()
+            .await?
+            .into_iter()
+            .filter(|n| *n != self.alias)
+            .max_by_key(|n| generation_of(&self.alias, n)))
+    }
+
+    async fn collection_exists(&self, name: &str) -> Result<bool> {
+        let e: Exists = self
+            .call(Method::GET, &format!("/collections/{name}/exists"), None)
+            .await?;
+        Ok(e.exists)
+    }
+
+    async fn create_generation(&self, name: &str, dim: usize) -> Result<()> {
+        let _: Value = self
+            .call(
+                Method::PUT,
+                &format!("/collections/{name}"),
+                Some(collection_body(dim)),
+            )
+            .await?;
+
+        // Payload indexes: without these, filtered search degrades to a
+        // full scan of the collection.
+        for (field, schema) in [
+            ("tags", "keyword"),
+            ("category", "keyword"),
+            ("source_id", "keyword"),
+            ("created_at", "integer"),
+            ("last_seen_at", "integer"),
+        ] {
+            let _: Value = self
+                .call(
+                    Method::PUT,
+                    &format!("/collections/{name}/index?wait=true"),
+                    Some(json!({ "field_name": field, "field_schema": schema })),
+                )
+                .await
+                .map_err(|e| Error::Vector(format!("payload index on {field}: {e}")))?;
+        }
+        tracing::info!(collection = %name, dim, "created qdrant collection");
+        Ok(())
+    }
+
+    /// Point the alias at `collection`, replacing any previous target. Qdrant
+    /// applies both actions in one transaction, so no request ever observes an
+    /// alias that resolves to nothing.
+    async fn point_alias_at(&self, collection: &str, replacing: bool) -> Result<()> {
+        let mut actions = Vec::new();
+        if replacing {
+            actions.push(json!({ "delete_alias": { "alias_name": self.alias } }));
+        }
+        actions.push(json!({
+            "create_alias": { "collection_name": collection, "alias_name": self.alias }
+        }));
+
+        let _: Value = self
+            .call(
+                Method::POST,
+                "/collections/aliases",
+                Some(json!({ "actions": actions })),
+            )
+            .await?;
+        tracing::info!(alias = %self.alias, collection, "alias now points at this generation");
+        Ok(())
+    }
+
+    async fn vector_dim(&self, collection: &str) -> Result<u64> {
+        let info: Value = self
+            .call(Method::GET, &format!("/collections/{collection}"), None)
+            .await?;
+        // Named vectors nest one level deeper than a pre-alias collection's
+        // single default vector; accept either so a rebuild can read its source.
+        info.pointer(&format!("/config/params/vectors/{DENSE}/size"))
+            .or_else(|| info.pointer("/config/params/vectors/size"))
+            .and_then(Value::as_u64)
+            .ok_or_else(|| Error::Vector("could not read collection vector dimension".into()))
+    }
+
+    /// `exact` because the collection-info counter is allowed to lag behind an
+    /// accepted write, and both callers act on the number.
+    async fn exact_count(&self, collection: &str) -> Result<u64> {
+        let res: CountResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{collection}/points/count"),
+                Some(json!({ "exact": true })),
+            )
+            .await?;
+        Ok(res.count)
+    }
+
+    async fn put_points(&self, collection: &str, points: Vec<Value>) -> Result<()> {
+        let _: Value = self
+            .call(
+                Method::PUT,
+                &format!("/collections/{collection}/points?wait=true"),
+                Some(json!({ "points": points })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Copy every point into a fresh generation and swap the alias onto it.
+    ///
+    /// Dense vectors are copied as they are, so a rebuild costs no embedding
+    /// calls. The previous generation is left in place: it is the only rollback
+    /// that exists, and deleting it is a decision for whoever ran this.
+    pub async fn reindex(&self, dim: usize, replace_legacy: bool) -> Result<String> {
+        let source = match self.resolve_alias().await? {
+            Some(c) => c,
+            None if self.collection_exists(&self.alias).await? => self.alias.clone(),
+            None => {
+                return Err(Error::Vector(format!(
+                    "nothing to reindex: neither an alias nor a collection named `{}` exists",
+                    self.alias
+                )));
+            }
+        };
+        let replacing = source != self.alias;
+
+        // Refuse before creating anything, so a run without consent leaves no
+        // half-built generation behind for the next one to trip over.
+        if !replacing && !replace_legacy {
+            return Err(legacy_layout(&self.alias));
+        }
+        let target = generation_name(&self.alias, generation_of(&self.alias, &source) + 1);
+
+        if self.collection_exists(&target).await? {
+            return Err(Error::Vector(format!(
+                "`{target}` already exists; a previous rebuild did not finish. \
+                 Delete it and run this again."
+            )));
+        }
+
+        let source_dim = self.vector_dim(&source).await?;
+        if source_dim as usize != dim {
+            return Err(dimension_mismatch(&source, dim, source_dim as usize));
+        }
+
+        self.create_generation(&target, dim).await?;
+
+        let mut offset = Value::Null;
+        let mut copied = 0usize;
+        loop {
+            let mut body = json!({
+                "limit": REINDEX_BATCH,
+                "with_payload": true,
+                "with_vector": true,
+            });
+            if !offset.is_null() {
+                body["offset"] = offset.clone();
+            }
+
+            let page: ScrollResult = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{source}/points/scroll"),
+                    Some(body),
+                )
+                .await?;
+
+            if page.points.is_empty() {
+                break;
+            }
+
+            let mut batch = Vec::with_capacity(page.points.len());
+            for p in &page.points {
+                let dense = dense_of(&p.vector).ok_or_else(|| {
+                    Error::Vector(format!("point {} in `{source}` has no dense vector", p.id))
+                })?;
+                // Dense vectors are copied; sparse ones are recomputed, which
+                // is free and lets a rebuild add the lexical half to a
+                // generation written before it existed.
+                let mut vector = json!({ DENSE: dense });
+                if let Some(sp) = sparse_body(&sparse_of_payload(&p.payload)) {
+                    vector[SPARSE] = sp;
+                }
+                batch.push(json!({
+                    "id": p.id,
+                    "vector": vector,
+                    "payload": p.payload,
+                }));
+            }
+            copied += batch.len();
+            self.put_points(&target, batch).await?;
+            tracing::info!(copied, source = %source, target = %target, "reindex progress");
+
+            offset = page.next_page_offset;
+            if offset.is_null() {
+                break;
+            }
+        }
+
+        if replacing {
+            self.point_alias_at(&target, true).await?;
+            tracing::info!(
+                copied,
+                previous = %source,
+                current = %target,
+                "reindex complete; the previous generation was left in place"
+            );
+        } else {
+            // The alias needs the name the source is holding. Count both sides
+            // first: deleting the only copy on the strength of an unverified
+            // loop is not a trade worth making.
+            let (before, after) = (
+                self.exact_count(&source).await?,
+                self.exact_count(&target).await?,
+            );
+            if before != after {
+                return Err(Error::Vector(format!(
+                    "refusing to delete `{source}`: it holds {before} points but `{target}` \
+                     received {after}. The copy is in `{target}`; nothing was deleted."
+                )));
+            }
+            let _: Value = self
+                .call(Method::DELETE, &format!("/collections/{source}"), None)
+                .await?;
+            self.point_alias_at(&target, false).await?;
+            tracing::warn!(
+                copied,
+                deleted = %source,
+                current = %target,
+                "reindex complete; the pre-alias collection was deleted to free its name"
+            );
+        }
+        Ok(target)
+    }
+}
+
+/// Seconds since the epoch, the unit `created_at` is stored in.
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Qdrant reports failures as `{"status": {"error": "..."}}`. Fall back to the
+/// raw body when it does not, but never dump an unbounded response into a log
+/// line or an error message.
+fn describe_failure(status: StatusCode, body: &str) -> String {
+    let detail = serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|v| {
+            v.get("status")
+                .and_then(|s| s.get("error"))
+                .and_then(|e| e.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| body.chars().take(200).collect());
+    format!("qdrant returned {status}: {detail}")
+}
+
+impl QdrantVectors {
+    /// The single place a Qdrant response turns into either a value or an
+    /// `Error::Vector`, so no call site has to reason about the envelope.
+    async fn call<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<T> {
+        let mut req = self.http.request(method, format!("{}{path}", self.base));
+        if let Some(k) = &self.api_key {
+            req = req.header("api-key", k);
+        }
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let res = req.send().await.map_err(|e| Error::Vector(e.to_string()))?;
+        let status = res.status();
+        let text = res.text().await.map_err(|e| Error::Vector(e.to_string()))?;
+
+        if !status.is_success() {
+            return Err(Error::Vector(describe_failure(status, &text)));
+        }
+
+        let env: Envelope<T> = serde_json::from_str(&text)
+            .map_err(|e| Error::Vector(format!("unreadable response from {path}: {e}")))?;
+        env.result
+            .ok_or_else(|| Error::Vector(format!("{path} returned no result")))
     }
 }
 
 #[async_trait]
 impl VectorStore for QdrantVectors {
     async fn ensure_collection(&self, dim: usize) -> Result<()> {
-        let exists = self
-            .client
-            .collection_exists(&self.collection)
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
-
-        if !exists {
-            self.client
-                .create_collection(
-                    CreateCollectionBuilder::new(&self.collection)
-                        .vectors_config(VectorParamsBuilder::new(dim as u64, Distance::Cosine)),
-                )
-                .await
-                .map_err(|e| Error::Vector(e.to_string()))?;
-
-            // Payload indexes: without these, filtered search degrades to a
-            // full scan of the collection.
-            for (field, kind) in [
-                ("tags", FieldType::Keyword),
-                ("category", FieldType::Keyword),
-                ("source_id", FieldType::Keyword),
-                ("created_at", FieldType::Integer),
-            ] {
-                self.client
-                    .create_field_index(CreateFieldIndexCollectionBuilder::new(
-                        &self.collection,
-                        field,
-                        kind,
-                    ))
-                    .await
-                    .map_err(|e| Error::Vector(format!("payload index on {field}: {e}")))?;
+        if let Some(current) = self.resolve_alias().await? {
+            let existing = self.vector_dim(&current).await?;
+            if existing as usize != dim {
+                return Err(dimension_mismatch(&current, dim, existing as usize));
             }
-            tracing::info!(collection = %self.collection, dim, "created qdrant collection");
             return Ok(());
         }
 
-        let info = self
-            .client
-            .collection_info(&self.collection)
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
-        let existing_dim = info
-            .result
-            .and_then(|r| r.config)
-            .and_then(|c| c.params)
-            .and_then(|p| p.vectors_config)
-            .and_then(|vc| vc.config)
-            .and_then(|c| match c {
-                qdrant_client::qdrant::vectors_config::Config::Params(p) => Some(p.size),
-                _ => None,
-            })
-            .ok_or_else(|| Error::Vector("could not read collection vector dimension".into()))?;
-
-        if existing_dim as usize != dim {
-            return Err(dimension_mismatch(
-                &self.collection,
-                dim,
-                existing_dim as usize,
-            ));
+        // A collection sitting where the alias should be holds real vectors.
+        // Refusing here is what keeps `--reindex` from being a data-loss step.
+        if self.collection_exists(&self.alias).await? {
+            return Err(legacy_layout(&self.alias));
         }
+
+        // Generations with no alias mean a rebuild died between deleting the
+        // old collection and creating the alias. The vectors are all there;
+        // adopting the newest generation is repair, not guesswork.
+        if let Some(orphan) = self.newest_generation().await? {
+            let existing = self.vector_dim(&orphan).await?;
+            if existing as usize != dim {
+                return Err(dimension_mismatch(&orphan, dim, existing as usize));
+            }
+            tracing::warn!(
+                collection = %orphan,
+                alias = %self.alias,
+                "found generations with no alias; adopting the newest, \
+                 which means an earlier rebuild did not finish"
+            );
+            self.point_alias_at(&orphan, false).await?;
+            return Ok(());
+        }
+
+        let first = generation_name(&self.alias, 1);
+        self.create_generation(&first, dim).await?;
+        self.point_alias_at(&first, false).await?;
         Ok(())
     }
 
@@ -128,63 +679,173 @@ impl VectorStore for QdrantVectors {
         if points.is_empty() {
             return Ok(());
         }
-        let mut structs = Vec::with_capacity(points.len());
+        let mut body = Vec::with_capacity(points.len());
         for p in points {
-            let value =
+            let payload =
                 serde_json::to_value(&p.payload).map_err(|e| Error::Vector(e.to_string()))?;
-            let payload: qdrant_client::Payload = value
-                .try_into()
-                .map_err(|e| Error::Vector(format!("payload conversion: {e}")))?;
-            structs.push(PointStruct::new(
-                point_uuid(&p.payload.chunk_id),
-                p.vector,
-                payload,
-            ));
+            let mut vector = json!({ DENSE: p.vector });
+            if let Some(sp) = sparse_body(&p.sparse) {
+                vector[SPARSE] = sp;
+            }
+            body.push(json!({
+                "id": point_uuid(&p.payload.chunk_id),
+                "vector": vector,
+                "payload": payload,
+            }));
         }
+        self.put_points(&self.alias, body).await
+    }
 
-        self.client
-            .upsert_points(UpsertPointsBuilder::new(&self.collection, structs).wait(true))
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
+    async fn set_payload(&self, payload: &VectorPayload) -> Result<()> {
+        let body = serde_json::to_value(payload).map_err(|e| Error::Vector(e.to_string()))?;
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/payload?wait=true", self.alias),
+                Some(json!({
+                    "payload": body,
+                    "points": [ point_uuid(&payload.chunk_id) ],
+                })),
+            )
+            .await?;
         Ok(())
     }
 
     async fn search(
         &self,
         vector: &[f32],
+        sparse: &SparseVector,
         limit: usize,
         filter: &SearchFilter,
     ) -> Result<Vec<SearchHit>> {
-        let mut q = QueryPointsBuilder::new(&self.collection)
-            .query(vector.to_vec())
-            .limit(limit as u64)
-            .with_payload(true);
+        let f = build_filter(filter);
 
-        if !filter.is_empty() {
-            let mut conds: Vec<Condition> = Vec::new();
-            for t in &filter.tags {
-                conds.push(Condition::matches("tags", t.clone()));
+        let mut body = match sparse_body(sparse) {
+            // Hybrid: both halves run as prefetch branches and Qdrant fuses
+            // their ranks. Reciprocal rank fusion needs no score calibration
+            // between a cosine similarity and a BM25 weight, which is exactly
+            // why it is the right combiner here.
+            Some(terms) => {
+                let mut dense_branch = json!({ "query": vector, "using": DENSE, "limit": limit });
+                let mut sparse_branch = json!({ "query": terms, "using": SPARSE, "limit": limit });
+                // The filter has to be repeated per branch: it narrows what
+                // each half retrieves, not what the fusion returns.
+                if let Some(f) = &f {
+                    dense_branch["filter"] = f.clone();
+                    sparse_branch["filter"] = f.clone();
+                }
+                json!({
+                    "prefetch": [dense_branch, sparse_branch],
+                    "query": { "fusion": "rrf" },
+                    "limit": limit,
+                    "with_payload": true,
+                })
             }
-            if let Some(c) = &filter.category {
-                conds.push(Condition::matches("category", c.clone()));
-            }
-            q = q.filter(Filter::must(conds));
+            // No indexable term in the query, so there is nothing for the
+            // lexical branch to match and asking it to would only cost a round
+            // trip through an empty index.
+            None => json!({
+                "query": vector,
+                "using": DENSE,
+                "limit": limit,
+                "with_payload": true,
+            }),
+        };
+        if let Some(f) = &f
+            && body.get("prefetch").is_none()
+        {
+            body["filter"] = f.clone();
         }
 
-        let res = self
-            .client
-            .query(q.build())
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
+        // Recency and pinning are applied as a final scoring stage over
+        // whatever retrieval returned, so they reorder results without
+        // changing which ones were retrieved.
+        if self.recency_weight > 0.0 || self.pinned_boost > 0.0 {
+            let inner = std::mem::replace(&mut body, Value::Null);
+            let mut prefetch = inner;
+            prefetch.as_object_mut().map(|m| m.remove("with_payload"));
+            body = json!({
+                "prefetch": [prefetch],
+                "query": scoring_formula(
+                    now_secs(),
+                    self.recency_half_life_days as u64 * SECONDS_PER_DAY,
+                    self.recency_weight,
+                    self.pinned_boost,
+                ),
+                "limit": limit,
+                "with_payload": true,
+            });
+        }
 
-        let mut out = Vec::new();
-        for p in res.result {
-            let map: serde_json::Map<String, serde_json::Value> = p
-                .payload
-                .into_iter()
-                .map(|(k, v)| (k, serde_json::Value::from(v)))
-                .collect();
-            let payload: VectorPayload = serde_json::from_value(serde_json::Value::Object(map))
+        let res: QueryResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/query", self.alias),
+                Some(body),
+            )
+            .await?;
+
+        let mut out = Vec::with_capacity(res.points.len());
+        for p in res.points {
+            let payload: VectorPayload = serde_json::from_value(p.payload)
+                .map_err(|e| Error::Vector(format!("payload did not match schema: {e}")))?;
+            out.push(SearchHit {
+                payload,
+                score: p.score,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn touch(&self, chunk_ids: &[String], seen_at: i64) -> Result<()> {
+        if chunk_ids.is_empty() {
+            return Ok(());
+        }
+        let ids: Vec<String> = chunk_ids.iter().map(|c| point_uuid(c)).collect();
+        // One request for the whole result list, and only the one key: this
+        // runs on every search, so it must not be a write per hit nor a
+        // read-modify-write of the full payload.
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/payload", self.alias),
+                Some(json!({ "payload": { "last_seen_at": seen_at }, "points": ids })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn resurface(
+        &self,
+        limit: usize,
+        older_than: i64,
+        unseen_since: i64,
+    ) -> Result<Vec<SearchHit>> {
+        let res: QueryResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/query", self.alias),
+                Some(json!({
+                    "query": { "sample": "random" },
+                    "filter": { "must": [
+                        { "key": "created_at", "range": { "lt": older_than } },
+                        // Nested so this reads as AND-of-OR. A chunk written
+                        // before the stamp existed has no `last_seen_at` at
+                        // all, and has certainly not been seen.
+                        { "should": [
+                            { "key": "last_seen_at", "range": { "lt": unseen_since } },
+                            { "is_empty": { "key": "last_seen_at" } },
+                        ] },
+                    ] },
+                    "limit": limit,
+                    "with_payload": true,
+                })),
+            )
+            .await?;
+
+        let mut out = Vec::with_capacity(res.points.len());
+        for p in res.points {
+            let payload: VectorPayload = serde_json::from_value(p.payload)
                 .map_err(|e| Error::Vector(format!("payload did not match schema: {e}")))?;
             out.push(SearchHit {
                 payload,
@@ -198,41 +859,32 @@ impl VectorStore for QdrantVectors {
         if chunk_ids.is_empty() {
             return Ok(());
         }
-        let ids: Vec<qdrant_client::qdrant::PointId> =
-            chunk_ids.iter().map(|c| point_uuid(c).into()).collect();
-        self.client
-            .delete_points(
-                DeletePointsBuilder::new(&self.collection)
-                    .points(ids)
-                    .wait(true),
+        let ids: Vec<String> = chunk_ids.iter().map(|c| point_uuid(c)).collect();
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/delete?wait=true", self.alias),
+                Some(json!({ "points": ids })),
             )
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
+            .await?;
         Ok(())
     }
 
     async fn delete_by_source(&self, source_id: &str) -> Result<()> {
-        self.client
-            .delete_points(
-                DeletePointsBuilder::new(&self.collection)
-                    .points(Filter::must([Condition::matches(
-                        "source_id",
-                        source_id.to_string(),
-                    )]))
-                    .wait(true),
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/delete?wait=true", self.alias),
+                Some(json!({
+                    "filter": { "must": [ { "key": "source_id", "match": { "value": source_id } } ] }
+                })),
             )
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
+            .await?;
         Ok(())
     }
 
     async fn count(&self) -> Result<u64> {
-        let info = self
-            .client
-            .collection_info(&self.collection)
-            .await
-            .map_err(|e| Error::Vector(e.to_string()))?;
-        Ok(info.result.and_then(|r| r.points_count).unwrap_or(0))
+        self.exact_count(&self.alias).await
     }
 }
 
@@ -247,6 +899,15 @@ mod tests {
         assert!(msg.contains("768"), "{msg}");
         assert!(msg.contains("1024"), "{msg}");
         assert!(msg.contains("chunks"), "{msg}");
+    }
+
+    #[test]
+    fn dimension_mismatch_does_not_promise_a_rebuild() {
+        // A rebuild copies vectors, so it can never resolve a width change.
+        // Suggesting it would send the reader in a circle.
+        let msg = dimension_mismatch("chunks_v1", 768, 1024).to_string();
+        assert!(msg.contains("cannot change their width"), "{msg}");
+        assert!(msg.contains("embed again"), "no way forward offered: {msg}");
     }
 
     #[test]
@@ -273,5 +934,120 @@ mod tests {
         // Qdrant rejects a point id that is neither an integer nor a UUID.
         let got = point_uuid("not-a-uuid");
         assert!(uuid::Uuid::parse_str(&got).is_ok(), "got {got}");
+    }
+
+    #[test]
+    fn base_url_loses_its_trailing_slash() {
+        // `{base}/collections` with a trailing slash becomes `//collections`,
+        // which a reverse proxy may answer with a redirect rather than JSON.
+        assert_eq!(
+            normalize_base("http://localhost:6333/"),
+            "http://localhost:6333"
+        );
+        assert_eq!(normalize_base("https://q.example//"), "https://q.example");
+        assert_eq!(
+            normalize_base("http://localhost:6333"),
+            "http://localhost:6333"
+        );
+    }
+
+    #[test]
+    fn an_empty_filter_produces_no_filter_at_all() {
+        // `{"must": []}` matches nothing in Qdrant, so an unfiltered search
+        // must omit the key rather than send an empty condition list.
+        assert!(build_filter(&SearchFilter::default()).is_none());
+    }
+
+    #[test]
+    fn every_tag_becomes_its_own_must_condition() {
+        // Tags are an AND. One condition per tag is what makes that true;
+        // a single condition with a list would be an OR.
+        let f = build_filter(&SearchFilter {
+            tags: vec!["linux".into(), "forensics".into()],
+            category: Some("procedure".into()),
+        })
+        .unwrap();
+        let must = f["must"].as_array().unwrap();
+        assert_eq!(must.len(), 3, "expected two tags plus the category: {f}");
+        assert_eq!(must[0]["key"], "tags");
+        assert_eq!(must[0]["match"]["value"], "linux");
+        assert_eq!(must[2]["key"], "category");
+    }
+
+    #[test]
+    fn a_qdrant_error_body_is_reduced_to_its_message() {
+        let body = r#"{"status":{"error":"Not found: Collection `x` doesn't exist!"},"time":0.0}"#;
+        let msg = describe_failure(StatusCode::NOT_FOUND, body);
+        assert!(msg.contains("doesn't exist"), "{msg}");
+        assert!(!msg.contains("time"), "raw envelope leaked: {msg}");
+    }
+
+    #[test]
+    fn an_unparseable_error_body_is_truncated_not_dumped() {
+        let body = "x".repeat(10_000);
+        let msg = describe_failure(StatusCode::BAD_GATEWAY, &body);
+        assert!(
+            msg.len() < 300,
+            "unbounded body reached the error: {}",
+            msg.len()
+        );
+    }
+
+    #[test]
+    fn generations_are_numbered_and_read_back() {
+        assert_eq!(generation_name("chunks", 1), "chunks_v1");
+        assert_eq!(generation_of("chunks", "chunks_v1"), 1);
+        assert_eq!(generation_of("chunks", "chunks_v12"), 12);
+    }
+
+    #[test]
+    fn a_pre_alias_collection_rebuilds_into_generation_one() {
+        // A collection named exactly like the alias carries no generation, so
+        // the next one must be _v1 rather than _v0 or a parse failure.
+        assert_eq!(generation_of("chunks", "chunks"), 0);
+        assert_eq!(
+            generation_name("chunks", generation_of("chunks", "chunks") + 1),
+            "chunks_v1"
+        );
+    }
+
+    #[test]
+    fn a_collection_whose_suffix_is_not_a_number_does_not_panic() {
+        assert_eq!(generation_of("chunks", "chunks_vNEXT"), 0);
+        assert_eq!(generation_of("chunks", "something_else"), 0);
+    }
+
+    #[test]
+    fn new_collections_declare_both_a_dense_and_a_sparse_vector() {
+        // The sparse slot is unused until hybrid search lands, but adding it
+        // later would mean another rebuild for every deployment.
+        let body = collection_body(768);
+        assert_eq!(body["vectors"][DENSE]["size"], 768);
+        assert_eq!(body["vectors"][DENSE]["distance"], "Cosine");
+        assert_eq!(body["sparse_vectors"][SPARSE]["modifier"], "idf");
+    }
+
+    #[test]
+    fn a_dense_vector_is_found_in_either_storage_layout() {
+        // A rebuild reads from the previous generation, which may predate
+        // named vectors.
+        let named = json!({ DENSE: [1.0, 0.0], "other": [9.0] });
+        assert_eq!(dense_of(&named).unwrap(), &json!([1.0, 0.0]));
+
+        let unnamed = json!([1.0, 0.0]);
+        assert_eq!(dense_of(&unnamed).unwrap(), &json!([1.0, 0.0]));
+
+        assert!(dense_of(&Value::Null).is_none());
+        assert!(
+            dense_of(&json!({ "sparse_only": {} })).is_none(),
+            "a point without a dense vector must be reported, not silently skipped"
+        );
+    }
+
+    #[test]
+    fn the_legacy_layout_error_offers_a_non_destructive_fix() {
+        let msg = legacy_layout("chunks").to_string();
+        assert!(msg.contains("--reindex"), "{msg}");
+        assert!(msg.contains("chunks_v1"), "{msg}");
     }
 }

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -37,6 +37,12 @@ pub const SPARSE: &str = "text";
 /// Points copied per scroll page during a rebuild.
 const REINDEX_BATCH: usize = 256;
 
+/// How long to wait for a collection another process just created to answer
+/// for itself: five attempts backing off 200ms, 400ms, … — three seconds in
+/// total, which is startup-shaped rather than request-shaped.
+const READY_ATTEMPTS: u32 = 5;
+const READY_BACKOFF: Duration = Duration::from_millis(200);
+
 /// A chunk carrying this tag is boosted past the decay curve. A tag rather than
 /// a column: `PATCH /api/v1/chunks/{id}` already edits tags without
 /// re-embedding, and the payload index that makes it filterable already exists.
@@ -108,14 +114,24 @@ fn generation_name(alias: &str, n: u32) -> String {
     format!("{alias}_v{n}")
 }
 
-/// Read the generation number back out of a physical collection name. A name
-/// that does not carry one is treated as generation 0, so the next rebuild
-/// lands on `_v1`.
-fn generation_of(alias: &str, collection: &str) -> u32 {
+/// Read the generation number back out of a physical collection name, if it
+/// carries one at all.
+///
+/// `None` is what separates `chunks_v2` from `chunks_verbose`: a prefix match
+/// alone would claim any collection whose name happens to start the same way,
+/// and this answer decides what `drop_collection` deletes and what
+/// `ensure_collection` adopts.
+fn generation_number(alias: &str, collection: &str) -> Option<u32> {
     collection
         .strip_prefix(&format!("{alias}_v"))
+        .filter(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
         .and_then(|n| n.parse().ok())
-        .unwrap_or(0)
+}
+
+/// The generation a rebuild would count from. A pre-alias collection carries no
+/// number, so the next one lands on `_v1`.
+fn generation_of(alias: &str, collection: &str) -> u32 {
+    generation_number(alias, collection).unwrap_or(0)
 }
 
 /// Qdrant answers `{"must": [...]}` with an implicit AND. An empty condition
@@ -169,6 +185,15 @@ fn sparse_of_payload(payload: &Value) -> SparseVector {
 /// between roughly 0.1 and 1.0. `exp_decay` returns 1.0 for something captured
 /// now and 0.5 at one half-life old, so the recency term is a small nudge
 /// rather than a second ranking.
+///
+/// `defaults` is not optional politeness: a single point whose payload lacks
+/// `created_at` fails the *whole* query with
+/// `Expected number value for created_at in the payload and/or in the formula
+/// defaults`, not just its own scoring. Every point engram writes carries the
+/// key, but `--reindex` copies payloads verbatim from whatever was in the
+/// source collection, so one hand-written point would otherwise take search
+/// down. Treating a missing stamp as the epoch scores it as maximally old,
+/// which is the honest reading of "we do not know when this arrived".
 fn scoring_formula(now: i64, half_life_secs: u64, recency: f32, pinned: f32) -> Value {
     let mut terms = vec![json!("$score")];
     if recency > 0.0 {
@@ -179,12 +204,16 @@ fn scoring_formula(now: i64, half_life_secs: u64, recency: f32, pinned: f32) -> 
         }));
     }
     if pinned > 0.0 {
-        // A filter condition evaluates to 1.0 for a point that matches it.
+        // A filter condition evaluates to 1.0 for a point that matches it, and
+        // needs no default: a point without tags simply does not match.
         terms.push(json!({
             "mult": [pinned, { "key": "tags", "match": { "value": PINNED_TAG } }]
         }));
     }
-    json!({ "formula": { "sum": terms } })
+    json!({
+        "formula": { "sum": terms },
+        "defaults": { "created_at": 0 },
+    })
 }
 
 /// A stored point's dense vector, whether the collection uses named vectors or
@@ -329,16 +358,19 @@ impl QdrantVectors {
             .map(|a| a.collection_name))
     }
 
-    /// Every collection belonging to this alias: the generations, plus a
-    /// pre-alias collection named exactly like it if one is still around.
+    /// Every collection belonging to this alias: the numbered generations, plus
+    /// a pre-alias collection named exactly like it if one is still around.
+    ///
+    /// Membership is by parsed generation number, never by prefix. A collection
+    /// called `{alias}_vault` belongs to whoever made it, and this list is what
+    /// `drop_collection` deletes.
     async fn generations(&self) -> Result<Vec<String>> {
         let list: CollectionList = self.call(Method::GET, "/collections", None).await?;
-        let prefix = format!("{}_v", self.alias);
         Ok(list
             .collections
             .into_iter()
             .map(|c| c.name)
-            .filter(|n| *n == self.alias || n.starts_with(&prefix))
+            .filter(|n| *n == self.alias || generation_number(&self.alias, n).is_some())
             .collect())
     }
 
@@ -349,8 +381,9 @@ impl QdrantVectors {
             .generations()
             .await?
             .into_iter()
-            .filter(|n| *n != self.alias)
-            .max_by_key(|n| generation_of(&self.alias, n)))
+            .filter_map(|n| generation_number(&self.alias, &n).map(|g| (g, n)))
+            .max_by_key(|(g, _)| *g)
+            .map(|(_, n)| n))
     }
 
     async fn collection_exists(&self, name: &str) -> Result<bool> {
@@ -361,13 +394,26 @@ impl QdrantVectors {
     }
 
     async fn create_generation(&self, name: &str, dim: usize) -> Result<()> {
-        let _: Value = self
-            .call(
+        if let Err(e) = self
+            .call::<Value>(
                 Method::PUT,
                 &format!("/collections/{name}"),
                 Some(collection_body(dim)),
             )
-            .await?;
+            .await
+        {
+            // Two processes starting together both find no alias and both try
+            // to build the first generation. Losing that race is not a failure,
+            // but inheriting a collection of the wrong width would be.
+            if !self.collection_exists(name).await? {
+                return Err(e);
+            }
+            let existing = self.await_readable(name).await?;
+            if existing as usize != dim {
+                return Err(dimension_mismatch(name, dim, existing as usize));
+            }
+            tracing::info!(collection = %name, "collection already existed; adopting it");
+        }
 
         // Payload indexes: without these, filtered search degrades to a
         // full scan of the collection.
@@ -412,6 +458,58 @@ impl QdrantVectors {
             .await?;
         tracing::info!(alias = %self.alias, collection, "alias now points at this generation");
         Ok(())
+    }
+
+    /// Create the alias, tolerating a process that got there first.
+    ///
+    /// Startup reads the alias, finds none, and writes one. Two processes
+    /// starting together both do that, and Qdrant refuses the second. Losing
+    /// that race is the outcome we wanted; the only thing worth failing on is
+    /// an alias pointing somewhere that cannot serve our vectors.
+    async fn claim_alias(&self, collection: &str, dim: usize) -> Result<()> {
+        let Err(e) = self.point_alias_at(collection, false).await else {
+            return Ok(());
+        };
+        let Some(current) = self.resolve_alias().await? else {
+            return Err(e);
+        };
+        let existing = self.await_readable(&current).await?;
+        if existing as usize != dim {
+            return Err(dimension_mismatch(&current, dim, existing as usize));
+        }
+        tracing::info!(
+            alias = %self.alias,
+            collection = %current,
+            "another process created the alias first"
+        );
+        Ok(())
+    }
+
+    /// The dimension of a collection that may still be coming up.
+    ///
+    /// A collection another process created a moment ago answers
+    /// `Service internal error: 0 of 0 read operations failed` until its shards
+    /// are ready. That is a state to wait out, not a startup to abort — but
+    /// only briefly, because the same message is what a genuinely broken
+    /// collection returns forever.
+    async fn await_readable(&self, collection: &str) -> Result<u64> {
+        let mut last = None;
+        for attempt in 0..READY_ATTEMPTS {
+            match self.vector_dim(collection).await {
+                Ok(dim) => return Ok(dim),
+                Err(e) => {
+                    tracing::debug!(collection, error = %e, "collection not readable yet");
+                    last = Some(e);
+                }
+            }
+            // No backoff after the last attempt: there is nothing left to wait
+            // for, and the caller is holding up a startup.
+            if attempt + 1 < READY_ATTEMPTS {
+                tokio::time::sleep(READY_BACKOFF * (attempt + 1)).await;
+            }
+        }
+        Err(last
+            .unwrap_or_else(|| Error::Vector(format!("`{collection}` did not become readable"))))
     }
 
     async fn vector_dim(&self, collection: &str) -> Result<u64> {
@@ -578,6 +676,31 @@ impl QdrantVectors {
     }
 }
 
+/// Turn a query response into hits, skipping any point whose payload is not
+/// one of ours.
+///
+/// A collection can hold points engram did not write — a rebuild copies
+/// payloads verbatim, and nothing stops an operator from inserting their own.
+/// Failing the whole result set over one of them would mean a single foreign
+/// point takes search down, which is a worse answer than a shorter list and a
+/// log line naming what was skipped.
+fn hits_of(res: QueryResult) -> Vec<SearchHit> {
+    let mut out = Vec::with_capacity(res.points.len());
+    for p in res.points {
+        match serde_json::from_value::<VectorPayload>(p.payload) {
+            Ok(payload) => out.push(SearchHit {
+                payload,
+                score: p.score,
+            }),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "skipping a point whose payload is not an engram chunk"
+            ),
+        }
+    }
+    out
+}
+
 /// Seconds since the epoch, the unit `created_at` is stored in.
 fn now_secs() -> i64 {
     std::time::SystemTime::now()
@@ -624,7 +747,13 @@ impl QdrantVectors {
         let text = res.text().await.map_err(|e| Error::Vector(e.to_string()))?;
 
         if !status.is_success() {
-            return Err(Error::Vector(describe_failure(status, &text)));
+            // The path is part of the message because several requests can fail
+            // the same way, and "which one" is the first thing anyone reading
+            // the log needs.
+            return Err(Error::Vector(format!(
+                "{path}: {}",
+                describe_failure(status, &text)
+            )));
         }
 
         let env: Envelope<T> = serde_json::from_str(&text)
@@ -665,13 +794,13 @@ impl VectorStore for QdrantVectors {
                 "found generations with no alias; adopting the newest, \
                  which means an earlier rebuild did not finish"
             );
-            self.point_alias_at(&orphan, false).await?;
+            self.claim_alias(&orphan, dim).await?;
             return Ok(());
         }
 
         let first = generation_name(&self.alias, 1);
         self.create_generation(&first, dim).await?;
-        self.point_alias_at(&first, false).await?;
+        self.claim_alias(&first, dim).await?;
         Ok(())
     }
 
@@ -761,9 +890,13 @@ impl VectorStore for QdrantVectors {
         // whatever retrieval returned, so they reorder results without
         // changing which ones were retrieved.
         if self.recency_weight > 0.0 || self.pinned_boost > 0.0 {
-            let inner = std::mem::replace(&mut body, Value::Null);
-            let mut prefetch = inner;
-            prefetch.as_object_mut().map(|m| m.remove("with_payload"));
+            let mut prefetch = std::mem::replace(&mut body, Value::Null);
+            // The payload is fetched once, by the outer stage. Asking the
+            // prefetch for it too would carry every candidate's full text
+            // through a stage that only reorders ids.
+            if let Some(m) = prefetch.as_object_mut() {
+                m.remove("with_payload");
+            }
             body = json!({
                 "prefetch": [prefetch],
                 "query": scoring_formula(
@@ -784,17 +917,7 @@ impl VectorStore for QdrantVectors {
                 Some(body),
             )
             .await?;
-
-        let mut out = Vec::with_capacity(res.points.len());
-        for p in res.points {
-            let payload: VectorPayload = serde_json::from_value(p.payload)
-                .map_err(|e| Error::Vector(format!("payload did not match schema: {e}")))?;
-            out.push(SearchHit {
-                payload,
-                score: p.score,
-            });
-        }
-        Ok(out)
+        Ok(hits_of(res))
     }
 
     async fn touch(&self, chunk_ids: &[String], seen_at: i64) -> Result<()> {
@@ -842,17 +965,7 @@ impl VectorStore for QdrantVectors {
                 })),
             )
             .await?;
-
-        let mut out = Vec::with_capacity(res.points.len());
-        for p in res.points {
-            let payload: VectorPayload = serde_json::from_value(p.payload)
-                .map_err(|e| Error::Vector(format!("payload did not match schema: {e}")))?;
-            out.push(SearchHit {
-                payload,
-                score: p.score,
-            });
-        }
-        Ok(out)
+        Ok(hits_of(res))
     }
 
     async fn delete_chunks(&self, chunk_ids: &[String]) -> Result<()> {
@@ -1015,6 +1128,41 @@ mod tests {
     fn a_collection_whose_suffix_is_not_a_number_does_not_panic() {
         assert_eq!(generation_of("chunks", "chunks_vNEXT"), 0);
         assert_eq!(generation_of("chunks", "something_else"), 0);
+    }
+
+    #[test]
+    fn only_a_numeric_suffix_makes_a_collection_ours() {
+        // `drop_collection` deletes everything this claims, so a neighbouring
+        // collection that merely starts the same way must not be claimed.
+        assert_eq!(generation_number("chunks", "chunks_v3"), Some(3));
+        assert_eq!(generation_number("chunks", "chunks_verbose"), None);
+        assert_eq!(generation_number("chunks", "chunks_vault"), None);
+        assert_eq!(generation_number("chunks", "chunks_v"), None);
+        assert_eq!(generation_number("chunks", "chunks_v1x"), None);
+        assert_eq!(generation_number("chunks", "chunks"), None);
+        // `+1` and `1_0` parse as numbers in Rust but are not names we write.
+        assert_eq!(generation_number("chunks", "chunks_v+1"), None);
+        assert_eq!(generation_number("chunks", "chunks_v1_0"), None);
+    }
+
+    #[test]
+    fn the_scoring_formula_survives_a_point_without_a_created_at() {
+        // Qdrant fails the entire query, not just the offending point, when a
+        // formula reads a key the payload does not have.
+        let f = scoring_formula(1_700_000_000, 86_400, 0.05, 0.15);
+        assert_eq!(
+            f["defaults"]["created_at"], 0,
+            "a payload missing created_at would take search down: {f}"
+        );
+    }
+
+    #[test]
+    fn a_disabled_weight_contributes_no_term() {
+        // Zero weights must drop out of the formula rather than multiply by
+        // zero, so an operator turning recency off stops paying for it.
+        let f = scoring_formula(0, 86_400, 0.0, 0.0);
+        assert_eq!(f["formula"]["sum"].as_array().unwrap().len(), 1);
+        assert_eq!(f["formula"]["sum"][0], "$score");
     }
 
     #[test]

--- a/src/vector/sparse.rs
+++ b/src/vector/sparse.rs
@@ -1,0 +1,269 @@
+//! BM25 sparse vectors, computed locally.
+//!
+//! Dense embeddings blur exact tokens. A knowledge base full of `E01`,
+//! `--dry-run`, `/usr/bin/env` and error strings needs the half of retrieval
+//! that matches characters rather than meaning, and the `ask` prompt asks the
+//! model to quote those things verbatim.
+//!
+//! Only the term-frequency half of BM25 is computed here. The inverse document
+//! frequency comes from Qdrant, whose sparse index carries a `"modifier":
+//! "idf"` and knows the corpus statistics that this process does not.
+
+/// Term-frequency saturation. The standard BM25 value: a term appearing ten
+/// times is worth more than once, but nowhere near ten times more.
+const K1: f32 = 1.2;
+
+/// Document-length normalisation, deliberately disabled.
+///
+/// A non-zero `b` needs the corpus average document length, which means
+/// corpus-wide statistics on the write path and a full re-encode whenever the
+/// average drifts. The segmenter already bounds chunk length, so the correction
+/// it would apply is small. Changing this means rebuilding every sparse vector,
+/// which `--reindex` exists to make routine.
+const B: f32 = 0.0;
+
+/// Longer than any real identifier; past this it is a base64 blob or a hash,
+/// and indexing it only costs space.
+const MAX_TOKEN_LEN: usize = 40;
+
+/// Characters allowed *inside* a token. Splitting on them would destroy exactly
+/// the identifiers this index exists to find.
+const CONNECTORS: [char; 4] = ['-', '_', '.', '/'];
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SparseVector {
+    pub indices: Vec<u32>,
+    pub values: Vec<f32>,
+}
+
+impl SparseVector {
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+}
+
+/// Split text into indexable terms.
+///
+/// A token containing connectors is emitted whole *and* in pieces, so
+/// `--dry-run` can be found by searching for `dry-run`, `dry`, or `run`. The
+/// whole form scores higher, because it is one term rather than shared with
+/// every other document mentioning "run".
+pub fn tokenize(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in text.split(|c: char| !c.is_alphanumeric() && !CONNECTORS.contains(&c)) {
+        // Leading and trailing connectors are punctuation, not part of the
+        // identifier: `--dry-run` is the flag `dry-run`.
+        let token = raw.trim_matches(|c| CONNECTORS.contains(&c)).to_lowercase();
+        if token.is_empty() || token.len() > MAX_TOKEN_LEN {
+            continue;
+        }
+        let compound = token.contains(|c| CONNECTORS.contains(&c));
+        out.push(token.clone());
+        if compound {
+            for part in token.split(|c| CONNECTORS.contains(&c)) {
+                if !part.is_empty() && part.len() <= MAX_TOKEN_LEN {
+                    out.push(part.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// A stable numeric id for a term.
+///
+/// Qdrant indexes sparse dimensions by number, so the mapping has to survive
+/// restarts and match between the write and the read path. Hashing gives that
+/// for free, without a vocabulary file that could drift out of sync with the
+/// stored vectors.
+pub fn term_id(token: &str) -> u32 {
+    let digest = <sha2::Sha256 as sha2::Digest>::digest(token.as_bytes());
+    u32::from_le_bytes([digest[0], digest[1], digest[2], digest[3]])
+}
+
+/// Encode a document: term ids with saturated term frequencies.
+pub fn encode_document(text: &str) -> SparseVector {
+    let mut counts: std::collections::HashMap<u32, f32> = std::collections::HashMap::new();
+    for token in tokenize(text) {
+        *counts.entry(term_id(&token)).or_insert(0.0) += 1.0;
+    }
+
+    let mut indices = Vec::with_capacity(counts.len());
+    let mut values = Vec::with_capacity(counts.len());
+    // Sorted so that two runs over the same text produce byte-identical
+    // requests, which makes a diff of what was written meaningful.
+    let mut pairs: Vec<(u32, f32)> = counts.into_iter().collect();
+    pairs.sort_unstable_by_key(|(id, _)| *id);
+    for (id, tf) in pairs {
+        indices.push(id);
+        values.push(saturate(tf));
+    }
+    SparseVector { indices, values }
+}
+
+/// Encode a query: presence, not frequency.
+///
+/// Repeating a word in a query says nothing about relevance, and the weighting
+/// that matters — how rare the term is across the corpus — is applied by Qdrant.
+pub fn encode_query(text: &str) -> SparseVector {
+    let mut ids: Vec<u32> = tokenize(text).iter().map(|t| term_id(t)).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    let values = vec![1.0; ids.len()];
+    SparseVector {
+        indices: ids,
+        values,
+    }
+}
+
+fn saturate(tf: f32) -> f32 {
+    // With B = 0 the length-normalisation term collapses to 1.
+    let norm = 1.0 - B + B;
+    tf * (K1 + 1.0) / (tf + K1 * norm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(text: &str) -> Vec<String> {
+        tokenize(text)
+    }
+
+    #[test]
+    fn a_flag_survives_its_leading_dashes_and_is_also_split() {
+        // Searching for `--dry-run`, `dry-run` or just `run` must all reach a
+        // document that mentions the flag.
+        let t = tokens("run it with --dry-run first");
+        assert!(t.contains(&"dry-run".to_string()), "{t:?}");
+        assert!(t.contains(&"dry".to_string()), "{t:?}");
+        assert!(t.contains(&"run".to_string()), "{t:?}");
+        assert!(
+            !t.contains(&"--dry-run".to_string()),
+            "leading dashes are punctuation: {t:?}"
+        );
+    }
+
+    #[test]
+    fn identifiers_keep_their_internal_punctuation() {
+        let t = tokens("edit src/vector/sparse.rs and file.rs");
+        assert!(t.contains(&"src/vector/sparse.rs".to_string()), "{t:?}");
+        assert!(t.contains(&"sparse".to_string()), "{t:?}");
+        assert!(t.contains(&"file.rs".to_string()), "{t:?}");
+        assert!(t.contains(&"rs".to_string()), "{t:?}");
+    }
+
+    #[test]
+    fn alphanumeric_identifiers_are_one_token() {
+        // The exact reason this index exists: `E01` means nothing to an
+        // embedding model and everything to a forensic examiner.
+        assert_eq!(
+            tokens("mounting an E01 image"),
+            vec!["mounting", "an", "e01", "image"]
+        );
+    }
+
+    #[test]
+    fn case_does_not_matter() {
+        assert_eq!(tokens("Ext4 EXT4 ext4"), vec!["ext4", "ext4", "ext4"]);
+    }
+
+    #[test]
+    fn punctuation_and_whitespace_never_become_terms() {
+        assert!(tokens("   ...  --  //  ").is_empty());
+        assert!(tokens("").is_empty());
+    }
+
+    #[test]
+    fn an_overlong_token_is_dropped() {
+        // A base64 blob or a hash is not a term anyone searches for.
+        let blob = "a".repeat(MAX_TOKEN_LEN + 1);
+        assert!(tokens(&blob).is_empty(), "an unbounded token was indexed");
+        let ok = "a".repeat(MAX_TOKEN_LEN);
+        assert_eq!(tokens(&ok), vec![ok]);
+    }
+
+    #[test]
+    fn term_ids_are_stable_and_distinct() {
+        // They are baked into stored vectors, so a change here invalidates
+        // every sparse vector in the collection.
+        assert_eq!(term_id("e01"), term_id("e01"));
+        assert_ne!(term_id("e01"), term_id("e02"));
+    }
+
+    #[test]
+    fn repeated_terms_saturate_rather_than_accumulate() {
+        let once = encode_document("alpha");
+        let many = encode_document("alpha alpha alpha alpha alpha alpha alpha alpha");
+        let id = term_id("alpha");
+        let w = |v: &SparseVector| v.values[v.indices.iter().position(|i| *i == id).unwrap()];
+
+        assert!(w(&many) > w(&once), "frequency should count for something");
+        assert!(
+            w(&many) < 8.0 * w(&once),
+            "eight mentions must not be worth eight times one"
+        );
+        assert!(w(&many) < K1 + 1.0, "saturation has an upper bound");
+    }
+
+    #[test]
+    fn a_document_vector_is_sorted_and_deduplicated() {
+        let v = encode_document("beta alpha beta");
+        assert_eq!(v.indices.len(), 2, "a repeated term is one dimension");
+        assert_eq!(v.indices.len(), v.values.len());
+        assert!(
+            v.indices.windows(2).all(|w| w[0] < w[1]),
+            "indices must be sorted: {:?}",
+            v.indices
+        );
+    }
+
+    #[test]
+    fn a_query_weighs_presence_not_frequency() {
+        // Typing a word twice does not make it twice as important; rarity is
+        // what matters, and Qdrant supplies that.
+        let v = encode_query("alpha alpha beta");
+        assert_eq!(v.indices.len(), 2);
+        assert!(v.values.iter().all(|x| *x == 1.0), "{:?}", v.values);
+    }
+
+    #[test]
+    fn a_query_of_pure_punctuation_is_empty_rather_than_meaningless() {
+        // An empty sparse branch has to be skipped, not sent: asking Qdrant to
+        // match nothing is not the same as not asking.
+        assert!(encode_query("?? ...").is_empty());
+        assert!(!encode_query("ext4").is_empty());
+    }
+
+    /// Queries a dense embedding is known to handle badly. Each pairs a query
+    /// with text that must match it on exact tokens alone.
+    #[test]
+    fn the_queries_dense_search_gets_wrong_share_terms_with_their_answer() {
+        for (query, document) in [
+            ("E01", "mounting an E01 image with ewfmount"),
+            ("--dry-run", "pass --dry-run to preview the changes"),
+            ("ext4", "the ext4 journal replays on mount"),
+            ("SIGSEGV", "the process died with SIGSEGV in the parser"),
+            ("qdrant_client", "the qdrant_client crate speaks gRPC only"),
+            ("/etc/fstab", "entries in /etc/fstab are read at boot"),
+        ] {
+            let q = encode_query(query);
+            let d = encode_document(document);
+            assert!(!q.is_empty(), "query `{query}` produced no terms");
+            let shared = q.indices.iter().filter(|i| d.indices.contains(i)).count();
+            assert!(
+                shared > 0,
+                "`{query}` shares no term with `{document}`, so lexical search cannot find it"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unrelated_document_shares_nothing_with_the_query() {
+        // Without this the test above would pass for a tokenizer that emitted
+        // the same terms for everything.
+        let q = encode_query("E01");
+        let d = encode_document("configuring a printer on Windows");
+        assert!(q.indices.iter().all(|i| !d.indices.contains(i)));
+    }
+}

--- a/src/vector/sparse.rs
+++ b/src/vector/sparse.rs
@@ -15,12 +15,17 @@ const K1: f32 = 1.2;
 
 /// Document-length normalisation, deliberately disabled.
 ///
-/// A non-zero `b` needs the corpus average document length, which means
-/// corpus-wide statistics on the write path and a full re-encode whenever the
-/// average drifts. The segmenter already bounds chunk length, so the correction
-/// it would apply is small. Changing this means rebuilding every sparse vector,
-/// which `--reindex` exists to make routine.
-const B: f32 = 0.0;
+/// BM25 divides term frequency by `1 - b + b * (len / avg_len)`. A non-zero `b`
+/// therefore needs the corpus average document length: corpus-wide statistics
+/// on the write path, and a full re-encode whenever the average drifts. The
+/// segmenter already bounds chunk length, so the correction it would apply is
+/// small.
+///
+/// Held as a constant rather than a parameter because the whole normalisation
+/// term collapses to `1.0` only while it is zero. Reintroducing it means
+/// bringing `avg_len` with it — and rebuilding every sparse vector, which
+/// `--reindex` exists to make routine.
+const LENGTH_NORM: f32 = 1.0;
 
 /// Longer than any real identifier; past this it is a base64 blob or a hash,
 /// and indexing it only costs space.
@@ -76,6 +81,16 @@ pub fn tokenize(text: &str) -> Vec<String> {
 /// restarts and match between the write and the read path. Hashing gives that
 /// for free, without a vocabulary file that could drift out of sync with the
 /// stored vectors.
+///
+/// The width is not a choice: Qdrant sparse indices are `u32`, so any hashed
+/// vocabulary collides eventually. At ~100k distinct terms the chance that
+/// *some* pair collides is better than even, though the chance that a given
+/// query hits one stays around one in forty thousand. A collision merges two
+/// terms into one dimension, so a document matches a word it does not contain —
+/// which the dense half of the hybrid query then has to outvote. Cheap
+/// insurance against the worst of it: this is the *only* place term ids are
+/// derived, so the day the tail matters, a vocabulary table replaces this
+/// function and `--reindex` rebuilds every sparse vector.
 pub fn term_id(token: &str) -> u32 {
     let digest = <sha2::Sha256 as sha2::Digest>::digest(token.as_bytes());
     u32::from_le_bytes([digest[0], digest[1], digest[2], digest[3]])
@@ -117,9 +132,7 @@ pub fn encode_query(text: &str) -> SparseVector {
 }
 
 fn saturate(tf: f32) -> f32 {
-    // With B = 0 the length-normalisation term collapses to 1.
-    let norm = 1.0 - B + B;
-    tf * (K1 + 1.0) / (tf + K1 * norm)
+    tf * (K1 + 1.0) / (tf + K1 * LENGTH_NORM)
 }
 
 #[cfg(test)]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -26,16 +26,90 @@ fn default_stage() -> String {
 
 /// Every field is optional so a caller can correct a tag without resending —
 /// and without re-embedding — the body text.
+///
+/// `title` and `category` are doubly optional on purpose: an absent key means
+/// "leave it alone" and an explicit `null` means "clear it". Collapsing the two
+/// would make a field that can be set but never unset. Tags need no such
+/// distinction, because an empty list already says it.
 #[derive(serde::Deserialize)]
 pub struct PatchChunkRequest {
     #[serde(default)]
     pub text: Option<String>,
-    #[serde(default)]
-    pub title: Option<String>,
-    #[serde(default)]
-    pub category: Option<String>,
+    #[serde(default, deserialize_with = "explicit_null")]
+    pub title: Option<Option<String>>,
+    #[serde(default, deserialize_with = "explicit_null")]
+    pub category: Option<Option<String>>,
     #[serde(default)]
     pub tags: Option<Vec<String>>,
+}
+
+/// Tell an absent key from an explicit `null`. Serde reaches this function only
+/// when the key was present, so the outer `Some` records that fact.
+fn explicit_null<'de, D, T>(d: D) -> std::result::Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(d).map(Some)
+}
+
+/// A chunk may carry this many tags, each this long.
+///
+/// Tags are a filter dimension and a payload index in Qdrant, not a place to
+/// put prose. Unbounded input here becomes unbounded payload on every point
+/// and an index that grows without limit.
+const MAX_TAGS: usize = 32;
+const MAX_TAG_LEN: usize = 64;
+/// Long enough for any label worth filtering on.
+const MAX_CATEGORY_LEN: usize = 64;
+const MAX_TITLE_LEN: usize = 512;
+
+/// Trim, drop blanks, deduplicate, and refuse what is out of bounds.
+///
+/// Deduplicating matters beyond tidiness: tags are ANDed in a search filter, so
+/// a repeated tag is a condition Qdrant evaluates twice for the same answer.
+fn clean_tags(tags: &[String]) -> Result<Vec<String>> {
+    let mut out: Vec<String> = Vec::with_capacity(tags.len());
+    for t in tags {
+        let t = t.trim();
+        if t.is_empty() {
+            continue;
+        }
+        if t.chars().count() > MAX_TAG_LEN {
+            return Err(Error::Validation(format!(
+                "tag is longer than {MAX_TAG_LEN} characters"
+            )));
+        }
+        if !out.iter().any(|k| k == t) {
+            out.push(t.to_string());
+        }
+    }
+    if out.len() > MAX_TAGS {
+        return Err(Error::Validation(format!(
+            "a chunk may carry at most {MAX_TAGS} tags, got {}",
+            out.len()
+        )));
+    }
+    Ok(out)
+}
+
+/// Trim a settable-or-clearable string field. An empty value after trimming is
+/// a clear, so `""` and `null` mean the same thing rather than storing a label
+/// that renders as nothing.
+fn clean_optional(value: Option<String>, max: usize, field: &str) -> Result<Option<String>> {
+    let Some(v) = value else {
+        return Ok(None);
+    };
+    let v = v.trim();
+    if v.is_empty() {
+        return Ok(None);
+    }
+    if v.chars().count() > max {
+        return Err(Error::Validation(format!(
+            "{field} is longer than {max} characters"
+        )));
+    }
+    Ok(Some(v.to_string()))
 }
 
 #[derive(serde::Serialize)]
@@ -198,37 +272,58 @@ async fn patch_chunk(
     if req.text.is_none() && req.title.is_none() && req.category.is_none() && req.tags.is_none() {
         return Err(Error::Validation("no fields to update".into()));
     }
-    if let Some(t) = &req.text
-        && t.trim().is_empty()
-    {
-        return Err(Error::Validation("chunk text is empty".into()));
-    }
+    // Validate everything before writing anything: a request half-applied and
+    // then rejected leaves a chunk in a state the caller never asked for.
+    let text = match &req.text {
+        Some(t) if t.trim().is_empty() => {
+            return Err(Error::Validation("chunk text is empty".into()));
+        }
+        Some(t) => Some(t.trim().to_string()),
+        None => None,
+    };
+    let title = req
+        .title
+        .map(|t| clean_optional(t, MAX_TITLE_LEN, "title"))
+        .transpose()?;
+    let category = req
+        .category
+        .map(|c| clean_optional(c, MAX_CATEGORY_LEN, "category"))
+        .transpose()?;
+    let tags = req.tags.as_deref().map(clean_tags).transpose()?;
+
     st.core.store.get_chunk(&cid).await?;
 
     // The embedder is shown the title followed by the body, so either of those
     // invalidates the stored vector. A category or a tag changes only what the
     // payload says about the chunk.
-    let revectorize = req.text.is_some() || req.title.is_some();
+    let revectorize = text.is_some() || title.is_some();
 
-    if let Some(t) = &req.text {
+    if let Some(t) = &text {
         st.core.store.update_chunk_text(&cid, t).await?;
     }
-    if let Some(t) = &req.title {
-        st.core.store.update_chunk_title(&cid, t).await?;
+    if let Some(t) = &title {
+        st.core.store.update_chunk_title(&cid, t.as_deref()).await?;
     }
-    if req.category.is_some() || req.tags.is_some() {
+    if let Some(c) = &category {
         st.core
             .store
-            .update_chunk_meta(&cid, req.category.as_deref(), req.tags.as_deref())
+            .update_chunk_category(&cid, c.as_deref())
             .await?;
+    }
+    if let Some(t) = &tags {
+        st.core.store.update_chunk_tags(&cid, t).await?;
     }
 
     let chunk = st.core.store.get_chunk(&cid).await?;
     if revectorize {
         st.core.store.enqueue(Stage::Embed, "chunk", &cid).await?;
-    } else {
+    } else if chunk.embed_state == crate::store::chunks::EmbedState::Embedded {
         // Nothing the model saw has changed, so rewrite the payload in place
         // rather than spending an inference call to recompute the same vector.
+        //
+        // Only when there is a point to rewrite: for a chunk still waiting to
+        // be embedded, this would be a request Qdrant accepts and applies to
+        // nothing, and the pending job writes the whole payload anyway.
         st.core
             .vectors
             .set_payload(&crate::vector::VectorPayload {
@@ -701,6 +796,133 @@ mod patch_tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn a_field_can_be_cleared_with_an_explicit_null() {
+        // An absent key means "leave it alone", so without this a category
+        // could be set and then never removed.
+        let (app, token, core, cid) = one_chunk().await;
+        assert_eq!(
+            core.store
+                .get_chunk(&cid)
+                .await
+                .unwrap()
+                .category
+                .as_deref(),
+            Some("concept")
+        );
+
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({ "category": null }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(core.store.get_chunk(&cid).await.unwrap().category, None);
+    }
+
+    #[tokio::test]
+    async fn an_untouched_field_keeps_its_value() {
+        let (app, token, core, cid) = one_chunk().await;
+        app.oneshot(patch_json(
+            &format!("/api/v1/chunks/{cid}"),
+            &token,
+            serde_json::json!({ "tags": ["fresh"] }),
+        ))
+        .await
+        .unwrap();
+
+        let c = core.store.get_chunk(&cid).await.unwrap();
+        assert_eq!(
+            c.category.as_deref(),
+            Some("concept"),
+            "category was erased"
+        );
+        assert_eq!(c.title.as_deref(), Some("a title"), "title was erased");
+    }
+
+    #[tokio::test]
+    async fn tags_are_trimmed_deduplicated_and_bounded() {
+        let (app, token, core, cid) = one_chunk().await;
+        app.oneshot(patch_json(
+            &format!("/api/v1/chunks/{cid}"),
+            &token,
+            serde_json::json!({ "tags": ["  linux ", "linux", "", "   ", "forensics"] }),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(
+            core.store.get_chunk(&cid).await.unwrap().tags,
+            vec!["linux".to_string(), "forensics".to_string()],
+            "a repeated tag is a filter condition evaluated twice for one answer"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unbounded_tag_list_is_refused() {
+        // Tags become payload on every point and a keyword index in Qdrant.
+        let (app, token, _core, cid) = one_chunk().await;
+        let many: Vec<String> = (0..500).map(|i| format!("t{i}")).collect();
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({ "tags": many }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn an_overlong_tag_is_refused() {
+        let (app, token, _core, cid) = one_chunk().await;
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({ "tags": ["x".repeat(500)] }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn a_rejected_field_leaves_the_other_fields_alone() {
+        // Validation happens before any write, so a request that fails is a
+        // request that changed nothing.
+        let (app, token, core, cid) = one_chunk().await;
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({ "title": "a new title", "tags": ["x".repeat(500)] }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+        let c = core.store.get_chunk(&cid).await.unwrap();
+        assert_eq!(c.title.as_deref(), Some("a title"), "a half-applied PATCH");
+        assert_eq!(c.embed_state, EmbedState::Embedded);
+    }
+
+    #[tokio::test]
+    async fn a_blank_title_clears_it_rather_than_storing_whitespace() {
+        let (app, token, core, cid) = one_chunk().await;
+        app.oneshot(patch_json(
+            &format!("/api/v1/chunks/{cid}"),
+            &token,
+            serde_json::json!({ "title": "   " }),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(core.store.get_chunk(&cid).await.unwrap().title, None);
     }
 
     #[tokio::test]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -24,9 +24,18 @@ fn default_stage() -> String {
     "segment".into()
 }
 
+/// Every field is optional so a caller can correct a tag without resending —
+/// and without re-embedding — the body text.
 #[derive(serde::Deserialize)]
 pub struct PatchChunkRequest {
-    pub text: String,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
 }
 
 #[derive(serde::Serialize)]
@@ -159,6 +168,19 @@ async fn ask(
     Ok(Json(st.core.ask(&req).await?))
 }
 
+#[derive(serde::Deserialize)]
+pub struct ResurfaceParams {
+    pub limit: Option<usize>,
+}
+
+async fn resurface(
+    State(st): State<AppState>,
+    _id: Identity,
+    Query(p): Query<ResurfaceParams>,
+) -> Result<Json<Vec<crate::core::search::SearchResult>>> {
+    Ok(Json(st.core.resurface(p.limit.unwrap_or(5)).await?))
+}
+
 async fn get_chunk(
     State(st): State<AppState>,
     _id: Identity,
@@ -173,14 +195,55 @@ async fn patch_chunk(
     Path(cid): Path<String>,
     Json(req): Json<PatchChunkRequest>,
 ) -> Result<Json<crate::store::chunks::Chunk>> {
-    if req.text.trim().is_empty() {
+    if req.text.is_none() && req.title.is_none() && req.category.is_none() && req.tags.is_none() {
+        return Err(Error::Validation("no fields to update".into()));
+    }
+    if let Some(t) = &req.text
+        && t.trim().is_empty()
+    {
         return Err(Error::Validation("chunk text is empty".into()));
     }
-    st.core.store.update_chunk_text(&cid, &req.text).await?;
-    // The stored vector now describes text that no longer exists, so queue a
-    // re-embed rather than leaving search pointing at the old wording.
-    st.core.store.enqueue(Stage::Embed, "chunk", &cid).await?;
-    Ok(Json(st.core.store.get_chunk(&cid).await?))
+    st.core.store.get_chunk(&cid).await?;
+
+    // The embedder is shown the title followed by the body, so either of those
+    // invalidates the stored vector. A category or a tag changes only what the
+    // payload says about the chunk.
+    let revectorize = req.text.is_some() || req.title.is_some();
+
+    if let Some(t) = &req.text {
+        st.core.store.update_chunk_text(&cid, t).await?;
+    }
+    if let Some(t) = &req.title {
+        st.core.store.update_chunk_title(&cid, t).await?;
+    }
+    if req.category.is_some() || req.tags.is_some() {
+        st.core
+            .store
+            .update_chunk_meta(&cid, req.category.as_deref(), req.tags.as_deref())
+            .await?;
+    }
+
+    let chunk = st.core.store.get_chunk(&cid).await?;
+    if revectorize {
+        st.core.store.enqueue(Stage::Embed, "chunk", &cid).await?;
+    } else {
+        // Nothing the model saw has changed, so rewrite the payload in place
+        // rather than spending an inference call to recompute the same vector.
+        st.core
+            .vectors
+            .set_payload(&crate::vector::VectorPayload {
+                chunk_id: chunk.id.clone(),
+                source_id: chunk.source_id.clone(),
+                text: chunk.text.clone(),
+                title: chunk.title.clone(),
+                category: chunk.category.clone(),
+                tags: chunk.tags.clone(),
+                created_at: chunk.created_at,
+                last_seen_at: None,
+            })
+            .await?;
+    }
+    Ok(Json(chunk))
 }
 
 async fn delete_chunk(
@@ -229,6 +292,7 @@ pub fn api_router() -> Router<AppState> {
         .route("/sources/{id}/reprocess", post(reprocess))
         .route("/search", get(search))
         .route("/ask", post(ask))
+        .route("/resurface", get(resurface))
         .route(
             "/chunks/{id}",
             get(get_chunk).patch(patch_chunk).delete(delete_chunk),
@@ -243,10 +307,16 @@ mod tests {
     use tower::ServiceExt;
 
     async fn app_and_token() -> (axum::Router, String) {
+        let (app, token, _core) = app_token_and_core().await;
+        (app, token)
+    }
+
+    pub async fn app_token_and_core() -> (axum::Router, String, crate::core::Core) {
         let core = crate::core::test_support::test_core().await;
         let (_, token) = crate::auth::tokens::mint(&core.store, "test", "user-1")
             .await
             .unwrap();
+        let state_core = core.clone();
         let state = crate::web::state::AppState {
             core,
             auth: std::sync::Arc::new(crate::web::state::AuthContext {
@@ -257,7 +327,7 @@ mod tests {
                 secure_cookies: false,
             }),
         };
-        (crate::web::router(state), token)
+        (crate::web::router(state), token, state_core)
     }
 
     fn get(uri: &str, token: Option<&str>) -> Request<Body> {
@@ -278,6 +348,16 @@ mod tests {
             .unwrap()
     }
 
+    pub fn patch_json(uri: &str, token: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method("PATCH")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
     async fn json_of(res: axum::response::Response) -> serde_json::Value {
         let bytes = axum::body::to_bytes(res.into_body(), 1 << 20)
             .await
@@ -292,6 +372,7 @@ mod tests {
         let (app, _) = app_and_token().await;
         for (method, uri) in [
             ("GET", "/api/v1/search?q=x"),
+            ("GET", "/api/v1/resurface"),
             ("GET", "/api/v1/sources"),
             ("POST", "/api/v1/sources"),
             ("GET", "/api/v1/sources/abc"),
@@ -492,5 +573,147 @@ mod tests {
         assert!(v["jobs"].is_array());
         assert!(v["sources"].is_array());
         assert!(v["failed"].is_array());
+    }
+}
+
+#[cfg(test)]
+mod patch_tests {
+    use super::tests::*;
+    use crate::store::chunks::{EmbedState, NewChunk};
+    use crate::vector::SearchFilter;
+    use axum::http::StatusCode;
+    use tower::ServiceExt;
+
+    /// One embedded chunk, and the app that can edit it.
+    async fn one_chunk() -> (axum::Router, String, crate::core::Core, String) {
+        let (app, token, core) = app_token_and_core().await;
+        let src = core.store.insert_source("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_chunks(
+                &src.id,
+                &[NewChunk {
+                    ordinal: 0,
+                    text: "the body".into(),
+                    source_span: None,
+                    title: Some("a title".into()),
+                    category: Some("concept".into()),
+                    tags: vec!["old".into()],
+                }],
+            )
+            .await
+            .unwrap();
+        let cid = made[0].id.clone();
+        crate::jobs::embed::run(&core, &cid).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        (app, token, core, cid)
+    }
+
+    #[tokio::test]
+    async fn editing_only_tags_rewrites_the_payload_without_re_embedding() {
+        // Tags are not shown to the embedding model, so recomputing the vector
+        // would spend an inference call to arrive at the same numbers.
+        let (app, token, core, cid) = one_chunk().await;
+
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({ "tags": ["fresh"] }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "a metadata edit queued a re-embed"
+        );
+        assert_eq!(
+            core.store.get_chunk(&cid).await.unwrap().embed_state,
+            EmbedState::Embedded,
+            "the stored vector is still correct and must stay so"
+        );
+
+        // And the vector store agrees, so a filtered search finds it.
+        let hits = core
+            .vectors
+            .search(
+                &[0.0; crate::core::test_support::TEST_DIM],
+                &Default::default(),
+                10,
+                &SearchFilter {
+                    tags: vec!["fresh".into()],
+                    category: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1, "the payload in Qdrant still says `old`");
+    }
+
+    #[tokio::test]
+    async fn editing_the_title_does_queue_a_re_embed() {
+        // The embedder is shown the title followed by the body, so a new title
+        // means the stored vector describes text that no longer exists.
+        let (app, token, core, cid) = one_chunk().await;
+
+        app.oneshot(patch_json(
+            &format!("/api/v1/chunks/{cid}"),
+            &token,
+            serde_json::json!({ "title": "a better title" }),
+        ))
+        .await
+        .unwrap();
+
+        assert!(
+            core.store.claim_job().await.unwrap().is_some(),
+            "a title change left a stale vector in place"
+        );
+        assert_eq!(
+            core.store.get_chunk(&cid).await.unwrap().embed_state,
+            EmbedState::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn editing_the_text_still_queues_a_re_embed() {
+        let (app, token, core, cid) = one_chunk().await;
+        app.oneshot(patch_json(
+            &format!("/api/v1/chunks/{cid}"),
+            &token,
+            serde_json::json!({ "text": "different body" }),
+        ))
+        .await
+        .unwrap();
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_patch_that_changes_nothing_is_rejected() {
+        let (app, token, _core, cid) = one_chunk().await;
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn an_empty_text_is_still_rejected() {
+        let (app, token, _core, cid) = one_chunk().await;
+        let res = app
+            .oneshot(patch_json(
+                &format!("/api/v1/chunks/{cid}"),
+                &token,
+                serde_json::json!({ "text": "   " }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/src/web/templates/_answer.html
+++ b/src/web/templates/_answer.html
@@ -12,7 +12,7 @@
 <div class="card">
   <div class="card-head">
     <span class="card-title">{{ r.title }}</span>
-    <span class="card-meta">{{ r.score }}</span>
+    <span class="card-meta">{{ r.rank }}</span>
   </div>
   <div class="md">{{ r.html|safe }}</div>
   <div class="chips">

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -5,7 +5,7 @@
   <div class="card">
     <div class="card-head">
       <span class="card-title">{{ r.title }}</span>
-      <span class="card-meta">{{ r.score }}</span>
+      <span class="card-meta">{{ r.rank }}</span>
     </div>
     <div class="md">{{ r.html|safe }}</div>
     <div class="chips">

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -19,7 +19,13 @@ pub struct RenderedResult {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub source_id: String,
-    pub score: String,
+    /// Position in the list, as `#1`, `#2`, …
+    ///
+    /// Not the raw score. That number is a fused rank from Qdrant plus a
+    /// recency term, so it is comparable within one result list and meaningless
+    /// between two — a hybrid query and a dense-only fallback do not even score
+    /// on the same scale. Showing it invited a comparison it cannot support.
+    pub rank: String,
 }
 
 pub struct BrowseRow {
@@ -267,19 +273,23 @@ async fn search_results(
         .await?;
 
     Ok(HtmlTemplate(ResultsTemplate {
-        results: hits.into_iter().map(render_hit).collect(),
+        results: hits
+            .into_iter()
+            .enumerate()
+            .map(|(i, h)| render_hit(i, h))
+            .collect(),
     })
     .into_response())
 }
 
-fn render_hit(h: crate::core::search::SearchResult) -> RenderedResult {
+fn render_hit(position: usize, h: crate::core::search::SearchResult) -> RenderedResult {
     RenderedResult {
         title: h.title.unwrap_or_else(|| "Untitled".into()),
         html: markdown::render(&h.text),
         category: h.category,
         tags: h.tags,
         source_id: h.source_id,
-        score: format!("{:.3}", h.score),
+        rank: format!("#{}", position + 1),
     }
 }
 
@@ -485,7 +495,12 @@ async fn ask_submit(
         // The answer is model output too, so it goes through the same
         // sanitizing renderer as chunk text.
         answer: markdown::render(&out.answer),
-        citations: out.citations.into_iter().map(render_hit).collect(),
+        citations: out
+            .citations
+            .into_iter()
+            .enumerate()
+            .map(|(i, h)| render_hit(i, h))
+            .collect(),
         dropped: out.dropped,
     })
     .into_response())

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -1003,3 +1003,121 @@ async fn editing_metadata_does_not_erase_when_a_chunk_was_last_seen() {
 
     v.drop_collection().await.unwrap();
 }
+
+#[tokio::test]
+#[ignore]
+async fn a_point_written_by_something_else_does_not_take_search_down() {
+    // A rebuild copies payloads verbatim, and nothing stops an operator from
+    // inserting their own point. Two things would otherwise turn one foreign
+    // point into a total outage: the scoring formula reads `created_at` and
+    // fails the whole query when it is missing, and the payload would not
+    // deserialize. Neither may cost the results that *are* ours.
+    let name = "engram_it_foreign_point";
+    let v = fresh(name, 4).await;
+    v.upsert(vec![point(
+        "mine",
+        "s1",
+        vec![1.0, 0.0, 0.0, 0.0],
+        &[],
+        "c",
+    )])
+    .await
+    .unwrap();
+
+    let collection = v.resolve_alias().await.unwrap().expect("no alias");
+    raw(
+        reqwest::Method::PUT,
+        &format!("/collections/{collection}/points?wait=true"),
+        Some(serde_json::json!({
+            "points": [{
+                "id": "11111111-1111-4111-8111-111111111111",
+                "vector": { "dense": [0.9, 0.1, 0.0, 0.0] },
+                "payload": { "something": "else" },
+            }],
+        })),
+    )
+    .await;
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1, "the foreign point was not skipped: {hits:?}");
+    assert_eq!(hits[0].payload.chunk_id, "mine");
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_neighbouring_collection_is_not_mistaken_for_a_generation() {
+    // `drop_collection` deletes everything the alias claims. Claiming by name
+    // prefix would make `engram_it_neighbour_vault` ours to delete.
+    let name = "engram_it_neighbour";
+    let neighbour = format!("{name}_vault");
+    let v = fresh(name, 4).await;
+    raw(
+        reqwest::Method::PUT,
+        &format!("/collections/{neighbour}"),
+        Some(serde_json::json!({ "vectors": { "size": 4, "distance": "Cosine" } })),
+    )
+    .await;
+
+    v.drop_collection().await.unwrap();
+
+    let body = raw(
+        reqwest::Method::GET,
+        &format!("/collections/{neighbour}/exists"),
+        None,
+    )
+    .await;
+    assert!(
+        body.contains("true"),
+        "a collection that merely starts the same way was deleted: {body}"
+    );
+
+    // And it is not adopted as a generation either: with no alias and no
+    // numbered generation, startup must build `_v1` rather than claim it.
+    v.ensure_collection(4).await.unwrap();
+    assert_eq!(
+        v.resolve_alias().await.unwrap().as_deref(),
+        Some(format!("{name}_v1").as_str()),
+        "the neighbour was adopted as this alias's newest generation"
+    );
+
+    v.drop_collection().await.unwrap();
+    raw(
+        reqwest::Method::DELETE,
+        &format!("/collections/{neighbour}"),
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn two_processes_starting_together_end_up_on_one_generation() {
+    // Both read no alias, both create the first generation, both write the
+    // alias. Losing that race is the outcome we wanted; failing startup over
+    // it is not.
+    let name = "engram_it_startup_race";
+    let v = QdrantVectors::connect(&cfg(name)).await.unwrap();
+    v.drop_collection().await.unwrap();
+
+    let a = QdrantVectors::connect(&cfg(name)).await.unwrap();
+    let b = QdrantVectors::connect(&cfg(name)).await.unwrap();
+    let (ra, rb) = tokio::join!(a.ensure_collection(4), b.ensure_collection(4));
+    ra.expect("first process failed to start");
+    rb.expect("second process failed to start");
+
+    assert_eq!(
+        v.resolve_alias().await.unwrap().as_deref(),
+        Some(format!("{name}_v1").as_str())
+    );
+    v.drop_collection().await.unwrap();
+}

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -1,12 +1,12 @@
 //! Integration tests against a real Qdrant.
 //!
 //! Requires a running server: `docker compose up -d` (or `podman run -d --name
-//! engram-qdrant -p 127.0.0.1:6333:6333 -p 127.0.0.1:6334:6334 qdrant/qdrant`).
+//! engram-qdrant -p 127.0.0.1:6333:6333 qdrant/qdrant`).
 //!
 //! Run with: `cargo test --test integration_qdrant -- --ignored`
 //!
 //! Override the endpoint with `ENGRAM_TEST_QDRANT`, e.g.
-//! `ENGRAM_TEST_QDRANT=http://localhost:16334`.
+//! `ENGRAM_TEST_QDRANT=http://localhost:16333`.
 
 use engram::config::VectorConfig;
 use engram::vector::{
@@ -15,15 +15,33 @@ use engram::vector::{
 
 fn cfg(collection: &str) -> VectorConfig {
     VectorConfig {
-        url: std::env::var("ENGRAM_TEST_QDRANT").unwrap_or_else(|_| "http://localhost:6334".into()),
+        url: url(),
         collection: collection.to_string(),
         api_key: None,
+        recency_weight: 0.05,
+        recency_half_life_days: 180,
+        pinned_boost: 0.15,
     }
+}
+
+fn url() -> String {
+    std::env::var("ENGRAM_TEST_QDRANT").unwrap_or_else(|_| "http://localhost:6333".into())
+}
+
+/// Raw REST, for setting up states engram itself will no longer create — such
+/// as a pre-alias collection left behind by an older deployment.
+async fn raw(method: reqwest::Method, path: &str, body: Option<serde_json::Value>) -> String {
+    let mut req = reqwest::Client::new().request(method, format!("{}{path}", url()));
+    if let Some(b) = body {
+        req = req.json(&b);
+    }
+    req.send().await.unwrap().text().await.unwrap()
 }
 
 fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPoint {
     VectorPoint {
         vector: v,
+        sparse: Default::default(),
         payload: VectorPayload {
             chunk_id: id.into(),
             source_id: src.into(),
@@ -32,6 +50,7 @@ fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPo
             category: Some(cat.into()),
             tags: tags.iter().map(|s| s.to_string()).collect(),
             created_at: 42,
+            last_seen_at: None,
         },
     }
 }
@@ -57,7 +76,12 @@ async fn upsert_search_and_payload_roundtrip() {
     .unwrap();
 
     let hits = v
-        .search(&[1.0, 0.0, 0.0, 0.0], 5, &SearchFilter::default())
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
         .await
         .unwrap();
     assert_eq!(hits[0].payload.chunk_id, "a");
@@ -91,7 +115,10 @@ async fn filtered_search_uses_payload_indexes() {
         tags: vec!["forensics".into()],
         category: None,
     };
-    let hits = v.search(&[1.0, 0.0, 0.0, 0.0], 5, &f).await.unwrap();
+    let hits = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
+        .await
+        .unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].payload.chunk_id, "a");
 
@@ -100,7 +127,9 @@ async fn filtered_search_uses_payload_indexes() {
         category: Some("concept".into()),
     };
     assert_eq!(
-        v.search(&[1.0, 0.0, 0.0, 0.0], 5, &f).await.unwrap()[0]
+        v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
+            .await
+            .unwrap()[0]
             .payload
             .chunk_id,
         "b"
@@ -137,7 +166,10 @@ async fn multiple_tags_are_an_and_not_an_or() {
         tags: vec!["linux".into(), "forensics".into()],
         category: None,
     };
-    let hits = v.search(&[1.0, 0.0, 0.0, 0.0], 5, &f).await.unwrap();
+    let hits = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
+        .await
+        .unwrap();
     assert_eq!(hits.len(), 1, "tag filter behaved as OR, not AND");
     assert_eq!(hits[0].payload.chunk_id, "both");
     v.drop_collection().await.unwrap();
@@ -155,7 +187,12 @@ async fn upsert_is_idempotent_per_chunk_id() {
         .unwrap();
 
     let hits = v
-        .search(&[0.0, 0.0, 0.0, 1.0], 5, &SearchFilter::default())
+        .search(
+            &[0.0, 0.0, 0.0, 1.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
         .await
         .unwrap();
     assert_eq!(hits.len(), 1, "re-embedding must overwrite, not duplicate");
@@ -176,7 +213,12 @@ async fn delete_by_source_removes_only_that_source() {
     v.delete_by_source("s1").await.unwrap();
 
     let hits = v
-        .search(&[1.0, 0.0, 0.0, 0.0], 5, &SearchFilter::default())
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
         .await
         .unwrap();
     assert_eq!(hits.len(), 1);
@@ -197,7 +239,12 @@ async fn delete_chunks_removes_exactly_the_listed_ids() {
     v.delete_chunks(&["a".to_string()]).await.unwrap();
 
     let hits = v
-        .search(&[1.0, 0.0, 0.0, 0.0], 5, &SearchFilter::default())
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
         .await
         .unwrap();
     assert_eq!(hits.len(), 1);
@@ -228,5 +275,731 @@ async fn ensure_collection_is_idempotent_at_the_same_dimension() {
         .unwrap();
     v.ensure_collection(4).await.unwrap();
     assert_eq!(v.count().await.unwrap(), 1, "restart dropped the vectors");
+    v.drop_collection().await.unwrap();
+}
+
+// ── Generations and aliases ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn a_new_collection_is_created_as_a_generation_behind_an_alias() {
+    let v = fresh("engram_it_alias_new", 4).await;
+    assert_eq!(
+        v.resolve_alias().await.unwrap().as_deref(),
+        Some("engram_it_alias_new_v1"),
+        "the configured name must be an alias, not the collection itself"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn reindex_copies_every_point_and_swaps_the_alias() {
+    let v = fresh("engram_it_reindex", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &["linux"], "procedure"),
+        point("b", "s1", vec![0.0, 1.0, 0.0, 0.0], &[], "concept"),
+        point("c", "s2", vec![0.0, 0.0, 1.0, 0.0], &[], "concept"),
+    ])
+    .await
+    .unwrap();
+
+    let target = v.reindex(4, false).await.unwrap();
+    assert_eq!(target, "engram_it_reindex_v2");
+    assert_eq!(
+        v.resolve_alias().await.unwrap().as_deref(),
+        Some("engram_it_reindex_v2")
+    );
+    assert_eq!(v.count().await.unwrap(), 3, "a rebuild lost points");
+
+    // Reading through the alias must land on the new generation, with the
+    // payload intact — the vectors were copied, not re-embedded.
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(hits[0].payload.chunk_id, "a");
+    assert_eq!(hits[0].payload.tags, vec!["linux".to_string()]);
+    assert_eq!(hits[0].payload.created_at, 42);
+    assert!(hits[0].score > 0.99);
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn reindex_leaves_the_previous_generation_in_place() {
+    // The old generation is the only rollback that exists. Deleting it is a
+    // decision for whoever ran the rebuild, not a side effect of running it.
+    let v = fresh("engram_it_reindex_keep", 4).await;
+    v.upsert(vec![point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c")])
+        .await
+        .unwrap();
+    v.reindex(4, false).await.unwrap();
+
+    let body = raw(
+        reqwest::Method::GET,
+        "/collections/engram_it_reindex_keep_v1/exists",
+        None,
+    )
+    .await;
+    assert!(
+        body.contains("true"),
+        "previous generation was deleted: {body}"
+    );
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_pre_alias_collection_is_refused_at_startup_then_migrated() {
+    let name = "engram_it_legacy";
+    let v = QdrantVectors::connect(&cfg(name)).await.unwrap();
+    v.drop_collection().await.unwrap();
+
+    // What an older engram left behind: a plain collection with a single
+    // unnamed vector, holding real data.
+    raw(
+        reqwest::Method::PUT,
+        &format!("/collections/{name}"),
+        Some(serde_json::json!({ "vectors": { "size": 4, "distance": "Cosine" } })),
+    )
+    .await;
+    raw(
+        reqwest::Method::PUT,
+        &format!("/collections/{name}/points?wait=true"),
+        Some(serde_json::json!({
+            "points": [ {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "vector": [1.0, 0.0, 0.0, 0.0],
+                "payload": {
+                    "chunk_id": "legacy", "source_id": "s1", "text": "text legacy",
+                    "title": "legacy", "category": "c", "tags": [], "created_at": 42
+                }
+            } ]
+        })),
+    )
+    .await;
+
+    // Starting up against it must fail loudly rather than create a second,
+    // empty home for the vectors.
+    let err = v.ensure_collection(4).await.unwrap_err().to_string();
+    assert!(err.contains("--reindex"), "unhelpful: {err}");
+
+    let target = v.reindex(4, true).await.unwrap();
+    assert_eq!(target, "engram_it_legacy_v1");
+    assert_eq!(
+        v.resolve_alias().await.unwrap().as_deref(),
+        Some("engram_it_legacy_v1")
+    );
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        hits[0].payload.chunk_id, "legacy",
+        "an unnamed vector must survive the move to named vectors"
+    );
+
+    // And the next startup is clean.
+    v.ensure_collection(4).await.unwrap();
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn reindex_refuses_when_there_is_nothing_to_rebuild() {
+    let v = QdrantVectors::connect(&cfg("engram_it_reindex_empty"))
+        .await
+        .unwrap();
+    v.drop_collection().await.unwrap();
+    let err = v.reindex(4, false).await.unwrap_err().to_string();
+    assert!(err.contains("nothing to reindex"), "{err}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn reindex_refuses_at_a_dimension_the_source_does_not_have() {
+    // Rebuilding copies vectors rather than re-embedding them, so it cannot
+    // change their width. Saying so beats writing 4-wide vectors into an
+    // 8-wide collection.
+    let v = fresh("engram_it_reindex_dim", 4).await;
+    let err = v.reindex(8, false).await.unwrap_err().to_string();
+    assert!(err.contains('4') && err.contains('8'), "unhelpful: {err}");
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_pre_alias_collection_is_never_deleted_without_being_asked() {
+    // Freeing the alias name costs the source collection, which is the only
+    // copy. Without the opt-in the rebuild must stop before creating anything.
+    let name = "engram_it_legacy_consent";
+    let v = QdrantVectors::connect(&cfg(name)).await.unwrap();
+    v.drop_collection().await.unwrap();
+    raw(
+        reqwest::Method::PUT,
+        &format!("/collections/{name}"),
+        Some(serde_json::json!({ "vectors": { "size": 4, "distance": "Cosine" } })),
+    )
+    .await;
+
+    let err = v.reindex(4, false).await.unwrap_err().to_string();
+    assert!(err.contains("--replace-legacy"), "unhelpful: {err}");
+
+    let body = raw(
+        reqwest::Method::GET,
+        &format!("/collections/{name}/exists"),
+        None,
+    )
+    .await;
+    assert!(
+        body.contains("true"),
+        "the source was deleted anyway: {body}"
+    );
+    let leftover = raw(
+        reqwest::Method::GET,
+        &format!("/collections/{name}_v1/exists"),
+        None,
+    )
+    .await;
+    assert!(
+        leftover.contains("false"),
+        "a refused rebuild left a half-built generation behind: {leftover}"
+    );
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn generations_without_an_alias_are_adopted_rather_than_duplicated() {
+    // A rebuild that dies between deleting the old collection and creating the
+    // alias leaves exactly this state. Starting up must find the vectors, not
+    // build a second empty home beside them.
+    let name = "engram_it_orphan";
+    let v = fresh(name, 4).await;
+    v.upsert(vec![point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c")])
+        .await
+        .unwrap();
+
+    raw(
+        reqwest::Method::POST,
+        "/collections/aliases",
+        Some(serde_json::json!({
+            "actions": [ { "delete_alias": { "alias_name": name } } ]
+        })),
+    )
+    .await;
+    assert!(v.resolve_alias().await.unwrap().is_none());
+
+    v.ensure_collection(4).await.unwrap();
+    assert_eq!(
+        v.resolve_alias().await.unwrap().as_deref(),
+        Some("engram_it_orphan_v1")
+    );
+    assert_eq!(v.count().await.unwrap(), 1, "adoption lost the vectors");
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn set_payload_rewrites_metadata_without_touching_the_vector() {
+    // Editing a tag must not cost an embedding call, and must not disturb the
+    // vector that makes the chunk findable in the first place.
+    let v = fresh("engram_it_set_payload", 4).await;
+    v.upsert(vec![point(
+        "a",
+        "s1",
+        vec![1.0, 0.0, 0.0, 0.0],
+        &["old"],
+        "concept",
+    )])
+    .await
+    .unwrap();
+
+    let mut updated = point("a", "s1", vec![], &["fresh", "second"], "procedure").payload;
+    updated.title = Some("a new title".into());
+    v.set_payload(&updated).await.unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].score > 0.99, "the vector was disturbed");
+    assert_eq!(
+        hits[0].payload.tags,
+        vec!["fresh".to_string(), "second".to_string()]
+    );
+    assert_eq!(hits[0].payload.category.as_deref(), Some("procedure"));
+
+    // The keyword index must see the new value, or filtered search would still
+    // answer for the old one.
+    let f = SearchFilter {
+        tags: vec!["fresh".into()],
+        category: None,
+    };
+    assert_eq!(
+        v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    let stale = SearchFilter {
+        tags: vec!["old".into()],
+        category: None,
+    };
+    assert!(
+        v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &stale)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the replaced tag is still indexed"
+    );
+
+    v.drop_collection().await.unwrap();
+}
+
+// ── Hybrid retrieval ────────────────────────────────────────────────────────
+
+/// A point whose sparse half is computed from real text, the way the embed job
+/// builds one. The dense vector is supplied separately so a test can make the
+/// semantic half deliberately unhelpful.
+fn hybrid_point(id: &str, text: &str, dense: Vec<f32>) -> VectorPoint {
+    VectorPoint {
+        vector: dense,
+        sparse: engram::vector::sparse::encode_document(text),
+        payload: VectorPayload {
+            chunk_id: id.into(),
+            source_id: "s1".into(),
+            text: text.into(),
+            title: None,
+            category: Some("c".into()),
+            tags: vec![],
+            created_at: 42,
+            last_seen_at: None,
+        },
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn an_exact_token_is_found_even_when_the_dense_vector_points_elsewhere() {
+    // The case hybrid search exists for. The dense query vector is orthogonal
+    // to the document that actually contains `E01`, so a dense-only search
+    // ranks it last. The lexical branch has to rescue it.
+    let v = fresh("engram_it_hybrid", 4).await;
+    v.upsert(vec![
+        hybrid_point(
+            "target",
+            "mounting an E01 image with ewfmount",
+            vec![0.0, 1.0, 0.0, 0.0],
+        ),
+        hybrid_point(
+            "decoy_a",
+            "configuring a printer on windows",
+            vec![1.0, 0.0, 0.0, 0.0],
+        ),
+        hybrid_point(
+            "decoy_b",
+            "resetting a password in the console",
+            vec![1.0, 0.0, 0.0, 0.0],
+        ),
+    ])
+    .await
+    .unwrap();
+
+    let dense_query = [1.0, 0.0, 0.0, 0.0];
+
+    // Dense only: the decoys win, because the query vector is theirs.
+    let dense_only = v
+        .search(
+            &dense_query,
+            &Default::default(),
+            1,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        dense_only[0].payload.chunk_id, "target",
+        "the fixture is wrong: dense search already finds it, so this proves nothing"
+    );
+
+    // Hybrid: the term rescues it.
+    let sparse = engram::vector::sparse::encode_query("E01");
+    let hybrid = v
+        .search(&dense_query, &sparse, 3, &SearchFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        hybrid[0].payload.chunk_id,
+        "target",
+        "hybrid search did not promote the exact-token match: {:?}",
+        hybrid
+            .iter()
+            .map(|h| &h.payload.chunk_id)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_filter_still_applies_to_both_halves_of_a_hybrid_query() {
+    // The filter has to be repeated per prefetch branch. If it were only on the
+    // outer query, the lexical branch would happily return excluded points.
+    let v = fresh("engram_it_hybrid_filter", 4).await;
+    let mut wanted = hybrid_point(
+        "wanted",
+        "the ext4 journal replays on mount",
+        vec![1.0, 0.0, 0.0, 0.0],
+    );
+    wanted.payload.tags = vec!["keep".into()];
+    let mut excluded = hybrid_point(
+        "excluded",
+        "the ext4 journal also replays here",
+        vec![1.0, 0.0, 0.0, 0.0],
+    );
+    excluded.payload.tags = vec!["drop".into()];
+    v.upsert(vec![wanted, excluded]).await.unwrap();
+
+    let sparse = engram::vector::sparse::encode_query("ext4 journal");
+    let f = SearchFilter {
+        tags: vec!["keep".into()],
+        category: None,
+    };
+    let hits = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 10, &f)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1, "the filter leaked on one of the branches");
+    assert_eq!(hits[0].payload.chunk_id, "wanted");
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_query_with_no_indexable_term_falls_back_to_dense_alone() {
+    // Punctuation produces no terms. Asking the lexical index to match nothing
+    // is not the same as not asking it, so the query shape has to change.
+    let v = fresh("engram_it_hybrid_empty", 4).await;
+    v.upsert(vec![hybrid_point(
+        "a",
+        "some text",
+        vec![1.0, 0.0, 0.0, 0.0],
+    )])
+    .await
+    .unwrap();
+
+    let sparse = engram::vector::sparse::encode_query("?? ...");
+    assert!(sparse.is_empty(), "the fixture must produce no terms");
+    let hits = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 5, &SearchFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert!(
+        hits[0].score > 0.99,
+        "a dense-only search still scores by cosine"
+    );
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_rebuild_adds_the_lexical_half_to_a_generation_without_it() {
+    // Sparse vectors are recomputed from the payload rather than copied, so a
+    // collection written before hybrid search gains it for free.
+    let v = fresh("engram_it_hybrid_reindex", 4).await;
+    v.upsert(vec![
+        // Written the old way: dense only, no terms.
+        point("target", "s1", vec![0.0, 1.0, 0.0, 0.0], &[], "c"),
+        point("decoy", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+    ])
+    .await
+    .unwrap();
+
+    // `point` builds its text as "text {id}", so this is the term to look for.
+    let sparse = engram::vector::sparse::encode_query("target");
+    let before = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 1, &SearchFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        before[0].payload.chunk_id, "decoy",
+        "the fixture is wrong: the term already matched before the rebuild"
+    );
+
+    v.reindex(4, false).await.unwrap();
+
+    let after = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 2, &SearchFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        after[0].payload.chunk_id, "target",
+        "the rebuild did not compute sparse vectors"
+    );
+
+    v.drop_collection().await.unwrap();
+}
+
+// ── Recency and pinning ─────────────────────────────────────────────────────
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint {
+    VectorPoint {
+        vector: dense,
+        sparse: Default::default(),
+        payload: VectorPayload {
+            chunk_id: id.into(),
+            source_id: "s1".into(),
+            text: format!("text {id}"),
+            title: None,
+            category: Some("c".into()),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            created_at: now_secs() - days_old * 86_400,
+            last_seen_at: None,
+        },
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn recency_breaks_a_tie_between_equally_relevant_chunks() {
+    let v = fresh("engram_it_recency", 4).await;
+    v.upsert(vec![
+        aged("old", vec![1.0, 0.0, 0.0, 0.0], 3650, &[]),
+        aged("new", vec![1.0, 0.0, 0.0, 0.0], 0, &[]),
+    ])
+    .await
+    .unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        hits[0].payload.chunk_id, "new",
+        "identical vectors, so only age can order them"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn recency_does_not_overturn_a_clearly_better_match() {
+    // The nudge has to stay a nudge. A note captured today must not outrank a
+    // genuinely better answer written years ago.
+    let v = fresh("engram_it_recency_bounded", 4).await;
+    v.upsert(vec![
+        aged("relevant_but_old", vec![1.0, 0.0, 0.0, 0.0], 3650, &[]),
+        aged("fresh_but_wrong", vec![0.0, 1.0, 0.0, 0.0], 0, &[]),
+    ])
+    .await
+    .unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(hits[0].payload.chunk_id, "relevant_but_old");
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_pinned_chunk_outranks_the_decay_curve() {
+    // Pinning is a decision the user made, and it has to beat the heuristic.
+    let v = fresh("engram_it_pinned", 4).await;
+    v.upsert(vec![
+        aged("pinned_old", vec![0.94, 0.34, 0.0, 0.0], 3650, &["pinned"]),
+        aged("plain_new", vec![1.0, 0.0, 0.0, 0.0], 0, &[]),
+    ])
+    .await
+    .unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        hits[0].payload.chunk_id, "pinned_old",
+        "the pinned tag did not beat a newer, slightly closer chunk"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn scoring_leaves_the_filter_alone() {
+    // The formula runs over what retrieval returned. If it were applied
+    // instead of the filter, excluded points would reappear at the top.
+    let v = fresh("engram_it_recency_filter", 4).await;
+    v.upsert(vec![
+        aged("keep", vec![1.0, 0.0, 0.0, 0.0], 3650, &["keep"]),
+        aged("drop", vec![1.0, 0.0, 0.0, 0.0], 0, &["pinned"]),
+    ])
+    .await
+    .unwrap();
+
+    let f = SearchFilter {
+        tags: vec!["keep".into()],
+        category: None,
+    };
+    let hits = v
+        .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 10, &f)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].payload.chunk_id, "keep");
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn resurface_finds_the_old_and_unseen_and_skips_everything_else() {
+    let v = fresh("engram_it_resurface", 4).await;
+    let month = 31 * 86_400;
+    v.upsert(vec![
+        aged("forgotten", vec![1.0, 0.0, 0.0, 0.0], 60, &[]),
+        aged("recent", vec![1.0, 0.0, 0.0, 0.0], 1, &[]),
+        aged("old_but_just_seen", vec![1.0, 0.0, 0.0, 0.0], 60, &[]),
+    ])
+    .await
+    .unwrap();
+    v.touch(&["old_but_just_seen".to_string()], now_secs())
+        .await
+        .unwrap();
+
+    let cutoff = now_secs() - month;
+    let out = v.resurface(10, cutoff, cutoff).await.unwrap();
+    let ids: Vec<&str> = out.iter().map(|h| h.payload.chunk_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["forgotten"],
+        "expected only the old, unseen chunk; got {ids:?}"
+    );
+
+    // Showing it counts as seeing it.
+    v.touch(&["forgotten".to_string()], now_secs())
+        .await
+        .unwrap();
+    assert!(
+        v.resurface(10, cutoff, cutoff).await.unwrap().is_empty(),
+        "a chunk shown a moment ago is not forgotten"
+    );
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn touching_a_chunk_leaves_the_rest_of_its_payload_alone() {
+    // The stamp is merged, not written as a whole payload. Getting this wrong
+    // would silently erase tags and text on every search.
+    let v = fresh("engram_it_touch_merge", 4).await;
+    v.upsert(vec![aged(
+        "a",
+        vec![1.0, 0.0, 0.0, 0.0],
+        1,
+        &["keep", "these"],
+    )])
+    .await
+    .unwrap();
+
+    v.touch(&["a".to_string()], 12_345).await.unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        hits[0].payload.tags,
+        vec!["keep".to_string(), "these".to_string()]
+    );
+    assert_eq!(hits[0].payload.text, "text a");
+    assert_eq!(hits[0].payload.last_seen_at, Some(12_345));
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn editing_metadata_does_not_erase_when_a_chunk_was_last_seen() {
+    // `set_payload` sends no stamp, and Qdrant merges, so the stored one has
+    // to survive a tag edit.
+    let v = fresh("engram_it_touch_survives", 4).await;
+    v.upsert(vec![aged("a", vec![1.0, 0.0, 0.0, 0.0], 1, &["old"])])
+        .await
+        .unwrap();
+    v.touch(&["a".to_string()], 12_345).await.unwrap();
+
+    let mut edited = aged("a", vec![], 1, &["fresh"]).payload;
+    edited.last_seen_at = None;
+    v.set_payload(&edited).await.unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(hits[0].payload.tags, vec!["fresh".to_string()]);
+    assert_eq!(
+        hits[0].payload.last_seen_at,
+        Some(12_345),
+        "a tag edit reset the last-seen stamp"
+    );
+
     v.drop_collection().await.unwrap();
 }


### PR DESCRIPTION
## Why

Qdrant was a dumb ANN index here: one collection, one unnamed dense vector, one query per search. This uses the parts that matter — and drops the gRPC requirement, which made a networked Qdrant instance unreachable entirely, since the Rust `qdrant-client` crate has no REST path for the data API.

## What changed

**Transport.** The vector backend speaks Qdrant's REST API over `reqwest`, which was already a dependency. Removes `qdrant-client`, `tonic`, `tonic-prost`, `prost` and `prost-types` with **no new crates**. `vector.url` is now a base URL; a value ending in `:6334` warns instead of failing like a network problem.

The 8 existing integration tests passed **unmodified** against the REST backend — that is the evidence the swap preserves behaviour.

**Generations behind an alias.** `vector.collection` names an alias; vectors live in `{name}_v1`, `_v2`, … `--reindex` scrolls into the next generation and swaps the alias atomically, copying dense vectors verbatim so a rebuild costs no embedding calls. The previous generation is kept — it is the only rollback there is.

Two constraints surfaced while building it:
- Qdrant refuses an alias whose name collides with an existing collection, so migrating a pre-alias collection **cannot** keep its source. That path now counts both sides and requires `--replace-legacy` before deleting anything.
- That leaves a window between the delete and the alias creation, so `ensure_collection` adopts orphaned generations rather than building a second empty home beside them.

**Batched embedding.** One job per source instead of per chunk: one inference call per 32 chunks, one upsert, `wait=true` kept so a chunk is never marked embedded before Qdrant accepted its vector. On exhausted retries the batch splits into per-chunk jobs, so one chunk the embedder rejects cannot keep its siblings out of search.

**Payload-only edits.** `PATCH /api/v1/chunks/{id}` now takes `title`, `tags`, `category`. Tags and category rewrite the Qdrant payload in place; `text` and `title` queue a re-embed, because those are what the model was shown.

**Grouping.** One source contributes at most three chunks to a result list. `ask` opts out — an answer often lives in one document, and rationing its paragraphs makes the answer worse rather than the list fairer.

**Hybrid search.** A BM25 sparse vector computed locally from the same text the embedder sees, fused with the dense branch by RRF inside Qdrant, one round trip. Dense embeddings blur exact tokens and this corpus is full of `E01`, `--dry-run`, `/etc/fstab`. Tokenisation keeps `-_./` inside terms and also emits the pieces; Qdrant's `idf` modifier supplies corpus statistics. A rebuild recomputes sparse vectors, so an older generation gains the lexical half for free.

**Decay and resurfacing.** A final scoring stage adds a small recency term plus a boost for anything tagged `pinned`. Weights are set so recency breaks a near-tie and never overturns a clearly better match — there is a test pinning that bound. Pinning is a **tag, not a column**: a filter condition works as a formula term, so it needs no migration and the existing PATCH already sets it. `GET /api/v1/resurface` returns a random sample of chunks older than a month that have not appeared in results since; every search records what it showed in one merged payload write off the request path.

## Incidental fixes

- The dimension-mismatch error pointed at `--reindex`, which copies vectors and therefore can never resolve a width change. It now names the real way forward.
- `settle_source` promoted a fallback-segmented source back to `ready`, hiding that its segmentation was degraded.

## Verification

237 unit tests and 28 integration tests pass against a real Qdrant 1.19.0. `cargo fmt --check` clean.

Behaviour claims that could not be settled from docs were probed against the running server first — formula scoring over a fusion prefetch, RRF's actual score scale (`k=1`, ~0.1–1.0), filter conditions as formula terms, and `sample: random` with a nested `should`.

## Not done

- **`clippy` was not run locally** — unavailable in this environment (no rustup, no distro package). CI is the only gate on it.
- **No retrieval-quality harness.** This changes ranking in four ways with nothing measuring whether it helped on a real corpus. The golden-query fixtures are at the tokenizer level only. Recorded as the first item in `ROADMAP.md`.
- The per-source cap is client-side, so a source whose chunks fill the entire candidate pool still crowds others out. `query/groups` would fix it properly.
- The SQLite FTS5 index and triggers are now unused — hybrid search happens in Qdrant. Either wire it up as a fallback or delete it.

## Docs

README rewritten and shortened (272 → 183 lines); prose and the security-posture section cut. Planned work moved to a new `ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRtGY4GYFAiGbL3X941Er2