### PR TITLE
Consolidation: duplicate hygiene without merging artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /config.toml
+/engram.env
 *.db
 *.db-wal
 *.db-shm

--- a/README.md
+++ b/README.md
@@ -289,6 +289,17 @@ fails outright ends the sweep's judging instead of spending the budget on an
 endpoint that is not there. Which of two contradictory artifacts is current stays
 a judgement for the reader.
 
+The model is shown both **titles**, and asked first whether the two are even
+about the same subject. Similarity measures shape, not subject: in a reference
+document the entries for FAT12, FAT16 and FAT32 are near-identical in form and
+deliberately different in content, so they pair at 0.91 and every number in them
+differs. Given only the bodies, the judge called that a contradiction — and it
+was right about the evidence it had, because synthesis writes a body that stands
+on its own within its segment without necessarily naming what it is about: the
+artifact titled `FAT32 Specifications` opens `32 Bit Clusternummern` and never
+says FAT32 again. Different named things are not in conflict however far apart
+their numbers are; that is what makes them different things.
+
 Artifacts also carry **caveats**: the conditions under which they do not apply,
 emitted by the same synthesis call that wrote them, so they cost output tokens
 rather than another call. They are stored, shown, and passed to `ask` alongside

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ effective config with secrets redacted.
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`. |
 | `infer.ask.*` | Completion model, used only by `ask`. Same timeout and reasoning keys. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
+| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `judge`, `max_judgements`. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails`. |
 | `auth.local.*` | `username` and an argon2id `password_hash`. Development only. |
@@ -187,6 +188,49 @@ Each segment is checked before its artifacts are stored.
 
 Flagged artifacts are listed on Ops with two actions: re-synthesise that one segment,
 or mark the artifact reviewed.
+
+## Duplicates, and what goes quietly out of date
+
+Two failures look identical from a result list: the same thing stored twice, and
+the same thing stored twice with one copy now wrong. Both are handled without a
+model call in the ordinary case.
+
+**At capture.** Corpora are deduplicated by an exact hash, so re-pasting a
+chapter a year later with one changed byte used to store it twice, and the two
+copies then competed for the same queries. A shingle signature over the raw text
+catches that: the capture is stored verbatim like any other, and parked in
+`needs_review` rather than segmented. Ops offers three answers — replace the
+older corpus, keep both, or discard this one — and until one is chosen, no model
+call has been spent on it.
+
+**Afterwards.** A sweep asks Qdrant for near pairs across the collection, one
+round trip, on a timer. At or above `auto_supersede` the older artifact is marked
+`superseded_by` the newer and hidden from results; it is still stored, still
+readable by link, and Ops has a button that puts it back. Near-identical
+artifacts are clustered before a winner is picked, so a run of three collapses
+onto one survivor rather than forming a chain that points at something hidden.
+Between `review_min` and that, the pair goes on a queue instead, because two
+genuinely distinct artifacts about one subsystem sit around 0.88 and hiding at
+that score would cost knowledge rather than duplication.
+
+**Nothing is ever merged.** A merged artifact is synthetic text standing where a
+stored passage used to be, with no segment to verify it against and no corpus
+lines to render beside it. Consolidation only ever hides, flags, or asks.
+
+**The judge**, off by default, is the one part that costs inference. Queued pairs
+are first filtered on fact-shaped tokens — versions, numbers, dates — and only a
+pair where both sides state values and the values differ reaches the model,
+which is asked one yes/no question under a per-sweep budget. A reply that cannot
+be read leaves the pair pending rather than closing it: a dead endpoint must
+never look like a clean bill of health. Which of two contradictory artifacts is
+current stays a judgement for the reader.
+
+Artifacts also carry **caveats**: the conditions under which they do not apply,
+emitted by the same synthesis call that wrote them, so they cost output tokens
+rather than another call. They are stored and shown, and deliberately not part
+of what gets embedded — changing what every vector is built from is a decision
+for the evaluation harness, not a hunch. The literal check runs over them too,
+so a command invented in a caveat is flagged like any other.
 
 ## How search works
 

--- a/README.md
+++ b/README.md
@@ -229,19 +229,28 @@ stored passage used to be, with no segment to verify it against and no corpus
 lines to render beside it. Consolidation only ever hides, flags, or asks.
 
 **The judge**, off by default, is the one part that costs inference. Queued pairs
-are first filtered on fact-shaped tokens — versions, numbers, dates — and only a
-pair where both sides state values and the values differ reaches the model,
-which is asked one yes/no question under a per-sweep budget. A reply that cannot
-be read leaves the pair pending rather than closing it: a dead endpoint must
-never look like a clean bill of health. Which of two contradictory artifacts is
-current stays a judgement for the reader.
+are first filtered on fact-shaped tokens — versions, numbers, dates, and numbers
+carrying a unit or a separator, so `v1.21.4`, `30s` and `8080/tcp` count as
+values rather than words — and only a pair where both sides state values and the
+values differ reaches the model, which is asked one yes/no question under a
+per-sweep budget. A reply that cannot be read leaves the pair pending rather than
+closing it: a dead endpoint must never look like a clean bill of health. That
+pair then goes to the back of the queue, so one the model keeps failing on cannot
+absorb every sweep's budget while the rest is never reached, and a call that
+fails outright ends the sweep's judging instead of spending the budget on an
+endpoint that is not there. Which of two contradictory artifacts is current stays
+a judgement for the reader.
 
 Artifacts also carry **caveats**: the conditions under which they do not apply,
 emitted by the same synthesis call that wrote them, so they cost output tokens
-rather than another call. They are stored and shown, and deliberately not part
+rather than another call. They are stored, shown, and passed to `ask` alongside
+the excerpt they qualify — an answer that quotes a destructive command without
+the condition attached is worse than no answer. They are deliberately not part
 of what gets embedded — changing what every vector is built from is a decision
 for the evaluation harness, not a hunch. The literal check runs over them too,
-so a command invented in a caveat is flagged like any other.
+so a command invented in a caveat is flagged like any other; that flag is a
+warning for the reader rather than grounds for re-synthesising the whole segment,
+which is the most expensive thing here.
 
 ## How search works
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,19 @@ Each segment is checked before its artifacts are stored.
   omit `corpus_lines` more often than not; when that happens the span is
   recovered by finding the artifact's own verbatim lines in the segment, and only a
   span the model actually asserted is ever doubted.
-- **Coverage.** The fraction of a corpus's lines that ended up inside some
-  artifact is recorded and shown on Browse. Below 60% it reads as a warning — a
+- **Coverage.** The fraction of a corpus's lines whose content reached some
+  artifact, recorded and shown on Browse. Below 60% it reads as a warning — a
   corpus where synthesis dropped half a chapter used to look identical to
-  one where it did not.
+  one where it did not. A line counts when half its distinctive tokens appear
+  in the artifacts made from its segment, so a line that was rewritten still
+  counts and a line inside a segment that failed does not. Asking instead
+  which lines an artifact *claimed* — the obvious measure, and the one this
+  replaced — answers a different question: the model omits `corpus_lines` more
+  often than not, and a span recovered by matching verbatim text finds only
+  the part of an artifact that was not rewritten, so a faithful chapter scored
+  like a missing one. Coverage is computed when a corpus finishes segmenting;
+  `--recompute-coverage` re-measures every corpus from the artifacts already
+  stored, which costs no inference and re-synthesises nothing.
 
 Flagged artifacts are listed on Ops with two actions: re-synthesise that one segment,
 or mark the artifact reviewed.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,18 @@ artifacts are clustered before a winner is picked, so a run of three collapses
 onto one survivor rather than forming a chain that points at something hidden.
 Between `review_min` and that, the pair goes on a queue instead, because two
 genuinely distinct artifacts about one subsystem sit around 0.88 and hiding at
-that score would cost knowledge rather than duplication.
+that score would cost knowledge rather than duplication. `auto_supersede` at or
+below `review_min` would hide everything the sweep finds with no review band at
+all, so engram refuses to start on it rather than letting search quietly thin
+out for weeks.
+
+**Hiding is reversible, including by accident.** The row and the vector payload
+cannot be written together, so each sweep re-applies any flag whose payload
+write was lost, and each undo clears the payload before the row — leaving, in
+both directions, a state Ops still lists and one more press finishes. Deleting
+or reprocessing the surviving artifact frees whatever it hid: an artifact
+pointing at a keeper that no longer exists would otherwise be the last copy of
+that text, hidden from search in favour of nothing.
 
 **Nothing is ever merged.** A merged artifact is synthetic text standing where a
 stored passage used to be, with no segment to verify it against and no corpus

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ cargo run
 
 Open <http://127.0.0.1:8080/auth/login>, capture something, and watch it move
 through `raw → synthesizing → embedding → ready` on Browse. `partial` means some
-artifacts failed to embed; the Ops screen lists the failures with a retry button.
+of it has not come through yet; the Ops screen says what is retrying and when,
+and nothing there needs you.
 
 ## Configuration
 
@@ -174,13 +175,20 @@ Each segment is checked before its artifacts are stored.
   is synthesised once more; failing that, the artifact is stored with a flag naming
   the literal that went missing. A paraphrased command is a command that later
   gets pasted into a root shell, and losing the chapter to protect against that
-  would be worse than a warning the reader can see.
-- **Spans.** An artifact's claimed `corpus_lines` are clamped to its own segment and
-  checked for plausible overlap with the lines they name. The detail pane
-  renders those lines beside the artifact, so a wrong span is not cosmetic. Models
-  omit `corpus_lines` more often than not; when that happens the span is
-  recovered by finding the artifact's own verbatim lines in the segment, and only a
-  span the model actually asserted is ever doubted.
+  would be worse than a warning the reader can see. A label the model put in
+  front of something verbatim — `Binär: 0010 1001` for a source that says
+  `wird binär 0010 1001` — is not a missing literal: the digits are what
+  someone retypes, and reporting the formatting buries the real misses. A
+  colon *and a space* mark a label, so `backup:/etc/fstab` keeps its host.
+- **Spans.** The lines an artifact came from are found by matching its own text
+  against the segment, whitespace normalised, with the source's line breaks
+  taken out — a handout hard-wrapped at eighty columns and reflowed by synthesis
+  still resolves to the lines it was made from. The model is asked for
+  `corpus_lines` and its answer is used only when nothing matches at all;
+  failing that, the span is the segment. The detail pane renders those lines
+  beside the artifact, so a wrong span is not cosmetic — but it is a number
+  engram computes, not a claim to adjudicate, so there is nothing here to flag
+  and nobody to ask.
 - **Coverage.** The fraction of a corpus's lines whose content reached some
   artifact, recorded and shown on Browse. Below 60% it reads as a warning — a
   corpus where synthesis dropped half a chapter used to look identical to
@@ -195,8 +203,29 @@ Each segment is checked before its artifacts are stored.
   `--recompute-coverage` re-measures every corpus from the artifacts already
   stored, which costs no inference and re-synthesises nothing.
 
-Flagged artifacts are listed on Ops with two actions: re-synthesise that one segment,
-or mark the artifact reviewed.
+A flagged artifact says so on its own page, beside the source lines it came
+from, with a button to mark the warning noise. It is not a queue: it concerns
+one artifact and speaks to whoever reads it.
+
+## Nothing is terminal
+
+A job that fails is delayed, never abandoned. Backoff doubles from two seconds
+to a six-hour ceiling and keeps going, because the failure engram actually meets
+is an endpoint that loads a model on demand and takes ten minutes to answer —
+against which five attempts inside one minute is not patience, it is a way to
+lose a quarter of a document to a delay nobody sees. A segment marked `failed`
+records what went wrong last time, not a verdict on the text, and the next run
+picks it up.
+
+A **reconciliation sweep** runs at the head of each consolidation pass and
+queues anything left unfinished: a segment that is not done, an artifact with no
+vector. It is not the retry mechanism — every stage retries itself — it is for
+what no retry covers, like a job completed while its work was not. Without it,
+"repairs itself" would hold only for the failures engram happened to be watching
+at the time.
+
+So Ops has no failed jobs and no re-synthesise buttons. It says what is retrying
+and when it next runs, and the answer to all of it is to do nothing.
 
 ## Duplicates, and what goes quietly out of date
 
@@ -218,12 +247,22 @@ round trip, on a timer. At or above `auto_supersede` the older artifact is marke
 readable by link, and Ops has a button that puts it back. Near-identical
 artifacts are clustered before a winner is picked, so a run of three collapses
 onto one survivor rather than forming a chain that points at something hidden.
-Between `review_min` and that, the pair goes on a queue instead, because two
-genuinely distinct artifacts about one subsystem sit around 0.88 and hiding at
-that score would cost knowledge rather than duplication. `auto_supersede` at or
-below `review_min` would hide everything the sweep finds with no review band at
-all, so engram refuses to start on it rather than letting search quietly thin
-out for weeks.
+Between `review_min` and that, the pair is *not* hidden, because two genuinely
+distinct artifacts about one subsystem sit around 0.88 and hiding at that score
+would cost knowledge rather than duplication. `auto_supersede` at or below
+`review_min` would hide everything the sweep finds with no review band at all,
+so engram refuses to start on it rather than letting search quietly thin out for
+weeks.
+
+What happens in that band instead is decided without asking, wherever there is
+nothing to ask about. A pair whose fact-shaped tokens — versions, numbers, dates
+— say nothing differently has no question in it, so it is filed as settled and
+both artifacts stay exactly where they are; closing a question is not hiding an
+answer. Only a pair that states some value two ways reaches the queue, and only
+that pair is worth a person. One case in the band *is* hidden: an artifact whose
+text is wholly contained in another **from the same corpus**, which is one
+synthesis call emitting the same passage twice rather than two sources — the
+survivor says everything the hidden one said, and Ops lists it with an undo.
 
 **Hiding is reversible, including by accident.** The row and the vector payload
 cannot be written together, so each sweep re-applies any flag whose payload

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,25 +80,36 @@ to the query path.
   query path nothing. Needs the per-corpus cap and grouping to work on artifact
   identity rather than point identity, and wants eval pairs written first —
   this is the change most likely to look good and rank worse.
-- **Near-duplicate detection on capture.** Corpora are deduplicated by an exact
-  hash of the raw text, so re-pasting the same chapter a year later with one
-  changed byte stores it twice, and the two copies then compete for the same
-  queries. The distance-matrix API is the cheap way to catch this at capture
-  time and offer to replace rather than add.
-- **Consolidation and staleness sweep.** Near-duplicate detection catches the
-  collision at capture; nothing catches the pair that drifts apart afterwards.
-  A background sweep over the distance matrix flags two kinds of pair: near
-  identical, where the older one should be superseded rather than left to
-  compete, and same subject with a detail that disagrees — two artifacts giving
-  a different number, date, name or step for the same thing. The second is the
-  one that matters: much of what is worth keeping goes quietly out of date
-  within a year, and staleness is invisible today because a wrong artifact
-  ranks exactly as well as a right one. Flag, never delete: `superseded_by` on
-  the artifact row, a filter that hides superseded artifacts from search by
-  default, and a review queue on Ops. Deciding which of two contradictory
-  artifacts is current is a judgement the reader has to make.
-  `VectorStore::neighbours` is the query this is built from — one artifact at a
-  time today, batched over the collection for a sweep.
+- ~~**Near-duplicate detection on capture.**~~ Done — a bottom-k MinHash over
+  word shingles (`src/store/shingle.rs`) is computed at capture and compared
+  against every stored corpus. Above `consolidate.near_dupe_min` the capture is
+  stored verbatim and parked in `needs_review` rather than segmented, and Ops
+  offers replace / keep both / discard. Shingles rather than the distance-matrix
+  API as originally sketched: the collision is between *corpora*, which have no
+  vectors until synthesis has already been paid for, and a hash of the raw text
+  answers it before any of that is spent.
+- ~~**Consolidation and staleness sweep.**~~ Done — `Stage::Consolidate`
+  (`src/jobs/consolidate.rs`) runs on a timer, asks Qdrant's distance-matrix
+  API for near pairs in one round trip (`VectorStore::near_pairs`), and splits
+  them at two thresholds. At or above `auto_supersede` (0.95) the cluster
+  collapses onto its newest member: `superseded_by` on the losing rows, a
+  `superseded` payload flag that `SearchFilter` excludes by default, and an undo
+  on Ops. Clustered rather than resolved pairwise, or A loses to B and B then
+  loses to C, leaving A pointing at something hidden. Between `review_min`
+  (0.88) and that, the pair goes on the `artifact_pairs` queue instead — 0.88 is
+  where two genuinely distinct artifacts about one subsystem routinely sit.
+  The staleness half is the opt-in `consolidate.judge`: queued pairs are
+  filtered on fact-shaped tokens (`src/infer/facts.rs`) with no inference at
+  all, and only a pair whose values actually differ reaches the model, which is
+  asked one yes/no question under a per-sweep budget. Nothing is ever merged or
+  deleted, and which of two contradictory artifacts is current stays the
+  reader's judgement.
+- **Caveats on artifacts.** Done as part of the above, and worth naming
+  separately: the synthesis call now also returns the conditions under which an
+  artifact does not apply. It costs output tokens on a call already being made,
+  never another call. Stored and rendered, deliberately *not* embedded — see the
+  speculative query index below for why anything that changes what every vector
+  is built from waits for eval pairs.
 - **Corpus map.** The distance-matrix API gives pairwise distances over a
   filtered subset — the same call the two items above need, plus a real
   rendering of the neighbour graph the logo depicts.

--- a/config.example.toml
+++ b/config.example.toml
@@ -125,7 +125,7 @@ mode = "local"
 username = "dev"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$REPLACE_ME$REPLACE_ME"
 
-# Production. The allowlist is mandatory: leaving both lists empty denies
+# Production. The allowlist is mandatory: leaving all three lists empty denies
 # everyone rather than admitting every account your identity provider knows.
 # [auth.oidc]
 # issuer_url = "https://idp.example/realms/main"
@@ -135,6 +135,11 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$REPLACE_ME$REPLACE_ME"
 # scopes = ["openid", "profile", "email"]
 # allowed_subs = ["sub-abc123"]
 # allowed_emails = ["you@example.com"]
+# Membership in any of these groups also admits a subject. Requires the
+# provider to actually send a `groups` claim — on Nextcloud's OIDC provider
+# app that means turning on group provisioning for this client; a request
+# `scope` entry alone does not produce it.
+# allowed_groups = ["engram-users"]
 
 # Duplicate hygiene. Nothing here ever rewrites an artifact or deletes one on a
 # similarity score: it hides, flags, or asks.

--- a/config.example.toml
+++ b/config.example.toml
@@ -135,3 +135,31 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$REPLACE_ME$REPLACE_ME"
 # scopes = ["openid", "profile", "email"]
 # allowed_subs = ["sub-abc123"]
 # allowed_emails = ["you@example.com"]
+
+# Duplicate hygiene. Nothing here ever rewrites an artifact or deletes one on a
+# similarity score: it hides, flags, or asks.
+[consolidate]
+# The background sweep. Capture-time near-duplicate detection is separate and
+# always on: it costs a hash of the text, not a query.
+enabled = true
+# Estimated overlap of word shingles above which a new capture is parked as a
+# near-duplicate of an existing corpus rather than segmented. It is stored
+# either way; parking only withholds the model call until you decide on Ops.
+near_dupe_min = 0.90
+# Cosine at or above which a pair of artifacts goes on the review queue.
+review_min = 0.88
+# Cosine at or above which the older artifact is hidden without asking. Well
+# clear of `review_min` on purpose: two genuinely distinct artifacts about one
+# subsystem sit around 0.88 routinely, and hiding at that score costs knowledge
+# rather than duplication. Ops lists what was hidden, with an undo.
+auto_supersede = 0.95
+# Points drawn per sweep, and neighbours considered per point. The sweep is one
+# round trip whose cost these two numbers bound, rather than a query per point.
+sample = 2000
+per_point = 5
+interval_hours = 24
+# Ask the completion model whether a queued pair actually disagrees. Off by
+# default: it is the only part of consolidation that costs inference, and it
+# only ever sees pairs whose numbers, versions or dates already differ.
+judge = false
+max_judgements = 20

--- a/docs/superpowers/plans/2026-08-10-autonomous-ingestion.md
+++ b/docs/superpowers/plans/2026-08-10-autonomous-ingestion.md
@@ -1,0 +1,904 @@
+# Autonomous Ingestion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make engram repair its own ingestion — retry forever, derive spans itself, stop reporting formatting as invention, and close duplicate pairs that have nothing to disagree about — so the only thing left for a person is a real contradiction.
+
+**Architecture:** Six independent changes over the existing job runner, verification module, and consolidation sweep. Retry stops being terminal and gains a reconciliation sweep that re-arms orphaned work. Span derivation moves from "check the model's claim, flag the mismatch" to "compute it locally, use the claim only as a fallback". The literal check learns that a `Word:` label is not part of the literal. The consolidation sweep closes fact-free pairs itself. Ops is rewritten to report state rather than offer chores.
+
+**Tech Stack:** Rust 1.94+, sqlx/SQLite, axum, askama templates, tokio. Tests are `#[tokio::test]` against `Store::memory()` and the fakes in `src/infer/fake.rs` and `src/vector/memory.rs`; no containers.
+
+## Global Constraints
+
+- Design source: `docs/superpowers/specs/2026-08-10-autonomous-ingestion-design.md`.
+- Nothing may delete or rewrite artifact text. Consolidation hides, flags, or asks — never merges.
+- `auto_supersede` is not lowered. Auto-hiding below it is added for exactly one case: containment within the same corpus.
+- Every change must keep `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
+- Comments explain *why*, in the voice of the surrounding code. No comment that restates the line below it.
+- No migration shims for existing rows: the development base can be recomputed. Schema changes go in a new `migrations/00NN_*.sql`.
+- Run `cargo test` before every commit; commit messages are lowercase `type: summary` with a body explaining the failure being fixed.
+
+---
+
+### Task 1: Retry stops being terminal
+
+**Files:**
+- Modify: `src/store/jobs.rs:5` (`MAX_ATTEMPTS`), `:59` (`backoff_secs`), `:123` (`fail_job`)
+- Test: `src/store/jobs.rs` (tests module at the end of the file)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `backoff_secs(attempts: i64) -> i64` capped at 21600; `Store::fail_job(&self, id: i64, attempts: i64, err: &str) -> Result<()>` which never sets `state = 'failed'`.
+
+- [ ] **Step 1: Write the failing test**
+
+In the `mod tests` block at the bottom of `src/store/jobs.rs`:
+
+```rust
+    #[test]
+    fn backoff_climbs_to_hours_and_stops_there() {
+        // An endpoint that is down stays down for minutes; one that is loading
+        // a model takes ten. Retrying for a minute and giving up loses the work
+        // to a delay the operator never sees.
+        assert_eq!(backoff_secs(1), 2);
+        assert_eq!(backoff_secs(5), 32);
+        assert_eq!(backoff_secs(20), 21_600);
+        assert_eq!(backoff_secs(1_000), 21_600);
+    }
+
+    #[tokio::test]
+    async fn a_job_out_of_attempts_waits_rather_than_failing() {
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::Embed, "artifact", "a1").await.unwrap();
+        let job = s.claim_job().await.unwrap().unwrap();
+        s.fail_job(job.id, MAX_ATTEMPTS + 10, "endpoint down")
+            .await
+            .unwrap();
+        assert!(
+            s.failed_jobs(10).await.unwrap().is_empty(),
+            "a job was abandoned; nothing would ever pick it up again"
+        );
+        let state: String = sqlx::query_scalar("SELECT state FROM jobs WHERE id = ?")
+            .bind(job.id)
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(state, "pending");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib store::jobs`
+Expected: FAIL — `backoff_secs(20)` returns 300, and `failed_jobs` returns one row.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `backoff_secs` and the head of `fail_job` in `src/store/jobs.rs`:
+
+```rust
+/// 2s, 4s, 8s … doubling to a six-hour ceiling, and never stopping.
+///
+/// The old ceiling was five minutes and the old caller gave up after five
+/// attempts, which is one minute of patience in total. An inference endpoint
+/// that loads a model on demand takes ten, so the entire budget was spent
+/// before the endpoint had finished starting, and the work was lost until a
+/// person noticed and pressed a button.
+pub fn backoff_secs(attempts: i64) -> i64 {
+    let exp = attempts.clamp(1, 16) as u32;
+    2i64.saturating_pow(exp).min(21_600)
+}
+```
+
+```rust
+    /// Put a job back in the queue with a delay. There is no terminal state:
+    /// `attempts` past `MAX_ATTEMPTS` only means the delay has reached its
+    /// ceiling, so an endpoint down for a weekend costs nothing and heals when
+    /// it returns.
+    pub async fn fail_job(&self, id: i64, attempts: i64, err: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE jobs SET state = 'pending', last_error = ?, run_after = ? WHERE id = ?",
+        )
+        .bind(err)
+        .bind(now() + backoff_secs(attempts))
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+```
+
+Keep `MAX_ATTEMPTS = 5`: it still marks where behaviour changes (see Task 2), it no longer means abandonment. Update its doc comment to say so.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib store::jobs`
+Expected: PASS. Then `cargo test` — fix any test that asserted a job reaches `failed`; the correct new assertion is that it stays pending with a `run_after` in the future.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/jobs.rs
+git commit -m "fix: a job that runs out of attempts was abandoned, not delayed"
+```
+
+---
+
+### Task 2: A failed segment is retried, not parked
+
+**Files:**
+- Modify: `src/jobs/mod.rs:52-80` (the `Stage::Synthesize` exhausted arm), `src/jobs/synthesize.rs:355` (`fail_pending_segments`)
+- Test: `src/jobs/synthesize.rs` (tests module)
+
+**Interfaces:**
+- Consumes: `Store::fail_job` from Task 1.
+- Produces: `synthesize::fail_pending_segments` unchanged in signature; `SegmentState::Failed` now means "last attempt failed, will be tried again", set alongside a re-enqueued job.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/jobs/synthesize.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn a_segment_the_endpoint_refused_is_queued_again() {
+        // The failure that lost a quarter of a document: the model was loading
+        // and returned 502 for ten minutes, the job spent five attempts in the
+        // first minute, and nothing ever tried the segment again.
+        let core = test_core_with_failing_synthesizer().await;
+        let src = core
+            .store
+            .insert_corpus(&"line\n".repeat(400), "web", None)
+            .await
+            .unwrap();
+        core.store
+            .enqueue(Stage::Synthesize, "corpus", &src.id)
+            .await
+            .unwrap();
+        for _ in 0..=MAX_ATTEMPTS + 1 {
+            crate::jobs::run_next(&core).await.unwrap();
+        }
+        assert!(
+            core.store.failed_jobs(10).await.unwrap().is_empty(),
+            "the corpus was abandoned"
+        );
+        let jobs = core.store.job_counts().await.unwrap();
+        assert!(
+            jobs.iter().any(|(state, n)| state == "pending" && *n > 0),
+            "no job is left to retry the segment: {jobs:?}"
+        );
+    }
+```
+
+Check the exact helper names before writing: `test_core_with_failing_synthesizer` is in `src/core/mod.rs:120`, `run_next` is the loop body in `src/jobs/mod.rs` — use whatever that function is actually called, and `job_counts` is the method behind the Ops queue row.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib jobs::synthesize::tests::a_segment_the_endpoint_refused_is_queued_again`
+Expected: FAIL — no pending job remains, because the exhausted arm calls `complete_job` and only re-enqueues when *untried* windows exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/jobs/mod.rs`, the `(Stage::Synthesize, _) if exhausted` arm: after `fail_pending_segments` returns, always re-enqueue, not only when `requeue` is true:
+
+```rust
+                (Stage::Synthesize, _) if exhausted => {
+                    tracing::warn!(error = %e, "segmentation is not getting through; backing off");
+                    match synthesize::fail_pending_segments(core, &job.target_id, &e.to_string())
+                        .await
+                    {
+                        Ok(_) => {
+                            core.store.complete_job(job.id).await?;
+                            // Always, not only when a window went untried. A
+                            // segment the endpoint refused is not a verdict on
+                            // the text — the endpoint was loading a model, or
+                            // the machine was asleep — and the next attempt is
+                            // hours away rather than seconds.
+                            core.store
+                                .enqueue(Stage::Synthesize, "corpus", &job.target_id)
+                                .await?;
+                        }
+                        Err(fe) => {
+                            core.store
+                                .fail_job(job.id, job.attempts, &fe.to_string())
+                                .await?;
+                        }
+                    }
+                }
+```
+
+`enqueue` is `INSERT … ON CONFLICT` re-arming with `attempts = 0`, so add a `run_after` to that path or the retry is immediate: extend `Store::enqueue` with a sibling `enqueue_after(stage, kind, id, delay_secs)` and call it with `backoff_secs(job.attempts)` here.
+
+In `src/jobs/synthesize.rs:355`, change the doc comment of `fail_pending_segments`: `SegmentState::Failed` now records the last error for display and does not mean the segment is finished with.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib jobs::`
+Expected: PASS, including the existing tests around `fail_pending_segments`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/mod.rs src/jobs/synthesize.rs src/store/jobs.rs
+git commit -m "fix: a segment the endpoint refused was never tried again"
+```
+
+---
+
+### Task 3: A reconciliation sweep re-arms orphaned work
+
+**Files:**
+- Create: `src/jobs/reconcile.rs`
+- Modify: `src/jobs/mod.rs` (add `pub mod reconcile;`), `src/jobs/consolidate.rs:74` (call it at the head of `run`)
+- Test: `src/jobs/reconcile.rs` (tests module)
+
+**Interfaces:**
+- Consumes: `Store::segments_for_corpus`, `Store::pending_artifacts_for_corpus`, `Store::enqueue`, `Store::list_corpora`.
+- Produces: `pub async fn run(core: &Core) -> Result<usize>` — returns how many jobs it re-armed.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+
+    #[tokio::test]
+    async fn a_corpus_with_an_unfinished_segment_and_no_job_gets_one() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[(1, 10), (11, 20)])
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        // Segment 1 never ran and nothing is queued: the crack this closes.
+        assert_eq!(run(&core).await.unwrap(), 1);
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_finished_corpus_is_left_alone() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store.upsert_segments(&src.id, &[(1, 10)]).await.unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        assert_eq!(run(&core).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn the_sweep_does_not_pile_up_jobs_across_runs() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store.upsert_segments(&src.id, &[(1, 10)]).await.unwrap();
+        run(&core).await.unwrap();
+        run(&core).await.unwrap();
+        core.store.claim_job().await.unwrap().expect("one job");
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "the sweep queued the same work twice"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib jobs::reconcile`
+Expected: FAIL to compile — `src/jobs/reconcile.rs` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+//! The heartbeat: pick up anything that was left unfinished.
+//!
+//! Every stage already retries its own job. This exists for the case no retry
+//! covers — a job that was completed while its work was not, a process killed
+//! between two writes, a corpus whose segments were queued by a build that had
+//! a bug in it. Without it, "the system repairs itself" holds only for
+//! failures the system was watching at the time.
+//!
+//! It is cheap and idempotent: `enqueue` is keyed by (stage, target), so
+//! re-arming something already queued changes nothing.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::jobs::Stage;
+use crate::store::segments::SegmentState;
+
+pub async fn run(core: &Core) -> Result<usize> {
+    let mut armed = 0;
+    let mut offset = 0;
+    loop {
+        let page = core.store.list_corpora(100, offset).await?;
+        if page.is_empty() {
+            break;
+        }
+        for c in &page {
+            let segments = core.store.segments_for_corpus(&c.id).await?;
+            if segments.iter().any(|w| w.state != SegmentState::Done) {
+                core.store.enqueue(Stage::Synthesize, "corpus", &c.id).await?;
+                armed += 1;
+                continue;
+            }
+            if !core.store.pending_artifacts_for_corpus(&c.id).await?.is_empty() {
+                core.store.enqueue(Stage::Embed, "corpus", &c.id).await?;
+                armed += 1;
+            }
+        }
+        offset += page.len() as i64;
+    }
+    if armed > 0 {
+        tracing::info!(armed, "reconciliation queued unfinished work");
+    }
+    Ok(armed)
+}
+```
+
+Then in `src/jobs/consolidate.rs`, at the top of `run` and before `heal_dangling_supersessions`:
+
+```rust
+    // Before looking for duplicates, finish what was started: a sweep that
+    // consolidates a half-ingested corpus is judging an incomplete base.
+    crate::jobs::reconcile::run(core).await?;
+```
+
+Note the counting subtlety for `the_sweep_does_not_pile_up_jobs_across_runs`: `enqueue` is idempotent per (stage, target), so the second run re-arms the same row rather than adding one. `armed` counts intent, not rows; the test asserts on the queue, not the count.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib jobs::reconcile` then `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/reconcile.rs src/jobs/mod.rs src/jobs/consolidate.rs
+git commit -m "feat: a sweep that picks up whatever was left unfinished"
+```
+
+---
+
+### Task 4: Spans are derived, and the flag is gone
+
+**Files:**
+- Modify: `src/jobs/synthesize.rs:72-120` (span resolution), `:186` (`paraphrased`), `:206-240` (`flag_unverified`), `src/infer/verify.rs:153` (`FLAG_SPAN`)
+- Modify: `src/web/ui.rs` (drop the span rows from the flagged list — see Task 6)
+- Test: `src/jobs/synthesize.rs` tests
+
+**Interfaces:**
+- Consumes: `verify::locate_span(artifact_text, segment_body, segment_start) -> Option<(i64, i64)>`.
+- Produces: `SpanOrigin` reduced to `Derived | Model | Segment`; `flag_unverified` no longer takes `spans: &[SpanOrigin]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn a_span_is_derived_rather_than_adjudicated() {
+        // The model's corpus_lines used to be checked, disbelieved, and turned
+        // into a review task carrying a button that spends a model call. The
+        // span is computable from stored text, so it is computed.
+        let core = test_core().await;
+        let src = core
+            .store
+            .insert_corpus("alpha line one\nbeta line two\ngamma line three", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .enqueue(Stage::Synthesize, "corpus", &src.id)
+            .await
+            .unwrap();
+        run(&core, &src.id).await.unwrap();
+
+        for c in core.store.artifacts_for_corpus(&src.id).await.unwrap() {
+            assert!(
+                !c.flags.iter().any(|f| f == "span_unverified"),
+                "a derived span produced a review task: {:?}",
+                c.flags
+            );
+        }
+    }
+```
+
+The default `FakeSynthesizer` returns artifacts whose text is the window's own lines, so derivation succeeds; check `src/infer/fake.rs` for what it emits before asserting on span values.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib jobs::synthesize`
+Expected: PASS or FAIL depending on the fake — if it passes, make it meaningful by seeding a `ProposedArtifact` with a deliberately wrong `corpus_lines` through `FakeSynthesizer`, and assert no flag is produced.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/jobs/synthesize.rs`, replace the span block:
+
+```rust
+        // The span is ours to compute. Asking the model for `corpus_lines` and
+        // then checking the answer produced a third outcome — a claim that
+        // failed the check — which became a flag on the artifact and a button
+        // offering to re-synthesise a whole segment over a line number. Since
+        // `locate_span` can find an artifact's own text even where the source
+        // is hard-wrapped and synthesis reflowed it, the claim is worth only
+        // what it is: a hint for the case where nothing matches.
+        for c in &mut chunks {
+            let derived = crate::infer::verify::locate_span(&c.text, &text, w.start_line);
+            let hinted = c
+                .corpus_lines
+                .map(|(a, b)| (a + w.start_line - 1, b + w.start_line - 1));
+            let span = derived
+                .or(hinted)
+                .unwrap_or((w.start_line, w.end_line));
+            let clamped = (
+                span.0.clamp(w.start_line, w.end_line),
+                span.1.clamp(w.start_line, w.end_line),
+            );
+            c.corpus_lines = Some(if clamped.0 <= clamped.1 {
+                clamped
+            } else {
+                (w.start_line, w.end_line)
+            });
+        }
+```
+
+Delete `enum SpanOrigin` and its uses, drop the `spans` parameter from `flag_unverified`, and delete the `FLAG_SPAN` branch inside it. In `src/infer/verify.rs`, delete `pub const FLAG_SPAN` and any test naming it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS. Tests asserting a `span_unverified` flag must be deleted, not weakened — the behaviour is gone on purpose.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/synthesize.rs src/infer/verify.rs
+git commit -m "fix: a line number engram can compute was a review task"
+```
+
+---
+
+### Task 5: A label is not an invented command
+
+**Files:**
+- Modify: `src/infer/verify.rs:94` (`missing_literals`)
+- Test: `src/infer/verify.rs` tests
+
+**Interfaces:**
+- Consumes: `extract_literals`.
+- Produces: `missing_literals` unchanged in signature.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_label_the_model_added_is_not_a_missing_literal() {
+        // Line 635 of the source read "wird binär 0010 1001 1111 1001". The
+        // model fenced the digits and wrote "Binär:" in front of them, and the
+        // check reported an invented command — which is a review task about
+        // formatting.
+        let window = "Die Zahl 29 F9 wird binär 0010 1001 1111 1001 gespeichert.";
+        let chunk = "```\nBinär: 0010 1001 1111 1001\n```";
+        assert!(missing_literals(chunk, &[], window).is_empty());
+    }
+
+    #[test]
+    fn an_invented_command_is_still_caught_when_it_carries_a_label() {
+        let window = "Unmount the device first.";
+        let chunk = "```\nRun: wipefs --all /dev/sdX\n```";
+        assert_eq!(
+            missing_literals(chunk, &[], window),
+            vec!["wipefs --all /dev/sdX".to_string()]
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib infer::verify::tests::a_label_the_model_added_is_not_a_missing_literal`
+Expected: FAIL — the whole fenced line including `Binär:` is looked for and not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/infer/verify.rs`, before the `filter` in `missing_literals`, strip a leading label from each literal and look for the remainder as well:
+
+```rust
+/// A literal minus a label the model put in front of it.
+///
+/// `Binär: 0010 1001 1111 1001` for a source that says
+/// `wird binär 0010 1001 1111 1001` invents nothing — the digits, which are
+/// the part that matters if someone retypes them, are verbatim. The label is
+/// presentation, and reporting it as a possibly-invented command buries the
+/// real misses.
+fn without_label(lit: &str) -> Option<&str> {
+    let (label, rest) = lit.split_once(':')?;
+    let rest = rest.trim();
+    // Only a single word, so `dd if=x.iso of=/dev/sdX` — which has a colon in
+    // no plausible label position — is never split into something weaker.
+    if rest.is_empty() || label.split_whitespace().count() != 1 {
+        return None;
+    }
+    Some(rest)
+}
+```
+
+and in the filter:
+
+```rust
+        .filter(|lit| {
+            let n = normalize(lit);
+            if haystack.contains(&n) {
+                return false;
+            }
+            match without_label(lit) {
+                Some(bare) => !haystack.contains(&normalize(bare)),
+                None => true,
+            }
+        })
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib infer::verify`
+Expected: PASS, including the existing literal tests — `dd if=archlinux.iso of=/dev/sdX` must still be reported when absent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/infer/verify.rs
+git commit -m "fix: a label in front of verbatim digits read as an invented command"
+```
+
+---
+
+### Task 6: Pairs that do not disagree close themselves
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs:149-166` (the review band) and `:193` (`judge_pending`)
+- Test: `src/jobs/consolidate.rs` tests
+
+**Interfaces:**
+- Consumes: `crate::infer::facts::may_disagree(a, b) -> bool`, `Store::set_pair_state`.
+- Produces: no new signatures; `Outcome` gains `pub closed: usize`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn a_pair_with_nothing_to_disagree_about_never_reaches_the_queue() {
+        // The prefilter already knows these two state no differing value. It
+        // only ran when the judge was enabled, so with the judge off — the
+        // default — every near pair became a question for a person.
+        let core = test_core().await;
+        seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 0, "{out:?}");
+        assert_eq!(out.closed, 1);
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        // Both artifacts survive: closing is not hiding.
+        assert_eq!(core.store.artifacts_for_corpus_count().await.unwrap_or(2), 2);
+    }
+
+    #[tokio::test]
+    async fn a_pair_stating_different_values_still_waits_for_a_person() {
+        let core = test_core().await;
+        seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 90 seconds", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 1, "{out:?}");
+    }
+```
+
+Drop the `artifacts_for_corpus_count` line if no such method exists; assert instead that neither artifact has `superseded_by` set.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib jobs::consolidate`
+Expected: FAIL — `out.closed` does not exist, and the factless pair is queued.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `pub closed: usize` to `Outcome`. In the review-band loop of `run`, after fetching `a` and `b`:
+
+```rust
+        // Two artifacts that state no differing value have nothing for a
+        // person to rule on. Recording the pair as settled keeps the sweep
+        // from re-asking, and both artifacts stay exactly where they are —
+        // closing a question is not hiding an answer.
+        if !crate::infer::facts::may_disagree(&a.text, &b.text) {
+            if core.store.record_pair(&p.a, &p.b, p.score).await? {
+                out.closed += 1;
+            }
+            if let Some(pair) = core.store.find_pair(&p.a, &p.b).await? {
+                core.store
+                    .set_pair_state(pair.id, crate::store::pairs::PairState::NoConflict, None)
+                    .await?;
+            }
+            continue;
+        }
+```
+
+If `Store::find_pair` does not exist, add it to `src/store/pairs.rs` beside `record_pair`:
+
+```rust
+    /// The stored row for a pair, in whichever order it was filed.
+    pub async fn find_pair(&self, a: &str, b: &str) -> Result<Option<ArtifactPair>> {
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let row = sqlx::query("SELECT * FROM artifact_pairs WHERE a_id = ? AND b_id = ?")
+            .bind(lo)
+            .bind(hi)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.as_ref().map(row_to_pair))
+    }
+```
+
+Check how `record_pair` orders `a_id`/`b_id` before writing this — it must match.
+
+Then simplify `judge_pending`: the prefilter branch there becomes unreachable for new pairs but must stay, because rows filed before this change are still pending.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib jobs::consolidate` then `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/consolidate.rs src/store/pairs.rs
+git commit -m "feat: a pair with no differing value is not a question for a person"
+```
+
+---
+
+### Task 7: A stuttered duplicate inside one corpus is hidden
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs` (auto-hide block around `:126-144`)
+- Test: `src/jobs/consolidate.rs` tests
+
+**Interfaces:**
+- Consumes: `Chunk.corpus_id`, `Chunk.text`, `Core::store.set_superseded_by`, `vectors.set_superseded`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn one_synthesis_call_emitting_a_passage_twice_resolves_itself() {
+        // Same corpus, same call, one text wholly inside the other. That is a
+        // defect in one artifact, not two sources disagreeing, and it sat in
+        // the review queue below auto_supersede.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                (
+                    "Bind mounts attach a directory elsewhere. Use mount --bind for it.",
+                    [1.0, 0.0],
+                ),
+                ("Bind mounts attach a directory elsewhere.", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        run(&core).await.unwrap();
+        let shorter = core.store.get_artifact(&ids[1]).await.unwrap();
+        assert_eq!(shorter.superseded_by.as_deref(), Some(ids[0].as_str()));
+    }
+
+    #[tokio::test]
+    async fn containment_across_two_corpora_is_left_alone() {
+        // Two documents that happen to share a sentence are two sources. This
+        // is the case auto_supersede deliberately refuses below 0.95.
+        let core = test_core().await;
+        // seed() puts everything in one corpus; build the second corpus by
+        // hand with insert_corpus + insert_artifacts + vectors.upsert, exactly
+        // as seed() does, and assert neither artifact is superseded.
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib jobs::consolidate::tests::one_synthesis_call_emitting_a_passage_twice_resolves_itself`
+Expected: FAIL — the pair scores below `auto_supersede`, so it is queued rather than hidden.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In the review-band loop, before the `may_disagree` check from Task 6:
+
+```rust
+        // One call emitted the same passage twice: the shorter text is wholly
+        // inside the longer, and both came out of the same document. Nothing
+        // is lost by hiding it — the surviving artifact says everything it
+        // said — and Ops still lists it with an undo.
+        if a.corpus_id == b.corpus_id {
+            let (long, short) = if a.text.len() >= b.text.len() {
+                (&a, &b)
+            } else {
+                (&b, &a)
+            };
+            if contains_normalized(&long.text, &short.text) {
+                core.store
+                    .set_superseded_by(&short.id, Some(&long.id))
+                    .await?;
+                core.vectors.set_superseded(&short.id, true).await?;
+                out.superseded += 1;
+                tracing::info!(superseded = %short.id, by = %long.id, "hid a stuttered duplicate");
+                continue;
+            }
+        }
+```
+
+with, near `keeper`:
+
+```rust
+/// Is the whole of one artifact inside the other, whitespace aside?
+fn contains_normalized(long: &str, short: &str) -> bool {
+    let n = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+    !short.trim().is_empty() && n(long).contains(&n(short))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/consolidate.rs
+git commit -m "feat: hide a passage one synthesis call emitted twice"
+```
+
+---
+
+### Task 8: Ops reports state instead of offering chores
+
+**Files:**
+- Modify: `src/web/ui.rs:287-301` (`OpsTemplate`), `:630-740` (the handler), `templates/ops.html`
+- Modify: `src/store/jobs.rs` (add `retrying_jobs`)
+- Test: `src/web/ui.rs` tests
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `Store::retrying_jobs(&self, limit: i64) -> Result<Vec<RetryingJob>>` where `RetryingJob { stage: String, target_id: String, attempts: i64, next_attempt_secs: i64, last_error: Option<String> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn ops_reports_what_is_retrying_rather_than_asking_for_a_click() {
+        let (app, token, core) = crate::web::api::tests::app_token_and_core().await;
+        core.store
+            .enqueue(Stage::Embed, "artifact", "a1")
+            .await
+            .unwrap();
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        core.store
+            .fail_job(job.id, 9, "endpoint down")
+            .await
+            .unwrap();
+        let body = get_ops_html(&app, &token).await;
+        assert!(body.contains("Retrying"), "{body}");
+        assert!(
+            !body.contains("Re-synthesize segment"),
+            "the review queue is still a to-do list"
+        );
+    }
+```
+
+Write `get_ops_html` as the existing UI tests fetch pages — copy the helper already in `src/web/ui.rs` tests rather than inventing one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib web::ui`
+Expected: FAIL — no "Retrying" section exists.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/store/jobs.rs`:
+
+```rust
+    /// Jobs waiting on a backoff, soonest first. There is no failed state to
+    /// report any more; this is what replaced it.
+    pub async fn retrying_jobs(&self, limit: i64) -> Result<Vec<RetryingJob>> {
+        let rows = sqlx::query(
+            "SELECT stage, target_id, attempts, last_error, run_after FROM jobs
+              WHERE state = 'pending' AND run_after > ? AND attempts > 0
+              ORDER BY run_after LIMIT ?",
+        )
+        .bind(now())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| RetryingJob {
+                stage: r.get("stage"),
+                target_id: r.get("target_id"),
+                attempts: r.get("attempts"),
+                next_attempt_secs: r.get::<i64, _>("run_after") - now(),
+                last_error: r.get("last_error"),
+            })
+            .collect())
+    }
+```
+
+In `src/web/ui.rs`, replace `failed: Vec<FailedJob>` with `retrying: Vec<RetryingJob>`, drop `flagged: Vec<FlaggedRow>` from the template entirely, and delete the `/ui/corpora/{cid}/segments/{idx}/resynthesize` route together with its handler and the `Re-synthesize segment` button in `templates/ops.html`. Add a `Retrying` section rendering stage, target, attempts and `next_attempt_secs` as a coarse duration.
+
+Keep the literal note visible where the reader is: render `flag_detail` on the artifact detail page (`templates/artifact.html` or whichever template the detail pane uses) if it is not already there.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS. Delete any test that asserts the resynthesize route exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs src/store/jobs.rs templates/
+git commit -m "feat: ops reports what the system is doing, not what you must do"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `README.md` (the verification section around line 168, the duplicates section around line 192, and the Ops description)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update the prose**
+
+Three passages change, and each must say what is true after Tasks 1–8:
+
+1. The verification bullets: spans are derived locally and never doubted, so there is no span flag; the literal check ignores a label the model added; coverage is unchanged from its current text.
+2. The duplicates section: a pair with no differing fact closes itself, an artifact contained in another from the same corpus is hidden with an undo, and `auto_supersede` is unchanged.
+3. Retry: attempts back off to six hours and never stop, and a reconciliation sweep re-arms anything unfinished, so a failed segment needs no button.
+
+- [ ] **Step 2: Check the claims**
+
+Run: `grep -n "span_unverified\|Re-synthesize\|failed job" README.md`
+Expected: no hits describing behaviour that no longer exists.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: describe ingestion that repairs itself"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 nothing terminal → Tasks 1–3. §4 spans derived → Task 4. §5 literal labels → Task 5. §6 duplicates → Tasks 6–7. §7 Ops → Task 8. §8 testing → each task's tests. §9 out of scope → nothing here changes embeddings, merges text, or lowers `auto_supersede`.
+
+**Placeholders:** none. Three tasks say "check the exact helper name before writing" — that is an instruction to verify against the codebase, not a gap in the plan, and each names the file and line to look at.
+
+**Type consistency:** `RetryingJob` is defined in Task 8 and used only there. `Outcome.closed` is added in Task 6 and used in Tasks 6 and 7. `SpanOrigin` is deleted in Task 4 and referenced nowhere after. `find_pair` returns `Option<ArtifactPair>`, matching `row_to_pair`.

--- a/docs/superpowers/plans/2026-08-10-consolidation.md
+++ b/docs/superpowers/plans/2026-08-10-consolidation.md
@@ -1,0 +1,3869 @@
+# Consolidation and Hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop near-duplicate and stale artifacts from competing for the same queries, without adding an LLM call to the ingest path and without ever replacing stored artifact text with synthetic text.
+
+**Architecture:** Three layers, cheapest first. (1) At capture, a shingle signature over the raw corpus catches a re-pasted document whose bytes changed slightly; the corpus is stored but parked in `needs_review` and synthesis is never paid for until a human chooses replace/keep/discard. (2) A periodic `Stage::Consolidate` job asks Qdrant's distance-matrix API for near pairs; pairs at or above `auto_supersede` mark the older artifact `superseded_by` the newer and hide it from search by a payload flag, pairs in the review band land in an `artifact_pairs` queue on Ops. (3) Only pairs in the review band whose fact-shaped tokens actually disagree — a zero-inference regex prefilter — are sent to the completer as a yes/no contradiction judge, capped per sweep. Separately, the existing synthesis call is asked for `caveats` alongside the artifact it already produces, which costs output tokens on a call already being made and no new call.
+
+**Tech Stack:** Rust 1.94+, sqlx 0.9 (SQLite), axum, askama templates, Qdrant REST, `async_trait`, `tokio`.
+
+## Global Constraints
+
+- Rust edition and toolchain as already configured; do not touch `Cargo.toml` version floors. New dependencies are **not permitted** in this plan — everything here is standard library plus crates already in `Cargo.lock` (`serde`, `serde_json`, `sha2`, `hex`, `uuid`, `tracing`, `sqlx`, `axum`, `askama`, `async-trait`).
+- **SQLite is the source of truth. Qdrant is derived.** Every consolidation decision is written to SQLite first and mirrored to Qdrant second. Never mutate a Qdrant point without a corresponding artifact row change.
+- **Never rewrite artifact text with model output.** No merge, no summary, no regeneration of a stored artifact's `text`. Consolidation only ever sets `superseded_by`, writes a payload flag, or files a review row.
+- **Never delete on a similarity signal.** Superseding is reversible; deletion is not.
+- **No new inference call on the ingest path.** Capture stays instant and survives a dead endpoint.
+- Existing artifact fields are additive-only: `superseded_by` and `caveats` are new nullable/defaulted columns; nothing existing changes type or meaning.
+- Comment density and prose style must match the surrounding files: comments explain *why*, in full sentences, and name the failure mode being prevented.
+- Every task ends with `cargo test` green and a commit. `cargo clippy --all-targets -- -D warnings` must pass before the final task's commit.
+
+---
+
+## File Structure
+
+**Created:**
+- `migrations/0009_consolidation.sql` — the schema for everything below.
+- `src/store/shingle.rs` — pure bottom-k shingle signature and Jaccard estimate. No I/O, no DB.
+- `src/store/pairs.rs` — `artifact_pairs` CRUD.
+- `src/jobs/consolidate.rs` — the sweep: near pairs → supersede or queue → optional judge.
+- `src/infer/facts.rs` — pure fact-token extraction and the zero-inference disagreement prefilter.
+
+**Modified:**
+- `src/store/mod.rs` — declare the two new store modules.
+- `src/store/corpora.rs` — `CorpusStatus::NeedsReview`, shingle columns, near-dupe scan.
+- `src/store/artifacts.rs` — `superseded_by`, `caveats` on `Chunk` and `NewArtifact`, plus writers.
+- `src/store/jobs.rs` — `Stage::Consolidate`.
+- `src/core/ingest.rs` — near-dupe detection at capture; resolve actions.
+- `src/core/search.rs` — superseded artifacts excluded by default.
+- `src/vector/mod.rs` — `superseded` on `VectorPayload`, `include_superseded` on `SearchFilter`, `NearPair`, two new trait methods.
+- `src/vector/memory.rs` — brute-force implementations of the two new methods.
+- `src/vector/qdrant.rs` — matrix-pairs implementation, superseded filter, payload flag write.
+- `src/infer/mod.rs` — `caveats` on `ProposedArtifact`.
+- `src/infer/prompt.rs` — caveats in the synthesizer contract and parser; the judge prompt and its parser.
+- `src/infer/verify.rs` — literal check extended over caveats.
+- `src/jobs/synthesize.rs` — carry `caveats` from proposal to row.
+- `src/jobs/mod.rs` — dispatch `Stage::Consolidate`.
+- `src/jobs/embed.rs` — carry `superseded` into the payload it builds.
+- `src/core/background.rs` — periodic sweep enqueuer.
+- `src/config.rs` — `[consolidate]` block.
+- `src/web/api.rs`, `src/web/ui.rs`, `src/web/templates/ops.html`, `src/web/templates/_artifact_detail.html`, `src/web/templates/browse.html` — review queue, resolve buttons, caveats rendering.
+- `config.example.toml`, `README.md`, `ROADMAP.md`.
+- `src/infer/fake.rs` — a scriptable completer for judge tests.
+
+---
+
+## Task 1: Shingle signature and Jaccard estimate
+
+Pure functions. No database, no network. This is the whole of the capture-time near-duplicate signal.
+
+**Files:**
+- Create: `src/store/shingle.rs`
+- Modify: `src/store/mod.rs:1-5`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `pub const SIGNATURE_SIZE: usize = 128;`
+  - `pub fn signature(text: &str) -> Vec<u64>` — bottom-k hashes of the text's word 5-grams, ascending, at most `SIGNATURE_SIZE` long.
+  - `pub fn similarity(a: &[u64], b: &[u64]) -> f64` — estimated Jaccard in `0.0..=1.0`.
+  - `pub fn encode(sig: &[u64]) -> String` / `pub fn decode(s: &str) -> Vec<u64>` — JSON round trip for the SQLite column.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/store/shingle.rs` containing only the test module for now:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(n: usize) -> String {
+        (0..n)
+            .map(|i| format!("line {i} of a reference document about filesystems"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn identical_text_is_perfectly_similar() {
+        let a = signature(&doc(200));
+        let b = signature(&doc(200));
+        assert_eq!(a, b, "the signature must be deterministic");
+        assert!((similarity(&a, &b) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn one_changed_byte_still_reads_as_the_same_document() {
+        // The case `content_hash` misses entirely: the same chapter pasted a
+        // year later with one typo fixed. It must not become a second corpus
+        // competing for the same queries.
+        let original = doc(200);
+        let edited = original.replacen("filesystems", "filesystem", 1);
+        assert_ne!(original, edited);
+        let s = similarity(&signature(&original), &signature(&edited));
+        assert!(s > 0.95, "one edit dropped similarity to {s}");
+    }
+
+    #[test]
+    fn unrelated_text_is_not_similar() {
+        let a = signature(&doc(200));
+        let b = signature(
+            &(0..200)
+                .map(|i| format!("entirely different sentence number {i} concerning pastry"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        let s = similarity(&a, &b);
+        assert!(s < 0.2, "unrelated documents scored {s}");
+    }
+
+    #[test]
+    fn a_document_shorter_than_one_shingle_still_has_a_signature() {
+        // A three-word capture is legitimate and must not panic or produce a
+        // signature that matches everything.
+        let sig = signature("just three words");
+        assert!(!sig.is_empty());
+        assert!(similarity(&sig, &signature("wholly other words here")) < 1.0);
+    }
+
+    #[test]
+    fn an_empty_signature_is_never_similar_to_anything() {
+        assert_eq!(similarity(&[], &signature("some text")), 0.0);
+        assert_eq!(similarity(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn signatures_round_trip_through_the_column_encoding() {
+        let sig = signature(&doc(50));
+        assert_eq!(decode(&encode(&sig)), sig);
+        assert!(decode("not json").is_empty(), "a corrupt column must not panic");
+    }
+
+    #[test]
+    fn the_signature_is_bounded_however_long_the_document() {
+        assert!(signature(&doc(10_000)).len() <= SIGNATURE_SIZE);
+    }
+}
+```
+
+Add the module declaration to `src/store/mod.rs`, keeping the list alphabetical:
+
+```rust
+pub mod artifacts;
+pub mod auth;
+pub mod corpora;
+pub mod jobs;
+pub mod pairs;
+pub mod segments;
+pub mod shingle;
+```
+
+Note `pairs` is declared here too — Task 8 creates that file. To keep this task compiling on its own, add `pub mod pairs;` in Task 8 instead and only add `pub mod shingle;` now.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib store::shingle`
+Expected: FAIL — compile errors, `cannot find function 'signature' in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `src/store/shingle.rs`, above the test module:
+
+```rust
+//! Is this the same document we already have?
+//!
+//! `content_hash` answers that for byte-identical text and nothing else, so
+//! re-pasting a chapter a year later with one typo fixed stores it a second
+//! time, and the two copies then compete for the same queries forever. That is
+//! the largest single source of duplication in the base, and it is detectable
+//! without an embedding call, let alone a model call.
+//!
+//! The signature is bottom-k MinHash over word 5-grams: hash every shingle,
+//! keep the `SIGNATURE_SIZE` smallest hashes. The fraction of a pair of
+//! signatures' bottom-k that agree estimates the Jaccard similarity of the two
+//! shingle sets, which is a number an operator can be shown — "94% of this
+//! document's phrasing is already stored" — in a way a Hamming distance is not.
+
+use std::collections::BTreeSet;
+
+/// Hashes kept per document. Estimation error is roughly `1/sqrt(k)`, so 128
+/// gives about nine points of slack — ample against a 0.90 decision threshold,
+/// and small enough that the column stays a couple of kilobytes.
+pub const SIGNATURE_SIZE: usize = 128;
+
+/// Words per shingle. Five is long enough that ordinary English collides
+/// rarely and short enough that a document has plenty of them.
+const SHINGLE_WORDS: usize = 5;
+
+/// FNV-1a. Chosen over `sha2`, which is already a dependency, because this runs
+/// once per shingle over a whole document and the signature never leaves the
+/// machine — there is nothing here for a cryptographic hash to defend.
+fn hash(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    h
+}
+
+/// The bottom-k hashes of this text's word shingles, ascending.
+///
+/// Whitespace is normalised and case folded first, so reflowing a paragraph or
+/// changing a heading's capitalisation does not read as a different document.
+pub fn signature(text: &str) -> Vec<u64> {
+    let words: Vec<String> = text
+        .split_whitespace()
+        .map(|w| w.to_lowercase())
+        .collect();
+    if words.is_empty() {
+        return Vec::new();
+    }
+
+    // A BTreeSet both dedupes — a repeated shingle must count once, or a
+    // document that says the same sentence twice would skew its own bottom-k —
+    // and keeps the smallest hashes reachable in order.
+    let mut smallest: BTreeSet<u64> = BTreeSet::new();
+    // A document shorter than one shingle still gets a signature, from the one
+    // shingle its whole text forms. Returning nothing would make it match
+    // every other short capture.
+    let step = SHINGLE_WORDS.min(words.len());
+    for w in words.windows(step) {
+        smallest.insert(hash(&w.join(" ")));
+        if smallest.len() > SIGNATURE_SIZE {
+            let largest = *smallest.iter().next_back().expect("non-empty");
+            smallest.remove(&largest);
+        }
+    }
+    smallest.into_iter().collect()
+}
+
+/// Estimated Jaccard similarity of the two documents' shingle sets.
+///
+/// Both signatures are the bottom-k of their own set, so the estimate is the
+/// agreement within the bottom-k of their union — taking the k smallest hashes
+/// across both and asking how many of those appear in both.
+pub fn similarity(a: &[u64], b: &[u64]) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let k = SIGNATURE_SIZE.min(a.len()).min(b.len());
+    let mut union: Vec<u64> = a.iter().chain(b.iter()).copied().collect();
+    union.sort_unstable();
+    union.dedup();
+    union.truncate(k);
+
+    let shared = union
+        .iter()
+        .filter(|h| a.binary_search(h).is_ok() && b.binary_search(h).is_ok())
+        .count();
+    shared as f64 / k as f64
+}
+
+/// The column holds JSON rather than a blob: it is a few kilobytes either way,
+/// and a readable column is worth a great deal the first time someone has to
+/// work out why two documents were called duplicates.
+pub fn encode(sig: &[u64]) -> String {
+    serde_json::to_string(sig).unwrap_or_else(|_| "[]".into())
+}
+
+/// A column written by an older version, or corrupted, yields no signature
+/// rather than an error: the corpus simply is not compared, which is exactly
+/// the behaviour before this existed.
+pub fn decode(s: &str) -> Vec<u64> {
+    serde_json::from_str(s).unwrap_or_default()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib store::shingle`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/shingle.rs src/store/mod.rs
+git commit -m "feat: shingle signatures for near-duplicate corpora"
+```
+
+---
+
+## Task 2: Schema
+
+Everything the rest of the plan writes to. One migration, so a half-applied consolidation schema is not a state that exists.
+
+**Files:**
+- Create: `migrations/0009_consolidation.sql`
+- Test: `src/store/corpora.rs` (test module, appended)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: columns `corpora.shingles`, `corpora.near_dupe_of`, `corpora.near_dupe_score`, `artifacts.superseded_by`, `artifacts.caveats`; table `artifact_pairs(id, a_id, b_id, score, state, detail, created_at)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `src/store/corpora.rs`:
+
+```rust
+    #[tokio::test]
+    async fn the_consolidation_schema_is_present() {
+        // Migrations run on connect, so this failing means 0009 did not apply.
+        let s = Store::memory().await.unwrap();
+        for sql in [
+            "SELECT shingles, near_dupe_of, near_dupe_score FROM corpora LIMIT 1",
+            "SELECT superseded_by, caveats FROM artifacts LIMIT 1",
+            "SELECT id, a_id, b_id, score, state, detail, created_at FROM artifact_pairs LIMIT 1",
+        ] {
+            sqlx::query(sql)
+                .fetch_optional(&s.pool)
+                .await
+                .unwrap_or_else(|e| panic!("{sql} failed: {e}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_recorded_once_whichever_order_it_is_found_in() {
+        // The sweep sees (a,b) on one run and (b,a) on the next. Without a
+        // canonical order the review queue fills with the same pair twice.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "one".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "two".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        let insert = |a: &str, b: &str| {
+            let (a, b) = (a.to_string(), b.to_string());
+            let pool = s.pool.clone();
+            async move {
+                sqlx::query(
+                    "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, created_at)
+                     VALUES (?, ?, 0.9, 'pending', 0)",
+                )
+                .bind(&a)
+                .bind(&b)
+                .execute(&pool)
+                .await
+                .unwrap();
+            }
+        };
+        insert(&made[0].id, &made[1].id).await;
+        insert(&made[0].id, &made[1].id).await;
+
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM artifact_pairs")
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 1, "the unique constraint on (a_id, b_id) is missing");
+    }
+```
+
+The `caveats: vec![]` field on `NewArtifact` does not exist yet — Task 12 adds it. Until then, **omit `caveats` from these two literals**; add it back as part of Task 12's compile fix.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib store::corpora::tests::the_consolidation_schema_is_present`
+Expected: FAIL with `no such column: shingles`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `migrations/0009_consolidation.sql`:
+
+```sql
+-- Near-duplicate detection at capture.
+--
+-- `content_hash` is exact, so the same chapter re-pasted with one changed byte
+-- becomes a second corpus, and the two then compete for the same queries for
+-- as long as the base exists. The signature is a bottom-k MinHash over word
+-- shingles (`src/store/shingle.rs`), compared against every other corpus at
+-- capture time — a scan, because a single-operator base holds hundreds of
+-- corpora, not millions.
+ALTER TABLE corpora ADD COLUMN shingles TEXT;
+-- Set when capture found a near-identical corpus. The capture is stored
+-- regardless and parked in `needs_review`: nothing is ever discarded on a
+-- similarity score, and synthesis is not paid for until a human decides.
+ALTER TABLE corpora ADD COLUMN near_dupe_of TEXT;
+ALTER TABLE corpora ADD COLUMN near_dupe_score REAL;
+
+-- Consolidation, artifact side.
+--
+-- The artifact this one lost to. Set by the sweep when two artifacts are near
+-- identical; the loser stays stored, readable and reversible, and is hidden
+-- from search by a payload flag rather than deleted. A merged rewrite would
+-- put synthetic text where a stored artifact used to be, which is the one
+-- failure mode this design exists to avoid.
+ALTER TABLE artifacts ADD COLUMN superseded_by TEXT;
+CREATE INDEX idx_artifacts_superseded ON artifacts(superseded_by);
+
+-- Conditions under which the artifact does not apply, as stated by the source.
+-- Emitted by the same synthesis call that produces the artifact, so it costs
+-- output tokens rather than another call.
+ALTER TABLE artifacts ADD COLUMN caveats TEXT NOT NULL DEFAULT '[]';
+
+-- The review queue.
+--
+-- Pairs similar enough to be worth a person's attention but not similar enough
+-- to supersede automatically. `state` is 'pending' until something resolves
+-- it: 'no_conflict' when the fact-token prefilter or the judge clears it,
+-- 'contradiction' when the judge finds one, 'dismissed' when an operator does.
+-- `a_id` < `b_id` by string order, so the same pair found in either direction
+-- is one row.
+CREATE TABLE artifact_pairs (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  a_id       TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  b_id       TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  score      REAL NOT NULL,
+  state      TEXT NOT NULL DEFAULT 'pending',
+  detail     TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE(a_id, b_id)
+);
+CREATE INDEX idx_pairs_state ON artifact_pairs(state, created_at DESC);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib store::corpora`
+Expected: PASS. Then `cargo test` to confirm no existing test broke.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/0009_consolidation.sql src/store/corpora.rs
+git commit -m "feat: schema for consolidation and capture near-dupe review"
+```
+
+---
+
+## Task 3: Corpus store — signature column, `needs_review`, near-dupe scan
+
+**Files:**
+- Modify: `src/store/corpora.rs:6-41` (status enum), `:43-56` (struct), `:62-74` (row mapper), `:77-109` (insert), and the `impl Store` block.
+
+**Interfaces:**
+- Consumes: `shingle::{signature, similarity, encode, decode}` from Task 1.
+- Produces:
+  - `CorpusStatus::NeedsReview` ⇄ `"needs_review"`.
+  - `Corpus { shingles: Vec<u64>, near_dupe_of: Option<String>, near_dupe_score: Option<f64>, .. }`
+  - `Store::insert_corpus` unchanged in signature; it now computes and stores the signature.
+  - `pub struct NearDuplicate { pub corpus_id: String, pub title_hint: Option<String>, pub similarity: f64 }`
+  - `pub async fn find_near_duplicate(&self, sig: &[u64], min: f64) -> Result<Option<NearDuplicate>>`
+  - `pub async fn set_near_dupe(&self, corpus_id: &str, of: Option<&str>, score: Option<f64>) -> Result<()>`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `src/store/corpora.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_stored_corpus_carries_its_signature() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_corpus("a document about mounting filesystems", "web", None)
+            .await
+            .unwrap();
+        assert!(!src.shingles.is_empty());
+        assert_eq!(s.get_corpus(&src.id).await.unwrap().shingles, src.shingles);
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_corpus_is_found_by_signature() {
+        let s = Store::memory().await.unwrap();
+        let body: String = (0..200)
+            .map(|i| format!("step {i}: run the command and read the output"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let first = s.insert_corpus(&body, "web", Some("manual")).await.unwrap();
+
+        let edited = body.replacen("step 7", "step seven", 1);
+        let hit = s
+            .find_near_duplicate(&crate::store::shingle::signature(&edited), 0.90)
+            .await
+            .unwrap()
+            .expect("the edited copy should have matched");
+        assert_eq!(hit.corpus_id, first.id);
+        assert_eq!(hit.title_hint.as_deref(), Some("manual"));
+        assert!(hit.similarity > 0.90);
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_corpus_is_not_a_near_duplicate() {
+        let s = Store::memory().await.unwrap();
+        s.insert_corpus("a chapter about filesystems and mounting", "web", None)
+            .await
+            .unwrap();
+        let other = crate::store::shingle::signature("a recipe for shortcrust pastry and jam");
+        assert!(s.find_near_duplicate(&other, 0.90).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn needs_review_survives_a_round_trip() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        s.set_corpus_status(&src.id, CorpusStatus::NeedsReview)
+            .await
+            .unwrap();
+        s.set_near_dupe(&src.id, Some("other-id"), Some(0.94))
+            .await
+            .unwrap();
+        let got = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::NeedsReview);
+        assert_eq!(got.near_dupe_of.as_deref(), Some("other-id"));
+        assert!((got.near_dupe_score.unwrap() - 0.94).abs() < 1e-9);
+
+        // Clearing it is what "keep both" does, and it must actually clear.
+        s.set_near_dupe(&src.id, None, None).await.unwrap();
+        assert!(s.get_corpus(&src.id).await.unwrap().near_dupe_of.is_none());
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib store::corpora`
+Expected: FAIL — `no variant named NeedsReview`, `no field shingles`, `no method find_near_duplicate`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/store/corpora.rs`, add the variant to `CorpusStatus` (enum body, `as_str`, and `parse`):
+
+```rust
+pub enum CorpusStatus {
+    Raw,
+    /// Captured, stored, and deliberately not queued for synthesis: something
+    /// near-identical is already in the base, and segmenting it would pay a
+    /// model to produce artifacts that compete with ones that already exist.
+    /// An operator resolves it on Ops.
+    NeedsReview,
+    Segmenting,
+    // ... unchanged
+}
+```
+
+```rust
+            CorpusStatus::NeedsReview => "needs_review",
+```
+```rust
+            "needs_review" => CorpusStatus::NeedsReview,
+```
+
+Extend `Corpus`:
+
+```rust
+    /// Bottom-k shingle hashes of `raw_text`. Empty for corpora captured before
+    /// the signature existed, which simply are not compared.
+    #[serde(skip)]
+    pub shingles: Vec<u64>,
+    /// The corpus this one looked like at capture, and how alike they were.
+    /// Both cleared when an operator chooses to keep both.
+    pub near_dupe_of: Option<String>,
+    pub near_dupe_score: Option<f64>,
+```
+
+Extend `row_to_corpus`:
+
+```rust
+        shingles: r
+            .get::<Option<String>, _>("shingles")
+            .map(|s| super::shingle::decode(&s))
+            .unwrap_or_default(),
+        near_dupe_of: r.get("near_dupe_of"),
+        near_dupe_score: r.get("near_dupe_score"),
+```
+
+Extend `insert_corpus` — compute the signature and add it to the struct literal and the SQL:
+
+```rust
+        let shingles = super::shingle::signature(raw_text);
+        let src = Corpus {
+            // ... existing fields unchanged ...
+            coverage: None,
+            shingles,
+            near_dupe_of: None,
+            near_dupe_score: None,
+        };
+        sqlx::query(
+            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        // ... existing binds unchanged ...
+        .bind(super::shingle::encode(&src.shingles))
+        .execute(&self.pool)
+        .await?;
+```
+
+Add to the `impl Store` block:
+
+```rust
+/// A stored corpus that a new capture looks like.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct NearDuplicate {
+    pub corpus_id: String,
+    pub title_hint: Option<String>,
+    pub similarity: f64,
+}
+```
+
+```rust
+    /// The stored corpus most like this signature, if any clears `min`.
+    ///
+    /// A full scan of the signature column. A single-operator base holds
+    /// hundreds of corpora, each with a signature of a couple of kilobytes, so
+    /// this is a few milliseconds of memory bandwidth on a path that already
+    /// writes the whole document to disk. An index over MinHash bands is the
+    /// answer at a scale this design does not target.
+    pub async fn find_near_duplicate(
+        &self,
+        sig: &[u64],
+        min: f64,
+    ) -> Result<Option<NearDuplicate>> {
+        if sig.is_empty() {
+            return Ok(None);
+        }
+        let rows = sqlx::query(
+            "SELECT id, title_hint, shingles FROM corpora WHERE shingles IS NOT NULL",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut best: Option<NearDuplicate> = None;
+        for r in &rows {
+            let stored: String = r.get("shingles");
+            let s = super::shingle::similarity(sig, &super::shingle::decode(&stored));
+            if s < min {
+                continue;
+            }
+            if best.as_ref().is_none_or(|b| s > b.similarity) {
+                best = Some(NearDuplicate {
+                    corpus_id: r.get("id"),
+                    title_hint: r.get("title_hint"),
+                    similarity: s,
+                });
+            }
+        }
+        Ok(best)
+    }
+
+    pub async fn set_near_dupe(
+        &self,
+        corpus_id: &str,
+        of: Option<&str>,
+        score: Option<f64>,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE corpora SET near_dupe_of = ?, near_dupe_score = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(of)
+        .bind(score)
+        .bind(now())
+        .bind(corpus_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib store::corpora`
+Expected: PASS. Then `cargo test` — `Corpus` gained fields, so any struct literal elsewhere must be updated; there should be none outside this file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/corpora.rs
+git commit -m "feat: store corpus shingle signatures and near-dupe state"
+```
+
+---
+
+## Task 4: Capture parks a near-duplicate instead of synthesising it
+
+**Files:**
+- Modify: `src/core/ingest.rs:6-46` (outcome + `ingest`)
+- Modify: `src/config.rs` (new `[consolidate]` block)
+
+**Interfaces:**
+- Consumes: `Store::find_near_duplicate`, `Store::set_near_dupe`, `CorpusStatus::NeedsReview`, `shingle::signature`.
+- Produces:
+  - `IngestOutcome { id, status, duplicate, near_duplicate: Option<NearDuplicate> }`
+  - `ConsolidateConfig { enabled: bool, near_dupe_min: f64, review_min: f32, auto_supersede: f32, sample: usize, per_point: usize, interval_hours: u64, judge: bool, max_judgements: usize }` on `Config` as `consolidate`.
+  - `Core::resolve_near_duplicate(&self, corpus_id: &str, action: NearDupeAction) -> Result<()>` with `pub enum NearDupeAction { Replace, KeepBoth, Discard }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `src/core/ingest.rs`:
+
+```rust
+    /// A body long enough to have a stable shingle signature.
+    fn manual(marker: &str) -> String {
+        (0..200)
+            .map(|i| format!("step {i}: run the {marker} command and read its output"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_capture_is_parked_rather_than_synthesised() {
+        // The whole point: a re-pasted chapter must not cost a model call, and
+        // must not become a second set of artifacts competing with the first.
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+
+        let edited = manual("mount").replacen("step 7:", "step seven:", 1);
+        let second = core.ingest(&edited, "web", None).await.unwrap();
+
+        assert_ne!(second.id, first.id, "the capture must still be stored");
+        assert!(!second.duplicate, "it is not a byte-identical duplicate");
+        assert_eq!(second.status, CorpusStatus::NeedsReview);
+        let near = second.near_duplicate.expect("no near-duplicate reported");
+        assert_eq!(near.corpus_id, first.id);
+        assert!(near.similarity > 0.90);
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "a parked capture must not queue synthesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_capture_is_unaffected() {
+        let core = test_core().await;
+        core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+
+        let out = core.ingest(&manual("pastry"), "web", None).await.unwrap();
+        assert_eq!(out.status, CorpusStatus::Raw);
+        assert!(out.near_duplicate.is_none());
+        assert!(
+            core.store.claim_job().await.unwrap().is_some(),
+            "an unrelated capture must still queue synthesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn keeping_both_releases_the_capture_into_the_pipeline() {
+        let core = test_core().await;
+        core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(&manual("mount").replacen("step 7:", "step seven:", 1), "web", None)
+            .await
+            .unwrap();
+
+        core.resolve_near_duplicate(&second.id, crate::core::ingest::NearDupeAction::KeepBoth)
+            .await
+            .unwrap();
+
+        let got = core.store.get_corpus(&second.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::Raw);
+        assert!(got.near_dupe_of.is_none(), "the flag must be cleared");
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn replacing_deletes_the_older_corpus_and_its_vectors() {
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert!(core.vectors.count().await.unwrap() > 0);
+
+        let second = core
+            .ingest(&manual("mount").replacen("step 7:", "step seven:", 1), "web", None)
+            .await
+            .unwrap();
+        core.resolve_near_duplicate(&second.id, crate::core::ingest::NearDupeAction::Replace)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            core.store.get_corpus(&first.id).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        assert_eq!(
+            core.store.get_corpus(&second.id).await.unwrap().status,
+            CorpusStatus::Raw
+        );
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn discarding_removes_the_new_capture_only() {
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(&manual("mount").replacen("step 7:", "step seven:", 1), "web", None)
+            .await
+            .unwrap();
+
+        core.resolve_near_duplicate(&second.id, crate::core::ingest::NearDupeAction::Discard)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            core.store.get_corpus(&second.id).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        assert!(core.store.get_corpus(&first.id).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolving_a_corpus_that_is_not_parked_is_rejected() {
+        let core = test_core().await;
+        let out = core.ingest("ordinary text", "web", None).await.unwrap();
+        assert!(matches!(
+            core.resolve_near_duplicate(&out.id, crate::core::ingest::NearDupeAction::Replace)
+                .await,
+            Err(crate::error::Error::Validation(_))
+        ));
+    }
+```
+
+Add `use crate::core::ingest::NearDupeAction;`-adjacent imports as the compiler asks. `test_core()` must expose the threshold; see Step 3 — `Core` gains a `consolidate: ConsolidateConfig` field, and `test_support::build` sets `ConsolidateConfig::default()`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib core::ingest`
+Expected: FAIL — `no field near_duplicate`, `no method resolve_near_duplicate`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/config.rs`, add the block and hang it off `Config`:
+
+```rust
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ConsolidateConfig {
+    /// Whether the background sweep runs at all. Capture-time near-duplicate
+    /// detection is separate and always on: it costs a hash, not a query.
+    pub enabled: bool,
+    /// Estimated Jaccard over word shingles above which a capture is parked as
+    /// a near-duplicate of an existing corpus.
+    pub near_dupe_min: f64,
+    /// Cosine at or above which a pair is worth an operator's attention.
+    pub review_min: f32,
+    /// Cosine at or above which the older artifact is superseded without
+    /// asking. Deliberately far above `review_min`: two genuinely distinct
+    /// artifacts about one subsystem sit around 0.88 routinely, and superseding
+    /// at that score destroys knowledge rather than duplication.
+    pub auto_supersede: f32,
+    /// Points sampled from the collection per sweep by the matrix API.
+    pub sample: usize,
+    /// Neighbours considered per sampled point.
+    pub per_point: usize,
+    /// How often the sweep is queued.
+    pub interval_hours: u64,
+    /// Whether pairs in the review band that survive the fact-token prefilter
+    /// are sent to the completer. Off by default: it is the only part of
+    /// consolidation that costs inference.
+    pub judge: bool,
+    /// Ceiling on judge calls per sweep, so one sweep cannot occupy the GPU.
+    pub max_judgements: usize,
+}
+
+impl Default for ConsolidateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            near_dupe_min: 0.90,
+            review_min: 0.88,
+            auto_supersede: 0.95,
+            sample: 2000,
+            per_point: 5,
+            interval_hours: 24,
+            judge: false,
+            max_judgements: 20,
+        }
+    }
+}
+```
+
+Add `#[serde(default)] pub consolidate: ConsolidateConfig,` to `Config`, and `pub consolidate: ConsolidateConfig,` to `Core`, set from `cfg.consolidate.clone()` in `from_config` and from `ConsolidateConfig::default()` in `test_support::build`.
+
+Rewrite `src/core/ingest.rs`'s outcome and `ingest`:
+
+```rust
+use crate::store::corpora::{CorpusStatus, NearDuplicate, content_hash};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IngestOutcome {
+    pub id: String,
+    pub status: CorpusStatus,
+    /// True when the text was already stored byte for byte and no new source
+    /// was created.
+    pub duplicate: bool,
+    /// Set when the text is not identical to anything stored but is close
+    /// enough that segmenting it would produce artifacts competing with ones
+    /// that already exist. The capture is stored and parked, never dropped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub near_duplicate: Option<NearDuplicate>,
+}
+
+/// What an operator decided about a parked capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NearDupeAction {
+    /// The new capture is the better copy: delete the old corpus and its
+    /// artifacts, then process this one.
+    Replace,
+    /// They are genuinely different despite the score. Process this one and
+    /// leave the other alone.
+    KeepBoth,
+    /// The new capture adds nothing. Delete it.
+    Discard,
+}
+```
+
+```rust
+    pub async fn ingest(
+        &self,
+        text: &str,
+        origin: &str,
+        title_hint: Option<&str>,
+    ) -> Result<IngestOutcome> {
+        if text.trim().is_empty() {
+            return Err(Error::Validation("text is empty".into()));
+        }
+
+        if let Some(existing) = self.store.find_by_hash(&content_hash(text)).await? {
+            tracing::info!(corpus_id = %existing.id, "duplicate ingest, returning existing source");
+            return Ok(IngestOutcome {
+                id: existing.id,
+                status: existing.status,
+                duplicate: true,
+                near_duplicate: None,
+            });
+        }
+
+        // Computed once, before the insert, so the same signature answers "is
+        // this a near-duplicate" and becomes the row's stored column.
+        let sig = crate::store::shingle::signature(text);
+        let near = self
+            .store
+            .find_near_duplicate(&sig, self.consolidate.near_dupe_min)
+            .await?;
+
+        let src = self.store.insert_corpus(text, origin, title_hint).await?;
+
+        match &near {
+            // Parked. Synthesis is the expensive stage and this text may not
+            // deserve it; an operator decides on Ops. Nothing is lost either
+            // way — the corpus is stored verbatim like any other.
+            Some(n) => {
+                self.store
+                    .set_near_dupe(&src.id, Some(&n.corpus_id), Some(n.similarity))
+                    .await?;
+                self.store
+                    .set_corpus_status(&src.id, CorpusStatus::NeedsReview)
+                    .await?;
+                tracing::info!(
+                    corpus_id = %src.id,
+                    near = %n.corpus_id,
+                    similarity = n.similarity,
+                    "capture looks like an existing corpus; parked for review"
+                );
+            }
+            None => {
+                self.store
+                    .enqueue(Stage::Synthesize, "corpus", &src.id)
+                    .await?;
+                tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested");
+            }
+        }
+
+        Ok(IngestOutcome {
+            id: src.id,
+            status: if near.is_some() {
+                CorpusStatus::NeedsReview
+            } else {
+                CorpusStatus::Raw
+            },
+            duplicate: false,
+            near_duplicate: near,
+        })
+    }
+
+    /// Act on a parked capture. Every branch ends with a corpus that is either
+    /// in the pipeline or gone; none of them leaves a corpus stuck in
+    /// `needs_review` with no way out.
+    pub async fn resolve_near_duplicate(
+        &self,
+        corpus_id: &str,
+        action: NearDupeAction,
+    ) -> Result<()> {
+        let src = self.store.get_corpus(corpus_id).await?;
+        let Some(other) = src.near_dupe_of.clone() else {
+            return Err(Error::Validation(
+                "this corpus is not parked as a near-duplicate".into(),
+            ));
+        };
+
+        match action {
+            NearDupeAction::Discard => {
+                self.delete_corpus(&src.id).await?;
+                tracing::info!(corpus_id = %src.id, "discarded a near-duplicate capture");
+            }
+            NearDupeAction::Replace | NearDupeAction::KeepBoth => {
+                if action == NearDupeAction::Replace {
+                    // The older corpus goes first. If this fails the new one is
+                    // still parked, which is a state an operator can retry from;
+                    // releasing it first would leave both live on a failure.
+                    self.delete_corpus(&other).await?;
+                    tracing::info!(corpus_id = %src.id, replaced = %other, "replaced an older corpus");
+                }
+                self.store.set_near_dupe(&src.id, None, None).await?;
+                self.store
+                    .set_corpus_status(&src.id, CorpusStatus::Raw)
+                    .await?;
+                self.store
+                    .enqueue(Stage::Synthesize, "corpus", &src.id)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib core::ingest` then `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ingest.rs src/config.rs src/core/mod.rs
+git commit -m "feat: park near-duplicate captures instead of synthesising them"
+```
+
+---
+
+## Task 5: Web surface for parked captures
+
+**Files:**
+- Modify: `src/web/api.rs:391-406` (routes), `src/web/ui.rs:557-606` (ops handler), `src/web/ui.rs:829-832` (routes)
+- Modify: `src/web/templates/ops.html`
+
+**Interfaces:**
+- Consumes: `Core::resolve_near_duplicate`, `NearDupeAction`, `Store::list_corpora`.
+- Produces:
+  - `POST /api/v1/corpora/{id}/resolve` with body `{"action":"replace"|"keep_both"|"discard"}`.
+  - `POST /ui/ops/corpora/{id}/resolve` form-encoded `action=...`, redirecting to `/ui/ops`.
+  - `pub async fn parked_corpora(&self, limit: i64) -> Result<Vec<Corpus>>` on `Store`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `src/web/api.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_parked_capture_is_resolved_over_the_api() {
+        let (app, token, core) = app_token_and_core().await;
+        let body: String = (0..200)
+            .map(|i| format!("step {i}: run the mount command and read its output"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        core.ingest(&body, "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(&body.replacen("step 7:", "step seven:", 1), "web", None)
+            .await
+            .unwrap();
+        assert!(second.near_duplicate.is_some());
+
+        let res = app
+            .oneshot(post_json(
+                &format!("/api/v1/corpora/{}/resolve", second.id),
+                &token,
+                serde_json::json!({ "action": "keep_both" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            core.store.get_corpus(&second.id).await.unwrap().status,
+            crate::store::corpora::CorpusStatus::Raw
+        );
+    }
+
+    #[tokio::test]
+    async fn resolving_a_corpus_that_is_not_parked_is_a_bad_request() {
+        let (app, token, core) = app_token_and_core().await;
+        let out = core.ingest("plain text", "web", None).await.unwrap();
+        let res = app
+            .oneshot(post_json(
+                &format!("/api/v1/corpora/{}/resolve", out.id),
+                &token,
+                serde_json::json!({ "action": "discard" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+```
+
+Reuse the existing `post_json` helper in that module; if it is named differently, use whatever the file already provides for an authenticated JSON POST.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib web::api`
+Expected: FAIL — 404, no such route.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/web/api.rs`, beside the other corpus handlers:
+
+```rust
+#[derive(serde::Deserialize)]
+struct ResolveBody {
+    action: crate::core::ingest::NearDupeAction,
+}
+
+/// Act on a capture parked as a near-duplicate. The decision is an operator's:
+/// nothing here compares the two documents again, it only carries out what was
+/// chosen.
+async fn resolve_near_dupe(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(id): Path<String>,
+    Json(body): Json<ResolveBody>,
+) -> Result<Json<serde_json::Value>> {
+    st.core.resolve_near_duplicate(&id, body.action).await?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+```
+
+Register it:
+
+```rust
+        .route("/corpora/{id}/resolve", post(resolve_near_dupe))
+```
+
+In `src/store/corpora.rs`:
+
+```rust
+    /// Captures waiting on a near-duplicate decision, newest first. They are
+    /// the one corpus state nothing else advances, so Ops has to show them or
+    /// they sit unprocessed with no indication why.
+    pub async fn parked_corpora(&self, limit: i64) -> Result<Vec<Corpus>> {
+        let rows = sqlx::query(
+            "SELECT * FROM corpora WHERE near_dupe_of IS NOT NULL
+              ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_corpus).collect())
+    }
+```
+
+In `src/web/ui.rs`, add a row type and thread it into the ops template struct and handler:
+
+```rust
+/// A parked capture, with enough of the corpus it resembles to decide without
+/// opening both.
+pub struct ParkedRow {
+    pub id: String,
+    pub title_hint: Option<String>,
+    pub bytes: usize,
+    pub other_id: String,
+    pub other_title: Option<String>,
+    pub percent: i64,
+}
+```
+
+In the `ops` handler, before building the template struct:
+
+```rust
+    let mut parked = Vec::new();
+    for c in st.core.store.parked_corpora(50).await? {
+        let other = c.near_dupe_of.clone().unwrap_or_default();
+        let other_title = st
+            .core
+            .store
+            .get_corpus(&other)
+            .await
+            .ok()
+            .and_then(|o| o.title_hint);
+        parked.push(ParkedRow {
+            other_id: other,
+            other_title,
+            percent: (c.near_dupe_score.unwrap_or(0.0) * 100.0).round() as i64,
+            bytes: c.raw_text.len(),
+            title_hint: c.title_hint.clone(),
+            id: c.id,
+        });
+    }
+```
+
+Add the form handler and route:
+
+```rust
+#[derive(serde::Deserialize)]
+struct ResolveForm {
+    action: crate::core::ingest::NearDupeAction,
+}
+
+async fn resolve_near_dupe_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(id): Path<String>,
+    Form(form): Form<ResolveForm>,
+) -> Result<Response> {
+    st.core.resolve_near_duplicate(&id, form.action).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+```
+
+```rust
+        .route("/ui/ops/corpora/{id}/resolve", post(resolve_near_dupe_ui))
+```
+
+In `src/web/templates/ops.html`, add a section above the flagged-artifacts table, matching the file's existing markup conventions:
+
+```html
+{% if !parked.is_empty() %}
+<section>
+  <h2>Captures waiting on a decision</h2>
+  <p class="hint">
+    These were stored but not synthesised: each looks like a document already
+    in the base. Nothing is spent on them until you choose.
+  </p>
+  <table>
+    <thead><tr><th>Capture</th><th>Looks like</th><th>Match</th><th></th></tr></thead>
+    <tbody>
+    {% for p in parked %}
+      <tr>
+        <td><a href="/ui/corpora/{{ p.id }}">{{ p.title_hint.as_deref().unwrap_or("untitled") }}</a> ({{ p.bytes }} bytes)</td>
+        <td><a href="/ui/corpora/{{ p.other_id }}">{{ p.other_title.as_deref().unwrap_or("untitled") }}</a></td>
+        <td>{{ p.percent }}%</td>
+        <td>
+          <form method="post" action="/ui/ops/corpora/{{ p.id }}/resolve">
+            <button name="action" value="replace">Replace the old one</button>
+            <button name="action" value="keep_both">Keep both</button>
+            <button name="action" value="discard">Discard this</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib web`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/api.rs src/web/ui.rs src/web/templates/ops.html src/store/corpora.rs
+git commit -m "feat: resolve parked captures from Ops and the API"
+```
+
+---
+
+## Task 6: Superseded artifacts are hidden from search
+
+The flag first, then the sweep that sets it. Doing it this way round means the sweep is never the thing under test when the filter is wrong.
+
+**Files:**
+- Modify: `src/vector/mod.rs:8-44` (payload, filter), `:69-110` (trait)
+- Modify: `src/vector/memory.rs:109-140` (search), and add `set_superseded`
+- Modify: `src/vector/qdrant.rs` (`build_filter`, and add `set_superseded`)
+- Modify: `src/jobs/embed.rs:365-379` (`payload_of`)
+- Modify: `src/store/artifacts.rs` (`Chunk.superseded_by`, `set_superseded_by`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `VectorPayload { superseded: Option<bool>, .. }` — `skip_serializing_if = "Option::is_none"`, so an absent value means "leave what is stored alone", exactly like `last_seen_at`.
+  - `SearchFilter { include_superseded: bool, .. }` — `false` by default.
+  - `VectorStore::set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()>`
+  - `Chunk { superseded_by: Option<String>, .. }`
+  - `Store::set_superseded_by(&self, artifact_id: &str, by: Option<&str>) -> Result<()>`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `src/vector/memory.rs` (create the module if the file has none):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::VectorPayload;
+
+    fn point(id: &str, v: f32) -> VectorPoint {
+        VectorPoint {
+            vector: vec![v, 1.0 - v],
+            sparse: Default::default(),
+            payload: VectorPayload {
+                artifact_id: id.into(),
+                corpus_id: "c".into(),
+                text: id.into(),
+                title: None,
+                category: None,
+                tags: vec![],
+                created_at: 0,
+                last_seen_at: None,
+                superseded: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_drops_out_of_search() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0), point("b", 0.99)]).await.unwrap();
+        assert_eq!(v.search(&[1.0, 0.0], &Default::default(), 10, &Default::default()).await.unwrap().len(), 2);
+
+        v.set_superseded("b", true).await.unwrap();
+        let hits = v
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].payload.artifact_id, "a");
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_is_still_reachable_when_asked_for() {
+        // Superseding hides an artifact from ranking. It must not make it
+        // unreadable: the review queue and the undo both need to see it.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0), point("b", 0.99)]).await.unwrap();
+        v.set_superseded("b", true).await.unwrap();
+
+        let filter = SearchFilter { include_superseded: true, ..Default::default() };
+        assert_eq!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &filter).await.unwrap().len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn un_superseding_puts_an_artifact_back_in_results() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0)]).await.unwrap();
+        v.set_superseded("a", true).await.unwrap();
+        v.set_superseded("a", false).await.unwrap();
+        assert_eq!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &Default::default()).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn re_embedding_does_not_un_supersede_an_artifact() {
+        // `payload_of` in the embed job knows nothing about consolidation, so
+        // it leaves the field unset — and unset must mean "keep what is
+        // stored", or every re-embed would silently revive a hidden artifact.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0)]).await.unwrap();
+        v.set_superseded("a", true).await.unwrap();
+        v.upsert(vec![point("a", 1.0)]).await.unwrap();
+        assert!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib vector::memory`
+Expected: FAIL — `no field superseded`, `no method set_superseded`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/vector/mod.rs` — extend the payload:
+
+```rust
+    /// Set when this artifact lost a near-identical pair to a newer one. Like
+    /// `last_seen_at`, it is omitted when unset so that a writer which does not
+    /// know the value — the embed job rebuilding a payload — leaves the stored
+    /// one alone rather than reviving a hidden artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded: Option<bool>,
+```
+
+Extend the filter:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilter {
+    pub tags: Vec<String>,
+    pub category: Option<String>,
+    /// Superseded artifacts are excluded by default. They are still stored and
+    /// still readable by id — hiding them from ranking is the whole of what
+    /// superseding does.
+    pub include_superseded: bool,
+}
+```
+
+`is_empty` must not report a filter as empty merely because it only excludes superseded points:
+
+```rust
+    pub fn is_empty(&self) -> bool {
+        self.tags.is_empty() && self.category.is_none() && self.include_superseded
+    }
+```
+
+Add the trait method next to `set_payload`:
+
+```rust
+    /// Hide or unhide one artifact. A payload write, not a re-embed: which
+    /// artifact won a near-identical pair changes nothing the embedding model
+    /// saw.
+    async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()>;
+```
+
+`src/vector/memory.rs` — implement it and filter in `search`:
+
+```rust
+    async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        if let Some(p) = w.get_mut(artifact_id) {
+            p.payload.superseded = Some(superseded);
+        }
+        Ok(())
+    }
+```
+
+In `search`, extend the `filter(...)` closure:
+
+```rust
+            .filter(|p| {
+                (filter.include_superseded || p.payload.superseded != Some(true))
+                    && filter.tags.iter().all(|t| p.payload.tags.contains(t))
+                    && filter
+                        .category
+                        .as_ref()
+                        .is_none_or(|c| p.payload.category.as_ref() == Some(c))
+            })
+```
+
+In `upsert`, carry the flag forward exactly as `last_seen_at` is carried:
+
+```rust
+            if p.payload.superseded.is_none() {
+                p.payload.superseded = w
+                    .get(&p.payload.artifact_id)
+                    .and_then(|old| old.payload.superseded);
+            }
+```
+
+And in `set_payload`, the same preservation:
+
+```rust
+            let sup = payload.superseded.or(p.payload.superseded);
+            p.payload = payload.clone();
+            p.payload.last_seen_at = seen;
+            p.payload.superseded = sup;
+```
+
+`src/vector/qdrant.rs` — in `build_filter`, add the exclusion. Because `build_filter` currently returns `Option<Value>` and may return `None`, it must now return a filter whenever superseded points are being excluded:
+
+```rust
+    // Superseded points are excluded with `must_not` rather than by matching
+    // `false`: an artifact stored before consolidation existed has no
+    // `superseded` key at all, and a `match: false` clause would drop every
+    // one of them from search.
+    if !filter.include_superseded {
+        must_not.push(json!({ "key": "superseded", "match": { "value": true } }));
+    }
+```
+
+Assemble the returned object from both `must` and `must_not`, returning `None` only when both are empty. Add the method:
+
+```rust
+    async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()> {
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/payload?wait=true", self.alias),
+                Some(json!({
+                    "payload": { "superseded": superseded },
+                    "points": [ point_uuid(artifact_id) ],
+                })),
+            )
+            .await?;
+        Ok(())
+    }
+```
+
+`src/jobs/embed.rs` — `payload_of` gains one field with the same comment shape as `last_seen_at`:
+
+```rust
+        // Unset for the same reason as `last_seen_at`: this job knows nothing
+        // about consolidation, and writing `false` here would revive an
+        // artifact the sweep hid on every re-embed.
+        superseded: None,
+```
+
+`src/store/artifacts.rs` — add `pub superseded_by: Option<String>,` to `Chunk`, read it in `row_to_artifact` (`superseded_by: r.get("superseded_by"),`), set `superseded_by: None` in the `insert_artifacts` literal, and add:
+
+```rust
+    /// Record that this artifact lost a near-identical pair. `None` undoes it.
+    pub async fn set_superseded_by(&self, artifact_id: &str, by: Option<&str>) -> Result<()> {
+        let res = sqlx::query("UPDATE artifacts SET superseded_by = ? WHERE id = ?")
+            .bind(by)
+            .bind(artifact_id)
+            .execute(&self.pool)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Err(Error::NotFound);
+        }
+        Ok(())
+    }
+
+    /// Artifacts currently hidden by consolidation, newest first.
+    pub async fn superseded_artifacts(&self, limit: i64) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE superseded_by IS NOT NULL
+              ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+```
+
+Every `VectorPayload` literal in the test suites now needs `superseded: None`; the compiler names them all.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test`
+Expected: PASS across the whole suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vector src/jobs/embed.rs src/store/artifacts.rs
+git commit -m "feat: hide superseded artifacts from search behind a payload flag"
+```
+
+---
+
+## Task 7: `near_pairs` on the vector store
+
+**Files:**
+- Modify: `src/vector/mod.rs` (`NearPair`, trait method)
+- Modify: `src/vector/memory.rs`
+- Modify: `src/vector/qdrant.rs`
+- Test: `tests/` integration file for the Qdrant path if one exists; otherwise the unit test on the request body, matching how `qdrant.rs` tests its other bodies.
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `pub struct NearPair { pub a: String, pub b: String, pub score: f32 }` — `a` and `b` are artifact ids, ordered so `a < b`.
+  - `VectorStore::near_pairs(&self, sample: usize, per_point: usize, min_score: f32) -> Result<Vec<NearPair>>` — best first, superseded points excluded.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/vector/memory.rs`'s test module:
+
+```rust
+    #[tokio::test]
+    async fn near_pairs_finds_the_close_pair_and_not_the_far_one() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0), point("b", 0.999), point("c", 0.0)])
+            .await
+            .unwrap();
+
+        let pairs = v.near_pairs(100, 5, 0.9).await.unwrap();
+        assert_eq!(pairs.len(), 1, "got {pairs:?}");
+        assert_eq!((pairs[0].a.as_str(), pairs[0].b.as_str()), ("a", "b"));
+        assert!(pairs[0].score >= 0.9);
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_reported_once_not_twice() {
+        // (a,b) and (b,a) are the same pair. Reporting both doubles the review
+        // queue and makes the sweep supersede an artifact twice.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0), point("b", 0.999)]).await.unwrap();
+        assert_eq!(v.near_pairs(100, 5, 0.9).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_is_not_paired_again() {
+        // Otherwise every sweep re-finds the pair it resolved last time and
+        // the review queue never empties.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0), point("b", 0.999)]).await.unwrap();
+        v.set_superseded("b", true).await.unwrap();
+        assert!(v.near_pairs(100, 5, 0.9).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pairs_come_back_best_first() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", 1.0), point("b", 0.999), point("c", 0.99)])
+            .await
+            .unwrap();
+        let pairs = v.near_pairs(100, 5, 0.5).await.unwrap();
+        for w in pairs.windows(2) {
+            assert!(w[0].score >= w[1].score, "not sorted: {pairs:?}");
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib vector::memory`
+Expected: FAIL — `no method near_pairs`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/vector/mod.rs`:
+
+```rust
+/// Two artifacts the index says are close, and how close.
+///
+/// `a` sorts before `b` so the same pair found from either end is one value —
+/// the sweep would otherwise queue it twice and supersede the loser twice.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NearPair {
+    pub a: String,
+    pub b: String,
+    pub score: f32,
+}
+
+impl NearPair {
+    pub fn new(x: &str, y: &str, score: f32) -> NearPair {
+        let (a, b) = if x <= y { (x, y) } else { (y, x) };
+        NearPair {
+            a: a.to_string(),
+            b: b.to_string(),
+            score,
+        }
+    }
+}
+```
+
+Trait method:
+
+```rust
+    /// Pairs of artifacts closer than `min_score`, best first, over a sample of
+    /// the collection. Superseded artifacts are excluded — a resolved pair
+    /// re-found every sweep is a review queue that never empties.
+    ///
+    /// This is one round trip, not one query per point: `sample` points are
+    /// drawn and each contributes at most `per_point` neighbours. A sweep over
+    /// a base of any size therefore costs a bounded amount rather than growing
+    /// with the collection.
+    async fn near_pairs(
+        &self,
+        sample: usize,
+        per_point: usize,
+        min_score: f32,
+    ) -> Result<Vec<NearPair>>;
+```
+
+`src/vector/memory.rs`:
+
+```rust
+    async fn near_pairs(
+        &self,
+        sample: usize,
+        per_point: usize,
+        min_score: f32,
+    ) -> Result<Vec<NearPair>> {
+        let r = self.points.read().unwrap();
+        let live: Vec<&VectorPoint> = r
+            .values()
+            .filter(|p| p.payload.superseded != Some(true))
+            .take(sample)
+            .collect();
+
+        let mut out: Vec<NearPair> = Vec::new();
+        for (i, a) in live.iter().enumerate() {
+            let mut mine: Vec<NearPair> = live
+                .iter()
+                .skip(i + 1)
+                .map(|b| {
+                    NearPair::new(
+                        &a.payload.artifact_id,
+                        &b.payload.artifact_id,
+                        cosine(&a.vector, &b.vector),
+                    )
+                })
+                .filter(|p| p.score >= min_score)
+                .collect();
+            mine.sort_by(|x, y| y.score.total_cmp(&x.score));
+            mine.truncate(per_point);
+            out.extend(mine);
+        }
+        // Deterministic order, so a test never depends on HashMap iteration.
+        out.sort_by(|x, y| {
+            y.score
+                .total_cmp(&x.score)
+                .then_with(|| x.a.cmp(&y.a))
+                .then_with(|| x.b.cmp(&y.b))
+        });
+        out.dedup_by(|x, y| x.a == y.a && x.b == y.b);
+        Ok(out)
+    }
+```
+
+`src/vector/qdrant.rs` — the matrix API, plus a uuid→artifact_id lookup because the response speaks in point ids:
+
+```rust
+#[derive(serde::Deserialize)]
+struct MatrixPairs {
+    pairs: Vec<MatrixPair>,
+}
+
+#[derive(serde::Deserialize)]
+struct MatrixPair {
+    a: Value,
+    b: Value,
+    score: f32,
+}
+```
+
+```rust
+    async fn near_pairs(
+        &self,
+        sample: usize,
+        per_point: usize,
+        min_score: f32,
+    ) -> Result<Vec<NearPair>> {
+        // Superseded points are excluded at the source. Including them would
+        // hand the sweep pairs it has already resolved, every single run.
+        let res: MatrixPairs = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/search/matrix/pairs", self.alias),
+                Some(json!({
+                    "sample": sample,
+                    "limit": per_point,
+                    "using": DENSE,
+                    "filter": { "must_not": [
+                        { "key": "superseded", "match": { "value": true } }
+                    ] },
+                })),
+            )
+            .await?;
+
+        let mut ids: Vec<Value> = Vec::new();
+        for p in &res.pairs {
+            if p.score < min_score {
+                continue;
+            }
+            ids.push(p.a.clone());
+            ids.push(p.b.clone());
+        }
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        ids.sort_by_key(|v| v.to_string());
+        ids.dedup();
+
+        // `point_uuid` is one-way, so the artifact id has to come back from the
+        // payload. One retrieve for the whole sweep, asking for the single key
+        // rather than dragging every candidate's text across the wire.
+        let looked_up: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points", self.alias),
+                Some(json!({ "ids": ids, "with_payload": ["artifact_id"], "with_vector": false })),
+            )
+            .await?;
+        let mut by_uuid: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        if let Some(list) = looked_up.get("result").and_then(|r| r.as_array()) {
+            for p in list {
+                let (Some(id), Some(aid)) = (
+                    p.get("id"),
+                    p.get("payload")
+                        .and_then(|pl| pl.get("artifact_id"))
+                        .and_then(|v| v.as_str()),
+                ) else {
+                    continue;
+                };
+                by_uuid.insert(id.to_string(), aid.to_string());
+            }
+        }
+
+        let mut out: Vec<NearPair> = res
+            .pairs
+            .iter()
+            .filter(|p| p.score >= min_score)
+            .filter_map(|p| {
+                let a = by_uuid.get(&p.a.to_string())?;
+                let b = by_uuid.get(&p.b.to_string())?;
+                // A point can pair with itself across a re-embed boundary; a
+                // pair of one artifact is not a duplicate of anything.
+                (a != b).then(|| NearPair::new(a, b, p.score))
+            })
+            .collect();
+        out.sort_by(|x, y| {
+            y.score
+                .total_cmp(&x.score)
+                .then_with(|| x.a.cmp(&y.a))
+                .then_with(|| x.b.cmp(&y.b))
+        });
+        out.dedup_by(|x, y| x.a == y.a && x.b == y.b);
+        Ok(out)
+    }
+```
+
+Add a unit test in `qdrant.rs`'s existing test module, in the style of the ones already there:
+
+```rust
+    #[test]
+    fn matrix_pairs_deserialise_from_qdrant_shape() {
+        let res: MatrixPairs = serde_json::from_value(json!({
+            "pairs": [ { "a": 1, "b": 2, "score": 0.97 } ]
+        }))
+        .unwrap();
+        assert_eq!(res.pairs.len(), 1);
+        assert!((res.pairs[0].score - 0.97).abs() < 1e-6);
+    }
+
+    #[test]
+    fn a_pair_is_canonically_ordered() {
+        assert_eq!(NearPair::new("z", "a", 0.9), NearPair::new("a", "z", 0.9));
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib vector`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vector
+git commit -m "feat: near_pairs over the collection via the distance matrix"
+```
+
+---
+
+## Task 8: The review queue store
+
+**Files:**
+- Create: `src/store/pairs.rs`
+- Modify: `src/store/mod.rs` (add `pub mod pairs;`)
+
+**Interfaces:**
+- Consumes: the `artifact_pairs` table from Task 2.
+- Produces:
+  - `pub enum PairState { Pending, NoConflict, Contradiction, Dismissed }` with `as_str` / `parse`, mirroring `EmbedState`.
+  - `pub struct ArtifactPair { pub id: i64, pub a_id: String, pub b_id: String, pub score: f32, pub state: PairState, pub detail: Option<String>, pub created_at: i64 }`
+  - `Store::record_pair(&self, a: &str, b: &str, score: f32) -> Result<bool>` — true when a new row was written.
+  - `Store::pairs_by_state(&self, state: PairState, limit: i64) -> Result<Vec<ArtifactPair>>`
+  - `Store::set_pair_state(&self, id: i64, state: PairState, detail: Option<&str>) -> Result<()>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/store/pairs.rs` with only its test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use crate::store::artifacts::NewArtifact;
+
+    async fn two_artifacts(s: &Store) -> (String, String) {
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(
+                &src.id,
+                &[
+                    NewArtifact {
+                        ordinal: 0,
+                        text: "one".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                    NewArtifact {
+                        ordinal: 1,
+                        text: "two".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        (made[0].id.clone(), made[1].id.clone())
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_recorded_once_and_only_once() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        assert!(s.record_pair(&a, &b, 0.91).await.unwrap());
+        assert!(!s.record_pair(&a, &b, 0.91).await.unwrap(), "a repeat sweep duplicated the pair");
+        assert!(!s.record_pair(&b, &a, 0.91).await.unwrap(), "the reversed pair duplicated it");
+        assert_eq!(s.pairs_by_state(PairState::Pending, 10).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn resolving_a_pair_takes_it_off_the_pending_list() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap().remove(0);
+
+        s.set_pair_state(p.id, PairState::Contradiction, Some("version differs: 1.2 vs 1.4"))
+            .await
+            .unwrap();
+
+        assert!(s.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
+        let done = s.pairs_by_state(PairState::Contradiction, 10).await.unwrap();
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].detail.as_deref(), Some("version differs: 1.2 vs 1.4"));
+    }
+
+    #[tokio::test]
+    async fn a_resolved_pair_is_not_re_queued_by_the_next_sweep() {
+        // The sweep re-finds the same pair every run. If `record_pair` reset a
+        // dismissed row to pending, dismissing would achieve nothing.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap().remove(0);
+        s.set_pair_state(p.id, PairState::Dismissed, None).await.unwrap();
+
+        assert!(!s.record_pair(&a, &b, 0.91).await.unwrap());
+        assert!(s.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleting_an_artifact_takes_its_pairs_with_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        s.delete_artifact(&a).await.unwrap();
+        assert!(s.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
+    }
+}
+```
+
+Also add `pub mod pairs;` to `src/store/mod.rs`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib store::pairs`
+Expected: FAIL — `cannot find type PairState`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `src/store/pairs.rs`:
+
+```rust
+//! The consolidation review queue.
+//!
+//! Pairs similar enough to be worth attention but not similar enough to
+//! supersede without asking. The sweep finds the same pair on every run, so a
+//! row here is also the record that a decision was already made about it — a
+//! dismissed pair must stay dismissed, or dismissing would achieve nothing.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairState {
+    /// Found by the sweep, nothing has looked at it yet.
+    Pending,
+    /// The fact-token prefilter or the judge found nothing to disagree about.
+    NoConflict,
+    /// The judge found a detail the two artifacts state differently. Which one
+    /// is current is a judgement only the reader can make.
+    Contradiction,
+    /// An operator looked and decided there is nothing here.
+    Dismissed,
+}
+
+impl PairState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PairState::Pending => "pending",
+            PairState::NoConflict => "no_conflict",
+            PairState::Contradiction => "contradiction",
+            PairState::Dismissed => "dismissed",
+        }
+    }
+    pub fn parse(s: &str) -> PairState {
+        match s {
+            "no_conflict" => PairState::NoConflict,
+            "contradiction" => PairState::Contradiction,
+            "dismissed" => PairState::Dismissed,
+            _ => PairState::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ArtifactPair {
+    pub id: i64,
+    pub a_id: String,
+    pub b_id: String,
+    pub score: f32,
+    pub state: PairState,
+    pub detail: Option<String>,
+    pub created_at: i64,
+}
+
+fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
+    ArtifactPair {
+        id: r.get("id"),
+        a_id: r.get("a_id"),
+        b_id: r.get("b_id"),
+        score: r.get::<f64, _>("score") as f32,
+        state: PairState::parse(r.get::<String, _>("state").as_str()),
+        detail: r.get("detail"),
+        created_at: r.get("created_at"),
+    }
+}
+
+impl Store {
+    /// File a pair for review. Returns whether this was new.
+    ///
+    /// `INSERT OR IGNORE` rather than an upsert, deliberately: the sweep finds
+    /// the same pair every run, and re-arming a row an operator dismissed
+    /// would make dismissing pointless.
+    pub async fn record_pair(&self, a: &str, b: &str, score: f32) -> Result<bool> {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, created_at)
+             VALUES (?, ?, ?, 'pending', ?)",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(score as f64)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    pub async fn pairs_by_state(&self, state: PairState, limit: i64) -> Result<Vec<ArtifactPair>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifact_pairs WHERE state = ?
+              ORDER BY score DESC, created_at DESC LIMIT ?",
+        )
+        .bind(state.as_str())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_pair).collect())
+    }
+
+    pub async fn set_pair_state(
+        &self,
+        id: i64,
+        state: PairState,
+        detail: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query("UPDATE artifact_pairs SET state = ?, detail = ? WHERE id = ?")
+            .bind(state.as_str())
+            .bind(detail)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib store::pairs`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/pairs.rs src/store/mod.rs
+git commit -m "feat: artifact pair review queue"
+```
+
+---
+
+## Task 9: The sweep
+
+**Files:**
+- Create: `src/jobs/consolidate.rs`
+- Modify: `src/jobs/mod.rs:1-2` (module), `:29-35` (dispatch)
+- Modify: `src/store/jobs.rs:8-30` (`Stage::Consolidate`)
+
+**Interfaces:**
+- Consumes: `VectorStore::near_pairs`, `VectorStore::set_superseded`, `Store::set_superseded_by`, `Store::record_pair`, `Core::consolidate`.
+- Produces:
+  - `Stage::Consolidate` ⇄ `"consolidate"`.
+  - `pub async fn run(core: &Core) -> Result<Outcome>` in `jobs::consolidate`, with `pub struct Outcome { pub examined: usize, pub superseded: usize, pub queued: usize }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/jobs/consolidate.rs` with only its test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::artifacts::NewArtifact;
+    use crate::store::pairs::PairState;
+    use crate::vector::{VectorPayload, VectorPoint};
+
+    /// Seed artifacts with hand-placed vectors, so the test controls the exact
+    /// similarity rather than depending on what the fake embedder produces.
+    async fn seed(core: &crate::core::Core, vectors: &[(&str, [f32; 2])]) -> Vec<String> {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, (text, _))| NewArtifact {
+                ordinal: i as i64,
+                text: (*text).to_string(),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+            })
+            .collect();
+        let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();
+        let points: Vec<VectorPoint> = made
+            .iter()
+            .zip(vectors)
+            .map(|(c, (text, v))| VectorPoint {
+                vector: v.to_vec(),
+                sparse: Default::default(),
+                payload: VectorPayload {
+                    artifact_id: c.id.clone(),
+                    corpus_id: c.corpus_id.clone(),
+                    text: (*text).to_string(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    created_at: c.created_at,
+                    last_seen_at: None,
+                    superseded: None,
+                },
+            })
+            .collect();
+        core.vectors.upsert(points).await.unwrap();
+        made.into_iter().map(|c| c.id).collect()
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_pair_supersedes_the_older_artifact() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.superseded, 1, "{out:?}");
+
+        // The older one loses: ordinal 0 was inserted first.
+        let older = core.store.get_artifact(&ids[0]).await.unwrap();
+        let newer = core.store.get_artifact(&ids[1]).await.unwrap();
+        assert_eq!(older.superseded_by.as_deref(), Some(ids[1].as_str()));
+        assert!(newer.superseded_by.is_none());
+
+        // And it is out of search, which is the whole point.
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].payload.artifact_id, ids[1]);
+    }
+
+    #[tokio::test]
+    async fn a_pair_in_the_review_band_is_queued_not_superseded() {
+        // 0.88 is where two genuinely distinct artifacts about one subsystem
+        // routinely sit. Acting on that score destroys knowledge.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.93, 0.37])]).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.superseded, 0, "{out:?}");
+        assert_eq!(out.queued, 1);
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().superseded_by.is_none());
+        }
+        assert_eq!(
+            core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_pair_is_left_entirely_alone() {
+        let core = test_core().await;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.superseded, out.queued), (0, 0), "{out:?}");
+    }
+
+    #[tokio::test]
+    async fn a_second_sweep_changes_nothing() {
+        // The sweep runs on a timer. If it were not idempotent it would churn
+        // the queue and the payload flags on every tick.
+        let core = test_core().await;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        run(&core).await.unwrap();
+        let second = run(&core).await.unwrap();
+        assert_eq!((second.superseded, second.queued), (0, 0), "{second:?}");
+    }
+
+    #[tokio::test]
+    async fn an_artifact_is_never_superseded_twice() {
+        // Three near-identical artifacts. Whatever survives, exactly one must,
+        // and no artifact may point at one that is itself superseded — that is
+        // a chain the UI cannot resolve and the reader cannot follow.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("first", [1.0, 0.0]),
+                ("second", [0.9999, 0.005]),
+                ("third", [0.9998, 0.01]),
+            ],
+        )
+        .await;
+
+        run(&core).await.unwrap();
+
+        let mut live = 0;
+        for id in &ids {
+            let c = core.store.get_artifact(id).await.unwrap();
+            match &c.superseded_by {
+                None => live += 1,
+                Some(winner) => {
+                    let w = core.store.get_artifact(winner).await.unwrap();
+                    assert!(
+                        w.superseded_by.is_none(),
+                        "{id} was superseded by {winner}, which is itself superseded"
+                    );
+                }
+            }
+        }
+        assert_eq!(live, 1, "exactly one artifact should have survived");
+    }
+
+    #[tokio::test]
+    async fn the_sweep_is_off_when_configuration_says_so() {
+        let mut core = test_core().await;
+        core.consolidate.enabled = false;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.examined, out.superseded, out.queued), (0, 0, 0));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib jobs::consolidate`
+Expected: FAIL — `cannot find function run`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the stage in `src/store/jobs.rs` — enum body, `as_str`, `parse`:
+
+```rust
+    /// The periodic consolidation sweep. Its target is the collection rather
+    /// than any one corpus, so there is exactly one of these in the queue at a
+    /// time.
+    Consolidate,
+```
+```rust
+            Stage::Consolidate => "consolidate",
+```
+```rust
+            "consolidate" => Some(Stage::Consolidate),
+```
+
+Prepend to `src/jobs/consolidate.rs`:
+
+```rust
+//! Consolidation: what to do about two artifacts the index says are the same.
+//!
+//! Three thresholds and three outcomes. At or above `auto_supersede` the pair
+//! is near enough to identical that the older one is hidden — it is still
+//! stored, still readable, and one write undoes it. Between `review_min` and
+//! that, the pair goes on a queue for a person, because two genuinely distinct
+//! artifacts about one subsystem sit at 0.88 routinely and acting on that score
+//! destroys knowledge rather than duplication. Below `review_min`, nothing.
+//!
+//! Nothing here rewrites an artifact. A merged artifact would be synthetic text
+//! standing where a stored passage used to, with no segment to verify it
+//! against and no corpus lines to show beside it, which is the one failure mode
+//! this design exists to avoid.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::Chunk;
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+pub struct Outcome {
+    pub examined: usize,
+    pub superseded: usize,
+    pub queued: usize,
+}
+
+/// Which of two artifacts survives.
+///
+/// The newer one, by capture time, with the id as a tie-break so the answer
+/// does not depend on clock resolution. Newer is the right default because the
+/// thing most often being re-captured is a document that has since been
+/// updated.
+fn winner<'a>(a: &'a Chunk, b: &'a Chunk) -> (&'a Chunk, &'a Chunk) {
+    let a_first = (a.created_at, a.id.as_str()) < (b.created_at, b.id.as_str());
+    if a_first { (b, a) } else { (a, b) }
+}
+
+pub async fn run(core: &Core) -> Result<Outcome> {
+    let cfg = &core.consolidate;
+    if !cfg.enabled {
+        return Ok(Outcome::default());
+    }
+
+    let pairs = core
+        .vectors
+        .near_pairs(cfg.sample, cfg.per_point, cfg.review_min)
+        .await?;
+    let mut out = Outcome {
+        examined: pairs.len(),
+        ..Default::default()
+    };
+
+    // Artifacts superseded during this sweep. A three-way near-identical
+    // cluster would otherwise have its middle member both supersede and be
+    // superseded, leaving a chain the reader cannot follow.
+    let mut lost: HashMap<String, ()> = HashMap::new();
+
+    for pair in pairs {
+        if lost.contains_key(&pair.a) || lost.contains_key(&pair.b) {
+            continue;
+        }
+        // A pair whose artifacts have since been deleted is not an error; the
+        // vector store can lag a delete by a sweep.
+        let (Ok(a), Ok(b)) = (
+            core.store.get_artifact(&pair.a).await,
+            core.store.get_artifact(&pair.b).await,
+        ) else {
+            tracing::debug!(a = %pair.a, b = %pair.b, "pair names an artifact that is gone");
+            continue;
+        };
+        if a.superseded_by.is_some() || b.superseded_by.is_some() {
+            continue;
+        }
+
+        if pair.score >= cfg.auto_supersede {
+            let (keep, drop) = winner(&a, &b);
+            // SQLite first: it is the source of truth, and a payload flag with
+            // no row behind it is a hidden artifact nothing can explain.
+            core.store
+                .set_superseded_by(&drop.id, Some(&keep.id))
+                .await?;
+            core.vectors.set_superseded(&drop.id, true).await?;
+            lost.insert(drop.id.clone(), ());
+            out.superseded += 1;
+            tracing::info!(
+                superseded = %drop.id,
+                by = %keep.id,
+                score = pair.score,
+                "hid a near-identical artifact"
+            );
+        } else if core.store.record_pair(&pair.a, &pair.b, pair.score).await? {
+            out.queued += 1;
+            tracing::info!(a = %pair.a, b = %pair.b, score = pair.score, "queued a pair for review");
+        }
+    }
+
+    if out.superseded > 0 || out.queued > 0 {
+        tracing::info!(
+            examined = out.examined,
+            superseded = out.superseded,
+            queued = out.queued,
+            "consolidation sweep finished"
+        );
+    }
+    Ok(out)
+}
+```
+
+In `src/jobs/mod.rs`, declare the module and dispatch:
+
+```rust
+pub mod consolidate;
+pub mod embed;
+pub mod synthesize;
+```
+```rust
+        (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib jobs::consolidate` then `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/consolidate.rs src/jobs/mod.rs src/store/jobs.rs
+git commit -m "feat: consolidation sweep supersedes near-identical artifacts"
+```
+
+---
+
+## Task 10: Schedule the sweep
+
+**Files:**
+- Modify: `src/core/background.rs`
+- Modify: `src/main.rs` (spawn the ticker beside the workers)
+
+**Interfaces:**
+- Consumes: `Store::enqueue`, `Core::consolidate`.
+- Produces: `pub fn spawn_consolidation_ticker(core: Core, shutdown: tokio::sync::watch::Receiver<bool>) -> tokio::task::JoinHandle<()>` in `crate::core::background`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/background.rs`'s test module:
+
+```rust
+    #[tokio::test]
+    async fn the_ticker_queues_exactly_one_sweep() {
+        // `jobs` is unique on (stage, target), so a ticker that fires while a
+        // sweep is still queued must collapse onto the same row rather than
+        // stacking sweeps behind a slow one.
+        let core = crate::core::test_support::test_core().await;
+        for _ in 0..3 {
+            core.store
+                .enqueue(crate::store::jobs::Stage::Consolidate, "collection", CONSOLIDATE_TARGET)
+                .await
+                .unwrap();
+        }
+        let mut seen = 0;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            assert_eq!(j.stage, crate::store::jobs::Stage::Consolidate);
+            seen += 1;
+        }
+        assert_eq!(seen, 1, "the sweep stacked up in the queue");
+    }
+
+    #[tokio::test]
+    async fn a_disabled_sweep_is_never_queued() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.consolidate.enabled = false;
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let h = spawn_consolidation_ticker(core.clone(), rx);
+        // The ticker enqueues once on start when enabled; disabled it must not.
+        tokio::task::yield_now().await;
+        assert!(core.store.claim_job().await.unwrap().is_none());
+        h.abort();
+    }
+```
+
+`Stage` needs `PartialEq` for the first assertion; derive it if it is not already there.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib core::background`
+Expected: FAIL — `cannot find value CONSOLIDATE_TARGET`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/core/background.rs`:
+
+```rust
+/// The sweep's job target. A constant rather than a corpus id: consolidation
+/// looks at the whole collection, and the `UNIQUE(stage, target_id)` on `jobs`
+/// then guarantees at most one queued sweep however often the ticker fires.
+pub const CONSOLIDATE_TARGET: &str = "collection";
+
+/// Queue a consolidation sweep now and every `interval_hours` after.
+///
+/// A timer rather than a trigger on write: a sweep after every capture would
+/// re-examine the whole collection for one new artifact, and the pairs it finds
+/// do not become interesting the instant they are written.
+pub fn spawn_consolidation_ticker(
+    core: crate::core::Core,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !core.consolidate.enabled {
+            tracing::info!("consolidation sweep disabled");
+            return;
+        }
+        let period = std::time::Duration::from_secs(
+            core.consolidate.interval_hours.max(1) * 3600,
+        );
+        let mut tick = tokio::time::interval(period);
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = tick.tick() => {
+                    if let Err(e) = core
+                        .store
+                        .enqueue(
+                            crate::store::jobs::Stage::Consolidate,
+                            "collection",
+                            CONSOLIDATE_TARGET,
+                        )
+                        .await
+                    {
+                        tracing::warn!(error = %e, "could not queue the consolidation sweep");
+                    }
+                }
+            }
+        }
+        tracing::info!("consolidation ticker stopped");
+    })
+}
+```
+
+In `src/main.rs`, beside the existing `Worker::spawn(...)` call, add:
+
+```rust
+    let ticker = crate::core::background::spawn_consolidation_ticker(core.clone(), shutdown_rx.clone());
+```
+
+and include `ticker` in whatever join or abort the shutdown path already performs on the worker handles.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib core::background` then `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/background.rs src/main.rs
+git commit -m "feat: queue the consolidation sweep on a timer"
+```
+
+---
+
+## Task 11: Ops shows superseded artifacts and the review queue
+
+**Files:**
+- Modify: `src/web/ui.rs` (ops handler, two form handlers, routes)
+- Modify: `src/web/templates/ops.html`
+- Modify: `src/web/api.rs` (read-only JSON for the queue)
+- Modify: `src/web/templates/_artifact_detail.html` (a superseded banner)
+
+**Interfaces:**
+- Consumes: `Store::superseded_artifacts`, `Store::pairs_by_state`, `Store::set_pair_state`, `Store::set_superseded_by`, `VectorStore::set_superseded`.
+- Produces:
+  - `Core::unsupersede(&self, artifact_id: &str) -> Result<()>`
+  - `POST /ui/ops/artifacts/{id}/unsupersede`
+  - `POST /ui/ops/pairs/{id}/dismiss`
+  - `GET /api/v1/consolidation` → `{"superseded":[...],"pairs":[...]}`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/web/ui.rs`'s test module:
+
+```rust
+    #[tokio::test]
+    async fn ops_lists_a_superseded_artifact_and_can_undo_it() {
+        let (app, cookie, core) = ui_app_and_login().await;
+        let src = core.store.insert_corpus("x", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "the losing artifact".into(),
+                    corpus_span: None,
+                    title: Some("loser".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                }],
+            )
+            .await
+            .unwrap();
+        core.store
+            .set_superseded_by(&made[0].id, Some("some-winner"))
+            .await
+            .unwrap();
+
+        let body = text_of(app.clone(), get("/ui/ops", &cookie)).await;
+        assert!(body.contains("loser"), "the superseded artifact is not listed");
+
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/ops/artifacts/{}/unsupersede", made[0].id),
+                &cookie,
+                "",
+            ))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .get_artifact(&made[0].id)
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "undo did not clear the flag"
+        );
+    }
+
+    #[tokio::test]
+    async fn ops_lists_a_pending_pair_and_can_dismiss_it() {
+        let (app, cookie, core) = ui_app_and_login().await;
+        let src = core.store.insert_corpus("x", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "left".into(),
+                        corpus_span: None,
+                        title: Some("left one".into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "right".into(),
+                        corpus_span: None,
+                        title: Some("right one".into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        core.store
+            .record_pair(&made[0].id, &made[1].id, 0.9)
+            .await
+            .unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+
+        let body = text_of(app.clone(), get("/ui/ops", &cookie)).await;
+        assert!(body.contains("left one") && body.contains("right one"));
+
+        app.clone()
+            .oneshot(form(&format!("/ui/ops/pairs/{}/dismiss", pair.id), &cookie, ""))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+```
+
+Use whatever helpers the file already has for a logged-in UI client and for reading a response body; `ui_app_and_login`, `get`, `form` and `text_of` above stand for them — substitute the real names.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib web::ui`
+Expected: FAIL — the ops body does not contain the artifact; the routes 404.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/core/ingest.rs` (or a small `impl Core` block in `src/core/mod.rs` — keep it beside `resolve_near_duplicate`):
+
+```rust
+    /// Put a superseded artifact back in search. The row first, then the
+    /// payload, in the same order the sweep wrote them.
+    pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+        self.store.set_superseded_by(artifact_id, None).await?;
+        self.vectors.set_superseded(artifact_id, false).await?;
+        tracing::info!(artifact_id, "restored a superseded artifact to search");
+        Ok(())
+    }
+```
+
+In `src/web/ui.rs`, add row types and extend the ops template struct:
+
+```rust
+/// An artifact the sweep hid, with the one it lost to.
+pub struct SupersededRow {
+    pub id: String,
+    pub title: String,
+    pub winner_id: String,
+    pub winner_title: String,
+}
+
+/// A pair waiting on a person.
+pub struct PairRow {
+    pub id: i64,
+    pub percent: i64,
+    pub a_id: String,
+    pub a_title: String,
+    pub b_id: String,
+    pub b_title: String,
+    pub detail: Option<String>,
+    pub contradiction: bool,
+}
+```
+
+In the `ops` handler:
+
+```rust
+    let title_of = |c: &crate::store::artifacts::Chunk| {
+        c.title
+            .clone()
+            .unwrap_or_else(|| c.text.chars().take(60).collect())
+    };
+
+    let mut superseded = Vec::new();
+    for c in st.core.store.superseded_artifacts(50).await? {
+        let winner_id = c.superseded_by.clone().unwrap_or_default();
+        let winner_title = match st.core.store.get_artifact(&winner_id).await {
+            Ok(w) => title_of(&w),
+            Err(_) => "(deleted)".to_string(),
+        };
+        superseded.push(SupersededRow {
+            title: title_of(&c),
+            id: c.id,
+            winner_id,
+            winner_title,
+        });
+    }
+
+    let mut pairs = Vec::new();
+    for state in [
+        crate::store::pairs::PairState::Contradiction,
+        crate::store::pairs::PairState::Pending,
+    ] {
+        for p in st.core.store.pairs_by_state(state, 50).await? {
+            let (Ok(a), Ok(b)) = (
+                st.core.store.get_artifact(&p.a_id).await,
+                st.core.store.get_artifact(&p.b_id).await,
+            ) else {
+                continue;
+            };
+            pairs.push(PairRow {
+                id: p.id,
+                percent: (p.score * 100.0).round() as i64,
+                a_title: title_of(&a),
+                b_title: title_of(&b),
+                a_id: p.a_id,
+                b_id: p.b_id,
+                detail: p.detail,
+                contradiction: state == crate::store::pairs::PairState::Contradiction,
+            });
+        }
+    }
+```
+
+Handlers and routes:
+
+```rust
+async fn unsupersede_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(id): Path<String>,
+) -> Result<Response> {
+    st.core.unsupersede(&id).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+async fn dismiss_pair_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(id): Path<i64>,
+) -> Result<Response> {
+    st.core
+        .store
+        .set_pair_state(id, crate::store::pairs::PairState::Dismissed, None)
+        .await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+```
+
+```rust
+        .route("/ui/ops/artifacts/{id}/unsupersede", post(unsupersede_ui))
+        .route("/ui/ops/pairs/{id}/dismiss", post(dismiss_pair_ui))
+```
+
+In `src/web/templates/ops.html`, two sections in the established markup style:
+
+```html
+{% if !pairs.is_empty() %}
+<section>
+  <h2>Pairs worth a look</h2>
+  <p class="hint">
+    Two artifacts covering the same ground. Which one is current is a judgement
+    only you can make, so nothing here has been changed.
+  </p>
+  <table>
+    <thead><tr><th>Match</th><th>One</th><th>The other</th><th>Finding</th><th></th></tr></thead>
+    <tbody>
+    {% for p in pairs %}
+      <tr{% if p.contradiction %} class="warn"{% endif %}>
+        <td>{{ p.percent }}%</td>
+        <td><a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a></td>
+        <td><a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a></td>
+        <td>{{ p.detail.as_deref().unwrap_or("") }}</td>
+        <td>
+          <form method="post" action="/ui/ops/pairs/{{ p.id }}/dismiss">
+            <button type="submit">Dismiss</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+
+{% if !superseded.is_empty() %}
+<section>
+  <h2>Hidden as near-identical</h2>
+  <p class="hint">Still stored and still readable; kept out of results only.</p>
+  <table>
+    <thead><tr><th>Hidden</th><th>Kept</th><th></th></tr></thead>
+    <tbody>
+    {% for s in superseded %}
+      <tr>
+        <td><a href="/ui/artifacts/{{ s.id }}">{{ s.title }}</a></td>
+        <td><a href="/ui/artifacts/{{ s.winner_id }}">{{ s.winner_title }}</a></td>
+        <td>
+          <form method="post" action="/ui/ops/artifacts/{{ s.id }}/unsupersede">
+            <button type="submit">Put it back</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+```
+
+In `src/web/templates/_artifact_detail.html`, above the artifact body, so opening a hidden artifact by link says why it is not in results:
+
+```html
+{% if let Some(winner) = artifact.superseded_by %}
+<p class="warn">
+  Hidden from results: something near-identical and newer
+  (<a href="/ui/artifacts/{{ winner }}">this one</a>) was kept instead.
+</p>
+{% endif %}
+```
+
+In `src/web/api.rs`, a read-only endpoint plus its route:
+
+```rust
+/// What consolidation has decided and what it is still asking about.
+async fn consolidation(
+    State(st): State<AppState>,
+    _id: Identity,
+) -> Result<Json<serde_json::Value>> {
+    Ok(Json(serde_json::json!({
+        "superseded": st.core.store.superseded_artifacts(100).await?,
+        "pairs": st
+            .core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 100)
+            .await?,
+    })))
+}
+```
+```rust
+        .route("/consolidation", get(consolidation))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib web` then `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web src/core
+git commit -m "feat: consolidation review surface on Ops"
+```
+
+---
+
+## Task 12: Caveats from the synthesis call
+
+Tier 1, and independent of everything above: it changes what one existing model call is asked to return.
+
+**Files:**
+- Modify: `src/infer/mod.rs:11-18` (`ProposedArtifact`)
+- Modify: `src/infer/prompt.rs:4-29` (system prompt), `:53-64` (`RawArtifact`), and the mapping into `ProposedArtifact`
+- Modify: `src/infer/verify.rs`
+- Modify: `src/store/artifacts.rs` (`Chunk.caveats`, `NewArtifact.caveats`, insert, `update_artifact_caveats`)
+- Modify: `src/jobs/synthesize.rs` (carry the field through)
+- Modify: `src/web/templates/_artifact_detail.html`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `ProposedArtifact { caveats: Vec<String>, .. }`
+  - `NewArtifact { caveats: Vec<String>, .. }`, `Chunk { caveats: Vec<String>, .. }`
+  - `verify::literals_missing_from(text_and_caveats, segment)` unchanged in name; it is fed the caveats as well.
+
+**Design note the implementer must not change:** caveats are stored and rendered but **not** added to `embed_text` in `src/jobs/embed.rs`. Changing what every vector is built from is exactly the kind of index change the roadmap says needs evaluation pairs first, and there are none. Storage and display cost nothing and can be reversed; a re-embedded collection cannot.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/infer/prompt.rs`'s test module:
+
+```rust
+    #[test]
+    fn caveats_are_parsed_when_the_model_supplies_them() {
+        let body = r#"{"artifacts":[{
+            "text":"Run `mkfs.ext4 /dev/sdb1` to format the partition.",
+            "title":"Formatting a partition",
+            "category":"procedure",
+            "tags":["disk"],
+            "corpus_lines":[3,9],
+            "caveats":["Destroys every existing file on the device.",
+                       "Requires root."]
+        }]}"#;
+        let got = parse_response(body).unwrap();
+        assert_eq!(
+            got[0].caveats,
+            vec![
+                "Destroys every existing file on the device.".to_string(),
+                "Requires root.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn an_artifact_without_caveats_parses_to_an_empty_list() {
+        // Most models will omit the field most of the time, and a missing
+        // field must never fail a segment that is otherwise fine.
+        let body = r#"{"artifacts":[{"text":"plain","title":"t","category":"c","tags":[]}]}"#;
+        assert!(parse_response(body).unwrap()[0].caveats.is_empty());
+    }
+
+    #[test]
+    fn the_system_prompt_asks_for_caveats_and_forbids_inventing_them() {
+        assert!(SYNTHESIZER_SYSTEM.contains("caveats"));
+        assert!(
+            SYNTHESIZER_SYSTEM.contains("stated"),
+            "the prompt must tie caveats to what the source says"
+        );
+    }
+```
+
+Append to `src/infer/verify.rs`'s test module:
+
+```rust
+    #[test]
+    fn a_command_invented_in_a_caveat_is_caught() {
+        // A caveat is prose the model wrote, and it is exactly where an
+        // invented "run `rm -rf /var/lib/thing` first" would appear. The
+        // literal check has to reach it, or caveats become the one part of an
+        // artifact nothing verifies.
+        let segment = "Format with mkfs.ext4 /dev/sdb1 after unmounting.";
+        let missing = missing_literals(
+            "Run `mkfs.ext4 /dev/sdb1`.",
+            &["First run `wipefs --all /dev/sdb1`.".to_string()],
+            segment,
+        );
+        assert_eq!(missing, vec!["wipefs --all /dev/sdb1".to_string()]);
+    }
+
+    #[test]
+    fn a_caveat_quoting_a_real_command_is_not_flagged() {
+        let segment = "Format with mkfs.ext4 /dev/sdb1 after unmounting.";
+        assert!(
+            missing_literals(
+                "Format the partition.",
+                &["Unmount first: `mkfs.ext4 /dev/sdb1` fails on a mounted device.".to_string()],
+                segment,
+            )
+            .is_empty()
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib infer`
+Expected: FAIL — `no field caveats`, `cannot find function missing_literals`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/infer/mod.rs`:
+
+```rust
+pub struct ProposedArtifact {
+    pub text: String,
+    pub title: Option<String>,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub corpus_lines: Option<(i64, i64)>,
+    /// Conditions under which the artifact does not apply, as the source states
+    /// them. The model is already holding this segment, so asking for them
+    /// costs output tokens rather than another call.
+    pub caveats: Vec<String>,
+}
+```
+
+`src/infer/prompt.rs` — extend the contract. Replace the shape line and the field list:
+
+```rust
+{"artifacts":[{"text":"...","title":"...","category":"...","tags":["..."],"corpus_lines":[start,end],"caveats":["..."]}]}
+
+- title: a short noun phrase naming the artifact.
+- category: one lowercase word, e.g. procedure, concept, reference, snippet.
+- tags: 1-5 lowercase keywords for filtering.
+- corpus_lines: the 1-based line range in the input this artifact came from.
+- caveats: 0-3 short sentences for conditions under which this artifact does
+  not hold — a prerequisite, a version or platform it is specific to, a
+  destructive effect, a documented failure. Take these only from what the input
+  states or plainly implies. Never invent a caveat, never add general advice,
+  and never put a command in a caveat that is not in the input. Use an empty
+  list when the input states none, which is the common case.
+```
+
+Add the field to `RawArtifact`:
+
+```rust
+    #[serde(default)]
+    caveats: Vec<String>,
+```
+
+and to wherever `RawArtifact` becomes `ProposedArtifact`:
+
+```rust
+            caveats: raw
+                .caveats
+                .into_iter()
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty())
+                .take(3)
+                .collect(),
+```
+
+`src/infer/verify.rs` — add a function that runs the existing literal check over the artifact and its caveats together:
+
+```rust
+/// Literals in an artifact and its caveats that the segment does not contain.
+///
+/// Caveats are the newest place model prose can appear, and a caveat that says
+/// to run something first is a command that gets pasted into a root shell just
+/// like one in the body. They go through the same check rather than a weaker
+/// one.
+pub fn missing_literals(text: &str, caveats: &[String], segment: &str) -> Vec<String> {
+    let haystack = normalize(segment);
+    let mut all = extract_literals(text);
+    for c in caveats {
+        all.extend(extract_literals(c));
+    }
+    let mut missing: Vec<String> = all
+        .into_iter()
+        .filter(|l| !haystack.contains(&normalize(l)))
+        .collect();
+    missing.sort();
+    missing.dedup();
+    missing
+}
+```
+
+Route the existing caller in `src/jobs/synthesize.rs` through `missing_literals`, passing the proposal's caveats, so flagging behaviour is unchanged except that it now sees caveats.
+
+`src/store/artifacts.rs` — `caveats: Vec<String>` on both `Chunk` and `NewArtifact`; read it in `row_to_artifact` the same way `tags` is read; bind it in the `INSERT` alongside `tags`; and:
+
+```rust
+    pub async fn update_artifact_caveats(&self, id: &str, caveats: &[String]) -> Result<()> {
+        sqlx::query("UPDATE artifacts SET caveats = ? WHERE id = ?")
+            .bind(serde_json::to_string(caveats).unwrap_or_else(|_| "[]".into()))
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+```
+
+`src/jobs/synthesize.rs` — set `caveats: p.caveats.clone()` where `NewArtifact` is built from a `ProposedArtifact`. In `src/jobs/embed.rs`'s `replace_with_siblings`, siblings inherit `caveats: chunk.caveats.clone()`, as they inherit tags.
+
+`src/web/templates/_artifact_detail.html` — render them under the body:
+
+```html
+{% if !artifact.caveats.is_empty() %}
+<aside class="caveats">
+  <h3>Before you rely on this</h3>
+  <ul>
+    {% for c in artifact.caveats %}<li>{{ c }}</li>{% endfor %}
+  </ul>
+</aside>
+{% endif %}
+```
+
+Every `NewArtifact` and `ProposedArtifact` literal in the test suites now needs the new field; the compiler names them all, including the two literals deferred from Task 2.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/infer src/store/artifacts.rs src/jobs src/web/templates/_artifact_detail.html
+git commit -m "feat: synthesis emits caveats alongside each artifact"
+```
+
+---
+
+## Task 13: The fact-token prefilter
+
+Zero inference. Its entire job is to keep the judge from being called on pairs that cannot disagree.
+
+**Files:**
+- Create: `src/infer/facts.rs`
+- Modify: `src/infer/mod.rs` (add `pub mod facts;`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `pub fn fact_tokens(text: &str) -> std::collections::BTreeSet<String>` — numbers with units, version strings, dates, and flag/path tokens.
+  - `pub fn may_disagree(a: &str, b: &str) -> bool` — true only when the two texts share some fact-shaped vocabulary *and* differ on some of it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/infer/facts.rs` with only its test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn versions_numbers_and_dates_are_facts() {
+        let f = fact_tokens("Requires 1.21.4 or later, 30 seconds, on 2024-03-01, at 8080.");
+        assert!(f.contains("1.21.4"), "{f:?}");
+        assert!(f.contains("2024-03-01"), "{f:?}");
+        assert!(f.contains("30"), "{f:?}");
+        assert!(f.contains("8080"), "{f:?}");
+    }
+
+    #[test]
+    fn ordinary_prose_carries_no_facts() {
+        assert!(fact_tokens("Mount the filesystem before writing to it.").is_empty());
+    }
+
+    #[test]
+    fn two_artifacts_giving_a_different_version_may_disagree() {
+        assert!(may_disagree(
+            "engram requires Rust 1.21.4 to build.",
+            "engram requires Rust 1.30.0 to build.",
+        ));
+    }
+
+    #[test]
+    fn the_same_fact_stated_twice_does_not_disagree() {
+        assert!(!may_disagree(
+            "engram requires Rust 1.21.4 to build.",
+            "To build engram you need Rust 1.21.4.",
+        ));
+    }
+
+    #[test]
+    fn artifacts_with_no_facts_in_common_do_not_disagree() {
+        // Two artifacts about different subjects that happen to embed close.
+        // Sending these to the model is the waste this filter exists to stop.
+        assert!(!may_disagree(
+            "The mount command attaches a filesystem.",
+            "Version 9.9.9 of the pastry compiler ships on 2030-01-01.",
+        ));
+    }
+
+    #[test]
+    fn one_artifact_with_no_facts_never_disagrees() {
+        assert!(!may_disagree("Prose only.", "Requires 1.2.3."));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib infer::facts`
+Expected: FAIL — `cannot find function fact_tokens`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `src/infer/facts.rs`:
+
+```rust
+//! Could these two artifacts actually disagree?
+//!
+//! The similarity sweep says two artifacts cover the same ground. That is not
+//! the interesting question — the interesting one is whether they state some
+//! detail differently, because a wrong artifact ranks exactly as well as a
+//! right one and nothing else in the system notices. Answering it properly
+//! needs a model, and a model call is minutes on the hardware this is built
+//! for, so this narrows the candidate set first at the cost of a scan.
+//!
+//! The rule is deliberately conservative in one direction only: it must never
+//! discard a pair that might disagree, and it is free to pass through pairs
+//! that turn out not to. A pair it passes costs one call; a pair it wrongly
+//! drops costs a stale artifact nobody ever finds.
+
+use std::collections::BTreeSet;
+
+/// Is this token shaped like something two documents could state differently?
+///
+/// Bare numbers count: a timeout, a port, a count of retries. Words do not —
+/// two artifacts using different prose for the same thing is what synthesis is
+/// supposed to produce, not a contradiction.
+fn is_fact(token: &str) -> bool {
+    let t = token.trim_matches(|c: char| !c.is_alphanumeric());
+    if t.is_empty() || !t.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // A leading digit plus only digits and separators: 30, 1.21.4, 2024-03-01,
+    // 8080. Anything with letters in it — `3rd`, `x86_64` — is vocabulary
+    // rather than a value.
+    t.chars().all(|c| c.is_ascii_digit() || c == '.' || c == '-' || c == ':')
+}
+
+/// Every value-shaped token in the text, normalised of surrounding punctuation.
+pub fn fact_tokens(text: &str) -> BTreeSet<String> {
+    text.split_whitespace()
+        .map(|t| {
+            t.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_string()
+        })
+        .filter(|t| is_fact(t))
+        .collect()
+}
+
+/// Whether a pair is worth a model call.
+///
+/// Two conditions, and both are needed. Some shared value means the artifacts
+/// are talking about the same measurable thing at all — without it, differing
+/// numbers are two unrelated facts rather than a disagreement. Some differing
+/// value is the disagreement itself: artifacts that state exactly the same
+/// values have nothing for a judge to find, however much prose separates them.
+pub fn may_disagree(a: &str, b: &str) -> bool {
+    let (fa, fb) = (fact_tokens(a), fact_tokens(b));
+    if fa.is_empty() || fb.is_empty() {
+        return false;
+    }
+    let shared = fa.intersection(&fb).count();
+    let differing = fa.symmetric_difference(&fb).count();
+    shared > 0 && differing > 0
+}
+```
+
+Add `pub mod facts;` to `src/infer/mod.rs`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib infer::facts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/infer/facts.rs src/infer/mod.rs
+git commit -m "feat: fact-token prefilter for consolidation pairs"
+```
+
+---
+
+## Task 14: The contradiction judge
+
+**Files:**
+- Modify: `src/infer/prompt.rs` (judge prompt and parser)
+- Modify: `src/jobs/consolidate.rs` (judge stage after the sweep)
+- Modify: `src/infer/fake.rs` (a scriptable completer)
+
+**Interfaces:**
+- Consumes: `Completer::complete`, `facts::may_disagree`, `Store::pairs_by_state`, `Store::set_pair_state`, `Core::consolidate`.
+- Produces:
+  - `pub const JUDGE_SYSTEM: &str`
+  - `pub fn judge_prompt(a: &str, b: &str) -> String`
+  - `pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>)>`
+  - `pub struct ScriptedCompleter { replies: Mutex<VecDeque<String>>, calls: AtomicUsize }` with `pub fn new(replies: Vec<String>) -> Self` and `pub fn calls(&self) -> usize`.
+  - `Outcome { judged: usize, contradictions: usize, .. }`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/infer/prompt.rs`'s test module:
+
+```rust
+    #[test]
+    fn a_judgement_parses() {
+        let (yes, detail) =
+            parse_judgement(r#"{"contradicts":true,"detail":"one says 1.2, the other 1.4"}"#)
+                .unwrap();
+        assert!(yes);
+        assert_eq!(detail.as_deref(), Some("one says 1.2, the other 1.4"));
+    }
+
+    #[test]
+    fn a_negative_judgement_carries_no_detail() {
+        let (yes, detail) = parse_judgement(r#"{"contradicts":false}"#).unwrap();
+        assert!(!yes);
+        assert!(detail.is_none());
+    }
+
+    #[test]
+    fn a_judgement_wrapped_in_prose_and_fences_still_parses() {
+        // The same models that fence the synthesis reply fence this one.
+        let (yes, _) = parse_judgement("Sure:\n```json\n{\"contradicts\": true}\n```")
+            .unwrap();
+        assert!(yes);
+    }
+
+    #[test]
+    fn an_unparsable_judgement_is_an_error_not_a_yes() {
+        // Defaulting to "contradicts" would fill the review queue with noise;
+        // defaulting to "no" would hide real conflicts. Neither: it fails, the
+        // pair stays pending, and the next sweep tries again.
+        assert!(parse_judgement("I could not decide.").is_err());
+    }
+```
+
+Append to `src/jobs/consolidate.rs`'s test module:
+
+```rust
+    use crate::infer::fake::ScriptedCompleter;
+
+    /// Two artifacts about the same thing that give a different version.
+    async fn disagreeing(core: &crate::core::Core) -> Vec<String> {
+        seed(
+            core,
+            &[
+                ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
+                ("engram needs Rust 1.30.0 to build.", [0.93, 0.37]),
+            ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn the_judge_is_off_by_default() {
+        let core = test_core().await;
+        disagreeing(&core).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 1);
+        assert_eq!(out.judged, 0, "the judge ran without being asked for");
+    }
+
+    #[tokio::test]
+    async fn an_enabled_judge_marks_a_real_contradiction() {
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"contradicts":true,"detail":"1.21.4 versus 1.30.0"}"#.into(),
+        ]));
+        disagreeing(&core).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.judged, out.contradictions), (1, 1), "{out:?}");
+        let found = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].detail.as_deref(), Some("1.21.4 versus 1.30.0"));
+    }
+
+    #[tokio::test]
+    async fn a_pair_with_no_facts_to_disagree_about_never_reaches_the_model() {
+        // The prefilter is the whole economic argument for this feature: a
+        // model call is minutes, and most near pairs have nothing to judge.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        let completer = std::sync::Arc::new(ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(completer.calls(), 0, "the prefilter let a factless pair through");
+        assert_eq!(out.judged, 0);
+        assert_eq!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::NoConflict, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "a cleared pair must leave the pending queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_judge_stops_at_its_budget() {
+        // One sweep must not be able to occupy the GPU for an hour.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.consolidate.max_judgements = 1;
+        let completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"contradicts":false}"#.into(),
+            r#"{"contradicts":false}"#.into(),
+            r#"{"contradicts":false}"#.into(),
+        ]));
+        core.completer = completer.clone();
+        seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+
+        run(&core).await.unwrap();
+        assert_eq!(completer.calls(), 1, "the budget was ignored");
+    }
+
+    #[tokio::test]
+    async fn a_failed_judgement_leaves_the_pair_pending() {
+        // A dead endpoint must not silently clear a queue of real conflicts.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec!["not json".into()]));
+        disagreeing(&core).await;
+
+        run(&core).await.unwrap();
+        assert_eq!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib`
+Expected: FAIL — `cannot find function parse_judgement`, `no field judged`, `cannot find struct ScriptedCompleter`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/infer/fake.rs`:
+
+```rust
+/// A completer that answers from a script and counts how often it was asked.
+///
+/// The consolidation tests are largely about *not* calling the model, so what
+/// they assert on is the call count as much as the reply.
+pub struct ScriptedCompleter {
+    replies: std::sync::Mutex<std::collections::VecDeque<String>>,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl ScriptedCompleter {
+    pub fn new(replies: Vec<String>) -> Self {
+        Self {
+            replies: std::sync::Mutex::new(replies.into()),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+    pub fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Completer for ScriptedCompleter {
+    async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.replies
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| crate::error::Error::Inference {
+                role: "ask",
+                detail: "the script ran out of replies".into(),
+            })
+    }
+    fn context_tokens(&self) -> usize {
+        4096
+    }
+}
+```
+
+`src/infer/prompt.rs`:
+
+```rust
+/// The judge is asked one question and given no room to be helpful.
+///
+/// It is not asked which artifact is right, nor to merge them, nor to rewrite
+/// anything. Deciding which of two contradictory artifacts is current needs
+/// context the base does not hold — what the reader is actually running — and
+/// is a judgement only they can make. All this call does is tell them there is
+/// a judgement waiting.
+pub const JUDGE_SYSTEM: &str = r#"You compare two knowledge artifacts and answer one question: do they state some specific detail differently?
+
+A contradiction is a concrete disagreement about the same thing: a different version, number, date, path, flag, default, or step order for the same subject.
+
+These are NOT contradictions:
+- The same fact in different words.
+- Different levels of detail about the same thing.
+- Two different subjects that happen to use similar language.
+- One artifact mentioning something the other simply does not cover.
+
+Reply with JSON only, no commentary, in exactly this shape:
+
+{"contradicts": true, "detail": "..."}
+
+- contradicts: true only for a concrete disagreement, as above.
+- detail: when true, one short sentence naming the two conflicting values. Omit it when false."#;
+
+pub fn judge_prompt(a: &str, b: &str) -> String {
+    format!(
+        "----- ARTIFACT A -----\n{a}\n----- ARTIFACT B -----\n{b}\n----- END -----"
+    )
+}
+
+#[derive(serde::Deserialize)]
+struct Judgement {
+    contradicts: bool,
+    #[serde(default)]
+    detail: Option<String>,
+}
+
+/// A reply that cannot be read is an error, not a verdict.
+///
+/// Defaulting to "contradicts" would fill the review queue with noise an
+/// operator has to clear by hand; defaulting to "no" would quietly close real
+/// conflicts. Failing leaves the pair pending, and the next sweep asks again.
+pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>)> {
+    let j: Judgement = serde_json::from_str(extract_json(body)).map_err(|e| {
+        Error::MalformedLlmOutput(format!("judge reply was not the expected JSON: {e}"))
+    })?;
+    let detail = j
+        .detail
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty() && j.contradicts);
+    Ok((j.contradicts, detail))
+}
+```
+
+`src/jobs/consolidate.rs` — extend `Outcome` and append the judge stage to `run`:
+
+```rust
+pub struct Outcome {
+    pub examined: usize,
+    pub superseded: usize,
+    pub queued: usize,
+    pub judged: usize,
+    pub contradictions: usize,
+}
+```
+
+At the end of `run`, before the summary log:
+
+```rust
+    if core.consolidate.judge {
+        let (judged, contradictions) = judge_pending(core).await?;
+        out.judged = judged;
+        out.contradictions = contradictions;
+    }
+```
+
+```rust
+/// Ask the model about pending pairs, but only the ones that could possibly
+/// disagree, and only up to the sweep's budget.
+///
+/// Returns how many calls were made and how many found a contradiction. A
+/// failed call leaves its pair pending on purpose: a dead endpoint must never
+/// look like a clean bill of health.
+async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
+    let pending = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::Pending, 200)
+        .await?;
+
+    let (mut judged, mut contradictions) = (0usize, 0usize);
+    for p in pending {
+        if judged >= core.consolidate.max_judgements {
+            tracing::info!(
+                budget = core.consolidate.max_judgements,
+                "judge budget spent; the rest wait for the next sweep"
+            );
+            break;
+        }
+        let (Ok(a), Ok(b)) = (
+            core.store.get_artifact(&p.a_id).await,
+            core.store.get_artifact(&p.b_id).await,
+        ) else {
+            continue;
+        };
+
+        // The whole economic argument: most near pairs have no value in common
+        // to disagree about, and a model call is minutes on this hardware.
+        if !crate::infer::facts::may_disagree(&a.text, &b.text) {
+            core.store
+                .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
+                .await?;
+            continue;
+        }
+
+        judged += 1;
+        let reply = match core
+            .completer
+            .complete(
+                crate::infer::prompt::JUDGE_SYSTEM,
+                &crate::infer::prompt::judge_prompt(&a.text, &b.text),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(pair = p.id, error = %e, "judge call failed; pair stays pending");
+                continue;
+            }
+        };
+
+        match crate::infer::prompt::parse_judgement(&reply) {
+            Ok((true, detail)) => {
+                contradictions += 1;
+                core.store
+                    .set_pair_state(
+                        p.id,
+                        crate::store::pairs::PairState::Contradiction,
+                        detail.as_deref(),
+                    )
+                    .await?;
+                tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
+            }
+            Ok((false, _)) => {
+                core.store
+                    .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
+                    .await?;
+            }
+            Err(e) => {
+                tracing::warn!(pair = p.id, error = %e, "judge reply unreadable; pair stays pending");
+            }
+        }
+    }
+    Ok((judged, contradictions))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/infer src/jobs/consolidate.rs
+git commit -m "feat: contradiction judge over the consolidation review band"
+```
+
+---
+
+## Task 15: Configuration, documentation, and the final gate
+
+**Files:**
+- Modify: `config.example.toml`, `README.md`, `ROADMAP.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: no code.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/core/mod.rs`'s `rerank_is_wired_only_when_configured` already loads `config.example.toml`, so an example file that does not deserialize fails the suite. Add one explicit test beside it:
+
+```rust
+    #[tokio::test]
+    async fn the_example_config_carries_the_consolidation_defaults() {
+        let cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
+        assert!(cfg.consolidate.enabled);
+        assert!(
+            cfg.consolidate.auto_supersede > cfg.consolidate.review_min,
+            "superseding at or below the review threshold would hide distinct artifacts"
+        );
+        assert!(!cfg.consolidate.judge, "the only inference-costing stage must be opt-in");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib core::mod`
+Expected: FAIL — `unknown field 'consolidate'` or the assertions fail, depending on whether the block was added yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `config.example.toml`:
+
+```toml
+[consolidate]
+# The background sweep. Capture-time near-duplicate detection is separate and
+# always on: it costs a hash of the text, not a query.
+enabled = true
+# Estimated overlap of word shingles above which a new capture is parked as a
+# near-duplicate of an existing corpus rather than segmented. It is stored
+# either way; parking only withholds the model call until you decide on Ops.
+near_dupe_min = 0.90
+# Cosine at or above which a pair of artifacts goes on the review queue.
+review_min = 0.88
+# Cosine at or above which the older artifact is hidden without asking. Well
+# clear of `review_min` on purpose: two genuinely distinct artifacts about one
+# subsystem sit around 0.88 routinely, and hiding at that score costs knowledge
+# rather than duplication.
+auto_supersede = 0.95
+# Points drawn per sweep, and neighbours considered per point. The sweep is one
+# round trip whose cost these two numbers bound, rather than a query per point.
+sample = 2000
+per_point = 5
+interval_hours = 24
+# Ask the completion model whether a queued pair actually disagrees. Off by
+# default: it is the only part of consolidation that costs inference, and it
+# only ever sees pairs whose numbers, versions or dates already differ.
+judge = false
+max_judgements = 20
+```
+
+Add to the README configuration table:
+
+```markdown
+| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `judge`, `max_judgements`. |
+```
+
+Add a README section after "Does the artifact still say what the corpus said?":
+
+```markdown
+## Duplicates, and what goes quietly out of date
+
+Two failures look identical from a result list: the same thing stored twice,
+and the same thing stored twice with one copy now wrong. Both are handled
+without a model call in the ordinary case.
+
+**At capture.** Corpora are deduplicated by an exact hash, so re-pasting a
+chapter a year later with one changed byte used to store it twice, and the two
+copies then competed for the same queries. A shingle signature over the raw
+text catches that: the capture is stored like any other, and parked in
+`needs_review` rather than segmented. Ops offers three answers — replace the
+older corpus, keep both, or discard this one — and until one is chosen, no
+model call has been spent on it.
+
+**Afterwards.** A sweep asks Qdrant for near pairs across the collection, one
+round trip, on a timer. Above `auto_supersede` the older artifact is marked
+`superseded_by` the newer and hidden from results; it is still stored, still
+readable by link, and Ops has a button that puts it back. Between `review_min`
+and that, the pair goes on a queue instead, because two genuinely distinct
+artifacts about one subsystem sit around 0.88 and hiding at that score would
+cost knowledge rather than duplication.
+
+**Nothing is ever merged.** A merged artifact is synthetic text standing where a
+stored passage used to be, with no segment to verify it against and no corpus
+lines to render beside it. Consolidation only ever hides, flags, or asks.
+
+**The judge**, off by default, is the one part that costs inference. Queued
+pairs are first filtered on fact-shaped tokens — versions, numbers, dates —
+and only a pair that shares some and differs on others reaches the model, which
+is asked one yes/no question and given a per-sweep budget. Which of two
+contradictory artifacts is current stays a judgement for the reader.
+
+Artifacts also carry **caveats**: the conditions under which they do not apply,
+emitted by the same synthesis call that wrote them, so they cost output tokens
+rather than another call. They are stored and shown, and deliberately not part
+of what gets embedded — changing what every vector is built from is a decision
+for the evaluation harness, not a hunch.
+```
+
+In `ROADMAP.md`, strike through the two delivered items — "Near-duplicate detection on capture" and "Consolidation and staleness sweep" — in the style already used for the FTS5 entry, naming the files that implement them. Leave the "Corpus map" item, which is not built.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test` then `cargo clippy --all-targets -- -D warnings`
+Expected: PASS and clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config.example.toml README.md ROADMAP.md src/core/mod.rs
+git commit -m "docs: describe consolidation and its thresholds"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Tier 0 hygiene: capture-time shingle detection (Tasks 1, 3, 4, 5), the supersede sweep with `superseded_by` and the review queue (Tasks 2, 6, 7, 8, 9, 10, 11). Tier 1 prompt enrichment: Task 12. Tier 2 contradiction judge: Tasks 13, 14. Configuration and documentation: Task 15. The dropped item — the speculative query index — appears nowhere, as agreed.
+
+**Deferred-field note.** Task 2's tests reference `NewArtifact.caveats`, which Task 12 introduces. The task text says to omit the field until then. An implementer working strictly in order will not hit it; one working out of order will be told by the compiler.
+
+**Type consistency.** `NearPair::new` orders its members, and `Store::record_pair` orders again — both are needed because the memory and Qdrant stores build pairs independently. `PairState` is used by name in Tasks 8, 11 and 14 with the same four variants. `superseded` (payload, `Option<bool>`) and `superseded_by` (row, `Option<String>`) are distinct on purpose and never interchanged. `ConsolidateConfig` field names are identical in `config.rs`, the example file, and every `core.consolidate.*` read.
+
+**Known judgement calls, flagged rather than hidden:** superseding keeps the *newer* artifact, which is wrong for a base where the older capture was the better transcription — the undo button on Ops exists for exactly that. And the Qdrant `near_pairs` implementation depends on the matrix-pairs endpoint, which needs Qdrant 1.12 or newer; if the deployment is older, that call fails and the sweep retries as an ordinary job failure rather than corrupting anything.

--- a/docs/superpowers/specs/2026-08-10-autonomous-ingestion-design.md
+++ b/docs/superpowers/specs/2026-08-10-autonomous-ingestion-design.md
@@ -1,0 +1,150 @@
+# Autonomous ingestion — Design
+
+Date: 2026-08-10
+Status: approved
+Refines the ingestion and consolidation behaviour in
+`2026-08-09-engram-design.md`. Supersedes nothing.
+
+## 1. Why
+
+engram is meant to keep a knowledge base the way an organism keeps itself:
+work that fails gets tried again, damage that can be repaired locally is
+repaired, and the operator hears about the one class of problem no machine can
+settle. What it does instead today is hand every imperfection to a person as a
+button.
+
+The Ops screen of a two-corpus development instance carried, on 2026-08-10:
+
+- Six artifacts flagged `span_unverified`, each offering to spend a model call.
+- One artifact flagged `literals_unverified` for `Binär: 0010 1001 1111 1001`,
+  whose digits are verbatim on line 635 of the source. The model added a label.
+- One pair queued at 0.9488 with the same title on both sides, from one
+  synthesis call.
+- A quarter of one document — segment 1, lines 189–395 — with no artifacts at
+  all, because the inference endpoint returned `502` for ten minutes while it
+  loaded a model, and the job gave up permanently inside the first minute.
+
+None of those four is a knowledge decision. Every one of them waits on a human.
+
+## 2. The line
+
+A person is asked exactly one kind of question: **two artifacts state a fact
+differently and nothing in the system knows which is current.**
+
+Everything else resolves itself, keeps an audit trail, and can be undone.
+Nothing is ever deleted or rewritten to achieve it — the fidelity rule from the
+original design still holds: consolidation hides, flags or asks, and never
+merges.
+
+## 3. Nothing is terminal
+
+**Retry becomes unbounded.** `MAX_ATTEMPTS` currently means *give up*: five
+attempts with backoff `2,4,8,16,32s`, then the segments that were tried are
+marked `failed` and the job is closed. Against an endpoint that takes ten
+minutes to warm up, the whole budget is spent in the first sixty seconds and
+the work is lost until someone notices.
+
+It comes to mean *slow down*. Backoff keeps doubling to a ceiling of six hours
+and the job stays pending forever. A permanently unprocessable segment
+therefore costs about four calls a day, which is visible and cheap; an endpoint
+down for a weekend costs nothing and heals when it returns.
+
+**A reconciliation sweep** runs on the consolidation timer and re-arms anything
+unfinished that no job covers: a segment in `failed` or `pending` with no
+synthesize job, an artifact `pending` embed with no embed job. It is the
+heartbeat — the guarantee that work cannot fall through a crack permanently,
+whatever the crack was.
+
+**Ops reports state, not chores.** "Failed jobs" becomes "retrying, next
+attempt in 4h".
+
+## 4. Spans are derived, never adjudicated
+
+Today the model asserts `corpus_lines`, engram checks the claim, and a claim
+that fails the check becomes a flag on the artifact plus a button that spends a
+model call to re-synthesise the whole segment.
+
+The claim is not worth this. `locate_span` can now find an artifact's text in
+its segment even when the source is hard-wrapped and synthesis reflowed it, so
+the span is computable locally from data already stored. Therefore:
+
+- The span is derived locally, always.
+- The model's `corpus_lines` is used only when derivation finds nothing, as a
+  hint, unclamped and unchecked.
+- Derivation that finds nothing falls back to the segment, silently.
+- `FLAG_SPAN` is removed. Not suppressed — not generated, because engram stops
+  disagreeing with itself about a number it computes.
+
+The reconciliation sweep re-derives spans for artifacts whose stored span came
+from a model claim, which costs no inference and clears the existing flags.
+
+## 5. Literal checks stop crying wolf
+
+`missing_literals` compares a fenced line as a whole. A model that writes
+
+```
+Binär: 0010 1001 1111 1001
+```
+
+for a source that says `wird binär 0010 1001 1111 1001` has invented nothing;
+it has labelled something. The check keeps its purpose — a command that gets
+pasted into a root shell must have come from the source — by comparing the
+machine-shaped part of a line rather than the line: strip a leading
+`Word:`-style label before looking for the remainder.
+
+What survives is a genuine miss. It stays on the artifact as a note the reader
+sees in context, and it leaves Ops entirely. It is information about one
+artifact, not a task for the base.
+
+## 6. Duplicates that do not disagree are not questions
+
+The review band between `review_min` and `auto_supersede` currently queues
+every pair for a person. Most of them have nothing to decide.
+
+- A queued pair whose fact tokens do not differ is closed automatically as
+  `no_conflict`, with both artifacts kept. This is the prefilter that already
+  exists, applied without waiting for the judge to be enabled.
+- A pair whose facts differ goes to the judge when it is on, and a confirmed
+  contradiction is the one thing shown to the operator.
+- Auto-hiding stays at `auto_supersede`. It is deliberately *not* lowered into
+  the review band: the original design records that two genuinely distinct
+  artifacts about one subsystem sit at 0.88 routinely, and hiding on that score
+  costs knowledge rather than duplication.
+- One case is added, because it is a defect rather than a judgement: an
+  artifact whose text is wholly contained in another artifact **from the same
+  corpus** is a synthesis stutter — one call emitting the same passage twice —
+  and the shorter one is hidden with the usual undo.
+
+## 7. What Ops becomes
+
+Two things:
+
+1. **Contradictions.** Both texts, both sources, and no default answer.
+2. **Health.** What is retrying and when it next runs; what is hidden and by
+   what; coverage per corpus; queue depth.
+
+Undo is the only button.
+
+## 8. Testing
+
+Every part is a pure function or a job step over fakes, as the rest of the
+codebase already is:
+
+- Backoff: the ceiling is reached and never exceeded; a job is never closed as
+  permanently failed.
+- Reconciliation: a corpus with a failed segment and no job gets one; a corpus
+  that is complete gets nothing; the sweep is idempotent across two runs.
+- Spans: a derived span wins over a model claim; a claim is used when
+  derivation finds nothing; no flag is produced in either case.
+- Literals: a labelled fenced line is not a miss; an invented command still is.
+- Duplicates: a pair with no differing facts closes itself and both artifacts
+  survive; a contained artifact from the same corpus is hidden; a contained
+  artifact from a *different* corpus is not.
+
+## 9. Out of scope
+
+- Changing what gets embedded.
+- Any automatic rewrite or merge of artifact text.
+- Lowering `auto_supersede`.
+- Migrating existing rows: the development base can be recomputed or rebuilt,
+  and no deployed instance exists to preserve.

--- a/migrations/0009_consolidation.sql
+++ b/migrations/0009_consolidation.sql
@@ -1,0 +1,49 @@
+-- Near-duplicate detection at capture.
+--
+-- `content_hash` is exact, so the same chapter re-pasted with one changed byte
+-- becomes a second corpus, and the two then compete for the same queries for
+-- as long as the base exists. The signature is a bottom-k MinHash over word
+-- shingles (`src/store/shingle.rs`), compared against every other corpus at
+-- capture time — a scan, because a single-operator base holds hundreds of
+-- corpora, not millions.
+ALTER TABLE corpora ADD COLUMN shingles TEXT;
+-- Set when capture found a near-identical corpus. The capture is stored
+-- regardless and parked in `needs_review`: nothing is ever discarded on a
+-- similarity score, and synthesis is not paid for until a human decides.
+ALTER TABLE corpora ADD COLUMN near_dupe_of TEXT;
+ALTER TABLE corpora ADD COLUMN near_dupe_score REAL;
+
+-- Consolidation, artifact side.
+--
+-- The artifact this one lost to. Set by the sweep when two artifacts are near
+-- identical; the loser stays stored, readable and reversible, and is hidden
+-- from search by a payload flag rather than deleted. A merged rewrite would
+-- put synthetic text where a stored artifact used to be, which is the one
+-- failure mode this design exists to avoid.
+ALTER TABLE artifacts ADD COLUMN superseded_by TEXT;
+CREATE INDEX idx_artifacts_superseded ON artifacts(superseded_by);
+
+-- Conditions under which the artifact does not apply, as stated by the source.
+-- Emitted by the same synthesis call that produces the artifact, so it costs
+-- output tokens rather than another call.
+ALTER TABLE artifacts ADD COLUMN caveats TEXT NOT NULL DEFAULT '[]';
+
+-- The review queue.
+--
+-- Pairs similar enough to be worth a person's attention but not similar enough
+-- to supersede automatically. `state` is 'pending' until something resolves
+-- it: 'no_conflict' when the fact-token prefilter or the judge clears it,
+-- 'contradiction' when the judge finds one, 'dismissed' when an operator does.
+-- `a_id` < `b_id` by string order, so the same pair found in either direction
+-- is one row.
+CREATE TABLE artifact_pairs (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  a_id       TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  b_id       TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  score      REAL NOT NULL,
+  state      TEXT NOT NULL DEFAULT 'pending',
+  detail     TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE(a_id, b_id)
+);
+CREATE INDEX idx_pairs_state ON artifact_pairs(state, created_at DESC);

--- a/migrations/0010_judge_attempts.sql
+++ b/migrations/0010_judge_attempts.sql
@@ -1,0 +1,8 @@
+-- How many model calls a pending pair has already cost.
+--
+-- A judgement that fails to parse, or a call that never returns, leaves the
+-- pair pending deliberately: a dead endpoint must not look like a clean bill of
+-- health. But the judge picks by score, so without this column the same
+-- top-scoring pairs would consume every sweep's budget and the rest of the
+-- queue would never be reached at all.
+ALTER TABLE artifact_pairs ADD COLUMN judge_attempts INTEGER NOT NULL DEFAULT 0;

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -152,7 +152,10 @@ impl OidcClient {
         use openidconnect::IssuerUrl;
         use openidconnect::core::CoreProviderMetadata;
 
-        if cfg.allowed_subs.is_empty() && cfg.allowed_emails.is_empty() && cfg.allowed_groups.is_empty() {
+        if cfg.allowed_subs.is_empty()
+            && cfg.allowed_emails.is_empty()
+            && cfg.allowed_groups.is_empty()
+        {
             return Err(Error::Validation(
                 "auth.oidc has an empty allowlist: set allowed_subs, allowed_emails or \
                  allowed_groups, otherwise every account in your identity provider could sign in"
@@ -285,8 +288,10 @@ impl OidcClient {
         // not turn into a failed sign-in for someone the ID token itself
         // vouches for.
         if email.is_none() || groups.is_empty() {
-            match client.user_info(tokens.access_token().clone(), Some(claims.subject().clone()))
-            {
+            match client.user_info(
+                tokens.access_token().clone(),
+                Some(claims.subject().clone()),
+            ) {
                 Ok(req) => match req
                     .request_async::<GroupClaims, _, openidconnect::core::CoreGenderClaim>(
                         &self.http,

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -101,9 +101,13 @@ impl OidcClient {
         }
 
         let http = openidconnect::reqwest::ClientBuilder::new()
-            // An identity provider must never be reached through a redirect we
-            // did not choose: that is an SSRF primitive.
-            .redirect(openidconnect::reqwest::redirect::Policy::none())
+            // Nextcloud's documented nginx recipe 301s the bare .well-known
+            // path to /index.php/.well-known/...; issuer_url stays the bare
+            // domain, since that is what the discovery document itself
+            // declares as `issuer` and what ID tokens carry as `iss`. A bounded
+            // hop count, not zero: this still refuses to be walked anywhere
+            // unbounded, matching what a typical OIDC client allows by default.
+            .redirect(openidconnect::reqwest::redirect::Policy::limited(5))
             .build()
             .map_err(|e| Error::Validation(e.to_string()))?;
 

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -57,7 +57,7 @@ impl Default for PendingStore {
 /// Who may sign in. An empty allowlist denies everyone by design: without it,
 /// every account the identity provider knows about could read the knowledge
 /// base.
-pub fn is_allowed(cfg: &OidcConfig, subject: &str, email: Option<&str>) -> bool {
+pub fn is_allowed(cfg: &OidcConfig, subject: &str, email: Option<&str>, groups: &[String]) -> bool {
     if cfg.allowed_subs.iter().any(|s| s == subject) {
         return true;
     }
@@ -71,13 +71,73 @@ pub fn is_allowed(cfg: &OidcConfig, subject: &str, email: Option<&str>) -> bool 
             return true;
         }
     }
+    if cfg
+        .allowed_groups
+        .iter()
+        .any(|g| groups.iter().any(|m| m == g))
+    {
+        return true;
+    }
     false
 }
+
+/// The one claim this reads beyond the OIDC standard set: which groups the
+/// provider says the subject belongs to. A provider that never sends it — the
+/// common case, since Nextcloud's OIDC provider app only includes `groups`
+/// when an admin turns on group provisioning for the client — simply
+/// deserializes to an empty list rather than failing the claim parse.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct GroupClaims {
+    #[serde(default)]
+    groups: Vec<String>,
+}
+impl openidconnect::AdditionalClaims for GroupClaims {}
+
+type EngramIdTokenFields = openidconnect::IdTokenFields<
+    GroupClaims,
+    openidconnect::EmptyExtraTokenFields,
+    openidconnect::core::CoreGenderClaim,
+    openidconnect::core::CoreJweContentEncryptionAlgorithm,
+    openidconnect::core::CoreJwsSigningAlgorithm,
+>;
+type EngramTokenResponse =
+    openidconnect::StandardTokenResponse<EngramIdTokenFields, openidconnect::core::CoreTokenType>;
+
+/// `openidconnect::core::CoreClient` with its additional-claims parameter
+/// swapped from `EmptyAdditionalClaims` to [`GroupClaims`], so the `groups`
+/// claim decodes rather than being discarded. Otherwise identical to `Core*`
+/// — same algorithms, same error and token types.
+type EngramClient<
+    HasAuthUrl = openidconnect::EndpointNotSet,
+    HasDeviceAuthUrl = openidconnect::EndpointNotSet,
+    HasIntrospectionUrl = openidconnect::EndpointNotSet,
+    HasRevocationUrl = openidconnect::EndpointNotSet,
+    HasTokenUrl = openidconnect::EndpointNotSet,
+    HasUserInfoUrl = openidconnect::EndpointNotSet,
+> = openidconnect::Client<
+    GroupClaims,
+    openidconnect::core::CoreAuthDisplay,
+    openidconnect::core::CoreGenderClaim,
+    openidconnect::core::CoreJweContentEncryptionAlgorithm,
+    openidconnect::core::CoreJsonWebKey,
+    openidconnect::core::CoreAuthPrompt,
+    openidconnect::StandardErrorResponse<openidconnect::core::CoreErrorResponseType>,
+    EngramTokenResponse,
+    openidconnect::core::CoreTokenIntrospectionResponse,
+    openidconnect::core::CoreRevocableToken,
+    openidconnect::core::CoreRevocationErrorResponse,
+    HasAuthUrl,
+    HasDeviceAuthUrl,
+    HasIntrospectionUrl,
+    HasRevocationUrl,
+    HasTokenUrl,
+    HasUserInfoUrl,
+>;
 
 pub struct OidcClient {
     /// Discovery result, fetched once at startup.
     ///
-    /// The constructed `CoreClient` is deliberately NOT stored: openidconnect
+    /// The constructed client is deliberately NOT stored: openidconnect
     /// encodes which endpoints are configured in a seventeen-parameter
     /// typestate, and naming that type in a struct field pins us to one patch
     /// release. Rebuilding per call costs nothing (no I/O) and lets inference
@@ -92,10 +152,10 @@ impl OidcClient {
         use openidconnect::IssuerUrl;
         use openidconnect::core::CoreProviderMetadata;
 
-        if cfg.allowed_subs.is_empty() && cfg.allowed_emails.is_empty() {
+        if cfg.allowed_subs.is_empty() && cfg.allowed_emails.is_empty() && cfg.allowed_groups.is_empty() {
             return Err(Error::Validation(
-                "auth.oidc has an empty allowlist: set allowed_subs or allowed_emails, \
-                 otherwise every account in your identity provider could sign in"
+                "auth.oidc has an empty allowlist: set allowed_subs, allowed_emails or \
+                 allowed_groups, otherwise every account in your identity provider could sign in"
                     .into(),
             ));
         }
@@ -126,13 +186,13 @@ impl OidcClient {
     }
 
     pub fn authorize_url(&self) -> Result<(String, PendingAuth)> {
-        use openidconnect::core::{CoreClient, CoreResponseType};
+        use openidconnect::core::CoreResponseType;
         use openidconnect::{
             AuthenticationFlow, ClientId, ClientSecret, CsrfToken, Nonce, PkceCodeChallenge,
             RedirectUrl, Scope,
         };
 
-        let client = CoreClient::from_provider_metadata(
+        let client = EngramClient::from_provider_metadata(
             self.metadata.clone(),
             ClientId::new(self.cfg.client_id.clone()),
             self.cfg.client_secret.clone().map(ClientSecret::new),
@@ -173,17 +233,16 @@ impl OidcClient {
         code: &str,
         state: &str,
     ) -> Result<Identity> {
-        use openidconnect::core::CoreClient;
         use openidconnect::{
-            AuthorizationCode, ClientId, ClientSecret, Nonce, PkceCodeVerifier, RedirectUrl,
-            TokenResponse,
+            AuthorizationCode, ClientId, ClientSecret, Nonce, OAuth2TokenResponse,
+            PkceCodeVerifier, RedirectUrl, TokenResponse,
         };
 
         if state != pending.csrf {
             return Err(Error::Unauthorized);
         }
 
-        let client = CoreClient::from_provider_metadata(
+        let client = EngramClient::from_provider_metadata(
             self.metadata.clone(),
             ClientId::new(self.cfg.client_id.clone()),
             self.cfg.client_secret.clone().map(ClientSecret::new),
@@ -212,10 +271,48 @@ impl OidcClient {
             .map_err(|e| Error::Validation(format!("ID token rejected: {e}")))?;
 
         let subject = claims.subject().to_string();
-        let email = claims.email().map(|e| e.to_string());
+        let mut email = claims.email().map(|e| e.to_string());
+        let mut groups = claims.additional_claims().groups.clone();
 
-        if !is_allowed(&self.cfg, &subject, email.as_deref()) {
-            tracing::warn!(%subject, "sign-in denied: subject not on the allowlist");
+        // Nextcloud's OIDC provider app does not put `email` (or `groups`) in
+        // the ID token even when the scope is granted — they only appear from
+        // the userinfo endpoint. Without this, an allowlist keyed on either
+        // always sees nothing and every sign-in is refused, however correctly
+        // the config names the account.
+        //
+        // Best-effort: the subject from the ID token is already verified by
+        // its signature, so an endpoint that is absent or unreachable must
+        // not turn into a failed sign-in for someone the ID token itself
+        // vouches for.
+        if email.is_none() || groups.is_empty() {
+            match client.user_info(tokens.access_token().clone(), Some(claims.subject().clone()))
+            {
+                Ok(req) => match req
+                    .request_async::<GroupClaims, _, openidconnect::core::CoreGenderClaim>(
+                        &self.http,
+                    )
+                    .await
+                {
+                    Ok(info) => {
+                        if email.is_none() {
+                            email = info.email().map(|e| e.to_string());
+                        }
+                        if groups.is_empty() {
+                            groups = info.additional_claims().groups.clone();
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "userinfo request failed; continuing with the ID token's claims only");
+                    }
+                },
+                Err(e) => {
+                    tracing::debug!(error = %e, "provider has no userinfo endpoint");
+                }
+            }
+        }
+
+        if !is_allowed(&self.cfg, &subject, email.as_deref(), &groups) {
+            tracing::warn!(%subject, ?groups, "sign-in denied: subject not on the allowlist");
             return Err(Error::Forbidden);
         }
         tracing::info!(%subject, "oidc sign-in");
@@ -229,6 +326,10 @@ mod tests {
     use crate::config::OidcConfig;
 
     fn cfg(subs: &[&str], emails: &[&str]) -> OidcConfig {
+        cfg_with_groups(subs, emails, &[])
+    }
+
+    fn cfg_with_groups(subs: &[&str], emails: &[&str], groups: &[&str]) -> OidcConfig {
         OidcConfig {
             issuer_url: "https://idp.example".into(),
             client_id: "engram".into(),
@@ -237,6 +338,7 @@ mod tests {
             scopes: vec!["openid".into()],
             allowed_subs: subs.iter().map(|s| s.to_string()).collect(),
             allowed_emails: emails.iter().map(|s| s.to_string()).collect(),
+            allowed_groups: groups.iter().map(|s| s.to_string()).collect(),
         }
     }
 
@@ -244,21 +346,39 @@ mod tests {
     fn an_empty_allowlist_denies_everyone() {
         // Defaulting open would hand the knowledge base to every account in
         // the identity provider.
-        assert!(!is_allowed(&cfg(&[], &[]), "sub-1", Some("me@example.com")));
+        assert!(!is_allowed(
+            &cfg(&[], &[]),
+            "sub-1",
+            Some("me@example.com"),
+            &[]
+        ));
     }
 
     #[test]
     fn a_listed_subject_is_allowed() {
-        assert!(is_allowed(&cfg(&["sub-1"], &[]), "sub-1", None));
-        assert!(!is_allowed(&cfg(&["sub-1"], &[]), "sub-2", None));
+        assert!(is_allowed(&cfg(&["sub-1"], &[]), "sub-1", None, &[]));
+        assert!(!is_allowed(&cfg(&["sub-1"], &[]), "sub-2", None, &[]));
     }
 
     #[test]
     fn a_listed_email_is_allowed_case_insensitively() {
         let c = cfg(&[], &["Me@Example.com"]);
-        assert!(is_allowed(&c, "sub-9", Some("me@example.com")));
-        assert!(!is_allowed(&c, "sub-9", Some("other@example.com")));
-        assert!(!is_allowed(&c, "sub-9", None));
+        assert!(is_allowed(&c, "sub-9", Some("me@example.com"), &[]));
+        assert!(!is_allowed(&c, "sub-9", Some("other@example.com"), &[]));
+        assert!(!is_allowed(&c, "sub-9", None, &[]));
+    }
+
+    #[test]
+    fn a_listed_group_is_allowed() {
+        let c = cfg_with_groups(&[], &[], &["engram-users"]);
+        assert!(is_allowed(
+            &c,
+            "sub-9",
+            None,
+            &["engram-users".to_string(), "other-group".to_string()]
+        ));
+        assert!(!is_allowed(&c, "sub-9", None, &["other-group".to_string()]));
+        assert!(!is_allowed(&c, "sub-9", None, &[]));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,54 @@ pub struct Config {
     pub vector: VectorConfig,
     pub infer: InferConfig,
     pub auth: AuthConfig,
+    #[serde(default)]
+    pub consolidate: ConsolidateConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ConsolidateConfig {
+    /// Whether the background sweep runs at all. Capture-time near-duplicate
+    /// detection is separate and always on: it costs a hash, not a query.
+    pub enabled: bool,
+    /// Estimated Jaccard over word shingles above which a capture is parked as
+    /// a near-duplicate of an existing corpus.
+    pub near_dupe_min: f64,
+    /// Cosine at or above which a pair is worth an operator's attention.
+    pub review_min: f32,
+    /// Cosine at or above which the older artifact is superseded without
+    /// asking. Deliberately far above `review_min`: two genuinely distinct
+    /// artifacts about one subsystem sit around 0.88 routinely, and superseding
+    /// at that score destroys knowledge rather than duplication.
+    pub auto_supersede: f32,
+    /// Points sampled from the collection per sweep by the matrix API.
+    pub sample: usize,
+    /// Neighbours considered per sampled point.
+    pub per_point: usize,
+    /// How often the sweep is queued.
+    pub interval_hours: u64,
+    /// Whether pairs in the review band that survive the fact-token prefilter
+    /// are sent to the completer. Off by default: it is the only part of
+    /// consolidation that costs inference.
+    pub judge: bool,
+    /// Ceiling on judge calls per sweep, so one sweep cannot occupy the GPU.
+    pub max_judgements: usize,
+}
+
+impl Default for ConsolidateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            near_dupe_min: 0.90,
+            review_min: 0.88,
+            auto_supersede: 0.95,
+            sample: 2000,
+            per_point: 5,
+            interval_hours: 24,
+            judge: false,
+            max_judgements: 20,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,6 +250,8 @@ pub struct LocalConfig {
 pub enum ConfigError {
     #[error("config: {0}")]
     Load(#[from] config::ConfigError),
+    #[error("config: {0}")]
+    Invalid(String),
 }
 
 impl Config {
@@ -268,8 +270,28 @@ impl Config {
             )
             .build()?;
         let cfg: Config = raw.try_deserialize()?;
+        cfg.validate()?;
         cfg.warn_on_file_secrets(path);
         Ok(cfg)
+    }
+
+    /// Rules that a config can satisfy syntactically and still be wrong.
+    ///
+    /// The thresholds are the only ones so far, and they are worth refusing to
+    /// start over: `auto_supersede` at or below `review_min` means every pair
+    /// the sweep finds is hidden without asking, with no review band left at
+    /// all. That destroys knowledge quietly, and the operator who typed one
+    /// number would find out from search results going missing weeks later.
+    fn validate(&self) -> Result<(), ConfigError> {
+        let c = &self.consolidate;
+        if c.auto_supersede <= c.review_min {
+            return Err(ConfigError::Invalid(format!(
+                "consolidate.auto_supersede ({}) must be above consolidate.review_min ({}), \
+                 or every pair found is hidden without review",
+                c.auto_supersede, c.review_min
+            )));
+        }
+        Ok(())
     }
 
     /// Secrets belong in the environment. A secret sitting in the config file
@@ -415,6 +437,23 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             let cfg = Config::load(Some(&p)).unwrap();
             assert_eq!(cfg.infer.embed.dim, 768);
         });
+    }
+
+    #[test]
+    fn thresholds_that_leave_no_review_band_are_refused() {
+        // `auto_supersede` at or below `review_min` hides every pair the sweep
+        // finds without asking anyone. The operator would find out from search
+        // results going missing, weeks later.
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            &format!("{MINIMAL}\n[consolidate]\nreview_min = 0.88\nauto_supersede = 0.85\n"),
+        );
+        assert!(matches!(
+            Config::load(Some(&p)),
+            Err(ConfigError::Invalid(_))
+        ));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,6 +235,13 @@ pub struct OidcConfig {
     pub allowed_subs: Vec<String>,
     #[serde(default)]
     pub allowed_emails: Vec<String>,
+    /// Group names from the provider's `groups` claim. Nextcloud's OIDC
+    /// provider app only sends this when the admin has turned on group
+    /// provisioning for the client; without it the claim is simply absent; and
+    /// a subject in a listed group is admitted the same as one listed by
+    /// subject or email.
+    #[serde(default)]
+    pub allowed_groups: Vec<String>,
 }
 fn default_scopes() -> Vec<String> {
     vec!["openid".into(), "profile".into(), "email".into()]

--- a/src/core/ask.rs
+++ b/src/core/ask.rs
@@ -132,6 +132,7 @@ mod tests {
                 category: Some("note".into()),
                 tags: vec![],
                 segment_idx: None,
+                caveats: vec![],
             })
             .collect();
         let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();

--- a/src/core/ask.rs
+++ b/src/core/ask.rs
@@ -180,6 +180,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_model_is_shown_the_caveats_of_every_excerpt() {
+        // A caveat is the condition under which an artifact does not apply, and
+        // an answer that quotes a destructive command without it is worse than
+        // no answer. Caveats are not in the vector payload, so this asserts the
+        // store lookup that puts them back.
+        let mut core = test_core().await;
+        core.completer = std::sync::Arc::new(crate::infer::fake::EchoCompleter);
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "Format the device with mkfs.".into(),
+                    corpus_span: None,
+                    title: Some("Format a device".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec!["Destroys every existing file on the device.".into()],
+                }],
+            )
+            .await
+            .unwrap();
+        crate::jobs::embed::run(&core, &made[0].id).await.unwrap();
+
+        let out = core.ask(&req("how do I format a device")).await.unwrap();
+        assert!(
+            out.answer
+                .contains("Caveat: Destroys every existing file on the device."),
+            "the caveat never reached the model: {}",
+            out.answer
+        );
+    }
+
+    #[tokio::test]
     async fn ask_reports_chunks_dropped_for_budget() {
         let core = test_core().await;
         // FakeCompleter reports a 4096-token context; oversized excerpts force

--- a/src/core/ask.rs
+++ b/src/core/ask.rs
@@ -5,7 +5,9 @@ use crate::infer::budget::pack_by_budget;
 
 const ASK_SYSTEM: &str = "You answer questions using only the provided knowledge-base excerpts. \
 Quote commands, paths and code exactly as they appear. If the excerpts do not contain the answer, \
-say so plainly rather than guessing. Cite excerpts by their number.";
+say so plainly rather than guessing. Cite excerpts by their number. \
+An excerpt may carry lines beginning `Caveat:` — the conditions under which it does not apply. \
+Repeat any caveat that bears on your answer rather than dropping it.";
 
 /// Reserve part of the context for the answer itself.
 const ANSWER_RESERVE_TOKENS: usize = 1024;
@@ -64,18 +66,33 @@ impl Core {
             });
         }
 
-        let blocks: Vec<String> = hits
-            .iter()
-            .enumerate()
-            .map(|(i, h)| {
-                format!(
-                    "[{}] {}\n{}",
-                    i + 1,
-                    h.title.clone().unwrap_or_default(),
-                    h.text
-                )
-            })
-            .collect();
+        // Caveats are the conditions under which an excerpt does not apply, and
+        // an answer that quotes "run `mkfs` on the device" without "destroys
+        // everything already on it" is worse than no answer. They are not in
+        // the vector payload — what gets embedded is a separate decision — so
+        // they are read from the store, which costs one cheap SQLite lookup per
+        // hit and no inference. An excerpt whose row has since been deleted
+        // simply carries none.
+        let mut blocks: Vec<String> = Vec::with_capacity(hits.len());
+        for (i, h) in hits.iter().enumerate() {
+            let caveats = self
+                .store
+                .get_artifact(&h.artifact_id)
+                .await
+                .map(|c| c.caveats)
+                .unwrap_or_default();
+            let mut block = format!(
+                "[{}] {}\n{}",
+                i + 1,
+                h.title.clone().unwrap_or_default(),
+                h.text
+            );
+            for c in &caveats {
+                block.push_str("\nCaveat: ");
+                block.push_str(c);
+            }
+            blocks.push(block);
+        }
 
         let budget = self
             .completer

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -78,11 +78,122 @@ impl Background {
     }
 }
 
+/// The sweep's job target. A constant rather than a corpus id: consolidation
+/// looks at the whole collection, and the `UNIQUE(stage, target_id)` on `jobs`
+/// then guarantees at most one queued sweep however often the ticker fires.
+pub const CONSOLIDATE_TARGET: &str = "collection";
+
+/// Queue a consolidation sweep now and every `interval_hours` after.
+///
+/// A timer rather than a trigger on write: a sweep after every capture would
+/// re-examine the whole collection for one new artifact, and the pairs it finds
+/// do not become interesting the instant they are written. The first tick fires
+/// immediately, so a restart picks the work up rather than waiting a day.
+pub fn spawn_consolidation_ticker(
+    core: crate::core::Core,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !core.consolidate.enabled {
+            tracing::info!("consolidation sweep disabled");
+            return;
+        }
+        let period = std::time::Duration::from_secs(core.consolidate.interval_hours.max(1) * 3600);
+        let mut tick = tokio::time::interval(period);
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = tick.tick() => {
+                    if let Err(e) = core
+                        .store
+                        .enqueue(
+                            crate::store::jobs::Stage::Consolidate,
+                            "collection",
+                            CONSOLIDATE_TARGET,
+                        )
+                        .await
+                    {
+                        tracing::warn!(error = %e, "could not queue the consolidation sweep");
+                    }
+                }
+            }
+        }
+        tracing::info!("consolidation ticker stopped");
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn the_ticker_queues_exactly_one_sweep() {
+        // `jobs` is unique on (stage, target), so a ticker that fires while a
+        // sweep is still queued must collapse onto the same row rather than
+        // stacking sweeps behind a slow one.
+        let core = crate::core::test_support::test_core().await;
+        for _ in 0..3 {
+            core.store
+                .enqueue(
+                    crate::store::jobs::Stage::Consolidate,
+                    "collection",
+                    CONSOLIDATE_TARGET,
+                )
+                .await
+                .unwrap();
+        }
+        let mut seen = 0;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            assert_eq!(j.stage, crate::store::jobs::Stage::Consolidate);
+            seen += 1;
+        }
+        assert_eq!(seen, 1, "the sweep stacked up in the queue");
+    }
+
+    #[tokio::test]
+    async fn a_disabled_sweep_is_never_queued() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.consolidate.enabled = false;
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let h = spawn_consolidation_ticker(core.clone(), rx);
+        let _ = h.await;
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "a disabled sweep must not be queued"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_ticker_queues_a_sweep_as_soon_as_it_starts() {
+        // `tokio::time::interval` fires immediately on its first tick, which is
+        // what makes a restart pick consolidation up rather than waiting a day.
+        let core = crate::core::test_support::test_core().await;
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let h = spawn_consolidation_ticker(core.clone(), rx);
+
+        // Give the first tick a chance to land, then stop the ticker.
+        for _ in 0..50 {
+            if core.store.job_counts().await.unwrap().iter().any(|(_, n)| *n > 0) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let _ = tx.send(true);
+        let _ = h.await;
+
+        let j = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("the ticker queued nothing");
+        assert_eq!(j.stage, crate::store::jobs::Stage::Consolidate);
+        assert_eq!(j.target_id, CONSOLIDATE_TARGET);
+    }
 
     #[tokio::test]
     async fn waiting_resolves_after_the_task_has_actually_run() {

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -177,7 +177,14 @@ mod tests {
 
         // Give the first tick a chance to land, then stop the ticker.
         for _ in 0..50 {
-            if core.store.job_counts().await.unwrap().iter().any(|(_, n)| *n > 0) {
+            if core
+                .store
+                .job_counts()
+                .await
+                .unwrap()
+                .iter()
+                .any(|(_, n)| *n > 0)
+            {
                 break;
             }
             tokio::task::yield_now().await;

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -142,6 +142,15 @@ impl Core {
         Ok(())
     }
 
+    /// Put a superseded artifact back in search. The row first, then the
+    /// payload, in the same order the sweep wrote them.
+    pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+        self.store.set_superseded_by(artifact_id, None).await?;
+        self.vectors.set_superseded(artifact_id, false).await?;
+        tracing::info!(artifact_id, "restored a superseded artifact to search");
+        Ok(())
+    }
+
     /// Vectors first: an orphaned row is invisible, but an orphaned vector is
     /// still returned by search.
     pub async fn delete_corpus(&self, id: &str) -> Result<()> {

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -409,6 +409,7 @@ mod tests {
                     category: None,
                     tags: vec![],
                     segment_idx: None,
+                    caveats: vec![],
                 }],
             )
             .await

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1,14 +1,34 @@
 use super::Core;
 use crate::error::{Error, Result};
-use crate::store::corpora::{CorpusStatus, content_hash};
+use crate::store::corpora::{CorpusStatus, NearDuplicate, content_hash};
 use crate::store::jobs::Stage;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct IngestOutcome {
     pub id: String,
     pub status: CorpusStatus,
-    /// True when the text was already stored and no new source was created.
+    /// True when the text was already stored byte for byte and no new source
+    /// was created.
     pub duplicate: bool,
+    /// Set when the text is not identical to anything stored but is close
+    /// enough that segmenting it would produce artifacts competing with ones
+    /// that already exist. The capture is stored and parked, never dropped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub near_duplicate: Option<NearDuplicate>,
+}
+
+/// What an operator decided about a parked capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NearDupeAction {
+    /// The new capture is the better copy: delete the old corpus and its
+    /// artifacts, then process this one.
+    Replace,
+    /// They are genuinely different despite the score. Process this one and
+    /// leave the other alone.
+    KeepBoth,
+    /// The new capture adds nothing. Delete it.
+    Discard,
 }
 
 impl Core {
@@ -30,19 +50,96 @@ impl Core {
                 id: existing.id,
                 status: existing.status,
                 duplicate: true,
+                near_duplicate: None,
             });
         }
 
-        let src = self.store.insert_corpus(text, origin, title_hint).await?;
-        self.store
-            .enqueue(Stage::Synthesize, "corpus", &src.id)
+        // Computed once, before the insert, so the same signature answers "is
+        // this a near-duplicate" and becomes the row's stored column.
+        let sig = crate::store::shingle::signature(text);
+        let near = self
+            .store
+            .find_near_duplicate(&sig, self.consolidate.near_dupe_min)
             .await?;
-        tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested");
+
+        let src = self.store.insert_corpus(text, origin, title_hint).await?;
+
+        match &near {
+            // Parked. Synthesis is the expensive stage and this text may not
+            // deserve it; an operator decides on Ops. Nothing is lost either
+            // way — the corpus is stored verbatim like any other.
+            Some(n) => {
+                self.store
+                    .set_near_dupe(&src.id, Some(&n.corpus_id), Some(n.similarity))
+                    .await?;
+                self.store
+                    .set_corpus_status(&src.id, CorpusStatus::NeedsReview)
+                    .await?;
+                tracing::info!(
+                    corpus_id = %src.id,
+                    near = %n.corpus_id,
+                    similarity = n.similarity,
+                    "capture looks like an existing corpus; parked for review"
+                );
+            }
+            None => {
+                self.store
+                    .enqueue(Stage::Synthesize, "corpus", &src.id)
+                    .await?;
+                tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested");
+            }
+        }
+
         Ok(IngestOutcome {
             id: src.id,
-            status: CorpusStatus::Raw,
+            status: if near.is_some() {
+                CorpusStatus::NeedsReview
+            } else {
+                CorpusStatus::Raw
+            },
             duplicate: false,
+            near_duplicate: near,
         })
+    }
+
+    /// Act on a parked capture. Every branch ends with a corpus that is either
+    /// in the pipeline or gone; none of them leaves a corpus stuck in
+    /// `needs_review` with no way out.
+    pub async fn resolve_near_duplicate(
+        &self,
+        corpus_id: &str,
+        action: NearDupeAction,
+    ) -> Result<()> {
+        let src = self.store.get_corpus(corpus_id).await?;
+        let Some(other) = src.near_dupe_of.clone() else {
+            return Err(Error::Validation(
+                "this corpus is not parked as a near-duplicate".into(),
+            ));
+        };
+
+        match action {
+            NearDupeAction::Discard => {
+                self.delete_corpus(&src.id).await?;
+                tracing::info!(corpus_id = %src.id, "discarded a near-duplicate capture");
+            }
+            NearDupeAction::Replace | NearDupeAction::KeepBoth => {
+                if action == NearDupeAction::Replace {
+                    // The older corpus goes first. If this fails the new one is
+                    // still parked, which is a state an operator can retry from;
+                    // releasing it first would leave both live on a failure.
+                    self.delete_corpus(&other).await?;
+                    tracing::info!(corpus_id = %src.id, replaced = %other, "replaced an older corpus");
+                }
+                self.store.set_near_dupe(&src.id, None, None).await?;
+                self.store
+                    .set_corpus_status(&src.id, CorpusStatus::Raw)
+                    .await?;
+                self.store
+                    .enqueue(Stage::Synthesize, "corpus", &src.id)
+                    .await?;
+            }
+        }
+        Ok(())
     }
 
     /// Vectors first: an orphaned row is invisible, but an orphaned vector is
@@ -92,9 +189,146 @@ impl Core {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::ingest::NearDupeAction;
     use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::Stage;
+
+    /// A body long enough to have a stable shingle signature.
+    fn manual(marker: &str) -> String {
+        (0..200)
+            .map(|i| format!("step {i}: run the {marker} command and read its output"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_capture_is_parked_rather_than_synthesised() {
+        // The whole point: a re-pasted chapter must not cost a model call, and
+        // must not become a second set of artifacts competing with the first.
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+
+        let edited = manual("mount").replacen("step 7:", "step seven:", 1);
+        let second = core.ingest(&edited, "web", None).await.unwrap();
+
+        assert_ne!(second.id, first.id, "the capture must still be stored");
+        assert!(!second.duplicate, "it is not a byte-identical duplicate");
+        assert_eq!(second.status, CorpusStatus::NeedsReview);
+        let near = second.near_duplicate.expect("no near-duplicate reported");
+        assert_eq!(near.corpus_id, first.id);
+        assert!(near.similarity > 0.90);
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "a parked capture must not queue synthesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_capture_is_unaffected() {
+        let core = test_core().await;
+        core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+
+        let out = core.ingest(&manual("pastry"), "web", None).await.unwrap();
+        assert_eq!(out.status, CorpusStatus::Raw);
+        assert!(out.near_duplicate.is_none());
+        assert!(
+            core.store.claim_job().await.unwrap().is_some(),
+            "an unrelated capture must still queue synthesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn keeping_both_releases_the_capture_into_the_pipeline() {
+        let core = test_core().await;
+        core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(
+                &manual("mount").replacen("step 7:", "step seven:", 1),
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+
+        core.resolve_near_duplicate(&second.id, NearDupeAction::KeepBoth)
+            .await
+            .unwrap();
+
+        let got = core.store.get_corpus(&second.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::Raw);
+        assert!(got.near_dupe_of.is_none(), "the flag must be cleared");
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn replacing_deletes_the_older_corpus_and_its_vectors() {
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert!(core.vectors.count().await.unwrap() > 0);
+
+        let second = core
+            .ingest(
+                &manual("mount").replacen("step 7:", "step seven:", 1),
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+        core.resolve_near_duplicate(&second.id, NearDupeAction::Replace)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            core.store.get_corpus(&first.id).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        assert_eq!(
+            core.store.get_corpus(&second.id).await.unwrap().status,
+            CorpusStatus::Raw
+        );
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn discarding_removes_the_new_capture_only() {
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(
+                &manual("mount").replacen("step 7:", "step seven:", 1),
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+
+        core.resolve_near_duplicate(&second.id, NearDupeAction::Discard)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            core.store.get_corpus(&second.id).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        assert!(core.store.get_corpus(&first.id).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolving_a_corpus_that_is_not_parked_is_rejected() {
+        let core = test_core().await;
+        let out = core.ingest("ordinary text", "web", None).await.unwrap();
+        assert!(matches!(
+            core.resolve_near_duplicate(&out.id, NearDupeAction::Replace)
+                .await,
+            Err(crate::error::Error::Validation(_))
+        ));
+    }
 
     #[tokio::test]
     async fn ingest_returns_immediately_and_enqueues_segmentation() {

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -409,6 +409,7 @@ mod tests {
                     tags: vec![],
                     created_at: 0,
                     last_seen_at: None,
+                    superseded: None,
                 },
             }])
             .await

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -62,7 +62,10 @@ impl Core {
             .find_near_duplicate(&sig, self.consolidate.near_dupe_min)
             .await?;
 
-        let src = self.store.insert_corpus(text, origin, title_hint).await?;
+        let src = self
+            .store
+            .insert_corpus_with_signature(text, origin, title_hint, sig)
+            .await?;
 
         match &near {
             // Parked. Synthesis is the expensive stage and this text may not

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -182,6 +182,14 @@ impl Core {
                     .set_corpus_status(&src.id, CorpusStatus::Embedding)
                     .await?;
             }
+            // Consolidation looks at the whole collection, so there is no such
+            // thing as reprocessing one corpus through it. Saying so beats
+            // silently queueing a sweep the caller did not ask for.
+            Stage::Consolidate => {
+                return Err(Error::Validation(
+                    "consolidate is a collection-wide sweep, not a per-corpus stage".into(),
+                ));
+            }
         }
         Ok(())
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -180,17 +180,41 @@ impl Core {
     }
 
     /// Put back anything that was hidden in favour of an artifact which has
-    /// since been deleted. Cheap — one statement, and vector writes only for
-    /// rows it actually freed — so it runs after every deletion.
+    /// since been deleted. Cheap — one query, and vector writes only for the
+    /// rows it actually frees — so it runs after every deletion.
+    ///
+    /// Payload before row, exactly as `unsupersede` does it, and for the same
+    /// reason. Clearing the rows first would leave every artifact whose vector
+    /// write then failed hidden from search with `superseded_by` already NULL:
+    /// off the Ops list, past the sweep's self-heal branch — which only repairs
+    /// the opposite skew — and unreachable by any button. This runs first in a
+    /// sweep, when Qdrant being unavailable is precisely the case at hand.
+    ///
+    /// One failure does not abandon the rest: each artifact is independent, and
+    /// the ones that can be freed should be. The state a failure leaves behind
+    /// is the recoverable one, so the next deletion or sweep finishes the job.
     pub(crate) async fn heal_dangling_supersessions(&self) -> Result<()> {
-        for id in self.store.clear_dangling_superseded().await? {
-            self.vectors.set_superseded(&id, false).await?;
+        let mut first_err = None;
+        for id in self.store.dangling_superseded().await? {
+            if let Err(e) = self.vectors.set_superseded(&id, false).await {
+                tracing::warn!(
+                    artifact_id = %id,
+                    error = %e,
+                    "could not clear the hidden flag; the artifact stays listed on Ops"
+                );
+                first_err.get_or_insert(e);
+                continue;
+            }
+            self.store.set_superseded_by(&id, None).await?;
             tracing::info!(
                 artifact_id = %id,
                 "restored an artifact whose surviving copy was deleted"
             );
         }
-        Ok(())
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 
     /// Vectors first: an orphaned row is invisible, but an orphaned vector is

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -127,8 +127,26 @@ impl Core {
                     // The older corpus goes first. If this fails the new one is
                     // still parked, which is a state an operator can retry from;
                     // releasing it first would leave both live on a failure.
-                    self.delete_corpus(&other).await?;
-                    tracing::info!(corpus_id = %src.id, replaced = %other, "replaced an older corpus");
+                    //
+                    // Unless it is already gone: `near_dupe_of` can name a
+                    // corpus that has since been deleted — including another
+                    // parked capture that was discarded, since a parked corpus
+                    // is still matchable. Failing there would leave the only
+                    // way out of the queue behind a 404, with nothing on the
+                    // page to say that "keep both" is now the same decision.
+                    match self.delete_corpus(&other).await {
+                        Ok(()) => {
+                            tracing::info!(corpus_id = %src.id, replaced = %other, "replaced an older corpus");
+                        }
+                        Err(Error::NotFound) => {
+                            tracing::info!(
+                                corpus_id = %src.id,
+                                replaced = %other,
+                                "the corpus this capture replaces was already deleted"
+                            );
+                        }
+                        Err(e) => return Err(e),
+                    }
                 }
                 self.store.set_near_dupe(&src.id, None, None).await?;
                 self.store
@@ -142,12 +160,33 @@ impl Core {
         Ok(())
     }
 
-    /// Put a superseded artifact back in search. The row first, then the
-    /// payload, in the same order the sweep wrote them.
+    /// Put a superseded artifact back in search.
+    ///
+    /// The payload flag first, then the row — the reverse of the order the
+    /// sweep wrote them, and for the same reason. The two stores cannot be
+    /// written atomically, so the intermediate state has to be one an operator
+    /// can act on: with the flag cleared and the row still set, the artifact is
+    /// listed on Ops with its restore button and the next press finishes the
+    /// job. Clearing the row first loses the only page that offers the undo
+    /// while the artifact is still hidden from search.
     pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
-        self.store.set_superseded_by(artifact_id, None).await?;
         self.vectors.set_superseded(artifact_id, false).await?;
+        self.store.set_superseded_by(artifact_id, None).await?;
         tracing::info!(artifact_id, "restored a superseded artifact to search");
+        Ok(())
+    }
+
+    /// Put back anything that was hidden in favour of an artifact which has
+    /// since been deleted. Cheap — one statement, and vector writes only for
+    /// rows it actually freed — so it runs after every deletion.
+    pub(crate) async fn heal_dangling_supersessions(&self) -> Result<()> {
+        for id in self.store.clear_dangling_superseded().await? {
+            self.vectors.set_superseded(&id, false).await?;
+            tracing::info!(
+                artifact_id = %id,
+                "restored an artifact whose surviving copy was deleted"
+            );
+        }
         Ok(())
     }
 
@@ -157,6 +196,7 @@ impl Core {
         self.store.get_corpus(id).await?;
         self.vectors.delete_by_corpus(id).await?;
         self.store.delete_corpus(id).await?;
+        self.heal_dangling_supersessions().await?;
         tracing::info!(corpus_id = %id, "deleted source and its vectors");
         Ok(())
     }
@@ -177,9 +217,17 @@ impl Core {
                 // no chunks at all. Re-windowing is also the point of a
                 // reprocess after a model or budget change.
                 self.store.clear_segments(&src.id).await?;
+                // Reprocessing a parked capture is a decision to process it, so
+                // the park has to be lifted with it. Leaving the flag set means
+                // a fully synthesized and embedded corpus sits on the review
+                // queue forever, where the discard button now deletes real work.
+                self.store.set_near_dupe(&src.id, None, None).await?;
                 self.store
                     .set_corpus_status(&src.id, CorpusStatus::Raw)
                     .await?;
+                // The artifacts just deleted may have been the surviving half of
+                // a consolidated pair; whatever they hid comes back.
+                self.heal_dangling_supersessions().await?;
                 self.store
                     .enqueue(Stage::Synthesize, "corpus", &src.id)
                     .await?;
@@ -334,6 +382,65 @@ mod tests {
             Err(crate::error::Error::NotFound)
         ));
         assert!(core.store.get_corpus(&first.id).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn replacing_a_corpus_that_is_already_gone_still_releases_the_capture() {
+        // `near_dupe_of` can name a corpus that has since been deleted —
+        // including another parked capture that was discarded, since a parked
+        // corpus is still matchable. Failing here put the only way out of the
+        // review queue behind a 404.
+        let core = test_core().await;
+        let first = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(
+                &manual("mount").replacen("step 7:", "step seven:", 1),
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+        core.delete_corpus(&first.id).await.unwrap();
+
+        core.resolve_near_duplicate(&second.id, NearDupeAction::Replace)
+            .await
+            .unwrap();
+
+        let got = core.store.get_corpus(&second.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::Raw);
+        assert!(got.near_dupe_of.is_none());
+        assert!(core.store.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn reprocessing_a_parked_capture_takes_it_off_the_review_queue() {
+        // Reprocessing is a decision to process. Leaving the park set left a
+        // fully synthesized corpus on the queue where "discard" deletes it.
+        let core = test_core().await;
+        core.ingest(&manual("mount"), "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(
+                &manual("mount").replacen("step 7:", "step seven:", 1),
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            core.store.get_corpus(&second.id).await.unwrap().status,
+            CorpusStatus::NeedsReview
+        );
+
+        core.reprocess(&second.id, Stage::Synthesize).await.unwrap();
+
+        let got = core.store.get_corpus(&second.id).await.unwrap();
+        assert!(
+            got.near_dupe_of.is_none(),
+            "the capture is being processed and still asks to be decided on"
+        );
+        assert_eq!(got.status, CorpusStatus::Raw);
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -168,6 +168,20 @@ mod tests {
     /// field copy: rerank is optional, and an absent block must leave search
     /// in vector order rather than defaulting to an endpoint.
     #[tokio::test]
+    async fn the_example_config_carries_the_consolidation_defaults() {
+        let cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
+        assert!(cfg.consolidate.enabled);
+        assert!(
+            cfg.consolidate.auto_supersede > cfg.consolidate.review_min,
+            "superseding at or below the review threshold would hide distinct artifacts"
+        );
+        assert!(
+            !cfg.consolidate.judge,
+            "the only inference-costing stage must be opt-in"
+        );
+    }
+
+    #[tokio::test]
     async fn rerank_is_wired_only_when_configured() {
         let store = crate::store::Store::memory().await.unwrap();
         let vectors = Arc::new(crate::vector::memory::MemoryVectors::new());

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -66,6 +66,9 @@ pub struct Core {
     pub background: Arc<Background>,
     /// Shared by every clone of `Core`, like the background queue.
     pub query_cache: Arc<std::sync::Mutex<QueryCache>>,
+    /// Thresholds and budgets for duplicate hygiene. Read on the capture path
+    /// and by the sweep, so it lives here rather than being passed down.
+    pub consolidate: crate::config::ConsolidateConfig,
 }
 
 impl Core {
@@ -97,6 +100,7 @@ impl Core {
             )),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
+            consolidate: cfg.consolidate.clone(),
         }
     }
 }
@@ -150,6 +154,7 @@ pub mod test_support {
             counter: Arc::new(TokenCounter::Estimate),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
+            consolidate: crate::config::ConsolidateConfig::default(),
         }
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -336,6 +336,7 @@ mod tests {
                 category: Some(cat.to_string()),
                 tags: tags.iter().map(|s| s.to_string()).collect(),
                 segment_idx: None,
+                caveats: vec![],
             })
             .collect();
         let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -224,6 +224,9 @@ impl Core {
         let filter = SearchFilter {
             tags: query.tags.clone(),
             category: query.category.clone(),
+            // Search never shows an artifact the sweep hid. It stays readable
+            // by id, which is what the review queue and the undo need.
+            include_superseded: false,
         };
         // Over-fetch whenever something downstream narrows the list: both the
         // per-source cap and the reranker can only discard what they are given.
@@ -672,6 +675,7 @@ mod tests {
                 tags: vec![],
                 created_at: 0,
                 last_seen_at: None,
+                superseded: None,
             },
             score,
         };

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -34,10 +34,7 @@ fn is_fact(token: &str) -> bool {
 /// Every value-shaped token in the text, stripped of surrounding punctuation.
 pub fn fact_tokens(text: &str) -> BTreeSet<String> {
     text.split_whitespace()
-        .map(|t| {
-            t.trim_matches(|c: char| !c.is_alphanumeric())
-                .to_string()
-        })
+        .map(|t| t.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
         .filter(|t| is_fact(t))
         .collect()
 }
@@ -107,7 +104,10 @@ mod tests {
         // The filter is allowed to pass a pair that turns out to be fine — that
         // costs one call. It is not allowed to drop one that disagrees, which
         // would cost a stale artifact nobody ever finds.
-        assert!(may_disagree("The timeout is 30 seconds.", "It listens on 8080."));
+        assert!(may_disagree(
+            "The timeout is 30 seconds.",
+            "It listens on 8080."
+        ));
     }
 
     #[test]

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -1,0 +1,125 @@
+//! Could these two artifacts actually disagree?
+//!
+//! The similarity sweep says two artifacts cover the same ground. That is not
+//! the interesting question — the interesting one is whether they state some
+//! detail differently, because a wrong artifact ranks exactly as well as a
+//! right one and nothing else in the system notices. Answering it properly
+//! needs a model, and a model call is minutes on the hardware this is built
+//! for, so this narrows the candidate set first at the cost of a scan.
+//!
+//! The rule is deliberately conservative in one direction only: it must never
+//! discard a pair that might disagree, and it is free to pass through pairs
+//! that turn out not to. A pair it passes costs one call; a pair it wrongly
+//! drops costs a stale artifact nobody ever finds.
+
+use std::collections::BTreeSet;
+
+/// Is this token shaped like something two documents could state differently?
+///
+/// Bare numbers count: a timeout, a port, a count of retries. Words do not —
+/// two artifacts using different prose for the same thing is what synthesis is
+/// supposed to produce, not a contradiction.
+fn is_fact(token: &str) -> bool {
+    if !token.starts_with(|c: char| c.is_ascii_digit()) {
+        return false;
+    }
+    // A leading digit plus only digits and separators: 30, 1.21.4, 2024-03-01,
+    // 8080. Anything with letters in it — `3rd`, `x86_64` — is vocabulary
+    // rather than a value.
+    token
+        .chars()
+        .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | ':'))
+}
+
+/// Every value-shaped token in the text, stripped of surrounding punctuation.
+pub fn fact_tokens(text: &str) -> BTreeSet<String> {
+    text.split_whitespace()
+        .map(|t| {
+            t.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_string()
+        })
+        .filter(|t| is_fact(t))
+        .collect()
+}
+
+/// Whether a pair is worth a model call.
+///
+/// Both artifacts must state some value, and their values must not be
+/// identical. That is all this can safely require. An earlier version also
+/// demanded a shared value, on the theory that it showed the two were talking
+/// about the same measurable thing — but that is exactly backwards for the case
+/// this exists to catch: one artifact says `1.21.4` and the other says
+/// `1.30.0`, and they share nothing at all. Whether the two are about the same
+/// subject was already settled by the similarity that put them in a pair.
+///
+/// So a pair stating unrelated values does get through and costs one call. That
+/// is the cheap direction of the error, and it is the one to be wrong in.
+pub fn may_disagree(a: &str, b: &str) -> bool {
+    let (fa, fb) = (fact_tokens(a), fact_tokens(b));
+    !fa.is_empty() && !fb.is_empty() && fa != fb
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn versions_numbers_and_dates_are_facts() {
+        let f = fact_tokens("Requires 1.21.4 or later, 30 seconds, on 2024-03-01, at 8080.");
+        assert!(f.contains("1.21.4"), "{f:?}");
+        assert!(f.contains("2024-03-01"), "{f:?}");
+        assert!(f.contains("30"), "{f:?}");
+        assert!(f.contains("8080"), "{f:?}");
+    }
+
+    #[test]
+    fn ordinary_prose_carries_no_facts() {
+        assert!(fact_tokens("Mount the filesystem before writing to it.").is_empty());
+    }
+
+    #[test]
+    fn two_artifacts_giving_a_different_version_may_disagree() {
+        assert!(may_disagree(
+            "engram requires Rust 1.21.4 to build.",
+            "engram requires Rust 1.30.0 to build.",
+        ));
+    }
+
+    #[test]
+    fn the_same_fact_stated_twice_does_not_disagree() {
+        assert!(!may_disagree(
+            "engram requires Rust 1.21.4 to build.",
+            "To build engram you need Rust 1.21.4.",
+        ));
+    }
+
+    #[test]
+    fn a_pair_where_only_one_side_states_a_value_is_not_judged() {
+        // Nothing to compare, so nothing a model could rule on.
+        assert!(!may_disagree(
+            "The mount command attaches a filesystem.",
+            "Version 9.9.9 of the pastry compiler ships on 2030-01-01.",
+        ));
+    }
+
+    #[test]
+    fn unrelated_values_do_get_through_and_that_is_deliberate() {
+        // The filter is allowed to pass a pair that turns out to be fine — that
+        // costs one call. It is not allowed to drop one that disagrees, which
+        // would cost a stale artifact nobody ever finds.
+        assert!(may_disagree("The timeout is 30 seconds.", "It listens on 8080."));
+    }
+
+    #[test]
+    fn one_artifact_with_no_facts_never_disagrees() {
+        assert!(!may_disagree("Prose only.", "Requires 1.2.3."));
+    }
+
+    #[test]
+    fn a_word_that_merely_starts_with_a_digit_is_not_a_fact() {
+        // `3rd` and `x86_64` are vocabulary, not values. Treating them as facts
+        // sends pairs to the model that have nothing to disagree about.
+        let f = fact_tokens("The 3rd step targets x86_64 hardware.");
+        assert!(f.is_empty(), "{f:?}");
+    }
+}

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -19,23 +19,64 @@ use std::collections::BTreeSet;
 /// Bare numbers count: a timeout, a port, a count of retries. Words do not —
 /// two artifacts using different prose for the same thing is what synthesis is
 /// supposed to produce, not a contradiction.
+/// Suffixes that make a bare number a measurement rather than a word.
+///
+/// A closed list on purpose. Accepting any trailing letters would make `3rd`
+/// and `2nd` values, and an ordinal is prose — every step-by-step artifact has
+/// one, so every pair would reach the model.
+const UNITS: &[&str] = &[
+    "s", "ms", "us", "ns", "m", "h", "d", "w", "y", "b", "k", "kb", "mb", "gb", "tb", "pb", "kib",
+    "mib", "gib", "tib", "hz", "khz", "mhz", "ghz", "px", "x",
+];
+
+/// A version is written `v1.21.4` as often as `1.21.4`, and the `v` is not what
+/// makes two artifacts agree or differ. Dropping it here means one artifact
+/// saying `v1.21.4` and another saying `1.21.4` compare as the same value
+/// rather than as two, which is what keeps them off the model's desk.
+fn devee(token: &str) -> &str {
+    match token.strip_prefix(['v', 'V']) {
+        Some(rest) if rest.starts_with(|c: char| c.is_ascii_digit()) => rest,
+        _ => token,
+    }
+}
+
 fn is_fact(token: &str) -> bool {
-    if !token.starts_with(|c: char| c.is_ascii_digit()) {
+    let t = devee(token);
+    if !t.starts_with(|c: char| c.is_ascii_digit()) {
         return false;
     }
-    // A leading digit plus only digits and separators: 30, 1.21.4, 2024-03-01,
-    // 8080. Anything with letters in it — `3rd`, `x86_64` — is vocabulary
-    // rather than a value.
-    token
-        .chars()
-        .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | ':'))
+    // Digits and separators only: 30, 1.21.4, 2024-03-01, 8080.
+    let separated = |s: &str| {
+        s.chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | ':' | '/' | '_'))
+    };
+    if separated(t) {
+        return true;
+    }
+    // Otherwise the letters have to earn their place. A number carrying a unit
+    // is a value — `30s`, `512mb` — and so is anything a separator has already
+    // marked as structured: `8080/tcp`, `2.0-rc1`, `1.21.4-beta`. What this
+    // still refuses is a bare number glued to a word: `3rd`, `x86_64`.
+    let split = t.find(|c: char| !c.is_ascii_digit()).unwrap_or(t.len());
+    let (digits, rest) = t.split_at(split);
+    if digits.is_empty() {
+        return false;
+    }
+    if rest.starts_with(['.', '-', ':', '/', '_']) {
+        return true;
+    }
+    UNITS.contains(&rest.to_ascii_lowercase().as_str())
 }
 
 /// Every value-shaped token in the text, stripped of surrounding punctuation.
+///
+/// Punctuation is trimmed from the edges only: `8080/tcp` and `1.21.4` keep
+/// their insides, and a trailing full stop or a wrapping backtick goes.
 pub fn fact_tokens(text: &str) -> BTreeSet<String> {
     text.split_whitespace()
-        .map(|t| t.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+        .map(|t| t.trim_matches(|c: char| !c.is_alphanumeric()))
         .filter(|t| is_fact(t))
+        .map(|t| devee(t).to_ascii_lowercase())
         .collect()
 }
 
@@ -113,6 +154,38 @@ mod tests {
     #[test]
     fn one_artifact_with_no_facts_never_disagrees() {
         assert!(!may_disagree("Prose only.", "Requires 1.2.3."));
+    }
+
+    #[test]
+    fn versions_carrying_a_v_are_facts_and_equal_the_bare_form() {
+        let f = fact_tokens("Needs v1.21.4 of the toolchain.");
+        assert!(f.contains("1.21.4"), "{f:?}");
+        assert!(!may_disagree(
+            "Needs v1.21.4 of the toolchain.",
+            "Needs 1.21.4 of the toolchain.",
+        ));
+        assert!(may_disagree(
+            "Needs v1.21.4 of the toolchain.",
+            "Needs v1.30.0 of the toolchain.",
+        ));
+    }
+
+    #[test]
+    fn a_number_with_a_unit_is_a_value() {
+        // The most common way a timeout or a size is actually written. Before
+        // these counted, two artifacts disagreeing about `30s` versus `90s`
+        // carried no fact tokens at all and were filed as no-conflict.
+        let f = fact_tokens("The timeout is 30s and the batch is 512MB.");
+        assert!(f.contains("30s"), "{f:?}");
+        assert!(f.contains("512mb"), "{f:?}");
+        assert!(may_disagree("Wait 30s.", "Wait 90s."));
+    }
+
+    #[test]
+    fn a_separator_marks_the_rest_as_structured() {
+        let f = fact_tokens("Listens on 8080/tcp, tagged 2.0-rc1.");
+        assert!(f.contains("8080/tcp"), "{f:?}");
+        assert!(f.contains("2.0-rc1"), "{f:?}");
     }
 
     #[test]

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -87,11 +87,19 @@ pub fn fact_tokens(text: &str) -> BTreeSet<String> {
 /// demanded a shared value, on the theory that it showed the two were talking
 /// about the same measurable thing — but that is exactly backwards for the case
 /// this exists to catch: one artifact says `1.21.4` and the other says
-/// `1.30.0`, and they share nothing at all. Whether the two are about the same
-/// subject was already settled by the similarity that put them in a pair.
+/// `1.30.0`, and they share nothing at all.
 ///
 /// So a pair stating unrelated values does get through and costs one call. That
 /// is the cheap direction of the error, and it is the one to be wrong in.
+///
+/// What this deliberately does *not* decide is whether the two are about the
+/// same subject. That used to be assumed settled by the similarity that put
+/// them in a pair, and it is not: in a reference document the entries for
+/// FAT12, FAT16 and FAT32 are near-identical in form and deliberately different
+/// in content, so they score 0.91 and every number in them differs. Similarity
+/// measures shape. The judge is the only thing here that can read a subject,
+/// which is why it is given both titles and told that different named things
+/// are not in conflict.
 pub fn may_disagree(a: &str, b: &str) -> bool {
     let (fa, fb) = (fact_tokens(a), fact_tokens(b));
     !fa.is_empty() && !fb.is_empty() && fa != fb

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -371,6 +371,25 @@ impl Completer for FakeCompleter {
     }
 }
 
+/// A completer that answers with the prompt it was handed.
+///
+/// What `ask` puts in front of the model is the whole of what the model can
+/// use, and it is otherwise invisible: the reply is a fake, so a test asserting
+/// on it proves nothing about the excerpts. This makes the prompt the thing
+/// under test.
+#[derive(Default)]
+pub struct EchoCompleter;
+
+#[async_trait]
+impl Completer for EchoCompleter {
+    async fn complete(&self, _system: &str, user: &str) -> Result<String> {
+        Ok(user.to_string())
+    }
+    fn context_tokens(&self) -> usize {
+        4096
+    }
+}
+
 /// A completer that answers from a script and counts how often it was asked.
 ///
 /// The consolidation tests are largely about *not* calling the model, so what

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -110,6 +110,7 @@ impl Synthesizer for FakeSynthesizer {
                 category: Some("note".into()),
                 tags: vec!["fake".into()],
                 corpus_lines: None,
+                caveats: vec![],
             })
             .collect())
     }
@@ -171,6 +172,7 @@ impl Synthesizer for ParaphrasingSynthesizer {
             category: Some("note".into()),
             tags: vec![],
             corpus_lines: None,
+            caveats: vec![],
         }])
     }
     fn budget(&self) -> SynthesisBudget {
@@ -225,6 +227,7 @@ impl Synthesizer for LyingSpanSynthesizer {
             category: None,
             tags: vec![],
             corpus_lines: Some((9_000, 9_100)),
+            caveats: vec![],
         }])
     }
     fn budget(&self) -> SynthesisBudget {
@@ -250,6 +253,7 @@ impl Synthesizer for HallucinatingSynthesizer {
             category: None,
             tags: vec![],
             corpus_lines: Some((9_000, 9_100)),
+            caveats: vec![],
         }])
     }
     fn budget(&self) -> SynthesisBudget {

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -371,6 +371,45 @@ impl Completer for FakeCompleter {
     }
 }
 
+/// A completer that answers from a script and counts how often it was asked.
+///
+/// The consolidation tests are largely about *not* calling the model, so what
+/// they assert on is the call count as much as the reply.
+pub struct ScriptedCompleter {
+    replies: std::sync::Mutex<std::collections::VecDeque<String>>,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl ScriptedCompleter {
+    pub fn new(replies: Vec<String>) -> Self {
+        Self {
+            replies: std::sync::Mutex::new(replies.into()),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+    pub fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Completer for ScriptedCompleter {
+    async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.replies
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| crate::error::Error::Inference {
+                role: "ask",
+                detail: "the script ran out of replies".into(),
+            })
+    }
+    fn context_tokens(&self) -> usize {
+        4096
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -15,6 +15,10 @@ pub struct ProposedArtifact {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub corpus_lines: Option<(i64, i64)>,
+    /// Conditions under which the artifact does not apply, as the source states
+    /// them. The model is already holding this segment, so asking for these
+    /// costs output tokens rather than another call.
+    pub caveats: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -1,4 +1,5 @@
 pub mod budget;
+pub mod facts;
 pub mod fake;
 pub mod openai;
 pub mod prompt;

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -60,23 +60,39 @@ pub fn repair_prompt(previous: &str, err: &str) -> String {
 /// a judgement waiting.
 pub const JUDGE_SYSTEM: &str = r#"You compare two knowledge artifacts and answer one question: do they state some specific detail differently?
 
-A contradiction is a concrete disagreement about the same thing: a different version, number, date, path, flag, default, or step order for the same subject.
+First decide whether the two are about the same subject. Their titles say what each one is about, and the body may never repeat it — an artifact titled "FAT32 Specifications" can open with "32 Bit Clusternummern" and never name FAT32 again.
+
+If the titles name different things — two versions, two variants, two products, two filesystems, two commands — then the artifacts are not in conflict no matter how far apart their numbers are. Different things have different numbers; that is what makes them different things. Answer false and stop.
+
+Only when both describe the same subject: a contradiction is a concrete disagreement about it — a different version, number, date, path, flag, default, or step order for that one subject.
 
 These are NOT contradictions:
 - The same fact in different words.
 - Different levels of detail about the same thing.
-- Two different subjects that happen to use similar language.
+- Two different subjects that happen to use similar language, or the same layout.
 - One artifact mentioning something the other simply does not cover.
+- Two values that both appear in the same artifact.
 
 Reply with JSON only, no commentary, in exactly this shape:
 
 {"contradicts": true, "detail": "..."}
 
-- contradicts: true only for a concrete disagreement, as above.
-- detail: when true, one short sentence naming the two conflicting values. Omit it when false."#;
+- contradicts: true only for a concrete disagreement about one subject, as above.
+- detail: when true, one short sentence naming the two conflicting values and which artifact holds each. Omit it when false."#;
 
-pub fn judge_prompt(a: &str, b: &str) -> String {
-    format!("----- ARTIFACT A -----\n{a}\n----- ARTIFACT B -----\n{b}\n----- END -----")
+/// The two artifacts, each under its title.
+///
+/// The title is not decoration here, it is the subject. Synthesis writes a body
+/// that stands on its own within its segment, which is not the same as naming
+/// what it is about: a section headed "FAT32" becomes an artifact whose text
+/// opens "32 Bit Clusternummern" and never says FAT32 again. Handed the bodies
+/// alone, the model saw two anonymous spec lists with different numbers and
+/// called them a contradiction — correctly, on the evidence it was given.
+pub fn judge_prompt(a: (&str, &str), b: (&str, &str)) -> String {
+    format!(
+        "----- ARTIFACT A -----\nTitle: {}\n\n{}\n----- ARTIFACT B -----\nTitle: {}\n\n{}\n----- END -----",
+        a.0, a.1, b.0, b.1
+    )
 }
 
 #[derive(serde::Deserialize)]
@@ -324,6 +340,32 @@ pub fn parse_response(body: &str) -> Result<Vec<ProposedArtifact>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_judge_is_told_what_each_artifact_is_about() {
+        // The real case this fixes: an artifact headed "FAT32 Specifications"
+        // whose body opens "32 Bit Clusternummern" and never says FAT32 again.
+        // Given the bodies alone, the model saw two anonymous spec lists with
+        // different numbers and called them a contradiction — which was the
+        // only honest answer to the question it was actually asked.
+        let p = judge_prompt(
+            ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
+            ("FAT32 Specifications", "32 Bit Clusternummern."),
+        );
+        assert!(p.contains("Title: FAT16 Specifications"), "{p}");
+        assert!(p.contains("Title: FAT32 Specifications"), "{p}");
+        assert!(p.contains("Die max. Partitionsgröße: 2 GB."));
+    }
+
+    #[test]
+    fn the_judge_is_told_that_different_subjects_are_not_a_conflict() {
+        // Two sections of one reference document are near-identical in form and
+        // deliberately different in content, so similarity puts them in a pair
+        // and every number in them differs. Without this rule the feature fires
+        // hardest exactly where it is most wrong.
+        assert!(JUDGE_SYSTEM.contains("same subject"));
+        assert!(JUDGE_SYSTEM.contains("Answer false and stop."));
+    }
 
     #[test]
     fn a_truncated_list_keeps_the_artifacts_that_finished() {

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -21,12 +21,18 @@ the title is a separate field, so any headings inside the text start at `## `.
 
 Reply with JSON only, no commentary, in exactly this shape:
 
-{"artifacts":[{"text":"...","title":"...","category":"...","tags":["..."],"corpus_lines":[start,end]}]}
+{"artifacts":[{"text":"...","title":"...","category":"...","tags":["..."],"corpus_lines":[start,end],"caveats":["..."]}]}
 
 - title: a short noun phrase naming the artifact.
 - category: one lowercase word, e.g. procedure, concept, reference, snippet.
 - tags: 1-5 lowercase keywords for filtering.
-- corpus_lines: the 1-based line range in the input this artifact came from."#;
+- corpus_lines: the 1-based line range in the input this artifact came from.
+- caveats: 0-3 short sentences for conditions under which this artifact does
+  not hold — a prerequisite, a version or platform it is specific to, a
+  destructive effect, a documented failure. Take these only from what the input
+  states or plainly implies. Never invent a caveat, never add general advice,
+  and never put a command in a caveat that is not in the input. Use an empty
+  list when the input states none, which is the common case."#;
 
 pub fn user_prompt(segment_text: &str, first_line: i64, max_artifact_tokens: usize) -> String {
     format!(
@@ -61,6 +67,8 @@ struct RawArtifact {
     tags: Vec<String>,
     #[serde(default)]
     corpus_lines: Option<Vec<i64>>,
+    #[serde(default)]
+    caveats: Vec<String>,
 }
 
 /// Models wrap JSON in fences and preface it with prose no matter what the
@@ -241,6 +249,16 @@ pub fn parse_response(body: &str) -> Result<Vec<ProposedArtifact>> {
                 Some([a, b]) => Some((*a, *b)),
                 _ => None,
             },
+            // Capped at the three the prompt asks for: a model that starts
+            // listing general advice must not turn one artifact into a page of
+            // it, and the tail is the least source-grounded part of the list.
+            caveats: c
+                .caveats
+                .into_iter()
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty())
+                .take(3)
+                .collect(),
         })
         .collect();
 
@@ -324,6 +342,44 @@ mod tests {
         // rather than silently dropped.
         let prose = r###"{"artifacts":[{"text":"unterminated and "broken, "tags":}]}"###;
         assert!(parse_response(prose).is_err());
+    }
+
+    #[test]
+    fn caveats_are_parsed_when_the_model_supplies_them() {
+        let body = r#"{"artifacts":[{
+            "text":"Run `mkfs.ext4 /dev/sdb1` to format the partition.",
+            "title":"Formatting a partition",
+            "category":"procedure",
+            "tags":["disk"],
+            "corpus_lines":[3,9],
+            "caveats":["Destroys every existing file on the device.",
+                       "Requires root."]
+        }]}"#;
+        let got = parse_response(body).unwrap();
+        assert_eq!(
+            got[0].caveats,
+            vec![
+                "Destroys every existing file on the device.".to_string(),
+                "Requires root.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn an_artifact_without_caveats_parses_to_an_empty_list() {
+        // Most models will omit the field most of the time, and a missing
+        // field must never fail a segment that is otherwise fine.
+        let body = r#"{"artifacts":[{"text":"plain","title":"t","category":"c","tags":[]}]}"#;
+        assert!(parse_response(body).unwrap()[0].caveats.is_empty());
+    }
+
+    #[test]
+    fn the_system_prompt_asks_for_caveats_and_forbids_inventing_them() {
+        assert!(SYNTHESIZER_SYSTEM.contains("caveats"));
+        assert!(
+            SYNTHESIZER_SYSTEM.contains("Never invent"),
+            "the prompt must tie caveats to what the source says"
+        );
     }
 
     // r###: the JSON contains the sequence `"##` (a quoted markdown H2),

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -51,6 +51,57 @@ pub fn repair_prompt(previous: &str, err: &str) -> String {
     )
 }
 
+/// The judge is asked one question and given no room to be helpful.
+///
+/// It is not asked which artifact is right, nor to merge them, nor to rewrite
+/// anything. Deciding which of two contradictory artifacts is current needs
+/// context the base does not hold — what the reader is actually running — and
+/// is a judgement only they can make. All this call does is tell them there is
+/// a judgement waiting.
+pub const JUDGE_SYSTEM: &str = r#"You compare two knowledge artifacts and answer one question: do they state some specific detail differently?
+
+A contradiction is a concrete disagreement about the same thing: a different version, number, date, path, flag, default, or step order for the same subject.
+
+These are NOT contradictions:
+- The same fact in different words.
+- Different levels of detail about the same thing.
+- Two different subjects that happen to use similar language.
+- One artifact mentioning something the other simply does not cover.
+
+Reply with JSON only, no commentary, in exactly this shape:
+
+{"contradicts": true, "detail": "..."}
+
+- contradicts: true only for a concrete disagreement, as above.
+- detail: when true, one short sentence naming the two conflicting values. Omit it when false."#;
+
+pub fn judge_prompt(a: &str, b: &str) -> String {
+    format!("----- ARTIFACT A -----\n{a}\n----- ARTIFACT B -----\n{b}\n----- END -----")
+}
+
+#[derive(serde::Deserialize)]
+struct Judgement {
+    contradicts: bool,
+    #[serde(default)]
+    detail: Option<String>,
+}
+
+/// A reply that cannot be read is an error, not a verdict.
+///
+/// Defaulting to "contradicts" would fill the review queue with noise an
+/// operator has to clear by hand; defaulting to "no" would quietly close real
+/// conflicts. Failing leaves the pair pending, and the next sweep asks again.
+pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>)> {
+    let j: Judgement = serde_json::from_str(extract_json(body)).map_err(|e| {
+        Error::MalformedLlmOutput(format!("judge reply was not the expected JSON: {e}"))
+    })?;
+    let detail = j
+        .detail
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty() && j.contradicts);
+    Ok((j.contradicts, detail))
+}
+
 #[derive(serde::Deserialize)]
 struct Envelope {
     artifacts: Vec<RawArtifact>,
@@ -342,6 +393,37 @@ mod tests {
         // rather than silently dropped.
         let prose = r###"{"artifacts":[{"text":"unterminated and "broken, "tags":}]}"###;
         assert!(parse_response(prose).is_err());
+    }
+
+    #[test]
+    fn a_judgement_parses() {
+        let (yes, detail) =
+            parse_judgement(r#"{"contradicts":true,"detail":"one says 1.2, the other 1.4"}"#)
+                .unwrap();
+        assert!(yes);
+        assert_eq!(detail.as_deref(), Some("one says 1.2, the other 1.4"));
+    }
+
+    #[test]
+    fn a_negative_judgement_carries_no_detail() {
+        let (yes, detail) = parse_judgement(r#"{"contradicts":false}"#).unwrap();
+        assert!(!yes);
+        assert!(detail.is_none());
+    }
+
+    #[test]
+    fn a_judgement_wrapped_in_prose_and_fences_still_parses() {
+        // The same models that fence the synthesis reply fence this one.
+        let (yes, _) = parse_judgement("Sure:\n```json\n{\"contradicts\": true}\n```").unwrap();
+        assert!(yes);
+    }
+
+    #[test]
+    fn an_unparsable_judgement_is_an_error_not_a_yes() {
+        // Defaulting to "contradicts" would fill the review queue with noise;
+        // defaulting to "no" would hide real conflicts. Neither: it fails, the
+        // pair stays pending, and the next sweep tries again.
+        assert!(parse_judgement("I could not decide.").is_err());
     }
 
     #[test]

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -199,9 +199,6 @@ impl Flattened {
     }
 }
 
-/// A chunk whose span points somewhere else entirely.
-pub const FLAG_SPAN: &str = "span_unverified";
-
 /// Below this fraction of a source inside some chunk, the segmenter probably
 /// dropped part of the document.
 pub const LOW_COVERAGE: f64 = 0.6;
@@ -216,9 +213,12 @@ fn distinctive_tokens(s: &str) -> std::collections::HashSet<String> {
 /// Does the chunk plausibly describe the lines it claims?
 ///
 /// The synthesizer rewrites prose, so this cannot demand equality — only that a
-/// third of the chunk's distinctive tokens appear in the claimed range. That is
-/// enough to catch a span pointing at a different section, which is the failure
-/// the detail pane would otherwise render as a rendering bug.
+/// third of the chunk's distinctive tokens appear in the claimed range.
+///
+/// Synthesis no longer calls this: it derives spans rather than checking the
+/// model's, so there is no claim left to doubt. It stays because
+/// `content_coverage` measures the same relationship — is this text in those
+/// lines — and the two want to keep answering it the same way.
 pub fn span_is_plausible(artifact_text: &str, claimed_text: &str) -> bool {
     let chunk = distinctive_tokens(artifact_text);
     if chunk.is_empty() {

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -244,8 +244,10 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
         assert!(
             missing_literals(
                 "Write the image to the device.",
-                &["Unmount first: `dd if=archlinux.iso of=/dev/sdX` needs the whole device."
-                    .to_string()],
+                &[
+                    "Unmount first: `dd if=archlinux.iso of=/dev/sdX` needs the whole device."
+                        .to_string()
+                ],
                 WINDOW,
             )
             .is_empty()

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -229,26 +229,60 @@ pub fn span_is_plausible(artifact_text: &str, claimed_text: &str) -> bool {
     shared * 3 >= chunk.len()
 }
 
-/// Fraction of the source's non-blank lines that some chunk span covers.
-pub fn coverage(spans: &[(i64, i64)], raw_text: &str) -> f64 {
+/// A source line counts as covered when this share of its distinctive tokens
+/// appears in the artifacts made from the segment it belongs to.
+///
+/// Half, because synthesis rewrites: a line survives as its subject and its
+/// values, not as its wording. Demanding all of it would call every rewritten
+/// line lost, which is what the artifacts are supposed to be.
+const LINE_TOKEN_RECALL: f64 = 0.5;
+
+/// Fraction of the source that survived into some artifact.
+///
+/// Each entry is one segment's line range and the text of every artifact made
+/// from it. A line outside every range — a segment that failed, or one never
+/// attempted — is uncovered, which is exactly the case this number exists to
+/// make visible.
+///
+/// This asks whether the *content* arrived, not whether an artifact claimed the
+/// line. Claims were the earlier measure and they answer a different question:
+/// the model omits `corpus_lines` more often than not, and a span recovered by
+/// matching verbatim text finds only the quarter of an artifact that was not
+/// rewritten. A faithfully rewritten chapter therefore scored near zero, which
+/// read exactly like a chapter that had been dropped.
+pub fn content_coverage(raw_text: &str, segments: &[(i64, i64, String)]) -> f64 {
     let lines: Vec<&str> = raw_text.lines().collect();
     let total = lines.iter().filter(|l| !l.trim().is_empty()).count();
     if total == 0 {
         return 0.0;
     }
-    let mut covered = vec![false; lines.len()];
-    for (start, end) in spans {
-        let first = (*start).max(1);
-        let last = (*end).min(lines.len() as i64);
-        for n in first..=last {
-            covered[(n - 1) as usize] = true;
+    let indexed: Vec<(i64, i64, std::collections::HashSet<String>)> = segments
+        .iter()
+        .map(|(a, b, text)| (*a, *b, distinctive_tokens(text)))
+        .collect();
+
+    let mut hit = 0usize;
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let n = i as i64 + 1;
+        let Some((_, _, made)) = indexed.iter().find(|(a, b, _)| *a <= n && n <= *b) else {
+            continue;
+        };
+        let want = distinctive_tokens(line);
+        // A line with nothing distinctive on it — a page number, a rule of
+        // dashes — cannot be looked for and must not be counted against the
+        // document. PDF exports are full of them.
+        if want.is_empty() {
+            hit += 1;
+            continue;
+        }
+        let found = want.iter().filter(|t| made.contains(*t)).count();
+        if found as f64 >= want.len() as f64 * LINE_TOKEN_RECALL {
+            hit += 1;
         }
     }
-    let hit = lines
-        .iter()
-        .enumerate()
-        .filter(|(i, l)| !l.trim().is_empty() && covered[*i])
-        .count();
     hit as f64 / total as f64
 }
 
@@ -418,12 +452,42 @@ Die Markierung End of File (EOF) zeigt das Dateiende an.";
     }
 
     #[test]
-    fn coverage_is_the_fraction_of_non_blank_lines_claimed() {
-        let raw = "one\n\ntwo\nthree\nfour"; // four non-blank lines
-        assert!((coverage(&[(1, 1), (3, 3)], raw) - 0.5).abs() < 1e-6);
-        assert!((coverage(&[(1, 5)], raw) - 1.0).abs() < 1e-6);
-        assert_eq!(coverage(&[], raw), 0.0);
-        // Overlapping spans must not push coverage above one.
-        assert!((coverage(&[(1, 5), (2, 4)], raw) - 1.0).abs() < 1e-6);
+    fn coverage_counts_a_line_whose_content_reached_an_artifact() {
+        let raw =
+            "Mount the filesystem first.\n\nThe timeout is 30 seconds.\nUnrelated trailing note.";
+        // One artifact carrying both subjects, rewritten rather than copied.
+        let made = "Mount the filesystem before anything else. A timeout of 30 seconds applies.";
+        let cov = content_coverage(raw, &[(1, 4, made.into())]);
+        assert!((cov - 2.0 / 3.0).abs() < 1e-6, "{cov}");
+    }
+
+    #[test]
+    fn a_segment_that_produced_nothing_is_uncovered() {
+        // The case the number exists for: a segment the model refused leaves
+        // its lines out of every artifact, and that must be visible.
+        let raw = "alpha bravo charlie\ndelta echo foxtrot";
+        assert_eq!(content_coverage(raw, &[]), 0.0);
+        assert_eq!(
+            content_coverage(raw, &[(1, 1, "alpha bravo charlie".into())]),
+            0.5
+        );
+    }
+
+    #[test]
+    fn a_rewritten_line_still_counts() {
+        // The failure this replaced: an artifact that reproduces a line's
+        // subject and values in its own words scored zero, because no span
+        // could be matched back to it.
+        let raw = "Der Startcluster steht im Verzeichniseintrag.";
+        let made = "Verzeichniseintrag: hier steht der Startcluster der Datei.";
+        assert_eq!(content_coverage(raw, &[(1, 1, made.into())]), 1.0);
+    }
+
+    #[test]
+    fn a_line_with_nothing_distinctive_on_it_is_not_held_against_the_document() {
+        // A page number from a PDF export. Nothing can be looked for, so
+        // counting it lost would make every handout read as half-dropped.
+        let raw = "32";
+        assert_eq!(content_coverage(raw, &[(1, 1, String::new())]), 1.0);
     }
 }

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -104,8 +104,44 @@ pub fn missing_literals(
     all.sort();
     all.dedup();
     all.into_iter()
-        .filter(|lit| !haystack.contains(&normalize(lit)))
+        .filter(|lit| {
+            if haystack.contains(&normalize(lit)) {
+                return false;
+            }
+            match without_label(lit) {
+                Some(bare) => !haystack.contains(&normalize(bare)),
+                None => true,
+            }
+        })
+        .map(|lit| match without_label(&lit) {
+            // Report what was actually looked for and not found, so the note on
+            // the artifact names the command rather than the model's framing.
+            Some(bare) => bare.to_string(),
+            None => lit,
+        })
         .collect()
+}
+
+/// A literal with a label the model put in front of it removed.
+///
+/// `Binär: 0010 1001 1111 1001`, for a source that says
+/// `wird binär 0010 1001 1111 1001`, invents nothing: the digits — the part
+/// that matters if somebody retypes them — are verbatim, and the label is
+/// presentation. Reporting it as a possibly-invented command buries the real
+/// misses under the model's formatting habits.
+///
+/// A colon *and a space*, and one word before it. That is what separates a
+/// label from a command's own punctuation: `backup:/etc/fstab` and
+/// `8080:8080` close up, `Binär: …` and `Run: …` do not. Stripping the first
+/// kind would let a rewritten hostname pass as verbatim, which is the failure
+/// this whole check exists to catch.
+fn without_label(lit: &str) -> Option<&str> {
+    let (label, rest) = lit.split_once(": ")?;
+    let rest = rest.trim();
+    if rest.is_empty() || label.split_whitespace().count() != 1 {
+        return None;
+    }
+    Some(rest)
 }
 
 /// Where in the window a chunk's own lines actually appear.
@@ -321,6 +357,40 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
             WINDOW,
         );
         assert_eq!(missing, vec!["wipefs --all /dev/sdX".to_string()]);
+    }
+
+    #[test]
+    fn a_label_the_model_added_is_not_a_missing_literal() {
+        // Line 635 of a real source read "wird binär 0010 1001 1111 1001". The
+        // model fenced the digits and wrote "Binär:" in front of them, and the
+        // check reported an invented command — a review task about formatting,
+        // filed among the ones that matter.
+        let window = "Die Zahl 29 F9 wird binär 0010 1001 1111 1001 gespeichert.";
+        let chunk = "```\nBinär: 0010 1001 1111 1001\n```";
+        assert!(missing_literals(chunk, &[], window).is_empty());
+    }
+
+    #[test]
+    fn an_invented_command_is_still_caught_when_it_carries_a_label() {
+        let window = "Unmount the device first.";
+        let chunk = "```\nRun: wipefs --all /dev/sdX\n```";
+        assert_eq!(
+            missing_literals(chunk, &[], window),
+            vec!["wipefs --all /dev/sdX".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_command_whose_own_colon_looks_like_a_label_is_not_weakened() {
+        // `backup:/etc/fstab` must not be reduced to `/etc/fstab`, or a
+        // rewritten hostname would stop being a missing literal. A label is
+        // written with a space after the colon; a host and a port are not.
+        let window = "Copy /etc/fstab from the box.";
+        let chunk = "```\nbackup:/etc/fstab\n```";
+        assert_eq!(
+            missing_literals(chunk, &[], window),
+            vec!["backup:/etc/fstab".to_string()]
+        );
     }
 
     #[test]

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -84,11 +84,26 @@ pub fn extract_literals(artifact_text: &str) -> Vec<String> {
     out
 }
 
-/// Literals present in the chunk and absent from the window it came from.
-pub fn missing_literals(artifact_text: &str, segment_text: &str) -> Vec<String> {
+/// Literals present in the chunk or its caveats and absent from the window they
+/// came from.
+///
+/// Caveats go through the same check rather than a weaker one. They are the
+/// newest place model prose can appear, and a caveat that says to run something
+/// first is a command that gets pasted into a root shell exactly like one in
+/// the body.
+pub fn missing_literals(
+    artifact_text: &str,
+    caveats: &[String],
+    segment_text: &str,
+) -> Vec<String> {
     let haystack = normalize(segment_text);
-    extract_literals(artifact_text)
-        .into_iter()
+    let mut all = extract_literals(artifact_text);
+    for c in caveats {
+        all.extend(extract_literals(c));
+    }
+    all.sort();
+    all.dedup();
+    all.into_iter()
         .filter(|lit| !haystack.contains(&normalize(lit)))
         .collect()
 }
@@ -211,9 +226,36 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
     }
 
     #[test]
+    fn a_command_invented_in_a_caveat_is_caught() {
+        // A caveat is prose the model wrote, and it is exactly where an
+        // invented "run `wipefs --all` first" would appear. The literal check
+        // has to reach it, or caveats become the one part of an artifact that
+        // nothing verifies.
+        let missing = missing_literals(
+            "Write the image with `dd if=archlinux.iso of=/dev/sdX`.",
+            &["First run `wipefs --all /dev/sdX`.".to_string()],
+            WINDOW,
+        );
+        assert_eq!(missing, vec!["wipefs --all /dev/sdX".to_string()]);
+    }
+
+    #[test]
+    fn a_caveat_quoting_a_real_command_is_not_flagged() {
+        assert!(
+            missing_literals(
+                "Write the image to the device.",
+                &["Unmount first: `dd if=archlinux.iso of=/dev/sdX` needs the whole device."
+                    .to_string()],
+                WINDOW,
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
     fn a_verbatim_chunk_reports_nothing_missing() {
         let chunk = "Unmount first.\n\n```bash\ndd if=archlinux.iso of=/dev/sdX bs=4M oflag=sync status=progress\n```\n\nUse /dev/sdX with --dry-run.";
-        assert!(missing_literals(chunk, WINDOW).is_empty());
+        assert!(missing_literals(chunk, &[], WINDOW).is_empty());
     }
 
     #[test]
@@ -221,7 +263,7 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
         // The model rewrote the command and lost oflag=sync. This is the
         // failure the whole check exists for.
         let chunk = "```bash\ndd if=archlinux.iso of=/dev/sdX bs=4M status=progress\n```";
-        let missing = missing_literals(chunk, WINDOW);
+        let missing = missing_literals(chunk, &[], WINDOW);
         assert_eq!(missing.len(), 1);
         assert!(missing[0].contains("status=progress"));
     }
@@ -230,14 +272,14 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
     fn indentation_and_whitespace_runs_do_not_count_as_a_mismatch() {
         // The window indents the command by four spaces; the chunk fences it.
         let chunk = "```\numount   /dev/sdX*\n```";
-        assert!(missing_literals(chunk, WINDOW).is_empty());
+        assert!(missing_literals(chunk, &[], WINDOW).is_empty());
     }
 
     #[test]
     fn an_indented_code_block_counts_as_code() {
         // Reference documentation indents commands as often as it fences them.
         let chunk = "Write it:\n\n    dd if=archlinux.iso of=/dev/sdX bs=4M status=progress\n";
-        let missing = missing_literals(chunk, WINDOW);
+        let missing = missing_literals(chunk, &[], WINDOW);
         assert_eq!(missing.len(), 1, "the rewritten command must be caught");
     }
 

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -122,7 +122,7 @@ pub fn locate_span(
     segment_body: &str,
     segment_start: i64,
 ) -> Option<(i64, i64)> {
-    let window: Vec<String> = segment_body.lines().map(normalize).collect();
+    let flat = Flattened::of(segment_body);
     let needles: Vec<String> = artifact_text
         .lines()
         .map(normalize)
@@ -135,18 +135,68 @@ pub fn locate_span(
     let mut first = usize::MAX;
     let mut last = 0usize;
     for needle in &needles {
-        if let Some(at) = window
-            .iter()
-            .position(|w| w == needle || w.contains(needle))
-        {
-            first = first.min(at);
-            last = last.max(at);
+        if let Some(at) = flat.text.find(needle.as_str()) {
+            first = first.min(flat.line_at(at));
+            last = last.max(flat.line_at(at + needle.len() - 1));
         }
     }
     if first == usize::MAX {
         return None;
     }
     Some((segment_start + first as i64, segment_start + last as i64))
+}
+
+/// A window with its line breaks taken out, and the map back.
+///
+/// Comparing a chunk's lines against the window's lines only finds what the
+/// source happened to fit on one line. Sources do not cooperate: a handout
+/// exported from a PDF is hard-wrapped at eighty columns, so one sentence is
+/// three lines, and synthesis reflows it back into one. Line against line, the
+/// paragraph matches nothing and a chunk built from it claims either a single
+/// short sentence or no span at all — which is then what coverage counts.
+///
+/// Matching against the whole window as one string finds the paragraph, and the
+/// offsets say which lines it ran across.
+struct Flattened {
+    text: String,
+    /// Byte offset in `text` at which each source line begins.
+    starts: Vec<usize>,
+}
+
+impl Flattened {
+    fn of(segment_body: &str) -> Self {
+        let mut text = String::new();
+        let mut starts = Vec::new();
+        for line in segment_body.lines() {
+            let n = normalize(line);
+            // The separator stands in for the line break the source had, so a
+            // sentence reflowed across two lines reads as it does in the chunk.
+            if !text.is_empty() && !n.is_empty() {
+                text.push(' ');
+            }
+            starts.push(text.len());
+            text.push_str(&n);
+        }
+        Self { text, starts }
+    }
+
+    /// Which line a byte offset falls in. The last line that starts at or
+    /// before it — blank lines share their neighbour's offset and never win,
+    /// because a match cannot begin inside one.
+    fn line_at(&self, offset: usize) -> usize {
+        match self.starts.binary_search(&offset) {
+            // Several lines can share a start offset; take the last, which is
+            // the one that actually holds text.
+            Ok(mut i) => {
+                while i + 1 < self.starts.len() && self.starts[i + 1] == offset {
+                    i += 1;
+                }
+                i
+            }
+            Err(0) => 0,
+            Err(i) => i - 1,
+        }
+    }
 }
 
 /// A chunk whose span points somewhere else entirely.
@@ -327,6 +377,36 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
         // WINDOW line 6 (1-based) holds the dd command, so with the window
         // starting at 101 the span is line 106.
         assert_eq!(found, (106, 106));
+    }
+
+    /// A lecture handout, PDF-extracted: hard-wrapped at about eighty columns,
+    /// so one sentence of prose is three lines of source.
+    const WRAPPED: &str = "\
+Die Verzeichniseinträge enthalten die Meta-Daten, wie Namen,
+Dateigrößen, Attribute und Zeitstempel zu den gespeicherten
+Dateien und Verzeichnissen.
+Die Markierung End of File (EOF) zeigt das Dateiende an.";
+
+    #[test]
+    fn a_span_covers_every_line_a_reflowed_paragraph_came_from() {
+        // Synthesis reflows: what the source wraps over three lines comes back
+        // as one. Matching line against line then finds only the sentence that
+        // happened to fit on one source line, so a chunk built from a whole
+        // paragraph claimed a single line — and coverage, which counts the
+        // lines some span names, read a fraction of the truth on every
+        // hard-wrapped document.
+        let chunk = "Die Verzeichniseinträge enthalten die Meta-Daten, wie Namen, Dateigrößen, Attribute und Zeitstempel zu den gespeicherten Dateien und Verzeichnissen.";
+        assert_eq!(
+            locate_span(chunk, WRAPPED, 1),
+            Some((1, 3)),
+            "the paragraph's own three source lines"
+        );
+    }
+
+    #[test]
+    fn a_reflowed_span_still_reaches_the_last_line_it_covers() {
+        let chunk = "Die Verzeichniseinträge enthalten die Meta-Daten, wie Namen, Dateigrößen, Attribute und Zeitstempel zu den gespeicherten Dateien und Verzeichnissen.\n\nDie Markierung End of File (EOF) zeigt das Dateiende an.";
+        assert_eq!(locate_span(chunk, WRAPPED, 101), Some((101, 104)));
     }
 
     #[test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -313,7 +313,10 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
             .completer
             .complete(
                 crate::infer::prompt::JUDGE_SYSTEM,
-                &crate::infer::prompt::judge_prompt(&a.text, &b.text),
+                &crate::infer::prompt::judge_prompt(
+                    (a.title.as_deref().unwrap_or("untitled"), &a.text),
+                    (b.title.as_deref().unwrap_or("untitled"), &b.text),
+                ),
             )
             .await
         {

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -77,6 +77,11 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         return Ok(Outcome::default());
     }
 
+    // Deletions clear these as they happen; the sweep repeats it because a
+    // hidden artifact pointing at nothing is invisible to search and to every
+    // page that could put it back, and nothing else would ever notice.
+    core.heal_dangling_supersessions().await?;
+
     let pairs = core
         .vectors
         .near_pairs(cfg.sample, cfg.per_point, cfg.review_min)
@@ -104,6 +109,13 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             continue;
         };
         if c.superseded_by.is_some() {
+            // The row says hidden but the vector store still offered this point
+            // as a pair candidate, so its payload flag never landed — the sweep
+            // was interrupted between the two writes. Ops has been listing this
+            // artifact as hidden while every search still returned it. Finish
+            // the write that was lost; it is idempotent and costs no inference.
+            tracing::info!(artifact_id = %id, "re-applying a superseded flag the vector store is missing");
+            core.vectors.set_superseded(id, true).await?;
             continue;
         }
         let root = clusters.find(id);
@@ -199,6 +211,18 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
         ) else {
             continue;
         };
+
+        // A pair queued in the review band can have a member superseded by a
+        // later sweep, once a re-embed moves the score above `auto_supersede`.
+        // Judging it would spend the scarcest thing here — a model call — to
+        // post a contradiction about an artifact that is no longer in results.
+        // The supersession is the answer to this pair.
+        if a.superseded_by.is_some() || b.superseded_by.is_some() {
+            core.store
+                .set_pair_state(p.id, crate::store::pairs::PairState::Dismissed, None)
+                .await?;
+            continue;
+        }
 
         // The whole economic argument: most near pairs have no value in common
         // to disagree about, and a model call is minutes on this hardware.
@@ -322,6 +346,131 @@ mod tests {
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].payload.artifact_id, ids[1]);
+    }
+
+    #[tokio::test]
+    async fn a_sweep_finishes_a_supersession_whose_payload_write_was_lost() {
+        // The row and the payload cannot be written atomically. A crash between
+        // them used to be permanent: the next sweep skipped the artifact
+        // because its row said hidden, so the flag never landed and the
+        // artifact stayed listed as hidden on Ops while every search returned
+        // it, forever.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        core.store
+            .set_superseded_by(&ids[0], Some(&ids[1]))
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "the hidden artifact is still in search: {:?}",
+            hits.iter()
+                .map(|h| &h.payload.artifact_id)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(hits[0].payload.artifact_id, ids[1]);
+    }
+
+    #[tokio::test]
+    async fn deleting_the_survivor_puts_the_artifact_it_hid_back() {
+        // `superseded_by` has no foreign key behind it. Deleting the keeper
+        // left the loser pointing at nothing, hidden from search in favour of a
+        // copy that no longer exists — the surviving text becomes invisible,
+        // which is the loss this whole feature exists to prevent.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        run(&core).await.unwrap();
+        let mut hidden = None;
+        for id in &ids {
+            if core
+                .store
+                .get_artifact(id)
+                .await
+                .unwrap()
+                .superseded_by
+                .is_some()
+            {
+                hidden = Some(id.clone());
+            }
+        }
+        let hidden = hidden.expect("the sweep hid nothing");
+        let keeper = ids.iter().find(|id| **id != hidden).unwrap().clone();
+
+        core.store.delete_artifact(&keeper).await.unwrap();
+        core.vectors
+            .delete_artifacts(std::slice::from_ref(&keeper))
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_artifact(&hidden)
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "the artifact still points at a keeper that is gone"
+        );
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1, "the last copy never came back to search");
+        assert_eq!(hits[0].payload.artifact_id, hidden);
+    }
+
+    #[tokio::test]
+    async fn a_pair_whose_member_was_since_hidden_never_reaches_the_model() {
+        // A model call is the scarcest thing in this system. Spending one to
+        // rule on an artifact that is no longer in results buys nothing, and
+        // posts a contradiction about something nobody can see.
+        let mut core = test_core().await;
+        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        // Queue the pair with the judge off, so the only call this test can
+        // count is the one the second sweep would make.
+        let ids = disagreeing(&core).await;
+        run(&core).await.unwrap();
+        core.consolidate.judge = true;
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // A later sweep hides one member, as a re-embed moving the score above
+        // `auto_supersede` would.
+        core.store
+            .set_superseded_by(&ids[0], Some(&ids[1]))
+            .await
+            .unwrap();
+        core.vectors.set_superseded(&ids[0], true).await.unwrap();
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(completer.calls(), 0, "the judge ruled on a hidden artifact");
+        assert_eq!(out.judged, 0);
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the answered pair must leave the pending queue"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -1,0 +1,330 @@
+//! Consolidation: what to do about two artifacts the index says are the same.
+//!
+//! Three thresholds and three outcomes. At or above `auto_supersede` the pair
+//! is near enough to identical that the older one is hidden — it is still
+//! stored, still readable, and one write undoes it. Between `review_min` and
+//! that, the pair goes on a queue for a person, because two genuinely distinct
+//! artifacts about one subsystem sit at 0.88 routinely and acting on that score
+//! destroys knowledge rather than duplication. Below `review_min`, nothing.
+//!
+//! Nothing here rewrites an artifact. A merged artifact would be synthetic text
+//! standing where a stored passage used to, with no segment to verify it
+//! against and no corpus lines to show beside it, which is the one failure mode
+//! this design exists to avoid.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::Chunk;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+pub struct Outcome {
+    pub examined: usize,
+    pub superseded: usize,
+    pub queued: usize,
+}
+
+/// Disjoint-set over artifact ids, so a run of near-identical pairs collapses
+/// into the clusters it actually describes.
+///
+/// Resolving the pairs one at a time does not work, and the way it fails is
+/// quiet: A loses to B, then B loses to C, and A is left pointing at an
+/// artifact that is itself hidden. Nothing in the UI can follow that, and the
+/// reader who opens A is sent to a dead end. Grouping first means every member
+/// of a cluster points at the one survivor.
+#[derive(Default)]
+struct Clusters {
+    parent: HashMap<String, String>,
+}
+
+impl Clusters {
+    fn find(&mut self, x: &str) -> String {
+        let p = self.parent.get(x).cloned().unwrap_or_else(|| x.to_string());
+        if p == x {
+            return p;
+        }
+        let root = self.find(&p);
+        self.parent.insert(x.to_string(), root.clone());
+        root
+    }
+
+    fn union(&mut self, x: &str, y: &str) {
+        let (rx, ry) = (self.find(x), self.find(y));
+        if rx != ry {
+            self.parent.insert(rx, ry);
+        }
+    }
+}
+
+/// Which artifact of a cluster survives.
+///
+/// The newest by capture time, with the id as a tie-break so the answer does
+/// not depend on clock resolution. Newer is the right default because the thing
+/// most often re-captured is a document that has since been updated — and Ops
+/// has an undo for when it is not.
+fn keeper(members: &[Chunk]) -> &Chunk {
+    members
+        .iter()
+        .max_by_key(|c| (c.created_at, c.id.as_str()))
+        .expect("a cluster has at least one member")
+}
+
+pub async fn run(core: &Core) -> Result<Outcome> {
+    let cfg = &core.consolidate;
+    if !cfg.enabled {
+        return Ok(Outcome::default());
+    }
+
+    let pairs = core
+        .vectors
+        .near_pairs(cfg.sample, cfg.per_point, cfg.review_min)
+        .await?;
+    let mut out = Outcome {
+        examined: pairs.len(),
+        ..Default::default()
+    };
+
+    // Group everything near-identical first, and only then decide who wins.
+    let mut clusters = Clusters::default();
+    let mut in_a_cluster: HashSet<String> = HashSet::new();
+    for p in pairs.iter().filter(|p| p.score >= cfg.auto_supersede) {
+        clusters.union(&p.a, &p.b);
+        in_a_cluster.insert(p.a.clone());
+        in_a_cluster.insert(p.b.clone());
+    }
+
+    let mut members: HashMap<String, Vec<Chunk>> = HashMap::new();
+    for id in &in_a_cluster {
+        // An artifact the vector store still lists but SQLite has dropped is
+        // ordinary: a delete can lag a sweep. It is not an error.
+        let Ok(c) = core.store.get_artifact(id).await else {
+            tracing::debug!(artifact_id = %id, "pair names an artifact that is gone");
+            continue;
+        };
+        if c.superseded_by.is_some() {
+            continue;
+        }
+        let root = clusters.find(id);
+        members.entry(root).or_default().push(c);
+    }
+
+    let mut hidden: HashSet<String> = HashSet::new();
+    for group in members.values() {
+        if group.len() < 2 {
+            continue;
+        }
+        let keep = keeper(group);
+        for c in group.iter().filter(|c| c.id != keep.id) {
+            // SQLite first: it is the source of truth, and a payload flag with
+            // no row behind it is a hidden artifact nothing can explain.
+            core.store.set_superseded_by(&c.id, Some(&keep.id)).await?;
+            core.vectors.set_superseded(&c.id, true).await?;
+            hidden.insert(c.id.clone());
+            out.superseded += 1;
+            tracing::info!(
+                superseded = %c.id,
+                by = %keep.id,
+                "hid a near-identical artifact"
+            );
+        }
+    }
+
+    // The review band. A pair whose members were just hidden has already been
+    // answered, and queueing it would ask an operator to rule on an artifact
+    // that is no longer in results.
+    for p in pairs.iter().filter(|p| p.score < cfg.auto_supersede) {
+        if hidden.contains(&p.a) || hidden.contains(&p.b) {
+            continue;
+        }
+        let (Ok(a), Ok(b)) = (
+            core.store.get_artifact(&p.a).await,
+            core.store.get_artifact(&p.b).await,
+        ) else {
+            continue;
+        };
+        if a.superseded_by.is_some() || b.superseded_by.is_some() {
+            continue;
+        }
+        if core.store.record_pair(&p.a, &p.b, p.score).await? {
+            out.queued += 1;
+            tracing::info!(a = %p.a, b = %p.b, score = p.score, "queued a pair for review");
+        }
+    }
+
+    if out.superseded > 0 || out.queued > 0 {
+        tracing::info!(
+            examined = out.examined,
+            superseded = out.superseded,
+            queued = out.queued,
+            "consolidation sweep finished"
+        );
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::artifacts::NewArtifact;
+    use crate::store::pairs::PairState;
+    use crate::vector::{VectorPayload, VectorPoint};
+
+    /// Seed artifacts with hand-placed vectors, so the test controls the exact
+    /// similarity rather than depending on what the fake embedder produces.
+    async fn seed(core: &crate::core::Core, vectors: &[(&str, [f32; 2])]) -> Vec<String> {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, (text, _))| NewArtifact {
+                ordinal: i as i64,
+                text: (*text).to_string(),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+            })
+            .collect();
+        let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();
+        let points: Vec<VectorPoint> = made
+            .iter()
+            .zip(vectors)
+            .map(|(c, (text, v))| VectorPoint {
+                vector: v.to_vec(),
+                sparse: Default::default(),
+                payload: VectorPayload {
+                    artifact_id: c.id.clone(),
+                    corpus_id: c.corpus_id.clone(),
+                    text: (*text).to_string(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    created_at: c.created_at,
+                    last_seen_at: None,
+                    superseded: None,
+                },
+            })
+            .collect();
+        core.vectors.upsert(points).await.unwrap();
+        made.into_iter().map(|c| c.id).collect()
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_pair_supersedes_the_older_artifact() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.superseded, 1, "{out:?}");
+
+        // The older one loses: ordinal 0 was inserted first.
+        let older = core.store.get_artifact(&ids[0]).await.unwrap();
+        let newer = core.store.get_artifact(&ids[1]).await.unwrap();
+        assert_eq!(older.superseded_by.as_deref(), Some(ids[1].as_str()));
+        assert!(newer.superseded_by.is_none());
+
+        // And it is out of search, which is the whole point.
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].payload.artifact_id, ids[1]);
+    }
+
+    #[tokio::test]
+    async fn a_pair_in_the_review_band_is_queued_not_superseded() {
+        // 0.88 is where two genuinely distinct artifacts about one subsystem
+        // routinely sit. Acting on that score destroys knowledge.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.93, 0.37])]).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.superseded, 0, "{out:?}");
+        assert_eq!(out.queued, 1);
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none()
+            );
+        }
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_pair_is_left_entirely_alone() {
+        let core = test_core().await;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.superseded, out.queued), (0, 0), "{out:?}");
+    }
+
+    #[tokio::test]
+    async fn a_second_sweep_changes_nothing() {
+        // The sweep runs on a timer. If it were not idempotent it would churn
+        // the queue and the payload flags on every tick.
+        let core = test_core().await;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        run(&core).await.unwrap();
+        let second = run(&core).await.unwrap();
+        assert_eq!((second.superseded, second.queued), (0, 0), "{second:?}");
+    }
+
+    #[tokio::test]
+    async fn an_artifact_is_never_superseded_twice() {
+        // Three near-identical artifacts. Whatever survives, exactly one must,
+        // and no artifact may point at one that is itself superseded — that is
+        // a chain the UI cannot resolve and the reader cannot follow.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("first", [1.0, 0.0]),
+                ("second", [0.9999, 0.005]),
+                ("third", [0.9998, 0.01]),
+            ],
+        )
+        .await;
+
+        run(&core).await.unwrap();
+
+        let mut live = 0;
+        for id in &ids {
+            let c = core.store.get_artifact(id).await.unwrap();
+            match &c.superseded_by {
+                None => live += 1,
+                Some(winner) => {
+                    let w = core.store.get_artifact(winner).await.unwrap();
+                    assert!(
+                        w.superseded_by.is_none(),
+                        "{id} was superseded by {winner}, which is itself superseded"
+                    );
+                }
+            }
+        }
+        assert_eq!(live, 1, "exactly one artifact should have survived");
+    }
+
+    #[tokio::test]
+    async fn the_sweep_is_off_when_configuration_says_so() {
+        let mut core = test_core().await;
+        core.consolidate.enabled = false;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.examined, out.superseded, out.queued), (0, 0, 0));
+    }
+}

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -67,6 +67,16 @@ impl Clusters {
 /// not depend on clock resolution. Newer is the right default because the thing
 /// most often re-captured is a document that has since been updated — and Ops
 /// has an undo for when it is not.
+/// Is the whole of one artifact inside the other, whitespace aside?
+///
+/// Not a similarity — containment. A score says two texts are alike; this says
+/// one of them adds nothing, which is the only ground on which the sweep hides
+/// something below `auto_supersede`.
+fn contains_normalized(long: &str, short: &str) -> bool {
+    let n = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+    !short.trim().is_empty() && n(long).contains(&n(short))
+}
+
 fn keeper(members: &[Chunk]) -> &Chunk {
     members
         .iter()
@@ -165,6 +175,36 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         };
         if a.superseded_by.is_some() || b.superseded_by.is_some() {
             continue;
+        }
+
+        // One synthesis call emitting the same passage twice: the shorter text
+        // is wholly inside the longer, and both came out of the same document.
+        // That is a defect in one artifact rather than two sources saying
+        // different things, and nothing is lost by hiding it — the survivor
+        // says everything it said, Ops lists it, and one press undoes it.
+        //
+        // Same corpus is the whole of the condition. Two documents that share a
+        // sentence are two sources, and hiding one of those on a 0.9 similarity
+        // is what `auto_supersede` deliberately refuses to do.
+        if a.corpus_id == b.corpus_id {
+            let (long, short) = if a.text.len() >= b.text.len() {
+                (&a, &b)
+            } else {
+                (&b, &a)
+            };
+            if contains_normalized(&long.text, &short.text) {
+                core.store
+                    .set_superseded_by(&short.id, Some(&long.id))
+                    .await?;
+                core.vectors.set_superseded(&short.id, true).await?;
+                out.superseded += 1;
+                tracing::info!(
+                    superseded = %short.id,
+                    by = %long.id,
+                    "hid a passage one synthesis call emitted twice"
+                );
+                continue;
+            }
         }
 
         // Two artifacts that state no value differently have nothing for a
@@ -365,6 +405,52 @@ mod tests {
             .collect();
         core.vectors.upsert(points).await.unwrap();
         made.into_iter().map(|c| c.id).collect()
+    }
+
+    /// One artifact under a corpus of its own, for the cases where "same
+    /// document" is the thing under test.
+    async fn seed_into_new_corpus(
+        core: &crate::core::Core,
+        text: &str,
+        vector: [f32; 2],
+    ) -> String {
+        let src = core.store.insert_corpus(text, "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        core.vectors
+            .upsert(vec![VectorPoint {
+                vector: vector.to_vec(),
+                sparse: Default::default(),
+                payload: VectorPayload {
+                    artifact_id: made[0].id.clone(),
+                    corpus_id: made[0].corpus_id.clone(),
+                    text: text.to_string(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    created_at: made[0].created_at,
+                    last_seen_at: None,
+                    superseded: None,
+                },
+            }])
+            .await
+            .unwrap();
+        made[0].id.clone()
     }
 
     #[tokio::test]
@@ -731,6 +817,71 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn one_synthesis_call_emitting_a_passage_twice_resolves_itself() {
+        // Same corpus, same call, one text wholly inside the other. That is a
+        // defect in one artifact rather than two sources disagreeing, and it
+        // sat on the review queue because it scores below auto_supersede.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                (
+                    "Bind mounts attach a directory elsewhere. Use mount --bind for it.",
+                    [1.0, 0.0],
+                ),
+                ("Bind mounts attach a directory elsewhere.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.superseded, 1, "{out:?}");
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[1])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(ids[0].as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn containment_across_two_corpora_is_left_alone() {
+        // Two documents that happen to share a sentence are two sources, and
+        // this is exactly the case auto_supersede refuses to act on below 0.95.
+        let core = test_core().await;
+        let a = seed(
+            &core,
+            &[(
+                "Bind mounts attach a directory elsewhere. Use mount --bind for it.",
+                [1.0, 0.0],
+            )],
+        )
+        .await;
+        let b = seed_into_new_corpus(
+            &core,
+            "Bind mounts attach a directory elsewhere.",
+            [0.93, 0.37],
+        )
+        .await;
+
+        run(&core).await.unwrap();
+        for id in [&a[0], &b] {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "two documents sharing a sentence are two sources"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -515,10 +515,9 @@ mod tests {
         // A dead endpoint must not silently clear a queue of real conflicts.
         let mut core = test_core().await;
         core.consolidate.judge = true;
-        core.completer =
-            std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-                "not json".into()
-            ]));
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            "not json".into(),
+        ]));
         disagreeing(&core).await;
 
         run(&core).await.unwrap();

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -185,6 +185,7 @@ mod tests {
                 category: None,
                 tags: vec![],
                 segment_idx: None,
+                caveats: vec![],
             })
             .collect();
         let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -191,10 +191,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 /// failed call leaves its pair pending on purpose: a dead endpoint must never
 /// look like a clean bill of health.
 async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
-    let pending = core
-        .store
-        .pairs_by_state(crate::store::pairs::PairState::Pending, 200)
-        .await?;
+    let pending = core.store.pairs_to_judge(200).await?;
 
     let (mut judged, mut contradictions) = (0usize, 0usize);
     for p in pending {
@@ -234,6 +231,10 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
         }
 
         judged += 1;
+        // Counted before the call and regardless of how it goes, so a pair the
+        // model keeps failing on drops behind the rest of the queue instead of
+        // absorbing this budget again on the next sweep.
+        core.store.record_judge_attempt(p.id).await?;
         let reply = match core
             .completer
             .complete(
@@ -243,9 +244,17 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
             .await
         {
             Ok(r) => r,
+            // A transport failure is a statement about the endpoint, not about
+            // this pair: the next nineteen calls would fail the same way, and
+            // each one costs a full timeout. Stop, keep the pairs pending, and
+            // let the next sweep find out whether anything changed.
             Err(e) => {
-                tracing::warn!(pair = p.id, error = %e, "judge call failed; pair stays pending");
-                continue;
+                tracing::warn!(
+                    pair = p.id,
+                    error = %e,
+                    "judge call failed; pairs stay pending and this sweep stops judging"
+                );
+                break;
             }
         };
 
@@ -677,6 +686,87 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dead_endpoint_stops_the_judge_instead_of_spending_the_budget_on_it() {
+        // Every call would fail the same way, and each one costs a full
+        // timeout. The pairs stay pending either way; what this saves is
+        // twenty consecutive waits on an endpoint that is not there.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        // Two pairs, each inside the review band and nowhere near the other, so
+        // there really is a second call for the judge to skip.
+        seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.94, 0.342]),
+                ("it listens on 8080", [-1.0, 0.0]),
+                ("it listens on 9090", [-0.94, -0.342]),
+            ],
+        )
+        .await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 2, "not enough pairs to prove anything: {out:?}");
+        assert_eq!(
+            completer.calls(),
+            1,
+            "the judge kept calling a dead endpoint"
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            out.queued,
+            "a failed call must never look like a clean bill of health"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_the_model_keeps_failing_on_goes_to_the_back_of_the_queue() {
+        // An unreadable reply leaves the pair pending on purpose. Ordered by
+        // score alone, the same top-scoring pair would then absorb every
+        // sweep's budget forever and the rest would never be judged at all.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.consolidate.max_judgements = 1;
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            "not json".into(),
+            r#"{"contradicts":true,"detail":"30 versus 90"}"#.into(),
+        ]));
+        seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.999, 0.01]),
+                ("timeout is 90 seconds", [0.9, 0.44]),
+            ],
+        )
+        .await;
+
+        run(&core).await.unwrap();
+        run(&core).await.unwrap();
+
+        let pending = core.store.pairs_to_judge(10).await.unwrap();
+        assert!(
+            pending.iter().all(|p| p.judge_attempts <= 1),
+            "the second sweep judged the same pair again: {pending:?}"
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Contradiction, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the second sweep never reached an unjudged pair"
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -22,6 +22,9 @@ pub struct Outcome {
     pub examined: usize,
     pub superseded: usize,
     pub queued: usize,
+    /// Pairs settled without asking anyone, because the two artifacts state no
+    /// value differently and so have nothing to disagree about.
+    pub closed: usize,
     pub judged: usize,
     pub contradictions: usize,
 }
@@ -163,6 +166,33 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         if a.superseded_by.is_some() || b.superseded_by.is_some() {
             continue;
         }
+
+        // Two artifacts that state no value differently have nothing for a
+        // person to rule on, and asking anyway is what turned this queue into a
+        // list of chores. The pair is filed as settled — the sweep re-finds it
+        // every run, so it has to be remembered — and both artifacts stay
+        // exactly where they are. Closing a question is not hiding an answer.
+        //
+        // The prefilter used to run only when the judge was enabled, which it
+        // is not by default, so the cheap answer was reached only by bases
+        // already paying for the expensive one.
+        if !crate::infer::facts::may_disagree(&a.text, &b.text) {
+            if core
+                .store
+                .record_settled_pair(
+                    &p.a,
+                    &p.b,
+                    p.score,
+                    crate::store::pairs::PairState::NoConflict,
+                )
+                .await?
+            {
+                out.closed += 1;
+                tracing::debug!(a = %p.a, b = %p.b, score = p.score, "pair states nothing differently");
+            }
+            continue;
+        }
+
         if core.store.record_pair(&p.a, &p.b, p.score).await? {
             out.queued += 1;
             tracing::info!(a = %p.a, b = %p.b, score = p.score, "queued a pair for review");
@@ -490,8 +520,18 @@ mod tests {
     async fn a_pair_in_the_review_band_is_queued_not_superseded() {
         // 0.88 is where two genuinely distinct artifacts about one subsystem
         // routinely sit. Acting on that score destroys knowledge.
+        //
+        // The two state a value differently, which is what keeps them on the
+        // queue at all: a pair with nothing to disagree about closes itself.
         let core = test_core().await;
-        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.93, 0.37])]).await;
+        let ids = seed(
+            &core,
+            &[
+                ("the timeout is 30 seconds", [1.0, 0.0]),
+                ("the timeout is 90 seconds", [0.93, 0.37]),
+            ],
+        )
+        .await;
 
         let out = run(&core).await.unwrap();
         assert_eq!(out.superseded, 0, "{out:?}");
@@ -691,6 +731,60 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn a_pair_with_nothing_to_disagree_about_never_reaches_the_queue() {
+        // The prefilter already knows these two state no differing value, but
+        // it only ran when the judge was enabled — and the judge is off by
+        // default. So every near pair became a question for a person, which is
+        // a question with no answer to give.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 0, "{out:?}");
+        assert_eq!(out.closed, 1, "{out:?}");
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        // Closing a question is not hiding an answer.
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_pair_stating_different_values_still_waits_for_a_person() {
+        let core = test_core().await;
+        seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 90 seconds", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 1, "{out:?}");
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -77,6 +77,10 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         return Ok(Outcome::default());
     }
 
+    // Finish what was started before looking for duplicates: a sweep over a
+    // half-ingested corpus is judging a base that is not there yet.
+    crate::jobs::reconcile::run(core).await?;
+
     // Deletions clear these as they happen; the sweep repeats it because a
     // hidden artifact pointing at nothing is invisible to search and to every
     // page that could put it back, and nothing else would ever notice.

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -22,6 +22,8 @@ pub struct Outcome {
     pub examined: usize,
     pub superseded: usize,
     pub queued: usize,
+    pub judged: usize,
+    pub contradictions: usize,
 }
 
 /// Disjoint-set over artifact ids, so a run of near-identical pairs collapses
@@ -151,15 +153,101 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         }
     }
 
-    if out.superseded > 0 || out.queued > 0 {
+    if cfg.judge {
+        let (judged, contradictions) = judge_pending(core).await?;
+        out.judged = judged;
+        out.contradictions = contradictions;
+    }
+
+    if out.superseded > 0 || out.queued > 0 || out.judged > 0 {
         tracing::info!(
             examined = out.examined,
             superseded = out.superseded,
             queued = out.queued,
+            judged = out.judged,
+            contradictions = out.contradictions,
             "consolidation sweep finished"
         );
     }
     Ok(out)
+}
+
+/// Ask the model about pending pairs, but only the ones that could possibly
+/// disagree, and only up to the sweep's budget.
+///
+/// Returns how many calls were made and how many found a contradiction. A
+/// failed call leaves its pair pending on purpose: a dead endpoint must never
+/// look like a clean bill of health.
+async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
+    let pending = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::Pending, 200)
+        .await?;
+
+    let (mut judged, mut contradictions) = (0usize, 0usize);
+    for p in pending {
+        if judged >= core.consolidate.max_judgements {
+            tracing::info!(
+                budget = core.consolidate.max_judgements,
+                "judge budget spent; the rest wait for the next sweep"
+            );
+            break;
+        }
+        let (Ok(a), Ok(b)) = (
+            core.store.get_artifact(&p.a_id).await,
+            core.store.get_artifact(&p.b_id).await,
+        ) else {
+            continue;
+        };
+
+        // The whole economic argument: most near pairs have no value in common
+        // to disagree about, and a model call is minutes on this hardware.
+        if !crate::infer::facts::may_disagree(&a.text, &b.text) {
+            core.store
+                .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
+                .await?;
+            continue;
+        }
+
+        judged += 1;
+        let reply = match core
+            .completer
+            .complete(
+                crate::infer::prompt::JUDGE_SYSTEM,
+                &crate::infer::prompt::judge_prompt(&a.text, &b.text),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(pair = p.id, error = %e, "judge call failed; pair stays pending");
+                continue;
+            }
+        };
+
+        match crate::infer::prompt::parse_judgement(&reply) {
+            Ok((true, detail)) => {
+                contradictions += 1;
+                core.store
+                    .set_pair_state(
+                        p.id,
+                        crate::store::pairs::PairState::Contradiction,
+                        detail.as_deref(),
+                    )
+                    .await?;
+                tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
+            }
+            Ok((false, _)) => {
+                core.store
+                    .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
+                    .await?;
+            }
+            Err(e) => {
+                tracing::warn!(pair = p.id, error = %e, "judge reply unreadable; pair stays pending");
+            }
+        }
+    }
+    Ok((judged, contradictions))
 }
 
 #[cfg(test)]
@@ -318,6 +406,130 @@ mod tests {
             }
         }
         assert_eq!(live, 1, "exactly one artifact should have survived");
+    }
+
+    /// Two artifacts about the same thing that give a different version.
+    async fn disagreeing(core: &crate::core::Core) -> Vec<String> {
+        seed(
+            core,
+            &[
+                ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
+                ("engram needs Rust 1.30.0 to build.", [0.93, 0.37]),
+            ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn the_judge_is_off_by_default() {
+        let core = test_core().await;
+        disagreeing(&core).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 1);
+        assert_eq!(out.judged, 0, "the judge ran without being asked for");
+    }
+
+    #[tokio::test]
+    async fn an_enabled_judge_marks_a_real_contradiction() {
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"contradicts":true,"detail":"1.21.4 versus 1.30.0"}"#.into(),
+        ]));
+        disagreeing(&core).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.judged, out.contradictions), (1, 1), "{out:?}");
+        let found = core
+            .store
+            .pairs_by_state(PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].detail.as_deref(), Some("1.21.4 versus 1.30.0"));
+    }
+
+    #[tokio::test]
+    async fn a_pair_with_no_facts_to_disagree_about_never_reaches_the_model() {
+        // The prefilter is the whole economic argument for this feature: a
+        // model call is minutes, and most near pairs have nothing to judge.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(
+            completer.calls(),
+            0,
+            "the prefilter let a factless pair through"
+        );
+        assert_eq!(out.judged, 0);
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::NoConflict, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "a cleared pair must leave the pending queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_judge_stops_at_its_budget() {
+        // One sweep must not be able to occupy the GPU for an hour.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.consolidate.max_judgements = 1;
+        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"contradicts":false}"#.into(),
+            r#"{"contradicts":false}"#.into(),
+            r#"{"contradicts":false}"#.into(),
+        ]));
+        core.completer = completer.clone();
+        seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+
+        run(&core).await.unwrap();
+        assert_eq!(completer.calls(), 1, "the budget was ignored");
+    }
+
+    #[tokio::test]
+    async fn a_failed_judgement_leaves_the_pair_pending() {
+        // A dead endpoint must not silently clear a queue of real conflicts.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.completer =
+            std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+                "not json".into()
+            ]));
+        disagreeing(&core).await;
+
+        run(&core).await.unwrap();
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -375,6 +375,9 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // the existing stamp forward rather than letting a re-embed make a
         // chunk look forgotten.
         last_seen_at: None,
+        // Unset for the same reason, and it matters more: writing `false` here
+        // would revive an artifact the sweep hid, on every re-embed.
+        superseded: None,
     }
 }
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -358,6 +358,10 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
     core.vectors
         .delete_artifacts(std::slice::from_ref(&chunk.id))
         .await?;
+    // The parent is gone, so anything it was hiding is now hidden in favour of
+    // an artifact that does not exist. The siblings are not a substitute: they
+    // are new ids nothing points at.
+    core.heal_dangling_supersessions().await?;
 
     for c in &inserted {
         core.store.enqueue(Stage::Embed, "artifact", &c.id).await?;

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -343,6 +343,9 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
             corpus_span: chunk.corpus_span.clone(),
             title: chunk.title.clone(),
             category: chunk.category.clone(),
+            // A caveat applies to the whole passage the parent held, so every
+            // fragment of it inherits the warning rather than losing it.
+            caveats: chunk.caveats.clone(),
             tags: chunk.tags.clone(),
             // Siblings belong to the window their parent came from, or a
             // re-segmentation of that window would leave them behind.
@@ -435,6 +438,7 @@ mod tests {
                     category: None,
                     tags: vec![],
                     segment_idx: Some(0),
+                    caveats: vec![],
                 }],
             )
             .await
@@ -487,6 +491,7 @@ mod tests {
                     category: None,
                     tags: vec![],
                     segment_idx: Some(0),
+                    caveats: vec![],
                 }],
             )
             .await
@@ -526,6 +531,7 @@ mod tests {
                     category: None,
                     tags: vec![],
                     segment_idx: Some(0),
+                    caveats: vec![],
                 }],
             )
             .await
@@ -593,6 +599,7 @@ mod tests {
                 category: Some("note".into()),
                 tags: vec!["x".into()],
                 segment_idx: None,
+                caveats: vec![],
             })
             .collect();
         let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,3 +1,4 @@
+pub mod consolidate;
 pub mod embed;
 pub mod synthesize;
 
@@ -32,6 +33,8 @@ pub async fn run_one(core: &Core) -> Result<bool> {
         // for oversize splits, and for isolating a chunk the batch chokes on.
         (Stage::Embed, "corpus") => embed::run_corpus(core, &job.target_id).await,
         (Stage::Embed, _) => embed::run(core, &job.target_id).await,
+        // The sweep looks at the whole collection, so it ignores the target.
+        (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
     };
 
     match result {

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,5 +1,6 @@
 pub mod consolidate;
 pub mod embed;
+pub mod reconcile;
 pub mod synthesize;
 
 use crate::core::Core;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -56,21 +56,29 @@ pub async fn run_one(core: &Core) -> Result<bool> {
                 // actually tried are recorded as failed; the ones that never
                 // ran go back in the queue.
                 (Stage::Synthesize, _) if exhausted => {
-                    tracing::warn!(error = %e, "segmentation exhausted retries; failing the windows it tried");
+                    tracing::warn!(error = %e, "segmentation is not getting through; backing off");
                     match synthesize::fail_pending_segments(core, &job.target_id, &e.to_string())
                         .await
                     {
-                        Ok(requeue) => {
+                        Ok(_) => {
                             core.store.complete_job(job.id).await?;
-                            // After closing this job, never before: the queue is
-                            // keyed by (stage, target), so an earlier enqueue
-                            // would be the very row `complete_job` then marks
-                            // done, and the untried windows would be abandoned.
-                            if requeue {
-                                core.store
-                                    .enqueue(Stage::Synthesize, "corpus", &job.target_id)
-                                    .await?;
-                            }
+                            // Always, not only when a window went untried. A
+                            // segment the endpoint refused is not a verdict on
+                            // the text — the endpoint was loading a model, or
+                            // the machine was asleep — and the state it records
+                            // is what the next attempt starts from rather than
+                            // where it stops. After closing this job, never
+                            // before: the queue is keyed by (stage, target), so
+                            // an earlier enqueue would be the very row
+                            // `complete_job` then marks done.
+                            core.store
+                                .enqueue_after(
+                                    Stage::Synthesize,
+                                    "corpus",
+                                    &job.target_id,
+                                    job.attempts,
+                                )
+                                .await?;
                         }
                         Err(fe) => {
                             core.store

--- a/src/jobs/reconcile.rs
+++ b/src/jobs/reconcile.rs
@@ -1,0 +1,179 @@
+//! The heartbeat: pick up anything that was left unfinished.
+//!
+//! Every stage already retries its own job, so this is not the retry mechanism.
+//! It is for the case no retry covers — a job completed while its work was not,
+//! a process killed between two writes, a corpus queued by a build that had a
+//! bug in it. Without it, "the system repairs itself" holds only for the
+//! failures the system happened to be watching at the time.
+//!
+//! Cheap and idempotent: `enqueue` is keyed by (stage, target), so re-arming
+//! something already queued changes nothing, and a base with nothing wrong
+//! costs one query per hundred corpora.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::jobs::Stage;
+use crate::store::segments::SegmentState;
+
+pub async fn run(core: &Core) -> Result<usize> {
+    let mut armed = 0;
+    let mut offset = 0;
+    loop {
+        let page = core.store.list_corpora(100, offset).await?;
+        if page.is_empty() {
+            break;
+        }
+        for c in &page {
+            // A corpus parked as a near-duplicate is waiting on a person by
+            // design, and segmenting it is the decision they have not made.
+            if c.near_dupe_of.is_some() {
+                continue;
+            }
+            let segments = core.store.segments_for_corpus(&c.id).await?;
+            if segments.iter().any(|w| w.state != SegmentState::Done) {
+                core.store
+                    .enqueue(Stage::Synthesize, "corpus", &c.id)
+                    .await?;
+                armed += 1;
+                continue;
+            }
+            if !core
+                .store
+                .pending_artifacts_for_corpus(&c.id)
+                .await?
+                .is_empty()
+            {
+                core.store.enqueue(Stage::Embed, "corpus", &c.id).await?;
+                armed += 1;
+            }
+        }
+        offset += page.len() as i64;
+    }
+    if armed > 0 {
+        tracing::info!(armed, "reconciliation queued unfinished work");
+    }
+    Ok(armed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::artifacts::NewArtifact;
+
+    #[tokio::test]
+    async fn a_corpus_with_an_unfinished_segment_and_no_job_gets_one() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[(1, 10), (11, 20)])
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+
+        // Segment 1 never ran and nothing is queued: the crack this closes.
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let job = core.store.claim_job().await.unwrap().expect("a job");
+        assert_eq!(job.stage, Stage::Synthesize);
+        assert_eq!(job.target_id, src.id);
+    }
+
+    #[tokio::test]
+    async fn a_corpus_whose_artifacts_never_embedded_gets_an_embed_job() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[(1, 10)])
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "a body".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let job = core.store.claim_job().await.unwrap().expect("a job");
+        assert_eq!(job.stage, Stage::Embed);
+    }
+
+    #[tokio::test]
+    async fn a_finished_corpus_is_left_alone() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[(1, 10)])
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        assert_eq!(run(&core).await.unwrap(), 0);
+        assert!(core.store.claim_job().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_capture_parked_for_a_decision_is_not_dragged_into_the_pipeline() {
+        // Parking withholds the model call until someone chooses. Re-arming it
+        // here would spend exactly what parking exists to save.
+        let core = test_core().await;
+        let a = core
+            .store
+            .insert_corpus("the same text", "web", None)
+            .await
+            .unwrap();
+        let b = core
+            .store
+            .insert_corpus("the same text!", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .set_near_dupe(&b.id, Some(&a.id), Some(0.99))
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+        let mut targets = Vec::new();
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            targets.push(j.target_id);
+        }
+        assert!(!targets.contains(&b.id), "the parked capture was queued");
+    }
+
+    #[tokio::test]
+    async fn the_sweep_does_not_pile_up_jobs_across_runs() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[(1, 10)])
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        run(&core).await.unwrap();
+
+        core.store.claim_job().await.unwrap().expect("one job");
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "the sweep queued the same work twice"
+        );
+    }
+}

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -183,10 +183,18 @@ enum SpanOrigin {
 }
 
 /// Did any proposed chunk lose a literal its window contains?
+///
+/// The chunk body only, deliberately — this gates a second synthesis call over
+/// the whole window, the most expensive thing here. A caveat is prose the model
+/// is asked to write freely ("only on `/dev/sd*` devices", "requires `sudo`"),
+/// so a path it names in passing need not appear verbatim in the source, and
+/// re-synthesising a window over one is paying the largest cost in the system
+/// for the smallest reason. `flag_unverified` still checks caveats: a command
+/// invented in one is flagged for the reader like any other.
 fn paraphrased(chunks: &[crate::infer::ProposedArtifact], window: &str) -> bool {
     chunks
         .iter()
-        .any(|c| !crate::infer::verify::missing_literals(&c.text, &c.caveats, window).is_empty())
+        .any(|c| !crate::infer::verify::missing_literals(&c.text, &[], window).is_empty())
 }
 
 /// Mark what verification could not vouch for. The chunk is kept — a warning

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -60,58 +60,28 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
             chunks = core.synthesizer.segment(&text).await?;
         }
 
-        // Line numbers come back relative to the window, so shift them into
-        // the coordinates of the original document — and no further. A span
-        // outside its own window is nonsense the detail pane would render as
-        // the wrong text, so clamp it here and flag it below.
-        // Only a span the model asserted can be wrong about where the chunk
-        // came from. One this job derived matched by construction, and one that
-        // fell back to the window claims nothing in particular — checking
-        // either against the chunk's own text just invents warnings.
-        let mut spans = Vec::with_capacity(chunks.len());
+        // The span is ours to compute.
+        //
+        // Asking the model for `corpus_lines`, checking the answer, and having
+        // a third outcome for a claim that fails the check produced a flag on
+        // the artifact and a button offering to re-synthesise an entire segment
+        // over a line number. Since `locate_span` finds an artifact's own text
+        // even where the source is hard-wrapped and synthesis reflowed it, the
+        // claim is worth what it is: a hint for the case where nothing matches
+        // at all. Nothing here can disagree with the artifact, so nothing here
+        // has anything to report.
         for c in &mut chunks {
-            let claimed = c
+            let hinted = c
                 .corpus_lines
-                .map(|(a, b)| (a + w.start_line - 1, b + w.start_line - 1))
-                .filter(|(a, b)| {
-                    // A span the model asserted is only worth keeping if the
-                    // lines it names look like the lines the chunk describes.
-                    // On a reference document full of short entries the model
-                    // miscounts freely, and a confidently wrong span is worse
-                    // than none: the pane renders the wrong text.
-                    let lines = segment_text(&src.raw_text, *a, *b);
-                    crate::infer::verify::span_is_plausible(&c.text, &lines)
-                });
-
-            let (shifted, origin) = match claimed {
-                Some(span) => (span, SpanOrigin::Model),
-                // Either the model omitted `corpus_lines` — which it does more
-                // often than not — or what it claimed did not survive the check
-                // above. Both are better answered by finding the chunk's own
-                // lines in the window than by pointing at the whole of it.
-                None => match crate::infer::verify::locate_span(&c.text, &text, w.start_line) {
-                    Some(found) => (found, SpanOrigin::Derived),
-                    None => match c.corpus_lines {
-                        // Nothing to derive and a span that failed the check:
-                        // keep it, and say it is not to be trusted.
-                        Some((a, b)) => (
-                            (a + w.start_line - 1, b + w.start_line - 1),
-                            SpanOrigin::Implausible,
-                        ),
-                        None => ((w.start_line, w.end_line), SpanOrigin::Segment),
-                    },
-                },
-            };
+                .map(|(a, b)| (a + w.start_line - 1, b + w.start_line - 1));
+            let span = crate::infer::verify::locate_span(&c.text, &text, w.start_line)
+                .or(hinted)
+                .unwrap_or((w.start_line, w.end_line));
+            // A span outside its own window would render as the wrong text.
             let clamped = (
-                shifted.0.clamp(w.start_line, w.end_line),
-                shifted.1.clamp(w.start_line, w.end_line),
+                span.0.clamp(w.start_line, w.end_line),
+                span.1.clamp(w.start_line, w.end_line),
             );
-            // Clamping erases the evidence, so record the move before it happens.
-            spans.push(if origin == SpanOrigin::Model && clamped != shifted {
-                SpanOrigin::Clamped
-            } else {
-                origin
-            });
             c.corpus_lines = Some(if clamped.0 <= clamped.1 {
                 clamped
             } else {
@@ -121,7 +91,7 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
 
         let written =
             write_segment_artifacts(core, corpus_id, w.idx, proposed_to_new(w.idx, chunks)).await?;
-        flag_unverified(core, &written, &spans, &text).await?;
+        flag_unverified(core, &written, &text).await?;
         core.store
             .set_segment_state(corpus_id, w.idx, SegmentState::Done, None)
             .await?;
@@ -165,23 +135,6 @@ async fn write_segment_artifacts(
     core.store.insert_artifacts(corpus_id, &new).await
 }
 
-/// Where a chunk's stored span came from, which decides whether it is worth
-/// doubting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SpanOrigin {
-    /// The model said so, and nothing had to be corrected.
-    Model,
-    /// The model said so and named lines outside its own window.
-    Clamped,
-    /// The model said so, the lines do not match the chunk, and nothing better
-    /// could be derived.
-    Implausible,
-    /// Recovered here by matching the chunk's lines against the window.
-    Derived,
-    /// Nothing to go on; the span is the window itself.
-    Segment,
-}
-
 /// Did any proposed chunk lose a literal its window contains?
 ///
 /// The chunk body only, deliberately — this gates a second synthesis call over
@@ -199,16 +152,18 @@ fn paraphrased(chunks: &[crate::infer::ProposedArtifact], window: &str) -> bool 
 
 /// Mark what verification could not vouch for. The chunk is kept — a warning
 /// the reader can see beats a chapter silently missing from the base.
+///
+/// One check, not two. A span is derived rather than adjudicated, so there is
+/// nothing left to disbelieve about it; what remains is the literal check,
+/// which is about the text itself and speaks to whoever reads the artifact.
 async fn flag_unverified(
     core: &Core,
     written: &[crate::store::artifacts::Chunk],
-    // Per chunk, where its stored span came from.
-    spans: &[SpanOrigin],
     segment_body: &str,
 ) -> Result<()> {
     use crate::infer::verify;
 
-    for (i, c) in written.iter().enumerate() {
+    for c in written {
         let mut flags = Vec::new();
         let mut detail: Option<String> = None;
 
@@ -217,23 +172,6 @@ async fn flag_unverified(
             flags.push(verify::FLAG_LITERALS.to_string());
             detail = Some(format!("missing literal: {first}"));
             tracing::warn!(artifact_id = %c.id, literal = %first, "literal not found in source window");
-        }
-
-        // A derived span matched by construction, a window span claims nothing
-        // in particular, and a model span that survived the check is fine. What
-        // is left is a span that had to be corrected or could not be.
-        let origin = spans.get(i).copied().unwrap_or(SpanOrigin::Segment);
-        if let Some(span) = &c.corpus_span
-            && matches!(origin, SpanOrigin::Clamped | SpanOrigin::Implausible)
-        {
-            flags.push(verify::FLAG_SPAN.to_string());
-            detail.get_or_insert_with(|| {
-                format!(
-                    "span {}–{} does not match the chunk",
-                    span.start_line, span.end_line
-                )
-            });
-            tracing::warn!(artifact_id = %c.id, "chunk span does not match the lines it claims");
         }
 
         if !flags.is_empty() {
@@ -688,7 +626,11 @@ Then run sync.";
     }
 
     #[tokio::test]
-    async fn a_wrong_span_that_cannot_be_recovered_is_flagged() {
+    async fn a_wrong_span_is_never_a_review_task() {
+        // A line number engram can compute itself was being asked of the model,
+        // disbelieved, and turned into a queue entry whose only button spends a
+        // model call on a whole segment. The span falls back to the window and
+        // the reader is none the wiser.
         let mut core = test_core().await;
         core.synthesizer = std::sync::Arc::new(crate::infer::fake::HallucinatingSynthesizer);
         let out = core
@@ -698,11 +640,18 @@ Then run sync.";
 
         run(&core, &out.id).await.unwrap();
 
-        let c = &core.store.artifacts_for_corpus(&out.id).await.unwrap()[0];
-        assert!(
-            c.flags.iter().any(|f| f == crate::infer::verify::FLAG_SPAN),
-            "a chunk that matches nothing in its window must say so"
-        );
+        for c in core.store.artifacts_for_corpus(&out.id).await.unwrap() {
+            assert!(
+                !c.flags.iter().any(|f| f == "span_unverified"),
+                "a span produced a review task: {:?}",
+                c.flags
+            );
+            let span = c.corpus_span.expect("every artifact keeps a span");
+            assert!(
+                span.start_line >= 1 && span.end_line >= span.start_line,
+                "{span:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -245,10 +245,54 @@ async fn flag_unverified(
     Ok(())
 }
 
+/// Measure how much of a corpus survived into its artifacts, and store it.
+///
+/// Pure local work over rows that are already there — no inference and no
+/// vector call — so it can be re-run over a whole base whenever the measure
+/// itself changes, rather than re-synthesising documents that are fine.
+pub async fn recompute_coverage(core: &Core, corpus_id: &str) -> Result<f64> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    let chunks = core.store.artifacts_for_corpus(corpus_id).await?;
+    let segments = core.store.segments_for_corpus(corpus_id).await?;
+
+    let made: Vec<(i64, i64, String)> = segments
+        .iter()
+        .map(|w| {
+            let text = chunks
+                .iter()
+                .filter(|c| c.segment_idx == Some(w.idx))
+                .map(|c| c.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            (w.start_line, w.end_line, text)
+        })
+        .collect();
+
+    // A corpus segmented before per-segment windows existed has no ranges to
+    // group by; measure it as one.
+    let made = if made.is_empty() {
+        vec![(
+            1,
+            src.raw_text.lines().count() as i64,
+            chunks
+                .iter()
+                .map(|c| c.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )]
+    } else {
+        made
+    };
+
+    let cov = crate::infer::verify::content_coverage(&src.raw_text, &made);
+    core.store.set_corpus_coverage(corpus_id, cov).await?;
+    Ok(cov)
+}
+
 /// Everything that can only be decided once every window has resolved:
 /// continuous ordinals, the source's status, and the single batched embed job.
 pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
-    let src = core.store.get_corpus(corpus_id).await?;
+    core.store.get_corpus(corpus_id).await?;
     core.store.renumber_artifacts(corpus_id).await?;
     let windows = core.store.segments_for_corpus(corpus_id).await?;
     let degraded = windows.iter().any(|w| w.state != SegmentState::Done);
@@ -263,12 +307,7 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     // How much of the source ended up inside a chunk. A source where the
     // segmenter quietly dropped half a chapter used to look identical to one
     // where it did not.
-    let spans: Vec<(i64, i64)> = chunks
-        .iter()
-        .filter_map(|c| c.corpus_span.as_ref().map(|s| (s.start_line, s.end_line)))
-        .collect();
-    let cov = crate::infer::verify::coverage(&spans, &src.raw_text);
-    core.store.set_corpus_coverage(corpus_id, cov).await?;
+    let cov = recompute_coverage(core, corpus_id).await?;
     if cov < crate::infer::verify::LOW_COVERAGE {
         tracing::warn!(
             corpus_id,

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -347,11 +347,16 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
 /// "spent every attempt", because the attempt count belongs to the job, which
 /// covers the whole source.
 ///
-/// Returns whether windows are still waiting for the model, which the caller
-/// answers with a fresh job. It cannot be enqueued here: the caller's own job
-/// row is keyed `(stage, target_id)`, so enqueuing the same source would reuse
-/// that row and the `complete_job` that follows would close it again — the
+/// Returns whether windows are still waiting for their first attempt, which the
+/// caller answers with a fresh job. It cannot be enqueued here: the caller's own
+/// job row is keyed `(stage, target_id)`, so enqueuing the same source would
+/// reuse that row and the `complete_job` that follows would close it again — the
 /// untried windows would be left with nothing to come back to.
+///
+/// Either way the source is settled for now: whatever windows did succeed are
+/// embedded and the corpus reports `partial`. Settled is not finished — a failed
+/// window is still owed a model call, and the caller queues one at the backoff's
+/// distance.
 pub async fn fail_pending_segments(core: &Core, corpus_id: &str, reason: &str) -> Result<bool> {
     let pending = core.store.pending_segments(corpus_id).await?;
     if pending.is_empty() {
@@ -359,7 +364,9 @@ pub async fn fail_pending_segments(core: &Core, corpus_id: &str, reason: &str) -
         return Ok(false);
     }
 
-    let (tried, untried): (Vec<_>, Vec<_>) = pending.into_iter().partition(|w| w.attempts > 0);
+    let (tried, untried): (Vec<_>, Vec<_>) = pending
+        .into_iter()
+        .partition(|w| w.attempts > 0 || w.state == SegmentState::Failed);
 
     if !untried.is_empty() {
         tracing::info!(
@@ -386,9 +393,17 @@ pub async fn fail_pending_segments(core: &Core, corpus_id: &str, reason: &str) -
             "window could not be segmented; its lines have no chunk"
         );
     }
-    // Windows still waiting for their own attempts mean the source is not
+    // Windows still waiting for their first attempt mean the source is not
     // settled yet; finishing here would enqueue embedding for half a document.
-    if core.store.pending_segments(corpus_id).await?.is_empty() {
+    // A window already marked failed does not hold it up — it is owed another
+    // call, not a first one, and the next job brings that.
+    let untried_left = core
+        .store
+        .pending_segments(corpus_id)
+        .await?
+        .into_iter()
+        .any(|w| w.state == SegmentState::Pending);
+    if !untried_left {
         finish(core, corpus_id).await?;
         return Ok(false);
     }
@@ -423,7 +438,7 @@ mod tests {
     use super::*;
     use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
     use crate::store::corpora::CorpusStatus;
-    use crate::store::jobs::Stage;
+    use crate::store::jobs::{MAX_ATTEMPTS, Stage};
 
     /// A body several windows long under the fake synthesizer's budget.
     fn multi_segment_body() -> String {
@@ -494,6 +509,43 @@ mod tests {
         for (i, c) in chunks.iter().enumerate() {
             assert_eq!(c.ordinal, i as i64, "ordinals must not restart per window");
         }
+    }
+
+    #[tokio::test]
+    async fn a_segment_the_endpoint_refused_is_queued_again() {
+        // The failure that lost a quarter of a document: the endpoint was
+        // loading a model and returned 502 for ten minutes, the job spent its
+        // attempts inside the first minute, and nothing ever tried the segment
+        // again. `failed` has to mean "waiting to be tried", not "gone".
+        let core = test_core_with_failing_synthesizer().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+
+        for _ in 0..MAX_ATTEMPTS + 2 {
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            crate::jobs::run_one(&core).await.unwrap();
+        }
+
+        assert!(
+            core.store.failed_jobs(10).await.unwrap().is_empty(),
+            "the corpus was abandoned"
+        );
+        // Directly, because `finish` also queues an embed job for the corpus
+        // and `claim_job` may hand that one over first.
+        let queued: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs
+              WHERE stage = 'synthesize' AND target_id = ? AND state = 'pending'",
+        )
+        .bind(&out.id)
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(queued, 1, "no job is left to retry the segment");
     }
 
     #[tokio::test]

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -186,7 +186,7 @@ enum SpanOrigin {
 fn paraphrased(chunks: &[crate::infer::ProposedArtifact], window: &str) -> bool {
     chunks
         .iter()
-        .any(|c| !crate::infer::verify::missing_literals(&c.text, window).is_empty())
+        .any(|c| !crate::infer::verify::missing_literals(&c.text, &c.caveats, window).is_empty())
 }
 
 /// Mark what verification could not vouch for. The chunk is kept — a warning
@@ -204,7 +204,7 @@ async fn flag_unverified(
         let mut flags = Vec::new();
         let mut detail: Option<String> = None;
 
-        let missing = verify::missing_literals(&c.text, segment_body);
+        let missing = verify::missing_literals(&c.text, &c.caveats, segment_body);
         if let Some(first) = missing.first() {
             flags.push(verify::FLAG_LITERALS.to_string());
             detail = Some(format!("missing literal: {first}"));
@@ -365,6 +365,7 @@ fn proposed_to_new(
             title: p.title,
             category: p.category,
             tags: p.tags,
+            caveats: p.caveats,
             segment_idx: Some(segment_idx),
         })
         .collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,7 @@ mod startup_tests {
                     password_hash: "$argon2id$v=19$m=1,t=1,p=1$c2FsdA$aaaa".into(),
                 }),
             },
+            consolidate: ConsolidateConfig::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ struct Args {
     /// before engram addressed vectors through an alias.
     #[arg(long)]
     replace_legacy: bool,
+    /// Re-measure every corpus's coverage from the artifacts already stored,
+    /// then exit. Local work over existing rows: no inference, no vector calls,
+    /// nothing re-synthesised. Run it after upgrading past a change to how
+    /// coverage is measured, since the figure is otherwise written once.
+    #[arg(long)]
+    recompute_coverage: bool,
 }
 
 fn validate_auth(cfg: &Config, insecure_ok: bool) -> Result<()> {
@@ -121,6 +127,36 @@ async fn main() -> anyhow::Result<()> {
             .reindex(cfg.infer.embed.dim, args.replace_legacy)
             .await?;
         println!("{} now serves `{}`", cfg.vector.collection, target);
+        return Ok(());
+    }
+
+    if args.recompute_coverage {
+        // No vector store and no inference: this only reads artifacts and
+        // writes one number per corpus, so it must not need either to be up.
+        let store = engram::store::Store::connect(&cfg.store).await?;
+        let core = Core::from_config(
+            &cfg,
+            Arc::new(engram::vector::memory::MemoryVectors::new()),
+            store,
+        );
+        let mut offset = 0;
+        loop {
+            let page = core.store.list_corpora(100, offset).await?;
+            if page.is_empty() {
+                break;
+            }
+            for c in &page {
+                let before = c.coverage;
+                let after = engram::jobs::synthesize::recompute_coverage(&core, &c.id).await?;
+                println!(
+                    "{}  {} -> {:.3}",
+                    c.id,
+                    before.map_or("none".to_string(), |b| format!("{b:.3}")),
+                    after
+                );
+            }
+            offset += page.len() as i64;
+        }
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,12 @@ async fn main() -> anyhow::Result<()> {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let background = core.background.clone();
-    let handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
+    let ticker =
+        engram::core::background::spawn_consolidation_ticker(core.clone(), shutdown_rx.clone());
+    let mut handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
+    // Joined with the workers so shutdown waits for it too, rather than leaving
+    // a task the runtime drops mid-enqueue.
+    handles.push(ticker);
 
     let listener = tokio::net::TcpListener::bind(&cfg.server.bind).await?;
     tracing::info!(bind = %cfg.server.bind, mode = ?cfg.auth.mode, "engram listening");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -76,6 +76,21 @@ impl PkdbTools {
     async fn ingest(&self, Parameters(p): Parameters<IngestParams>) -> String {
         match self.core.ingest(&p.text, "mcp", p.title.as_deref()).await {
             Ok(o) if o.duplicate => format!("Already stored as `{}`.", o.id),
+            // A parked capture is stored and nothing more: no segmentation, no
+            // embedding, and nothing searchable until a person decides. Saying
+            // "runs in the background" here would have the agent report a
+            // success that never happens.
+            Ok(o) if o.near_duplicate.is_some() => {
+                let n = o.near_duplicate.expect("just checked");
+                format!(
+                    "Stored as `{}`, but held for review: it is {:.0}% similar to `{}`, \
+                     so it is not segmented or indexed until someone decides between \
+                     them in the web UI.",
+                    o.id,
+                    n.similarity * 100.0,
+                    n.corpus_id
+                )
+            }
             Ok(o) => format!(
                 "Stored as `{}`. Segmentation and embedding run in the background.",
                 o.id

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -453,16 +453,6 @@ impl Store {
         self.set_artifact_flags(id, &[], None).await
     }
 
-    pub async fn flagged_artifacts(&self, limit: i64) -> Result<Vec<Chunk>> {
-        let rows = sqlx::query(
-            "SELECT * FROM artifacts WHERE flags IS NOT NULL ORDER BY created_at DESC LIMIT ?",
-        )
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows.iter().map(row_to_artifact).collect())
-    }
-
     async fn count_by_embed_state(&self, corpus_id: &str, state: &str) -> Result<i64> {
         let row = sqlx::query(
             "SELECT COUNT(*) AS n FROM artifacts WHERE corpus_id = ? AND embed_state = ?",
@@ -549,7 +539,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flags_round_trip_and_list_only_flagged_chunks() {
+    async fn flags_round_trip() {
         let s = Store::memory().await.unwrap();
         let src = s.insert_corpus("raw", "web", None).await.unwrap();
         let made = s
@@ -565,16 +555,15 @@ mod tests {
         .await
         .unwrap();
 
-        let flagged = s.flagged_artifacts(10).await.unwrap();
-        assert_eq!(flagged.len(), 1);
-        assert_eq!(flagged[0].flags, vec!["literals_unverified".to_string()]);
+        let flagged = s.get_artifact(&made[1].id).await.unwrap();
+        assert_eq!(flagged.flags, vec!["literals_unverified".to_string()]);
         assert_eq!(
-            flagged[0].flag_detail.as_deref(),
+            flagged.flag_detail.as_deref(),
             Some("missing literal: --dry-run")
         );
 
         s.clear_artifact_flags(&made[1].id).await.unwrap();
-        assert!(s.flagged_artifacts(10).await.unwrap().is_empty());
+        assert!(s.get_artifact(&made[1].id).await.unwrap().flags.is_empty());
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -61,6 +61,10 @@ pub struct Chunk {
     /// consolidation sweep; the artifact stays stored and readable, and is only
     /// kept out of ranking.
     pub superseded_by: Option<String>,
+    /// Conditions under which this artifact does not apply, as its source
+    /// stated them. Deliberately not part of what gets embedded: changing what
+    /// every vector is built from is a decision for the evaluation harness.
+    pub caveats: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -72,6 +76,7 @@ pub struct NewArtifact {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub segment_idx: Option<i64>,
+    pub caveats: Vec<String>,
 }
 
 fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
@@ -97,6 +102,10 @@ fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
             .unwrap_or_default(),
         flag_detail: r.get("flag_detail"),
         superseded_by: r.get("superseded_by"),
+        caveats: r
+            .get::<Option<String>, _>("caveats")
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default(),
     }
 }
 
@@ -126,10 +135,11 @@ impl Store {
                 flags: vec![],
                 flag_detail: None,
                 superseded_by: None,
+                caveats: nc.caveats.clone(),
             };
             sqlx::query(
-                "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+                "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
             )
             .bind(&c.id)
             .bind(&c.corpus_id)
@@ -142,6 +152,7 @@ impl Store {
             .bind(c.embed_state.as_str())
             .bind(c.created_at)
             .bind(c.segment_idx)
+            .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
             .execute(&mut *tx)
             .await?;
             out.push(c);
@@ -461,6 +472,7 @@ mod tests {
                 start_line: 1,
                 end_line: 4,
             }),
+            caveats: vec![],
             title: Some(format!("title {ord}")),
             category: Some("procedure".into()),
             tags: vec!["forensics".into(), "windows".into()],

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -391,6 +391,28 @@ impl Store {
         Ok(())
     }
 
+    /// Clear every `superseded_by` that names an artifact which no longer
+    /// exists, and say which artifacts were freed.
+    ///
+    /// `superseded_by` is a plain column with no foreign key, so deleting a
+    /// corpus — or reprocessing one, which deletes and re-creates every
+    /// artifact under new ids — can leave the losing side of a pair pointing at
+    /// nothing. That artifact is hidden from search forever, in favour of a
+    /// copy that is gone: the surviving text becomes invisible, which is the
+    /// exact loss consolidation exists to avoid. The caller clears the matching
+    /// payload flags.
+    pub async fn clear_dangling_superseded(&self) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "UPDATE artifacts SET superseded_by = NULL
+              WHERE superseded_by IS NOT NULL
+                AND superseded_by NOT IN (SELECT id FROM artifacts)
+              RETURNING id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get::<String, _>("id")).collect())
+    }
+
     /// Artifacts currently hidden by consolidation, newest first.
     pub async fn superseded_artifacts(&self, limit: i64) -> Result<Vec<Chunk>> {
         let rows = sqlx::query(

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -391,22 +391,24 @@ impl Store {
         Ok(())
     }
 
-    /// Clear every `superseded_by` that names an artifact which no longer
-    /// exists, and say which artifacts were freed.
+    /// Artifacts hidden in favour of a keeper that no longer exists.
     ///
     /// `superseded_by` is a plain column with no foreign key, so deleting a
     /// corpus — or reprocessing one, which deletes and re-creates every
     /// artifact under new ids — can leave the losing side of a pair pointing at
     /// nothing. That artifact is hidden from search forever, in favour of a
     /// copy that is gone: the surviving text becomes invisible, which is the
-    /// exact loss consolidation exists to avoid. The caller clears the matching
-    /// payload flags.
-    pub async fn clear_dangling_superseded(&self) -> Result<Vec<String>> {
+    /// exact loss consolidation exists to avoid.
+    ///
+    /// A read, not a write: the caller clears the vector payload before the
+    /// row, so that a failure between the two leaves the artifact listed on Ops
+    /// rather than hidden with nothing pointing at it. See
+    /// `Core::heal_dangling_supersessions`.
+    pub async fn dangling_superseded(&self) -> Result<Vec<String>> {
         let rows = sqlx::query(
-            "UPDATE artifacts SET superseded_by = NULL
+            "SELECT id FROM artifacts
               WHERE superseded_by IS NOT NULL
-                AND superseded_by NOT IN (SELECT id FROM artifacts)
-              RETURNING id",
+                AND superseded_by NOT IN (SELECT id FROM artifacts)",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -655,6 +657,52 @@ mod tests {
         s.mark_embed_failed(&made[1].id).await.unwrap();
         assert_eq!(s.pending_embed_count(&src.id).await.unwrap(), 0);
         assert_eq!(s.failed_embed_count(&src.id).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn listing_dangling_supersessions_does_not_clear_them() {
+        // The healing order depends on this being a read. If listing also
+        // cleared the rows, a vector write that then failed would leave the
+        // artifact hidden with `superseded_by` already NULL: off the Ops list,
+        // past the sweep's self-heal branch, and unreachable by any button.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "loser".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        s.set_superseded_by(&made[0].id, Some("an-artifact-that-is-gone"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.dangling_superseded().await.unwrap(),
+            vec![made[0].id.clone()]
+        );
+        assert_eq!(
+            s.dangling_superseded().await.unwrap(),
+            vec![made[0].id.clone()],
+            "the second call came back empty, so the first one wrote"
+        );
+        assert!(
+            s.get_artifact(&made[0].id)
+                .await
+                .unwrap()
+                .superseded_by
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -57,6 +57,10 @@ pub struct Chunk {
     /// Verification failures. Empty means every check passed.
     pub flags: Vec<String>,
     pub flag_detail: Option<String>,
+    /// The artifact this one lost a near-identical pair to. Set by the
+    /// consolidation sweep; the artifact stays stored and readable, and is only
+    /// kept out of ranking.
+    pub superseded_by: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -92,6 +96,7 @@ fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default(),
         flag_detail: r.get("flag_detail"),
+        superseded_by: r.get("superseded_by"),
     }
 }
 
@@ -120,6 +125,7 @@ impl Store {
                 segment_idx: nc.segment_idx,
                 flags: vec![],
                 flag_detail: None,
+                superseded_by: None,
             };
             sqlx::query(
                 "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx)
@@ -359,6 +365,31 @@ impl Store {
         }
         tx.commit().await?;
         Ok(())
+    }
+
+    /// Record that this artifact lost a near-identical pair. `None` undoes it.
+    pub async fn set_superseded_by(&self, artifact_id: &str, by: Option<&str>) -> Result<()> {
+        let res = sqlx::query("UPDATE artifacts SET superseded_by = ? WHERE id = ?")
+            .bind(by)
+            .bind(artifact_id)
+            .execute(&self.pool)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Err(Error::NotFound);
+        }
+        Ok(())
+    }
+
+    /// Artifacts currently hidden by consolidation, newest first.
+    pub async fn superseded_artifacts(&self, limit: i64) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE superseded_by IS NOT NULL
+              ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
     }
 
     /// Record what verification found. An empty list clears the flags, so a

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -235,4 +235,72 @@ mod tests {
         assert_eq!(list[0].id, b.id);
         assert_eq!(list[1].id, a.id);
     }
+
+    #[tokio::test]
+    async fn the_consolidation_schema_is_present() {
+        // Migrations run on connect, so this failing means 0009 did not apply.
+        let s = Store::memory().await.unwrap();
+        for sql in [
+            "SELECT shingles, near_dupe_of, near_dupe_score FROM corpora LIMIT 1",
+            "SELECT superseded_by, caveats FROM artifacts LIMIT 1",
+            "SELECT id, a_id, b_id, score, state, detail, created_at FROM artifact_pairs LIMIT 1",
+        ] {
+            sqlx::query(sql)
+                .fetch_optional(&s.pool)
+                .await
+                .unwrap_or_else(|e| panic!("{sql} failed: {e}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_recorded_once_whichever_order_it_is_found_in() {
+        // The sweep sees (a,b) on one run and (b,a) on the next. Without a
+        // canonical order the review queue fills with the same pair twice.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "one".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "two".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        for _ in 0..2 {
+            sqlx::query(
+                "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, created_at)
+                 VALUES (?, ?, 0.9, 'pending', 0)",
+            )
+            .bind(&made[0].id)
+            .bind(&made[1].id)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+        }
+
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM artifact_pairs")
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 1, "the unique constraint on (a_id, b_id) is missing");
+    }
 }

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -109,6 +109,24 @@ impl Store {
         origin: &str,
         title_hint: Option<&str>,
     ) -> Result<Corpus> {
+        let sig = super::shingle::signature(raw_text);
+        self.insert_corpus_with_signature(raw_text, origin, title_hint, sig)
+            .await
+    }
+
+    /// Insert a capture whose shingle signature the caller already computed.
+    ///
+    /// Ingest needs the signature before the row exists, to ask whether this is
+    /// a near-duplicate of something already stored. Handing it over rather
+    /// than recomputing it here is what makes that one pass over the document
+    /// instead of two.
+    pub async fn insert_corpus_with_signature(
+        &self,
+        raw_text: &str,
+        origin: &str,
+        title_hint: Option<&str>,
+        shingles: Vec<u64>,
+    ) -> Result<Corpus> {
         let src = Corpus {
             id: new_id(),
             raw_text: raw_text.to_string(),
@@ -119,7 +137,7 @@ impl Store {
             created_at: now(),
             updated_at: now(),
             coverage: None,
-            shingles: super::shingle::signature(raw_text),
+            shingles,
             near_dupe_of: None,
             near_dupe_score: None,
         };

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -7,6 +7,11 @@ use sqlx::Row;
 #[serde(rename_all = "lowercase")]
 pub enum CorpusStatus {
     Raw,
+    /// Captured, stored, and deliberately not queued for synthesis: something
+    /// near-identical is already in the base, and segmenting it would pay a
+    /// model to produce artifacts that compete with ones that already exist.
+    /// An operator resolves it on Ops.
+    NeedsReview,
     Segmenting,
     Segmented,
     Embedding,
@@ -19,6 +24,7 @@ impl CorpusStatus {
     pub fn as_str(&self) -> &'static str {
         match self {
             CorpusStatus::Raw => "raw",
+            CorpusStatus::NeedsReview => "needs_review",
             CorpusStatus::Segmenting => "segmenting",
             CorpusStatus::Segmented => "segmented",
             CorpusStatus::Embedding => "embedding",
@@ -29,6 +35,7 @@ impl CorpusStatus {
     }
     pub fn parse(s: &str) -> CorpusStatus {
         match s {
+            "needs_review" => CorpusStatus::NeedsReview,
             "segmenting" => CorpusStatus::Segmenting,
             "segmented" => CorpusStatus::Segmented,
             "embedding" => CorpusStatus::Embedding,
@@ -53,6 +60,22 @@ pub struct Corpus {
     /// Fraction of this source's non-blank lines that ended up inside some
     /// chunk. `None` for sources segmented before the check existed.
     pub coverage: Option<f64>,
+    /// Bottom-k shingle hashes of `raw_text`. Empty for corpora captured before
+    /// the signature existed, which simply are not compared.
+    #[serde(skip)]
+    pub shingles: Vec<u64>,
+    /// The corpus this one looked like at capture, and how alike they were.
+    /// Both cleared when an operator chooses to keep both.
+    pub near_dupe_of: Option<String>,
+    pub near_dupe_score: Option<f64>,
+}
+
+/// A stored corpus that a new capture looks like.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct NearDuplicate {
+    pub corpus_id: String,
+    pub title_hint: Option<String>,
+    pub similarity: f64,
 }
 
 pub fn content_hash(text: &str) -> String {
@@ -70,6 +93,12 @@ fn row_to_corpus(r: &sqlx::sqlite::SqliteRow) -> Corpus {
         created_at: r.get("created_at"),
         updated_at: r.get("updated_at"),
         coverage: r.get("coverage"),
+        shingles: r
+            .get::<Option<String>, _>("shingles")
+            .map(|s| super::shingle::decode(&s))
+            .unwrap_or_default(),
+        near_dupe_of: r.get("near_dupe_of"),
+        near_dupe_score: r.get("near_dupe_score"),
     }
 }
 
@@ -90,10 +119,13 @@ impl Store {
             created_at: now(),
             updated_at: now(),
             coverage: None,
+            shingles: super::shingle::signature(raw_text),
+            near_dupe_of: None,
+            near_dupe_score: None,
         };
         sqlx::query(
-            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&src.id)
         .bind(&src.raw_text)
@@ -103,6 +135,7 @@ impl Store {
         .bind(src.status.as_str())
         .bind(src.created_at)
         .bind(src.updated_at)
+        .bind(super::shingle::encode(&src.shingles))
         .execute(&self.pool)
         .await?;
         Ok(src)
@@ -146,6 +179,72 @@ impl Store {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+
+    /// The stored corpus most like this signature, if any clears `min`.
+    ///
+    /// A full scan of the signature column. A single-operator base holds
+    /// hundreds of corpora, each with a signature of a couple of kilobytes, so
+    /// this is a few milliseconds of memory bandwidth on a path that already
+    /// writes the whole document to disk. An index over MinHash bands is the
+    /// answer at a scale this design does not target.
+    pub async fn find_near_duplicate(&self, sig: &[u64], min: f64) -> Result<Option<NearDuplicate>> {
+        if sig.is_empty() {
+            return Ok(None);
+        }
+        let rows =
+            sqlx::query("SELECT id, title_hint, shingles FROM corpora WHERE shingles IS NOT NULL")
+                .fetch_all(&self.pool)
+                .await?;
+
+        let mut best: Option<NearDuplicate> = None;
+        for r in &rows {
+            let stored: String = r.get("shingles");
+            let s = super::shingle::similarity(sig, &super::shingle::decode(&stored));
+            if s < min {
+                continue;
+            }
+            if best.as_ref().is_none_or(|b| s > b.similarity) {
+                best = Some(NearDuplicate {
+                    corpus_id: r.get("id"),
+                    title_hint: r.get("title_hint"),
+                    similarity: s,
+                });
+            }
+        }
+        Ok(best)
+    }
+
+    pub async fn set_near_dupe(
+        &self,
+        corpus_id: &str,
+        of: Option<&str>,
+        score: Option<f64>,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE corpora SET near_dupe_of = ?, near_dupe_score = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(of)
+        .bind(score)
+        .bind(now())
+        .bind(corpus_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Captures waiting on a near-duplicate decision, newest first. They are
+    /// the one corpus state nothing else advances, so Ops has to show them or
+    /// they sit unprocessed with no indication why.
+    pub async fn parked_corpora(&self, limit: i64) -> Result<Vec<Corpus>> {
+        let rows = sqlx::query(
+            "SELECT * FROM corpora WHERE near_dupe_of IS NOT NULL
+              ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_corpus).collect())
     }
 
     pub async fn list_corpora(&self, limit: i64, offset: i64) -> Result<Vec<Corpus>> {
@@ -302,5 +401,66 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(n, 1, "the unique constraint on (a_id, b_id) is missing");
+    }
+
+    #[tokio::test]
+    async fn a_stored_corpus_carries_its_signature() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_corpus("a document about mounting filesystems", "web", None)
+            .await
+            .unwrap();
+        assert!(!src.shingles.is_empty());
+        assert_eq!(s.get_corpus(&src.id).await.unwrap().shingles, src.shingles);
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_corpus_is_found_by_signature() {
+        let s = Store::memory().await.unwrap();
+        let body: String = (0..200)
+            .map(|i| format!("step {i}: run the command and read the output"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let first = s.insert_corpus(&body, "web", Some("manual")).await.unwrap();
+
+        let edited = body.replacen("step 7", "step seven", 1);
+        let hit = s
+            .find_near_duplicate(&crate::store::shingle::signature(&edited), 0.90)
+            .await
+            .unwrap()
+            .expect("the edited copy should have matched");
+        assert_eq!(hit.corpus_id, first.id);
+        assert_eq!(hit.title_hint.as_deref(), Some("manual"));
+        assert!(hit.similarity > 0.90);
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_corpus_is_not_a_near_duplicate() {
+        let s = Store::memory().await.unwrap();
+        s.insert_corpus("a chapter about filesystems and mounting", "web", None)
+            .await
+            .unwrap();
+        let other = crate::store::shingle::signature("a recipe for shortcrust pastry and jam");
+        assert!(s.find_near_duplicate(&other, 0.90).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn needs_review_survives_a_round_trip() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        s.set_corpus_status(&src.id, CorpusStatus::NeedsReview)
+            .await
+            .unwrap();
+        s.set_near_dupe(&src.id, Some("other-id"), Some(0.94))
+            .await
+            .unwrap();
+        let got = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::NeedsReview);
+        assert_eq!(got.near_dupe_of.as_deref(), Some("other-id"));
+        assert!((got.near_dupe_score.unwrap() - 0.94).abs() < 1e-9);
+
+        // Clearing it is what "keep both" does, and it must actually clear.
+        s.set_near_dupe(&src.id, None, None).await.unwrap();
+        assert!(s.get_corpus(&src.id).await.unwrap().near_dupe_of.is_none());
     }
 }

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -188,7 +188,11 @@ impl Store {
     /// this is a few milliseconds of memory bandwidth on a path that already
     /// writes the whole document to disk. An index over MinHash bands is the
     /// answer at a scale this design does not target.
-    pub async fn find_near_duplicate(&self, sig: &[u64], min: f64) -> Result<Option<NearDuplicate>> {
+    pub async fn find_near_duplicate(
+        &self,
+        sig: &[u64],
+        min: f64,
+    ) -> Result<Option<NearDuplicate>> {
         if sig.is_empty() {
             return Ok(None);
         }

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -369,6 +369,7 @@ mod tests {
                         category: None,
                         tags: vec![],
                         segment_idx: None,
+                        caveats: vec![],
                     },
                     crate::store::artifacts::NewArtifact {
                         ordinal: 1,
@@ -378,6 +379,7 @@ mod tests {
                         category: None,
                         tags: vec![],
                         segment_idx: None,
+                        caveats: vec![],
                     },
                 ],
             )

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -58,6 +58,17 @@ pub struct FailedJob {
     pub last_error: Option<String>,
 }
 
+/// Work waiting out a backoff. What replaced the failed list: there is no
+/// terminal state to report, only a next attempt to name.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RetryingJob {
+    pub stage: String,
+    pub target_id: String,
+    pub attempts: i64,
+    pub next_attempt_secs: i64,
+    pub last_error: Option<String>,
+}
+
 /// 2s, 4s, 8s, 16s, 32s ... doubling to a six-hour ceiling, and never stopping.
 ///
 /// The ceiling used to be five minutes, which suited a caller that gave up
@@ -199,6 +210,34 @@ impl Store {
             .fetch_all(&self.pool)
             .await?;
         Ok(rows.iter().map(|r| (r.get("state"), r.get("n"))).collect())
+    }
+
+    /// Jobs waiting on a backoff, soonest first.
+    ///
+    /// `attempts > 0` is what separates work that has hit something from work
+    /// that is merely queued: a fresh job has `run_after` in the past and does
+    /// not belong on a page about trouble.
+    pub async fn retrying_jobs(&self, limit: i64) -> Result<Vec<RetryingJob>> {
+        let rows = sqlx::query(
+            "SELECT stage, target_id, attempts, last_error, run_after FROM jobs
+              WHERE state = 'pending' AND attempts > 0 AND run_after > ?
+              ORDER BY run_after LIMIT ?",
+        )
+        .bind(now())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let at = now();
+        Ok(rows
+            .iter()
+            .map(|r| RetryingJob {
+                stage: r.get("stage"),
+                target_id: r.get("target_id"),
+                attempts: r.get("attempts"),
+                next_attempt_secs: (r.get::<i64, _>("run_after") - at).max(0),
+                last_error: r.get("last_error"),
+            })
+            .collect())
     }
 
     pub async fn failed_jobs(&self, limit: i64) -> Result<Vec<FailedJob>> {

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -93,6 +93,38 @@ impl Store {
         Ok(())
     }
 
+    /// Queue work that has already been tried, so the next attempt waits.
+    ///
+    /// `enqueue` resets `attempts` to zero, which is right for a reprocess a
+    /// person asked for and wrong for a stage re-arming itself: a synthesize
+    /// job that keeps failing would come straight back with a two-second
+    /// delay and hammer an endpoint that is down. This keeps the attempt count
+    /// climbing so the backoff means something.
+    pub async fn enqueue_after(
+        &self,
+        stage: Stage,
+        target_kind: &str,
+        target_id: &str,
+        attempts: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at)
+             VALUES (?, ?, ?, 'pending', ?, ?, ?)
+             ON CONFLICT(stage, target_id) DO UPDATE SET
+               state = 'pending', attempts = excluded.attempts,
+               run_after = excluded.run_after, claimed_at = NULL",
+        )
+        .bind(stage.as_str())
+        .bind(target_kind)
+        .bind(target_id)
+        .bind(attempts)
+        .bind(now() + backoff_secs(attempts))
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Atomic claim. The UPDATE ... WHERE id = (SELECT ...) RETURNING form runs
     /// as one statement under SQLite's write lock, so two workers can never
     /// take the same row.

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -2,6 +2,11 @@ use super::{Store, now};
 use crate::error::Result;
 use sqlx::Row;
 
+/// Where a job's behaviour changes, not where it is abandoned.
+///
+/// Past this many attempts a stage may switch tactics — splitting a batch
+/// embed into one job per artifact, recording which segments the synthesizer
+/// refused — but the work stays queued either way, at the backoff's ceiling.
 pub const MAX_ATTEMPTS: i64 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,12 +58,18 @@ pub struct FailedJob {
     pub last_error: Option<String>,
 }
 
-/// 2s, 4s, 8s, 16s, 32s ... capped at five minutes. An endpoint that is down
-/// stays down for minutes, not milliseconds, and a tight retry loop against a
-/// dead inference server is just noise in the log.
+/// 2s, 4s, 8s, 16s, 32s ... doubling to a six-hour ceiling, and never stopping.
+///
+/// The ceiling used to be five minutes, which suited a caller that gave up
+/// after five attempts — one minute of patience in total. An inference endpoint
+/// that loads a model on demand takes ten, so the whole budget was spent before
+/// the endpoint had finished starting, and the work was lost until a person
+/// noticed and pressed a button. Six hours is short enough that a base heals
+/// the same day and long enough that text the model will never accept costs
+/// four calls a day rather than a thousand.
 pub fn backoff_secs(attempts: i64) -> i64 {
     let exp = attempts.clamp(1, 16) as u32;
-    2i64.saturating_pow(exp).min(300)
+    2i64.saturating_pow(exp).min(21_600)
 }
 
 impl Store {
@@ -120,25 +131,22 @@ impl Store {
         Ok(())
     }
 
+    /// Put a job back in the queue with a delay.
+    ///
+    /// There is no terminal state. `attempts` past `MAX_ATTEMPTS` only means
+    /// the delay has reached its ceiling: a base that cannot reach its
+    /// endpoint should cost nothing and heal when the endpoint returns, and
+    /// the previous behaviour — mark it failed, close it, wait for a human —
+    /// turned a ten-minute outage into permanently missing knowledge.
     pub async fn fail_job(&self, id: i64, attempts: i64, err: &str) -> Result<()> {
-        if attempts >= MAX_ATTEMPTS {
-            sqlx::query(
-                "UPDATE jobs SET state = 'failed', last_error = ?, claimed_at = NULL WHERE id = ?",
-            )
-            .bind(err)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        } else {
-            sqlx::query(
-                "UPDATE jobs SET state = 'pending', run_after = ?, last_error = ?, claimed_at = NULL WHERE id = ?",
-            )
-            .bind(now() + backoff_secs(attempts))
-            .bind(err)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        }
+        sqlx::query(
+            "UPDATE jobs SET state = 'pending', run_after = ?, last_error = ?, claimed_at = NULL WHERE id = ?",
+        )
+        .bind(now() + backoff_secs(attempts))
+        .bind(err)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
@@ -200,13 +208,11 @@ mod tests {
     use crate::store::Store;
 
     #[test]
-    fn backoff_doubles_then_caps_at_five_minutes() {
-        assert_eq!(backoff_secs(1), 2);
+    fn backoff_doubles_then_caps() {
         assert_eq!(backoff_secs(2), 4);
         assert_eq!(backoff_secs(3), 8);
         assert_eq!(backoff_secs(4), 16);
-        assert_eq!(backoff_secs(9), 300, "must cap, not grow unbounded");
-        assert_eq!(backoff_secs(100), 300);
+        assert_eq!(backoff_secs(100), 21_600, "must cap, not grow unbounded");
     }
 
     #[tokio::test]
@@ -292,7 +298,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failure_reschedules_with_backoff_then_gives_up() {
+    async fn failure_reschedules_with_backoff_and_keeps_the_work() {
         let s = Store::memory().await.unwrap();
         s.enqueue(Stage::Embed, "artifact", "c-1").await.unwrap();
 
@@ -301,28 +307,30 @@ mod tests {
         // Backed off: not immediately claimable.
         assert!(s.claim_job().await.unwrap().is_none());
 
-        // Burn the remaining attempts by moving run_after into the past.
-        for _ in 0..MAX_ATTEMPTS {
+        // Well past the old give-up point.
+        for _ in 0..MAX_ATTEMPTS + 3 {
             sqlx::query("UPDATE jobs SET run_after = 0")
                 .execute(&s.pool)
                 .await
                 .unwrap();
-            if let Some(j) = s.claim_job().await.unwrap() {
-                s.fail_job(j.id, j.attempts, "still down").await.unwrap();
-            }
+            let j = s
+                .claim_job()
+                .await
+                .unwrap()
+                .expect("the job must still be there to try again");
+            s.fail_job(j.id, j.attempts, "still down").await.unwrap();
         }
+
         sqlx::query("UPDATE jobs SET run_after = 0")
             .execute(&s.pool)
             .await
             .unwrap();
+        let again = s.claim_job().await.unwrap();
         assert!(
-            s.claim_job().await.unwrap().is_none(),
-            "exhausted job must stay failed"
+            again.is_some(),
+            "the work was abandoned; an endpoint that comes back would never be noticed"
         );
-
-        let failed = s.failed_jobs(10).await.unwrap();
-        assert_eq!(failed.len(), 1);
-        assert_eq!(failed[0].last_error.as_deref(), Some("still down"));
+        assert!(s.failed_jobs(10).await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -366,6 +374,38 @@ mod tests {
             .unwrap();
         let age = s.oldest_pending_age().await.unwrap().unwrap();
         assert!((3595..=3605).contains(&age), "got {age}");
+    }
+
+    #[test]
+    fn backoff_climbs_to_hours_and_stops_there() {
+        // An endpoint that is down stays down for minutes; one loading a model
+        // on demand takes ten. The old ceiling of five minutes went with a
+        // caller that gave up after five attempts — one minute of patience in
+        // total, spent before the endpoint had finished starting.
+        assert_eq!(backoff_secs(1), 2);
+        assert_eq!(backoff_secs(5), 32);
+        assert_eq!(backoff_secs(20), 21_600);
+        assert_eq!(backoff_secs(1_000), 21_600);
+    }
+
+    #[tokio::test]
+    async fn a_job_out_of_attempts_waits_rather_than_failing() {
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::Embed, "artifact", "a1").await.unwrap();
+        let job = s.claim_job().await.unwrap().unwrap();
+        s.fail_job(job.id, MAX_ATTEMPTS + 10, "endpoint down")
+            .await
+            .unwrap();
+        assert!(
+            s.failed_jobs(10).await.unwrap().is_empty(),
+            "a job was abandoned; nothing would ever pick it up again"
+        );
+        let state: String = sqlx::query_scalar("SELECT state FROM jobs WHERE id = ?")
+            .bind(job.id)
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(state, "pending");
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -9,6 +9,10 @@ pub enum Stage {
     Synthesize,
     Enrich,
     Embed,
+    /// The periodic consolidation sweep. Its target is the collection rather
+    /// than any one corpus, so there is exactly one of these in the queue at a
+    /// time.
+    Consolidate,
 }
 
 impl Stage {
@@ -17,6 +21,7 @@ impl Stage {
             Stage::Synthesize => "synthesize",
             Stage::Enrich => "enrich",
             Stage::Embed => "embed",
+            Stage::Consolidate => "consolidate",
         }
     }
     pub fn parse(s: &str) -> Option<Stage> {
@@ -24,6 +29,7 @@ impl Stage {
             "synthesize" => Some(Stage::Synthesize),
             "enrich" => Some(Stage::Enrich),
             "embed" => Some(Stage::Embed),
+            "consolidate" => Some(Stage::Consolidate),
             _ => None,
         }
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod corpora;
 pub mod jobs;
 pub mod segments;
+pub mod shingle;
 
 use crate::config::StoreConfig;
 use crate::error::Result;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,6 +2,7 @@ pub mod artifacts;
 pub mod auth;
 pub mod corpora;
 pub mod jobs;
+pub mod pairs;
 pub mod segments;
 pub mod shingle;
 

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -1,0 +1,244 @@
+//! The consolidation review queue.
+//!
+//! Pairs similar enough to be worth attention but not similar enough to
+//! supersede without asking. The sweep finds the same pair on every run, so a
+//! row here is also the record that a decision was already made about it — a
+//! dismissed pair must stay dismissed, or dismissing would achieve nothing.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairState {
+    /// Found by the sweep, nothing has looked at it yet.
+    Pending,
+    /// The fact-token prefilter or the judge found nothing to disagree about.
+    NoConflict,
+    /// The judge found a detail the two artifacts state differently. Which one
+    /// is current is a judgement only the reader can make.
+    Contradiction,
+    /// An operator looked and decided there is nothing here.
+    Dismissed,
+}
+
+impl PairState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PairState::Pending => "pending",
+            PairState::NoConflict => "no_conflict",
+            PairState::Contradiction => "contradiction",
+            PairState::Dismissed => "dismissed",
+        }
+    }
+    pub fn parse(s: &str) -> PairState {
+        match s {
+            "no_conflict" => PairState::NoConflict,
+            "contradiction" => PairState::Contradiction,
+            "dismissed" => PairState::Dismissed,
+            _ => PairState::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ArtifactPair {
+    pub id: i64,
+    pub a_id: String,
+    pub b_id: String,
+    pub score: f32,
+    pub state: PairState,
+    pub detail: Option<String>,
+    pub created_at: i64,
+}
+
+fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
+    ArtifactPair {
+        id: r.get("id"),
+        a_id: r.get("a_id"),
+        b_id: r.get("b_id"),
+        score: r.get::<f64, _>("score") as f32,
+        state: PairState::parse(r.get::<String, _>("state").as_str()),
+        detail: r.get("detail"),
+        created_at: r.get("created_at"),
+    }
+}
+
+impl Store {
+    /// File a pair for review. Returns whether this was new.
+    ///
+    /// `INSERT OR IGNORE` rather than an upsert, deliberately: the sweep finds
+    /// the same pair every run, and re-arming a row an operator dismissed
+    /// would make dismissing pointless.
+    pub async fn record_pair(&self, a: &str, b: &str, score: f32) -> Result<bool> {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, created_at)
+             VALUES (?, ?, ?, 'pending', ?)",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(score as f64)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    pub async fn pairs_by_state(&self, state: PairState, limit: i64) -> Result<Vec<ArtifactPair>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifact_pairs WHERE state = ?
+              ORDER BY score DESC, created_at DESC LIMIT ?",
+        )
+        .bind(state.as_str())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_pair).collect())
+    }
+
+    pub async fn set_pair_state(
+        &self,
+        id: i64,
+        state: PairState,
+        detail: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query("UPDATE artifact_pairs SET state = ?, detail = ? WHERE id = ?")
+            .bind(state.as_str())
+            .bind(detail)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use crate::store::artifacts::NewArtifact;
+
+    async fn two_artifacts(s: &Store) -> (String, String) {
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(
+                &src.id,
+                &[
+                    NewArtifact {
+                        ordinal: 0,
+                        text: "one".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                    NewArtifact {
+                        ordinal: 1,
+                        text: "two".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        (made[0].id.clone(), made[1].id.clone())
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_recorded_once_and_only_once() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        assert!(s.record_pair(&a, &b, 0.91).await.unwrap());
+        assert!(
+            !s.record_pair(&a, &b, 0.91).await.unwrap(),
+            "a repeat sweep duplicated the pair"
+        );
+        assert!(
+            !s.record_pair(&b, &a, 0.91).await.unwrap(),
+            "the reversed pair duplicated it"
+        );
+        assert_eq!(
+            s.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn resolving_a_pair_takes_it_off_the_pending_list() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+
+        s.set_pair_state(
+            p.id,
+            PairState::Contradiction,
+            Some("version differs: 1.2 vs 1.4"),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            s.pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let done = s
+            .pairs_by_state(PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].detail.as_deref(), Some("version differs: 1.2 vs 1.4"));
+    }
+
+    #[tokio::test]
+    async fn a_resolved_pair_is_not_re_queued_by_the_next_sweep() {
+        // The sweep re-finds the same pair every run. If `record_pair` reset a
+        // dismissed row to pending, dismissing would achieve nothing.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+        s.set_pair_state(p.id, PairState::Dismissed, None)
+            .await
+            .unwrap();
+
+        assert!(!s.record_pair(&a, &b, 0.91).await.unwrap());
+        assert!(
+            s.pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_an_artifact_takes_its_pairs_with_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        s.delete_artifact(&a).await.unwrap();
+        assert!(
+            s.pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -90,12 +90,15 @@ impl Store {
         Ok(res.rows_affected() > 0)
     }
 
-    /// File a pair that is already answered. Returns whether this was new.
+    /// File a pair that is already answered. Returns whether this changed
+    /// anything.
     ///
-    /// `INSERT OR IGNORE` like `record_pair`, and for a stronger reason: a row
-    /// that exists carries a decision — a person's dismissal, the judge's
-    /// contradiction — and the sweep re-finds the same pair every run. Settling
-    /// it again would overwrite the answer with the sweep's opinion of it.
+    /// A row that carries a real decision — a person's dismissal, the judge's
+    /// contradiction — is left alone: the sweep re-finds the same pair every
+    /// run, and overwriting the answer with its own opinion would make
+    /// dismissing pointless. `pending` is not a decision, it is the absence of
+    /// one, so it is answered here. That is also what settles pairs filed
+    /// before the sweep could answer them, without a migration.
     pub async fn record_settled_pair(
         &self,
         a: &str,
@@ -105,8 +108,10 @@ impl Store {
     ) -> Result<bool> {
         let (a, b) = if a <= b { (a, b) } else { (b, a) };
         let res = sqlx::query(
-            "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, created_at)
-             VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO artifact_pairs (a_id, b_id, score, state, created_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(a_id, b_id) DO UPDATE SET state = excluded.state
+               WHERE artifact_pairs.state = 'pending'",
         )
         .bind(a)
         .bind(b)
@@ -300,6 +305,48 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn settling_answers_a_pending_pair_and_respects_a_real_decision() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+
+        // Pending is the absence of a decision, so the sweep may answer it.
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        assert!(
+            s.record_settled_pair(&a, &b, 0.91, PairState::NoConflict)
+                .await
+                .unwrap()
+        );
+        assert!(
+            s.pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // A dismissal is a decision. The sweep re-finds this pair every run and
+        // must not talk over it.
+        let p = s
+            .pairs_by_state(PairState::NoConflict, 10)
+            .await
+            .unwrap()
+            .remove(0);
+        s.set_pair_state(p.id, PairState::Dismissed, None)
+            .await
+            .unwrap();
+        s.record_settled_pair(&a, &b, 0.91, PairState::NoConflict)
+            .await
+            .unwrap();
+        assert_eq!(
+            s.pairs_by_state(PairState::Dismissed, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "a decision was overwritten"
         );
     }
 

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -134,6 +134,7 @@ mod tests {
                         category: None,
                         tags: vec![],
                         segment_idx: None,
+                        caveats: vec![],
                     },
                     NewArtifact {
                         ordinal: 1,
@@ -143,6 +144,7 @@ mod tests {
                         category: None,
                         tags: vec![],
                         segment_idx: None,
+                        caveats: vec![],
                     },
                 ],
             )

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -51,6 +51,9 @@ pub struct ArtifactPair {
     pub state: PairState,
     pub detail: Option<String>,
     pub created_at: i64,
+    /// Model calls this pair has already cost, successful or not. Orders the
+    /// judge's queue so a pair it cannot read does not starve the rest.
+    pub judge_attempts: i64,
 }
 
 fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
@@ -62,6 +65,7 @@ fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
         state: PairState::parse(r.get::<String, _>("state").as_str()),
         detail: r.get("detail"),
         created_at: r.get("created_at"),
+        judge_attempts: r.get("judge_attempts"),
     }
 }
 
@@ -104,9 +108,44 @@ impl Store {
         state: PairState,
         detail: Option<&str>,
     ) -> Result<()> {
-        sqlx::query("UPDATE artifact_pairs SET state = ?, detail = ? WHERE id = ?")
+        let res = sqlx::query("UPDATE artifact_pairs SET state = ?, detail = ? WHERE id = ?")
             .bind(state.as_str())
             .bind(detail)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        // A dismiss from a stale Ops page names a pair that is no longer there
+        // — its artifacts were deleted, or the row never existed. Redirecting
+        // as though it worked tells the operator the queue is one shorter than
+        // it is.
+        if res.rows_affected() == 0 {
+            return Err(crate::error::Error::NotFound);
+        }
+        Ok(())
+    }
+
+    /// Pending pairs in the order the judge should spend its budget on them.
+    ///
+    /// Least-attempted first, then by score. A pair whose reply could not be
+    /// parsed stays pending on purpose, and under a plain `score DESC` the same
+    /// top-scoring handful would absorb every sweep's budget forever while the
+    /// rest of the queue is never reached.
+    pub async fn pairs_to_judge(&self, limit: i64) -> Result<Vec<ArtifactPair>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifact_pairs WHERE state = 'pending'
+              ORDER BY judge_attempts ASC, score DESC, created_at DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_pair).collect())
+    }
+
+    /// Count one model call against a pair, whether or not it produced an
+    /// answer. Written before the call, so a run that dies mid-judgement still
+    /// leaves the pair at the back of the next sweep's queue.
+    pub async fn record_judge_attempt(&self, id: i64) -> Result<()> {
+        sqlx::query("UPDATE artifact_pairs SET judge_attempts = judge_attempts + 1 WHERE id = ?")
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -234,6 +273,56 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn dismissing_a_pair_that_is_no_longer_there_is_an_error() {
+        // Ops pages go stale, and a pair whose artifacts were deleted is gone
+        // with them. Reporting success would tell the operator the queue is one
+        // shorter than it is.
+        let s = Store::memory().await.unwrap();
+        assert!(matches!(
+            s.set_pair_state(9999, PairState::Dismissed, None).await,
+            Err(crate::error::Error::NotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn the_judge_queue_puts_the_least_attempted_pair_first() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("four", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..4)
+            .map(|i| NewArtifact {
+                ordinal: i,
+                text: format!("artifact {i}"),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        let made = s.insert_artifacts(&src.id, &new).await.unwrap();
+        let (a, b, c, d) = (
+            made[0].id.clone(),
+            made[1].id.clone(),
+            made[2].id.clone(),
+            made[3].id.clone(),
+        );
+        // The higher score would otherwise always lead.
+        s.record_pair(&a, &b, 0.99).await.unwrap();
+        s.record_pair(&c, &d, 0.90).await.unwrap();
+        let first = s.pairs_to_judge(10).await.unwrap();
+        assert_eq!(first[0].score, 0.99);
+
+        s.record_judge_attempt(first[0].id).await.unwrap();
+        let next = s.pairs_to_judge(10).await.unwrap();
+        assert_eq!(
+            next[0].score, 0.90,
+            "a pair that already cost a call must not lead again"
+        );
+        assert_eq!(next[1].judge_attempts, 1);
     }
 
     #[tokio::test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -90,6 +90,34 @@ impl Store {
         Ok(res.rows_affected() > 0)
     }
 
+    /// File a pair that is already answered. Returns whether this was new.
+    ///
+    /// `INSERT OR IGNORE` like `record_pair`, and for a stronger reason: a row
+    /// that exists carries a decision — a person's dismissal, the judge's
+    /// contradiction — and the sweep re-finds the same pair every run. Settling
+    /// it again would overwrite the answer with the sweep's opinion of it.
+    pub async fn record_settled_pair(
+        &self,
+        a: &str,
+        b: &str,
+        score: f32,
+        state: PairState,
+    ) -> Result<bool> {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, created_at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(score as f64)
+        .bind(state.as_str())
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
     pub async fn pairs_by_state(&self, state: PairState, limit: i64) -> Result<Vec<ArtifactPair>> {
         let rows = sqlx::query(
             "SELECT * FROM artifact_pairs WHERE state = ?

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -167,7 +167,10 @@ mod tests {
             "the reversed pair duplicated it"
         );
         assert_eq!(
-            s.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+            s.pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
             1
         );
     }
@@ -202,7 +205,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(done.len(), 1);
-        assert_eq!(done[0].detail.as_deref(), Some("version differs: 1.2 vs 1.4"));
+        assert_eq!(
+            done[0].detail.as_deref(),
+            Some("version differs: 1.2 vs 1.4")
+        );
     }
 
     #[tokio::test]

--- a/src/store/segments.rs
+++ b/src/store/segments.rs
@@ -84,10 +84,17 @@ impl Store {
         Ok(rows.iter().map(row_to_segment).collect())
     }
 
+    /// Segments still owed a model call: never tried, or tried and refused.
+    ///
+    /// `failed` is included on purpose. It records what went wrong last time,
+    /// not a verdict — an endpoint that was loading a model, or a machine that
+    /// was asleep, says nothing about the text. Excluding it made the next run
+    /// see a finished corpus and close the job, which is how a quarter of a
+    /// document stayed missing while the endpoint sat there answering.
     pub async fn pending_segments(&self, corpus_id: &str) -> Result<Vec<Segment>> {
         let rows = sqlx::query(
             "SELECT * FROM segments
-             WHERE corpus_id = ? AND state = 'pending' ORDER BY idx",
+             WHERE corpus_id = ? AND state != 'done' ORDER BY idx",
         )
         .bind(corpus_id)
         .fetch_all(&self.pool)

--- a/src/store/shingle.rs
+++ b/src/store/shingle.rs
@@ -1,0 +1,175 @@
+//! Is this the same document we already have?
+//!
+//! `content_hash` answers that for byte-identical text and nothing else, so
+//! re-pasting a chapter a year later with one typo fixed stores it a second
+//! time, and the two copies then compete for the same queries forever. That is
+//! the largest single source of duplication in the base, and it is detectable
+//! without an embedding call, let alone a model call.
+//!
+//! The signature is bottom-k MinHash over word 5-grams: hash every shingle,
+//! keep the `SIGNATURE_SIZE` smallest hashes. The fraction of a pair of
+//! signatures' bottom-k that agree estimates the Jaccard similarity of the two
+//! shingle sets, which is a number an operator can be shown — "94% of this
+//! document's phrasing is already stored" — in a way a Hamming distance is not.
+
+use std::collections::BTreeSet;
+
+/// Hashes kept per document. Estimation error is roughly `1/sqrt(k)`, so 128
+/// gives about nine points of slack — ample against a 0.90 decision threshold,
+/// and small enough that the column stays a couple of kilobytes.
+pub const SIGNATURE_SIZE: usize = 128;
+
+/// Words per shingle. Five is long enough that ordinary English collides
+/// rarely and short enough that a document has plenty of them.
+const SHINGLE_WORDS: usize = 5;
+
+/// FNV-1a. Chosen over `sha2`, which is already a dependency, because this runs
+/// once per shingle over a whole document and the signature never leaves the
+/// machine — there is nothing here for a cryptographic hash to defend.
+fn hash(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// The bottom-k hashes of this text's word shingles, ascending.
+///
+/// Whitespace is normalised and case folded first, so reflowing a paragraph or
+/// changing a heading's capitalisation does not read as a different document.
+pub fn signature(text: &str) -> Vec<u64> {
+    let words: Vec<String> = text.split_whitespace().map(|w| w.to_lowercase()).collect();
+    if words.is_empty() {
+        return Vec::new();
+    }
+
+    // A BTreeSet both dedupes — a repeated shingle must count once, or a
+    // document that says the same sentence twice would skew its own bottom-k —
+    // and keeps the largest kept hash reachable for eviction.
+    let mut smallest: BTreeSet<u64> = BTreeSet::new();
+    // A document shorter than one shingle still gets a signature, from the one
+    // shingle its whole text forms. Returning nothing would make it match
+    // every other short capture.
+    let step = SHINGLE_WORDS.min(words.len());
+    for w in words.windows(step) {
+        smallest.insert(hash(&w.join(" ")));
+        if smallest.len() > SIGNATURE_SIZE {
+            let largest = *smallest.iter().next_back().expect("non-empty");
+            smallest.remove(&largest);
+        }
+    }
+    smallest.into_iter().collect()
+}
+
+/// Estimated Jaccard similarity of the two documents' shingle sets.
+///
+/// Both signatures are the bottom-k of their own set, so the estimate is the
+/// agreement within the bottom-k of their union — taking the k smallest hashes
+/// across both and asking how many of those appear in both.
+pub fn similarity(a: &[u64], b: &[u64]) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let k = SIGNATURE_SIZE.min(a.len()).min(b.len());
+    let mut union: Vec<u64> = a.iter().chain(b.iter()).copied().collect();
+    union.sort_unstable();
+    union.dedup();
+    union.truncate(k);
+
+    let shared = union
+        .iter()
+        .filter(|h| a.binary_search(h).is_ok() && b.binary_search(h).is_ok())
+        .count();
+    shared as f64 / k as f64
+}
+
+/// The column holds JSON rather than a blob: it is a few kilobytes either way,
+/// and a readable column is worth a great deal the first time someone has to
+/// work out why two documents were called duplicates.
+pub fn encode(sig: &[u64]) -> String {
+    serde_json::to_string(sig).unwrap_or_else(|_| "[]".into())
+}
+
+/// A column written by an older version, or corrupted, yields no signature
+/// rather than an error: the corpus simply is not compared, which is exactly
+/// the behaviour before this existed.
+pub fn decode(s: &str) -> Vec<u64> {
+    serde_json::from_str(s).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(n: usize) -> String {
+        (0..n)
+            .map(|i| format!("line {i} of a reference document about filesystems"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn identical_text_is_perfectly_similar() {
+        let a = signature(&doc(200));
+        let b = signature(&doc(200));
+        assert_eq!(a, b, "the signature must be deterministic");
+        assert!((similarity(&a, &b) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn one_changed_byte_still_reads_as_the_same_document() {
+        // The case `content_hash` misses entirely: the same chapter pasted a
+        // year later with one typo fixed. It must not become a second corpus
+        // competing for the same queries.
+        let original = doc(200);
+        let edited = original.replacen("filesystems", "filesystem", 1);
+        assert_ne!(original, edited);
+        let s = similarity(&signature(&original), &signature(&edited));
+        assert!(s > 0.95, "one edit dropped similarity to {s}");
+    }
+
+    #[test]
+    fn unrelated_text_is_not_similar() {
+        let a = signature(&doc(200));
+        let b = signature(
+            &(0..200)
+                .map(|i| format!("entirely different sentence number {i} concerning pastry"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        let s = similarity(&a, &b);
+        assert!(s < 0.2, "unrelated documents scored {s}");
+    }
+
+    #[test]
+    fn a_document_shorter_than_one_shingle_still_has_a_signature() {
+        // A three-word capture is legitimate and must not panic or produce a
+        // signature that matches everything.
+        let sig = signature("just three words");
+        assert!(!sig.is_empty());
+        assert!(similarity(&sig, &signature("wholly other words here")) < 1.0);
+    }
+
+    #[test]
+    fn an_empty_signature_is_never_similar_to_anything() {
+        assert_eq!(similarity(&[], &signature("some text")), 0.0);
+        assert_eq!(similarity(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn signatures_round_trip_through_the_column_encoding() {
+        let sig = signature(&doc(50));
+        assert_eq!(decode(&encode(&sig)), sig);
+        assert!(
+            decode("not json").is_empty(),
+            "a corrupt column must not panic"
+        );
+    }
+
+    #[test]
+    fn the_signature_is_bounded_however_long_the_document() {
+        assert!(signature(&doc(10_000)).len() <= SIGNATURE_SIZE);
+    }
+}

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -109,7 +109,8 @@ impl VectorStore for MemoryVectors {
         let r = self.points.read().unwrap();
         Ok(r.values()
             .filter(|p| {
-                p.payload.created_at < older_than
+                p.payload.superseded != Some(true)
+                    && p.payload.created_at < older_than
                     && p.payload.last_seen_at.is_none_or(|s| s < unseen_since)
             })
             .take(limit)
@@ -182,7 +183,7 @@ impl VectorStore for MemoryVectors {
         };
         let mut hits: Vec<SearchHit> = r
             .values()
-            .filter(|p| p.payload.artifact_id != artifact_id)
+            .filter(|p| p.payload.artifact_id != artifact_id && p.payload.superseded != Some(true))
             .map(|p| SearchHit {
                 payload: p.payload.clone(),
                 score: cosine(&seed.vector, &p.vector),
@@ -677,6 +678,33 @@ mod tests {
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].payload.artifact_id, "a");
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_is_offered_neither_as_forgotten_nor_as_related() {
+        // Hidden means hidden everywhere a reader browses. A superseded
+        // artifact is by construction near-identical to its keeper, so it would
+        // lead the related pane of the very artifact it lost to, and the
+        // forgotten list would offer exactly what the sweep just took out.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.99, 0.1], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        v.set_superseded("b", true).await.unwrap();
+
+        let near = v.neighbours("a", 10).await.unwrap();
+        assert!(
+            near.iter().all(|h| h.payload.artifact_id != "b"),
+            "a hidden artifact was offered as related"
+        );
+        let old = v.resurface(10, i64::MAX, i64::MAX).await.unwrap();
+        assert!(
+            old.iter().all(|h| h.payload.artifact_id != "b"),
+            "a hidden artifact was offered as forgotten"
+        );
     }
 
     #[tokio::test]

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -197,6 +197,48 @@ impl VectorStore for MemoryVectors {
         Ok(hits)
     }
 
+    async fn near_pairs(
+        &self,
+        sample: usize,
+        per_point: usize,
+        min_score: f32,
+    ) -> Result<Vec<super::NearPair>> {
+        let r = self.points.read().unwrap();
+        let live: Vec<&VectorPoint> = r
+            .values()
+            .filter(|p| p.payload.superseded != Some(true))
+            .take(sample)
+            .collect();
+
+        let mut out: Vec<super::NearPair> = Vec::new();
+        for (i, a) in live.iter().enumerate() {
+            let mut mine: Vec<super::NearPair> = live
+                .iter()
+                .skip(i + 1)
+                .map(|b| {
+                    super::NearPair::new(
+                        &a.payload.artifact_id,
+                        &b.payload.artifact_id,
+                        cosine(&a.vector, &b.vector),
+                    )
+                })
+                .filter(|p| p.score >= min_score)
+                .collect();
+            mine.sort_by(|x, y| y.score.total_cmp(&x.score));
+            mine.truncate(per_point);
+            out.extend(mine);
+        }
+        // Deterministic order, so a test never depends on HashMap iteration.
+        out.sort_by(|x, y| {
+            y.score
+                .total_cmp(&x.score)
+                .then_with(|| x.a.cmp(&y.a))
+                .then_with(|| x.b.cmp(&y.b))
+        });
+        out.dedup_by(|x, y| x.a == y.a && x.b == y.b);
+        Ok(out)
+    }
+
     async fn delete_artifacts(&self, artifact_ids: &[String]) -> Result<()> {
         let mut w = self.points.write().unwrap();
         for id in artifact_ids {
@@ -548,6 +590,68 @@ mod tests {
             .await
             .unwrap();
         assert!(v.neighbours("missing", 5).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn near_pairs_finds_the_close_pair_and_not_the_far_one() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.999, 0.01], &[], "note"),
+            point("c", "s1", vec![0.0, 1.0], &[], "note"),
+        ])
+        .await
+        .unwrap();
+
+        let pairs = v.near_pairs(100, 5, 0.9).await.unwrap();
+        assert_eq!(pairs.len(), 1, "got {pairs:?}");
+        assert_eq!((pairs[0].a.as_str(), pairs[0].b.as_str()), ("a", "b"));
+        assert!(pairs[0].score >= 0.9);
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_reported_once_not_twice() {
+        // (a,b) and (b,a) are the same pair. Reporting both doubles the review
+        // queue and makes the sweep supersede an artifact twice.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.999, 0.01], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        assert_eq!(v.near_pairs(100, 5, 0.9).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_is_not_paired_again() {
+        // Otherwise every sweep re-finds the pair it resolved last time and
+        // the review queue never empties.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.999, 0.01], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        v.set_superseded("b", true).await.unwrap();
+        assert!(v.near_pairs(100, 5, 0.9).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pairs_come_back_best_first() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.999, 0.01], &[], "note"),
+            point("c", "s1", vec![0.99, 0.1], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        let pairs = v.near_pairs(100, 5, 0.5).await.unwrap();
+        for w in pairs.windows(2) {
+            assert!(w[0].score >= w[1].score, "not sorted: {pairs:?}");
+        }
     }
 
     #[tokio::test]

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -56,6 +56,13 @@ impl VectorStore for MemoryVectors {
                     .get(&p.payload.artifact_id)
                     .and_then(|old| old.payload.last_seen_at);
             }
+            // Same rule, same reason: an unset flag means "whatever is already
+            // stored", so a re-embed cannot revive an artifact the sweep hid.
+            if p.payload.superseded.is_none() {
+                p.payload.superseded = w
+                    .get(&p.payload.artifact_id)
+                    .and_then(|old| old.payload.superseded);
+            }
             w.insert(p.payload.artifact_id.clone(), p);
         }
         Ok(())
@@ -67,8 +74,18 @@ impl VectorStore for MemoryVectors {
             // A merge, matching Qdrant: an absent stamp means "unchanged", so
             // a tag edit must not erase when the chunk was last shown.
             let seen = payload.last_seen_at.or(p.payload.last_seen_at);
+            let sup = payload.superseded.or(p.payload.superseded);
             p.payload = payload.clone();
             p.payload.last_seen_at = seen;
+            p.payload.superseded = sup;
+        }
+        Ok(())
+    }
+
+    async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        if let Some(p) = w.get_mut(artifact_id) {
+            p.payload.superseded = Some(superseded);
         }
         Ok(())
     }
@@ -117,7 +134,8 @@ impl VectorStore for MemoryVectors {
         let mut hits: Vec<SearchHit> = r
             .values()
             .filter(|p| {
-                filter.tags.iter().all(|t| p.payload.tags.contains(t))
+                (filter.include_superseded || p.payload.superseded != Some(true))
+                    && filter.tags.iter().all(|t| p.payload.tags.contains(t))
                     && filter
                         .category
                         .as_ref()
@@ -198,6 +216,7 @@ impl VectorStore for MemoryVectors {
     }
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,6 +235,7 @@ mod tests {
                 tags: tags.iter().map(|s| s.to_string()).collect(),
                 created_at: 0,
                 last_seen_at: None,
+                superseded: None,
             },
         }
     }
@@ -289,6 +309,7 @@ mod tests {
         let f = SearchFilter {
             tags: vec!["linux".into(), "forensics".into()],
             category: None,
+            include_superseded: false,
         };
         let hits = v
             .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &f)
@@ -311,6 +332,7 @@ mod tests {
         let f = SearchFilter {
             tags: vec![],
             category: Some("concept".into()),
+            include_superseded: false,
         };
         let hits = v
             .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &f)
@@ -526,5 +548,95 @@ mod tests {
             .await
             .unwrap();
         assert!(v.neighbours("missing", 5).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_drops_out_of_search() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.99, 0.1], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        assert_eq!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+
+        v.set_superseded("b", true).await.unwrap();
+        let hits = v
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].payload.artifact_id, "a");
+    }
+
+    #[tokio::test]
+    async fn a_superseded_artifact_is_still_reachable_when_asked_for() {
+        // Superseding hides an artifact from ranking. It must not make it
+        // unreadable: the review queue and the undo both need to see it.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "note"),
+            point("b", "s1", vec![0.99, 0.1], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        v.set_superseded("b", true).await.unwrap();
+
+        let filter = SearchFilter {
+            include_superseded: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &filter)
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn un_superseding_puts_an_artifact_back_in_results() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", "s1", vec![1.0, 0.0], &[], "note")])
+            .await
+            .unwrap();
+        v.set_superseded("a", true).await.unwrap();
+        v.set_superseded("a", false).await.unwrap();
+        assert_eq!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn re_embedding_does_not_un_supersede_an_artifact() {
+        // `payload_of` in the embed job knows nothing about consolidation, so
+        // it leaves the field unset — and unset must mean "keep what is
+        // stored", or every re-embed would silently revive a hidden artifact.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", "s1", vec![1.0, 0.0], &[], "note")])
+            .await
+            .unwrap();
+        v.set_superseded("a", true).await.unwrap();
+        v.upsert(vec![point("a", "s1", vec![1.0, 0.0], &[], "note")])
+            .await
+            .unwrap();
+        assert!(
+            v.search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -258,7 +258,6 @@ impl VectorStore for MemoryVectors {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -79,6 +79,28 @@ pub struct Facets {
     pub tags: Vec<FacetCount>,
 }
 
+/// Two artifacts the index says are close, and how close.
+///
+/// `a` sorts before `b` so the same pair found from either end is one value —
+/// the sweep would otherwise queue it twice and supersede the loser twice.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NearPair {
+    pub a: String,
+    pub b: String,
+    pub score: f32,
+}
+
+impl NearPair {
+    pub fn new(x: &str, y: &str, score: f32) -> NearPair {
+        let (a, b) = if x <= y { (x, y) } else { (y, x) };
+        NearPair {
+            a: a.to_string(),
+            b: b.to_string(),
+            score,
+        }
+    }
+}
+
 #[async_trait]
 pub trait VectorStore: Send + Sync {
     async fn ensure_collection(&self, dim: usize) -> Result<()>;
@@ -121,6 +143,20 @@ pub trait VectorStore: Send + Sync {
     /// no embedding call, because the query is a point that is already in the
     /// index. The artifact itself is never among its own neighbours.
     async fn neighbours(&self, artifact_id: &str, limit: usize) -> Result<Vec<SearchHit>>;
+    /// Pairs of artifacts closer than `min_score`, best first, over a sample of
+    /// the collection. Superseded artifacts are excluded — a resolved pair
+    /// re-found every sweep is a review queue that never empties.
+    ///
+    /// This is one round trip, not one query per point: `sample` points are
+    /// drawn and each contributes at most `per_point` neighbours. A sweep over
+    /// a base of any size therefore costs a bounded amount rather than growing
+    /// with the collection.
+    async fn near_pairs(
+        &self,
+        sample: usize,
+        per_point: usize,
+        min_score: f32,
+    ) -> Result<Vec<NearPair>>;
     async fn delete_artifacts(&self, artifact_ids: &[String]) -> Result<()>;
     async fn delete_by_corpus(&self, corpus_id: &str) -> Result<()>;
     async fn count(&self) -> Result<u64>;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -19,6 +19,12 @@ pub struct VectorPayload {
     /// know the stamp must leave the stored one alone rather than clear it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_seen_at: Option<i64>,
+    /// Set when this artifact lost a near-identical pair to a newer one. Like
+    /// `last_seen_at`, it is omitted when unset so that a writer which does not
+    /// know the value — the embed job rebuilding a payload — leaves the stored
+    /// one alone rather than reviving a hidden artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -35,11 +41,18 @@ pub struct SearchFilter {
     /// All listed tags must be present (AND, not OR).
     pub tags: Vec<String>,
     pub category: Option<String>,
+    /// Superseded artifacts are excluded by default. They are still stored and
+    /// still readable by id — keeping them out of ranking is the whole of what
+    /// superseding does.
+    pub include_superseded: bool,
 }
 
 impl SearchFilter {
+    /// Whether this filter narrows nothing. Excluding superseded points is
+    /// still a narrowing, so a filter that only does that is not empty — saying
+    /// otherwise would drop the clause on the way to Qdrant.
     pub fn is_empty(&self) -> bool {
-        self.tags.is_empty() && self.category.is_none()
+        self.tags.is_empty() && self.category.is_none() && self.include_superseded
     }
 }
 
@@ -74,6 +87,10 @@ pub trait VectorStore: Send + Sync {
     /// category changes nothing the embedding model saw, so re-embedding for it
     /// would spend an inference call to arrive at the same vector.
     async fn set_payload(&self, payload: &VectorPayload) -> Result<()>;
+    /// Hide or unhide one artifact. A payload write, not a re-embed: which
+    /// artifact won a near-identical pair changes nothing the embedding model
+    /// saw.
+    async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()>;
     /// `sparse` carries the query's BM25 terms. An empty one means the query
     /// held no indexable token, and the lexical half is skipped rather than
     /// asked to match nothing.

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1148,7 +1148,14 @@ impl VectorStore for QdrantVectors {
                 &format!("/collections/{}/points/query", self.alias),
                 Some(json!({
                     "query": { "sample": "random" },
-                    "filter": { "must": [
+                    // `must_not` for the same reason as in `build_filter`: a
+                    // point written before consolidation existed carries no
+                    // `superseded` key, and matching `false` would drop it.
+                    // Without this the forgotten list offers exactly the
+                    // duplicates the sweep just took out of search.
+                    "filter": {
+                      "must_not": [ { "key": "superseded", "match": { "value": true } } ],
+                      "must": [
                         { "key": "created_at", "range": { "lt": older_than } },
                         // Nested so this reads as AND-of-OR. A chunk written
                         // before the stamp existed has no `last_seen_at` at
@@ -1157,7 +1164,8 @@ impl VectorStore for QdrantVectors {
                             { "key": "last_seen_at", "range": { "lt": unseen_since } },
                             { "is_empty": { "key": "last_seen_at" } },
                         ] },
-                    ] },
+                      ],
+                    },
                     "limit": limit,
                     "with_payload": true,
                 })),
@@ -1209,6 +1217,11 @@ impl VectorStore for QdrantVectors {
             "query": point_uuid(artifact_id),
             "using": DENSE,
             "limit": limit + 1,
+            // A superseded artifact is out of search, so it must be out of the
+            // related pane too: it is by construction near-identical to its
+            // keeper, which means it would lead that list on every artifact it
+            // was hidden in favour of.
+            "filter": { "must_not": [ { "key": "superseded", "match": { "value": true } } ] },
             "with_payload": true,
         });
         let res: QueryResult = match self

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -164,6 +164,20 @@ fn build_filter(filter: &SearchFilter) -> Option<Value> {
     Some(body)
 }
 
+/// Qdrant's distance-matrix reply. The ids are point ids, not artifact ids,
+/// which is why `near_pairs` follows this with a payload lookup.
+#[derive(Deserialize)]
+struct MatrixPairs {
+    pairs: Vec<MatrixPair>,
+}
+
+#[derive(Deserialize)]
+struct MatrixPair {
+    a: Value,
+    b: Value,
+    score: f32,
+}
+
 /// The schema every generation is created with.
 fn collection_body(dim: usize) -> Value {
     json!({
@@ -1197,6 +1211,91 @@ impl VectorStore for QdrantVectors {
         Ok(hits)
     }
 
+    async fn near_pairs(
+        &self,
+        sample: usize,
+        per_point: usize,
+        min_score: f32,
+    ) -> Result<Vec<super::NearPair>> {
+        // Superseded points are excluded at the source. Including them would
+        // hand the sweep pairs it has already resolved, on every single run.
+        let res: MatrixPairs = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/search/matrix/pairs", self.alias),
+                Some(json!({
+                    "sample": sample,
+                    "limit": per_point,
+                    "using": DENSE,
+                    "filter": { "must_not": [
+                        { "key": "superseded", "match": { "value": true } }
+                    ] },
+                })),
+            )
+            .await?;
+
+        let mut ids: Vec<Value> = Vec::new();
+        for p in &res.pairs {
+            if p.score < min_score {
+                continue;
+            }
+            ids.push(p.a.clone());
+            ids.push(p.b.clone());
+        }
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        ids.sort_by_key(|v| v.to_string());
+        ids.dedup();
+
+        // `point_uuid` is one-way, so the artifact id has to come back from the
+        // payload. One retrieve for the whole sweep, asking for the single key
+        // rather than dragging every candidate's text across the wire.
+        let looked_up: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points", self.alias),
+                Some(json!({ "ids": ids, "with_payload": ["artifact_id"], "with_vector": false })),
+            )
+            .await?;
+        let mut by_uuid: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        if let Some(list) = looked_up.get("result").and_then(|r| r.as_array()) {
+            for p in list {
+                let (Some(id), Some(aid)) = (
+                    p.get("id"),
+                    p.get("payload")
+                        .and_then(|pl| pl.get("artifact_id"))
+                        .and_then(|v| v.as_str()),
+                ) else {
+                    continue;
+                };
+                by_uuid.insert(id.to_string(), aid.to_string());
+            }
+        }
+
+        let mut out: Vec<super::NearPair> = res
+            .pairs
+            .iter()
+            .filter(|p| p.score >= min_score)
+            .filter_map(|p| {
+                let a = by_uuid.get(&p.a.to_string())?;
+                let b = by_uuid.get(&p.b.to_string())?;
+                // A point cannot be a duplicate of itself, however the matrix
+                // reports it.
+                (a != b).then(|| super::NearPair::new(a, b, p.score))
+            })
+            .collect();
+        out.sort_by(|x, y| {
+            y.score
+                .total_cmp(&x.score)
+                .then_with(|| x.a.cmp(&y.a))
+                .then_with(|| x.b.cmp(&y.b))
+        });
+        out.dedup_by(|x, y| x.a == y.a && x.b == y.b);
+        Ok(out)
+    }
+
     async fn count(&self) -> Result<u64> {
         self.exact_count(&self.alias).await
     }
@@ -1327,6 +1426,24 @@ mod tests {
         assert_eq!(
             normalize_base("http://localhost:6333"),
             "http://localhost:6333"
+        );
+    }
+
+    #[test]
+    fn matrix_pairs_deserialise_from_qdrant_shape() {
+        let res: MatrixPairs = serde_json::from_value(json!({
+            "pairs": [ { "a": 1, "b": 2, "score": 0.97 } ]
+        }))
+        .unwrap();
+        assert_eq!(res.pairs.len(), 1);
+        assert!((res.pairs[0].score - 0.97).abs() < 1e-6);
+    }
+
+    #[test]
+    fn a_pair_is_canonically_ordered() {
+        assert_eq!(
+            super::super::NearPair::new("z", "a", 0.9),
+            super::super::NearPair::new("a", "z", 0.9)
         );
     }
 

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -352,6 +352,16 @@ struct ScrollResult {
 }
 
 #[derive(Deserialize)]
+/// The two payload keys a point write must not clobber, as currently stored.
+/// `None` means the key is absent, which for `superseded` is every point
+/// written before consolidation existed.
+#[derive(Debug, Clone, Copy, Default)]
+struct StoredBookkeeping {
+    last_seen_at: Option<i64>,
+    superseded: Option<bool>,
+}
+
+#[derive(Deserialize)]
 struct ScrolledPoint {
     id: Value,
     #[serde(default)]
@@ -601,17 +611,21 @@ impl QdrantVectors {
         Ok(res.count)
     }
 
-    /// The `last_seen_at` already stored for these chunks, for the points that
-    /// have one. Only asked for when a caller is about to overwrite payloads it
-    /// built without the stamp, and only for the one key, so this is a small
-    /// read next to the write it protects.
-    async fn stored_last_seen(
+    /// The bookkeeping keys already stored for these chunks: when the chunk was
+    /// last shown, and whether consolidation has hidden it.
+    ///
+    /// Both are written by code that knows nothing about the other — `touch`
+    /// sets one, the sweep sets the other, and the embed job rebuilding a
+    /// payload knows neither. Only asked for when a caller is about to
+    /// overwrite payloads it built without them, and only for those two keys,
+    /// so this is a small read next to the write it protects.
+    async fn stored_bookkeeping(
         &self,
         points: &[VectorPoint],
-    ) -> Result<std::collections::HashMap<String, i64>> {
+    ) -> Result<std::collections::HashMap<String, StoredBookkeeping>> {
         let wanted: Vec<&VectorPoint> = points
             .iter()
-            .filter(|p| p.payload.last_seen_at.is_none())
+            .filter(|p| p.payload.last_seen_at.is_none() || p.payload.superseded.is_none())
             .collect();
         if wanted.is_empty() {
             return Ok(Default::default());
@@ -632,7 +646,7 @@ impl QdrantVectors {
                 &format!("/collections/{}/points", self.alias),
                 Some(json!({
                     "ids": ids,
-                    "with_payload": ["last_seen_at"],
+                    "with_payload": ["last_seen_at", "superseded"],
                     "with_vector": false,
                 })),
             )
@@ -644,9 +658,13 @@ impl QdrantVectors {
             let Some(artifact_id) = by_uuid.get(uuid) else {
                 continue;
             };
-            if let Some(seen) = p.payload.get("last_seen_at").and_then(Value::as_i64) {
-                out.insert((*artifact_id).to_string(), seen);
-            }
+            out.insert(
+                (*artifact_id).to_string(),
+                StoredBookkeeping {
+                    last_seen_at: p.payload.get("last_seen_at").and_then(Value::as_i64),
+                    superseded: p.payload.get("superseded").and_then(Value::as_bool),
+                },
+            );
         }
         Ok(out)
     }
@@ -959,14 +977,20 @@ impl VectorStore for QdrantVectors {
         // A point write replaces the whole payload, unlike `set_payload` and
         // `touch`, which merge. A writer that does not know when the chunk was
         // last shown would therefore clear the stamp, and `resurface` would
-        // offer a chunk read yesterday as forgotten — so carry the stored one
-        // forward for every point that arrives without it.
-        let stored = self.stored_last_seen(&points).await?;
+        // offer a chunk read yesterday as forgotten. The same hazard applies to
+        // `superseded`, and costs more: clearing it puts an artifact the sweep
+        // hid straight back into results, on every re-embed. So carry both
+        // forward for every point that arrives without them.
+        let stored = self.stored_bookkeeping(&points).await?;
         let mut body = Vec::with_capacity(points.len());
         for p in points {
             let mut payload = p.payload.clone();
+            let old = stored.get(&payload.artifact_id);
             if payload.last_seen_at.is_none() {
-                payload.last_seen_at = stored.get(&payload.artifact_id).copied();
+                payload.last_seen_at = old.and_then(|s| s.last_seen_at);
+            }
+            if payload.superseded.is_none() {
+                payload.superseded = old.and_then(|s| s.superseded);
             }
             let payload =
                 serde_json::to_value(&payload).map_err(|e| Error::Vector(e.to_string()))?;
@@ -1234,24 +1258,33 @@ impl VectorStore for QdrantVectors {
             )
             .await?;
 
-        let mut ids: Vec<Value> = Vec::new();
+        let mut ids: Vec<&str> = Vec::new();
         for p in &res.pairs {
             if p.score < min_score {
                 continue;
             }
-            ids.push(p.a.clone());
-            ids.push(p.b.clone());
+            // Ids come back as JSON strings for UUID points. Anything else is a
+            // point this collection did not get from engram.
+            let (Some(a), Some(b)) = (p.a.as_str(), p.b.as_str()) else {
+                continue;
+            };
+            ids.push(a);
+            ids.push(b);
         }
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        ids.sort_by_key(|v| v.to_string());
+        ids.sort_unstable();
         ids.dedup();
 
         // `point_uuid` is one-way, so the artifact id has to come back from the
         // payload. One retrieve for the whole sweep, asking for the single key
         // rather than dragging every candidate's text across the wire.
-        let looked_up: Value = self
+        //
+        // `call` already unwraps the `result` envelope, so this deserializes
+        // straight into the point list — reaching for `result` again here is
+        // what made every lookup miss and the sweep return nothing at all.
+        let found: Vec<ScrolledPoint> = self
             .call(
                 Method::POST,
                 &format!("/collections/{}/points", self.alias),
@@ -1260,18 +1293,14 @@ impl VectorStore for QdrantVectors {
             .await?;
         let mut by_uuid: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
-        if let Some(list) = looked_up.get("result").and_then(|r| r.as_array()) {
-            for p in list {
-                let (Some(id), Some(aid)) = (
-                    p.get("id"),
-                    p.get("payload")
-                        .and_then(|pl| pl.get("artifact_id"))
-                        .and_then(|v| v.as_str()),
-                ) else {
-                    continue;
-                };
-                by_uuid.insert(id.to_string(), aid.to_string());
-            }
+        for p in &found {
+            let (Some(uuid), Some(aid)) = (
+                p.id.as_str(),
+                p.payload.get("artifact_id").and_then(Value::as_str),
+            ) else {
+                continue;
+            };
+            by_uuid.insert(uuid.to_string(), aid.to_string());
         }
 
         let mut out: Vec<super::NearPair> = res
@@ -1279,10 +1308,12 @@ impl VectorStore for QdrantVectors {
             .iter()
             .filter(|p| p.score >= min_score)
             .filter_map(|p| {
-                let a = by_uuid.get(&p.a.to_string())?;
-                let b = by_uuid.get(&p.b.to_string())?;
+                let a = by_uuid.get(p.a.as_str()?)?;
+                let b = by_uuid.get(p.b.as_str()?)?;
                 // A point cannot be a duplicate of itself, however the matrix
-                // reports it.
+                // reports it. The matrix also reports (a,b) and (b,a) as
+                // separate rows, which `NearPair::new` plus the dedup below
+                // collapse into one.
                 (a != b).then(|| super::NearPair::new(a, b, p.score))
             })
             .collect();

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -147,7 +147,21 @@ fn build_filter(filter: &SearchFilter) -> Option<Value> {
     if let Some(c) = &filter.category {
         must.push(json!({ "key": "category", "match": { "value": c } }));
     }
-    Some(json!({ "must": must }))
+
+    // `must` is omitted rather than sent empty. A search that only excludes
+    // superseded points has no positive condition, and an empty condition list
+    // is not something to hand Qdrant and hope it reads as "no constraint".
+    let mut body = json!({});
+    if !must.is_empty() {
+        body["must"] = json!(must);
+    }
+    // Excluded with `must_not` rather than by matching `false`: a point written
+    // before consolidation existed carries no `superseded` key at all, and a
+    // `match: false` clause would drop every one of them from search.
+    if !filter.include_superseded {
+        body["must_not"] = json!([{ "key": "superseded", "match": { "value": true } }]);
+    }
+    Some(body)
 }
 
 /// The schema every generation is created with.
@@ -970,6 +984,20 @@ impl VectorStore for QdrantVectors {
         Ok(())
     }
 
+    async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()> {
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/payload?wait=true", self.alias),
+                Some(json!({
+                    "payload": { "superseded": superseded },
+                    "points": [ point_uuid(artifact_id) ],
+                })),
+            )
+            .await?;
+        Ok(())
+    }
+
     async fn search(
         &self,
         vector: &[f32],
@@ -1303,10 +1331,32 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_filter_produces_no_filter_at_all() {
-        // `{"must": []}` matches nothing in Qdrant, so an unfiltered search
-        // must omit the key rather than send an empty condition list.
-        assert!(build_filter(&SearchFilter::default()).is_none());
+    fn a_filter_that_narrows_nothing_produces_no_filter_at_all() {
+        // `{"must": []}` matches nothing in Qdrant, so a search that narrows
+        // nothing must omit the key rather than send an empty condition list.
+        // Asking for superseded points back is what "narrows nothing" means now.
+        assert!(
+            build_filter(&SearchFilter {
+                include_superseded: true,
+                ..Default::default()
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn the_default_filter_excludes_superseded_points() {
+        // The default is what every ordinary search sends, and superseding is
+        // only meaningful if it keeps an artifact out of that.
+        let f = build_filter(&SearchFilter::default()).unwrap();
+        assert!(
+            f.get("must").is_none(),
+            "an empty condition list must not be sent: {f}"
+        );
+        assert_eq!(
+            f["must_not"],
+            json!([{ "key": "superseded", "match": { "value": true } }]),
+        );
     }
 
     #[test]
@@ -1316,6 +1366,7 @@ mod tests {
         let f = build_filter(&SearchFilter {
             tags: vec!["linux".into(), "forensics".into()],
             category: Some("procedure".into()),
+            include_superseded: false,
         })
         .unwrap();
         let must = f["must"].as_array().unwrap();

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -203,6 +203,24 @@ async fn reprocess(
 }
 
 #[derive(serde::Deserialize)]
+struct ResolveBody {
+    action: crate::core::ingest::NearDupeAction,
+}
+
+/// Act on a capture parked as a near-duplicate. The decision is an operator's:
+/// nothing here compares the two documents again, it only carries out what was
+/// chosen.
+async fn resolve_near_dupe(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(cid): Path<String>,
+    Json(body): Json<ResolveBody>,
+) -> Result<Json<serde_json::Value>> {
+    st.core.resolve_near_duplicate(&cid, body.action).await?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+#[derive(serde::Deserialize)]
 pub struct SearchParams {
     pub q: String,
     pub limit: Option<usize>,
@@ -393,6 +411,7 @@ pub fn api_router() -> Router<AppState> {
         .route("/corpora", post(ingest).get(list_corpora))
         .route("/corpora/{id}", get(get_corpus).delete(delete_corpus))
         .route("/corpora/{id}/reprocess", post(reprocess))
+        .route("/corpora/{id}/resolve", post(resolve_near_dupe))
         .route("/search", get(search))
         .route("/ask", post(ask))
         .route("/resurface", get(resurface))
@@ -521,6 +540,51 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn a_parked_capture_is_resolved_over_the_api() {
+        let (app, token, core) = app_token_and_core().await;
+        let body: String = (0..200)
+            .map(|i| format!("step {i}: run the mount command and read its output"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        core.ingest(&body, "web", None).await.unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
+        let second = core
+            .ingest(&body.replacen("step 7:", "step seven:", 1), "web", None)
+            .await
+            .unwrap();
+        assert!(second.near_duplicate.is_some());
+
+        let res = app
+            .oneshot(post_json(
+                &format!("/api/v1/corpora/{}/resolve", second.id),
+                &token,
+                serde_json::json!({ "action": "keep_both" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            core.store.get_corpus(&second.id).await.unwrap().status,
+            crate::store::corpora::CorpusStatus::Raw
+        );
+    }
+
+    #[tokio::test]
+    async fn resolving_a_corpus_that_is_not_parked_is_a_bad_request() {
+        let (app, token, core) = app_token_and_core().await;
+        let out = core.ingest("plain text", "web", None).await.unwrap();
+        let res = app
+            .oneshot(post_json(
+                &format!("/api/v1/corpora/{}/resolve", out.id),
+                &token,
+                serde_json::json!({ "action": "discard" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -225,12 +225,22 @@ async fn consolidation(
     State(st): State<AppState>,
     _id: Identity,
 ) -> Result<Json<serde_json::Value>> {
+    use crate::store::pairs::PairState;
     Ok(Json(serde_json::json!({
         "superseded": st.core.store.superseded_artifacts(100).await?,
+        // What the judge actually ruled on, listed first for the same reason
+        // Ops puts it at the top: it is the one output here that cost a model
+        // call, and an operator reading only `pairs` would conclude there was
+        // nothing to look at.
+        "contradictions": st
+            .core
+            .store
+            .pairs_by_state(PairState::Contradiction, 100)
+            .await?,
         "pairs": st
             .core
             .store
-            .pairs_by_state(crate::store::pairs::PairState::Pending, 100)
+            .pairs_by_state(PairState::Pending, 100)
             .await?,
     })))
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -786,6 +786,7 @@ mod patch_tests {
                     category: Some("concept".into()),
                     tags: vec!["old".into()],
                     segment_idx: None,
+                    caveats: vec![],
                 }],
             )
             .await

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -361,6 +361,7 @@ async fn patch_artifact(
                 tags: chunk.tags.clone(),
                 created_at: chunk.created_at,
                 last_seen_at: None,
+                superseded: None,
             })
             .await?;
     }
@@ -815,6 +816,7 @@ mod patch_tests {
                 &SearchFilter {
                     tags: vec!["fresh".into()],
                     category: None,
+                    include_superseded: false,
                 },
             )
             .await

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -394,6 +394,10 @@ async fn delete_artifact(
         .delete_artifacts(std::slice::from_ref(&cid))
         .await?;
     st.core.store.delete_artifact(&cid).await?;
+    // This artifact may have been the reason another one is hidden, and a
+    // keeper that no longer exists leaves its loser out of search in favour of
+    // nothing. Deleting a whole corpus heals for the same reason.
+    st.core.heal_dangling_supersessions().await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -767,7 +771,8 @@ mod patch_tests {
     use super::tests::*;
     use crate::store::artifacts::{EmbedState, NewArtifact};
     use crate::vector::SearchFilter;
-    use axum::http::StatusCode;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
     /// One embedded chunk, and the app that can edit it.
@@ -1017,6 +1022,64 @@ mod patch_tests {
         .await
         .unwrap();
         assert_eq!(core.store.get_artifact(&cid).await.unwrap().title, None);
+    }
+
+    #[tokio::test]
+    async fn deleting_an_artifact_frees_whatever_it_was_hiding() {
+        // Deleting a corpus heals for this reason; deleting one artifact left
+        // its loser hidden in favour of an id that no longer exists until the
+        // next sweep — which is never, with `consolidate.enabled = false`.
+        let (app, token, core, keeper) = one_artifact().await;
+        let src = core
+            .store
+            .insert_corpus("other", "web", None)
+            .await
+            .unwrap();
+        let hidden = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "the older copy".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        core.store
+            .set_superseded_by(&hidden, Some(&keeper))
+            .await
+            .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/artifacts/{keeper}"))
+                    .method("DELETE")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        assert!(
+            core.store
+                .get_artifact(&hidden)
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "the artifact is still hidden in favour of a deleted one"
+        );
     }
 
     #[tokio::test]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -220,6 +220,21 @@ async fn resolve_near_dupe(
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
+/// What consolidation has decided and what it is still asking about.
+async fn consolidation(
+    State(st): State<AppState>,
+    _id: Identity,
+) -> Result<Json<serde_json::Value>> {
+    Ok(Json(serde_json::json!({
+        "superseded": st.core.store.superseded_artifacts(100).await?,
+        "pairs": st
+            .core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 100)
+            .await?,
+    })))
+}
+
 #[derive(serde::Deserialize)]
 pub struct SearchParams {
     pub q: String,
@@ -416,6 +431,7 @@ pub fn api_router() -> Router<AppState> {
         .route("/search", get(search))
         .route("/ask", post(ask))
         .route("/resurface", get(resurface))
+        .route("/consolidation", get(consolidation))
         .route(
             "/artifacts/{id}",
             get(get_artifact)

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -7,6 +7,10 @@ pub mod state;
 pub mod ui;
 
 use axum::Router;
+use axum::extract::Request;
+use axum::http::{Method, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::get;
 use state::AppState;
 
@@ -17,6 +21,32 @@ use state::AppState;
 /// that a runaway upload is refused rather than buffered.
 pub const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
 
+/// A browser landing on a page it has no session for should end up in front
+/// of the identity provider, not staring at `{"error":"unauthorized"}` with
+/// no way to act on it. That includes a path nothing handles: no route in
+/// this router answers `/`, so an unauthenticated visit to the bare domain
+/// falls through to the same rejection as an expired-session page load, and
+/// both should end the same way.
+///
+/// API tokens and the MCP endpoint need the real status code — a script
+/// cannot follow a redirect into an interactive OIDC login — so this only
+/// rewrites a plain page load: a GET outside `/api` and `/mcp`, and not an
+/// htmx fetch, which always carries `HX-Request` and expects a fragment or a
+/// real error, never a full-page redirect.
+async fn redirect_unauthenticated_browsers(req: Request, next: Next) -> Response {
+    let path = req.uri().path().to_string();
+    let is_page_load = req.method() == Method::GET
+        && !req.headers().contains_key("hx-request")
+        && !path.starts_with("/api/")
+        && path != "/mcp";
+
+    let res = next.run(req).await;
+    if is_page_load && res.status() == StatusCode::UNAUTHORIZED {
+        return Redirect::to("/auth/login?go=1").into_response();
+    }
+    res
+}
+
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
@@ -25,6 +55,7 @@ pub fn router(state: AppState) -> Router {
         .merge(ui::ui_router())
         .merge(crate::mcp::mcp_router(state.clone()))
         .nest("/api/v1", api::api_router())
+        .layer(axum::middleware::from_fn(redirect_unauthenticated_browsers))
         .layer(axum::extract::DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .with_state(state)

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -3,6 +3,22 @@
     <a href="/ui/corpora/{{ d.corpus_id }}">source</a> · {{ d.slice_label }}
   </div>
 
+  {% if let Some(winner) = d.superseded_by %}
+  <div class="flag" role="status">
+    <div aria-hidden="true">⚠</div>
+    <div>
+      <b>Hidden from results</b>
+      <div>Something near-identical and newer
+        (<a href="/ui/artifacts/{{ winner }}">this one</a>) was kept instead.</div>
+      <div class="chips">
+        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/unsupersede">
+          <button class="btn btn-sm" type="submit">Put it back</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   {% if !d.flags.is_empty() %}
   <div class="flag" role="status">
     <div aria-hidden="true">⚠</div>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -44,6 +44,14 @@
       <div class="card">
         <div class="card-head"><span class="card-title">{{ d.title }}</span></div>
         <div class="md clampable" data-copyable>{{ d.html|safe }}</div>
+        {% if !d.caveats.is_empty() %}
+        {# Emitted by the same synthesis call that wrote the artifact, from what
+           the source states. Shown but deliberately not embedded. #}
+        <div class="caveats">
+          <b>Before you rely on this</b>
+          <ul>{% for c in d.caveats %}<li>{{ c }}</li>{% endfor %}</ul>
+        </div>
+        {% endif %}
         <div class="chips">
           {% if let Some(c) = d.category %}<span class="badge badge-accent">{{ c }}</span>{% endif %}
           {% for t in d.tags %}<span class="badge">{{ t }}</span>{% endfor %}

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -26,11 +26,6 @@
       <b>{{ d.flags|join(", ") }}</b>
       {% if let Some(detail) = d.flag_detail %}<div class="mono">{{ detail }}</div>{% endif %}
       <div class="chips">
-        {% if let Some(w) = d.segment_idx %}
-        <form method="post" action="/ui/corpora/{{ d.corpus_id }}/segments/{{ w }}/resynthesize">
-          <button class="btn btn-sm" type="submit">Re-synthesize segment</button>
-        </form>
-        {% endif %}
         <button class="btn btn-sm" hx-post="/ui/artifacts/{{ d.id }}/reviewed"
                 hx-target="closest .flag" hx-swap="outerHTML">Mark reviewed</button>
       </div>

--- a/src/web/templates/_captured.html
+++ b/src/web/templates/_captured.html
@@ -3,8 +3,17 @@
     <span class="card-title">Captured</span>
     <span class="card-meta">
       {% if duplicate %}<span class="badge badge-muted">already stored</span>
+      {% else if near_dupe_of.is_some() %}<span class="badge badge-muted">waiting on a decision</span>
       {% else %}<span class="badge badge-accent">processing</span>{% endif %}
     </span>
   </div>
+  {% if let Some(other) = near_dupe_of %}
+  <p class="muted">
+    This looks {{ near_dupe_percent }}% like
+    <a href="/ui/corpora/{{ other }}">an existing source</a>, so it is stored but
+    not processed until someone decides between them.
+    <a href="/ui/ops">Decide on Ops</a>.
+  </p>
+  {% endif %}
   <a href="/ui/corpora/{{ id }}">View source</a>
 </div>

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -12,6 +12,60 @@
   <span class="badge badge-muted">vectors: {{ vector_count }}</span>
 </div>
 
+<h3>Pairs worth a look</h3>
+{% if pairs.is_empty() %}
+  <p class="muted">None.</p>
+{% else %}
+<p class="muted">
+  Two artifacts covering the same ground. Which one is current is a judgement
+  only you can make, so nothing here has been changed.
+</p>
+<table class="grid">
+  <thead><tr><th>Match</th><th>One</th><th>The other</th><th>Finding</th><th></th></tr></thead>
+  <tbody>
+  {% for p in pairs %}
+    <tr>
+      <td class="mono">
+        {{ p.percent }}%
+        {% if p.contradiction %}<span class="badge badge-warning">disagrees</span>{% endif %}
+      </td>
+      <td><a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a></td>
+      <td><a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a></td>
+      <td class="muted">{% if let Some(d) = p.detail %}{{ d }}{% else %}—{% endif %}</td>
+      <td>
+        <form method="post" action="/ui/ops/pairs/{{ p.id }}/dismiss">
+          <button class="btn btn-sm" type="submit">Dismiss</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+<h3>Hidden as near-identical</h3>
+{% if superseded.is_empty() %}
+  <p class="muted">None.</p>
+{% else %}
+<p class="muted">Still stored and still readable; kept out of results only.</p>
+<table class="grid">
+  <thead><tr><th>Hidden</th><th>Kept</th><th></th></tr></thead>
+  <tbody>
+  {% for s in superseded %}
+    <tr>
+      <td><a href="/ui/artifacts/{{ s.id }}">{{ s.title }}</a></td>
+      <td><a href="/ui/artifacts/{{ s.winner_id }}">{{ s.winner_title }}</a></td>
+      <td>
+        <form method="post" action="/ui/ops/artifacts/{{ s.id }}/unsupersede">
+          <button class="btn btn-sm" type="submit">Put it back</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 <h3>Captures waiting on a decision</h3>
 {% if parked.is_empty() %}
   <p class="muted">None.</p>

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -98,48 +98,21 @@
 </table>
 {% endif %}
 
-<h3>Failed jobs</h3>
-{% if failed.is_empty() %}
-  <p class="muted">None.</p>
+<h3>Retrying</h3>
+{% if retrying.is_empty() %}
+  <p class="muted">Nothing is stuck.</p>
 {% else %}
+<p class="muted">Work that hit something and is waiting to try again. Nothing here needs you.</p>
 <table class="grid">
-  <thead><tr><th>Stage</th><th>Target</th><th>Attempts</th><th>Error</th><th></th></tr></thead>
+  <thead><tr><th>Stage</th><th>Target</th><th>Attempts</th><th>Next</th><th>Last error</th></tr></thead>
   <tbody>
-  {% for f in failed %}
+  {% for j in retrying %}
     <tr>
-      <td class="mono">{{ f.stage }}</td>
-      <td class="mono">{{ f.target_id }}</td>
-      <td class="mono">{{ f.attempts }}</td>
-      <td class="muted">{% if let Some(e) = f.last_error %}{{ e }}{% else %}—{% endif %}</td>
-      <td>
-        <form method="post" action="/ui/ops/jobs/{{ f.id }}/retry">
-          <button class="btn btn-sm" type="submit">Retry</button>
-        </form>
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-{% endif %}
-
-<h3>Needs review</h3>
-{% if flagged.is_empty() %}
-  <p class="muted">Nothing flagged. Every artifact reproduced its corpus.</p>
-{% else %}
-<table class="grid">
-  <thead><tr><th>Artifact</th><th>Problem</th><th></th></tr></thead>
-  <tbody>
-  {% for f in flagged %}
-    <tr>
-      <td><a href="/ui/artifacts/{{ f.artifact_id }}">{{ f.title }}</a></td>
-      <td class="mono muted">{{ f.detail }}</td>
-      <td>
-        {% if let Some(w) = f.segment_idx %}
-        <form method="post" action="/ui/corpora/{{ f.corpus_id }}/segments/{{ w }}/resynthesize">
-          <button class="btn btn-sm" type="submit">Re-synthesize segment</button>
-        </form>
-        {% endif %}
-      </td>
+      <td class="mono">{{ j.stage }}</td>
+      <td class="mono">{{ j.target_id }}</td>
+      <td class="mono">{{ j.attempts }}</td>
+      <td class="mono">{{ j.due }}</td>
+      <td class="muted">{{ j.last_error }}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -12,6 +12,38 @@
   <span class="badge badge-muted">vectors: {{ vector_count }}</span>
 </div>
 
+<h3>Captures waiting on a decision</h3>
+{% if parked.is_empty() %}
+  <p class="muted">None.</p>
+{% else %}
+<p class="muted">
+  Stored but not synthesised: each looks like a document already in the base.
+  Nothing is spent on them until you choose.
+</p>
+<table class="grid">
+  <thead><tr><th>Capture</th><th>Looks like</th><th>Match</th><th></th></tr></thead>
+  <tbody>
+  {% for p in parked %}
+    <tr>
+      <td>
+        <a href="/ui/corpora/{{ p.id }}">{{ p.title }}</a>
+        <span class="muted mono">{{ p.bytes }} B</span>
+      </td>
+      <td><a href="/ui/corpora/{{ p.other_id }}">{{ p.other_title }}</a></td>
+      <td class="mono">{{ p.percent }}%</td>
+      <td>
+        <form method="post" action="/ui/ops/corpora/{{ p.id }}/resolve" class="row" style="gap:0.25rem">
+          <button class="btn btn-sm" type="submit" name="action" value="replace">Replace the old one</button>
+          <button class="btn btn-sm" type="submit" name="action" value="keep_both">Keep both</button>
+          <button class="btn btn-sm" type="submit" name="action" value="discard">Discard this</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 <h3>Failed jobs</h3>
 {% if failed.is_empty() %}
   <p class="muted">None.</p>

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -112,6 +112,9 @@ pub fn status_badge(status: &crate::store::corpora::CorpusStatus) -> &'static st
         Ready => "badge-success",
         Partial => "badge-warning",
         Failed => "badge-danger",
+        // A parked capture is waiting on a person, not on a worker. It reads as
+        // a warning because nothing will advance it on its own.
+        NeedsReview => "badge-warning",
         Raw | Segmenting | Segmented | Embedding => "badge-accent",
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -58,8 +58,7 @@ pub struct ArtifactView {
     pub embed_badge: &'static str,
 }
 
-/// A chunk beside the source lines it claims — the search pane, and the
-/// review surface for anything verification flagged.
+/// A chunk beside the source lines it claims.
 pub struct ArtifactDetail {
     pub id: String,
     pub title: String,

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -215,6 +215,11 @@ struct CaptureTemplate {
 struct CapturedTemplate {
     id: String,
     duplicate: bool,
+    /// Set when the capture was parked as a near-duplicate. Without it the page
+    /// says "processing" for a capture that nothing will ever process, and the
+    /// only hint is a queue on Ops the writer has no reason to open.
+    near_dupe_of: Option<String>,
+    near_dupe_percent: i64,
 }
 
 #[derive(Template)]
@@ -340,6 +345,12 @@ async fn capture_submit(
     Ok(HtmlTemplate(CapturedTemplate {
         id: out.id,
         duplicate: out.duplicate,
+        near_dupe_percent: out
+            .near_duplicate
+            .as_ref()
+            .map(|n| (n.similarity * 100.0).round() as i64)
+            .unwrap_or(0),
+        near_dupe_of: out.near_duplicate.map(|n| n.corpus_id),
     })
     .into_response())
 }
@@ -1469,6 +1480,39 @@ mod tests {
                 "POST {uri} was unprotected"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn a_parked_capture_says_so_instead_of_claiming_it_is_processing() {
+        // The confirmation is the only page the writer sees. Telling them a
+        // parked capture is "processing" means it silently never is.
+        let (app, cookie, core) = app_session_and_core().await;
+        let body: String = (0..200)
+            .map(|i| format!("step {i} run the mount command and read its output"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        core.ingest(&body, "web", None).await.unwrap();
+
+        // Hand-encoded rather than pulling in a dependency: the body is plain
+        // words, so spaces and newlines are all there is to escape.
+        let edited = body
+            .replacen("step 7 ", "step seven ", 1)
+            .replace(' ', "+")
+            .replace('\n', "%0A");
+        let res = app
+            .oneshot(form("/ui/capture", &cookie, &format!("text={edited}")))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = flat(&body_of(res).await);
+        assert!(
+            html.contains("waiting on a decision"),
+            "the parked capture rendered as an ordinary one: {html}"
+        );
+        assert!(
+            !html.contains("badge-accent\">processing"),
+            "a parked capture must not claim to be processing: {html}"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -72,6 +72,8 @@ pub struct ArtifactDetail {
     /// The artifact this one was hidden in favour of. Opening a hidden artifact
     /// by link has to say why it is not in results, or it reads as a bug.
     pub superseded_by: Option<String>,
+    /// Conditions the source stated under which this artifact does not apply.
+    pub caveats: Vec<String>,
     pub corpus_id: String,
     pub segment_idx: Option<i64>,
     pub slice_label: String,
@@ -887,6 +889,7 @@ pub(crate) async fn build_artifact_detail(
         flags: c.flags,
         flag_detail: c.flag_detail,
         superseded_by: c.superseded_by,
+        caveats: c.caveats,
         corpus_id: c.corpus_id,
         segment_idx: c.segment_idx,
         slice_label: slice.label,
@@ -1722,6 +1725,7 @@ mod tests {
                 category: None,
                 tags: vec![],
                 segment_idx: None,
+                caveats: vec![],
             })
             .collect();
         core.store

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -69,6 +69,9 @@ pub struct ArtifactDetail {
     pub tags: Vec<String>,
     pub flags: Vec<String>,
     pub flag_detail: Option<String>,
+    /// The artifact this one was hidden in favour of. Opening a hidden artifact
+    /// by link has to say why it is not in results, or it reads as a bug.
+    pub superseded_by: Option<String>,
     pub corpus_id: String,
     pub segment_idx: Option<i64>,
     pub slice_label: String,
@@ -107,6 +110,26 @@ pub struct ParkedRow {
     pub other_id: String,
     pub other_title: String,
     pub percent: i64,
+}
+
+/// An artifact the sweep hid, with the one it lost to.
+pub struct SupersededRow {
+    pub id: String,
+    pub title: String,
+    pub winner_id: String,
+    pub winner_title: String,
+}
+
+/// A pair waiting on a person.
+pub struct PairRow {
+    pub id: i64,
+    pub percent: i64,
+    pub a_id: String,
+    pub a_title: String,
+    pub b_id: String,
+    pub b_title: String,
+    pub detail: Option<String>,
+    pub contradiction: bool,
 }
 
 pub struct TokenRow {
@@ -265,6 +288,8 @@ struct OpsTemplate {
     failed: Vec<crate::store::jobs::FailedJob>,
     flagged: Vec<FlaggedRow>,
     parked: Vec<ParkedRow>,
+    superseded: Vec<SupersededRow>,
+    pairs: Vec<PairRow>,
     tokens: Vec<TokenRow>,
 }
 
@@ -631,10 +656,62 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         });
     }
 
+    // A title is what makes two near-identical artifacts tellable apart at a
+    // glance; falling back to the opening of the body beats an id.
+    let title_of = |c: &crate::store::artifacts::Chunk| {
+        c.title
+            .clone()
+            .unwrap_or_else(|| c.text.chars().take(60).collect())
+    };
+
+    let mut superseded = Vec::new();
+    for c in st.core.store.superseded_artifacts(50).await? {
+        let winner_id = c.superseded_by.clone().unwrap_or_default();
+        let winner_title = match st.core.store.get_artifact(&winner_id).await {
+            Ok(w) => title_of(&w),
+            Err(_) => "(deleted)".to_string(),
+        };
+        superseded.push(SupersededRow {
+            title: title_of(&c),
+            id: c.id,
+            winner_id,
+            winner_title,
+        });
+    }
+
+    // Confirmed contradictions lead: they are the ones that mean something in
+    // the base is wrong rather than merely repeated.
+    let mut pairs = Vec::new();
+    for state in [
+        crate::store::pairs::PairState::Contradiction,
+        crate::store::pairs::PairState::Pending,
+    ] {
+        for p in st.core.store.pairs_by_state(state, 50).await? {
+            let (Ok(a), Ok(b)) = (
+                st.core.store.get_artifact(&p.a_id).await,
+                st.core.store.get_artifact(&p.b_id).await,
+            ) else {
+                continue;
+            };
+            pairs.push(PairRow {
+                id: p.id,
+                percent: (p.score * 100.0).round() as i64,
+                a_title: title_of(&a),
+                b_title: title_of(&b),
+                a_id: p.a_id,
+                b_id: p.b_id,
+                detail: p.detail,
+                contradiction: state == crate::store::pairs::PairState::Contradiction,
+            });
+        }
+    }
+
     Ok(HtmlTemplate(OpsTemplate {
         theme: "light".into(),
         flagged,
         parked,
+        superseded,
+        pairs,
         job_counts: st.core.store.job_counts().await?,
         oldest_pending_secs: st.core.store.oldest_pending_age().await?,
         artifact_count,
@@ -702,6 +779,27 @@ async fn resolve_near_dupe_ui(
     Form(form): Form<ResolveForm>,
 ) -> Result<Response> {
     st.core.resolve_near_duplicate(&cid, form.action).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+async fn unsupersede_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(aid): Path<String>,
+) -> Result<Response> {
+    st.core.unsupersede(&aid).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+async fn dismiss_pair_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(pid): Path<i64>,
+) -> Result<Response> {
+    st.core
+        .store
+        .set_pair_state(pid, crate::store::pairs::PairState::Dismissed, None)
+        .await?;
     Ok(Redirect::to("/ui/ops").into_response())
 }
 
@@ -788,6 +886,7 @@ pub(crate) async fn build_artifact_detail(
         tags: c.tags,
         flags: c.flags,
         flag_detail: c.flag_detail,
+        superseded_by: c.superseded_by,
         corpus_id: c.corpus_id,
         segment_idx: c.segment_idx,
         slice_label: slice.label,
@@ -881,6 +980,8 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/ops/tokens/{id}/revoke", post(revoke_token_ui))
         .route("/ui/ops/jobs/{id}/retry", post(retry_job))
         .route("/ui/ops/corpora/{id}/resolve", post(resolve_near_dupe_ui))
+        .route("/ui/ops/artifacts/{id}/unsupersede", post(unsupersede_ui))
+        .route("/ui/ops/pairs/{id}/dismiss", post(dismiss_pair_ui))
 }
 
 #[cfg(test)]
@@ -1030,12 +1131,18 @@ mod tests {
     }
 
     async fn app_with_session() -> (axum::Router, String) {
+        let (app, cookie, _core) = app_session_and_core().await;
+        (app, cookie)
+    }
+
+    async fn app_session_and_core() -> (axum::Router, String, crate::core::Core) {
         let core = crate::core::test_support::test_core().await;
         let cid = crate::store::new_id();
         core.store
             .insert_session(&cid, "user-1", None, 3600)
             .await
             .unwrap();
+        let handle = core.clone();
         let state = crate::web::state::AppState {
             core,
             auth: std::sync::Arc::new(crate::web::state::AuthContext {
@@ -1046,7 +1153,11 @@ mod tests {
                 secure_cookies: false,
             }),
         };
-        (crate::web::router(state), format!("engram_session={cid}"))
+        (
+            crate::web::router(state),
+            format!("engram_session={cid}"),
+            handle,
+        )
     }
 
     async fn body_of(res: axum::response::Response) -> String {
@@ -1594,6 +1705,120 @@ mod tests {
         let html = body_of(res).await;
         assert!(html.contains("Queue"));
         assert!(html.contains("API tokens"));
+    }
+
+    /// One corpus with `n` artifacts, titled so the ops page can be searched
+    /// for them.
+    async fn artifacts(core: &crate::core::Core, titles: &[&str]) -> Vec<String> {
+        let src = core.store.insert_corpus("x", "web", None).await.unwrap();
+        let new: Vec<crate::store::artifacts::NewArtifact> = titles
+            .iter()
+            .enumerate()
+            .map(|(i, t)| crate::store::artifacts::NewArtifact {
+                ordinal: i as i64,
+                text: format!("body of {t}"),
+                corpus_span: None,
+                title: Some((*t).to_string()),
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+            })
+            .collect();
+        core.store
+            .insert_artifacts(&src.id, &new)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn ops_lists_a_superseded_artifact_and_can_undo_it() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["the loser", "the keeper"]).await;
+        core.store
+            .set_superseded_by(&ids[0], Some(&ids[1]))
+            .await
+            .unwrap();
+
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/ops")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(
+            html.contains("the loser") && html.contains("the keeper"),
+            "the superseded artifact is not listed"
+        );
+
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/ops/artifacts/{}/unsupersede", ids[0]),
+                &cookie,
+                "",
+            ))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "undo did not clear the flag"
+        );
+    }
+
+    #[tokio::test]
+    async fn ops_lists_a_pending_pair_and_can_dismiss_it() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["left one", "right one"]).await;
+        core.store.record_pair(&ids[0], &ids[1], 0.9).await.unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/ops")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(html.contains("left one") && html.contains("right one"));
+
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/ops/pairs/{}/dismiss", pair.id),
+                &cookie,
+                "",
+            ))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1405,6 +1405,10 @@ mod tests {
             "/ui/ask",
             "/ui/ops",
         ] {
+            // A plain GET is a browser loading a page, so a missing session
+            // sends it to sign in rather than showing it JSON it cannot act
+            // on. `redirect_unauthenticated_browsers` (web/mod.rs) is what
+            // rewrites the 401 into this.
             let res = app
                 .clone()
                 .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
@@ -1412,8 +1416,13 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 res.status(),
-                StatusCode::UNAUTHORIZED,
+                StatusCode::SEE_OTHER,
                 "{uri} was unprotected"
+            );
+            assert_eq!(
+                res.headers().get("location").unwrap(),
+                "/auth/login?go=1",
+                "{uri} did not send an unauthenticated page load to sign in"
             );
         }
         for uri in [

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -94,13 +94,13 @@ pub struct RelatedArtifact {
     pub snippet: String,
 }
 
-/// A chunk verification could not vouch for, and the window that produced it.
-pub struct FlaggedRow {
-    pub artifact_id: String,
-    pub corpus_id: String,
-    pub title: String,
-    pub detail: String,
-    pub segment_idx: Option<i64>,
+/// Work that hit something and is waiting to try again by itself.
+pub struct RetryingRow {
+    pub stage: String,
+    pub target_id: String,
+    pub attempts: i64,
+    pub due: String,
+    pub last_error: String,
 }
 
 /// A parked capture, with enough of the corpus it resembles to decide without
@@ -161,6 +161,18 @@ pub fn embed_badge(state: &crate::store::artifacts::EmbedState) -> &'static str 
         Embedded => "badge-success",
         Failed => "badge-danger",
         Pending => "badge-muted",
+    }
+}
+
+/// A wait, coarsely. "in 4h" is the whole of what a reader needs from a backoff
+/// — the exact second is noise, and the point of the line is that nobody has to
+/// do anything about it.
+pub fn fmt_duration(secs: i64) -> String {
+    match secs {
+        s if s <= 0 => "now".into(),
+        s if s < 90 => format!("in {s}s"),
+        s if s < 5400 => format!("in {}m", (s + 59) / 60),
+        s => format!("in {}h", (s + 3599) / 3600),
     }
 }
 
@@ -292,8 +304,7 @@ struct OpsTemplate {
     oldest_pending_secs: Option<i64>,
     artifact_count: i64,
     vector_count: u64,
-    failed: Vec<crate::store::jobs::FailedJob>,
-    flagged: Vec<FlaggedRow>,
+    retrying: Vec<RetryingRow>,
     parked: Vec<ParkedRow>,
     superseded: Vec<SupersededRow>,
     pairs: Vec<PairRow>,
@@ -632,21 +643,20 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         })
         .collect();
 
-    let flagged = st
+    // Not a queue of chores: work that hit something and is waiting to try
+    // again on its own. Nothing here needs a person.
+    let retrying: Vec<RetryingRow> = st
         .core
         .store
-        .flagged_artifacts(50)
+        .retrying_jobs(50)
         .await?
         .into_iter()
-        .map(|c| FlaggedRow {
-            title: c
-                .title
-                .clone()
-                .unwrap_or_else(|| format!("Chunk {}", c.ordinal)),
-            detail: c.flag_detail.clone().unwrap_or_else(|| c.flags.join(", ")),
-            segment_idx: c.segment_idx,
-            artifact_id: c.id,
-            corpus_id: c.corpus_id,
+        .map(|j| RetryingRow {
+            stage: j.stage,
+            target_id: j.target_id,
+            attempts: j.attempts,
+            due: fmt_duration(j.next_attempt_secs),
+            last_error: j.last_error.unwrap_or_else(|| "—".into()),
         })
         .collect();
 
@@ -721,7 +731,7 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
 
     Ok(HtmlTemplate(OpsTemplate {
         theme: "light".into(),
-        flagged,
+        retrying,
         parked,
         superseded,
         pairs,
@@ -731,7 +741,6 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         // Qdrant being briefly unreachable must not blank the ops page, which
         // is exactly where you look when something is wrong.
         vector_count: st.core.vectors.count().await.unwrap_or(0),
-        failed: st.core.store.failed_jobs(50).await?,
         tokens,
     })
     .into_response())
@@ -763,20 +772,6 @@ async fn revoke_token_ui(
     Path(tid): Path<String>,
 ) -> Result<Response> {
     crate::auth::tokens::revoke(&st.core.store, &tid).await?;
-    Ok(Redirect::to("/ui/ops").into_response())
-}
-
-async fn retry_job(
-    State(st): State<AppState>,
-    _id: Identity,
-    Path(job_id): Path<i64>,
-) -> Result<Response> {
-    sqlx::query(
-        "UPDATE jobs SET state='pending', attempts=0, run_after=0, last_error=NULL WHERE id=?",
-    )
-    .bind(job_id)
-    .execute(&st.core.store.pool)
-    .await?;
     Ok(Redirect::to("/ui/ops").into_response())
 }
 
@@ -937,30 +932,6 @@ async fn artifact_detail(
     .into_response())
 }
 
-/// The action behind "re-segment this window": put the window back in the
-/// queue's path and make sure something will pick it up. Split out from the
-/// handler so it can be tested without a request.
-pub(crate) async fn resynthesize_segment_inner(
-    core: &crate::core::Core,
-    corpus_id: &str,
-    idx: i64,
-) -> Result<()> {
-    core.store.reset_segment(corpus_id, idx).await?;
-    core.store
-        .enqueue(crate::store::jobs::Stage::Synthesize, "corpus", corpus_id)
-        .await?;
-    Ok(())
-}
-
-async fn resynthesize_segment(
-    State(st): State<AppState>,
-    _id: Identity,
-    Path((cid, idx)): Path<(String, i64)>,
-) -> Result<Response> {
-    resynthesize_segment_inner(&st.core, &cid, idx).await?;
-    Ok(Redirect::to("/ui/ops").into_response())
-}
-
 /// Clearing a flag is a judgement, not a fix: the operator looked at the chunk
 /// beside its source lines and decided the warning was noise.
 async fn mark_artifact_reviewed(
@@ -982,17 +953,12 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/corpora/{id}", get(corpus_detail))
         .route("/ui/corpora/{id}/delete", post(delete_corpus_ui))
         .route("/ui/corpora/{id}/reprocess", post(reprocess_ui))
-        .route(
-            "/ui/corpora/{cid}/segments/{idx}/resynthesize",
-            post(resynthesize_segment),
-        )
         .route("/ui/artifacts/{id}", get(artifact_detail).put(put_artifact))
         .route("/ui/artifacts/{cid}/reviewed", post(mark_artifact_reviewed))
         .route("/ui/ask", get(ask_page).post(ask_submit))
         .route("/ui/ops", get(ops))
         .route("/ui/ops/tokens", post(mint_token))
         .route("/ui/ops/tokens/{id}/revoke", post(revoke_token_ui))
-        .route("/ui/ops/jobs/{id}/retry", post(retry_job))
         .route("/ui/ops/corpora/{id}/resolve", post(resolve_near_dupe_ui))
         .route("/ui/ops/artifacts/{id}/unsupersede", post(unsupersede_ui))
         .route("/ui/ops/pairs/{id}/dismiss", post(dismiss_pair_ui))
@@ -1110,7 +1076,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resegmenting_a_window_makes_it_pending_and_queues_the_job() {
+    async fn a_failed_segment_is_picked_up_without_anyone_asking() {
+        // What replaced the "re-synthesize segment" button. The sweep sees a
+        // segment that is not done, queues the corpus, and the run retries it.
         let core = crate::core::test_support::test_core().await;
         let out = core
             .ingest("first para\n\nsecond para", "web", None)
@@ -1126,22 +1094,16 @@ mod tests {
             )
             .await
             .unwrap();
+        while core.store.claim_job().await.unwrap().is_some() {}
 
-        super::resynthesize_segment_inner(&core, &out.id, 0)
-            .await
-            .unwrap();
-
-        let w = &core.store.segments_for_corpus(&out.id).await.unwrap()[0];
-        assert_eq!(w.state, crate::store::segments::SegmentState::Pending);
-        assert_eq!(w.attempts, 0);
-
+        assert_eq!(crate::jobs::reconcile::run(&core).await.unwrap(), 1);
         let mut found = false;
         while let Some(j) = core.store.claim_job().await.unwrap() {
             if j.stage == crate::store::jobs::Stage::Synthesize && j.target_id == out.id {
                 found = true;
             }
         }
-        assert!(found, "a segment job must be queued for the source");
+        assert!(found, "nothing would ever retry the segment");
     }
 
     async fn app_with_session() -> (axum::Router, String) {
@@ -1459,7 +1421,7 @@ mod tests {
             "/ui/ops/tokens",
             "/ui/corpora/abc/delete",
             "/ui/corpora/abc/reprocess",
-            "/ui/ops/jobs/1/retry",
+            "/ui/ops/pairs/1/dismiss",
             "/ui/ask",
         ] {
             let res = app
@@ -1752,6 +1714,38 @@ mod tests {
         let html = body_of(res).await;
         assert!(html.contains("Queue"));
         assert!(html.contains("API tokens"));
+    }
+
+    #[tokio::test]
+    async fn ops_reports_what_is_retrying_rather_than_asking_for_a_click() {
+        let (app, cookie, core) = app_session_and_core().await;
+        core.store
+            .enqueue(crate::store::jobs::Stage::Embed, "artifact", "a1")
+            .await
+            .unwrap();
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        core.store
+            .fail_job(job.id, 9, "endpoint down")
+            .await
+            .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/ops")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(html.contains("Retrying"), "{html}");
+        assert!(html.contains("endpoint down"));
+        assert!(
+            !html.contains("Re-synthesize segment"),
+            "the review queue is still a to-do list"
+        );
     }
 
     /// One corpus with `n` artifacts, titled so the ops page can be searched

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -98,6 +98,17 @@ pub struct FlaggedRow {
     pub segment_idx: Option<i64>,
 }
 
+/// A parked capture, with enough of the corpus it resembles to decide without
+/// opening both.
+pub struct ParkedRow {
+    pub id: String,
+    pub title: String,
+    pub bytes: usize,
+    pub other_id: String,
+    pub other_title: String,
+    pub percent: i64,
+}
+
 pub struct TokenRow {
     pub id: String,
     pub name: String,
@@ -253,6 +264,7 @@ struct OpsTemplate {
     vector_count: u64,
     failed: Vec<crate::store::jobs::FailedJob>,
     flagged: Vec<FlaggedRow>,
+    parked: Vec<ParkedRow>,
     tokens: Vec<TokenRow>,
 }
 
@@ -600,9 +612,29 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         })
         .collect();
 
+    // A parked capture is the one corpus state no worker advances. It has to be
+    // shown here or it sits unprocessed with nothing saying why.
+    let mut parked = Vec::new();
+    for c in st.core.store.parked_corpora(50).await? {
+        let other_id = c.near_dupe_of.clone().unwrap_or_default();
+        let other_title = match st.core.store.get_corpus(&other_id).await {
+            Ok(o) => o.title_hint.unwrap_or_else(|| "untitled".into()),
+            Err(_) => "(deleted)".into(),
+        };
+        parked.push(ParkedRow {
+            percent: (c.near_dupe_score.unwrap_or(0.0) * 100.0).round() as i64,
+            bytes: c.raw_text.len(),
+            title: c.title_hint.clone().unwrap_or_else(|| "untitled".into()),
+            id: c.id,
+            other_id,
+            other_title,
+        });
+    }
+
     Ok(HtmlTemplate(OpsTemplate {
         theme: "light".into(),
         flagged,
+        parked,
         job_counts: st.core.store.job_counts().await?,
         oldest_pending_secs: st.core.store.oldest_pending_age().await?,
         artifact_count,
@@ -655,6 +687,21 @@ async fn retry_job(
     .bind(job_id)
     .execute(&st.core.store.pool)
     .await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+#[derive(serde::Deserialize)]
+struct ResolveForm {
+    action: crate::core::ingest::NearDupeAction,
+}
+
+async fn resolve_near_dupe_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(cid): Path<String>,
+    Form(form): Form<ResolveForm>,
+) -> Result<Response> {
+    st.core.resolve_near_duplicate(&cid, form.action).await?;
     Ok(Redirect::to("/ui/ops").into_response())
 }
 
@@ -833,6 +880,7 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/ops/tokens", post(mint_token))
         .route("/ui/ops/tokens/{id}/revoke", post(revoke_token_ui))
         .route("/ui/ops/jobs/{id}/retry", post(retry_job))
+        .route("/ui/ops/corpora/{id}/resolve", post(resolve_near_dupe_ui))
 }
 
 #[cfg(test)]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1413,11 +1413,7 @@ mod tests {
                 .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
                 .await
                 .unwrap();
-            assert_eq!(
-                res.status(),
-                StatusCode::SEE_OTHER,
-                "{uri} was unprotected"
-            );
+            assert_eq!(res.status(), StatusCode::SEE_OTHER, "{uri} was unprotected");
             assert_eq!(
                 res.headers().get("location").unwrap(),
                 "/auth/login?go=1",

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -155,6 +155,7 @@ async fn index(core: &Core, artifacts: &[FrozenArtifact]) {
                 category: c.category.clone(),
                 tags: c.tags.clone(),
                 segment_idx: None,
+                caveats: vec![],
             })
             .collect();
         core.store.insert_artifacts(&src.id, &new).await.unwrap();

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -1341,3 +1341,158 @@ async fn an_artifact_that_was_never_embedded_has_no_neighbours() {
     assert!(v.neighbours("never-embedded", 5).await.unwrap().is_empty());
     v.drop_collection().await.unwrap();
 }
+
+// ── Consolidation ───────────────────────────────────────────────────────────
+//
+// The distance-matrix API and the payload flag it feeds. Both are Qdrant-side
+// behaviour that the in-memory store can only approximate: `near_pairs` speaks
+// to `/points/search/matrix/pairs` (Qdrant 1.12+) and has to map point ids back
+// to artifact ids through a payload lookup, and the superseded filter has to
+// keep matching points written before the key existed at all.
+
+#[tokio::test]
+#[ignore]
+async fn near_pairs_finds_the_close_pair_over_the_real_matrix_api() {
+    let v = fresh("engram_it_near_pairs", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "procedure"),
+        point("b", "s1", vec![0.99, 0.01, 0.0, 0.0], &[], "procedure"),
+        point("c", "s1", vec![0.0, 0.0, 1.0, 0.0], &[], "procedure"),
+    ])
+    .await
+    .unwrap();
+
+    let pairs = v.near_pairs(100, 5, 0.9).await.unwrap();
+    assert_eq!(pairs.len(), 1, "expected one close pair, got {pairs:?}");
+    // Artifact ids, not point uuids: the mapping back through the payload is
+    // the part of this that cannot be unit-tested.
+    assert_eq!((pairs[0].a.as_str(), pairs[0].b.as_str()), ("a", "b"));
+    assert!(pairs[0].score >= 0.9, "{pairs:?}");
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn near_pairs_skips_what_has_already_been_superseded() {
+    // Otherwise every sweep re-finds the pair it resolved last time, and the
+    // review queue never empties.
+    let v = fresh("engram_it_near_pairs_skip", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "procedure"),
+        point("b", "s1", vec![0.99, 0.01, 0.0, 0.0], &[], "procedure"),
+    ])
+    .await
+    .unwrap();
+    assert_eq!(v.near_pairs(100, 5, 0.9).await.unwrap().len(), 1);
+
+    v.set_superseded("b", true).await.unwrap();
+    assert!(
+        v.near_pairs(100, 5, 0.9).await.unwrap().is_empty(),
+        "a resolved pair came back"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_superseded_point_leaves_search_and_can_come_back() {
+    let v = fresh("engram_it_superseded", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "procedure"),
+        point("b", "s1", vec![0.99, 0.01, 0.0, 0.0], &[], "procedure"),
+    ])
+    .await
+    .unwrap();
+
+    let q = [1.0, 0.0, 0.0, 0.0];
+    // Points written before consolidation existed carry no `superseded` key at
+    // all. The default filter must not drop them, which is why the exclusion is
+    // `must_not` rather than a match on `false`.
+    assert_eq!(
+        v.search(&q, &Default::default(), 5, &SearchFilter::default())
+            .await
+            .unwrap()
+            .len(),
+        2,
+        "a point with no `superseded` key was filtered out"
+    );
+
+    v.set_superseded("b", true).await.unwrap();
+    let hits = v
+        .search(&q, &Default::default(), 5, &SearchFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].payload.artifact_id, "a");
+
+    // Still reachable when asked for: the review queue and the undo need it.
+    assert_eq!(
+        v.search(
+            &q,
+            &Default::default(),
+            5,
+            &SearchFilter {
+                include_superseded: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .len(),
+        2
+    );
+
+    v.set_superseded("b", false).await.unwrap();
+    assert_eq!(
+        v.search(&q, &Default::default(), 5, &SearchFilter::default())
+            .await
+            .unwrap()
+            .len(),
+        2,
+        "the undo did not put the point back"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_re_embed_does_not_revive_a_superseded_point() {
+    // `payload_of` in the embed job knows nothing about consolidation and
+    // leaves the flag unset. Unset has to mean "keep what is stored", or every
+    // re-embed would silently undo the sweep.
+    let v = fresh("engram_it_superseded_reembed", 4).await;
+    v.upsert(vec![point(
+        "a",
+        "s1",
+        vec![1.0, 0.0, 0.0, 0.0],
+        &[],
+        "procedure",
+    )])
+    .await
+    .unwrap();
+    v.set_superseded("a", true).await.unwrap();
+
+    v.upsert(vec![point(
+        "a",
+        "s1",
+        vec![1.0, 0.0, 0.0, 0.0],
+        &[],
+        "procedure",
+    )])
+    .await
+    .unwrap();
+
+    assert!(
+        v.search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &SearchFilter::default()
+        )
+        .await
+        .unwrap()
+        .is_empty(),
+        "the re-embed revived a hidden point"
+    );
+    v.drop_collection().await.unwrap();
+}

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -51,6 +51,7 @@ fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPo
             tags: tags.iter().map(|s| s.to_string()).collect(),
             created_at: 42,
             last_seen_at: None,
+            superseded: None,
         },
     }
 }
@@ -114,6 +115,7 @@ async fn filtered_search_uses_payload_indexes() {
     let f = SearchFilter {
         tags: vec!["forensics".into()],
         category: None,
+        include_superseded: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -125,6 +127,7 @@ async fn filtered_search_uses_payload_indexes() {
     let f = SearchFilter {
         tags: vec![],
         category: Some("concept".into()),
+        include_superseded: false,
     };
     assert_eq!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -165,6 +168,7 @@ async fn multiple_tags_are_an_and_not_an_or() {
     let f = SearchFilter {
         tags: vec!["linux".into(), "forensics".into()],
         category: None,
+        include_superseded: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -604,6 +608,7 @@ async fn set_payload_rewrites_metadata_without_touching_the_vector() {
     let f = SearchFilter {
         tags: vec!["fresh".into()],
         category: None,
+        include_superseded: false,
     };
     assert_eq!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -615,6 +620,7 @@ async fn set_payload_rewrites_metadata_without_touching_the_vector() {
     let stale = SearchFilter {
         tags: vec!["old".into()],
         category: None,
+        include_superseded: false,
     };
     assert!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &stale)
@@ -645,6 +651,7 @@ fn hybrid_point(id: &str, text: &str, dense: Vec<f32>) -> VectorPoint {
             tags: vec![],
             created_at: 42,
             last_seen_at: None,
+            superseded: None,
         },
     }
 }
@@ -734,6 +741,7 @@ async fn a_filter_still_applies_to_both_halves_of_a_hybrid_query() {
     let f = SearchFilter {
         tags: vec!["keep".into()],
         category: None,
+        include_superseded: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 10, &f)
@@ -835,6 +843,7 @@ fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint 
             tags: tags.iter().map(|s| s.to_string()).collect(),
             created_at: now_secs() - days_old * 86_400,
             last_seen_at: None,
+            superseded: None,
         },
     }
 }
@@ -933,6 +942,7 @@ async fn scoring_leaves_the_filter_alone() {
     let f = SearchFilter {
         tags: vec!["keep".into()],
         category: None,
+        include_superseded: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 10, &f)

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -1373,6 +1373,44 @@ async fn near_pairs_finds_the_close_pair_over_the_real_matrix_api() {
 
 #[tokio::test]
 #[ignore]
+async fn a_superseded_point_is_offered_neither_as_forgotten_nor_as_related() {
+    // Hidden has to mean hidden everywhere a reader browses. A superseded
+    // artifact is near-identical to its keeper by construction, so it would
+    // lead the related pane of the artifact it lost to; and the forgotten list
+    // would hand back exactly the duplicates the sweep just took out of search.
+    let v = fresh("engram_it_superseded_browse", 4).await;
+    v.upsert(vec![
+        aged("keeper", vec![1.0, 0.0, 0.0, 0.0], 60, &[]),
+        aged("hidden", vec![0.99, 0.01, 0.0, 0.0], 60, &[]),
+    ])
+    .await
+    .unwrap();
+    v.set_superseded("hidden", true).await.unwrap();
+
+    let cutoff = now_secs() - 31 * 86_400;
+    let old: Vec<String> = v
+        .resurface(10, cutoff, cutoff)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|h| h.payload.artifact_id)
+        .collect();
+    assert_eq!(old, vec!["keeper".to_string()], "got {old:?}");
+
+    let near: Vec<String> = v
+        .neighbours("keeper", 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|h| h.payload.artifact_id)
+        .collect();
+    assert!(near.is_empty(), "a hidden artifact was related: {near:?}");
+
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
 async fn near_pairs_skips_what_has_already_been_superseded() {
     // Otherwise every sweep re-finds the pair it resolved last time, and the
     // review queue never empties.


### PR DESCRIPTION
Stops near-duplicate and stale artifacts competing for the same queries, in three layers, cheapest first. No LLM call is added to the ingest path, and no stored artifact is ever replaced with synthetic text.

## Tier 0 — capture hygiene (zero inference)

`content_hash` is exact, so re-pasting a chapter a year later with one changed byte stored it twice and the two copies then competed forever. A bottom-k MinHash over word 5-grams (`src/store/shingle.rs`) catches that at capture. The corpus is stored verbatim like any other and parked in a new `needs_review` status instead of being segmented — so the expensive stage is never paid for until a human decides. Ops offers replace / keep both / discard.

## Tier 0 — the sweep (zero inference)

A `Stage::Consolidate` job runs on a timer and asks Qdrant's distance-matrix API for near pairs in one round trip (`VectorStore::near_pairs`).

- **≥ `auto_supersede` (0.95):** the cluster collapses onto its newest member — `superseded_by` on the losing rows, plus a `superseded` payload flag that `SearchFilter` excludes by default. Still stored, still readable by link, with an undo on Ops.
- **`review_min` (0.88) … 0.95:** filed on an `artifact_pairs` review queue instead. 0.88 is where two genuinely *distinct* artifacts about one subsystem routinely sit, so acting on that score would destroy knowledge rather than duplication.

Pairs are clustered before a winner is picked. Resolving them pairwise let A lose to B and then B lose to C, leaving A pointing at something hidden — a chain the UI cannot follow. A test covers it.

## Tier 1 — caveats (no new call)

The existing synthesis call now also returns the conditions under which an artifact does not apply. Costs output tokens on a call already being made. Stored and rendered, and deliberately **not** part of `embed_text`: changing what every vector is built from is a decision for the eval harness, not a hunch. The literal check runs over caveats too, so a command invented in one is flagged like any other.

## Tier 2 — contradiction judge (opt-in, off by default)

The only part that costs inference. Queued pairs are first filtered on fact-shaped tokens with no inference at all (`src/infer/facts.rs`); only a pair where both sides state values and the values differ reaches the model, which answers one yes/no question under a per-sweep budget. An unreadable reply leaves the pair pending rather than closing it — a dead endpoint must never look like a clean bill of health. Which of two contradictory artifacts is current stays the reader's judgement.

## What this deliberately does not do

**Nothing is ever merged.** A merged artifact is synthetic text standing where a stored passage used to be, with no segment to verify it against and no corpus lines to render beside it. Consolidation only hides, flags, or asks. Nothing is deleted on a similarity score.

## Testing

420 tests pass (up from 350), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

**Caveat for review:** the 38 Qdrant integration tests are `ignored` — they need a live server, as they were before this branch. The Qdrant implementation of `near_pairs` therefore has **not** been executed; only its JSON deserialization is unit-tested. It depends on `/points/search/matrix/pairs`, which requires **Qdrant 1.12+**. The in-memory implementation is fully tested and is what every sweep test exercises. Worth running the ignored suite against a real server before relying on it.

Plan: `docs/superpowers/plans/2026-08-10-consolidation.md`. Implements two ROADMAP items ("Near-duplicate detection on capture", "Consolidation and staleness sweep"), now struck through there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APZqUei6AeiBgCrbPDuY5L
