### PR TITLE
Artifact lifecycle status, decay-based ranking, deprecation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ effective config with secrets redacted.
 | `vector.recency_weight` | How much age counts against a result. `0.0` disables. Default 0.05. |
 | `vector.recency_half_life_days` | Age at which half that boost is gone. Default 180. |
 | `vector.pinned_boost` | Extra score for an artifact tagged `pinned`. Default 0.15. |
+| `vector.weak_below` | Cosine similarity under which a result is labelled "loose" rather than presented as an answer. Default 0.35; `0.0` turns the labelling off. |
 | `infer.synthesize.*` | Synthesis model: `base_url`, `model`, `context_tokens`, `max_output_tokens`, `output_ratio`, optional `tokenizer_path`, `timeout_secs`, `reasoning_effort`, `cooldown_secs`. |
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`. |
 | `infer.ask.*` | Completion model, used only by `ask`. Same timeout and reasoning keys. |

--- a/assets/app.css
+++ b/assets/app.css
@@ -254,7 +254,16 @@ nav.top a.brand img { display: block; }
   border-radius: var(--radius-md); overflow: auto; max-height: 30rem;
 }
 .raw table { border-collapse: collapse; width: 100%; font-family: var(--font-mono); font-size: 0.8125rem; }
-.raw td { padding: 1px 0.5rem; vertical-align: top; white-space: pre-wrap; }
+/* `pre`, not `pre-wrap`: these are the source's own lines, and most of them are
+   shell commands. Wrapping broke one command across two rows with the
+   continuation aligned under the code column, so it read as two commands — in a
+   pane whose whole purpose is showing exactly what the source says. The
+   container already scrolls; wrapping is what stopped it from ever needing to. */
+.raw td { padding: 1px 0.5rem; vertical-align: top; white-space: pre; }
+/* The line numbers stay put while the code scrolls under them; a line number
+   that scrolls out of view makes the column useless for finding a line. */
+.raw td.ln { position: sticky; left: 0; background: var(--color-bg-elevated); z-index: 1; }
+.raw tr.in td.ln { background: var(--color-accent-dim); }
 .raw td.ln {
   width: 3.5rem; text-align: right; color: var(--color-fg-muted); user-select: none;
   border-right: 1px solid var(--color-border-subtle); font-variant-numeric: tabular-nums;
@@ -328,6 +337,13 @@ nav.top a.brand img { display: block; }
    sight, so none of that is reimplemented in script. */
 .facets { display: flex; flex-direction: column; gap: 0.375rem; margin-top: 0.625rem; }
 .facets .chips { margin-top: 0; }
+/* Each row says what it narrows by. The label sits on the baseline of the first
+   chip rather than above the row, so two rows cost two lines, not four. */
+.facet-row { display: flex; gap: 0.5rem; align-items: baseline; }
+.facet-label {
+  flex: none; width: 2.5rem; font-size: 0.75rem; text-transform: uppercase;
+  letter-spacing: 0.03em; color: var(--color-fg-muted); padding-top: 3px;
+}
 .chip { display: inline-flex; cursor: pointer; }
 .chip input {
   position: absolute; width: 1px; height: 1px; margin: -1px;

--- a/assets/app.css
+++ b/assets/app.css
@@ -138,6 +138,24 @@ nav.top a[aria-current="page"] { color: var(--color-fg-primary); background: var
 .btn-danger:hover { background: var(--color-danger); color: #fff; }
 .btn-sm { height: 32px; padding: 0 0.75rem; font-size: 0.75rem; }
 
+/* Icon-only actions: verify, deprecate, delete.
+   The label lives in `aria-label` and `title` rather than in visible text, so a
+   row of controls stays small enough to sit beside an artifact without
+   competing with it for attention. Square, so the three read as one set. */
+.btn-icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; padding: 0; cursor: pointer;
+  border-radius: var(--radius-sm); font-family: inherit;
+  background: transparent; border: 1px solid var(--color-border);
+  color: var(--color-fg-secondary);
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.btn-icon:hover { background: var(--color-bg-hover); color: var(--color-fg-primary); }
+.btn-icon svg { width: 16px; height: 16px; display: block; }
+.btn-icon-danger:hover {
+  background: var(--color-danger); border-color: var(--color-danger); color: #fff;
+}
+
 .input, .textarea, .select {
   width: 100%; font-size: 0.875rem; font-family: inherit;
   color: var(--color-fg-primary); background: var(--color-bg-elevated);
@@ -271,6 +289,23 @@ nav.top a.brand img { display: block; }
   border-radius: var(--radius-md); padding: 0.625rem 0.75rem;
 }
 .rail-item:hover { background: var(--color-bg-hover); }
+
+/* A result row is the link plus a delete control *beside* it, not inside it: a
+   <button> nested in an <a> is invalid HTML, and the anchor has to stay the
+   `.rail-item` because that is the element the arrow-key navigation focuses.
+   The control is held out of the way until the row is hovered or something
+   inside it takes focus, so the rail still reads as a list of results rather
+   than a list of delete buttons. Keyboard users reach it by tabbing, which
+   `:focus-within` reveals; a touch screen has no hover, so there it is simply
+   always visible. */
+.rail-row { position: relative; }
+.rail-row .rail-item { padding-right: 2.75rem; }
+.rail-del {
+  position: absolute; top: 0.5rem; right: 0.5rem;
+  opacity: 0; transition: opacity 120ms ease;
+}
+.rail-row:hover .rail-del, .rail-del:focus-within { opacity: 1; }
+@media (hover: none) { .rail-del { opacity: 1; } }
 .rail-item[aria-selected="true"] { border-color: var(--color-accent); background: var(--color-accent-dim); }
 .rail-head { display: flex; gap: 0.5rem; align-items: baseline; }
 .rail-rank { font-size: 0.75rem; color: var(--color-fg-muted); }

--- a/migrations/0011_lifecycle.sql
+++ b/migrations/0011_lifecycle.sql
@@ -1,0 +1,22 @@
+-- Artifact lifecycle: freshness and deprecation.
+--
+-- `status` makes "hidden because a duplicate won" (superseded, already
+-- tracked via `superseded_by`) and "flagged stale with no replacement"
+-- (deprecated) distinguishable, instead of overloading one boolean for both.
+-- `last_verified_at` is the recency input search ranking decays against —
+-- separate from `created_at`, because an artifact confirmed accurate last
+-- week should outrank one merely written last week and never looked at
+-- since.
+ALTER TABLE artifacts ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE artifacts ADD COLUMN last_verified_at INTEGER;
+
+UPDATE artifacts SET status = 'superseded' WHERE superseded_by IS NOT NULL;
+UPDATE artifacts SET last_verified_at = created_at WHERE last_verified_at IS NULL;
+
+CREATE INDEX idx_artifacts_status ON artifacts(status);
+
+-- Which side of a judged pair the model believes is obsolete, so the review
+-- UI can offer "apply supersede" without asking the model again. Set only
+-- when the judge names a direction with confidence; NULL for an ordinary
+-- contradiction with no clear winner.
+ALTER TABLE artifact_pairs ADD COLUMN obsolete_id TEXT REFERENCES artifacts(id);

--- a/migrations/0012_restored.sql
+++ b/migrations/0012_restored.sql
@@ -1,0 +1,15 @@
+-- Marks a corpus row that exists only because its artifacts were restored from
+-- the vector store, not because the source document was ever captured here.
+--
+-- The vector payload carries everything an artifact row needs, but nothing
+-- about the document it came from: no `raw_text`, no `origin`, no
+-- `content_hash`. `artifacts.corpus_id` is NOT NULL and references this table,
+-- so an artifact cannot be restored without a parent to point at, and inventing
+-- one silently would leave an operator reading a source page that claims to
+-- show a captured document while showing reconstructed fragments.
+--
+-- So the stub is inserted and then labelled. NULL — every ordinary corpus — is
+-- "captured here"; a timestamp is "this row is a placeholder, its `raw_text` is
+-- the restored artifacts joined together, and re-segmenting it would not
+-- reproduce the base". The UI reads exactly this to say so.
+ALTER TABLE corpora ADD COLUMN restored_at INTEGER;

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,21 @@ pub struct VectorConfig {
     /// decided matters can outrank the decay curve.
     #[serde(default = "default_pinned_boost")]
     pub pinned_boost: f32,
+    /// Cosine similarity below which a result is only loosely related to the
+    /// query, and is labelled as such rather than presented like a real answer.
+    ///
+    /// This is a similarity, not a rank: hybrid retrieval returns reciprocal
+    /// rank fusion values, which say where a result placed and nothing about
+    /// how close it was, so the top hit for a typo scores exactly like the top
+    /// hit for a perfect match. The similarity is read separately — see
+    /// `VectorStore::search` — and compared here.
+    ///
+    /// Normalised embeddings put unrelated text around 0.0–0.2 and genuinely
+    /// related text well above 0.4, so the default sits between them. Raise it
+    /// to be told more often that nothing really matched; `0.0` turns the
+    /// labelling off.
+    #[serde(default = "default_weak_below")]
+    pub weak_below: f32,
 }
 fn default_recency_weight() -> f32 {
     0.05
@@ -113,6 +128,9 @@ fn default_recency_half_life_days() -> u32 {
 }
 fn default_pinned_boost() -> f32 {
     0.15
+}
+fn default_weak_below() -> f32 {
+    0.35
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,16 @@ pub struct ConsolidateConfig {
     pub judge: bool,
     /// Ceiling on judge calls per sweep, so one sweep cannot occupy the GPU.
     pub max_judgements: usize,
+    /// An active artifact not confirmed accurate (`last_verified_at`) in this
+    /// many days becomes a deprecation-review candidate — never anything more
+    /// automatic than that. See `stale_max_hits`.
+    pub stale_after_days: u32,
+    /// ...and retrieved at most this many times since. Both conditions must
+    /// hold: staleness alone is not suspicious for a rare topic, and
+    /// popularity alone says nothing about accuracy. This is read-only input
+    /// to the candidate list — it never feeds search scoring, or a frequently
+    /// shown result would keep boosting its own visibility.
+    pub stale_max_hits: i64,
 }
 
 impl Default for ConsolidateConfig {
@@ -54,6 +64,8 @@ impl Default for ConsolidateConfig {
             interval_hours: 24,
             judge: false,
             max_judgements: 20,
+            stale_after_days: 365,
+            stale_max_hits: 0,
         }
     }
 }

--- a/src/core/ask.rs
+++ b/src/core/ask.rs
@@ -51,6 +51,8 @@ impl Core {
                     category: req.category.clone(),
                     // Asking a question is as deliberate as a search gets.
                     mark: true,
+                    include_deprecated: false,
+                    include_superseded: false,
                 },
                 None,
             )

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -19,6 +19,24 @@ pub struct IngestOutcome {
     pub near_duplicate: Option<NearDuplicate>,
 }
 
+/// What one pass of `Core::heal_store_drift` put back.
+///
+/// Reported rather than merely logged because "the stores agreed" and "the
+/// stores disagreed and were repaired" are different facts, and a repair that
+/// fires on every sweep over a base in agreement is a bug that hides behind a
+/// correct end state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub struct StoreDrift {
+    /// Artifact rows rebuilt from a surviving vector payload.
+    pub rows_restored: usize,
+    /// Placeholder corpus rows written because a restored artifact's source was
+    /// not stored either.
+    pub corpora_restored: usize,
+    /// Artifacts whose row claimed `done` but had no point, re-queued for
+    /// embedding.
+    pub points_requeued: usize,
+}
+
 /// What an operator decided about a parked capture.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -289,10 +307,35 @@ impl Core {
     /// many times *since*" the last verification, and a lifetime counter would
     /// mean one appearance in a marked search result kept an artifact off the
     /// review list forever.
+    /// A failed vector write puts the row back the way it was. Nothing else
+    /// reconciles this pair: `repair_lifecycle_drift` only examines artifacts
+    /// that are non-active on one side or the other, so an artifact that is
+    /// active on both but stamped on only one is invisible to it — it would keep
+    /// ranking as stale and keep appearing on the review list while the row
+    /// claimed it had just been confirmed, and the operator would have no way to
+    /// tell that from a press that simply did not take. Rolling back leaves both
+    /// stores saying the same (old) thing and surfaces the error, so pressing
+    /// again is a repair rather than a guess.
     pub async fn verify(&self, id: &str) -> Result<()> {
         let at = now();
+        let previous = self.store.get_artifact(id).await?.last_verified_at;
         self.store.set_last_verified_at(id, at).await?;
-        self.vectors.set_last_verified_at(id, at, true).await?;
+        if let Err(e) = self.vectors.set_last_verified_at(id, at, true).await {
+            // A row that never had a stamp has nothing to roll back to, and
+            // clearing the column is not available here; the drift it leaves is
+            // the one the backfill already stamps.
+            if let Some(previous) = previous
+                && let Err(undo) = self.store.set_last_verified_at(id, previous).await
+            {
+                tracing::warn!(
+                    artifact_id = id,
+                    error = %undo,
+                    "could not undo the verification stamp; sqlite now claims a \
+                     verification the vector store did not record"
+                );
+            }
+            return Err(e);
+        }
         tracing::info!(artifact_id = id, "verified an artifact");
         Ok(())
     }
@@ -310,8 +353,9 @@ impl Core {
     /// logged and skipped rather than abandoning every artifact after it —
     /// a single missing row must not be what keeps a base unbackfilled.
     ///
-    /// Finishes with `drop_orphan_points`, which is what lets the startup check
-    /// ever see zero unstamped points again.
+    /// Finishes with `heal_store_drift`, so a point whose row is gone gets the
+    /// row back and is stamped by the next pass, rather than sitting unstamped
+    /// forever and re-triggering this one on every start.
     pub async fn backfill_lifecycle(&self) -> Result<usize> {
         const BATCH: usize = 256;
         let ids = self.store.list_all_artifact_ids().await?;
@@ -336,44 +380,173 @@ impl Core {
             n += rows.len();
             tracing::info!(done = n, total, "lifecycle backfill progress");
         }
-        self.drop_orphan_points().await?;
+        self.heal_store_drift().await?;
         tracing::info!(n, "backfilled lifecycle fields into the vector store");
         Ok(n)
     }
 
-    /// Delete points whose SQLite row is gone.
+    /// Make the two stores agree about which artifacts exist, by restoring
+    /// whichever side is missing one — never by deleting.
     ///
-    /// The pass above is driven by SQLite, so a point with no row can never be
-    /// stamped by it — and startup decides whether to run the backfill by
-    /// counting points with no stamp. One orphan therefore means the count never
-    /// reaches zero and every process start kicks off another full-base rewrite.
+    /// The two stores hold complementary halves of the same artifact and are
+    /// written separately, so either can end up with an entry the other lacks: a
+    /// crash between the two writes, a restore of one store from a backup taken
+    /// at a different moment, an operator pointing a process at the wrong
+    /// `store.path`. Each direction has its own repair, and neither destroys
+    /// anything:
     ///
-    /// Deleting is the right answer rather than stamping: SQLite is the source
-    /// of truth for what exists, so a point it does not name is a delete that a
-    /// crash left half-applied, and until it goes it stays searchable.
+    /// - A point with no row rebuilds the row from the payload (see
+    ///   `Store::restore_artifact`) and queues a re-embed. The vector store
+    ///   carries the text, the title, the tags and the lifecycle stamps, so the
+    ///   artifact comes back searchable and correctly retired if it was retired.
+    /// - A row that says `done` with no point queues a re-embed, which writes
+    ///   the point through the ordinary pipeline. A row still `pending` is not
+    ///   drift at all — it is every artifact that was just ingested.
     ///
-    /// The order matters. The point list is read *first* and the row list
+    /// Deleting used to be this method's whole job, and it was a loaded gun. It
+    /// ran unconditionally from the backfill, which startup spawns in the
+    /// background, so a process started against an empty or wrong SQLite file
+    /// found every point orphaned and emptied the collection — no confirmation,
+    /// no dry run, and nothing to reindex from afterwards, because the vectors
+    /// were the last copy. Restoring is the safe direction of the same repair:
+    /// the worst a wrong `store.path` can now do is fill that database with the
+    /// artifacts it was missing.
+    ///
+    /// What this costs is that a deletion interrupted between its two writes
+    /// comes back instead of finishing. That is the deliberate trade — an
+    /// artifact that reappears is a nuisance an operator can fix with the delete
+    /// button, and an artifact that is gone is gone. See `Core::delete_artifact`
+    /// for the deliberate path.
+    ///
+    /// The read order matters. The point list is read *first* and the row list
     /// second, so an artifact captured while this runs is either absent from the
-    /// scroll or present in the newer row list — never mistaken for an orphan.
-    /// The opposite skew is harmless: a row deleted just after the read leaves
-    /// its point for the next run.
-    async fn drop_orphan_points(&self) -> Result<()> {
+    /// scroll or present in the newer row list — never mistaken for an orphan
+    /// point and restored on top of itself.
+    pub async fn heal_store_drift(&self) -> Result<StoreDrift> {
+        use std::collections::{BTreeMap, HashSet};
+
         let points = self.vectors.all_artifact_ids().await?;
-        let live: std::collections::HashSet<String> = self
-            .store
-            .list_all_artifact_ids()
-            .await?
-            .into_iter()
+        let rows = self.store.list_all_artifact_ids().await?;
+        let embedded = self.store.list_embedded_artifact_ids().await?;
+
+        let has_row: HashSet<&str> = rows.iter().map(String::as_str).collect();
+        let has_point: HashSet<&str> = points.iter().map(String::as_str).collect();
+
+        let mut out = StoreDrift::default();
+
+        // Vector store has it, SQLite does not: rebuild the row.
+        let orphan_points: Vec<String> = points
+            .iter()
+            .filter(|id| !has_row.contains(id.as_str()))
+            .cloned()
             .collect();
-        let orphans: Vec<String> = points.into_iter().filter(|id| !live.contains(id)).collect();
-        if orphans.is_empty() {
-            return Ok(());
+        if !orphan_points.is_empty() {
+            let payloads = self.vectors.payloads_of(&orphan_points).await?;
+            // Grouped by corpus so a placeholder parent, if one is needed, is
+            // written once and holds every artifact restored under it rather
+            // than only whichever happened to come first.
+            let mut by_corpus: BTreeMap<&str, Vec<&crate::vector::VectorPayload>> = BTreeMap::new();
+            for id in &orphan_points {
+                match payloads.get(id) {
+                    Some(p) => by_corpus.entry(p.corpus_id.as_str()).or_default().push(p),
+                    // The point was there for the id scroll and gone for the
+                    // retrieve, or its payload does not parse as a chunk.
+                    // Neither is an error and neither is restorable.
+                    None => tracing::debug!(
+                        artifact_id = %id,
+                        "no readable payload for an artifact the vector store listed"
+                    ),
+                }
+            }
+            for (corpus_id, group) in by_corpus {
+                if self.store.get_corpus(corpus_id).await.is_err() {
+                    let joined = group
+                        .iter()
+                        .map(|p| p.text.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n\n");
+                    if self
+                        .store
+                        .ensure_restored_corpus(corpus_id, &joined)
+                        .await?
+                    {
+                        out.corpora_restored += 1;
+                        tracing::info!(
+                            corpus_id,
+                            artifacts = group.len(),
+                            "the source of a restored artifact was not stored; \
+                             wrote a placeholder so the artifact has a parent"
+                        );
+                    }
+                }
+                for p in group {
+                    let restored = crate::store::artifacts::RestoredArtifact {
+                        id: p.artifact_id.clone(),
+                        corpus_id: p.corpus_id.clone(),
+                        text: p.text.clone(),
+                        title: p.title.clone(),
+                        category: p.category.clone(),
+                        tags: p.tags.clone(),
+                        created_at: p.created_at,
+                        // A payload with no `status` key predates lifecycle
+                        // tracking, which every filter reads as active — so the
+                        // restored row has to say the same thing, or the heal
+                        // would quietly retire artifacts on an unbackfilled base.
+                        status: p.status.unwrap_or(ArtifactStatus::Active),
+                        last_verified_at: p.last_verified_at,
+                        superseded_by: p.superseded_by.clone(),
+                    };
+                    if self.store.restore_artifact(&restored).await? {
+                        out.rows_restored += 1;
+                        self.store
+                            .enqueue(Stage::Embed, "artifact", &p.artifact_id)
+                            .await?;
+                    }
+                }
+            }
         }
-        tracing::info!(
-            orphans = orphans.len(),
-            "deleting vector points whose artifact row is gone"
-        );
-        self.vectors.delete_artifacts(&orphans).await
+
+        // SQLite says the vector was written and the vector store has nothing:
+        // send it back through the pipeline that writes it.
+        for id in embedded
+            .iter()
+            .filter(|id| !has_point.contains(id.as_str()))
+        {
+            self.store.enqueue(Stage::Embed, "artifact", id).await?;
+            out.points_requeued += 1;
+        }
+
+        if out.rows_restored > 0 || out.points_requeued > 0 {
+            tracing::info!(
+                rows_restored = out.rows_restored,
+                corpora_restored = out.corpora_restored,
+                points_requeued = out.points_requeued,
+                "the two stores disagreed about which artifacts exist; restored both ways"
+            );
+        }
+        Ok(out)
+    }
+
+    /// Delete an artifact from both stores, on purpose.
+    ///
+    /// The vector point goes first. `heal_store_drift` restores a row from a
+    /// surviving point, so deleting the row first would mean an interrupted
+    /// delete is undone by the very next heal; this way the interrupted state is
+    /// a row whose point is gone, which the heal answers by re-embedding — the
+    /// artifact survives intact instead of half-existing, and pressing delete
+    /// again finishes it.
+    pub async fn delete_artifact(&self, id: &str) -> Result<()> {
+        self.store.get_artifact(id).await?;
+        self.vectors
+            .delete_artifacts(std::slice::from_ref(&id.to_string()))
+            .await?;
+        self.store.delete_artifact(id).await?;
+        // This artifact may have been the reason another one is hidden, and a
+        // keeper that no longer exists leaves its loser out of search in favour
+        // of nothing.
+        self.heal_dangling_supersessions().await?;
+        tracing::info!(artifact_id = id, "deleted an artifact");
+        Ok(())
     }
 
     /// Put back anything that was hidden in favour of an artifact which has
@@ -482,8 +655,9 @@ impl Core {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ingest::NearDupeAction;
+    use crate::core::ingest::{NearDupeAction, StoreDrift};
     use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
+    use crate::store::artifacts::EmbedState;
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::Stage;
 
@@ -950,11 +1124,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_backfill_deletes_points_whose_artifact_row_is_gone() {
-        // The backfill is driven by SQLite, so it can never stamp a point with
-        // no row — and startup decides whether to run it by counting unstamped
-        // points. One orphan therefore meant a full-base rewrite on every single
-        // process start, forever.
+    async fn a_point_whose_row_is_gone_gets_its_row_back() {
+        // This used to delete the point. The backfill it ran from is spawned at
+        // startup whenever anything is unstamped, so a process pointed at an
+        // empty or wrong sqlite file found every point orphaned and emptied the
+        // collection — with the vectors being the last copy, there was nothing
+        // left to reindex from.
         let core = test_core().await;
         let (corpus, artifact) = one_artifact(&core).await;
         core.vectors
@@ -962,17 +1137,104 @@ mod tests {
             .await
             .unwrap();
 
-        core.backfill_lifecycle().await.unwrap();
+        let drift = core.heal_store_drift().await.unwrap();
 
+        assert_eq!(drift.rows_restored, 1, "{drift:?}");
         assert_eq!(
-            core.vectors.all_artifact_ids().await.unwrap(),
-            vec![artifact],
-            "the orphaned point survived the backfill"
+            core.vectors.all_artifact_ids().await.unwrap().len(),
+            2,
+            "the heal deleted a point instead of restoring its row"
         );
+        let back = core.store.get_artifact("gone").await.unwrap();
+        assert_eq!(back.text, "t");
+        assert_eq!(back.corpus_id, corpus);
         assert_eq!(
-            core.vectors.unstamped_count().await.unwrap(),
-            0,
-            "startup would run the backfill again on the next start"
+            back.embed_state,
+            EmbedState::Pending,
+            "a restored row must be re-embedded: the stored vector may be from \
+             another model, and nothing else would ever check"
         );
+    }
+
+    #[tokio::test]
+    async fn restoring_an_artifact_whose_corpus_is_also_gone_writes_a_marked_placeholder() {
+        // The whole-database-lost case. `artifacts.corpus_id` is NOT NULL and
+        // references `corpora`, so without a parent the restore cannot happen at
+        // all — and a placeholder that did not say it was one would present
+        // reconstructed fragments as a captured document.
+        let core = test_core().await;
+        core.vectors
+            .upsert(vec![point("orphan", "corpus-that-never-existed")])
+            .await
+            .unwrap();
+
+        let drift = core.heal_store_drift().await.unwrap();
+
+        assert_eq!(drift.rows_restored, 1, "{drift:?}");
+        assert_eq!(drift.corpora_restored, 1, "{drift:?}");
+        let stub = core
+            .store
+            .get_corpus("corpus-that-never-existed")
+            .await
+            .unwrap();
+        assert!(
+            stub.restored_at.is_some(),
+            "the placeholder is indistinguishable from a real capture"
+        );
+        assert_eq!(stub.raw_text, "t", "the stub holds what was recoverable");
+    }
+
+    #[tokio::test]
+    async fn healing_twice_changes_nothing_the_second_time() {
+        // The heal runs at startup and on every consolidation sweep, so a pass
+        // that keeps finding work on a base already in agreement is a permanent
+        // background rewrite — and, with `restore_artifact` keeping the original
+        // id, the way to get that wrong is to mint a new one and orphan the
+        // point all over again.
+        let core = test_core().await;
+        let (corpus, _) = one_artifact(&core).await;
+        core.vectors
+            .upsert(vec![point("gone", &corpus)])
+            .await
+            .unwrap();
+
+        core.heal_store_drift().await.unwrap();
+        let second = core.heal_store_drift().await.unwrap();
+
+        assert_eq!(second, StoreDrift::default(), "the heal is not idempotent");
+    }
+
+    #[tokio::test]
+    async fn a_row_that_claims_it_is_embedded_with_no_point_is_requeued() {
+        // The other direction. A row still `pending` is not drift — that is
+        // every artifact that was just captured — so only a row claiming `done`
+        // counts, and the repair is to send it back through the pipeline that
+        // writes points rather than to delete the row.
+        let core = test_core().await;
+        let (_, artifact) = one_artifact(&core).await;
+        core.store
+            .mark_embedded(&artifact, "some-model", 0)
+            .await
+            .unwrap();
+
+        let drift = core.heal_store_drift().await.unwrap();
+
+        assert_eq!(drift.points_requeued, 1, "{drift:?}");
+        assert!(
+            core.store.get_artifact(&artifact).await.is_ok(),
+            "the heal deleted the row instead of re-embedding it"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_artifact_still_waiting_to_embed_is_not_drift() {
+        // Everything just ingested has a row and no point. Treating that as
+        // drift would re-queue the entire backlog on every sweep.
+        let core = test_core().await;
+        one_artifact(&core).await;
+
+        let drift = core.heal_store_drift().await.unwrap();
+
+        assert_eq!(drift, StoreDrift::default(), "{drift:?}");
     }
 }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -213,11 +213,18 @@ impl Core {
         Ok(())
     }
 
-    /// Move an artifact back to active. Does not touch `superseded_by` — an
-    /// artifact reactivated out of `Superseded` keeps pointing at what it lost
-    /// to, same as `unsupersede`; callers that mean to undo a supersession
-    /// specifically should use that instead.
+    /// Move an artifact back to active.
+    ///
+    /// An artifact that was hidden by a supersession is handed to
+    /// `unsupersede`, which clears `superseded_by` on both sides. Flipping the
+    /// status alone would leave the row pointing at its winner while the
+    /// payload no longer does, so Ops would keep listing it as hidden and the
+    /// next consolidation sweep would re-apply `Superseded` to the vector
+    /// store — undoing the operator without saying so.
     pub async fn reactivate(&self, id: &str) -> Result<()> {
+        if self.store.get_artifact(id).await?.superseded_by.is_some() {
+            return self.unsupersede(id).await;
+        }
         self.store
             .set_artifact_status(id, ArtifactStatus::Active)
             .await?;
@@ -230,10 +237,15 @@ impl Core {
 
     /// Stamp an artifact as confirmed accurate now — what search ranking's
     /// recency decay reads.
+    ///
+    /// Also zeroes `hit_count`: `stale_max_hits` is "retrieved at most this
+    /// many times *since*" the last verification, and a lifetime counter would
+    /// mean one appearance in a marked search result kept an artifact off the
+    /// review list forever.
     pub async fn verify(&self, id: &str) -> Result<()> {
         let at = now();
         self.store.set_last_verified_at(id, at).await?;
-        self.vectors.set_last_verified_at(id, at).await?;
+        self.vectors.set_last_verified_at(id, at, true).await?;
         tracing::info!(artifact_id = id, "verified an artifact");
         Ok(())
     }
@@ -251,7 +263,10 @@ impl Core {
                 .set_lifecycle(&id, c.status, c.superseded_by.as_deref())
                 .await?;
             self.vectors
-                .set_last_verified_at(&id, c.last_verified_at.unwrap_or(c.created_at))
+                // `false`: this pass touches every artifact, and a verify-style
+                // counter reset here would wipe every retrieval count in the
+                // base.
+                .set_last_verified_at(&id, c.last_verified_at.unwrap_or(c.created_at), false)
                 .await?;
             n += 1;
         }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -189,6 +189,21 @@ impl Core {
     /// on, since the artifact is already listed on Ops with its `superseded_by`
     /// set, even if the search-side flag has not caught up yet.
     pub async fn supersede(&self, loser_id: &str, winner_id: &str) -> Result<()> {
+        // Neither side may be retired. `set_superseded_by` writes
+        // `status = 'superseded'` unconditionally, so superseding an artifact
+        // an operator deprecated would silently overwrite that decision with
+        // one nothing distinguishes from the sweep's own work. And a deprecated
+        // *winner* is worse: the loser gets hidden in favour of an artifact
+        // that is itself out of results, so the answer disappears entirely.
+        for (id, role) in [(loser_id, "loser"), (winner_id, "winner")] {
+            let status = self.store.get_artifact(id).await?.status;
+            if status != ArtifactStatus::Active {
+                return Err(Error::Validation(format!(
+                    "cannot supersede: {role} {id} is {}",
+                    status.as_str()
+                )));
+            }
+        }
         self.store
             .set_superseded_by(loser_id, Some(winner_id))
             .await?;
@@ -202,6 +217,13 @@ impl Core {
     /// Flag an artifact stale with no specific replacement. Unlike `supersede`,
     /// there is no winning artifact on the other end — an operator judged the
     /// content itself no longer current.
+    ///
+    /// Row before payload. SQLite is the source of truth, so the state a
+    /// partial failure leaves — row deprecated, still in results — is the one
+    /// the sweep's drift repair (`jobs::consolidate::repair_lifecycle_drift`)
+    /// finishes by pushing the row's status into the payload. Writing the
+    /// payload first would instead hide the artifact behind a row that still
+    /// says active, and the repair, reading the row, would undo it.
     pub async fn deprecate(&self, id: &str) -> Result<()> {
         self.store
             .set_artifact_status(id, ArtifactStatus::Deprecated)
@@ -221,15 +243,24 @@ impl Core {
     /// payload no longer does, so Ops would keep listing it as hidden and the
     /// next consolidation sweep would re-apply `Superseded` to the vector
     /// store — undoing the operator without saying so.
+    ///
+    /// Payload before row, as `unsupersede` does it and for the same reason:
+    /// this direction *reveals*, so the intermediate state has to be the
+    /// visible one. Clearing the row first would leave the artifact hidden by a
+    /// payload nothing on the page explains — off the Ops deprecated list,
+    /// because the row now says active, and so out of reach of the very button
+    /// that would fix it. With the payload cleared first the artifact is back
+    /// in results immediately, still listed on Ops as deprecated, and one more
+    /// press finishes the job.
     pub async fn reactivate(&self, id: &str) -> Result<()> {
         if self.store.get_artifact(id).await?.superseded_by.is_some() {
             return self.unsupersede(id).await;
         }
-        self.store
-            .set_artifact_status(id, ArtifactStatus::Active)
-            .await?;
         self.vectors
             .set_lifecycle(id, ArtifactStatus::Active, None)
+            .await?;
+        self.store
+            .set_artifact_status(id, ArtifactStatus::Active)
             .await?;
         tracing::info!(artifact_id = id, "reactivated an artifact");
         Ok(())
@@ -250,27 +281,43 @@ impl Core {
         Ok(())
     }
 
-    /// One-shot: push every artifact's SQLite-side lifecycle state (source of
-    /// truth) into Qdrant. Run once after deploying the lifecycle migration —
-    /// existing points have no `status`/`last_verified_at` until this runs,
-    /// which every filter safely treats as active in the meantime, just not
-    /// yet filterable as deprecated.
+    /// Push every artifact's SQLite-side lifecycle state (source of truth) into
+    /// the vector store. Runs automatically at startup when any point is
+    /// missing its stamp, and on demand via `--backfill-lifecycle` — existing
+    /// points have no `status`/`last_verified_at` until it does, which every
+    /// filter safely treats as active in the meantime, just not yet filterable
+    /// as deprecated.
+    ///
+    /// Batched, and restartable by construction: the work is idempotent and
+    /// driven by a list SQLite regenerates, so a run that dies halfway is
+    /// resumed simply by running it again. One artifact that cannot be read is
+    /// logged and skipped rather than abandoning every artifact after it —
+    /// a single missing row must not be what keeps a base unbackfilled.
     pub async fn backfill_lifecycle(&self) -> Result<usize> {
+        const BATCH: usize = 256;
+        let ids = self.store.list_all_artifact_ids().await?;
+        let total = ids.len();
         let mut n = 0;
-        for id in self.store.list_all_artifact_ids().await? {
-            let c = self.store.get_artifact(&id).await?;
-            self.vectors
-                .set_lifecycle(&id, c.status, c.superseded_by.as_deref())
-                .await?;
-            self.vectors
-                // `false`: this pass touches every artifact, and a verify-style
-                // counter reset here would wipe every retrieval count in the
-                // base.
-                .set_last_verified_at(&id, c.last_verified_at.unwrap_or(c.created_at), false)
-                .await?;
-            n += 1;
+        for chunk in ids.chunks(BATCH) {
+            let mut rows = Vec::with_capacity(chunk.len());
+            for id in chunk {
+                match self.store.get_artifact(id).await {
+                    Ok(c) => rows.push(crate::vector::LifecycleRow {
+                        artifact_id: c.id.clone(),
+                        status: c.status,
+                        superseded_by: c.superseded_by.clone(),
+                        last_verified_at: c.last_verified_at.unwrap_or(c.created_at),
+                    }),
+                    Err(e) => {
+                        tracing::warn!(artifact_id = %id, error = %e, "skipped in the lifecycle backfill");
+                    }
+                }
+            }
+            self.vectors.apply_lifecycle(&rows).await?;
+            n += rows.len();
+            tracing::info!(done = n, total, "lifecycle backfill progress");
         }
-        tracing::info!(n, "backfilled lifecycle fields into qdrant");
+        tracing::info!(n, "backfilled lifecycle fields into the vector store");
         Ok(n)
     }
 

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -225,6 +225,22 @@ impl Core {
     /// payload first would instead hide the artifact behind a row that still
     /// says active, and the repair, reading the row, would undo it.
     pub async fn deprecate(&self, id: &str) -> Result<()> {
+        // A superseded artifact is already out of search, and `deprecate` does
+        // not clear `superseded_by`, so this would leave a row that is both:
+        // listed on Ops under "deprecated" *and* under "hidden as near
+        // identical", with a detail page that renders only the supersession
+        // branch and therefore never offers the button that undoes it. The
+        // payload would carry `status: deprecated, superseded_by: <winner>`, a
+        // combination nothing else in the system produces. The Ops page does not
+        // render the button in that state, but the route is reachable directly
+        // and this is a public API — so the rule lives here, next to
+        // `supersede`'s own guard.
+        if self.store.get_artifact(id).await?.superseded_by.is_some() {
+            return Err(Error::Validation(format!(
+                "cannot deprecate: {id} is already hidden in favour of another artifact; \
+                 reactivate it first"
+            )));
+        }
         self.store
             .set_artifact_status(id, ArtifactStatus::Deprecated)
             .await?;
@@ -293,6 +309,9 @@ impl Core {
     /// resumed simply by running it again. One artifact that cannot be read is
     /// logged and skipped rather than abandoning every artifact after it —
     /// a single missing row must not be what keeps a base unbackfilled.
+    ///
+    /// Finishes with `drop_orphan_points`, which is what lets the startup check
+    /// ever see zero unstamped points again.
     pub async fn backfill_lifecycle(&self) -> Result<usize> {
         const BATCH: usize = 256;
         let ids = self.store.list_all_artifact_ids().await?;
@@ -317,8 +336,44 @@ impl Core {
             n += rows.len();
             tracing::info!(done = n, total, "lifecycle backfill progress");
         }
+        self.drop_orphan_points().await?;
         tracing::info!(n, "backfilled lifecycle fields into the vector store");
         Ok(n)
+    }
+
+    /// Delete points whose SQLite row is gone.
+    ///
+    /// The pass above is driven by SQLite, so a point with no row can never be
+    /// stamped by it — and startup decides whether to run the backfill by
+    /// counting points with no stamp. One orphan therefore means the count never
+    /// reaches zero and every process start kicks off another full-base rewrite.
+    ///
+    /// Deleting is the right answer rather than stamping: SQLite is the source
+    /// of truth for what exists, so a point it does not name is a delete that a
+    /// crash left half-applied, and until it goes it stays searchable.
+    ///
+    /// The order matters. The point list is read *first* and the row list
+    /// second, so an artifact captured while this runs is either absent from the
+    /// scroll or present in the newer row list — never mistaken for an orphan.
+    /// The opposite skew is harmless: a row deleted just after the read leaves
+    /// its point for the next run.
+    async fn drop_orphan_points(&self) -> Result<()> {
+        let points = self.vectors.all_artifact_ids().await?;
+        let live: std::collections::HashSet<String> = self
+            .store
+            .list_all_artifact_ids()
+            .await?
+            .into_iter()
+            .collect();
+        let orphans: Vec<String> = points.into_iter().filter(|id| !live.contains(id)).collect();
+        if orphans.is_empty() {
+            return Ok(());
+        }
+        tracing::info!(
+            orphans = orphans.len(),
+            "deleting vector points whose artifact row is gone"
+        );
+        self.vectors.delete_artifacts(&orphans).await
     }
 
     /// Put back anything that was hidden in favour of an artifact which has
@@ -794,6 +849,130 @@ mod tests {
         assert_ne!(
             core.store.get_corpus(&out.id).await.unwrap().status,
             CorpusStatus::Failed
+        );
+    }
+
+    /// One point for `artifact_id`, with nothing set beyond what a write needs.
+    fn point(artifact_id: &str, corpus_id: &str) -> crate::vector::VectorPoint {
+        crate::vector::VectorPoint {
+            sparse: Default::default(),
+            vector: vec![0.1; 8],
+            payload: crate::vector::VectorPayload {
+                artifact_id: artifact_id.to_string(),
+                corpus_id: corpus_id.to_string(),
+                text: "t".into(),
+                title: None,
+                category: None,
+                tags: vec![],
+                created_at: 0,
+                last_seen_at: None,
+                hit_count: None,
+                superseded: None,
+                status: None,
+                last_verified_at: None,
+                superseded_by: None,
+            },
+        }
+    }
+
+    /// A corpus with one artifact in it, and the ids of both.
+    async fn one_artifact(core: &crate::core::Core) -> (String, String) {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "t".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        (src.id, made[0].id.clone())
+    }
+
+    #[tokio::test]
+    async fn deprecating_an_already_superseded_artifact_is_refused() {
+        // `set_artifact_status` leaves `superseded_by` alone, so this used to
+        // produce a row that is deprecated *and* hidden in favour of a winner:
+        // listed in both Ops tables, rendered only as a supersession, and so out
+        // of reach of the button that would undo it.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "loser".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "winner".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        core.supersede(&made[0].id, &made[1].id).await.unwrap();
+
+        assert!(matches!(
+            core.deprecate(&made[0].id).await,
+            Err(crate::error::Error::Validation(_))
+        ));
+        let after = core.store.get_artifact(&made[0].id).await.unwrap();
+        assert_eq!(
+            after.status,
+            crate::store::artifacts::ArtifactStatus::Superseded,
+            "the refused call changed the row anyway"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_backfill_deletes_points_whose_artifact_row_is_gone() {
+        // The backfill is driven by SQLite, so it can never stamp a point with
+        // no row — and startup decides whether to run it by counting unstamped
+        // points. One orphan therefore meant a full-base rewrite on every single
+        // process start, forever.
+        let core = test_core().await;
+        let (corpus, artifact) = one_artifact(&core).await;
+        core.vectors
+            .upsert(vec![point(&artifact, &corpus), point("gone", &corpus)])
+            .await
+            .unwrap();
+
+        core.backfill_lifecycle().await.unwrap();
+
+        assert_eq!(
+            core.vectors.all_artifact_ids().await.unwrap(),
+            vec![artifact],
+            "the orphaned point survived the backfill"
+        );
+        assert_eq!(
+            core.vectors.unstamped_count().await.unwrap(),
+            0,
+            "startup would run the backfill again on the next start"
         );
     }
 }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1,7 +1,9 @@
 use super::Core;
 use crate::error::{Error, Result};
+use crate::store::artifacts::ArtifactStatus;
 use crate::store::corpora::{CorpusStatus, NearDuplicate, content_hash};
 use crate::store::jobs::Stage;
+use crate::store::now;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct IngestOutcome {
@@ -173,10 +175,88 @@ impl Core {
     /// job. Clearing the row first loses the only page that offers the undo
     /// while the artifact is still hidden from search.
     pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
-        self.vectors.set_superseded(artifact_id, false).await?;
+        self.vectors
+            .set_lifecycle(artifact_id, ArtifactStatus::Active, None)
+            .await?;
         self.store.set_superseded_by(artifact_id, None).await?;
         tracing::info!(artifact_id, "restored a superseded artifact to search");
         Ok(())
+    }
+
+    /// Hide `loser_id` in favour of `winner_id`. Row before payload, matching
+    /// the sweep's existing auto-supersede order (`jobs::consolidate`): the
+    /// intermediate state after a partial failure is one an operator can act
+    /// on, since the artifact is already listed on Ops with its `superseded_by`
+    /// set, even if the search-side flag has not caught up yet.
+    pub async fn supersede(&self, loser_id: &str, winner_id: &str) -> Result<()> {
+        self.store
+            .set_superseded_by(loser_id, Some(winner_id))
+            .await?;
+        self.vectors
+            .set_lifecycle(loser_id, ArtifactStatus::Superseded, Some(winner_id))
+            .await?;
+        tracing::info!(loser_id, winner_id, "superseded an artifact");
+        Ok(())
+    }
+
+    /// Flag an artifact stale with no specific replacement. Unlike `supersede`,
+    /// there is no winning artifact on the other end — an operator judged the
+    /// content itself no longer current.
+    pub async fn deprecate(&self, id: &str) -> Result<()> {
+        self.store
+            .set_artifact_status(id, ArtifactStatus::Deprecated)
+            .await?;
+        self.vectors
+            .set_lifecycle(id, ArtifactStatus::Deprecated, None)
+            .await?;
+        tracing::info!(artifact_id = id, "deprecated an artifact");
+        Ok(())
+    }
+
+    /// Move an artifact back to active. Does not touch `superseded_by` — an
+    /// artifact reactivated out of `Superseded` keeps pointing at what it lost
+    /// to, same as `unsupersede`; callers that mean to undo a supersession
+    /// specifically should use that instead.
+    pub async fn reactivate(&self, id: &str) -> Result<()> {
+        self.store
+            .set_artifact_status(id, ArtifactStatus::Active)
+            .await?;
+        self.vectors
+            .set_lifecycle(id, ArtifactStatus::Active, None)
+            .await?;
+        tracing::info!(artifact_id = id, "reactivated an artifact");
+        Ok(())
+    }
+
+    /// Stamp an artifact as confirmed accurate now — what search ranking's
+    /// recency decay reads.
+    pub async fn verify(&self, id: &str) -> Result<()> {
+        let at = now();
+        self.store.set_last_verified_at(id, at).await?;
+        self.vectors.set_last_verified_at(id, at).await?;
+        tracing::info!(artifact_id = id, "verified an artifact");
+        Ok(())
+    }
+
+    /// One-shot: push every artifact's SQLite-side lifecycle state (source of
+    /// truth) into Qdrant. Run once after deploying the lifecycle migration —
+    /// existing points have no `status`/`last_verified_at` until this runs,
+    /// which every filter safely treats as active in the meantime, just not
+    /// yet filterable as deprecated.
+    pub async fn backfill_lifecycle(&self) -> Result<usize> {
+        let mut n = 0;
+        for id in self.store.list_all_artifact_ids().await? {
+            let c = self.store.get_artifact(&id).await?;
+            self.vectors
+                .set_lifecycle(&id, c.status, c.superseded_by.as_deref())
+                .await?;
+            self.vectors
+                .set_last_verified_at(&id, c.last_verified_at.unwrap_or(c.created_at))
+                .await?;
+            n += 1;
+        }
+        tracing::info!(n, "backfilled lifecycle fields into qdrant");
+        Ok(n)
     }
 
     /// Put back anything that was hidden in favour of an artifact which has
@@ -196,7 +276,11 @@ impl Core {
     pub(crate) async fn heal_dangling_supersessions(&self) -> Result<()> {
         let mut first_err = None;
         for id in self.store.dangling_superseded().await? {
-            if let Err(e) = self.vectors.set_superseded(&id, false).await {
+            if let Err(e) = self
+                .vectors
+                .set_lifecycle(&id, ArtifactStatus::Active, None)
+                .await
+            {
                 tracing::warn!(
                     artifact_id = %id,
                     error = %e,
@@ -561,7 +645,11 @@ mod tests {
                     tags: vec![],
                     created_at: 0,
                     last_seen_at: None,
+                    hit_count: None,
                     superseded: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
                 },
             }])
             .await

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -69,6 +69,9 @@ pub struct Core {
     /// Thresholds and budgets for duplicate hygiene. Read on the capture path
     /// and by the sweep, so it lives here rather than being passed down.
     pub consolidate: crate::config::ConsolidateConfig,
+    /// Cosine similarity below which a result is reported as only loosely
+    /// related. See `VectorConfig::weak_below`.
+    pub weak_below: f32,
 }
 
 impl Core {
@@ -101,6 +104,7 @@ impl Core {
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: cfg.consolidate.clone(),
+            weak_below: cfg.vector.weak_below,
         }
     }
 }
@@ -155,6 +159,11 @@ pub mod test_support {
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: crate::config::ConsolidateConfig::default(),
+            // The fake embedder's vectors are not a semantic space, so a
+            // realistic threshold would mark arbitrary results weak and every
+            // search test would be asserting against noise. Tests that care
+            // about the labelling set it themselves.
+            weak_below: 0.0,
         }
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -2,6 +2,7 @@ use super::Core;
 use crate::error::{Error, Result};
 use crate::store::artifacts::ArtifactStatus;
 use crate::vector::SearchFilter;
+use std::collections::HashMap;
 
 pub const DEFAULT_LIMIT: usize = 10;
 pub const MAX_LIMIT: usize = 50;
@@ -105,6 +106,19 @@ fn cap_per_corpus(
     kept
 }
 
+/// Each hit's stored retrieval count, keyed by artifact id. Absent means the
+/// payload carried no `hit_count`, which reads as zero.
+fn counts_of(hits: &[crate::vector::SearchHit]) -> HashMap<String, i64> {
+    hits.iter()
+        .map(|h| {
+            (
+                h.payload.artifact_id.clone(),
+                h.payload.hit_count.unwrap_or(0),
+            )
+        })
+        .collect()
+}
+
 /// Chunks older than this are candidates for resurfacing, and a chunk shown
 /// within this window counts as still remembered.
 pub const FORGOTTEN_AFTER_DAYS: i64 = 30;
@@ -117,15 +131,25 @@ impl Core {
     /// get slower, or fail, because a bookkeeping write did. Tracked rather
     /// than merely spawned, so shutdown drains it instead of dropping it — a
     /// lost stamp makes a chunk look forgotten when it is not.
-    fn mark_seen(&self, results: &[SearchResult]) {
+    /// `hit_counts` carries what the payloads the caller just read said, keyed
+    /// by artifact id. `touch` needs the current count to increment it, and
+    /// passing along the copy already in hand is what keeps a marked search
+    /// from costing an extra read of every hit it just fetched.
+    fn mark_seen(&self, results: &[SearchResult], hit_counts: &HashMap<String, i64>) {
         if results.is_empty() {
             return;
         }
-        let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
+        let targets: Vec<crate::vector::Touch> = results
+            .iter()
+            .map(|r| crate::vector::Touch {
+                hit_count: hit_counts.get(&r.artifact_id).copied(),
+                artifact_id: r.artifact_id.clone(),
+            })
+            .collect();
         let vectors = self.vectors.clone();
         let now = now_secs();
         self.background.spawn(async move {
-            if let Err(e) = vectors.touch(&ids, now).await {
+            if let Err(e) = vectors.touch(&targets, now).await {
                 tracing::warn!(error = %e, "could not record which chunks were shown");
             }
         });
@@ -135,11 +159,13 @@ impl Core {
     /// which is why the detail pane records it and an incremental search does
     /// not.
     pub fn mark_artifact_seen(&self, artifact_id: &str) {
-        let ids = vec![artifact_id.to_string()];
+        // No payload in hand here — only an id — so the store reads the current
+        // count itself, for this one point.
+        let targets = vec![crate::vector::Touch::unknown(artifact_id)];
         let vectors = self.vectors.clone();
         let now = now_secs();
         self.background.spawn(async move {
-            if let Err(e) = vectors.touch(&ids, now).await {
+            if let Err(e) = vectors.touch(&targets, now).await {
                 tracing::warn!(error = %e, "could not record that a chunk was opened");
             }
         });
@@ -156,6 +182,7 @@ impl Core {
             .vectors
             .resurface(limit.clamp(1, MAX_LIMIT), cutoff, cutoff)
             .await?;
+        let hit_counts = counts_of(&hits);
         let results: Vec<SearchResult> = hits
             .into_iter()
             .map(|h| SearchResult {
@@ -172,7 +199,7 @@ impl Core {
             })
             .collect();
         // Surfacing counts as seeing, or the same chunks come back tomorrow.
-        self.mark_seen(&results);
+        self.mark_seen(&results, &hit_counts);
         Ok(results)
     }
 
@@ -305,6 +332,9 @@ impl Core {
             Some(max) => cap_per_corpus(hits, max, candidates),
             None => hits,
         };
+        // Taken before the payloads are consumed: `mark_seen` needs each hit's
+        // stored `hit_count` to increment it without reading it back.
+        let hit_counts = counts_of(&hits);
 
         let mut results: Vec<SearchResult> = hits
             .into_iter()
@@ -345,7 +375,7 @@ impl Core {
 
         results.truncate(limit);
         if query.mark {
-            self.mark_seen(&results);
+            self.mark_seen(&results, &hit_counts);
         }
         tracing::info!(
             q = %query.q,

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -135,15 +135,31 @@ impl Core {
     /// by artifact id. `touch` needs the current count to increment it, and
     /// passing along the copy already in hand is what keeps a marked search
     /// from costing an extra read of every hit it just fetched.
-    fn mark_seen(&self, results: &[SearchResult], hit_counts: &HashMap<String, i64>) {
+    ///
+    /// `counts_as_hit` is false for a list nobody asked for — `resurface` draws
+    /// its chunks at random, and counting that as a retrieval would let the
+    /// forgotten-chunks feature quietly disqualify the same artifacts from the
+    /// stale-review list. See `vector::Touch`.
+    fn mark_seen(
+        &self,
+        results: &[SearchResult],
+        hit_counts: &HashMap<String, i64>,
+        counts_as_hit: bool,
+    ) {
         if results.is_empty() {
             return;
         }
         let targets: Vec<crate::vector::Touch> = results
             .iter()
-            .map(|r| crate::vector::Touch {
-                hit_count: hit_counts.get(&r.artifact_id).copied(),
-                artifact_id: r.artifact_id.clone(),
+            .map(|r| {
+                if counts_as_hit {
+                    crate::vector::Touch::retrieved(
+                        &r.artifact_id,
+                        hit_counts.get(&r.artifact_id).copied(),
+                    )
+                } else {
+                    crate::vector::Touch::shown(&r.artifact_id)
+                }
             })
             .collect();
         let vectors = self.vectors.clone();
@@ -158,10 +174,14 @@ impl Core {
     /// Opening a chunk is the deliberate act that counts as remembering it,
     /// which is why the detail pane records it and an incremental search does
     /// not.
+    ///
+    /// It stamps `last_seen_at` only. An open is not a retrieval: the stale
+    /// review list surfaces artifacts with at most `stale_max_hits` hits since
+    /// they were last verified — zero by default — so counting the click that
+    /// opens a candidate would remove it from the list that offered it, and
+    /// only a `verify` could ever put it back.
     pub fn mark_artifact_seen(&self, artifact_id: &str) {
-        // No payload in hand here — only an id — so the store reads the current
-        // count itself, for this one point.
-        let targets = vec![crate::vector::Touch::unknown(artifact_id)];
+        let targets = vec![crate::vector::Touch::shown(artifact_id)];
         let vectors = self.vectors.clone();
         let now = now_secs();
         self.background.spawn(async move {
@@ -198,8 +218,9 @@ impl Core {
                 last_verified_at: h.payload.last_verified_at,
             })
             .collect();
-        // Surfacing counts as seeing, or the same chunks come back tomorrow.
-        self.mark_seen(&results, &hit_counts);
+        // Surfacing counts as seeing, or the same chunks come back tomorrow —
+        // but not as a retrieval: nobody asked for these.
+        self.mark_seen(&results, &hit_counts, false);
         Ok(results)
     }
 
@@ -375,7 +396,8 @@ impl Core {
 
         results.truncate(limit);
         if query.mark {
-            self.mark_seen(&results, &hit_counts);
+            // A query answered these, so they count as retrievals.
+            self.mark_seen(&results, &hit_counts, true);
         }
         tracing::info!(
             q = %query.q,
@@ -939,5 +961,138 @@ mod tests {
 
         core.verify(&id).await.unwrap();
         assert_eq!(hits_now().await, Some(0), "verify must restart the count");
+    }
+
+    #[tokio::test]
+    async fn opening_a_stale_candidate_does_not_remove_it_from_the_review_list() {
+        // `stale_max_hits` is zero by default, so counting the click that opens
+        // a candidate meant an operator who read a row and decided to defer had
+        // just disqualified it — permanently, since only a `verify` clears the
+        // counter, and a verify is the other answer entirely.
+        let core = test_core().await;
+        seed(&core, &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        core.vectors
+            .set_last_verified_at(&id, 1, false)
+            .await
+            .unwrap();
+
+        let listed = || async {
+            core.stale_candidates(10)
+                .await
+                .unwrap()
+                .iter()
+                .any(|r| r.artifact_id == id)
+        };
+        assert!(listed().await, "the fixture is not a stale candidate");
+
+        core.mark_artifact_seen(&id);
+        core.background.wait_idle().await;
+
+        assert!(
+            listed().await,
+            "reading a candidate took it off the list that offered it"
+        );
+    }
+
+    #[tokio::test]
+    async fn resurfacing_does_not_count_as_a_retrieval() {
+        // The forgotten list draws at random from exactly the population the
+        // stale review list targets — old and unseen — so counting what it drew
+        // as a hit quietly emptied the review list over time. It still stamps
+        // `last_seen_at`, which is what keeps the same handful from returning
+        // every day.
+        let core = test_core().await;
+        seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
+        let old = now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1;
+        sqlx::query("UPDATE artifacts SET created_at = ?")
+            .bind(old)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        core.vectors
+            .set_last_verified_at(&id, 1, false)
+            .await
+            .unwrap();
+
+        assert_eq!(core.resurface(10).await.unwrap().len(), 1);
+        core.background.wait_idle().await;
+
+        assert!(
+            core.stale_candidates(10)
+                .await
+                .unwrap()
+                .iter()
+                .any(|r| r.artifact_id == id),
+            "being drawn at random counted as a retrieval"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deprecated_artifact_is_not_offered_as_forgotten() {
+        // Old and unseen is exactly what a retired artifact looks like, so the
+        // forgotten list used to hand back the very things an operator had just
+        // taken out of search — and `resurface` marks what it shows as seen, so
+        // it also rewrote their bookkeeping on the way.
+        let core = test_core().await;
+        seed_from(
+            &core,
+            "old",
+            &[("long forgotten", "c", &[]), ("also forgotten", "c", &[])],
+        )
+        .await;
+        let old = now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1;
+        sqlx::query("UPDATE artifacts SET created_at = ?")
+            .bind(old)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        reembed_all(&core).await;
+        let ids = core.store.list_all_artifact_ids().await.unwrap();
+
+        core.deprecate(&ids[0]).await.unwrap();
+
+        let out = core.resurface(10).await.unwrap();
+        assert_eq!(
+            out.iter().map(|r| &r.artifact_id).collect::<Vec<_>>(),
+            vec![&ids[1]],
+            "the forgotten list offered an artifact that was just retired"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deprecated_artifact_is_not_a_neighbour() {
+        // The related pane is a list of live content. A deprecated artifact is
+        // near-identical to nothing in particular, but it is *near* — and
+        // linking to it from a live artifact presents retired knowledge as
+        // current. The legacy `superseded` flag never catches this: a
+        // deprecation deliberately writes it false.
+        let core = test_core().await;
+        seed(
+            &core,
+            &[("alpha text", "note", &[]), ("alpha text too", "note", &[])],
+        )
+        .await;
+        reembed_all(&core).await;
+        let ids = core.store.list_all_artifact_ids().await.unwrap();
+        assert_eq!(
+            core.vectors.neighbours(&ids[0], 10).await.unwrap().len(),
+            1,
+            "the fixture has no neighbour to lose"
+        );
+
+        core.deprecate(&ids[1]).await.unwrap();
+
+        assert!(
+            core.vectors
+                .neighbours(&ids[0], 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a retired artifact is still linked from a live one"
+        );
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -1,5 +1,6 @@
 use super::Core;
 use crate::error::{Error, Result};
+use crate::store::artifacts::ArtifactStatus;
 use crate::vector::SearchFilter;
 
 pub const DEFAULT_LIMIT: usize = 10;
@@ -29,6 +30,12 @@ pub struct SearchQuery {
     /// and so do the API and MCP paths, which are deliberate by construction.
     #[serde(default)]
     pub mark: bool,
+    /// Include deprecated artifacts, excluded by default.
+    #[serde(default)]
+    pub include_deprecated: bool,
+    /// Include superseded artifacts, excluded by default.
+    #[serde(default)]
+    pub include_superseded: bool,
 }
 
 /// What a search cost, for the faint line under the rail.
@@ -47,6 +54,15 @@ pub struct SearchResult {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub score: f32,
+    /// Absent means active — see `VectorPayload::status`. Only worth reading
+    /// when the query opted into deprecated/superseded results; an ordinary
+    /// search never returns anything else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<ArtifactStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_verified_at: Option<i64>,
 }
 
 fn now_secs() -> i64 {
@@ -150,11 +166,46 @@ impl Core {
                 category: h.payload.category,
                 tags: h.payload.tags,
                 score: h.score,
+                status: h.payload.status,
+                superseded_by: h.payload.superseded_by,
+                last_verified_at: h.payload.last_verified_at,
             })
             .collect();
         // Surfacing counts as seeing, or the same chunks come back tomorrow.
         self.mark_seen(&results);
         Ok(results)
+    }
+
+    /// Active artifacts confirmed stale a while ago and rarely or never
+    /// retrieved since — candidates for an operator to review and deprecate,
+    /// never anything applied automatically. A one-way signal: it can only
+    /// surface a candidate, never rank anything higher, so it cannot create a
+    /// popularity feedback loop the way scoring on `hit_count` directly would.
+    pub async fn stale_candidates(&self, limit: usize) -> Result<Vec<SearchResult>> {
+        let cutoff = now_secs() - self.consolidate.stale_after_days as i64 * SECONDS_PER_DAY;
+        let hits = self
+            .vectors
+            .stale_candidates(
+                cutoff,
+                self.consolidate.stale_max_hits,
+                limit.clamp(1, MAX_LIMIT),
+            )
+            .await?;
+        Ok(hits
+            .into_iter()
+            .map(|h| SearchResult {
+                artifact_id: h.payload.artifact_id,
+                corpus_id: h.payload.corpus_id,
+                title: h.payload.title,
+                text: h.payload.text,
+                category: h.payload.category,
+                tags: h.payload.tags,
+                score: h.score,
+                status: h.payload.status,
+                superseded_by: h.payload.superseded_by,
+                last_verified_at: h.payload.last_verified_at,
+            })
+            .collect())
     }
 
     /// The hot path. One embedding call, one vector search, and optionally one
@@ -224,9 +275,11 @@ impl Core {
         let filter = SearchFilter {
             tags: query.tags.clone(),
             category: query.category.clone(),
-            // Search never shows an artifact the sweep hid. It stays readable
-            // by id, which is what the review queue and the undo need.
-            include_superseded: false,
+            // Deprecated/superseded artifacts stay out of ordinary search by
+            // default; they remain readable by id either way, which is what
+            // the review queue and the undo need. A caller opts in explicitly.
+            include_superseded: query.include_superseded,
+            include_deprecated: query.include_deprecated,
         };
         // Over-fetch whenever something downstream narrows the list: both the
         // per-source cap and the reranker can only discard what they are given.
@@ -263,6 +316,9 @@ impl Core {
                 category: h.payload.category,
                 tags: h.payload.tags,
                 score: h.score,
+                status: h.payload.status,
+                superseded_by: h.payload.superseded_by,
+                last_verified_at: h.payload.last_verified_at,
             })
             .collect();
 
@@ -364,6 +420,8 @@ mod tests {
             // The default for these tests is the deliberate search the API and
             // MCP make; the incremental case is exercised explicitly below.
             mark: true,
+            include_deprecated: false,
+            include_superseded: false,
         }
     }
 
@@ -676,7 +734,11 @@ mod tests {
                 tags: vec![],
                 created_at: 0,
                 last_seen_at: None,
+                hit_count: None,
                 superseded: None,
+                status: None,
+                last_verified_at: None,
+                superseded_by: None,
             },
             score,
         };

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -64,6 +64,20 @@ pub struct SearchResult {
     pub superseded_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_verified_at: Option<i64>,
+    /// This artifact is only loosely related to the query.
+    ///
+    /// Retrieval always returns its best candidates, however bad they are, and
+    /// `score` cannot expose that: hybrid retrieval fuses ranks, so the top hit
+    /// for a typed-in typo carries the same score as the top hit for an exact
+    /// question. Presenting both the same way is how a search for nonsense came
+    /// back with four confident-looking answers. This is read from the cosine
+    /// similarity, which does mean the same thing from one query to the next.
+    ///
+    /// False when nothing can be said — a hit the lexical half found contains
+    /// the query's terms verbatim, and a store that reports no similarity gets
+    /// the benefit of the doubt. Weakness has to be demonstrated, never assumed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub weak: bool,
 }
 
 fn now_secs() -> i64 {
@@ -216,6 +230,9 @@ impl Core {
                 status: h.payload.status,
                 superseded_by: h.payload.superseded_by,
                 last_verified_at: h.payload.last_verified_at,
+                // Not an answer to a query, so there is no query to be far
+                // from. These lists are drawn, not matched.
+                weak: false,
             })
             .collect();
         // Surfacing counts as seeing, or the same chunks come back tomorrow —
@@ -252,6 +269,9 @@ impl Core {
                 status: h.payload.status,
                 superseded_by: h.payload.superseded_by,
                 last_verified_at: h.payload.last_verified_at,
+                // Not an answer to a query, so there is no query to be far
+                // from. These lists are drawn, not matched.
+                weak: false,
             })
             .collect())
     }
@@ -370,6 +390,9 @@ impl Core {
                 status: h.payload.status,
                 superseded_by: h.payload.superseded_by,
                 last_verified_at: h.payload.last_verified_at,
+                // Demonstrated, never assumed: a hit with no similarity to
+                // read is one the lexical half matched verbatim.
+                weak: h.similarity.is_some_and(|s| s < self.weak_below),
             })
             .collect();
 
@@ -793,6 +816,7 @@ mod tests {
                 superseded_by: None,
             },
             score,
+            similarity: Some(score),
         };
         let ranked = || {
             vec![

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -828,4 +828,86 @@ mod tests {
         let core = test_core().await;
         assert!(core.search(&q("anything")).await.unwrap().is_empty());
     }
+
+    #[tokio::test]
+    async fn include_deprecated_surfaces_a_deprecated_artifact() {
+        // The opt-in exists to let an operator look at what was retired. It has
+        // to reach past the legacy `superseded` flag, which a deprecation must
+        // therefore leave alone — see `lifecycle_payload`.
+        let core = test_core().await;
+        seed(&core, &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.search(&q("alpha")).await.unwrap()[0]
+            .artifact_id
+            .clone();
+        core.deprecate(&id).await.unwrap();
+
+        assert!(
+            core.search(&q("alpha")).await.unwrap().is_empty(),
+            "a deprecated artifact must stay out of an ordinary search"
+        );
+
+        let mut opted_in = q("alpha");
+        opted_in.include_deprecated = true;
+        let hits = core.search(&opted_in).await.unwrap();
+        assert_eq!(hits.len(), 1, "include_deprecated returned nothing");
+        assert_eq!(hits[0].artifact_id, id);
+        assert_eq!(hits[0].status, Some(ArtifactStatus::Deprecated));
+    }
+
+    #[tokio::test]
+    async fn a_newly_embedded_artifact_is_not_already_stale() {
+        // The scoring formula reads a missing `last_verified_at` as epoch, so
+        // an unstamped point ranks as maximally stale and lands on the
+        // deprecation-review list the moment it is ingested.
+        let core = test_core().await;
+        seed(&core, &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+
+        let hit = &core.search(&q("alpha")).await.unwrap()[0];
+        let stamp = hit
+            .last_verified_at
+            .expect("a fresh artifact carries no last_verified_at");
+        assert!(
+            stamp > now_secs() - 300,
+            "the stamp must be the artifact's own, not epoch: {stamp}"
+        );
+
+        assert!(
+            core.stale_candidates(10).await.unwrap().is_empty(),
+            "an artifact ingested seconds ago is not a deprecation candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn verifying_restarts_the_retrieval_count() {
+        // `stale_max_hits` counts retrievals *since* the last verification. A
+        // lifetime counter would mean one appearance in a marked search kept an
+        // artifact off the review list for good.
+        let core = test_core().await;
+        seed(&core, &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.search(&q("alpha")).await.unwrap()[0]
+            .artifact_id
+            .clone();
+        core.background.wait_idle().await;
+
+        let hits_now = || async {
+            core.vectors
+                .stale_candidates(i64::MAX, i64::MAX, 10)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|h| h.payload.artifact_id == id)
+                .and_then(|h| h.payload.hit_count)
+        };
+        assert_eq!(
+            hits_now().await,
+            Some(1),
+            "the marked search was not counted"
+        );
+
+        core.verify(&id).await.unwrap();
+        assert_eq!(hits_now().await, Some(0), "verify must restart the count");
+    }
 }

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -75,10 +75,11 @@ These are NOT contradictions:
 
 Reply with JSON only, no commentary, in exactly this shape:
 
-{"contradicts": true, "detail": "..."}
+{"contradicts": true, "detail": "...", "obsolete": "a"}
 
 - contradicts: true only for a concrete disagreement about one subject, as above.
-- detail: when true, one short sentence naming the two conflicting values and which artifact holds each. Omit it when false."#;
+- detail: when true, one short sentence naming the two conflicting values and which artifact holds each. Omit it when false.
+- obsolete: "a" or "b" — only when you are confident one artifact plainly replaces the other (a deprecated flag, step, or default versus its current replacement), not merely that they differ. Omit this field whenever the direction is unclear, the two describe genuinely different but still-valid options, or you are not sure."#;
 
 /// The two artifacts, each under its title.
 ///
@@ -100,6 +101,8 @@ struct Judgement {
     contradicts: bool,
     #[serde(default)]
     detail: Option<String>,
+    #[serde(default)]
+    obsolete: Option<String>,
 }
 
 /// A reply that cannot be read is an error, not a verdict.
@@ -107,7 +110,13 @@ struct Judgement {
 /// Defaulting to "contradicts" would fill the review queue with noise an
 /// operator has to clear by hand; defaulting to "no" would quietly close real
 /// conflicts. Failing leaves the pair pending, and the next sweep asks again.
-pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>)> {
+///
+/// The third element is which side the judge named obsolete — `'a'` or
+/// `'b'` — when it named one with confidence. Anything else the model wrote
+/// there (a stray word, a full sentence) is treated the same as omitting it:
+/// an unreadable direction must not fail the whole reply, since the
+/// contradiction verdict itself may still be perfectly readable.
+pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>, Option<char>)> {
     let j: Judgement = serde_json::from_str(extract_json(body)).map_err(|e| {
         Error::MalformedLlmOutput(format!("judge reply was not the expected JSON: {e}"))
     })?;
@@ -115,7 +124,12 @@ pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>)> {
         .detail
         .map(|d| d.trim().to_string())
         .filter(|d| !d.is_empty() && j.contradicts);
-    Ok((j.contradicts, detail))
+    let obsolete = j.obsolete.as_deref().and_then(|o| match o.trim() {
+        "a" | "A" => Some('a'),
+        "b" | "B" => Some('b'),
+        _ => None,
+    });
+    Ok((j.contradicts, detail, obsolete))
 }
 
 #[derive(serde::Deserialize)]
@@ -439,16 +453,17 @@ mod tests {
 
     #[test]
     fn a_judgement_parses() {
-        let (yes, detail) =
+        let (yes, detail, obsolete) =
             parse_judgement(r#"{"contradicts":true,"detail":"one says 1.2, the other 1.4"}"#)
                 .unwrap();
         assert!(yes);
         assert_eq!(detail.as_deref(), Some("one says 1.2, the other 1.4"));
+        assert!(obsolete.is_none());
     }
 
     #[test]
     fn a_negative_judgement_carries_no_detail() {
-        let (yes, detail) = parse_judgement(r#"{"contradicts":false}"#).unwrap();
+        let (yes, detail, _) = parse_judgement(r#"{"contradicts":false}"#).unwrap();
         assert!(!yes);
         assert!(detail.is_none());
     }
@@ -456,8 +471,28 @@ mod tests {
     #[test]
     fn a_judgement_wrapped_in_prose_and_fences_still_parses() {
         // The same models that fence the synthesis reply fence this one.
-        let (yes, _) = parse_judgement("Sure:\n```json\n{\"contradicts\": true}\n```").unwrap();
+        let (yes, ..) = parse_judgement("Sure:\n```json\n{\"contradicts\": true}\n```").unwrap();
         assert!(yes);
+    }
+
+    #[test]
+    fn a_judgement_names_the_obsolete_side() {
+        let (yes, _, obsolete) = parse_judgement(
+            r#"{"contradicts":true,"detail":"a uses --old-flag, b uses --new-flag","obsolete":"a"}"#,
+        )
+        .unwrap();
+        assert!(yes);
+        assert_eq!(obsolete, Some('a'));
+    }
+
+    #[test]
+    fn an_unreadable_obsolete_value_is_treated_as_absent() {
+        // An unparsable direction must not fail the whole reply — the
+        // contradiction verdict itself is still readable.
+        let (yes, _, obsolete) =
+            parse_judgement(r#"{"contradicts":true,"obsolete":"not sure honestly"}"#).unwrap();
+        assert!(yes);
+        assert!(obsolete.is_none());
     }
 
     #[test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -132,7 +132,13 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             // artifact as hidden while every search still returned it. Finish
             // the write that was lost; it is idempotent and costs no inference.
             tracing::info!(artifact_id = %id, "re-applying a superseded flag the vector store is missing");
-            core.vectors.set_superseded(id, true).await?;
+            core.vectors
+                .set_lifecycle(
+                    id,
+                    crate::store::artifacts::ArtifactStatus::Superseded,
+                    c.superseded_by.as_deref(),
+                )
+                .await?;
             continue;
         }
         let root = clusters.find(id);
@@ -147,9 +153,9 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         let keep = keeper(group);
         for c in group.iter().filter(|c| c.id != keep.id) {
             // SQLite first: it is the source of truth, and a payload flag with
-            // no row behind it is a hidden artifact nothing can explain.
-            core.store.set_superseded_by(&c.id, Some(&keep.id)).await?;
-            core.vectors.set_superseded(&c.id, true).await?;
+            // no row behind it is a hidden artifact nothing can explain. See
+            // `Core::supersede`.
+            core.supersede(&c.id, &keep.id).await?;
             hidden.insert(c.id.clone());
             out.superseded += 1;
             tracing::info!(
@@ -193,10 +199,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
                 (&b, &a)
             };
             if contains_normalized(&long.text, &short.text) {
-                core.store
-                    .set_superseded_by(&short.id, Some(&long.id))
-                    .await?;
-                core.vectors.set_superseded(&short.id, true).await?;
+                core.supersede(&short.id, &long.id).await?;
                 out.superseded += 1;
                 tracing::info!(
                     superseded = %short.id,
@@ -336,18 +339,47 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
         };
 
         match crate::infer::prompt::parse_judgement(&reply) {
-            Ok((true, detail)) => {
+            Ok((true, detail, obsolete)) => {
                 contradictions += 1;
-                core.store
-                    .set_pair_state(
-                        p.id,
-                        crate::store::pairs::PairState::Contradiction,
-                        detail.as_deref(),
-                    )
-                    .await?;
-                tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
+                // Trust the judge's named direction only when it agrees with
+                // the sweep's own newest-wins bias (see `keeper`): a call that
+                // names the *newer* artifact obsolete is exactly the failure
+                // mode worth guarding against, since it would otherwise
+                // propose hiding the side more likely to be current.
+                let obsolete_id = obsolete.and_then(|side| {
+                    let (named, other) = match side {
+                        'a' => (&a, &b),
+                        _ => (&b, &a),
+                    };
+                    (named.created_at <= other.created_at).then(|| named.id.clone())
+                });
+                match obsolete_id {
+                    Some(obsolete_id) => {
+                        // Proposed, not applied: an operator confirms via the
+                        // pair's "apply supersede" action before anything is
+                        // actually hidden.
+                        core.store
+                            .set_pair_superseded(p.id, &obsolete_id, detail.as_deref())
+                            .await?;
+                        tracing::info!(
+                            pair = p.id,
+                            obsolete = %obsolete_id,
+                            "judge proposed a supersede, pending operator confirmation"
+                        );
+                    }
+                    None => {
+                        core.store
+                            .set_pair_state(
+                                p.id,
+                                crate::store::pairs::PairState::Contradiction,
+                                detail.as_deref(),
+                            )
+                            .await?;
+                        tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
+                    }
+                }
             }
-            Ok((false, _)) => {
+            Ok((false, _, _)) => {
                 core.store
                     .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
                     .await?;
@@ -402,7 +434,11 @@ mod tests {
                     tags: vec![],
                     created_at: c.created_at,
                     last_seen_at: None,
+                    hit_count: None,
                     superseded: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
                 },
             })
             .collect();
@@ -448,7 +484,11 @@ mod tests {
                     tags: vec![],
                     created_at: made[0].created_at,
                     last_seen_at: None,
+                    hit_count: None,
                     superseded: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
                 },
             }])
             .await
@@ -738,6 +778,73 @@ mod tests {
             .unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].detail.as_deref(), Some("1.21.4 versus 1.30.0"));
+    }
+
+    #[tokio::test]
+    async fn a_confident_direction_proposes_a_supersede_but_does_not_apply_it() {
+        // The judge names a direction; an operator still has to confirm it.
+        // Nothing about either artifact changes here — only the pair.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"contradicts":true,"detail":"old flag vs new flag","obsolete":"a"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!((out.judged, out.contradictions), (1, 1), "{out:?}");
+        let found = core
+            .store
+            .pairs_by_state(PairState::Superseded, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1, "the pair did not land as proposed");
+        assert_eq!(found[0].obsolete_id.as_deref(), Some(ids[0].as_str()));
+
+        // Proposed, not applied.
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "the judge's proposal must not hide anything by itself"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_direction_naming_the_newer_artifact_is_not_trusted() {
+        // A miscalibrated call proposing to hide the *newer* side is exactly
+        // the failure mode the newest-wins guard exists to catch: it disagrees
+        // with the sweep's own bias, so it must fall back to a plain
+        // contradiction rather than being trusted.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        let ids = disagreeing(&core).await;
+        // Force `b` (ids[1]) strictly newer than `a`: `now()` is second-grained,
+        // so two rows inserted in the same test would otherwise tie, and a tie
+        // is meant to pass the guard. Naming the genuinely newer side obsolete
+        // disagrees with `keeper()`'s bias and must be rejected.
+        sqlx::query("UPDATE artifacts SET created_at = created_at + 100 WHERE id = ?")
+            .bind(&ids[1])
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"contradicts":true,"detail":"x","obsolete":"b"}"#.into(),
+        ]));
+
+        run(&core).await.unwrap();
+        let superseded = core
+            .store
+            .pairs_by_state(PairState::Superseded, 10)
+            .await
+            .unwrap();
+        assert!(
+            superseded.is_empty(),
+            "a direction naming the newer artifact must not be trusted: {superseded:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -521,6 +521,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reactivating_a_superseded_artifact_survives_the_next_sweep() {
+        // Flipping the status without clearing `superseded_by` left the row
+        // still pointing at its winner, so the next sweep re-applied the
+        // superseded flag and the operator's decision quietly disappeared.
+        // The pair sits in the review band, below `auto_supersede`, so nothing
+        // here is a near-identical copy the sweep would re-hide on merit. The
+        // supersession is an applied judge proposal, which is the case an
+        // operator would reverse.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("the timeout is 30 seconds", [1.0, 0.0]),
+                ("the timeout is 90 seconds", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        core.supersede(&ids[0], &ids[1]).await.unwrap();
+
+        core.reactivate(&ids[0]).await.unwrap();
+
+        let back = core.store.get_artifact(&ids[0]).await.unwrap();
+        assert!(
+            back.superseded_by.is_none(),
+            "reactivate left the row pointing at its winner"
+        );
+        assert_eq!(back.status, crate::store::artifacts::ArtifactStatus::Active);
+
+        run(&core).await.unwrap();
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.payload.artifact_id == ids[0]),
+            "the sweep re-hid an artifact an operator had reactivated"
+        );
+    }
+
+    #[tokio::test]
     async fn a_sweep_finishes_a_supersession_whose_payload_write_was_lost() {
         // The row and the payload cannot be written atomically. A crash between
         // them used to be permanent: the next sweep skipped the artifact

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -14,7 +14,7 @@
 
 use crate::core::Core;
 use crate::error::Result;
-use crate::store::artifacts::Chunk;
+use crate::store::artifacts::{ArtifactStatus, Chunk};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Default, Clone, Copy, serde::Serialize)]
@@ -84,6 +84,77 @@ fn keeper(members: &[Chunk]) -> &Chunk {
         .expect("a cluster has at least one member")
 }
 
+/// How many hidden artifacts the drift repair compares per sweep, from either
+/// side. A base with more than this many hidden artifacts drifting at once is
+/// not a case worth unbounded scanning for; the next sweep continues.
+const DRIFT_SCAN: usize = 5_000;
+
+fn lifecycle_row_of(c: &Chunk) -> crate::vector::LifecycleRow {
+    crate::vector::LifecycleRow {
+        artifact_id: c.id.clone(),
+        status: c.status,
+        superseded_by: c.superseded_by.clone(),
+        last_verified_at: c.last_verified_at.unwrap_or(c.created_at),
+    }
+}
+
+/// Make the vector store's lifecycle payloads agree with SQLite, which is the
+/// source of truth for all of them.
+///
+/// Every lifecycle change is two writes to two stores that cannot be written
+/// atomically, so each of `deprecate`, `reactivate`, `supersede` and
+/// `unsupersede` can be interrupted halfway. Both resulting skews are silent
+/// and neither self-corrects: a row that says deprecated behind a payload that
+/// does not leaves the artifact in search results while Ops calls it retired,
+/// and a payload that says deprecated behind an active row leaves it out of
+/// search with no page listing it and no button that reaches it. The pair of
+/// scans below is the only thing in the system that notices either.
+///
+/// Broader than `heal_dangling_supersessions`, which repairs one specific case
+/// (a winner that has since been deleted) in the SQLite direction only.
+async fn repair_lifecycle_drift(core: &Core) -> Result<()> {
+    let payload_hidden: HashSet<String> = core
+        .vectors
+        .non_active_ids(DRIFT_SCAN)
+        .await?
+        .into_iter()
+        .collect();
+    let store_hidden = core.store.list_non_active_artifacts(DRIFT_SCAN).await?;
+    let store_ids: HashSet<&str> = store_hidden.iter().map(|c| c.id.as_str()).collect();
+
+    let mut rows = Vec::new();
+    // Hidden in SQLite, still visible to search: finish the write that was
+    // lost.
+    for c in &store_hidden {
+        if !payload_hidden.contains(&c.id) {
+            rows.push(lifecycle_row_of(c));
+        }
+    }
+    // Hidden in the payload, active in SQLite: put it back. An id the vector
+    // store still lists but SQLite has dropped is ordinary — a delete can lag a
+    // sweep — and not an error.
+    for id in &payload_hidden {
+        if store_ids.contains(id.as_str()) {
+            continue;
+        }
+        match core.store.get_artifact(id).await {
+            Ok(c) => rows.push(lifecycle_row_of(&c)),
+            Err(_) => {
+                tracing::debug!(artifact_id = %id, "hidden point names an artifact that is gone")
+            }
+        }
+    }
+
+    if !rows.is_empty() {
+        tracing::info!(
+            repaired = rows.len(),
+            "lifecycle state disagreed between sqlite and the vector store"
+        );
+        core.vectors.apply_lifecycle(&rows).await?;
+    }
+    Ok(())
+}
+
 pub async fn run(core: &Core) -> Result<Outcome> {
     let cfg = &core.consolidate;
     if !cfg.enabled {
@@ -98,6 +169,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     // hidden artifact pointing at nothing is invisible to search and to every
     // page that could put it back, and nothing else would ever notice.
     core.heal_dangling_supersessions().await?;
+    repair_lifecycle_drift(core).await?;
 
     let pairs = core
         .vectors
@@ -125,20 +197,14 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             tracing::debug!(artifact_id = %id, "pair names an artifact that is gone");
             continue;
         };
-        if c.superseded_by.is_some() {
+        if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
             // The row says hidden but the vector store still offered this point
-            // as a pair candidate, so its payload flag never landed — the sweep
-            // was interrupted between the two writes. Ops has been listing this
-            // artifact as hidden while every search still returned it. Finish
-            // the write that was lost; it is idempotent and costs no inference.
-            tracing::info!(artifact_id = %id, "re-applying a superseded flag the vector store is missing");
-            core.vectors
-                .set_lifecycle(
-                    id,
-                    crate::store::artifacts::ArtifactStatus::Superseded,
-                    c.superseded_by.as_deref(),
-                )
-                .await?;
+            // as a pair candidate, so its payload never caught up — the write
+            // was interrupted, and `repair_lifecycle_drift` at the top of this
+            // sweep has already re-issued it. Either way the artifact takes no
+            // part in this run: a retired artifact must not win a cluster and
+            // hide a live one, and a resolved pair has nothing left to decide.
+            tracing::debug!(artifact_id = %id, status = c.status.as_str(), "skipping a hidden artifact");
             continue;
         }
         let root = clusters.find(id);
@@ -179,7 +245,13 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         ) else {
             continue;
         };
-        if a.superseded_by.is_some() || b.superseded_by.is_some() {
+        // Same rule as the cluster pass: only two live artifacts have a
+        // question worth a queue slot, an inference call, or a containment
+        // supersede below.
+        if [&a, &b]
+            .iter()
+            .any(|c| c.status != ArtifactStatus::Active || c.superseded_by.is_some())
+        {
             continue;
         }
 
@@ -591,6 +663,116 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert_eq!(hits[0].payload.artifact_id, ids[1]);
+    }
+
+    #[tokio::test]
+    async fn a_deprecated_artifact_never_wins_a_cluster() {
+        // The newest member of a cluster wins, so a *newer* artifact an
+        // operator retired used to be handed the win over a live older one:
+        // the loser went superseded, the winner stayed deprecated, and the
+        // knowledge left search entirely. It also overwrote the operator's
+        // `deprecated` status with `superseded` on the way past.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        core.deprecate(&ids[1]).await.unwrap();
+
+        let out = run(&core).await.unwrap();
+
+        assert_eq!(out.superseded, 0, "{out:?}");
+        let older = core.store.get_artifact(&ids[0]).await.unwrap();
+        assert!(
+            older.superseded_by.is_none(),
+            "a deprecated artifact hid a live one"
+        );
+        assert_eq!(
+            core.store.get_artifact(&ids[1]).await.unwrap().status,
+            ArtifactStatus::Deprecated,
+            "the sweep overwrote an operator's deprecation"
+        );
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "the live artifact should be the one thing search returns"
+        );
+        assert_eq!(hits[0].payload.artifact_id, ids[0]);
+    }
+
+    #[tokio::test]
+    async fn superseding_refuses_to_overwrite_a_deprecation() {
+        // `set_superseded_by` writes `status = 'superseded'` unconditionally,
+        // so this is the guard that keeps an applied judge proposal from
+        // erasing what an operator decided, with nothing left to tell the two
+        // apart afterwards.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.deprecate(&ids[0]).await.unwrap();
+
+        assert!(core.supersede(&ids[0], &ids[1]).await.is_err());
+        assert!(
+            core.supersede(&ids[1], &ids[0]).await.is_err(),
+            "a deprecated winner would hide the loser behind something out of results"
+        );
+        assert_eq!(
+            core.store.get_artifact(&ids[0]).await.unwrap().status,
+            ArtifactStatus::Deprecated
+        );
+    }
+
+    #[tokio::test]
+    async fn the_sweep_finishes_a_deprecation_whose_payload_write_was_lost() {
+        // Row written, payload not: Ops lists the artifact as deprecated while
+        // every search still returns it, and the only button that row offers is
+        // "Reactivate". Nothing used to notice — the old self-heal branch fired
+        // only on `superseded_by`.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.store
+            .set_artifact_status(&ids[0], ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            !hits.iter().any(|h| h.payload.artifact_id == ids[0]),
+            "a deprecated artifact is still in search"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_sweep_frees_an_artifact_hidden_by_a_payload_alone() {
+        // The other skew, and the worse one: the payload says deprecated but
+        // the row says active, so the artifact is out of search, off the Ops
+        // deprecated list, and out of reach of every button — invisible and
+        // unrecoverable until something reconciles the two stores.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.vectors
+            .set_lifecycle(&ids[0], ArtifactStatus::Deprecated, None)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.payload.artifact_id == ids[0]),
+            "an artifact SQLite calls active is still hidden from search"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -112,36 +112,68 @@ fn lifecycle_row_of(c: &Chunk) -> crate::vector::LifecycleRow {
 ///
 /// Broader than `heal_dangling_supersessions`, which repairs one specific case
 /// (a winner that has since been deleted) in the SQLite direction only.
-async fn repair_lifecycle_drift(core: &Core) -> Result<()> {
-    let payload_hidden: HashSet<String> = core
-        .vectors
-        .non_active_ids(DRIFT_SCAN)
-        .await?
-        .into_iter()
-        .collect();
-    let store_hidden = core.store.list_non_active_artifacts(DRIFT_SCAN).await?;
-    let store_ids: HashSet<&str> = store_hidden.iter().map(|c| c.id.as_str()).collect();
+///
+/// Returns how many artifacts it rewrote, which is a number worth asserting on:
+/// a repair that fires on a base in agreement is a bug that hides behind a
+/// correct end state.
+async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
+    repair_lifecycle_drift_scanning(core, DRIFT_SCAN).await
+}
+
+/// The above with its cap as a parameter, so a test can reproduce what the two
+/// truncated scans do to each other without seeding `DRIFT_SCAN` artifacts.
+async fn repair_lifecycle_drift_scanning(core: &Core, scan: usize) -> Result<usize> {
+    // Both scans are capped, and neither cap lines up with the other:
+    // `list_non_active_artifacts` returns the newest rows while `non_active_ids`
+    // scrolls in point-id order. So set membership across the two proves
+    // nothing — on a base with more hidden artifacts than `DRIFT_SCAN` the lists
+    // barely intersect, and treating "missing from the other list" as drift
+    // reported the whole scan as broken every sweep and rewrote every payload in
+    // it. The union of the two scans names the artifacts worth *looking at*;
+    // what each store actually says about them is then read per id, and only a
+    // real disagreement is repaired.
+    let store_hidden = core.store.list_non_active_artifacts(scan).await?;
+    let payload_hidden = core.vectors.non_active_ids(scan).await?;
+
+    let mut ids: Vec<String> = store_hidden.iter().map(|c| c.id.clone()).collect();
+    ids.extend(payload_hidden);
+    ids.sort_unstable();
+    ids.dedup();
+
+    let stored = core.vectors.lifecycle_of(&ids).await?;
+    let known: HashMap<&str, &Chunk> = store_hidden.iter().map(|c| (c.id.as_str(), c)).collect();
 
     let mut rows = Vec::new();
-    // Hidden in SQLite, still visible to search: finish the write that was
-    // lost.
-    for c in &store_hidden {
-        if !payload_hidden.contains(&c.id) {
-            rows.push(lifecycle_row_of(c));
-        }
-    }
-    // Hidden in the payload, active in SQLite: put it back. An id the vector
-    // store still lists but SQLite has dropped is ordinary — a delete can lag a
-    // sweep — and not an error.
-    for id in &payload_hidden {
-        if store_ids.contains(id.as_str()) {
+    for id in &ids {
+        // The row is already in hand for everything the SQLite scan returned;
+        // only an id that came from the payload side alone costs a read.
+        let fetched;
+        let chunk = match known.get(id.as_str()) {
+            Some(c) => *c,
+            // An id the vector store still lists but SQLite has dropped is
+            // ordinary — a delete can lag a sweep — and not an error.
+            None => match core.store.get_artifact(id).await {
+                Ok(c) => {
+                    fetched = c;
+                    &fetched
+                }
+                Err(_) => {
+                    tracing::debug!(artifact_id = %id, "hidden point names an artifact that is gone");
+                    continue;
+                }
+            },
+        };
+        // No point at all is not drift: a freshly captured artifact is hidden
+        // in SQLite before its embedding job has written anything to hide.
+        let Some(p) = stored.get(id) else {
             continue;
-        }
-        match core.store.get_artifact(id).await {
-            Ok(c) => rows.push(lifecycle_row_of(&c)),
-            Err(_) => {
-                tracing::debug!(artifact_id = %id, "hidden point names an artifact that is gone")
-            }
+        };
+        // SQLite is the source of truth for both fields. Comparing them rather
+        // than just "hidden or not" also catches the subtler skew — a payload
+        // that says superseded behind a row that says deprecated, or one
+        // pointing at a winner the row no longer names.
+        if p.status != chunk.status || p.superseded_by != chunk.superseded_by {
+            rows.push(lifecycle_row_of(chunk));
         }
     }
 
@@ -152,7 +184,7 @@ async fn repair_lifecycle_drift(core: &Core) -> Result<()> {
         );
         core.vectors.apply_lifecycle(&rows).await?;
     }
-    Ok(())
+    Ok(rows.len())
 }
 
 pub async fn run(core: &Core) -> Result<Outcome> {
@@ -358,12 +390,22 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
             continue;
         };
 
-        // A pair queued in the review band can have a member superseded by a
-        // later sweep, once a re-embed moves the score above `auto_supersede`.
-        // Judging it would spend the scarcest thing here — a model call — to
-        // post a contradiction about an artifact that is no longer in results.
-        // The supersession is the answer to this pair.
-        if a.superseded_by.is_some() || b.superseded_by.is_some() {
+        // A pair queued in the review band can have a member retired after the
+        // fact: superseded by a later sweep once a re-embed moves the score
+        // above `auto_supersede`, or deprecated by an operator. Judging it would
+        // spend the scarcest thing here — a model call — to post a
+        // contradiction about an artifact that is no longer in results.
+        //
+        // The status half matters beyond the wasted call. A judgement can
+        // propose a supersede, which Ops renders as an "apply supersede" button
+        // — and `Core::supersede` refuses a deprecated side, so pressing it
+        // returns a validation error and the pair stays pending forever. The
+        // same guard runs in `run`'s cluster pass and review band.
+        if a.status != ArtifactStatus::Active
+            || b.status != ArtifactStatus::Active
+            || a.superseded_by.is_some()
+            || b.superseded_by.is_some()
+        {
             core.store
                 .set_pair_state(p.id, crate::store::pairs::PairState::Dismissed, None)
                 .await?;
@@ -866,6 +908,113 @@ mod tests {
                 .is_empty(),
             "the answered pair must leave the pending queue"
         );
+    }
+
+    #[tokio::test]
+    async fn a_pair_whose_member_was_deprecated_never_reaches_the_judge() {
+        // The other half of the same rule, and the one that leaves a button
+        // nothing can press: a judgement can propose a supersede, Ops renders
+        // "Apply supersede" for it, and `Core::supersede` refuses a deprecated
+        // side — so the operator gets a validation error and the pair stays
+        // pending forever. The dismissal guard used to check `superseded_by`
+        // only, which a deprecation never sets.
+        let mut core = test_core().await;
+        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        let ids = disagreeing(&core).await;
+        run(&core).await.unwrap();
+        core.consolidate.judge = true;
+
+        core.deprecate(&ids[0]).await.unwrap();
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(
+            completer.calls(),
+            0,
+            "the judge ruled on a deprecated artifact"
+        );
+        assert_eq!(out.judged, 0);
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a pair naming a retired artifact must leave the pending queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_drift_repair_rewrites_nothing_when_the_two_stores_agree() {
+        // Both scans are capped and neither cap lines up with the other, so
+        // "missing from the other list" used to read as drift. On a base with
+        // more hidden artifacts than one scan returns, that reported the whole
+        // scan as broken every sweep and rewrote every payload in it — a
+        // permanent false alarm with write amplification behind it. Only a real
+        // disagreement counts.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("first", [1.0, 0.0]),
+                ("second", [0.0, 1.0]),
+                ("third", [0.5, 0.5]),
+            ],
+        )
+        .await;
+        // One hidden each way, both written through the paths that keep the two
+        // stores in step.
+        core.deprecate(&ids[0]).await.unwrap();
+        core.supersede(&ids[1], &ids[2]).await.unwrap();
+
+        assert_eq!(
+            repair_lifecycle_drift(&core).await.unwrap(),
+            0,
+            "the repair fired on a base that agrees with itself"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_scan_cap_reached_from_both_sides_is_not_drift() {
+        // The bug in miniature. The two scans are capped independently and
+        // ordered differently — newest rows on one side, point order on the
+        // other — so past the cap they name largely different artifacts. Reading
+        // "absent from the other list" as drift then reports both whole scans as
+        // broken on every sweep and rewrites every payload in them. Two hidden
+        // artifacts and a cap of one reproduces exactly that.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.deprecate(&ids[0]).await.unwrap();
+        core.deprecate(&ids[1]).await.unwrap();
+
+        assert_eq!(
+            repair_lifecycle_drift_scanning(&core, 1).await.unwrap(),
+            0,
+            "the edge of a page was reported as a disagreement"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_drift_repair_notices_a_payload_naming_the_wrong_status() {
+        // Not just hidden-or-not: a payload that says superseded behind a row
+        // that says deprecated is drift too, and comparing set membership alone
+        // never saw it.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.deprecate(&ids[0]).await.unwrap();
+        core.vectors
+            .set_lifecycle(&ids[0], ArtifactStatus::Superseded, Some(&ids[1]))
+            .await
+            .unwrap();
+
+        assert_eq!(repair_lifecycle_drift(&core).await.unwrap(), 1);
+        let stored = core
+            .vectors
+            .lifecycle_of(std::slice::from_ref(&ids[0]))
+            .await
+            .unwrap();
+        assert_eq!(stored[&ids[0]].status, ArtifactStatus::Deprecated);
+        assert_eq!(stored[&ids[0]].superseded_by, None);
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -200,8 +200,34 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     // Deletions clear these as they happen; the sweep repeats it because a
     // hidden artifact pointing at nothing is invisible to search and to every
     // page that could put it back, and nothing else would ever notice.
-    core.heal_dangling_supersessions().await?;
-    repair_lifecycle_drift(core).await?;
+    // Neither repair is allowed to take the sweep with it. Both are maintenance
+    // over state the rest of the sweep does not read, both are retried on every
+    // sweep, and both are most likely to fail on exactly the base that needs
+    // them most — the one that drifted far enough to make the repair large.
+    // Propagating the error stopped consolidation *permanently*: the next sweep
+    // reached the same call and failed the same way, so near-duplicate
+    // detection and judging never ran again.
+    if let Err(e) = core.heal_dangling_supersessions().await {
+        tracing::warn!(
+            error = %e,
+            "could not restore every artifact whose winner was deleted; retrying on the next sweep"
+        );
+    }
+    if let Err(e) = repair_lifecycle_drift(core).await {
+        tracing::warn!(
+            error = %e,
+            "could not reconcile lifecycle state with the vector store; retrying on the next sweep"
+        );
+    }
+    // Startup heals too, but a process that stays up for weeks is exactly the
+    // one whose stores drift: every interrupted write between the two happens
+    // while it is running, not while it is starting.
+    if let Err(e) = core.heal_store_drift().await {
+        tracing::warn!(
+            error = %e,
+            "could not reconcile which artifacts the two stores hold; retrying on the next sweep"
+        );
+    }
 
     let pairs = core
         .vectors
@@ -253,7 +279,22 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             // SQLite first: it is the source of truth, and a payload flag with
             // no row behind it is a hidden artifact nothing can explain. See
             // `Core::supersede`.
-            core.supersede(&c.id, &keep.id).await?;
+            //
+            // One failure does not abandon the rest, as in
+            // `heal_dangling_supersessions`. `supersede` refuses a side that is
+            // no longer active, and these statuses were read earlier in this
+            // same sweep — so an operator deprecating one of them from Ops in
+            // the meantime is an ordinary race, not a reason to abandon the
+            // remaining clusters, the judge pass, and every pair below.
+            if let Err(e) = core.supersede(&c.id, &keep.id).await {
+                tracing::warn!(
+                    superseded = %c.id,
+                    by = %keep.id,
+                    error = %e,
+                    "could not hide a near-identical artifact; it stays active"
+                );
+                continue;
+            }
             hidden.insert(c.id.clone());
             out.superseded += 1;
             tracing::info!(
@@ -303,7 +344,16 @@ pub async fn run(core: &Core) -> Result<Outcome> {
                 (&b, &a)
             };
             if contains_normalized(&long.text, &short.text) {
-                core.supersede(&short.id, &long.id).await?;
+                // Same race, same treatment as the cluster pass above.
+                if let Err(e) = core.supersede(&short.id, &long.id).await {
+                    tracing::warn!(
+                        superseded = %short.id,
+                        by = %long.id,
+                        error = %e,
+                        "could not hide a duplicated passage; it stays active"
+                    );
+                    continue;
+                }
                 out.superseded += 1;
                 tracing::info!(
                     superseded = %short.id,

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -387,7 +387,15 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // would revive an artifact the sweep hid, on every re-embed.
         superseded: None,
         status: None,
-        last_verified_at: None,
+        // Written, not deferred: a brand-new point has no stored stamp to carry
+        // forward, and the scoring formula reads a missing `last_verified_at`
+        // as epoch — so leaving it unset would rank every freshly ingested
+        // artifact as maximally stale and put it straight on the
+        // deprecation-review list. SQLite is the source of truth here (set at
+        // insert, updated by `Core::verify`), so this is the current value.
+        // The `created_at` fallback covers any row written before the column
+        // existed.
+        last_verified_at: chunk.last_verified_at.or(Some(chunk.created_at)),
         superseded_by: None,
     }
 }

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -884,7 +884,7 @@ mod tests {
         let (_src, ids) = seed(&core, &["text"]).await;
         run(&core, &ids[0]).await.unwrap();
         core.vectors
-            .touch(&[crate::vector::Touch::unknown(&ids[0])], 1_700_000_000)
+            .touch(&[crate::vector::Touch::shown(&ids[0])], 1_700_000_000)
             .await
             .unwrap();
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -883,7 +883,10 @@ mod tests {
         let core = test_core().await;
         let (_src, ids) = seed(&core, &["text"]).await;
         run(&core, &ids[0]).await.unwrap();
-        core.vectors.touch(&ids[0..1], 1_700_000_000).await.unwrap();
+        core.vectors
+            .touch(&[crate::vector::Touch::unknown(&ids[0])], 1_700_000_000)
+            .await
+            .unwrap();
 
         core.store
             .update_artifact_text(&ids[0], "edited text")

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -382,9 +382,13 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // the existing stamp forward rather than letting a re-embed make a
         // chunk look forgotten.
         last_seen_at: None,
+        hit_count: None,
         // Unset for the same reason, and it matters more: writing `false` here
         // would revive an artifact the sweep hid, on every re-embed.
         superseded: None,
+        status: None,
+        last_verified_at: None,
+        superseded_by: None,
     }
 }
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -1,6 +1,6 @@
 use crate::core::Core;
 use crate::error::{Error, Result};
-use crate::store::artifacts::{Chunk, NewArtifact};
+use crate::store::artifacts::{ArtifactStatus, Chunk, NewArtifact};
 use crate::store::corpora::CorpusStatus;
 use crate::store::jobs::Stage;
 use crate::vector::{VectorPayload, VectorPoint};
@@ -383,10 +383,29 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // chunk look forgotten.
         last_seen_at: None,
         hit_count: None,
-        // Unset for the same reason, and it matters more: writing `false` here
-        // would revive an artifact the sweep hid, on every re-embed.
-        superseded: None,
-        status: None,
+        // Retired state is written; active state is deferred. The asymmetry is
+        // the point.
+        //
+        // Deferring unconditionally loses the state outright on a *first*
+        // embed: there is no stored value to carry forward, so an artifact
+        // deprecated while its embed job was still pending — the detail page
+        // offers the button whatever the embed state — lands as a point with no
+        // `status` at all and is back in ordinary results. Nothing notices until
+        // the next sweep's `repair_lifecycle_drift`, and nothing ever does if
+        // consolidation is disabled.
+        //
+        // Writing unconditionally has the opposite failure: `false`/`active` on
+        // every re-embed would revive an artifact the sweep hid, because the row
+        // is read here before the embedding call and an operator can retire the
+        // artifact while that call is in flight.
+        //
+        // Writing only the retired values takes neither. SQLite is the source of
+        // truth (`set_superseded_by` maintains `status` alongside
+        // `superseded_by`), so a row that says retired is a fact worth writing;
+        // a row that says active cannot distinguish "still active" from "stale
+        // read", so it defers to the stored value as before.
+        superseded: (chunk.superseded_by.is_some()).then_some(true),
+        status: (chunk.status != ArtifactStatus::Active).then_some(chunk.status),
         // Written, not deferred: a brand-new point has no stored stamp to carry
         // forward, and the scoring formula reads a missing `last_verified_at`
         // as epoch — so leaving it unset would rank every freshly ingested
@@ -396,7 +415,10 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // The `created_at` fallback covers any row written before the column
         // existed.
         last_verified_at: chunk.last_verified_at.or(Some(chunk.created_at)),
-        superseded_by: None,
+        // Same rule as `status` directly above, and it has to be the same rule:
+        // a point that says superseded while naming no winner is a hidden
+        // artifact whose replacement the UI cannot show.
+        superseded_by: chunk.superseded_by.clone(),
     }
 }
 
@@ -423,6 +445,49 @@ pub async fn settle_corpus(core: &Core, corpus_id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn an_artifact_retired_before_its_first_embed_lands_retired() {
+        // The detail page offers Deprecate whatever the embed state, so this is
+        // reachable by pressing it on a freshly captured artifact. The payload
+        // deferred `status` to whatever was already stored — and on a first
+        // embed nothing is, so the point arrived with no status at all and the
+        // deprecated artifact was back in ordinary results. Nothing noticed
+        // until the next sweep, and nothing ever did with consolidation off.
+        let core = crate::core::test_support::test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "a stale instruction".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        core.deprecate(&made[0].id).await.unwrap();
+
+        run(&core, &made[0].id).await.unwrap();
+
+        let stored = core
+            .vectors
+            .payloads_of(&[made[0].id.clone()])
+            .await
+            .unwrap();
+        assert_eq!(
+            stored[&made[0].id].status,
+            Some(crate::store::artifacts::ArtifactStatus::Deprecated),
+            "the first embed put a deprecated artifact back into results"
+        );
+    }
 
     #[tokio::test]
     async fn a_chunk_the_endpoint_refuses_is_split_rather_than_retried() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,10 @@ struct Args {
     #[arg(long)]
     recompute_coverage: bool,
     /// Push every artifact's SQLite-side lifecycle state (status,
-    /// last_verified_at, superseded_by) into Qdrant, then exit. Run once after
-    /// deploying the lifecycle migration: existing points have none of these
-    /// fields until this runs, which every filter treats as active in the
-    /// meantime, just not yet filterable as deprecated.
+    /// last_verified_at, superseded_by) into Qdrant, then exit. Rarely needed:
+    /// startup runs the same pass in the background whenever it finds points
+    /// without the fields. This is the way to run it in the foreground and see
+    /// it finish.
     #[arg(long)]
     backfill_lifecycle: bool,
 }
@@ -84,6 +84,36 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
     let purged = core.store.purge_expired_sessions().await?;
     if purged > 0 {
         tracing::info!(purged, "removed expired sessions");
+    }
+
+    // Points written before the lifecycle migration carry no `status` or
+    // `last_verified_at`. Every filter treats that as active, and ranking
+    // treats a missing stamp as neutral, so nothing is broken in the meantime —
+    // but until the backfill runs, no deprecation is filterable and no decay
+    // applies, and an operator who never reads the release notes never learns
+    // that. So it runs itself, once, when there is anything to do.
+    //
+    // In the background: it is a write over every artifact, and a base large
+    // enough for that to take a while is exactly the one that must not have its
+    // startup blocked by it. Two processes starting together may both run it;
+    // the writes are idempotent and both compute the same values.
+    match core.vectors.unstamped_count().await {
+        Ok(0) => {}
+        Ok(n) => {
+            tracing::info!(
+                unstamped = n,
+                "backfilling lifecycle fields in the background"
+            );
+            let worker = core.clone();
+            core.background.spawn(async move {
+                if let Err(e) = worker.backfill_lifecycle().await {
+                    tracing::warn!(error = %e, "lifecycle backfill did not finish; it will be retried at the next start");
+                }
+            });
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "could not tell whether the lifecycle backfill is needed")
+        }
     }
 
     engram::infer::openai::probe(

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,13 @@ struct Args {
     /// coverage is measured, since the figure is otherwise written once.
     #[arg(long)]
     recompute_coverage: bool,
+    /// Push every artifact's SQLite-side lifecycle state (status,
+    /// last_verified_at, superseded_by) into Qdrant, then exit. Run once after
+    /// deploying the lifecycle migration: existing points have none of these
+    /// fields until this runs, which every filter treats as active in the
+    /// meantime, just not yet filterable as deprecated.
+    #[arg(long)]
+    backfill_lifecycle: bool,
 }
 
 fn validate_auth(cfg: &Config, insecure_ok: bool) -> Result<()> {
@@ -127,6 +134,16 @@ async fn main() -> anyhow::Result<()> {
             .reindex(cfg.infer.embed.dim, args.replace_legacy)
             .await?;
         println!("{} now serves `{}`", cfg.vector.collection, target);
+        return Ok(());
+    }
+
+    if args.backfill_lifecycle {
+        let store = engram::store::Store::connect(&cfg.store).await?;
+        let vectors: Arc<dyn engram::vector::VectorStore> =
+            Arc::new(engram::vector::qdrant::QdrantVectors::connect(&cfg.vector).await?);
+        let core = Core::from_config(&cfg, vectors, store);
+        let n = core.backfill_lifecycle().await?;
+        println!("backfilled lifecycle fields for {n} artifacts");
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,8 @@ struct Args {
     /// last_verified_at, superseded_by) into Qdrant, then exit. Rarely needed:
     /// startup runs the same pass in the background whenever it finds points
     /// without the fields. This is the way to run it in the foreground and see
-    /// it finish.
+    /// it finish. It also deletes points whose artifact row is gone, which is
+    /// what lets the startup check ever consider the base fully stamped.
     #[arg(long)]
     backfill_lifecycle: bool,
 }
@@ -97,6 +98,11 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
     // enough for that to take a while is exactly the one that must not have its
     // startup blocked by it. Two processes starting together may both run it;
     // the writes are idempotent and both compute the same values.
+    //
+    // "Once" depends on the pass being able to stamp everything this count sees.
+    // It is driven by SQLite and the count is not, so a point whose row is gone
+    // used to keep the number above zero forever and rerun the whole rewrite on
+    // every single start — which is why the backfill also deletes those.
     match core.vectors.unstamped_count().await {
         Ok(0) => {}
         Ok(n) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,9 @@ struct Args {
     /// last_verified_at, superseded_by) into Qdrant, then exit. Rarely needed:
     /// startup runs the same pass in the background whenever it finds points
     /// without the fields. This is the way to run it in the foreground and see
-    /// it finish. It also deletes points whose artifact row is gone, which is
-    /// what lets the startup check ever consider the base fully stamped.
+    /// it finish. It also reconciles which artifacts the two stores hold,
+    /// restoring whichever side is missing one, which is what lets the startup
+    /// check ever consider the base fully stamped.
     #[arg(long)]
     backfill_lifecycle: bool,
 }
@@ -323,6 +324,7 @@ mod startup_tests {
                 recency_weight: 0.05,
                 recency_half_life_days: 180,
                 pinned_boost: 0.15,
+                weak_below: 0.35,
             },
             infer: InferConfig {
                 synthesize: SynthesizeRole {

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,10 +101,22 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
     //
     // "Once" depends on the pass being able to stamp everything this count sees.
     // It is driven by SQLite and the count is not, so a point whose row is gone
-    // used to keep the number above zero forever and rerun the whole rewrite on
-    // every single start — which is why the backfill also deletes those.
+    // would keep the number above zero forever and rerun the whole rewrite on
+    // every single start — which is why the backfill finishes by healing the
+    // drift, and why the count ignores points that name no artifact at all.
     match core.vectors.unstamped_count().await {
-        Ok(0) => {}
+        Ok(0) => {
+            // No backfill to run, so nothing else would look at the two stores.
+            // They can still disagree — a crash between the two writes, a
+            // restore of one from a backup taken at a different moment — and
+            // until something notices, one side's artifacts are simply missing.
+            let worker = core.clone();
+            core.background.spawn(async move {
+                if let Err(e) = worker.heal_store_drift().await {
+                    tracing::warn!(error = %e, "could not reconcile the two stores; the next sweep retries");
+                }
+            });
+        }
         Ok(n) => {
             tracing::info!(
                 unstamped = n,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -112,6 +112,8 @@ impl PkdbTools {
             category: p.category,
             // A tool call is one deliberate question, not a keystroke.
             mark: true,
+            include_deprecated: false,
+            include_superseded: false,
         };
         match self.core.search(&query).await {
             Ok(r) => format_search_results(&r),
@@ -234,6 +236,8 @@ mod tests {
                     tags: vec![],
                     category: None,
                     mark: true,
+                    include_deprecated: false,
+                    include_superseded: false,
                 })
                 .await
                 .unwrap(),

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -469,6 +469,20 @@ impl Store {
         )
     }
 
+    /// Artifacts SQLite does not consider active, newest first. What the
+    /// sweep's drift repair compares the vector store's own idea of hidden
+    /// against.
+    pub async fn list_non_active_artifacts(&self, limit: usize) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE status != 'active' OR superseded_by IS NOT NULL
+             ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
     /// Every artifact id, for the one-shot Qdrant lifecycle backfill.
     pub async fn list_all_artifact_ids(&self) -> Result<Vec<String>> {
         let rows = sqlx::query("SELECT id FROM artifacts")

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -114,6 +114,27 @@ pub struct NewArtifact {
     pub caveats: Vec<String>,
 }
 
+/// An artifact rebuilt from a vector payload, keeping its original id.
+///
+/// Separate from `NewArtifact` because the two are opposites: that one describes
+/// an artifact being created, and the store assigns its id, while this one
+/// describes an artifact that already existed and whose id is the one thing that
+/// must not change. Only the fields a `VectorPayload` actually carries are here
+/// — see `Store::restore_artifact` for what is left neutral and why.
+#[derive(Debug, Clone)]
+pub struct RestoredArtifact {
+    pub id: String,
+    pub corpus_id: String,
+    pub text: String,
+    pub title: Option<String>,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub created_at: i64,
+    pub status: ArtifactStatus,
+    pub last_verified_at: Option<i64>,
+    pub superseded_by: Option<String>,
+}
+
 fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
     let tags_json: String = r.get("tags");
     let span_json: Option<String> = r.get("corpus_span");
@@ -201,6 +222,46 @@ impl Store {
         }
         tx.commit().await?;
         Ok(out)
+    }
+
+    /// Re-create an artifact row from what the vector store still holds about
+    /// it, keeping the original id. Returns whether a row was written; an id
+    /// that already exists is left exactly as it is.
+    ///
+    /// This is the SQLite half of the two-way heal (`Core::heal_store_drift`),
+    /// so it is deliberately not `insert_artifacts`: that mints a new id, and a
+    /// restored artifact that does not keep its own is a second copy rather than
+    /// the same artifact — its point would still be an orphan, and the next heal
+    /// would restore it again.
+    ///
+    /// What the payload cannot supply is left at its neutral value rather than
+    /// guessed. `ordinal` is 0 and `corpus_span` NULL because a payload records
+    /// neither, so a restored artifact has no position within its source; the
+    /// same goes for `segment_idx`, `caveats`, and `flags`. `embed_state` is
+    /// `pending` on purpose even though a vector demonstrably exists: the stored
+    /// vector may have been written by a different embedding model than the
+    /// collection now uses, and a restored row that claims `done` would keep
+    /// that mismatch permanently invisible. Re-embedding costs one call and
+    /// makes `embed_model` true.
+    pub async fn restore_artifact(&self, c: &RestoredArtifact) -> Result<bool> {
+        let res = sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, superseded_by)
+             VALUES (?, ?, 0, ?, NULL, ?, ?, ?, 'pending', NULL, ?, NULL, '[]', ?, ?, ?)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(&c.id)
+        .bind(&c.corpus_id)
+        .bind(&c.text)
+        .bind(&c.title)
+        .bind(&c.category)
+        .bind(serde_json::to_string(&c.tags).unwrap_or_else(|_| "[]".into()))
+        .bind(c.created_at)
+        .bind(c.status.as_str())
+        .bind(c.last_verified_at)
+        .bind(&c.superseded_by)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
     }
 
     pub async fn get_artifact(&self, id: &str) -> Result<Chunk> {
@@ -486,6 +547,22 @@ impl Store {
     /// Every artifact id, for the one-shot Qdrant lifecycle backfill.
     pub async fn list_all_artifact_ids(&self) -> Result<Vec<String>> {
         let rows = sqlx::query("SELECT id FROM artifacts")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(|r| r.get::<String, _>("id")).collect())
+    }
+
+    /// Ids of artifacts whose row claims a vector was written for them.
+    ///
+    /// The heal uses this rather than `list_all_artifact_ids` for the
+    /// SQLite-has-it/vectors-do-not direction, because an artifact still waiting
+    /// on its embed job has no point *correctly* — that is the normal state of
+    /// everything just ingested, not drift. Nor is a `failed` row: the embedder
+    /// refused that text, and re-queueing it every sweep is a retry loop with no
+    /// end. Only a row that says `embedded` while the vector store holds nothing
+    /// is a write that went missing.
+    pub async fn list_embedded_artifact_ids(&self) -> Result<Vec<String>> {
+        let rows = sqlx::query("SELECT id FROM artifacts WHERE embed_state = 'embedded'")
             .fetch_all(&self.pool)
             .await?;
         Ok(rows.iter().map(|r| r.get::<String, _>("id")).collect())

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -27,6 +27,33 @@ impl EmbedState {
     }
 }
 
+/// Where an artifact stands: still current, flagged stale with no named
+/// replacement, or hidden in favour of a specific `superseded_by` artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactStatus {
+    Active,
+    Deprecated,
+    Superseded,
+}
+
+impl ArtifactStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ArtifactStatus::Active => "active",
+            ArtifactStatus::Deprecated => "deprecated",
+            ArtifactStatus::Superseded => "superseded",
+        }
+    }
+    pub fn parse(s: &str) -> ArtifactStatus {
+        match s {
+            "deprecated" => ArtifactStatus::Deprecated,
+            "superseded" => ArtifactStatus::Superseded,
+            _ => ArtifactStatus::Active,
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct CorpusSpan {
     pub start_line: i64,
@@ -65,6 +92,14 @@ pub struct Chunk {
     /// stated them. Deliberately not part of what gets embedded: changing what
     /// every vector is built from is a decision for the evaluation harness.
     pub caveats: Vec<String>,
+    /// Active, deprecated, or superseded. Kept in sync with `superseded_by`
+    /// by `set_superseded_by`; set directly by `set_artifact_status` for the
+    /// deprecate/reactivate actions, which have no artifact on the other end.
+    pub status: ArtifactStatus,
+    /// When this artifact was last confirmed accurate. Defaults to
+    /// `created_at` at insert; this, not `created_at`, is what search ranking
+    /// decays against.
+    pub last_verified_at: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +141,8 @@ fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
             .get::<Option<String>, _>("caveats")
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default(),
+        status: ArtifactStatus::parse(r.get::<String, _>("status").as_str()),
+        last_verified_at: r.get("last_verified_at"),
     }
 }
 
@@ -118,6 +155,7 @@ impl Store {
         let mut tx = self.pool.begin().await?;
         let mut out = Vec::with_capacity(chunks.len());
         for nc in chunks {
+            let created_at = now();
             let c = Chunk {
                 id: new_id(),
                 corpus_id: corpus_id.to_string(),
@@ -129,17 +167,19 @@ impl Store {
                 tags: nc.tags.clone(),
                 embed_state: EmbedState::Pending,
                 embed_model: None,
-                created_at: now(),
+                created_at,
                 embed_rev: 0,
                 segment_idx: nc.segment_idx,
                 flags: vec![],
                 flag_detail: None,
                 superseded_by: None,
                 caveats: nc.caveats.clone(),
+                status: ArtifactStatus::Active,
+                last_verified_at: Some(created_at),
             };
             sqlx::query(
-                "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
+                "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)",
             )
             .bind(&c.id)
             .bind(&c.corpus_id)
@@ -153,6 +193,8 @@ impl Store {
             .bind(c.created_at)
             .bind(c.segment_idx)
             .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
+            .bind(c.status.as_str())
+            .bind(c.last_verified_at)
             .execute(&mut *tx)
             .await?;
             out.push(c);
@@ -379,9 +421,19 @@ impl Store {
     }
 
     /// Record that this artifact lost a near-identical pair. `None` undoes it.
+    /// `status` moves in lockstep: superseded when a winner is set, active
+    /// when it's cleared — the one place that keeps the two columns
+    /// consistent, so callers of `unsupersede`/`heal_dangling_supersessions`
+    /// need no changes of their own.
     pub async fn set_superseded_by(&self, artifact_id: &str, by: Option<&str>) -> Result<()> {
-        let res = sqlx::query("UPDATE artifacts SET superseded_by = ? WHERE id = ?")
+        let status = if by.is_some() {
+            ArtifactStatus::Superseded
+        } else {
+            ArtifactStatus::Active
+        };
+        let res = sqlx::query("UPDATE artifacts SET superseded_by = ?, status = ? WHERE id = ?")
             .bind(by)
+            .bind(status.as_str())
             .bind(artifact_id)
             .execute(&self.pool)
             .await?;
@@ -389,6 +441,40 @@ impl Store {
             return Err(Error::NotFound);
         }
         Ok(())
+    }
+
+    /// Set an artifact's lifecycle status directly — used for deprecate and
+    /// reactivate, which (unlike supersede) have no winning artifact on the
+    /// other end. Does not touch `superseded_by`; callers that mean to clear
+    /// a supersession should use `set_superseded_by(id, None)` instead.
+    pub async fn set_artifact_status(&self, id: &str, status: ArtifactStatus) -> Result<()> {
+        self.expect_updated(
+            sqlx::query("UPDATE artifacts SET status = ? WHERE id = ?")
+                .bind(status.as_str())
+                .bind(id)
+                .execute(&self.pool)
+                .await?,
+        )
+    }
+
+    /// Stamp an artifact as confirmed accurate now — what search ranking's
+    /// recency decay reads.
+    pub async fn set_last_verified_at(&self, id: &str, at: i64) -> Result<()> {
+        self.expect_updated(
+            sqlx::query("UPDATE artifacts SET last_verified_at = ? WHERE id = ?")
+                .bind(at)
+                .bind(id)
+                .execute(&self.pool)
+                .await?,
+        )
+    }
+
+    /// Every artifact id, for the one-shot Qdrant lifecycle backfill.
+    pub async fn list_all_artifact_ids(&self) -> Result<Vec<String>> {
+        let rows = sqlx::query("SELECT id FROM artifacts")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(|r| r.get::<String, _>("id")).collect())
     }
 
     /// Artifacts hidden in favour of a keeper that no longer exists.
@@ -421,6 +507,24 @@ impl Store {
             "SELECT * FROM artifacts WHERE superseded_by IS NOT NULL
               ORDER BY created_at DESC LIMIT ?",
         )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
+    /// Artifacts currently carrying one lifecycle status, newest first. Used
+    /// for the Ops "deprecated" list — superseded artifacts have their own
+    /// query (`superseded_artifacts`) since that one also needs the winner.
+    pub async fn artifacts_by_status(
+        &self,
+        status: ArtifactStatus,
+        limit: i64,
+    ) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE status = ? ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(status.as_str())
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -68,6 +68,12 @@ pub struct Corpus {
     /// Both cleared when an operator chooses to keep both.
     pub near_dupe_of: Option<String>,
     pub near_dupe_score: Option<f64>,
+    /// Set when this row is a placeholder for a corpus that was never captured
+    /// here — its artifacts came back from the vector store and needed a parent
+    /// to hang from. `raw_text` is then those artifacts joined, not the source
+    /// document, so nothing that reasons about the original text should trust
+    /// it. `None` for every ordinary capture.
+    pub restored_at: Option<i64>,
 }
 
 /// A stored corpus that a new capture looks like.
@@ -99,6 +105,7 @@ fn row_to_corpus(r: &sqlx::sqlite::SqliteRow) -> Corpus {
             .unwrap_or_default(),
         near_dupe_of: r.get("near_dupe_of"),
         near_dupe_score: r.get("near_dupe_score"),
+        restored_at: r.get("restored_at"),
     }
 }
 
@@ -140,6 +147,8 @@ impl Store {
             shingles,
             near_dupe_of: None,
             near_dupe_score: None,
+            // A capture, not a placeholder. See `ensure_restored_corpus`.
+            restored_at: None,
         };
         sqlx::query(
             "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles)
@@ -157,6 +166,47 @@ impl Store {
         .execute(&self.pool)
         .await?;
         Ok(src)
+    }
+
+    /// Insert the placeholder parent a restored artifact needs, if it is not
+    /// already there. Returns whether a row was created.
+    ///
+    /// `artifacts.corpus_id` is NOT NULL and references this table, so an
+    /// artifact whose corpus row is gone — the whole-database-lost case this
+    /// exists for — cannot be restored without one. Everything here is derived
+    /// rather than invented where that is possible at all: the id is the one the
+    /// vector payload named, and `raw_text` is the restored artifacts joined,
+    /// which is genuinely all of that document still in the system.
+    ///
+    /// `content_hash` is seeded from the id rather than from `raw_text` because
+    /// the column is UNIQUE and this is not a capture: two stubs whose artifacts
+    /// happen to hold identical text are still two different sources, and
+    /// hashing the reconstructed text would make the second insert fail. Seeding
+    /// from the id also keeps a stub from ever colliding with a real capture of
+    /// the same text, which would silently attach these artifacts to it.
+    ///
+    /// `Partial` is the honest status: some of this source is present, and how
+    /// much is unknowable. `shingles` stays empty so the near-duplicate
+    /// comparison skips it — the reconstructed text is not the document, and
+    /// letting it be compared would report near-duplicates that do not exist.
+    pub async fn ensure_restored_corpus(&self, id: &str, raw_text: &str) -> Result<bool> {
+        let at = now();
+        let res = sqlx::query(
+            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, restored_at)
+             VALUES (?, ?, ?, NULL, ?, ?, ?, ?, '', ?)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(id)
+        .bind(raw_text)
+        .bind("restored:vector-store")
+        .bind(content_hash(&format!("restored:{id}")))
+        .bind(CorpusStatus::Partial.as_str())
+        .bind(at)
+        .bind(at)
+        .bind(at)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
     }
 
     pub async fn get_corpus(&self, id: &str) -> Result<Corpus> {

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -155,18 +155,29 @@ impl Store {
         Ok(rows.iter().map(row_to_pair).collect())
     }
 
+    /// Move a pair to any state other than `Superseded`, clearing the judge's
+    /// proposed direction along with it.
+    ///
+    /// `obsolete_id` is cleared rather than left alone because it belongs to the
+    /// `Superseded` state and to nothing else — see `set_pair_superseded`, the
+    /// only path that writes it. A pair the judge proposed a winner for and an
+    /// operator then dismissed would otherwise keep naming a supersede that was
+    /// explicitly rejected, and any later listing of dismissed pairs would offer
+    /// to apply it.
     pub async fn set_pair_state(
         &self,
         id: i64,
         state: PairState,
         detail: Option<&str>,
     ) -> Result<()> {
-        let res = sqlx::query("UPDATE artifact_pairs SET state = ?, detail = ? WHERE id = ?")
-            .bind(state.as_str())
-            .bind(detail)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+        let res = sqlx::query(
+            "UPDATE artifact_pairs SET state = ?, detail = ?, obsolete_id = NULL WHERE id = ?",
+        )
+        .bind(state.as_str())
+        .bind(detail)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         // A dismiss from a stale Ops page names a pair that is no longer there
         // — its artifacts were deleted, or the row never existed. Redirecting
         // as though it worked tells the operator the queue is one shorter than
@@ -350,6 +361,39 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn leaving_the_superseded_state_drops_the_judge_s_proposal() {
+        // `obsolete_id` belongs to `Superseded` and to no other state. A pair
+        // the judge proposed a winner for and an operator then dismissed used to
+        // keep naming that winner, so any listing of dismissed pairs would offer
+        // to apply a supersede that had been explicitly rejected.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+        s.set_pair_superseded(p.id, &a, Some("a is stale"))
+            .await
+            .unwrap();
+        assert_eq!(
+            s.get_pair(p.id).await.unwrap().obsolete_id.as_deref(),
+            Some(a.as_str())
+        );
+
+        s.set_pair_state(p.id, PairState::Dismissed, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.get_pair(p.id).await.unwrap().obsolete_id,
+            None,
+            "a dismissed pair still carries the supersede that was rejected"
         );
     }
 

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -16,9 +16,13 @@ pub enum PairState {
     Pending,
     /// The fact-token prefilter or the judge found nothing to disagree about.
     NoConflict,
-    /// The judge found a detail the two artifacts state differently. Which one
-    /// is current is a judgement only the reader can make.
+    /// The judge found a detail the two artifacts state differently, with no
+    /// clear direction — both readings could still be current.
     Contradiction,
+    /// The judge named which artifact is obsolete (`obsolete_id`) with enough
+    /// confidence to propose a supersede, but it is not applied automatically:
+    /// an operator confirms via the pair's "apply supersede" action.
+    Superseded,
     /// An operator looked and decided there is nothing here.
     Dismissed,
 }
@@ -29,6 +33,7 @@ impl PairState {
             PairState::Pending => "pending",
             PairState::NoConflict => "no_conflict",
             PairState::Contradiction => "contradiction",
+            PairState::Superseded => "superseded",
             PairState::Dismissed => "dismissed",
         }
     }
@@ -36,6 +41,7 @@ impl PairState {
         match s {
             "no_conflict" => PairState::NoConflict,
             "contradiction" => PairState::Contradiction,
+            "superseded" => PairState::Superseded,
             "dismissed" => PairState::Dismissed,
             _ => PairState::Pending,
         }
@@ -54,6 +60,10 @@ pub struct ArtifactPair {
     /// Model calls this pair has already cost, successful or not. Orders the
     /// judge's queue so a pair it cannot read does not starve the rest.
     pub judge_attempts: i64,
+    /// Which artifact the judge named obsolete, when `state` is `Superseded`.
+    /// Lets the review UI offer "apply supersede" without asking the model
+    /// again.
+    pub obsolete_id: Option<String>,
 }
 
 fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
@@ -66,6 +76,7 @@ fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
         detail: r.get("detail"),
         created_at: r.get("created_at"),
         judge_attempts: r.get("judge_attempts"),
+        obsolete_id: r.get("obsolete_id"),
     }
 }
 
@@ -123,6 +134,15 @@ impl Store {
         Ok(res.rows_affected() > 0)
     }
 
+    pub async fn get_pair(&self, id: i64) -> Result<ArtifactPair> {
+        let row = sqlx::query("SELECT * FROM artifact_pairs WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(crate::error::Error::NotFound)?;
+        Ok(row_to_pair(&row))
+    }
+
     pub async fn pairs_by_state(&self, state: PairState, limit: i64) -> Result<Vec<ArtifactPair>> {
         let rows = sqlx::query(
             "SELECT * FROM artifact_pairs WHERE state = ?
@@ -151,6 +171,31 @@ impl Store {
         // — its artifacts were deleted, or the row never existed. Redirecting
         // as though it worked tells the operator the queue is one shorter than
         // it is.
+        if res.rows_affected() == 0 {
+            return Err(crate::error::Error::NotFound);
+        }
+        Ok(())
+    }
+
+    /// Record the judge's proposed direction: `state` becomes `Superseded`,
+    /// `obsolete_id` names which artifact it believes is stale. Separate from
+    /// `set_pair_state` because this is the only path that writes
+    /// `obsolete_id`, and a plain contradiction must never carry a stale value
+    /// left over from a different pair.
+    pub async fn set_pair_superseded(
+        &self,
+        id: i64,
+        obsolete_id: &str,
+        detail: Option<&str>,
+    ) -> Result<()> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs SET state = 'superseded', detail = ?, obsolete_id = ? WHERE id = ?",
+        )
+        .bind(detail)
+        .bind(obsolete_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         if res.rows_affected() == 0 {
             return Err(crate::error::Error::NotFound);
         }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -169,6 +169,39 @@ impl VectorStore for MemoryVectors {
         Ok(())
     }
 
+    async fn apply_lifecycle(&self, rows: &[super::LifecycleRow]) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        for r in rows {
+            if let Some(p) = w.get_mut(&r.artifact_id) {
+                p.payload.status = Some(r.status);
+                p.payload.superseded = Some(r.status == ArtifactStatus::Superseded);
+                p.payload.superseded_by = r.superseded_by.clone();
+                p.payload.last_verified_at = Some(r.last_verified_at);
+            }
+        }
+        Ok(())
+    }
+
+    async fn unstamped_count(&self) -> Result<u64> {
+        let r = self.points.read().unwrap();
+        Ok(r.values()
+            .filter(|p| p.payload.last_verified_at.is_none())
+            .count() as u64)
+    }
+
+    async fn non_active_ids(&self, limit: usize) -> Result<Vec<String>> {
+        let r = self.points.read().unwrap();
+        let mut out: Vec<String> = r
+            .values()
+            .filter(|p| status_of(&p.payload) != ArtifactStatus::Active)
+            .map(|p| p.payload.artifact_id.clone())
+            .collect();
+        // Deterministic, so a test never depends on HashMap iteration order.
+        out.sort();
+        out.truncate(limit);
+        Ok(out)
+    }
+
     async fn stale_candidates(
         &self,
         older_than: i64,
@@ -179,7 +212,10 @@ impl VectorStore for MemoryVectors {
         Ok(r.values()
             .filter(|p| {
                 status_of(&p.payload) == ArtifactStatus::Active
-                    && p.payload.last_verified_at.unwrap_or(0) < older_than
+                    // Present and old. An unstamped point is unbackfilled, not
+                    // stale — see the trait doc. A missing `hit_count` is the
+                    // other way round: never retrieved is what it means.
+                    && p.payload.last_verified_at.is_some_and(|v| v < older_than)
                     && p.payload.hit_count.unwrap_or(0) <= max_hits
             })
             .take(limit)
@@ -190,10 +226,14 @@ impl VectorStore for MemoryVectors {
             .collect())
     }
 
-    async fn touch(&self, artifact_ids: &[String], seen_at: i64) -> Result<()> {
+    async fn touch(&self, targets: &[super::Touch], seen_at: i64) -> Result<()> {
         let mut w = self.points.write().unwrap();
-        for id in artifact_ids {
-            if let Some(p) = w.get_mut(id) {
+        for t in targets {
+            // The count the caller passed is ignored here on purpose: this
+            // store holds the authoritative value already, and reading it is
+            // free. The Qdrant path uses the caller's copy to skip a round
+            // trip, which is a network optimisation, not a semantic one.
+            if let Some(p) = w.get_mut(&t.artifact_id) {
                 p.payload.last_seen_at = Some(seen_at);
                 p.payload.hit_count = Some(p.payload.hit_count.unwrap_or(0) + 1);
             }
@@ -308,9 +348,12 @@ impl VectorStore for MemoryVectors {
         min_score: f32,
     ) -> Result<Vec<super::NearPair>> {
         let r = self.points.read().unwrap();
+        // Active only, matching the Qdrant backend: a deprecated artifact must
+        // not enter the sweep, where being newer would let it win a cluster and
+        // hide a live one.
         let live: Vec<&VectorPoint> = r
             .values()
-            .filter(|p| p.payload.superseded != Some(true))
+            .filter(|p| status_of(&p.payload) == ArtifactStatus::Active)
             .take(sample)
             .collect();
 
@@ -387,6 +430,49 @@ mod tests {
                 superseded_by: None,
             },
         }
+    }
+
+    #[tokio::test]
+    async fn a_point_with_no_stamp_is_unknown_rather_than_stale() {
+        // Every point predates the lifecycle backfill until it runs. Reading a
+        // missing `last_verified_at` as the epoch made the whole base a
+        // deprecation candidate and asked an operator to act on it.
+        let v = MemoryVectors::new();
+        let mut stamped = point("stamped", "s1", vec![1.0], &[], "note");
+        stamped.payload.last_verified_at = Some(10);
+        v.upsert(vec![
+            point("unstamped", "s1", vec![1.0], &[], "note"),
+            stamped,
+        ])
+        .await
+        .unwrap();
+
+        let ids: Vec<String> = v
+            .stale_candidates(i64::MAX, i64::MAX, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|h| h.payload.artifact_id)
+            .collect();
+        assert_eq!(ids, vec!["stamped".to_string()], "{ids:?}");
+    }
+
+    #[tokio::test]
+    async fn a_deprecated_point_is_no_longer_a_consolidation_candidate() {
+        // A deprecated artifact entering the sweep can win a cluster on being
+        // newer and hide a live one, leaving the knowledge in neither.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("live", "s1", vec![1.0, 0.0], &[], "note"),
+            point("retired", "s2", vec![0.99, 0.01], &[], "note"),
+        ])
+        .await
+        .unwrap();
+        v.set_lifecycle("retired", ArtifactStatus::Deprecated, None)
+            .await
+            .unwrap();
+
+        assert!(v.near_pairs(10, 5, 0.5).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -142,16 +142,29 @@ impl VectorStore for MemoryVectors {
         let mut w = self.points.write().unwrap();
         if let Some(p) = w.get_mut(artifact_id) {
             p.payload.status = Some(status);
-            p.payload.superseded = Some(status != ArtifactStatus::Active);
+            // Tracks `Superseded` specifically, matching the Qdrant backend:
+            // the legacy flag feeds a `must_not superseded == true` net that is
+            // active whenever superseded results are excluded, so setting it
+            // for a deprecated artifact would make `include_deprecated`
+            // unable to surface anything.
+            p.payload.superseded = Some(status == ArtifactStatus::Superseded);
             p.payload.superseded_by = superseded_by.map(str::to_string);
         }
         Ok(())
     }
 
-    async fn set_last_verified_at(&self, artifact_id: &str, at: i64) -> Result<()> {
+    async fn set_last_verified_at(
+        &self,
+        artifact_id: &str,
+        at: i64,
+        reset_hits: bool,
+    ) -> Result<()> {
         let mut w = self.points.write().unwrap();
         if let Some(p) = w.get_mut(artifact_id) {
             p.payload.last_verified_at = Some(at);
+            if reset_hits {
+                p.payload.hit_count = Some(0);
+            }
         }
         Ok(())
     }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -275,6 +275,8 @@ impl VectorStore for MemoryVectors {
             .map(|payload| SearchHit {
                 payload: payload.clone(),
                 score: 0.0,
+                // No query vector to be similar to; this is a listing.
+                similarity: None,
             })
             .collect())
     }
@@ -318,6 +320,8 @@ impl VectorStore for MemoryVectors {
             .map(|p| SearchHit {
                 payload: p.payload.clone(),
                 score: 0.0,
+                // Drawn at random rather than matched; nothing to be close to.
+                similarity: None,
             })
             .collect())
     }
@@ -345,9 +349,16 @@ impl VectorStore for MemoryVectors {
                         .as_ref()
                         .is_none_or(|c| p.payload.category.as_ref() == Some(c))
             })
-            .map(|p| SearchHit {
-                payload: p.payload.clone(),
-                score: cosine(vector, &p.vector),
+            .map(|p| {
+                // Dense only here, so the ranking score *is* the similarity.
+                // The Qdrant store has to fetch it separately because fusion
+                // throws the magnitude away.
+                let similarity = cosine(vector, &p.vector);
+                SearchHit {
+                    payload: p.payload.clone(),
+                    score: similarity,
+                    similarity: Some(similarity),
+                }
             })
             .collect();
         // Tie-break on artifact_id so equal scores produce a stable order rather
@@ -395,6 +406,9 @@ impl VectorStore for MemoryVectors {
             .map(|p| SearchHit {
                 payload: p.payload.clone(),
                 score: cosine(&seed.vector, &p.vector),
+                // The seed is an artifact, not a query. "Loosely related" is
+                // the honest description of every neighbour list.
+                similarity: None,
             })
             .collect();
         hits.sort_by(|a, b| {
@@ -538,6 +552,50 @@ mod tests {
             .unwrap();
 
         assert!(v.near_pairs(10, 5, 0.5).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_reports_the_similarity_it_ranked_by() {
+        // The store has to say how close each hit actually was, not only where
+        // it placed. Here they are the same number because this store is dense
+        // only; the Qdrant one fuses ranks and has to fetch the similarity
+        // separately, and both must report it the same way.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("near", "s1", vec![1.0, 0.0, 0.0], &[], "c"),
+            point("far", "s1", vec![0.0, 0.0, 1.0], &[], "c"),
+        ])
+        .await
+        .unwrap();
+
+        let hits = v
+            .search(
+                &[1.0, 0.0, 0.0],
+                &Default::default(),
+                10,
+                &SearchFilter::default(),
+            )
+            .await
+            .unwrap();
+
+        let near = hits
+            .iter()
+            .find(|h| h.payload.artifact_id == "near")
+            .unwrap();
+        let far = hits
+            .iter()
+            .find(|h| h.payload.artifact_id == "far")
+            .unwrap();
+        assert!(
+            near.similarity.is_some_and(|s| s > 0.99),
+            "{:?}",
+            near.similarity
+        );
+        assert!(
+            far.similarity.is_some_and(|s| s < 0.01),
+            "{:?}",
+            far.similarity
+        );
     }
 
     #[tokio::test]

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -1,5 +1,6 @@
 use super::{FacetCount, Facets, SearchFilter, SearchHit, VectorPoint, VectorStore, cosine};
 use crate::error::Result;
+use crate::store::artifacts::ArtifactStatus;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -22,6 +23,17 @@ impl Default for MemoryVectors {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// A payload's effective lifecycle status. Falls back to the legacy
+/// `superseded` boolean when `status` is unset, matching the Qdrant backend's
+/// dual-check `build_filter` so both implementations agree on points written
+/// before `status` existed.
+fn status_of(payload: &super::VectorPayload) -> ArtifactStatus {
+    payload.status.unwrap_or(match payload.superseded {
+        Some(true) => ArtifactStatus::Superseded,
+        _ => ArtifactStatus::Active,
+    })
 }
 
 /// Counts into chips, most frequent first. Ties break on the value so a
@@ -63,6 +75,26 @@ impl VectorStore for MemoryVectors {
                     .get(&p.payload.artifact_id)
                     .and_then(|old| old.payload.superseded);
             }
+            if p.payload.hit_count.is_none() {
+                p.payload.hit_count = w
+                    .get(&p.payload.artifact_id)
+                    .and_then(|old| old.payload.hit_count);
+            }
+            if p.payload.status.is_none() {
+                p.payload.status = w
+                    .get(&p.payload.artifact_id)
+                    .and_then(|old| old.payload.status);
+            }
+            if p.payload.last_verified_at.is_none() {
+                p.payload.last_verified_at = w
+                    .get(&p.payload.artifact_id)
+                    .and_then(|old| old.payload.last_verified_at);
+            }
+            if p.payload.superseded_by.is_none() {
+                p.payload.superseded_by = w
+                    .get(&p.payload.artifact_id)
+                    .and_then(|old| old.payload.superseded_by.clone());
+            }
             w.insert(p.payload.artifact_id.clone(), p);
         }
         Ok(())
@@ -74,10 +106,21 @@ impl VectorStore for MemoryVectors {
             // A merge, matching Qdrant: an absent stamp means "unchanged", so
             // a tag edit must not erase when the chunk was last shown.
             let seen = payload.last_seen_at.or(p.payload.last_seen_at);
+            let hits = payload.hit_count.or(p.payload.hit_count);
             let sup = payload.superseded.or(p.payload.superseded);
+            let status = payload.status.or(p.payload.status);
+            let verified = payload.last_verified_at.or(p.payload.last_verified_at);
+            let superseded_by = payload
+                .superseded_by
+                .clone()
+                .or_else(|| p.payload.superseded_by.clone());
             p.payload = payload.clone();
             p.payload.last_seen_at = seen;
+            p.payload.hit_count = hits;
             p.payload.superseded = sup;
+            p.payload.status = status;
+            p.payload.last_verified_at = verified;
+            p.payload.superseded_by = superseded_by;
         }
         Ok(())
     }
@@ -90,11 +133,56 @@ impl VectorStore for MemoryVectors {
         Ok(())
     }
 
+    async fn set_lifecycle(
+        &self,
+        artifact_id: &str,
+        status: ArtifactStatus,
+        superseded_by: Option<&str>,
+    ) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        if let Some(p) = w.get_mut(artifact_id) {
+            p.payload.status = Some(status);
+            p.payload.superseded = Some(status != ArtifactStatus::Active);
+            p.payload.superseded_by = superseded_by.map(str::to_string);
+        }
+        Ok(())
+    }
+
+    async fn set_last_verified_at(&self, artifact_id: &str, at: i64) -> Result<()> {
+        let mut w = self.points.write().unwrap();
+        if let Some(p) = w.get_mut(artifact_id) {
+            p.payload.last_verified_at = Some(at);
+        }
+        Ok(())
+    }
+
+    async fn stale_candidates(
+        &self,
+        older_than: i64,
+        max_hits: i64,
+        limit: usize,
+    ) -> Result<Vec<SearchHit>> {
+        let r = self.points.read().unwrap();
+        Ok(r.values()
+            .filter(|p| {
+                status_of(&p.payload) == ArtifactStatus::Active
+                    && p.payload.last_verified_at.unwrap_or(0) < older_than
+                    && p.payload.hit_count.unwrap_or(0) <= max_hits
+            })
+            .take(limit)
+            .map(|p| SearchHit {
+                payload: p.payload.clone(),
+                score: 0.0,
+            })
+            .collect())
+    }
+
     async fn touch(&self, artifact_ids: &[String], seen_at: i64) -> Result<()> {
         let mut w = self.points.write().unwrap();
         for id in artifact_ids {
             if let Some(p) = w.get_mut(id) {
                 p.payload.last_seen_at = Some(seen_at);
+                p.payload.hit_count = Some(p.payload.hit_count.unwrap_or(0) + 1);
             }
         }
         Ok(())
@@ -135,7 +223,9 @@ impl VectorStore for MemoryVectors {
         let mut hits: Vec<SearchHit> = r
             .values()
             .filter(|p| {
-                (filter.include_superseded || p.payload.superseded != Some(true))
+                let status = status_of(&p.payload);
+                (filter.include_superseded || status != ArtifactStatus::Superseded)
+                    && (filter.include_deprecated || status != ArtifactStatus::Deprecated)
                     && filter.tags.iter().all(|t| p.payload.tags.contains(t))
                     && filter
                         .category
@@ -277,7 +367,11 @@ mod tests {
                 tags: tags.iter().map(|s| s.to_string()).collect(),
                 created_at: 0,
                 last_seen_at: None,
+                hit_count: None,
                 superseded: None,
+                status: None,
+                last_verified_at: None,
+                superseded_by: None,
             },
         }
     }
@@ -352,6 +446,7 @@ mod tests {
             tags: vec!["linux".into(), "forensics".into()],
             category: None,
             include_superseded: false,
+            include_deprecated: false,
         };
         let hits = v
             .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &f)
@@ -375,6 +470,7 @@ mod tests {
             tags: vec![],
             category: Some("concept".into()),
             include_superseded: false,
+            include_deprecated: false,
         };
         let hits = v
             .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &f)

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -202,6 +202,34 @@ impl VectorStore for MemoryVectors {
         Ok(out)
     }
 
+    async fn lifecycle_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<HashMap<String, super::StoredLifecycle>> {
+        let r = self.points.read().unwrap();
+        Ok(artifact_ids
+            .iter()
+            .filter_map(|id| {
+                let p = r.get(id)?;
+                Some((
+                    id.clone(),
+                    super::StoredLifecycle {
+                        status: status_of(&p.payload),
+                        superseded_by: p.payload.superseded_by.clone(),
+                    },
+                ))
+            })
+            .collect())
+    }
+
+    async fn all_artifact_ids(&self) -> Result<Vec<String>> {
+        let r = self.points.read().unwrap();
+        let mut out: Vec<String> = r.keys().cloned().collect();
+        // Deterministic, so a test never depends on HashMap iteration order.
+        out.sort();
+        Ok(out)
+    }
+
     async fn stale_candidates(
         &self,
         older_than: i64,
@@ -235,7 +263,10 @@ impl VectorStore for MemoryVectors {
             // trip, which is a network optimisation, not a semantic one.
             if let Some(p) = w.get_mut(&t.artifact_id) {
                 p.payload.last_seen_at = Some(seen_at);
-                p.payload.hit_count = Some(p.payload.hit_count.unwrap_or(0) + 1);
+                // Only a search result counts as a retrieval; see `Touch`.
+                if t.counts_as_hit {
+                    p.payload.hit_count = Some(p.payload.hit_count.unwrap_or(0) + 1);
+                }
             }
         }
         Ok(())
@@ -250,7 +281,11 @@ impl VectorStore for MemoryVectors {
         let r = self.points.read().unwrap();
         Ok(r.values()
             .filter(|p| {
-                p.payload.superseded != Some(true)
+                // Anything not active is out, matching the Qdrant backend: a
+                // deprecated artifact is old and by definition unseen, which
+                // makes it a prime candidate for a list of things nobody has
+                // looked at — and it has just been retired on purpose.
+                status_of(&p.payload) == ArtifactStatus::Active
                     && p.payload.created_at < older_than
                     && p.payload.last_seen_at.is_none_or(|s| s < unseen_since)
             })
@@ -326,7 +361,12 @@ impl VectorStore for MemoryVectors {
         };
         let mut hits: Vec<SearchHit> = r
             .values()
-            .filter(|p| p.payload.artifact_id != artifact_id && p.payload.superseded != Some(true))
+            // Anything out of search is out of the related pane too, matching
+            // the Qdrant backend.
+            .filter(|p| {
+                p.payload.artifact_id != artifact_id
+                    && status_of(&p.payload) == ArtifactStatus::Active
+            })
             .map(|p| SearchHit {
                 payload: p.payload.clone(),
                 score: cosine(&seed.vector, &p.vector),

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -1,4 +1,6 @@
-use super::{FacetCount, Facets, SearchFilter, SearchHit, VectorPoint, VectorStore, cosine};
+use super::{
+    FacetCount, Facets, SearchFilter, SearchHit, VectorPayload, VectorPoint, VectorStore, cosine,
+};
 use crate::error::Result;
 use crate::store::artifacts::ArtifactStatus;
 use async_trait::async_trait;
@@ -222,6 +224,14 @@ impl VectorStore for MemoryVectors {
             .collect())
     }
 
+    async fn payloads_of(&self, artifact_ids: &[String]) -> Result<HashMap<String, VectorPayload>> {
+        let r = self.points.read().unwrap();
+        Ok(artifact_ids
+            .iter()
+            .filter_map(|id| Some((id.clone(), r.get(id)?.payload.clone())))
+            .collect())
+    }
+
     async fn all_artifact_ids(&self) -> Result<Vec<String>> {
         let r = self.points.read().unwrap();
         let mut out: Vec<String> = r.keys().cloned().collect();
@@ -237,18 +247,33 @@ impl VectorStore for MemoryVectors {
         limit: usize,
     ) -> Result<Vec<SearchHit>> {
         let r = self.points.read().unwrap();
-        Ok(r.values()
+        let mut found: Vec<&VectorPayload> = r
+            .values()
+            .map(|p| &p.payload)
             .filter(|p| {
-                status_of(&p.payload) == ArtifactStatus::Active
+                status_of(p) == ArtifactStatus::Active
                     // Present and old. An unstamped point is unbackfilled, not
                     // stale — see the trait doc. A missing `hit_count` is the
                     // other way round: never retrieved is what it means.
-                    && p.payload.last_verified_at.is_some_and(|v| v < older_than)
-                    && p.payload.hit_count.unwrap_or(0) <= max_hits
+                    && p.last_verified_at.is_some_and(|v| v < older_than)
+                    && p.hit_count.unwrap_or(0) <= max_hits
             })
+            .collect();
+        // Sorted before truncating, and sorted at all: this backs a work queue
+        // an operator returns to after every action, and `values()` iterates a
+        // HashMap in an order that is neither stable nor meaningful. Stalest
+        // first, id as the tiebreak — see the Qdrant implementation, whose order
+        // this has to match for the two to be testable against each other.
+        found.sort_by(|a, b| {
+            a.last_verified_at
+                .cmp(&b.last_verified_at)
+                .then_with(|| a.artifact_id.cmp(&b.artifact_id))
+        });
+        Ok(found
+            .into_iter()
             .take(limit)
-            .map(|p| SearchHit {
-                payload: p.payload.clone(),
+            .map(|payload| SearchHit {
+                payload: payload.clone(),
                 score: 0.0,
             })
             .collect())

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -160,7 +160,17 @@ pub trait VectorStore: Send + Sync {
     ) -> Result<()>;
     /// Stamp an artifact as confirmed accurate now — what the recency-decay
     /// scoring formula reads.
-    async fn set_last_verified_at(&self, artifact_id: &str, at: i64) -> Result<()>;
+    ///
+    /// `reset_hits` also zeroes `hit_count`, because `stale_max_hits` counts
+    /// retrievals *since* the last verification. An operator verifying an
+    /// artifact passes `true`; the one-shot backfill passes `false`, since it
+    /// stamps every artifact and would otherwise wipe every counter.
+    async fn set_last_verified_at(
+        &self,
+        artifact_id: &str,
+        at: i64,
+        reset_hits: bool,
+    ) -> Result<()>;
     /// Active artifacts confirmed stale a while ago (`last_verified_at` older
     /// than `older_than`) and rarely or never retrieved since (`hit_count` at
     /// most `max_hits`) — candidates for an operator to review and deprecate.

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -131,20 +131,54 @@ pub struct NearPair {
 /// marked search holds every hit's count already, so passing it spares `touch`
 /// a read round trip it would otherwise pay on every query. `None` means the
 /// caller does not know (opening one artifact by id), and the store reads the
-/// current value itself.
+/// current value itself. It is only ever read when `counts_as_hit`.
+///
+/// `counts_as_hit` separates the two stamps this carries. `last_seen_at` answers
+/// "when was this last put in front of anyone", which every path updates —
+/// that is what keeps the forgotten-chunks list from offering the same artifact
+/// every day. `hit_count` answers "how often did search return this as an
+/// answer since it was last verified", which is what `stale_candidates` reads,
+/// so only a query result may increment it. Opening one artifact from the
+/// review list, or being drawn at random by `resurface`, is the operator
+/// *looking at* a candidate — counting either as a retrieval is how reading a
+/// row used to remove it from the very list that offered it.
 #[derive(Debug, Clone)]
 pub struct Touch {
     pub artifact_id: String,
     pub hit_count: Option<i64>,
+    pub counts_as_hit: bool,
 }
 
 impl Touch {
-    pub fn unknown(artifact_id: &str) -> Touch {
+    /// Returned by a search: bumps both stamps. `hit_count` is the value the
+    /// caller just read, or `None` to make the store look it up.
+    pub fn retrieved(artifact_id: &str, hit_count: Option<i64>) -> Touch {
+        Touch {
+            artifact_id: artifact_id.to_string(),
+            hit_count,
+            counts_as_hit: true,
+        }
+    }
+
+    /// Shown without being asked for — an artifact opened by id, or drawn by
+    /// `resurface`. Stamps `last_seen_at` only.
+    pub fn shown(artifact_id: &str) -> Touch {
         Touch {
             artifact_id: artifact_id.to_string(),
             hit_count: None,
+            counts_as_hit: false,
         }
     }
+}
+
+/// What a point's payload says about its lifecycle, as the drift repair reads
+/// it back. A point missing from a `lifecycle_of` answer is simply absent from
+/// the map; an absent `status` key reads as `Active`, which is how every filter
+/// treats a point written before lifecycle tracking existed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredLifecycle {
+    pub status: ArtifactStatus,
+    pub superseded_by: Option<String>,
 }
 
 /// One artifact's SQLite-side lifecycle state, as the backfill pushes it into
@@ -235,7 +269,8 @@ pub trait VectorStore: Send + Sync {
         filter: &SearchFilter,
     ) -> Result<Vec<SearchHit>>;
     /// Record that these chunks were just shown. Merged into the stored
-    /// payload, never written as a whole one.
+    /// payload, never written as a whole one. `last_seen_at` is stamped for
+    /// every target; `hit_count` only for the ones marked `counts_as_hit`.
     async fn touch(&self, targets: &[Touch], seen_at: i64) -> Result<()>;
     /// Push a batch of artifacts' SQLite-side lifecycle state into the store,
     /// as one request rather than one per artifact per field. What the
@@ -250,6 +285,21 @@ pub trait VectorStore: Send + Sync {
     /// to repair drift left by a half-applied lifecycle change in either
     /// direction.
     async fn non_active_ids(&self, limit: usize) -> Result<Vec<String>>;
+    /// What these artifacts' payloads currently say about their lifecycle. Ids
+    /// with no point are absent from the answer.
+    ///
+    /// The drift repair needs this because set membership in two independently
+    /// truncated lists proves nothing: an id missing from a capped scan may be
+    /// in agreement and simply past the cap. Comparing the stored value per id
+    /// is what tells an actual disagreement from the edge of a page.
+    async fn lifecycle_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, StoredLifecycle>>;
+    /// Every artifact id the store holds a point for. Unbounded on purpose:
+    /// the one caller is the backfill, which is already a pass over the whole
+    /// base and uses this to find points whose SQLite row is gone.
+    async fn all_artifact_ids(&self) -> Result<Vec<String>>;
     /// A random sample of chunks captured before `older_than` and not shown
     /// since `unseen_since`. Random rather than ranked: there is no query here,
     /// only the question of what has been forgotten.

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -279,6 +279,15 @@ pub trait VectorStore: Send + Sync {
     /// How many points carry no `last_verified_at`, i.e. still need the
     /// lifecycle backfill. Startup reads this to decide whether to run it,
     /// rather than making an operator remember a flag.
+    ///
+    /// Points with no `artifact_id` are excluded, and that exclusion is what
+    /// makes "run the backfill once" true. The backfill stamps artifacts, so a
+    /// point naming none can never be stamped by it — counting those meant the
+    /// number never reached zero and every process start kicked off another
+    /// full-base rewrite. Such a point can come from a hand-populated
+    /// collection or a `--reindex` over one, it is invisible to search anyway
+    /// (its payload will not parse as a chunk), and it is left alone rather than
+    /// deleted: nothing here knows what it is.
     async fn unstamped_count(&self) -> Result<u64>;
     /// Artifact ids whose payload says deprecated or superseded, capped at
     /// `limit`. The sweep compares these against SQLite — the source of truth —
@@ -297,9 +306,23 @@ pub trait VectorStore: Send + Sync {
         artifact_ids: &[String],
     ) -> Result<std::collections::HashMap<String, StoredLifecycle>>;
     /// Every artifact id the store holds a point for. Unbounded on purpose:
-    /// the one caller is the backfill, which is already a pass over the whole
-    /// base and uses this to find points whose SQLite row is gone.
+    /// the one caller is the heal, which is already a pass over the whole base
+    /// and compares this against SQLite in both directions.
+    ///
+    /// A point whose payload carries no `artifact_id` at all cannot appear here
+    /// and is not counted by `unstamped_count` either — see that method. It is
+    /// not an engram point and nothing can be said about it.
     async fn all_artifact_ids(&self) -> Result<Vec<String>>;
+    /// The full stored payloads for these ids. Ids with no point are absent
+    /// from the answer.
+    ///
+    /// This is what the heal restores an artifact row from, so unlike
+    /// `lifecycle_of` it has to hand back everything the payload holds — the
+    /// text, the title, the tags — not just the lifecycle fields.
+    async fn payloads_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, VectorPayload>>;
     /// A random sample of chunks captured before `older_than` and not shown
     /// since `unseen_since`. Random rather than ranked: there is no query here,
     /// only the question of what has been forgotten.

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -3,6 +3,7 @@ pub mod qdrant;
 pub mod sparse;
 
 use crate::error::Result;
+use crate::store::artifacts::ArtifactStatus;
 use async_trait::async_trait;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -19,12 +20,37 @@ pub struct VectorPayload {
     /// know the stamp must leave the stored one alone rather than clear it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_seen_at: Option<i64>,
-    /// Set when this artifact lost a near-identical pair to a newer one. Like
-    /// `last_seen_at`, it is omitted when unset so that a writer which does not
-    /// know the value — the embed job rebuilding a payload — leaves the stored
-    /// one alone rather than reviving a hidden artifact.
+    /// How many times this chunk has appeared in results, ever. Bumped
+    /// alongside `last_seen_at`. Read only by the deprecation-candidate query
+    /// (`stale_candidates`) — deliberately never a term in search scoring, or
+    /// a popular result would keep boosting itself further while a correct
+    /// but rarely-queried artifact never gets the chance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hit_count: Option<i64>,
+    /// Set when this artifact lost a near-identical pair to a newer one. Kept
+    /// for filter backward-compatibility now that `status` is the source of
+    /// truth for the same thing — see `SearchFilter`. Like `last_seen_at`, it
+    /// is omitted when unset so a writer which does not know the value — the
+    /// embed job rebuilding a payload — leaves the stored one alone rather
+    /// than reviving a hidden artifact.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub superseded: Option<bool>,
+    /// Active, deprecated, or superseded. Mirrors the SQLite source of truth
+    /// (`store::artifacts::Chunk::status`). Omitted when unset for the same
+    /// merge-write reason as `last_seen_at`; absent is treated as active by
+    /// every filter, so a point written before this field existed is not
+    /// hidden until backfilled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<ArtifactStatus>,
+    /// When this artifact was last confirmed accurate. What search ranking's
+    /// recency decay reads, in place of `created_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_verified_at: Option<i64>,
+    /// The artifact this one was superseded by, if any. Mirrors
+    /// `Chunk::superseded_by` so a search result can show the replacement
+    /// without a second lookup.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,14 +71,22 @@ pub struct SearchFilter {
     /// still readable by id — keeping them out of ranking is the whole of what
     /// superseding does.
     pub include_superseded: bool,
+    /// Deprecated artifacts (flagged stale, no specific replacement) are
+    /// excluded by default, independently of `include_superseded` — the two
+    /// statuses mean different things and callers may want to audit one
+    /// without the other.
+    pub include_deprecated: bool,
 }
 
 impl SearchFilter {
-    /// Whether this filter narrows nothing. Excluding superseded points is
-    /// still a narrowing, so a filter that only does that is not empty — saying
-    /// otherwise would drop the clause on the way to Qdrant.
+    /// Whether this filter narrows nothing. Excluding superseded/deprecated
+    /// points is still a narrowing, so a filter that only does that is not
+    /// empty — saying otherwise would drop the clause on the way to Qdrant.
     pub fn is_empty(&self) -> bool {
-        self.tags.is_empty() && self.category.is_none() && self.include_superseded
+        self.tags.is_empty()
+            && self.category.is_none()
+            && self.include_superseded
+            && self.include_deprecated
     }
 }
 
@@ -113,6 +147,31 @@ pub trait VectorStore: Send + Sync {
     /// artifact won a near-identical pair changes nothing the embedding model
     /// saw.
     async fn set_superseded(&self, artifact_id: &str, superseded: bool) -> Result<()>;
+    /// Set an artifact's lifecycle status (and, for `Superseded`, the winner
+    /// it was replaced by). A payload write, not a re-embed, for the same
+    /// reason as `set_superseded` — also derives and writes the legacy
+    /// `superseded: bool` flag so `build_filter`'s pre-backfill safety net
+    /// keeps working.
+    async fn set_lifecycle(
+        &self,
+        artifact_id: &str,
+        status: ArtifactStatus,
+        superseded_by: Option<&str>,
+    ) -> Result<()>;
+    /// Stamp an artifact as confirmed accurate now — what the recency-decay
+    /// scoring formula reads.
+    async fn set_last_verified_at(&self, artifact_id: &str, at: i64) -> Result<()>;
+    /// Active artifacts confirmed stale a while ago (`last_verified_at` older
+    /// than `older_than`) and rarely or never retrieved since (`hit_count` at
+    /// most `max_hits`) — candidates for an operator to review and deprecate.
+    /// A one-way signal: it can only surface a candidate, never rank anything
+    /// higher, so it cannot create a popularity feedback loop.
+    async fn stale_candidates(
+        &self,
+        older_than: i64,
+        max_hits: i64,
+        limit: usize,
+    ) -> Result<Vec<SearchHit>>;
     /// `sparse` carries the query's BM25 terms. An empty one means the query
     /// held no indexable token, and the lexical half is skipped rather than
     /// asked to match nothing.

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -94,7 +94,23 @@ impl SearchFilter {
 pub struct SearchHit {
     #[serde(flatten)]
     pub payload: VectorPayload,
+    /// What this hit was ranked by. Deliberately not comparable across queries
+    /// or across stores: hybrid retrieval fuses ranks, so this says where the
+    /// result placed rather than how good it was. Use `similarity` to judge
+    /// whether it is any good.
     pub score: f32,
+    /// Cosine similarity between the query vector and this artifact's, when the
+    /// store can say. This *is* comparable across queries — that is the whole
+    /// difference from `score` — so it is what decides whether a result is
+    /// worth presenting as an answer.
+    ///
+    /// `None` means "no opinion", and is not the same as a low value. It covers
+    /// a hit the lexical half found that the dense half did not return, which is
+    /// an exact term match and the opposite of weak; a store with no notion of a
+    /// query vector, as in the listing methods; and any store that does not
+    /// implement the second lookup.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub similarity: Option<f32>,
 }
 
 /// One facet value and how many points carry it, counted straight from the

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -124,6 +124,41 @@ pub struct NearPair {
     pub score: f32,
 }
 
+/// One artifact to stamp as shown, and the `hit_count` the caller already read
+/// for it.
+///
+/// `hit_count` is `Some` when the caller has just seen the stored payload — a
+/// marked search holds every hit's count already, so passing it spares `touch`
+/// a read round trip it would otherwise pay on every query. `None` means the
+/// caller does not know (opening one artifact by id), and the store reads the
+/// current value itself.
+#[derive(Debug, Clone)]
+pub struct Touch {
+    pub artifact_id: String,
+    pub hit_count: Option<i64>,
+}
+
+impl Touch {
+    pub fn unknown(artifact_id: &str) -> Touch {
+        Touch {
+            artifact_id: artifact_id.to_string(),
+            hit_count: None,
+        }
+    }
+}
+
+/// One artifact's SQLite-side lifecycle state, as the backfill pushes it into
+/// the vector store. `last_verified_at` is never optional here: the backfill's
+/// whole job is to give every point the stamp that ranking decays against, and
+/// an artifact never explicitly verified falls back to its `created_at`.
+#[derive(Debug, Clone)]
+pub struct LifecycleRow {
+    pub artifact_id: String,
+    pub status: ArtifactStatus,
+    pub superseded_by: Option<String>,
+    pub last_verified_at: i64,
+}
+
 impl NearPair {
     pub fn new(x: &str, y: &str, score: f32) -> NearPair {
         let (a, b) = if x <= y { (x, y) } else { (y, x) };
@@ -176,6 +211,13 @@ pub trait VectorStore: Send + Sync {
     /// most `max_hits`) — candidates for an operator to review and deprecate.
     /// A one-way signal: it can only surface a candidate, never rank anything
     /// higher, so it cannot create a popularity feedback loop.
+    ///
+    /// A point with no `last_verified_at` at all is *not* a candidate. Missing
+    /// means unknown, not stale: every point predates the backfill until it
+    /// runs, and treating those as maximally stale would fill the review list
+    /// with an arbitrary sample of the whole base and invite an operator to
+    /// deprecate it. A missing `hit_count` is different — never retrieved is a
+    /// fact the absent key states correctly — so it counts as zero.
     async fn stale_candidates(
         &self,
         older_than: i64,
@@ -194,7 +236,20 @@ pub trait VectorStore: Send + Sync {
     ) -> Result<Vec<SearchHit>>;
     /// Record that these chunks were just shown. Merged into the stored
     /// payload, never written as a whole one.
-    async fn touch(&self, artifact_ids: &[String], seen_at: i64) -> Result<()>;
+    async fn touch(&self, targets: &[Touch], seen_at: i64) -> Result<()>;
+    /// Push a batch of artifacts' SQLite-side lifecycle state into the store,
+    /// as one request rather than one per artifact per field. What the
+    /// migration backfill runs on; also what the sweep's drift repair uses.
+    async fn apply_lifecycle(&self, rows: &[LifecycleRow]) -> Result<()>;
+    /// How many points carry no `last_verified_at`, i.e. still need the
+    /// lifecycle backfill. Startup reads this to decide whether to run it,
+    /// rather than making an operator remember a flag.
+    async fn unstamped_count(&self) -> Result<u64>;
+    /// Artifact ids whose payload says deprecated or superseded, capped at
+    /// `limit`. The sweep compares these against SQLite — the source of truth —
+    /// to repair drift left by a half-applied lifecycle change in either
+    /// direction.
+    async fn non_active_ids(&self, limit: usize) -> Result<Vec<String>>;
     /// A random sample of chunks captured before `older_than` and not shown
     /// since `unseen_since`. Random rather than ranked: there is no query here,
     /// only the question of what has been forgotten.
@@ -213,8 +268,9 @@ pub trait VectorStore: Send + Sync {
     /// index. The artifact itself is never among its own neighbours.
     async fn neighbours(&self, artifact_id: &str, limit: usize) -> Result<Vec<SearchHit>>;
     /// Pairs of artifacts closer than `min_score`, best first, over a sample of
-    /// the collection. Superseded artifacts are excluded — a resolved pair
-    /// re-found every sweep is a review queue that never empties.
+    /// the collection. Anything not active is excluded — a resolved pair
+    /// re-found every sweep is a review queue that never empties, and a
+    /// deprecated artifact must never win a supersession and hide a live one.
     ///
     /// This is one round trip, not one query per point: `sample` points are
     /// drawn and each contributes at most `per_point` neighbours. A sweep over

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -196,6 +196,20 @@ fn lifecycle_payload(status: ArtifactStatus, superseded_by: Option<&str>) -> Val
     })
 }
 
+/// What a stored payload says its lifecycle status is, read the way every
+/// filter reads it: an absent `status` falls back to the legacy `superseded`
+/// flag, and an absent flag means active — which is every point written before
+/// lifecycle tracking existed.
+fn stored_status(payload: &Value) -> ArtifactStatus {
+    match payload.get("status").and_then(Value::as_str) {
+        Some(s) => ArtifactStatus::parse(s),
+        None if payload.get("superseded").and_then(Value::as_bool) == Some(true) => {
+            ArtifactStatus::Superseded
+        }
+        None => ArtifactStatus::Active,
+    }
+}
+
 /// The payload `set_last_verified_at` merges into a point.
 ///
 /// `reset_hits` zeroes `hit_count` in the same write, because `stale_max_hits`
@@ -1274,6 +1288,90 @@ impl VectorStore for QdrantVectors {
             .collect())
     }
 
+    async fn lifecycle_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, super::StoredLifecycle>> {
+        let mut out = std::collections::HashMap::new();
+        if artifact_ids.is_empty() {
+            return Ok(out);
+        }
+        // Batched, because the drift repair asks about every hidden artifact it
+        // found and a single retrieve of thousands of ids is a request body
+        // Qdrant may well refuse.
+        const BATCH: usize = 512;
+        for batch in artifact_ids.chunks(BATCH) {
+            let ids: Vec<String> = batch.iter().map(|id| point_uuid(id)).collect();
+            let found: Vec<ScrolledPoint> = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{}/points", self.alias),
+                    Some(json!({
+                        "ids": ids,
+                        // `point_uuid` is one-way, so the artifact id has to
+                        // come back from the payload.
+                        "with_payload": ["artifact_id", "status", "superseded", "superseded_by"],
+                        "with_vector": false,
+                    })),
+                )
+                .await?;
+            for p in found {
+                let Some(id) = p.payload.get("artifact_id").and_then(Value::as_str) else {
+                    continue;
+                };
+                out.insert(
+                    id.to_string(),
+                    super::StoredLifecycle {
+                        status: stored_status(&p.payload),
+                        superseded_by: p
+                            .payload
+                            .get("superseded_by")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                    },
+                );
+            }
+        }
+        Ok(out)
+    }
+
+    async fn all_artifact_ids(&self) -> Result<Vec<String>> {
+        const PAGE: usize = 1_000;
+        let mut out = Vec::new();
+        let mut offset = Value::Null;
+        loop {
+            let mut body = json!({
+                "limit": PAGE,
+                "with_payload": ["artifact_id"],
+                "with_vector": false,
+            });
+            if !offset.is_null() {
+                body["offset"] = offset.clone();
+            }
+            let page: ScrollResult = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{}/points/scroll", self.alias),
+                    Some(body),
+                )
+                .await?;
+            if page.points.is_empty() {
+                break;
+            }
+            out.extend(page.points.iter().filter_map(|p| {
+                p.payload
+                    .get("artifact_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            }));
+            offset = page.next_page_offset;
+            if offset.is_null() {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
     async fn stale_candidates(
         &self,
         older_than: i64,
@@ -1401,8 +1499,8 @@ impl VectorStore for QdrantVectors {
         // Qdrant has no atomic increment — so the current value has to come
         // from somewhere. A marked search has just read every hit's payload and
         // passes the counts in, which is the common case and costs no round
-        // trip; only the callers that know nothing but an id (opening one
-        // artifact) pay for a read, and only for their own points.
+        // trip; a caller that counts a hit while knowing nothing but an id pays
+        // for a read, and only for its own points.
         //
         // Both stay off the request path (the caller backgrounds this call),
         // and this still waits: the shutdown drain exists to keep these stamps,
@@ -1410,18 +1508,24 @@ impl VectorStore for QdrantVectors {
         // meant to prevent. A count missed under a rare concurrent double-touch
         // is an acceptable soft-counter race — it only ever feeds the one-way
         // stale-candidate query, never live scoring.
+        //
+        // A target that does not count as a hit needs no count at all: it only
+        // stamps `last_seen_at`, so it neither joins the read below nor carries
+        // a `hit_count` key into the write.
         let mut counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
-        let mut ids: Vec<String> = Vec::with_capacity(targets.len());
+        let mut ids: Vec<(String, bool)> = Vec::with_capacity(targets.len());
         let mut unknown: Vec<String> = Vec::new();
         for t in targets {
             let uuid = point_uuid(&t.artifact_id);
-            match t.hit_count {
-                Some(n) => {
-                    counts.insert(uuid.clone(), n);
+            if t.counts_as_hit {
+                match t.hit_count {
+                    Some(n) => {
+                        counts.insert(uuid.clone(), n);
+                    }
+                    None => unknown.push(uuid.clone()),
                 }
-                None => unknown.push(uuid.clone()),
             }
-            ids.push(uuid);
+            ids.push((uuid, t.counts_as_hit));
         }
         if !unknown.is_empty() {
             let found: Vec<ScrolledPoint> = self
@@ -1447,11 +1551,14 @@ impl VectorStore for QdrantVectors {
         }
         let ops: Vec<Value> = ids
             .iter()
-            .map(|uuid| {
-                let next = counts.get(uuid).copied().unwrap_or(0) + 1;
+            .map(|(uuid, counts_as_hit)| {
+                let mut payload = json!({ "last_seen_at": seen_at });
+                if *counts_as_hit {
+                    payload["hit_count"] = json!(counts.get(uuid).copied().unwrap_or(0) + 1);
+                }
                 json!({
                     "set_payload": {
-                        "payload": { "last_seen_at": seen_at, "hit_count": next },
+                        "payload": payload,
                         "points": [uuid],
                     }
                 })
@@ -1483,9 +1590,15 @@ impl VectorStore for QdrantVectors {
                     // point written before consolidation existed carries no
                     // `superseded` key, and matching `false` would drop it.
                     // Without this the forgotten list offers exactly the
-                    // duplicates the sweep just took out of search.
+                    // duplicates the sweep just took out of search — and, since
+                    // a deprecated artifact is old and by definition unseen,
+                    // exactly the artifacts an operator has just retired.
                     "filter": {
-                      "must_not": [ { "key": "superseded", "match": { "value": true } } ],
+                      "must_not": [
+                        { "key": "status", "match": { "value": "superseded" } },
+                        { "key": "status", "match": { "value": "deprecated" } },
+                        { "key": "superseded", "match": { "value": true } }
+                      ],
                       "must": [
                         { "key": "created_at", "range": { "lt": older_than } },
                         // Nested so this reads as AND-of-OR. A chunk written
@@ -1548,11 +1661,19 @@ impl VectorStore for QdrantVectors {
             "query": point_uuid(artifact_id),
             "using": DENSE,
             "limit": limit + 1,
-            // A superseded artifact is out of search, so it must be out of the
-            // related pane too: it is by construction near-identical to its
-            // keeper, which means it would lead that list on every artifact it
-            // was hidden in favour of.
-            "filter": { "must_not": [ { "key": "superseded", "match": { "value": true } } ] },
+            // Anything out of search is out of the related pane too. A
+            // superseded artifact is by construction near-identical to its
+            // keeper, so it would lead that list on every artifact it was
+            // hidden in favour of; a deprecated one is content an operator
+            // retired, and linking to it from a live artifact presents it as
+            // current. `status` and the legacy flag are both matched because a
+            // deprecation deliberately writes `superseded: false` — see
+            // `lifecycle_payload` — so the legacy net alone never catches it.
+            "filter": { "must_not": [
+                { "key": "status", "match": { "value": "superseded" } },
+                { "key": "status", "match": { "value": "deprecated" } },
+                { "key": "superseded", "match": { "value": true } }
+            ] },
             "with_payload": true,
         });
         let res: QueryResult = match self

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1220,26 +1220,37 @@ impl VectorStore for QdrantVectors {
         // stamps artifacts it knows nothing about, and zeroing every retrieval
         // counter in the base is not a migration step. See `Core::verify` for
         // the case that does reset it.
-        let ops: Vec<Value> = rows
-            .iter()
-            .map(|r| {
-                let mut payload = lifecycle_payload(r.status, r.superseded_by.as_deref());
-                payload["last_verified_at"] = json!(r.last_verified_at);
-                json!({
-                    "set_payload": {
-                        "payload": payload,
-                        "points": [ point_uuid(&r.artifact_id) ],
-                    }
+        //
+        // Capped per request for the same reason `lifecycle_of` caps its
+        // retrieves: one operation per artifact means an unbounded caller
+        // produces an unbounded request body, and Qdrant may well refuse it.
+        // The callers that most need this pass are the ones with the most to
+        // write — a full backfill, or a drift repair over a base that drifted
+        // badly — so the largest request is exactly the one that must not be
+        // the one that fails.
+        const BATCH: usize = 512;
+        for group in rows.chunks(BATCH) {
+            let ops: Vec<Value> = group
+                .iter()
+                .map(|r| {
+                    let mut payload = lifecycle_payload(r.status, r.superseded_by.as_deref());
+                    payload["last_verified_at"] = json!(r.last_verified_at);
+                    json!({
+                        "set_payload": {
+                            "payload": payload,
+                            "points": [ point_uuid(&r.artifact_id) ],
+                        }
+                    })
                 })
-            })
-            .collect();
-        let _: Value = self
-            .call(
-                Method::POST,
-                &format!("/collections/{}/points/batch?wait=true", self.alias),
-                Some(json!({ "operations": ops })),
-            )
-            .await?;
+                .collect();
+            let _: Value = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{}/points/batch?wait=true", self.alias),
+                    Some(json!({ "operations": ops })),
+                )
+                .await?;
+        }
         Ok(())
     }
 
@@ -1250,7 +1261,13 @@ impl VectorStore for QdrantVectors {
                 &format!("/collections/{}/points/count", self.alias),
                 Some(json!({
                     "exact": true,
-                    "filter": { "must": [ { "is_empty": { "key": "last_verified_at" } } ] },
+                    "filter": {
+                        "must": [ { "is_empty": { "key": "last_verified_at" } } ],
+                        // A point naming no artifact is not backfillable — see
+                        // the trait doc. Counting it kept this above zero
+                        // forever.
+                        "must_not": [ { "is_empty": { "key": "artifact_id" } } ],
+                    },
                 })),
             )
             .await?;
@@ -1286,6 +1303,45 @@ impl VectorStore for QdrantVectors {
                     .map(str::to_string)
             })
             .collect())
+    }
+
+    async fn payloads_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, VectorPayload>> {
+        let mut out = std::collections::HashMap::new();
+        if artifact_ids.is_empty() {
+            return Ok(out);
+        }
+        // Batched for the same reason as `lifecycle_of` below, and with more
+        // reason: these retrieves carry the full payload, text included.
+        const BATCH: usize = 256;
+        for batch in artifact_ids.chunks(BATCH) {
+            let ids: Vec<String> = batch.iter().map(|id| point_uuid(id)).collect();
+            let found: Vec<ScrolledPoint> = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{}/points", self.alias),
+                    Some(json!({
+                        "ids": ids,
+                        "with_payload": true,
+                        "with_vector": false,
+                    })),
+                )
+                .await?;
+            for p in found {
+                match serde_json::from_value::<VectorPayload>(p.payload) {
+                    Ok(payload) => {
+                        out.insert(payload.artifact_id.clone(), payload);
+                    }
+                    Err(e) => tracing::warn!(
+                        error = %e,
+                        "skipping a point whose payload is not an engram chunk"
+                    ),
+                }
+            }
+        }
+        Ok(out)
     }
 
     async fn lifecycle_of(
@@ -1372,42 +1428,108 @@ impl VectorStore for QdrantVectors {
         Ok(out)
     }
 
+    /// Scrolled and sorted rather than sampled, because this list is a work
+    /// queue.
+    ///
+    /// A random draw meant every render of Ops produced a different set: acting
+    /// on a candidate redirects back to the page, which re-drew, so an operator
+    /// could not work the queue down and a given artifact might take many page
+    /// loads to reappear. A scroll is deterministic (Qdrant returns points in id
+    /// order), so the same base with the same threshold yields the same queue,
+    /// and answering a candidate is what removes it — verifying restamps it out
+    /// of the range, deprecating filters it out.
+    ///
+    /// The scroll is capped: the filtered set is "everything stale enough", with
+    /// no upper bound on a neglected base, and this runs on a page render. The
+    /// cap costs nothing an operator can perceive, since the whole point is to
+    /// hand back `limit` rows and `limit` is small — it only means that on a
+    /// base with more than `STALE_SCAN` stale artifacts, the queue is drawn from
+    /// the first window in point-id order rather than the true global worst.
     async fn stale_candidates(
         &self,
         older_than: i64,
         max_hits: i64,
         limit: usize,
     ) -> Result<Vec<SearchHit>> {
-        let res: QueryResult = self
-            .call(
-                Method::POST,
-                &format!("/collections/{}/points/query", self.alias),
-                Some(json!({
-                    "query": { "sample": "random" },
-                    "filter": {
-                      "must_not": [
-                        { "key": "status", "match": { "value": "deprecated" } },
-                        { "key": "status", "match": { "value": "superseded" } },
-                        { "key": "superseded", "match": { "value": true } },
-                      ],
-                      "must": [
-                        // Present *and* old. A point with no stamp is not a
-                        // stale candidate, it is an unbackfilled one — see the
-                        // trait doc. `hit_count` below is the opposite case:
-                        // absent legitimately means never retrieved.
-                        { "key": "last_verified_at", "range": { "lt": older_than } },
-                        { "should": [
-                            { "key": "hit_count", "range": { "lte": max_hits } },
-                            { "is_empty": { "key": "hit_count" } },
-                        ] },
-                      ],
-                    },
-                    "limit": limit,
-                    "with_payload": true,
-                })),
-            )
-            .await?;
-        Ok(hits_of(res))
+        /// How many matching points the queue is drawn from.
+        const STALE_SCAN: usize = 10_000;
+        const PAGE: usize = 1_000;
+
+        let filter = json!({
+            "must_not": [
+                { "key": "status", "match": { "value": "deprecated" } },
+                { "key": "status", "match": { "value": "superseded" } },
+                { "key": "superseded", "match": { "value": true } },
+            ],
+            "must": [
+                // Present *and* old. A point with no stamp is not a stale
+                // candidate, it is an unbackfilled one — see the trait doc.
+                // `hit_count` below is the opposite case: absent legitimately
+                // means never retrieved.
+                { "key": "last_verified_at", "range": { "lt": older_than } },
+                { "should": [
+                    { "key": "hit_count", "range": { "lte": max_hits } },
+                    { "is_empty": { "key": "hit_count" } },
+                ] },
+            ],
+        });
+
+        let mut found: Vec<VectorPayload> = Vec::new();
+        let mut offset = Value::Null;
+        while found.len() < STALE_SCAN {
+            let mut body = json!({
+                "filter": filter,
+                "limit": PAGE.min(STALE_SCAN - found.len()),
+                "with_payload": true,
+                "with_vector": false,
+            });
+            if !offset.is_null() {
+                body["offset"] = offset.clone();
+            }
+            let page: ScrollResult = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{}/points/scroll", self.alias),
+                    Some(body),
+                )
+                .await?;
+            if page.points.is_empty() {
+                break;
+            }
+            for p in page.points {
+                match serde_json::from_value::<VectorPayload>(p.payload) {
+                    Ok(payload) => found.push(payload),
+                    Err(e) => tracing::warn!(
+                        error = %e,
+                        "skipping a point whose payload is not an engram chunk"
+                    ),
+                }
+            }
+            offset = page.next_page_offset;
+            if offset.is_null() {
+                break;
+            }
+        }
+
+        // Stalest first, so the queue leads with the artifacts most worth an
+        // operator's attention rather than with whichever ids sort lowest. The
+        // id tiebreak keeps the order total: two artifacts stamped in the same
+        // second must not swap places between one render and the next.
+        found.sort_by(|a, b| {
+            a.last_verified_at
+                .cmp(&b.last_verified_at)
+                .then_with(|| a.artifact_id.cmp(&b.artifact_id))
+        });
+        found.truncate(limit);
+        Ok(found
+            .into_iter()
+            .map(|payload| SearchHit {
+                payload,
+                // No query to be similar to. The caller ranks this list by
+                // staleness, which the order above already carries.
+                score: 0.0,
+            })
+            .collect())
     }
 
     async fn search(

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -11,7 +11,10 @@
 //! background rebuild followed by an atomic swap, rather than an outage.
 
 use super::sparse::SparseVector;
-use super::{FacetCount, Facets, SearchFilter, SearchHit, VectorPayload, VectorPoint, VectorStore};
+use super::{
+    FacetCount, Facets, LifecycleRow, SearchFilter, SearchHit, Touch, VectorPayload, VectorPoint,
+    VectorStore,
+};
 use crate::config::VectorConfig;
 use crate::error::{Error, Result};
 use crate::store::artifacts::ArtifactStatus;
@@ -284,9 +287,15 @@ fn sparse_of_payload(payload: &Value) -> SparseVector {
 /// formula defaults`, not just its own scoring. Every point engram writes
 /// carries the key, but `--reindex` copies payloads verbatim from whatever was
 /// in the source collection, so one hand-written point would otherwise take
-/// search down. Treating a missing stamp as the epoch scores it as maximally
-/// stale, which is the honest reading of "we do not know when this was last
-/// confirmed accurate".
+/// search down.
+///
+/// The default is `now`, not the epoch. A missing stamp means unknown, not
+/// stale, and the difference is the whole collection on the day the lifecycle
+/// migration lands: every pre-existing point lacks the key until the backfill
+/// has run, and defaulting to the epoch would collapse the recency term to
+/// zero for all of them at once — a base-wide reranking nobody asked for.
+/// Defaulting to `now` leaves the term neutral (`exp_decay` returns 1.0), so an
+/// unstamped point ranks exactly as it did before this field existed.
 ///
 /// Decays against `last_verified_at` rather than `created_at`, deliberately:
 /// an artifact confirmed correct last week should outrank one merely written
@@ -312,7 +321,7 @@ fn scoring_formula(now: i64, half_life_secs: u64, recency: f32, pinned: f32) -> 
     }
     json!({
         "formula": { "sum": terms },
-        "defaults": { "last_verified_at": 0 },
+        "defaults": { "last_verified_at": now },
     })
 }
 
@@ -543,8 +552,21 @@ impl QdrantVectors {
             tracing::info!(collection = %name, "collection already existed; adopting it");
         }
 
-        // Payload indexes: without these, filtered search degrades to a
-        // full scan of the collection.
+        self.ensure_payload_indexes(name).await?;
+        tracing::info!(collection = %name, dim, "created qdrant collection");
+        Ok(())
+    }
+
+    /// Create every payload index this codebase filters on, tolerating ones
+    /// that already exist (Qdrant treats an identical index as a no-op).
+    ///
+    /// Called on every path that adopts a collection, not only on the one that
+    /// creates it. A field added to this list by a later release exists in no
+    /// collection created before it — and `build_filter` starts emitting a
+    /// clause on it immediately — so a deployment that only ever ran the
+    /// creation path once would run every filtered search as a full scan until
+    /// someone thought to `--reindex`.
+    async fn ensure_payload_indexes(&self, name: &str) -> Result<()> {
         for (field, schema) in [
             ("tags", "keyword"),
             ("category", "keyword"),
@@ -564,7 +586,6 @@ impl QdrantVectors {
                 .await
                 .map_err(|e| Error::Vector(format!("payload index on {field}: {e}")))?;
         }
-        tracing::info!(collection = %name, dim, "created qdrant collection");
         Ok(())
     }
 
@@ -1017,6 +1038,9 @@ impl VectorStore for QdrantVectors {
             if existing as usize != dim {
                 return Err(dimension_mismatch(&current, dim, existing as usize));
             }
+            // An already-serving collection predates any index this release
+            // added, so this is the path that matters most.
+            self.ensure_payload_indexes(&current).await?;
             return Ok(());
         }
 
@@ -1041,6 +1065,7 @@ impl VectorStore for QdrantVectors {
                  which means an earlier rebuild did not finish"
             );
             self.claim_alias(&orphan, dim).await?;
+            self.ensure_payload_indexes(&orphan).await?;
             return Ok(());
         }
 
@@ -1167,6 +1192,88 @@ impl VectorStore for QdrantVectors {
         Ok(())
     }
 
+    async fn apply_lifecycle(&self, rows: &[LifecycleRow]) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        // One request per batch, not two writes per artifact. The backfill runs
+        // over every artifact in the base, and at two round trips each — both
+        // with `wait=true` — it was slow enough that an operator would be
+        // tempted to skip it, which is the failure this batching is really
+        // preventing.
+        //
+        // `last_verified_at` is merged without touching `hit_count`: this pass
+        // stamps artifacts it knows nothing about, and zeroing every retrieval
+        // counter in the base is not a migration step. See `Core::verify` for
+        // the case that does reset it.
+        let ops: Vec<Value> = rows
+            .iter()
+            .map(|r| {
+                let mut payload = lifecycle_payload(r.status, r.superseded_by.as_deref());
+                payload["last_verified_at"] = json!(r.last_verified_at);
+                json!({
+                    "set_payload": {
+                        "payload": payload,
+                        "points": [ point_uuid(&r.artifact_id) ],
+                    }
+                })
+            })
+            .collect();
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/batch?wait=true", self.alias),
+                Some(json!({ "operations": ops })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn unstamped_count(&self) -> Result<u64> {
+        let res: CountResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/count", self.alias),
+                Some(json!({
+                    "exact": true,
+                    "filter": { "must": [ { "is_empty": { "key": "last_verified_at" } } ] },
+                })),
+            )
+            .await?;
+        Ok(res.count)
+    }
+
+    async fn non_active_ids(&self, limit: usize) -> Result<Vec<String>> {
+        // `point_uuid` is one-way, so the artifact id has to come out of the
+        // payload rather than the point id.
+        let page: ScrollResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/scroll", self.alias),
+                Some(json!({
+                    "filter": { "should": [
+                        { "key": "status", "match": { "value": "deprecated" } },
+                        { "key": "status", "match": { "value": "superseded" } },
+                        { "key": "superseded", "match": { "value": true } },
+                    ] },
+                    "limit": limit,
+                    "with_payload": ["artifact_id"],
+                    "with_vector": false,
+                })),
+            )
+            .await?;
+        Ok(page
+            .points
+            .iter()
+            .filter_map(|p| {
+                p.payload
+                    .get("artifact_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect())
+    }
+
     async fn stale_candidates(
         &self,
         older_than: i64,
@@ -1186,10 +1293,11 @@ impl VectorStore for QdrantVectors {
                         { "key": "superseded", "match": { "value": true } },
                       ],
                       "must": [
-                        { "should": [
-                            { "key": "last_verified_at", "range": { "lt": older_than } },
-                            { "is_empty": { "key": "last_verified_at" } },
-                        ] },
+                        // Present *and* old. A point with no stamp is not a
+                        // stale candidate, it is an unbackfilled one — see the
+                        // trait doc. `hit_count` below is the opposite case:
+                        // absent legitimately means never retrieved.
+                        { "key": "last_verified_at", "range": { "lt": older_than } },
                         { "should": [
                             { "key": "hit_count", "range": { "lte": max_hits } },
                             { "is_empty": { "key": "hit_count" } },
@@ -1284,37 +1392,57 @@ impl VectorStore for QdrantVectors {
         Ok(hits_of(res))
     }
 
-    async fn touch(&self, artifact_ids: &[String], seen_at: i64) -> Result<()> {
-        if artifact_ids.is_empty() {
+    async fn touch(&self, targets: &[Touch], seen_at: i64) -> Result<()> {
+        if targets.is_empty() {
             return Ok(());
         }
-        let ids: Vec<String> = artifact_ids.iter().map(|c| point_uuid(c)).collect();
-        // `last_seen_at` is the same value for the whole batch, so it stays
-        // one uniform merge write. `hit_count` is not — each point's next
-        // value depends on its own current one — so it costs one extra read
-        // first. Both stay off the request path (the caller backgrounds this
-        // call), and this still waits: the shutdown drain exists to keep
-        // these stamps, and an acknowledged-but-unapplied write is exactly the
-        // loss it is meant to prevent. A count missed under a rare concurrent
-        // double-touch is an acceptable soft-counter race — it only ever feeds
-        // the one-way stale-candidate query, never live scoring.
-        let found: Vec<ScrolledPoint> = self
-            .call(
-                Method::POST,
-                &format!("/collections/{}/points", self.alias),
-                Some(json!({ "ids": ids, "with_payload": ["hit_count"], "with_vector": false })),
-            )
-            .await?;
+        // `last_seen_at` is the same value for the whole batch. `hit_count` is
+        // not — each point's next value depends on its own current one, and
+        // Qdrant has no atomic increment — so the current value has to come
+        // from somewhere. A marked search has just read every hit's payload and
+        // passes the counts in, which is the common case and costs no round
+        // trip; only the callers that know nothing but an id (opening one
+        // artifact) pay for a read, and only for their own points.
+        //
+        // Both stay off the request path (the caller backgrounds this call),
+        // and this still waits: the shutdown drain exists to keep these stamps,
+        // and an acknowledged-but-unapplied write is exactly the loss it is
+        // meant to prevent. A count missed under a rare concurrent double-touch
+        // is an acceptable soft-counter race — it only ever feeds the one-way
+        // stale-candidate query, never live scoring.
         let mut counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
-        for p in found {
-            if let Some(uuid) = p.id.as_str() {
-                counts.insert(
-                    uuid.to_string(),
-                    p.payload
-                        .get("hit_count")
-                        .and_then(Value::as_i64)
-                        .unwrap_or(0),
-                );
+        let mut ids: Vec<String> = Vec::with_capacity(targets.len());
+        let mut unknown: Vec<String> = Vec::new();
+        for t in targets {
+            let uuid = point_uuid(&t.artifact_id);
+            match t.hit_count {
+                Some(n) => {
+                    counts.insert(uuid.clone(), n);
+                }
+                None => unknown.push(uuid.clone()),
+            }
+            ids.push(uuid);
+        }
+        if !unknown.is_empty() {
+            let found: Vec<ScrolledPoint> = self
+                .call(
+                    Method::POST,
+                    &format!("/collections/{}/points", self.alias),
+                    Some(
+                        json!({ "ids": unknown, "with_payload": ["hit_count"], "with_vector": false }),
+                    ),
+                )
+                .await?;
+            for p in found {
+                if let Some(uuid) = p.id.as_str() {
+                    counts.insert(
+                        uuid.to_string(),
+                        p.payload
+                            .get("hit_count")
+                            .and_then(Value::as_i64)
+                            .unwrap_or(0),
+                    );
+                }
             }
         }
         let ops: Vec<Value> = ids
@@ -1457,8 +1585,14 @@ impl VectorStore for QdrantVectors {
         per_point: usize,
         min_score: f32,
     ) -> Result<Vec<super::NearPair>> {
-        // Superseded points are excluded at the source. Including them would
-        // hand the sweep pairs it has already resolved, on every single run.
+        // Anything not active is excluded at the source. Superseded points
+        // would hand the sweep pairs it has already resolved, on every single
+        // run. Deprecated points are worse than redundant: the sweep's `keeper`
+        // picks the newest member of a cluster, so a newer artifact an operator
+        // retired would *win* against a live older one and hide it — leaving
+        // one artifact deprecated, the other superseded, and the knowledge in
+        // neither reachable by search. `supersede` would also overwrite the
+        // operator's `deprecated` status with `superseded` on the way past.
         let res: MatrixPairs = self
             .call(
                 Method::POST,
@@ -1468,6 +1602,8 @@ impl VectorStore for QdrantVectors {
                     "limit": per_point,
                     "using": DENSE,
                     "filter": { "must_not": [
+                        { "key": "status", "match": { "value": "superseded" } },
+                        { "key": "status", "match": { "value": "deprecated" } },
                         { "key": "superseded", "match": { "value": true } }
                     ] },
                 })),
@@ -1808,11 +1944,14 @@ mod tests {
     #[test]
     fn the_scoring_formula_survives_a_point_without_a_last_verified_at() {
         // Qdrant fails the entire query, not just the offending point, when a
-        // formula reads a key the payload does not have.
+        // formula reads a key the payload does not have. The default is `now`,
+        // not the epoch: every point predates the lifecycle backfill until it
+        // runs, and defaulting to the epoch would zero the recency term for the
+        // whole collection at once. `now` leaves it neutral.
         let f = scoring_formula(1_700_000_000, 86_400, 0.05, 0.15);
         assert_eq!(
-            f["defaults"]["last_verified_at"], 0,
-            "a payload missing last_verified_at would take search down: {f}"
+            f["defaults"]["last_verified_at"], 1_700_000_000,
+            "an unstamped payload must score as unknown, not as maximally stale: {f}"
         );
     }
 

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -176,6 +176,37 @@ fn build_filter(filter: &SearchFilter) -> Option<Value> {
     Some(body)
 }
 
+/// The payload `set_lifecycle` merges into a point.
+///
+/// The legacy `superseded` boolean is derived and written alongside `status` so
+/// `build_filter`'s pre-backfill safety net and any reader that still checks it
+/// stay correct. It tracks `Superseded` specifically and *not* "anything not
+/// active": that net is a `must_not superseded == true` which `build_filter`
+/// emits whenever `include_superseded` is false, so writing `true` for a
+/// deprecated artifact would make `include_deprecated` unable to surface
+/// anything at all.
+fn lifecycle_payload(status: ArtifactStatus, superseded_by: Option<&str>) -> Value {
+    json!({
+        "status": status.as_str(),
+        "superseded": status == ArtifactStatus::Superseded,
+        "superseded_by": superseded_by,
+    })
+}
+
+/// The payload `set_last_verified_at` merges into a point.
+///
+/// `reset_hits` zeroes `hit_count` in the same write, because `stale_max_hits`
+/// counts retrievals *since* the last verification — see `Core::verify`. The
+/// backfill pass leaves it alone: it stamps every artifact and must not wipe
+/// every counter.
+fn verified_payload(at: i64, reset_hits: bool) -> Value {
+    let mut p = json!({ "last_verified_at": at });
+    if reset_hits {
+        p["hit_count"] = json!(0);
+    }
+    p
+}
+
 /// Qdrant's distance-matrix reply. The ids are point ids, not artifact ids,
 /// which is why `near_pairs` follows this with a payload lookup.
 #[derive(Deserialize)]
@@ -1109,14 +1140,7 @@ impl VectorStore for QdrantVectors {
                 Method::POST,
                 &format!("/collections/{}/points/payload?wait=true", self.alias),
                 Some(json!({
-                    // The legacy boolean is derived and written alongside
-                    // `status` so `build_filter`'s pre-backfill safety net and
-                    // any reader that still checks it stay correct.
-                    "payload": {
-                        "status": status.as_str(),
-                        "superseded": status != ArtifactStatus::Active,
-                        "superseded_by": superseded_by,
-                    },
+                    "payload": lifecycle_payload(status, superseded_by),
                     "points": [ point_uuid(artifact_id) ],
                 })),
             )
@@ -1124,13 +1148,18 @@ impl VectorStore for QdrantVectors {
         Ok(())
     }
 
-    async fn set_last_verified_at(&self, artifact_id: &str, at: i64) -> Result<()> {
+    async fn set_last_verified_at(
+        &self,
+        artifact_id: &str,
+        at: i64,
+        reset_hits: bool,
+    ) -> Result<()> {
         let _: Value = self
             .call(
                 Method::POST,
                 &format!("/collections/{}/points/payload?wait=true", self.alias),
                 Some(json!({
-                    "payload": { "last_verified_at": at },
+                    "payload": verified_payload(at, reset_hits),
                     "points": [ point_uuid(artifact_id) ],
                 })),
             )
@@ -1784,6 +1813,40 @@ mod tests {
         assert_eq!(
             f["defaults"]["last_verified_at"], 0,
             "a payload missing last_verified_at would take search down: {f}"
+        );
+    }
+
+    #[test]
+    fn deprecating_does_not_set_the_legacy_superseded_flag() {
+        // `build_filter` excludes `superseded == true` whenever superseded
+        // results are not asked for, which is the normal case for a caller that
+        // only set `include_deprecated`. Writing the flag for a deprecation
+        // would make that request unable to return anything.
+        let p = lifecycle_payload(ArtifactStatus::Deprecated, None);
+        assert_eq!(p["status"], "deprecated");
+        assert_eq!(p["superseded"], false, "deprecated is not superseded: {p}");
+
+        let s = lifecycle_payload(ArtifactStatus::Superseded, Some("winner"));
+        assert_eq!(s["superseded"], true);
+        assert_eq!(s["superseded_by"], "winner");
+
+        let a = lifecycle_payload(ArtifactStatus::Active, None);
+        assert_eq!(a["superseded"], false);
+    }
+
+    #[test]
+    fn only_a_verify_resets_the_hit_counter() {
+        // The backfill pass stamps every artifact; resetting there would wipe
+        // every retrieval count in the base.
+        let verified = verified_payload(42, true);
+        assert_eq!(verified["last_verified_at"], 42);
+        assert_eq!(verified["hit_count"], 0);
+
+        let backfilled = verified_payload(42, false);
+        assert_eq!(backfilled["last_verified_at"], 42);
+        assert!(
+            backfilled.get("hit_count").is_none(),
+            "a backfill must leave the counter alone: {backfilled}"
         );
     }
 

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -23,6 +23,7 @@ use reqwest::{Client, Method, StatusCode};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::time::Duration;
 
 /// Generous enough for a cold HNSW segment load, short enough that a wedged
@@ -954,6 +955,9 @@ fn hits_of(res: QueryResult) -> Vec<SearchHit> {
             Ok(payload) => out.push(SearchHit {
                 payload,
                 score: p.score,
+                // Filled in by `search` from the batched dense lookup; every
+                // other caller of this helper is a listing with no query.
+                similarity: None,
             }),
             Err(e) => tracing::warn!(
                 error = %e,
@@ -1528,6 +1532,7 @@ impl VectorStore for QdrantVectors {
                 // No query to be similar to. The caller ranks this list by
                 // staleness, which the order above already carries.
                 score: 0.0,
+                similarity: None,
             })
             .collect())
     }
@@ -1602,14 +1607,57 @@ impl VectorStore for QdrantVectors {
             });
         }
 
-        let res: QueryResult = self
+        // The second half of the request: the same dense vector, on its own,
+        // with no fusion and no recency stage over it. That returns raw cosine
+        // similarity, which is the only number in this whole path that means
+        // the same thing from one query to the next — the ranking score above
+        // is a fused rank, so the top hit for a typo scores like the top hit for
+        // a perfect match.
+        //
+        // Batched rather than sent after, so the confidence costs a round trip
+        // of nothing. `limit` matches the ranking query's, so every hit the
+        // dense branch contributed is covered; a hit only the lexical branch
+        // found is absent from this set and gets no similarity, which is
+        // correct — it contains the query's terms verbatim.
+        let mut confidence = json!({
+            "query": vector,
+            "using": DENSE,
+            "limit": limit,
+            "with_payload": ["artifact_id"],
+        });
+        if let Some(f) = &f {
+            confidence["filter"] = f.clone();
+        }
+
+        let mut res: Vec<QueryResult> = self
             .call(
                 Method::POST,
-                &format!("/collections/{}/points/query", self.alias),
-                Some(body),
+                &format!("/collections/{}/points/query/batch", self.alias),
+                Some(json!({ "searches": [body, confidence] })),
             )
             .await?;
-        Ok(hits_of(res))
+        if res.len() != 2 {
+            return Err(Error::Vector(format!(
+                "asked qdrant for 2 batched searches and got {}",
+                res.len()
+            )));
+        }
+        let similarities: HashMap<String, f32> = res
+            .pop()
+            .expect("length checked")
+            .points
+            .into_iter()
+            .filter_map(|p| {
+                let id = p.payload.get("artifact_id")?.as_str()?.to_string();
+                Some((id, p.score))
+            })
+            .collect();
+
+        let mut hits = hits_of(res.pop().expect("length checked"));
+        for h in &mut hits {
+            h.similarity = similarities.get(&h.payload.artifact_id).copied();
+        }
+        Ok(hits)
     }
 
     async fn touch(&self, targets: &[Touch], seen_at: i64) -> Result<()> {

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -14,6 +14,7 @@ use super::sparse::SparseVector;
 use super::{FacetCount, Facets, SearchFilter, SearchHit, VectorPayload, VectorPoint, VectorStore};
 use crate::config::VectorConfig;
 use crate::error::{Error, Result};
+use crate::store::artifacts::ArtifactStatus;
 use async_trait::async_trait;
 use reqwest::{Client, Method, StatusCode};
 use serde::Deserialize;
@@ -156,10 +157,21 @@ fn build_filter(filter: &SearchFilter) -> Option<Value> {
         body["must"] = json!(must);
     }
     // Excluded with `must_not` rather than by matching `false`: a point written
-    // before consolidation existed carries no `superseded` key at all, and a
-    // `match: false` clause would drop every one of them from search.
+    // before consolidation existed carries no `status`/`superseded` key at
+    // all, and a `match: false` clause would drop every one of them from
+    // search.
+    let mut must_not: Vec<Value> = Vec::new();
     if !filter.include_superseded {
-        body["must_not"] = json!([{ "key": "superseded", "match": { "value": true } }]);
+        must_not.push(json!({ "key": "status", "match": { "value": "superseded" } }));
+        // Legacy flag, kept as a safety net for points written before the
+        // `status` field existed and not yet caught up by a backfill pass.
+        must_not.push(json!({ "key": "superseded", "match": { "value": true } }));
+    }
+    if !filter.include_deprecated {
+        must_not.push(json!({ "key": "status", "match": { "value": "deprecated" } }));
+    }
+    if !must_not.is_empty() {
+        body["must_not"] = json!(must_not);
     }
     Some(body)
 }
@@ -236,19 +248,27 @@ fn sparse_of_payload(payload: &Value) -> SparseVector {
 /// rather than a second ranking.
 ///
 /// `defaults` is not optional politeness: a single point whose payload lacks
-/// `created_at` fails the *whole* query with
-/// `Expected number value for created_at in the payload and/or in the formula
-/// defaults`, not just its own scoring. Every point engram writes carries the
-/// key, but `--reindex` copies payloads verbatim from whatever was in the
-/// source collection, so one hand-written point would otherwise take search
-/// down. Treating a missing stamp as the epoch scores it as maximally old,
-/// which is the honest reading of "we do not know when this arrived".
+/// `last_verified_at` fails the *whole* query with
+/// `Expected number value for last_verified_at in the payload and/or in the
+/// formula defaults`, not just its own scoring. Every point engram writes
+/// carries the key, but `--reindex` copies payloads verbatim from whatever was
+/// in the source collection, so one hand-written point would otherwise take
+/// search down. Treating a missing stamp as the epoch scores it as maximally
+/// stale, which is the honest reading of "we do not know when this was last
+/// confirmed accurate".
+///
+/// Decays against `last_verified_at` rather than `created_at`, deliberately:
+/// an artifact confirmed correct last week should outrank one merely written
+/// last week and never looked at since. Nothing here reads `hit_count` — a
+/// popularity term would let a frequently-shown result keep boosting itself
+/// further, at the expense of a correct but rarely-queried one that never
+/// gets the chance to accumulate hits.
 fn scoring_formula(now: i64, half_life_secs: u64, recency: f32, pinned: f32) -> Value {
     let mut terms = vec![json!("$score")];
     if recency > 0.0 {
         terms.push(json!({
             "mult": [recency, {
-                "exp_decay": { "x": "created_at", "target": now, "scale": half_life_secs, "midpoint": 0.5 }
+                "exp_decay": { "x": "last_verified_at", "target": now, "scale": half_life_secs, "midpoint": 0.5 }
             }]
         }));
     }
@@ -261,7 +281,7 @@ fn scoring_formula(now: i64, half_life_secs: u64, recency: f32, pinned: f32) -> 
     }
     json!({
         "formula": { "sum": terms },
-        "defaults": { "created_at": 0 },
+        "defaults": { "last_verified_at": 0 },
     })
 }
 
@@ -351,14 +371,17 @@ struct ScrollResult {
     next_page_offset: Value,
 }
 
-#[derive(Deserialize)]
-/// The two payload keys a point write must not clobber, as currently stored.
-/// `None` means the key is absent, which for `superseded` is every point
-/// written before consolidation existed.
-#[derive(Debug, Clone, Copy, Default)]
+/// The payload keys a point write must not clobber, as currently stored.
+/// `None` means the key is absent, which for `superseded`/`status` is every
+/// point written before consolidation/lifecycle tracking existed.
+#[derive(Debug, Clone, Default)]
 struct StoredBookkeeping {
     last_seen_at: Option<i64>,
+    hit_count: Option<i64>,
     superseded: Option<bool>,
+    status: Option<ArtifactStatus>,
+    last_verified_at: Option<i64>,
+    superseded_by: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -497,6 +520,9 @@ impl QdrantVectors {
             ("corpus_id", "keyword"),
             ("created_at", "integer"),
             ("last_seen_at", "integer"),
+            ("status", "keyword"),
+            ("last_verified_at", "integer"),
+            ("hit_count", "integer"),
         ] {
             let _: Value = self
                 .call(
@@ -612,20 +638,28 @@ impl QdrantVectors {
     }
 
     /// The bookkeeping keys already stored for these chunks: when the chunk was
-    /// last shown, and whether consolidation has hidden it.
+    /// last shown, how often, and its lifecycle status.
     ///
-    /// Both are written by code that knows nothing about the other — `touch`
-    /// sets one, the sweep sets the other, and the embed job rebuilding a
-    /// payload knows neither. Only asked for when a caller is about to
-    /// overwrite payloads it built without them, and only for those two keys,
-    /// so this is a small read next to the write it protects.
+    /// Each is written by code that knows nothing about the others — `touch`
+    /// sets the first two, the sweep or an operator action sets the rest, and
+    /// the embed job rebuilding a payload knows none of them. Only asked for
+    /// when a caller is about to overwrite payloads it built without them, and
+    /// only for those keys, so this is a small read next to the write it
+    /// protects.
     async fn stored_bookkeeping(
         &self,
         points: &[VectorPoint],
     ) -> Result<std::collections::HashMap<String, StoredBookkeeping>> {
         let wanted: Vec<&VectorPoint> = points
             .iter()
-            .filter(|p| p.payload.last_seen_at.is_none() || p.payload.superseded.is_none())
+            .filter(|p| {
+                p.payload.last_seen_at.is_none()
+                    || p.payload.hit_count.is_none()
+                    || p.payload.superseded.is_none()
+                    || p.payload.status.is_none()
+                    || p.payload.last_verified_at.is_none()
+                    || p.payload.superseded_by.is_none()
+            })
             .collect();
         if wanted.is_empty() {
             return Ok(Default::default());
@@ -646,7 +680,10 @@ impl QdrantVectors {
                 &format!("/collections/{}/points", self.alias),
                 Some(json!({
                     "ids": ids,
-                    "with_payload": ["last_seen_at", "superseded"],
+                    "with_payload": [
+                        "last_seen_at", "hit_count", "superseded",
+                        "status", "last_verified_at", "superseded_by",
+                    ],
                     "with_vector": false,
                 })),
             )
@@ -662,7 +699,19 @@ impl QdrantVectors {
                 (*artifact_id).to_string(),
                 StoredBookkeeping {
                     last_seen_at: p.payload.get("last_seen_at").and_then(Value::as_i64),
+                    hit_count: p.payload.get("hit_count").and_then(Value::as_i64),
                     superseded: p.payload.get("superseded").and_then(Value::as_bool),
+                    status: p
+                        .payload
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .map(ArtifactStatus::parse),
+                    last_verified_at: p.payload.get("last_verified_at").and_then(Value::as_i64),
+                    superseded_by: p
+                        .payload
+                        .get("superseded_by")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
                 },
             );
         }
@@ -978,9 +1027,10 @@ impl VectorStore for QdrantVectors {
         // `touch`, which merge. A writer that does not know when the chunk was
         // last shown would therefore clear the stamp, and `resurface` would
         // offer a chunk read yesterday as forgotten. The same hazard applies to
-        // `superseded`, and costs more: clearing it puts an artifact the sweep
-        // hid straight back into results, on every re-embed. So carry both
-        // forward for every point that arrives without them.
+        // `superseded`/`status`, and costs more: clearing it puts an artifact
+        // the sweep hid straight back into results, on every re-embed. So
+        // carry every bookkeeping key forward for every point that arrives
+        // without it.
         let stored = self.stored_bookkeeping(&points).await?;
         let mut body = Vec::with_capacity(points.len());
         for p in points {
@@ -989,8 +1039,20 @@ impl VectorStore for QdrantVectors {
             if payload.last_seen_at.is_none() {
                 payload.last_seen_at = old.and_then(|s| s.last_seen_at);
             }
+            if payload.hit_count.is_none() {
+                payload.hit_count = old.and_then(|s| s.hit_count);
+            }
             if payload.superseded.is_none() {
                 payload.superseded = old.and_then(|s| s.superseded);
+            }
+            if payload.status.is_none() {
+                payload.status = old.and_then(|s| s.status);
+            }
+            if payload.last_verified_at.is_none() {
+                payload.last_verified_at = old.and_then(|s| s.last_verified_at);
+            }
+            if payload.superseded_by.is_none() {
+                payload.superseded_by = old.and_then(|s| s.superseded_by.clone());
             }
             let payload =
                 serde_json::to_value(&payload).map_err(|e| Error::Vector(e.to_string()))?;
@@ -1034,6 +1096,83 @@ impl VectorStore for QdrantVectors {
             )
             .await?;
         Ok(())
+    }
+
+    async fn set_lifecycle(
+        &self,
+        artifact_id: &str,
+        status: ArtifactStatus,
+        superseded_by: Option<&str>,
+    ) -> Result<()> {
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/payload?wait=true", self.alias),
+                Some(json!({
+                    // The legacy boolean is derived and written alongside
+                    // `status` so `build_filter`'s pre-backfill safety net and
+                    // any reader that still checks it stay correct.
+                    "payload": {
+                        "status": status.as_str(),
+                        "superseded": status != ArtifactStatus::Active,
+                        "superseded_by": superseded_by,
+                    },
+                    "points": [ point_uuid(artifact_id) ],
+                })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn set_last_verified_at(&self, artifact_id: &str, at: i64) -> Result<()> {
+        let _: Value = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/payload?wait=true", self.alias),
+                Some(json!({
+                    "payload": { "last_verified_at": at },
+                    "points": [ point_uuid(artifact_id) ],
+                })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn stale_candidates(
+        &self,
+        older_than: i64,
+        max_hits: i64,
+        limit: usize,
+    ) -> Result<Vec<SearchHit>> {
+        let res: QueryResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/query", self.alias),
+                Some(json!({
+                    "query": { "sample": "random" },
+                    "filter": {
+                      "must_not": [
+                        { "key": "status", "match": { "value": "deprecated" } },
+                        { "key": "status", "match": { "value": "superseded" } },
+                        { "key": "superseded", "match": { "value": true } },
+                      ],
+                      "must": [
+                        { "should": [
+                            { "key": "last_verified_at", "range": { "lt": older_than } },
+                            { "is_empty": { "key": "last_verified_at" } },
+                        ] },
+                        { "should": [
+                            { "key": "hit_count", "range": { "lte": max_hits } },
+                            { "is_empty": { "key": "hit_count" } },
+                        ] },
+                      ],
+                    },
+                    "limit": limit,
+                    "with_payload": true,
+                })),
+            )
+            .await?;
+        Ok(hits_of(res))
     }
 
     async fn search(
@@ -1121,16 +1260,51 @@ impl VectorStore for QdrantVectors {
             return Ok(());
         }
         let ids: Vec<String> = artifact_ids.iter().map(|c| point_uuid(c)).collect();
-        // One request for the whole result list, and only the one key: this
-        // runs on every search, so it must not be a write per hit nor a
-        // read-modify-write of the full payload. It still waits: the shutdown
-        // drain exists to keep these stamps, and an acknowledged-but-unapplied
-        // write is exactly the loss it is meant to prevent.
+        // `last_seen_at` is the same value for the whole batch, so it stays
+        // one uniform merge write. `hit_count` is not — each point's next
+        // value depends on its own current one — so it costs one extra read
+        // first. Both stay off the request path (the caller backgrounds this
+        // call), and this still waits: the shutdown drain exists to keep
+        // these stamps, and an acknowledged-but-unapplied write is exactly the
+        // loss it is meant to prevent. A count missed under a rare concurrent
+        // double-touch is an acceptable soft-counter race — it only ever feeds
+        // the one-way stale-candidate query, never live scoring.
+        let found: Vec<ScrolledPoint> = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points", self.alias),
+                Some(json!({ "ids": ids, "with_payload": ["hit_count"], "with_vector": false })),
+            )
+            .await?;
+        let mut counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+        for p in found {
+            if let Some(uuid) = p.id.as_str() {
+                counts.insert(
+                    uuid.to_string(),
+                    p.payload
+                        .get("hit_count")
+                        .and_then(Value::as_i64)
+                        .unwrap_or(0),
+                );
+            }
+        }
+        let ops: Vec<Value> = ids
+            .iter()
+            .map(|uuid| {
+                let next = counts.get(uuid).copied().unwrap_or(0) + 1;
+                json!({
+                    "set_payload": {
+                        "payload": { "last_seen_at": seen_at, "hit_count": next },
+                        "points": [uuid],
+                    }
+                })
+            })
+            .collect();
         let _: Value = self
             .call(
                 Method::POST,
-                &format!("/collections/{}/points/payload?wait=true", self.alias),
-                Some(json!({ "payload": { "last_seen_at": seen_at }, "points": ids })),
+                &format!("/collections/{}/points/batch?wait=true", self.alias),
+                Some(json!({ "operations": ops })),
             )
             .await?;
         Ok(())
@@ -1495,10 +1669,12 @@ mod tests {
     fn a_filter_that_narrows_nothing_produces_no_filter_at_all() {
         // `{"must": []}` matches nothing in Qdrant, so a search that narrows
         // nothing must omit the key rather than send an empty condition list.
-        // Asking for superseded points back is what "narrows nothing" means now.
+        // Asking for superseded and deprecated points back is what "narrows
+        // nothing" means now.
         assert!(
             build_filter(&SearchFilter {
                 include_superseded: true,
+                include_deprecated: true,
                 ..Default::default()
             })
             .is_none()
@@ -1506,9 +1682,9 @@ mod tests {
     }
 
     #[test]
-    fn the_default_filter_excludes_superseded_points() {
-        // The default is what every ordinary search sends, and superseding is
-        // only meaningful if it keeps an artifact out of that.
+    fn the_default_filter_excludes_superseded_and_deprecated_points() {
+        // The default is what every ordinary search sends, and superseding /
+        // deprecating is only meaningful if it keeps an artifact out of that.
         let f = build_filter(&SearchFilter::default()).unwrap();
         assert!(
             f.get("must").is_none(),
@@ -1516,7 +1692,11 @@ mod tests {
         );
         assert_eq!(
             f["must_not"],
-            json!([{ "key": "superseded", "match": { "value": true } }]),
+            json!([
+                { "key": "status", "match": { "value": "superseded" } },
+                { "key": "superseded", "match": { "value": true } },
+                { "key": "status", "match": { "value": "deprecated" } },
+            ]),
         );
     }
 
@@ -1528,6 +1708,7 @@ mod tests {
             tags: vec!["linux".into(), "forensics".into()],
             category: Some("procedure".into()),
             include_superseded: false,
+            include_deprecated: false,
         })
         .unwrap();
         let must = f["must"].as_array().unwrap();
@@ -1596,13 +1777,13 @@ mod tests {
     }
 
     #[test]
-    fn the_scoring_formula_survives_a_point_without_a_created_at() {
+    fn the_scoring_formula_survives_a_point_without_a_last_verified_at() {
         // Qdrant fails the entire query, not just the offending point, when a
         // formula reads a key the payload does not have.
         let f = scoring_formula(1_700_000_000, 86_400, 0.05, 0.15);
         assert_eq!(
-            f["defaults"]["created_at"], 0,
-            "a payload missing created_at would take search down: {f}"
+            f["defaults"]["last_verified_at"], 0,
+            "a payload missing last_verified_at would take search down: {f}"
         );
     }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -251,6 +251,10 @@ pub struct SearchParams {
     pub limit: Option<usize>,
     pub tags: Option<String>,
     pub category: Option<String>,
+    #[serde(default)]
+    pub include_deprecated: bool,
+    #[serde(default)]
+    pub include_superseded: bool,
 }
 
 async fn search(
@@ -275,8 +279,26 @@ async fn search(
         category: q.category.filter(|c| !c.is_empty()),
         // An API call is one deliberate question; only the typing UI opts out.
         mark: true,
+        include_deprecated: q.include_deprecated,
+        include_superseded: q.include_superseded,
     };
     Ok(Json(st.core.search(&query).await?))
+}
+
+#[derive(serde::Deserialize)]
+pub struct StaleParams {
+    pub limit: Option<usize>,
+}
+
+/// Active artifacts nobody has confirmed or retrieved in a while — candidates
+/// for an operator to review and deprecate. Read-only: nothing here changes
+/// an artifact, and nothing here feeds search ranking.
+async fn stale(
+    State(st): State<AppState>,
+    _id: Identity,
+    Query(p): Query<StaleParams>,
+) -> Result<Json<Vec<crate::core::search::SearchResult>>> {
+    Ok(Json(st.core.stale_candidates(p.limit.unwrap_or(20)).await?))
 }
 
 async fn ask(
@@ -386,7 +408,11 @@ async fn patch_artifact(
                 tags: chunk.tags.clone(),
                 created_at: chunk.created_at,
                 last_seen_at: None,
+                hit_count: None,
                 superseded: None,
+                status: None,
+                last_verified_at: None,
+                superseded_by: None,
             })
             .await?;
     }
@@ -446,6 +472,7 @@ pub fn api_router() -> Router<AppState> {
         .route("/ask", post(ask))
         .route("/resurface", get(resurface))
         .route("/consolidation", get(consolidation))
+        .route("/consolidation/stale", get(stale))
         .route(
             "/artifacts/{id}",
             get(get_artifact)
@@ -849,6 +876,7 @@ mod patch_tests {
                     tags: vec!["fresh".into()],
                     category: None,
                     include_superseded: false,
+                    include_deprecated: false,
                 },
             )
             .await

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -237,6 +237,15 @@ async fn consolidation(
             .store
             .pairs_by_state(PairState::Contradiction, 100)
             .await?,
+        // Judge-proposed supersedes awaiting an operator's confirmation. Listed
+        // for the same reason Ops renders them: without this a pair the judge
+        // ruled on simply disappears from `pairs`, and an API consumer never
+        // sees the proposal it left behind.
+        "supersede_proposals": st
+            .core
+            .store
+            .pairs_by_state(PairState::Superseded, 100)
+            .await?,
         "pairs": st
             .core
             .store

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -433,16 +433,9 @@ async fn delete_artifact(
     _id: Identity,
     Path(cid): Path<String>,
 ) -> Result<StatusCode> {
-    st.core.store.get_artifact(&cid).await?;
-    st.core
-        .vectors
-        .delete_artifacts(std::slice::from_ref(&cid))
-        .await?;
-    st.core.store.delete_artifact(&cid).await?;
-    // This artifact may have been the reason another one is hidden, and a
-    // keeper that no longer exists leaves its loser out of search in favour of
-    // nothing. Deleting a whole corpus heals for the same reason.
-    st.core.heal_dangling_supersessions().await?;
+    // Both stores, in the order that survives an interruption — see
+    // `Core::delete_artifact`, which the UI button posts to as well.
+    st.core.delete_artifact(&cid).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/src/web/templates/_artifact.html
+++ b/src/web/templates/_artifact.html
@@ -10,9 +10,18 @@
             onclick="document.getElementById('edit-{{ c.id }}').style.display='block';this.style.display='none'">
       edit
     </button>
+    {# This page could delete the whole source but not one artifact out of it.
+       Swaps its own card away and leaves the rest of the list alone. #}
+    <button class="btn-icon btn-icon-danger" title="Delete artifact"
+            aria-label="Delete artifact"
+            hx-post="/ui/artifacts/{{ c.id }}/delete"
+            hx-target="#artifact-{{ c.id }}" hx-swap="outerHTML"
+            hx-confirm="Delete this artifact for good? Deprecating hides it instead and can be undone.">
+      {% include "_icon_trash.html" %}
+    </button>
   </div>
   <form id="edit-{{ c.id }}" style="display:none;margin-top:0.75rem"
-        hx-put="/ui/artifacts/{{ c.id }}" hx-target="#chunk-{{ c.id }}" hx-swap="outerHTML">
+        hx-put="/ui/artifacts/{{ c.id }}" hx-target="#artifact-{{ c.id }}" hx-swap="outerHTML">
     <textarea class="textarea" name="text" style="min-height:8rem">{{ c.text }}</textarea>
     <div class="row" style="margin-top:0.5rem">
       <button class="btn btn-accent btn-sm" type="submit">Save and re-embed</button>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -144,10 +144,18 @@
       {% endif %}
     </div>
     <div>
+      {# Two links to the source, doing different jobs. The crumb above opens
+         the document plainly; this one opens it scrolled to and highlighting
+         the very lines this artifact was drawn from. An artifact with no
+         recorded span has no lines to jump to, so it gets the plain link.
+
+         "highlighted" rather than a bare range: the panel shows a few lines of
+         context either side, so naming the span alone read as a mismatch
+         against the line numbers actually on screen. #}
       <div class="pane-label">
-        {{ d.slice_label }}
+        {{ d.slice_label }} highlighted
         <span class="spacer"></span>
-        <a href="/ui/corpora/{{ d.corpus_id }}">open full source</a>
+        <a href="{{ d.source_at_lines }}">open source at these lines</a>
       </div>
       <div class="raw">
         <table>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -11,7 +11,10 @@
       <div>Something near-identical and newer
         (<a href="/ui/artifacts/{{ winner }}">this one</a>) was kept instead.</div>
       <div class="chips">
+        {# `to`: these buttons also live on Ops, whose copies send nothing and
+           land back on the queue. Pressed from here, they come back here. #}
         <form method="post" action="/ui/ops/artifacts/{{ d.id }}/unsupersede">
+          <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
           <button class="btn btn-sm" type="submit">Put it back</button>
         </form>
       </div>
@@ -26,6 +29,7 @@
         readable; kept out of results only.</div>
       <div class="chips">
         <form method="post" action="/ui/ops/artifacts/{{ d.id }}/reactivate">
+          <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
           <button class="btn btn-sm" type="submit">Reactivate</button>
         </form>
       </div>
@@ -34,9 +38,11 @@
   {% else %}
   <div class="chips">
     <form method="post" action="/ui/ops/artifacts/{{ d.id }}/verify">
+      <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
       <button class="btn btn-sm" type="submit">Confirm still accurate</button>
     </form>
     <form method="post" action="/ui/ops/artifacts/{{ d.id }}/deprecate">
+      <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
       <button class="btn btn-sm" type="submit">Deprecate</button>
     </form>
   </div>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -48,6 +48,31 @@
   </div>
   {% endif %}
 
+  {# Deprecating hides an artifact and keeps it; this removes it from both
+     stores and cannot be undone, which is why it sits apart from the lifecycle
+     buttons above and is offered whatever the artifact's status. Nothing
+     deletes an artifact except this press — see `Core::heal_store_drift`. #}
+  <div class="chips">
+    <form method="post" action="/ui/artifacts/{{ d.id }}/delete"
+          onsubmit="return confirm('Delete this artifact for good? Deprecating hides it instead and can be undone.')">
+      <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+    </form>
+  </div>
+
+  {% if d.corpus_restored %}
+  <div class="flag" role="status">
+    <div aria-hidden="true">⚠</div>
+    <div>
+      <b>Source not stored</b>
+      <div>This artifact was restored from the vector store after its row went
+        missing, and the document it came from was not in the database to
+        restore. The source shown beside it is the restored artifacts joined
+        together, not the original — line numbers and the highlighted span mean
+        nothing here, and re-segmenting would not reproduce this artifact.</div>
+    </div>
+  </div>
+  {% endif %}
+
   {% if !d.flags.is_empty() %}
   <div class="flag" role="status">
     <div aria-hidden="true">⚠</div>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -17,6 +17,29 @@
       </div>
     </div>
   </div>
+  {% else if d.status.as_str() == "deprecated" %}
+  <div class="flag" role="status">
+    <div aria-hidden="true">⚠</div>
+    <div>
+      <b>Deprecated</b>
+      <div>Flagged stale, with no specific replacement. Still stored and still
+        readable; kept out of results only.</div>
+      <div class="chips">
+        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/reactivate">
+          <button class="btn btn-sm" type="submit">Reactivate</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% else %}
+  <div class="chips">
+    <form method="post" action="/ui/ops/artifacts/{{ d.id }}/verify">
+      <button class="btn btn-sm" type="submit">Confirm still accurate</button>
+    </form>
+    <form method="post" action="/ui/ops/artifacts/{{ d.id }}/deprecate">
+      <button class="btn btn-sm" type="submit">Deprecate</button>
+    </form>
+  </div>
   {% endif %}
 
   {% if !d.flags.is_empty() %}

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -35,27 +35,43 @@
       </div>
     </div>
   </div>
-  {% else %}
+  {% endif %}
+
+  {# Icons rather than labels: controls that belong to the artifact, not
+     sentences competing with it. Each carries its meaning in `title` and
+     `aria-label`, so the tooltip and the screen reader say the same thing.
+
+     Verify and deprecate only apply to an artifact that is actually in results
+     — the flag above already offers the way back for one that is not — but
+     delete is offered whatever the status, because "get rid of this" is a
+     decision that does not depend on whether it is currently hidden. #}
   <div class="chips">
+    {% if d.superseded_by.is_none() && d.status.as_str() != "deprecated" %}
     <form method="post" action="/ui/ops/artifacts/{{ d.id }}/verify">
       <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
-      <button class="btn btn-sm" type="submit">Confirm still accurate</button>
+      <button class="btn-icon" type="submit"
+              title="Confirm still accurate" aria-label="Confirm still accurate">
+        {% include "_icon_check.html" %}
+      </button>
     </form>
     <form method="post" action="/ui/ops/artifacts/{{ d.id }}/deprecate">
       <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
-      <button class="btn btn-sm" type="submit">Deprecate</button>
+      <button class="btn-icon" type="submit"
+              title="Deprecate — hide from results, keep the artifact"
+              aria-label="Deprecate: hide from results, keep the artifact">
+        {% include "_icon_hide.html" %}
+      </button>
     </form>
-  </div>
-  {% endif %}
-
-  {# Deprecating hides an artifact and keeps it; this removes it from both
-     stores and cannot be undone, which is why it sits apart from the lifecycle
-     buttons above and is offered whatever the artifact's status. Nothing
-     deletes an artifact except this press — see `Core::heal_store_drift`. #}
-  <div class="chips">
+    {% endif %}
+    {# Deprecating hides an artifact and keeps it; this removes it from both
+       stores and cannot be undone. Nothing else deletes an artifact — see
+       `Core::heal_store_drift`. #}
     <form method="post" action="/ui/artifacts/{{ d.id }}/delete"
           onsubmit="return confirm('Delete this artifact for good? Deprecating hides it instead and can be undone.')">
-      <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+      <button class="btn-icon btn-icon-danger" type="submit"
+              title="Delete permanently" aria-label="Delete artifact permanently">
+        {% include "_icon_trash.html" %}
+      </button>
     </form>
   </div>
 

--- a/src/web/templates/_icon_check.html
+++ b/src/web/templates/_icon_check.html
@@ -1,0 +1,5 @@
+{# Decorative: every button that uses it carries its own aria-label. #}
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+  <path d="M20 6L9 17l-5-5"/>
+</svg>

--- a/src/web/templates/_icon_hide.html
+++ b/src/web/templates/_icon_hide.html
@@ -1,0 +1,9 @@
+{# A struck-through eye: deprecating takes an artifact out of results without
+   deleting it. Decorative; the button carries its own aria-label. #}
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+  <path d="M17.94 17.94A10.1 10.1 0 0 1 12 20c-7 0-11-8-11-8a18.5 18.5 0 0 1 5.06-5.94"/>
+  <path d="M9.9 4.24A9.1 9.1 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/>
+  <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/>
+  <path d="M1 1l22 22"/>
+</svg>

--- a/src/web/templates/_icon_trash.html
+++ b/src/web/templates/_icon_trash.html
@@ -1,0 +1,8 @@
+{# Decorative: every button that uses it carries its own aria-label. #}
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+  <path d="M3 6h18"/>
+  <path d="M8 6V4h8v2"/>
+  <path d="M19 6l-1 14H6L5 6"/>
+  <path d="M10 11v6M14 11v6"/>
+</svg>

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -4,20 +4,36 @@
 {% else %}
 <div data-terms="{{ terms }}">
   {% for r in results %}
-  <a class="rail-item" role="option" aria-selected="false"
-     href="/ui/artifacts/{{ r.artifact_id }}"
-     hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}"
-     hx-target="#pane" hx-swap="innerHTML" hx-push-url="true">
-    <div class="rail-head">
-      <span class="rail-rank mono">{{ r.rank }}</span>
-      <span class="rail-title">{{ r.title }}</span>
+  {# The delete control is a sibling of the link rather than a child: a button
+     inside an anchor is invalid, and the anchor must keep being the
+     `.rail-item` the arrow keys move between. #}
+  <div class="rail-row">
+    <a class="rail-item" role="option" aria-selected="false"
+       href="/ui/artifacts/{{ r.artifact_id }}"
+       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}"
+       hx-target="#pane" hx-swap="innerHTML" hx-push-url="true">
+      <div class="rail-head">
+        <span class="rail-rank mono">{{ r.rank }}</span>
+        <span class="rail-title">{{ r.title }}</span>
+      </div>
+      <div class="rail-snippet">{{ r.snippet }}</div>
+      <div class="chips">
+        {% if let Some(c) = r.category %}<span class="badge badge-accent">{{ c }}</span>{% endif %}
+        {% for t in r.tags %}<span class="badge">{{ t }}</span>{% endfor %}
+      </div>
+    </a>
+    {# Swaps its own row out and leaves the rest of the results alone, so the
+       search you were reading is still on screen afterwards. #}
+    <div class="rail-del">
+      <button class="btn-icon btn-icon-danger" title="Delete artifact"
+              aria-label="Delete artifact"
+              hx-post="/ui/artifacts/{{ r.artifact_id }}/delete"
+              hx-target="closest .rail-row" hx-swap="outerHTML"
+              hx-confirm="Delete this artifact for good? Deprecating hides it instead and can be undone.">
+        {% include "_icon_trash.html" %}
+      </button>
     </div>
-    <div class="rail-snippet">{{ r.snippet }}</div>
-    <div class="chips">
-      {% if let Some(c) = r.category %}<span class="badge badge-accent">{{ c }}</span>{% endif %}
-      {% for t in r.tags %}<span class="badge">{{ t }}</span>{% endfor %}
-    </div>
-  </a>
+  </div>
   {% endfor %}
 </div>
 {% endif %}

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -3,6 +3,21 @@
   <p class="muted">No matches.</p>
 {% else %}
 <div data-terms="{{ terms }}">
+  {# Said once, above the list, rather than repeated on every card: when the
+     whole answer is loose the useful statement is about the search, not about
+     each result. Retrieval always returns its best candidates however bad they
+     are, so without this a typo comes back looking like an answer. #}
+  {% if all_weak %}
+  <div class="flag" role="status">
+    <div aria-hidden="true">⚠</div>
+    <div>
+      <b>Nothing matches closely</b>
+      <div>These are the nearest artifacts, but none of them is a close match
+        for what you typed. Check the spelling, or try describing the thing
+        rather than naming it.</div>
+    </div>
+  </div>
+  {% endif %}
   {% for r in results %}
   {# The delete control is a sibling of the link rather than a child: a button
      inside an anchor is invalid, and the anchor must keep being the
@@ -13,7 +28,11 @@
        hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}"
        hx-target="#pane" hx-swap="innerHTML" hx-push-url="true">
       <div class="rail-head">
+        {% if r.weak %}
+        <span class="badge badge-warning">loose</span>
+        {% else %}
         <span class="rail-rank mono">{{ r.rank }}</span>
+        {% endif %}
         <span class="rail-title">{{ r.title }}</span>
       </div>
       <div class="rail-snippet">{{ r.snippet }}</div>

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -4,17 +4,36 @@
 <div class="row" style="margin-bottom:1rem">
   <span class="badge {{ badge }}">{{ status }}</span>
   <span class="spacer"></span>
+  {# Re-segmenting a placeholder would delete the restored artifacts and pay the
+     model to re-derive them from their own text. Nothing to re-segment. #}
+  {% if !restored %}
   <form method="post" action="/ui/corpora/{{ id }}/reprocess" style="display:inline">
     <button class="btn btn-sm" type="submit">Re-segment</button>
   </form>
+  {% endif %}
   <form method="post" action="/ui/corpora/{{ id }}/delete" style="display:inline"
         onsubmit="return confirm('Delete this corpus and all its artifacts?')">
     <button class="btn btn-sm btn-danger" type="submit">Delete</button>
   </form>
 </div>
 
+{% if restored %}
+<div class="flag" role="status">
+  <div aria-hidden="true">⚠</div>
+  <div>
+    <b>Placeholder source</b>
+    <div>This source was never captured here. Its artifacts were restored from
+      the vector store after their rows went missing, and every artifact needs a
+      source to belong to, so this row was written to hold them. The text below
+      is those artifacts joined together — not the original document.</div>
+  </div>
+</div>
+{% endif %}
+
 <div class="card">
-  <div class="card-head"><span class="card-title">Raw corpus</span></div>
+  <div class="card-head">
+    <span class="card-title">{% if restored %}Restored artifacts{% else %}Raw corpus{% endif %}</span>
+  </div>
   <pre class="mono" style="white-space:pre-wrap;font-size:0.8125rem;margin:0">{{ raw_text }}</pre>
 </div>
 

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -34,7 +34,18 @@
   <div class="card-head">
     <span class="card-title">{% if restored %}Restored artifacts{% else %}Raw corpus{% endif %}</span>
   </div>
-  <pre class="mono" style="white-space:pre-wrap;font-size:0.8125rem;margin:0">{{ raw_text }}</pre>
+  {# Every line is anchored, so an artifact's "open at these lines" link lands
+     on the exact lines it was drawn from instead of the top of the document.
+     Same markup and highlighting as the excerpt in the artifact pane. #}
+  <div class="raw" style="max-height:none">
+    <table>
+      {% for l in lines %}
+      <tr id="L{{ l.number }}" class="{% if l.in_span %}in{% endif %}">
+        <td class="ln">{{ l.number }}</td><td>{{ l.text }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
 </div>
 
 <h3>Artifacts</h3>

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -28,13 +28,71 @@
       <td class="mono">
         {{ p.percent }}%
         {% if p.contradiction %}<span class="badge badge-warning">disagrees</span>{% endif %}
+        {% if let Some(t) = p.obsolete_title %}<span class="badge badge-accent">proposes superseding "{{ t }}"</span>{% endif %}
       </td>
       <td><a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a></td>
       <td><a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a></td>
       <td class="muted">{% if let Some(d) = p.detail %}{{ d }}{% else %}—{% endif %}</td>
-      <td>
+      <td class="row" style="gap:0.25rem">
+        {% if p.obsolete_title.is_some() %}
+        <form method="post" action="/ui/ops/pairs/{{ p.id }}/supersede">
+          <button class="btn btn-sm" type="submit">Apply supersede</button>
+        </form>
+        {% endif %}
         <form method="post" action="/ui/ops/pairs/{{ p.id }}/dismiss">
           <button class="btn btn-sm" type="submit">Dismiss</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+<h3>Deprecated</h3>
+{% if deprecated.is_empty() %}
+  <p class="muted">None.</p>
+{% else %}
+<p class="muted">Flagged stale with no specific replacement. Still stored and still readable; kept out of results only.</p>
+<table class="grid">
+  <thead><tr><th>Artifact</th><th></th></tr></thead>
+  <tbody>
+  {% for d in deprecated %}
+    <tr>
+      <td><a href="/ui/artifacts/{{ d.id }}">{{ d.title }}</a></td>
+      <td>
+        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/reactivate">
+          <button class="btn btn-sm" type="submit">Reactivate</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+<h3>Worth a second look</h3>
+{% if stale.is_empty() %}
+  <p class="muted">None.</p>
+{% else %}
+<p class="muted">
+  Active, but not confirmed accurate in a while and rarely or never retrieved
+  since. A candidate list only — nothing here has been changed, and this never
+  affects search ranking.
+</p>
+<table class="grid">
+  <thead><tr><th>Artifact</th><th>Last verified</th><th></th></tr></thead>
+  <tbody>
+  {% for s in stale %}
+    <tr>
+      <td><a href="/ui/artifacts/{{ s.id }}">{{ s.title }}</a></td>
+      <td class="muted mono">{{ s.last_verified }}</td>
+      <td class="row" style="gap:0.25rem">
+        <form method="post" action="/ui/ops/artifacts/{{ s.id }}/verify">
+          <button class="btn btn-sm" type="submit">Still accurate</button>
+        </form>
+        <form method="post" action="/ui/ops/artifacts/{{ s.id }}/deprecate">
+          <button class="btn btn-sm" type="submit">Deprecate</button>
         </form>
       </td>
     </tr>

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -33,15 +33,38 @@
       <td><a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a></td>
       <td><a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a></td>
       <td class="muted">{% if let Some(d) = p.detail %}{{ d }}{% else %}—{% endif %}</td>
-      <td class="row" style="gap:0.25rem">
-        {% if p.obsolete_title.is_some() %}
-        <form method="post" action="/ui/ops/pairs/{{ p.id }}/supersede">
-          <button class="btn btn-sm" type="submit">Apply supersede</button>
+      {# Resolving a pair means saying which artifact is current. Both sides are
+         offered for every pair, not only the ones the judge could call: a pair
+         flagged as disagreeing with no proposed direction used to offer nothing
+         but Dismiss, so the only way to clear it was to declare the
+         disagreement uninteresting and leave both artifacts in results.
+
+         The judge's pick, when it has one, is the accented button rather than a
+         separate action — a recommendation about which of these two to press,
+         not a third thing to do. #}
+      {# The flex container is a div inside the cell, not the cell itself:
+         `display:flex` on a <td> takes it out of the table layout, so it stops
+         sizing with its column and its buttons spill past the row's rule. #}
+      <td>
+      <div class="row" style="gap:0.25rem;flex-wrap:wrap">
+        <form method="post" action="/ui/ops/pairs/{{ p.id }}/supersede"
+              onsubmit="return confirm('Keep &quot;{{ p.a_title }}&quot; and hide the other? You can undo this from Ops.')">
+          <input type="hidden" name="keep" value="{{ p.a_id }}">
+          <button class="btn btn-sm {% if p.keeps_a %}btn-accent{% endif %}" type="submit">
+            Keep one
+          </button>
         </form>
-        {% endif %}
+        <form method="post" action="/ui/ops/pairs/{{ p.id }}/supersede"
+              onsubmit="return confirm('Keep &quot;{{ p.b_title }}&quot; and hide the other? You can undo this from Ops.')">
+          <input type="hidden" name="keep" value="{{ p.b_id }}">
+          <button class="btn btn-sm {% if p.keeps_b %}btn-accent{% endif %}" type="submit">
+            Keep the other
+          </button>
+        </form>
         <form method="post" action="/ui/ops/pairs/{{ p.id }}/dismiss">
-          <button class="btn btn-sm" type="submit">Dismiss</button>
+          <button class="btn btn-sm btn-ghost" type="submit">Dismiss</button>
         </form>
+      </div>
       </td>
     </tr>
   {% endfor %}
@@ -87,13 +110,25 @@
     <tr>
       <td><a href="/ui/artifacts/{{ s.id }}">{{ s.title }}</a></td>
       <td class="muted mono">{{ s.last_verified }}</td>
-      <td class="row" style="gap:0.25rem">
-        <form method="post" action="/ui/ops/artifacts/{{ s.id }}/verify">
-          <button class="btn btn-sm" type="submit">Still accurate</button>
-        </form>
-        <form method="post" action="/ui/ops/artifacts/{{ s.id }}/deprecate">
-          <button class="btn btn-sm" type="submit">Deprecate</button>
-        </form>
+      {# Same icons as the artifact pane, and a div rather than a flex <td> for
+         the same reason as the pairs table above. Fifty rows of two labelled
+         buttons is a wall of repeated words; the meaning is in the column. #}
+      <td>
+        <div class="row" style="gap:0.25rem">
+          <form method="post" action="/ui/ops/artifacts/{{ s.id }}/verify">
+            <button class="btn-icon" type="submit"
+                    title="Confirm still accurate" aria-label="Confirm still accurate">
+              {% include "_icon_check.html" %}
+            </button>
+          </form>
+          <form method="post" action="/ui/ops/artifacts/{{ s.id }}/deprecate">
+            <button class="btn-icon" type="submit"
+                    title="Deprecate — hide from results, keep the artifact"
+                    aria-label="Deprecate: hide from results, keep the artifact">
+              {% include "_icon_hide.html" %}
+            </button>
+          </form>
+        </div>
       </td>
     </tr>
   {% endfor %}

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -20,8 +20,14 @@
 
   {% if !facets.categories.is_empty() || !facets.tags.is_empty() %}
   <div class="facets">
+    {# Labelled in the page, not only in `aria-label`: two unlabelled rows both
+       starting with "All" left the same word appearing in both with different
+       numbers beside it, which read as a contradiction rather than as a kind
+       and a tag. #}
     {% if !facets.categories.is_empty() %}
-    <div class="chips" role="group" aria-label="Category">
+    <div class="facet-row">
+    <span class="facet-label">Kind</span>
+    <div class="chips" role="group" aria-label="Kind">
       <label class="chip">
         <input type="radio" name="category" value="" {% if category.is_empty() %}checked{% endif %}>
         <span>All</span>
@@ -30,13 +36,16 @@
       <label class="chip">
         <input type="radio" name="category" value="{{ f.value }}"
                {% if category == f.value %}checked{% endif %}>
-        <span>{{ f.value }}{% if f.count > 0 %} <span class="muted mono">{{ f.count }}</span>{% endif %}</span>
+        <span>{{ f.value }}</span>
       </label>
       {% endfor %}
+    </div>
     </div>
     {% endif %}
 
     {% if !facets.tags.is_empty() %}
+    <div class="facet-row">
+    <span class="facet-label">Tag</span>
     <div class="chips" role="group" aria-label="Tag">
       <label class="chip">
         <input type="radio" name="tags" value="" {% if tag.is_empty() %}checked{% endif %}>
@@ -46,9 +55,10 @@
       <label class="chip">
         <input type="radio" name="tags" value="{{ f.value }}"
                {% if tag == f.value %}checked{% endif %}>
-        <span>{{ f.value }}{% if f.count > 0 %} <span class="muted mono">{{ f.count }}</span>{% endif %}</span>
+        <span>{{ f.value }}</span>
       </label>
       {% endfor %}
+    </div>
     </div>
     {% endif %}
   </div>

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -76,6 +76,12 @@ pub struct ArtifactDetail {
     /// Conditions the source stated under which this artifact does not apply.
     pub caveats: Vec<String>,
     pub corpus_id: String,
+    /// True when this artifact's source was never captured here — the artifact
+    /// was restored from the vector store and its corpus row is a placeholder.
+    /// The pane shows the source beside the artifact, so it has to say when what
+    /// it is showing is the artifact's own text reflected back rather than the
+    /// document it was drawn from.
+    pub corpus_restored: bool,
     pub segment_idx: Option<i64>,
     pub slice_label: String,
     pub slice_lines: Vec<crate::web::corpus_view::CorpusLine>,
@@ -293,6 +299,12 @@ struct CorpusTemplate {
     status: String,
     badge: &'static str,
     artifacts: Vec<ArtifactView>,
+    /// This row is a placeholder for a source that was never captured here, so
+    /// `raw_text` is its restored artifacts joined rather than a document. The
+    /// page has to say so: it otherwise presents reconstructed fragments under
+    /// the same "Raw corpus" heading as a real capture, and offers to
+    /// re-segment them.
+    restored: bool,
 }
 
 #[derive(Template)]
@@ -588,6 +600,7 @@ async fn corpus_detail(
         raw_text: s.raw_text,
         badge: status_badge(&s.status),
         status: s.status.as_str().to_string(),
+        restored: s.restored_at.is_some(),
         artifacts,
     })
     .into_response())
@@ -627,6 +640,26 @@ async fn delete_corpus_ui(
 ) -> Result<Response> {
     st.core.delete_corpus(&cid).await?;
     Ok(Redirect::to("/ui/browse").into_response())
+}
+
+/// Remove an artifact from both stores, from the page that shows it.
+///
+/// The deliberate counterpart to what `Core::heal_store_drift` stopped doing on
+/// its own. A background pass cannot tell an artifact deleted on purpose from
+/// one whose row a crash lost, so it now restores both and this button is the
+/// only thing that removes anything — a person who can see the artifact deciding
+/// it should go.
+///
+/// Lands on the source afterwards rather than back here, which would be a page
+/// for an artifact that no longer exists.
+async fn delete_artifact_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(aid): Path<String>,
+) -> Result<Response> {
+    let corpus_id = st.core.store.get_artifact(&aid).await?.corpus_id;
+    st.core.delete_artifact(&aid).await?;
+    Ok(Redirect::to(&format!("/ui/corpora/{corpus_id}")).into_response())
 }
 
 async fn reprocess_ui(
@@ -1050,6 +1083,7 @@ pub(crate) async fn build_artifact_detail(
         last_verified_at: c.last_verified_at,
         caveats: c.caveats,
         corpus_id: c.corpus_id,
+        corpus_restored: src.restored_at.is_some(),
         segment_idx: c.segment_idx,
         slice_label: slice.label,
         slice_lines: slice.lines,
@@ -1108,6 +1142,7 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/corpora/{id}/reprocess", post(reprocess_ui))
         .route("/ui/artifacts/{id}", get(artifact_detail).put(put_artifact))
         .route("/ui/artifacts/{cid}/reviewed", post(mark_artifact_reviewed))
+        .route("/ui/artifacts/{id}/delete", post(delete_artifact_ui))
         .route("/ui/ask", get(ask_page).post(ask_submit))
         .route("/ui/ops", get(ops))
         .route("/ui/ops/tokens", post(mint_token))

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -856,13 +856,38 @@ async fn resolve_near_dupe_ui(
     Ok(Redirect::to("/ui/ops").into_response())
 }
 
+/// Where a lifecycle button should land afterwards.
+///
+/// The same four actions are offered from two places: the Ops review lists,
+/// where the queue is the thing being worked through, and an artifact's own
+/// page, where being thrown onto Ops for pressing "Confirm still accurate"
+/// loses the reader's place. The page that rendered the button says where it
+/// leads; Ops sends nothing and keeps the default.
+#[derive(serde::Deserialize, Default)]
+struct ReturnTo {
+    to: Option<String>,
+}
+
+impl ReturnTo {
+    /// Only a path inside this UI. A form field is user input, and a redirect
+    /// that will follow anything it is handed is an open redirect — worth
+    /// nothing to the operator and a phishing hop to everyone else.
+    fn path(&self) -> &str {
+        match self.to.as_deref() {
+            Some(p) if p.starts_with("/ui/") && !p.starts_with("/ui//") => p,
+            _ => "/ui/ops",
+        }
+    }
+}
+
 async fn unsupersede_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(aid): Path<String>,
+    Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.unsupersede(&aid).await?;
-    Ok(Redirect::to("/ui/ops").into_response())
+    Ok(Redirect::to(back.path()).into_response())
 }
 
 async fn dismiss_pair_ui(
@@ -911,27 +936,30 @@ async fn deprecate_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(aid): Path<String>,
+    Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.deprecate(&aid).await?;
-    Ok(Redirect::to("/ui/ops").into_response())
+    Ok(Redirect::to(back.path()).into_response())
 }
 
 async fn reactivate_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(aid): Path<String>,
+    Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.reactivate(&aid).await?;
-    Ok(Redirect::to("/ui/ops").into_response())
+    Ok(Redirect::to(back.path()).into_response())
 }
 
 async fn verify_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(aid): Path<String>,
+    Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.verify(&aid).await?;
-    Ok(Redirect::to("/ui/ops").into_response())
+    Ok(Redirect::to(back.path()).into_response())
 }
 
 async fn ask_page(_id: Identity) -> impl IntoResponse {
@@ -1471,6 +1499,7 @@ mod tests {
             .split(r#"hx-get="/ui/artifacts/"#)
             .nth(1)
             .and_then(|s| s.split('"').next())
+            .and_then(|s| s.split('?').next())
             .expect("no result to open")
             .to_string();
 
@@ -1487,6 +1516,87 @@ mod tests {
             page.contains(r#"hx-target="closest [data-terms]""#),
             "a neighbour must swap the detail it is listed under"
         );
+    }
+
+    #[tokio::test]
+    async fn a_lifecycle_button_comes_back_to_the_page_that_offered_it() {
+        // These four actions are rendered both on Ops and on an artifact's own
+        // page. Always redirecting to Ops threw a reader who pressed "Confirm
+        // still accurate" while reading an artifact onto a queue they were not
+        // working through.
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let rail = get(&app, "/ui/search/results?q=alpha", &cookie).await;
+        let id = rail
+            .split(r#"hx-get="/ui/artifacts/"#)
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .and_then(|s| s.split('?').next())
+            .expect("no result to open")
+            .to_string();
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/ops/artifacts/{id}/verify"),
+                &cookie,
+                &format!("to=/ui/artifacts/{id}"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            res.headers().get("location").unwrap(),
+            format!("/ui/artifacts/{id}").as_str()
+        );
+
+        // Ops sends no `to` and keeps the default.
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/ops/artifacts/{id}/deprecate"),
+                &cookie,
+                "",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.headers().get("location").unwrap(), "/ui/ops");
+    }
+
+    #[tokio::test]
+    async fn a_return_path_pointing_off_this_ui_is_ignored() {
+        // The field is user input, and a redirect that follows anything handed
+        // to it is an open redirect: worth nothing here, a phishing hop
+        // everywhere else.
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let rail = get(&app, "/ui/search/results?q=alpha", &cookie).await;
+        let id = rail
+            .split(r#"hx-get="/ui/artifacts/"#)
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .and_then(|s| s.split('?').next())
+            .expect("no result to open")
+            .to_string();
+
+        for hostile in ["https://evil.example/x", "//evil.example/x", "/ui//evil"] {
+            let res = app
+                .clone()
+                .oneshot(form(
+                    &format!("/ui/ops/artifacts/{id}/verify"),
+                    &cookie,
+                    &format!("to={}", urlencoding_of(hostile)),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(
+                res.headers().get("location").unwrap(),
+                "/ui/ops",
+                "followed {hostile}"
+            );
+        }
+    }
+
+    /// Percent-encoding for the handful of characters these test bodies carry.
+    fn urlencoding_of(s: &str) -> String {
+        s.replace(':', "%3A").replace('/', "%2F")
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -650,15 +650,25 @@ async fn delete_corpus_ui(
 /// only thing that removes anything — a person who can see the artifact deciding
 /// it should go.
 ///
-/// Lands on the source afterwards rather than back here, which would be a page
-/// for an artifact that no longer exists.
+/// Two callers, two right answers. Pressed in a list — a search result, a card
+/// on the source page — the answer is nothing at all: htmx swaps the row that
+/// was pressed out of the list, and the page the operator was reading stays
+/// where it was. Pressed in the pane, where the whole view *is* the artifact,
+/// there is nothing left to stay on, so it lands on the source.
+///
+/// An empty 200 rather than a 204: htmx treats no-content as "swap nothing",
+/// which would leave the deleted artifact on screen until a reload.
 async fn delete_artifact_ui(
     State(st): State<AppState>,
     _id: Identity,
+    headers: axum::http::HeaderMap,
     Path(aid): Path<String>,
 ) -> Result<Response> {
     let corpus_id = st.core.store.get_artifact(&aid).await?.corpus_id;
     st.core.delete_artifact(&aid).await?;
+    if headers.contains_key("hx-request") {
+        return Ok(axum::response::Html(String::new()).into_response());
+    }
     Ok(Redirect::to(&format!("/ui/corpora/{corpus_id}")).into_response())
 }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -23,13 +23,20 @@ pub struct RenderedResult {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub corpus_id: String,
-    /// Position in the list, as `#1`, `#2`, …
+    /// Position in the list, as `#1`, `#2`, … Empty for a weak result.
     ///
     /// Not the raw score. That number is a fused rank from Qdrant plus a
     /// recency term, so it is comparable within one result list and meaningless
     /// between two — a hybrid query and a dense-only fallback do not even score
     /// on the same scale. Showing it invited a comparison it cannot support.
+    ///
+    /// Dropped entirely once a result is `weak`, because a rank is a claim
+    /// about standing among answers, and something the query barely matches is
+    /// not one. `#1` over a result the search itself calls loose is the exact
+    /// false confidence this labelling exists to remove.
     pub rank: String,
+    /// Only loosely related to the query — see `SearchResult::weak`.
+    pub weak: bool,
 }
 
 pub struct BrowseRow {
@@ -82,6 +89,10 @@ pub struct ArtifactDetail {
     /// it is showing is the artifact's own text reflected back rather than the
     /// document it was drawn from.
     pub corpus_restored: bool,
+    /// Link to the source, scrolled to and highlighting the exact lines this
+    /// artifact was drawn from. Falls back to the plain source page for an
+    /// artifact with no recorded span — a restored one, for instance.
+    pub source_at_lines: String,
     pub segment_idx: Option<i64>,
     pub slice_label: String,
     pub slice_lines: Vec<crate::web::corpus_view::CorpusLine>,
@@ -282,6 +293,9 @@ struct SearchTemplate {
 #[template(path = "_results.html")]
 struct ResultsTemplate {
     results: Vec<RenderedResult>,
+    /// Every result is only loosely related, so the page says so once above the
+    /// list instead of repeating it on each card.
+    all_weak: bool,
     /// The query's indexable terms, for client-side highlighting.
     terms: String,
     /// `embed 41ms · total 138ms`, swapped into the header out of band.
@@ -300,7 +314,8 @@ struct BrowseTemplate {
 struct CorpusTemplate {
     theme: String,
     id: String,
-    raw_text: String,
+    /// The whole source, one row per line, each anchored so a link can name it.
+    lines: Vec<crate::web::corpus_view::CorpusLine>,
     status: String,
     badge: &'static str,
     artifacts: Vec<ArtifactView>,
@@ -505,6 +520,7 @@ async fn search_results(
     if p.q.trim().is_empty() {
         return Ok(HtmlTemplate(ResultsTemplate {
             results: vec![],
+            all_weak: false,
             terms: String::new(),
             timing: String::new(),
         })
@@ -530,12 +546,18 @@ async fn search_results(
         })
         .await?;
 
+    let results: Vec<RenderedResult> = hits
+        .into_iter()
+        .enumerate()
+        .map(|(i, h)| render_hit(i, h))
+        .collect();
     Ok(HtmlTemplate(ResultsTemplate {
-        results: hits
-            .into_iter()
-            .enumerate()
-            .map(|(i, h)| render_hit(i, h))
-            .collect(),
+        // Only when *every* result is loose. One weak hit at the bottom of a
+        // good list is ordinary — it is the tail of any ranking — and saying
+        // "nothing matches" over a list that plainly does would train the
+        // operator to ignore the warning.
+        all_weak: !results.is_empty() && results.iter().all(|r| r.weak),
+        results,
         terms,
         timing: format!("embed {}ms · total {}ms", t.embed_ms, t.total_ms),
     })
@@ -551,7 +573,12 @@ fn render_hit(position: usize, h: crate::core::search::SearchResult) -> Rendered
         category: h.category,
         tags: h.tags,
         corpus_id: h.corpus_id,
-        rank: format!("#{}", position + 1),
+        rank: if h.weak {
+            String::new()
+        } else {
+            format!("#{}", position + 1)
+        },
+        weak: h.weak,
     }
 }
 
@@ -585,10 +612,19 @@ async fn browse(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     .into_response())
 }
 
+/// Which lines to highlight, when the page was opened from an artifact that
+/// claims them. Absent for an ordinary visit, which highlights nothing.
+#[derive(serde::Deserialize, Default)]
+struct LineRange {
+    from: Option<i64>,
+    to: Option<i64>,
+}
+
 async fn corpus_detail(
     State(st): State<AppState>,
     _id: Identity,
     Path(cid): Path<String>,
+    Query(range): Query<LineRange>,
 ) -> Result<Response> {
     let s = st.core.store.get_corpus(&cid).await?;
     let artifacts = st
@@ -599,10 +635,29 @@ async fn corpus_detail(
         .iter()
         .map(artifact_view)
         .collect();
+    // Numbered rather than one blob of text, so an artifact can link to the
+    // exact lines it was drawn from and the browser can scroll to them. Every
+    // row carries an `L<n>` anchor for that; the range, when given, is
+    // highlighted the same way the pane highlights a span.
+    let lines = s
+        .raw_text
+        .lines()
+        .enumerate()
+        .map(|(i, text)| {
+            let number = i as i64 + 1;
+            crate::web::corpus_view::CorpusLine {
+                number,
+                text: text.to_string(),
+                in_span: range
+                    .from
+                    .is_some_and(|f| number >= f && number <= range.to.unwrap_or(f)),
+            }
+        })
+        .collect();
     Ok(HtmlTemplate(CorpusTemplate {
         theme: "light".into(),
         id: s.id,
-        raw_text: s.raw_text,
+        lines,
         badge: status_badge(&s.status),
         status: s.status.as_str().to_string(),
         restored: s.restored_at.is_some(),
@@ -1125,8 +1180,19 @@ pub(crate) async fn build_artifact_detail(
             id: h.payload.artifact_id,
         })
         .collect();
+    // Built before the struct consumes `c`. The fragment is what makes the
+    // browser scroll to the span; the query parameters are what make the page
+    // highlight it.
+    let source_at_lines = match c.corpus_span.as_ref() {
+        Some(sp) => format!(
+            "/ui/corpora/{}?from={}&to={}#L{}",
+            c.corpus_id, sp.start_line, sp.end_line, sp.start_line
+        ),
+        None => format!("/ui/corpora/{}", c.corpus_id),
+    };
     Ok(ArtifactDetail {
         related,
+        source_at_lines,
         id: c.id,
         title: c.title.unwrap_or_else(|| format!("Chunk {}", c.ordinal)),
         html: markdown::render(&c.text),
@@ -1709,6 +1775,41 @@ mod tests {
             .unwrap();
         assert!(d.related.is_empty());
         assert!(!d.html.is_empty(), "the artifact itself must still render");
+    }
+
+    #[test]
+    fn a_loose_result_is_labelled_and_never_ranked() {
+        // `#1` over something the search itself calls a poor match is the false
+        // confidence this exists to remove: a rank is a claim about standing
+        // among answers, and a barely-matching artifact is not one.
+        let result = |weak: bool| crate::core::search::SearchResult {
+            artifact_id: "a".into(),
+            corpus_id: "s".into(),
+            title: Some("t".into()),
+            text: "body".into(),
+            category: None,
+            tags: vec![],
+            score: 0.5,
+            status: None,
+            superseded_by: None,
+            last_verified_at: None,
+            weak,
+        };
+
+        let loose = render_hit(0, result(true));
+        assert!(loose.weak);
+        assert!(loose.rank.is_empty(), "a loose result was presented as #1");
+        assert_eq!(render_hit(0, result(false)).rank, "#1");
+
+        let html = askama::Template::render(&ResultsTemplate {
+            results: vec![loose],
+            all_weak: true,
+            terms: String::new(),
+            timing: String::new(),
+        })
+        .unwrap();
+        assert!(html.contains("Nothing matches closely"), "{html}");
+        assert!(!html.contains("#1"), "{html}");
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -893,9 +893,16 @@ async fn apply_pair_supersede_ui(
         pair.a_id
     };
     st.core.supersede(&obsolete_id, &winner_id).await?;
+    // The judge's explanation is carried through rather than dropped: it is the
+    // only record of why this supersede was applied, and `set_pair_state`
+    // writes `detail` unconditionally, so passing `None` would null it.
     st.core
         .store
-        .set_pair_state(pid, crate::store::pairs::PairState::Dismissed, None)
+        .set_pair_state(
+            pid,
+            crate::store::pairs::PairState::Dismissed,
+            pair.detail.as_deref(),
+        )
         .await?;
     Ok(Redirect::to("/ui/ops").into_response())
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -140,9 +140,14 @@ pub struct PairRow {
     pub detail: Option<String>,
     pub contradiction: bool,
     /// Set when the judge named a direction with enough confidence to propose
-    /// a supersede — the pair's "apply supersede" button shows only then.
-    /// Applying it is a separate press; nothing here has hidden anything yet.
+    /// a supersede. A recommendation only: nothing here has hidden anything,
+    /// and either side can still be kept.
     pub obsolete_title: Option<String>,
+    /// Which side the judge's proposal amounts to keeping, so the row can
+    /// accent that button. Both false when it made no proposal — every pair is
+    /// still resolvable, just with nothing recommended.
+    pub keeps_a: bool,
+    pub keeps_b: bool,
 }
 
 /// An artifact flagged stale with no specific replacement.
@@ -790,6 +795,10 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
                     title_of(&b)
                 }
             });
+            // Keeping one side is superseding the other, so the judge naming
+            // `a` obsolete is a recommendation to keep `b`.
+            let keeps_a = p.obsolete_id.as_deref() == Some(b.id.as_str());
+            let keeps_b = p.obsolete_id.as_deref() == Some(a.id.as_str());
             pairs.push(PairRow {
                 id: p.id,
                 percent: (p.score * 100.0).round() as i64,
@@ -800,6 +809,8 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
                 detail: p.detail,
                 contradiction: state == crate::store::pairs::PairState::Contradiction,
                 obsolete_title,
+                keeps_a,
+                keeps_b,
             });
         }
     }
@@ -945,16 +956,51 @@ async fn dismiss_pair_ui(
     Ok(Redirect::to("/ui/ops").into_response())
 }
 
-/// The operator confirmation step for a judge-proposed supersede: the pair's
-/// `obsolete_id` becomes an actual `Core::supersede` call. Nothing before this
-/// press hides anything — see `jobs::consolidate::judge_pending`.
+/// Which artifact of a pair the operator is keeping. Absent means "whichever
+/// the judge proposed", which is what the confirmation button on a proposed
+/// supersede sends.
+#[derive(serde::Deserialize, Default)]
+struct KeepForm {
+    keep: Option<String>,
+}
+
+/// Resolve a pair by naming the artifact that survives; the other is superseded
+/// by it.
+///
+/// Two callers, one action. The judge's proposal is a suggestion an operator
+/// confirms, and a contradiction the judge could not call is the same decision
+/// with nobody suggesting anything — so both are "keep this one", and only the
+/// default differs. Before this, a pair the judge flagged as disagreeing but
+/// could not rule on offered nothing except Dismiss: the operator could see two
+/// artifacts stating different things and had no way to say which was right,
+/// so the only way out of the queue was to declare the disagreement uninteresting
+/// and leave both in results.
+///
+/// Nothing before this press hides anything — see `jobs::consolidate::judge_pending`.
 async fn apply_pair_supersede_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(pid): Path<i64>,
+    Form(f): Form<KeepForm>,
 ) -> Result<Response> {
     let pair = st.core.store.get_pair(pid).await?;
-    let obsolete_id = pair.obsolete_id.ok_or(crate::error::Error::NotFound)?;
+    // The winner has to be one of this pair's own artifacts. A form field is
+    // user input, and superseding an arbitrary id because it arrived in a POST
+    // would hide an artifact that has nothing to do with the row that was
+    // pressed.
+    let obsolete_id = match f.keep {
+        Some(keep) if keep == pair.a_id => pair.b_id.clone(),
+        Some(keep) if keep == pair.b_id => pair.a_id.clone(),
+        Some(_) => {
+            return Err(crate::error::Error::Validation(
+                "the artifact to keep is not part of this pair".into(),
+            ));
+        }
+        None => pair
+            .obsolete_id
+            .clone()
+            .ok_or(crate::error::Error::NotFound)?,
+    };
     let winner_id = if obsolete_id == pair.a_id {
         pair.b_id
     } else {
@@ -2112,6 +2158,93 @@ mod tests {
                 .is_none(),
             "undo did not clear the flag"
         );
+    }
+
+    #[tokio::test]
+    async fn a_contradiction_the_judge_could_not_call_is_still_resolvable() {
+        // The dead end this fixes: the judge finds two artifacts stating a
+        // detail differently but names no winner, so `obsolete_id` is NULL. The
+        // row then offered nothing but Dismiss — an operator who could see which
+        // one was right had no way to say so, and clearing the queue meant
+        // declaring the disagreement uninteresting and leaving both in results.
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["left one", "right one"]).await;
+        core.store.record_pair(&ids[0], &ids[1], 0.9).await.unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+        core.store
+            .set_pair_state(
+                pair.id,
+                crate::store::pairs::PairState::Contradiction,
+                Some("they disagree about the tag"),
+            )
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .get_pair(pair.id)
+                .await
+                .unwrap()
+                .obsolete_id
+                .is_none(),
+            "this test is only meaningful with no judge proposal to fall back on"
+        );
+
+        // Keep the first; the second is the one that gets hidden.
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/ops/pairs/{}/supersede", pair.id),
+                &cookie,
+                &format!("keep={}", pair.a_id),
+            ))
+            .await
+            .unwrap();
+
+        let kept = core.store.get_artifact(&pair.a_id).await.unwrap();
+        let hidden = core.store.get_artifact(&pair.b_id).await.unwrap();
+        assert_eq!(kept.status, crate::store::artifacts::ArtifactStatus::Active);
+        assert_eq!(
+            hidden.status,
+            crate::store::artifacts::ArtifactStatus::Superseded
+        );
+        assert_eq!(hidden.superseded_by.as_deref(), Some(pair.a_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn keeping_an_artifact_from_outside_the_pair_is_refused() {
+        // `keep` is a form field, so it is user input. Superseding whatever id
+        // arrives would hide an artifact that has nothing to do with the row
+        // that was pressed.
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["left one", "right one", "unrelated"]).await;
+        core.store.record_pair(&ids[0], &ids[1], 0.9).await.unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()
+            .remove(0);
+
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/ops/pairs/{}/supersede", pair.id),
+                &cookie,
+                &format!("keep={}", ids[2]),
+            ))
+            .await
+            .unwrap();
+
+        for id in &ids {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().status,
+                crate::store::artifacts::ArtifactStatus::Active,
+                "an artifact outside the pair was touched"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -71,6 +71,8 @@ pub struct ArtifactDetail {
     /// The artifact this one was hidden in favour of. Opening a hidden artifact
     /// by link has to say why it is not in results, or it reads as a bug.
     pub superseded_by: Option<String>,
+    pub status: crate::store::artifacts::ArtifactStatus,
+    pub last_verified_at: Option<i64>,
     /// Conditions the source stated under which this artifact does not apply.
     pub caveats: Vec<String>,
     pub corpus_id: String,
@@ -131,6 +133,23 @@ pub struct PairRow {
     pub b_title: String,
     pub detail: Option<String>,
     pub contradiction: bool,
+    /// Set when the judge named a direction with enough confidence to propose
+    /// a supersede — the pair's "apply supersede" button shows only then.
+    /// Applying it is a separate press; nothing here has hidden anything yet.
+    pub obsolete_title: Option<String>,
+}
+
+/// An artifact flagged stale with no specific replacement.
+pub struct DeprecatedRow {
+    pub id: String,
+    pub title: String,
+}
+
+/// An active artifact nobody has confirmed or retrieved in a while.
+pub struct StaleRow {
+    pub id: String,
+    pub title: String,
+    pub last_verified: String,
 }
 
 pub struct TokenRow {
@@ -306,6 +325,8 @@ struct OpsTemplate {
     retrying: Vec<RetryingRow>,
     parked: Vec<ParkedRow>,
     superseded: Vec<SupersededRow>,
+    deprecated: Vec<DeprecatedRow>,
+    stale: Vec<StaleRow>,
     pairs: Vec<PairRow>,
     tokens: Vec<TokenRow>,
 }
@@ -487,6 +508,8 @@ async fn search_results(
             category: p.category.filter(|c| !c.is_empty()),
             // Incremental: a prefix must not stamp what it happened to match.
             mark: false,
+            include_deprecated: false,
+            include_superseded: false,
         })
         .await?;
 
@@ -701,11 +724,13 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         });
     }
 
-    // Confirmed contradictions lead: they are the ones that mean something in
-    // the base is wrong rather than merely repeated.
+    // Confirmed contradictions and judge-proposed supersedes lead: they are
+    // the ones that mean something in the base is wrong or stale, rather than
+    // merely repeated.
     let mut pairs = Vec::new();
     for state in [
         crate::store::pairs::PairState::Contradiction,
+        crate::store::pairs::PairState::Superseded,
         crate::store::pairs::PairState::Pending,
     ] {
         for p in st.core.store.pairs_by_state(state, 50).await? {
@@ -715,6 +740,13 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             ) else {
                 continue;
             };
+            let obsolete_title = p.obsolete_id.as_deref().map(|id| {
+                if id == a.id {
+                    title_of(&a)
+                } else {
+                    title_of(&b)
+                }
+            });
             pairs.push(PairRow {
                 id: p.id,
                 percent: (p.score * 100.0).round() as i64,
@@ -724,15 +756,50 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
                 b_id: p.b_id,
                 detail: p.detail,
                 contradiction: state == crate::store::pairs::PairState::Contradiction,
+                obsolete_title,
             });
         }
     }
+
+    let deprecated = st
+        .core
+        .store
+        .artifacts_by_status(crate::store::artifacts::ArtifactStatus::Deprecated, 50)
+        .await?
+        .into_iter()
+        .map(|c| DeprecatedRow {
+            title: title_of(&c),
+            id: c.id,
+        })
+        .collect();
+
+    // Read-only candidates: nothing here has been changed, only listed.
+    let stale = st
+        .core
+        .stale_candidates(50)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "no stale candidates for ops");
+            vec![]
+        })
+        .into_iter()
+        .map(|r| StaleRow {
+            title: r.title.unwrap_or_else(|| markdown::snippet(&r.text, 60)),
+            id: r.artifact_id,
+            last_verified: r
+                .last_verified_at
+                .map(fmt_time)
+                .unwrap_or_else(|| "never".to_string()),
+        })
+        .collect();
 
     Ok(HtmlTemplate(OpsTemplate {
         theme: "light".into(),
         retrying,
         parked,
         superseded,
+        deprecated,
+        stale,
         pairs,
         job_counts: st.core.store.job_counts().await?,
         oldest_pending_secs: st.core.store.oldest_pending_age().await?,
@@ -807,6 +874,56 @@ async fn dismiss_pair_ui(
         .store
         .set_pair_state(pid, crate::store::pairs::PairState::Dismissed, None)
         .await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+/// The operator confirmation step for a judge-proposed supersede: the pair's
+/// `obsolete_id` becomes an actual `Core::supersede` call. Nothing before this
+/// press hides anything — see `jobs::consolidate::judge_pending`.
+async fn apply_pair_supersede_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(pid): Path<i64>,
+) -> Result<Response> {
+    let pair = st.core.store.get_pair(pid).await?;
+    let obsolete_id = pair.obsolete_id.ok_or(crate::error::Error::NotFound)?;
+    let winner_id = if obsolete_id == pair.a_id {
+        pair.b_id
+    } else {
+        pair.a_id
+    };
+    st.core.supersede(&obsolete_id, &winner_id).await?;
+    st.core
+        .store
+        .set_pair_state(pid, crate::store::pairs::PairState::Dismissed, None)
+        .await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+async fn deprecate_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(aid): Path<String>,
+) -> Result<Response> {
+    st.core.deprecate(&aid).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+async fn reactivate_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(aid): Path<String>,
+) -> Result<Response> {
+    st.core.reactivate(&aid).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
+}
+
+async fn verify_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(aid): Path<String>,
+) -> Result<Response> {
+    st.core.verify(&aid).await?;
     Ok(Redirect::to("/ui/ops").into_response())
 }
 
@@ -894,6 +1011,8 @@ pub(crate) async fn build_artifact_detail(
         flags: c.flags,
         flag_detail: c.flag_detail,
         superseded_by: c.superseded_by,
+        status: c.status,
+        last_verified_at: c.last_verified_at,
         caveats: c.caveats,
         corpus_id: c.corpus_id,
         segment_idx: c.segment_idx,
@@ -960,7 +1079,14 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/ops/tokens/{id}/revoke", post(revoke_token_ui))
         .route("/ui/ops/corpora/{id}/resolve", post(resolve_near_dupe_ui))
         .route("/ui/ops/artifacts/{id}/unsupersede", post(unsupersede_ui))
+        .route("/ui/ops/artifacts/{id}/deprecate", post(deprecate_ui))
+        .route("/ui/ops/artifacts/{id}/reactivate", post(reactivate_ui))
+        .route("/ui/ops/artifacts/{id}/verify", post(verify_ui))
         .route("/ui/ops/pairs/{id}/dismiss", post(dismiss_pair_ui))
+        .route(
+            "/ui/ops/pairs/{id}/supersede",
+            post(apply_pair_supersede_ui),
+        )
 }
 
 #[cfg(test)]
@@ -1005,6 +1131,8 @@ mod tests {
                 tags: vec![],
                 category: None,
                 mark: false,
+                include_deprecated: false,
+                include_superseded: false,
             })
             .await
             .unwrap();

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -110,6 +110,8 @@ async fn evaluate_retrieval() {
             // A benchmark must not stamp last_seen_at: resurfacing reads the
             // same field, and a scored run is not someone reading their notes.
             mark: false,
+            include_deprecated: false,
+            include_superseded: false,
         };
         let results = core.search_capped(&q, cap).await.expect("search failed");
         let rank = results.iter().position(|r| r.artifact_id == pair.expect);

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -101,6 +101,113 @@ async fn upsert_search_and_payload_roundtrip() {
 
 #[tokio::test]
 #[ignore]
+async fn a_deprecated_artifact_is_hidden_by_default_and_reachable_on_request() {
+    // The two exclusions are independent opt-ins, and the deprecated one used
+    // to be unreachable: `set_lifecycle` wrote the legacy `superseded` boolean
+    // for any non-active status, and the filter drops `superseded == true`
+    // whenever superseded results were not asked for. Only a real Qdrant runs
+    // that filter, so this is where it has to be proved.
+    use engram::store::artifacts::ArtifactStatus;
+
+    let v = fresh("engram_it_deprecated", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &["linux"], "procedure"),
+        point("b", "s1", vec![1.0, 0.0, 0.0, 0.0], &["linux"], "procedure"),
+    ])
+    .await
+    .unwrap();
+    v.set_lifecycle("a", ArtifactStatus::Deprecated, None)
+        .await
+        .unwrap();
+    v.set_lifecycle("b", ArtifactStatus::Superseded, Some("a"))
+        .await
+        .unwrap();
+
+    let ids = |f: SearchFilter| {
+        let v = &v;
+        async move {
+            let mut got: Vec<String> = v
+                .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|h| h.payload.artifact_id)
+                .collect();
+            got.sort();
+            got
+        }
+    };
+
+    assert!(
+        ids(SearchFilter::default()).await.is_empty(),
+        "neither retired artifact belongs in an ordinary search"
+    );
+    assert_eq!(
+        ids(SearchFilter {
+            include_deprecated: true,
+            ..Default::default()
+        })
+        .await,
+        vec!["a".to_string()],
+        "include_deprecated returned nothing, or leaked the superseded one"
+    );
+    assert_eq!(
+        ids(SearchFilter {
+            include_superseded: true,
+            ..Default::default()
+        })
+        .await,
+        vec!["b".to_string()]
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn only_a_verify_clears_the_hit_counter() {
+    // `stale_max_hits` counts retrievals since the last verification, so a
+    // verify restarts the count while the one-shot backfill — which stamps
+    // every artifact — must leave every counter alone.
+    let v = fresh("engram_it_verify", 4).await;
+    v.upsert(vec![point(
+        "a",
+        "s1",
+        vec![1.0, 0.0, 0.0, 0.0],
+        &["linux"],
+        "procedure",
+    )])
+    .await
+    .unwrap();
+    v.touch(&["a".to_string()], 1_000).await.unwrap();
+    v.touch(&["a".to_string()], 2_000).await.unwrap();
+
+    let counted = |older: i64| {
+        let v = &v;
+        async move {
+            v.stale_candidates(older, i64::MAX, 10)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|h| h.payload.artifact_id == "a")
+                .and_then(|h| h.payload.hit_count)
+        }
+    };
+    assert_eq!(counted(i64::MAX).await, Some(2));
+
+    v.set_last_verified_at("a", 5_000, false).await.unwrap();
+    assert_eq!(
+        counted(i64::MAX).await,
+        Some(2),
+        "a backfill stamp must not wipe the counter"
+    );
+
+    v.set_last_verified_at("a", 6_000, true).await.unwrap();
+    assert_eq!(counted(i64::MAX).await, Some(0), "verify must restart it");
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
 async fn filtered_search_uses_payload_indexes() {
     let v = fresh("engram_it_filter", 4).await;
     v.upsert(vec![

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -182,10 +182,10 @@ async fn only_a_verify_clears_the_hit_counter() {
     // A stamp first: `stale_candidates` only considers points that have one,
     // since a missing stamp means unbackfilled rather than stale.
     v.set_last_verified_at("a", 1, false).await.unwrap();
-    v.touch(&[engram::vector::Touch::unknown("a")], 1_000)
+    v.touch(&[engram::vector::Touch::retrieved("a", None)], 1_000)
         .await
         .unwrap();
-    v.touch(&[engram::vector::Touch::unknown("a")], 2_000)
+    v.touch(&[engram::vector::Touch::retrieved("a", None)], 2_000)
         .await
         .unwrap();
 
@@ -1105,7 +1105,7 @@ async fn resurface_finds_the_old_and_unseen_and_skips_everything_else() {
     .await
     .unwrap();
     v.touch(
-        &[engram::vector::Touch::unknown("old_but_just_seen")],
+        &[engram::vector::Touch::shown("old_but_just_seen")],
         now_secs(),
     )
     .await
@@ -1121,7 +1121,7 @@ async fn resurface_finds_the_old_and_unseen_and_skips_everything_else() {
     );
 
     // Showing it counts as seeing it.
-    v.touch(&[engram::vector::Touch::unknown("forgotten")], now_secs())
+    v.touch(&[engram::vector::Touch::shown("forgotten")], now_secs())
         .await
         .unwrap();
     assert!(
@@ -1147,7 +1147,7 @@ async fn touching_a_chunk_leaves_the_rest_of_its_payload_alone() {
     .await
     .unwrap();
 
-    v.touch(&[engram::vector::Touch::unknown("a")], 12_345)
+    v.touch(&[engram::vector::Touch::shown("a")], 12_345)
         .await
         .unwrap();
 
@@ -1179,7 +1179,7 @@ async fn editing_metadata_does_not_erase_when_a_chunk_was_last_seen() {
     v.upsert(vec![aged("a", vec![1.0, 0.0, 0.0, 0.0], 1, &["old"])])
         .await
         .unwrap();
-    v.touch(&[engram::vector::Touch::unknown("a")], 12_345)
+    v.touch(&[engram::vector::Touch::shown("a")], 12_345)
         .await
         .unwrap();
 
@@ -1217,7 +1217,7 @@ async fn re_embedding_does_not_erase_when_a_chunk_was_last_seen() {
     v.upsert(vec![aged("a", vec![1.0, 0.0, 0.0, 0.0], 60, &["t"])])
         .await
         .unwrap();
-    v.touch(&[engram::vector::Touch::unknown("a")], now_secs())
+    v.touch(&[engram::vector::Touch::shown("a")], now_secs())
         .await
         .unwrap();
 
@@ -1794,5 +1794,150 @@ async fn a_re_embed_does_not_revive_a_superseded_point() {
         .is_empty(),
         "the re-embed revived a hidden point"
     );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_deprecated_artifact_is_not_a_neighbour() {
+    // The related pane is a list of live content, and only a real Qdrant runs
+    // the filter that keeps it that way. The legacy `superseded` flag never
+    // catches a deprecation — `lifecycle_payload` writes it false on purpose —
+    // so a `must_not superseded == true` alone let every retired artifact keep
+    // linking itself from the live one it sits next to.
+    let v = fresh("engram_it_neighbours_deprecated", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+        point("b", "s1", vec![0.99, 0.01, 0.0, 0.0], &[], "c"),
+    ])
+    .await
+    .unwrap();
+    assert_eq!(
+        v.neighbours("a", 10).await.unwrap().len(),
+        1,
+        "the fixture has no neighbour to lose"
+    );
+
+    v.set_lifecycle("b", ArtifactStatus::Deprecated, None)
+        .await
+        .unwrap();
+
+    assert!(
+        v.neighbours("a", 10).await.unwrap().is_empty(),
+        "a retired artifact is still linked from a live one"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn resurface_skips_a_deprecated_point() {
+    // Old and never seen is exactly what a retired artifact looks like, so the
+    // forgotten list used to offer back the very things an operator had just
+    // taken out of search — and stamp them as shown on the way past.
+    let v = fresh("engram_it_resurface_deprecated", 4).await;
+    v.upsert(vec![
+        aged("live", vec![1.0, 0.0, 0.0, 0.0], 60, &[]),
+        aged("retired", vec![1.0, 0.0, 0.0, 0.0], 60, &[]),
+    ])
+    .await
+    .unwrap();
+    v.set_lifecycle("retired", ArtifactStatus::Deprecated, None)
+        .await
+        .unwrap();
+
+    let cutoff = now_secs() - 31 * 86_400;
+    let ids: Vec<String> = v
+        .resurface(10, cutoff, cutoff)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|h| h.payload.artifact_id)
+        .collect();
+    assert_eq!(ids, vec!["live".to_string()], "got {ids:?}");
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn opening_an_artifact_does_not_count_as_a_retrieval() {
+    // `stale_max_hits` is zero by default, so counting the click that opens a
+    // review candidate would disqualify it from the list that offered it. The
+    // stamp that says it was shown still has to land.
+    let v = fresh("engram_it_touch_shown", 4).await;
+    v.upsert(vec![point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c")])
+        .await
+        .unwrap();
+    v.set_last_verified_at("a", 1, false).await.unwrap();
+
+    v.touch(&[engram::vector::Touch::shown("a")], 9_000)
+        .await
+        .unwrap();
+
+    let found = v
+        .stale_candidates(i64::MAX, 0, 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|h| h.payload.artifact_id == "a")
+        .expect("an opened artifact left the stale review list");
+    assert_eq!(found.payload.hit_count, None, "the open counted as a hit");
+    assert_eq!(found.payload.last_seen_at, Some(9_000));
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn lifecycle_of_reads_back_what_each_point_says() {
+    // What the drift repair compares against SQLite. An id with no point is
+    // absent rather than defaulted, because "no point yet" is not drift.
+    let v = fresh("engram_it_lifecycle_of", 4).await;
+    v.upsert(vec![
+        point("plain", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+        point("dep", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+        point("sup", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+    ])
+    .await
+    .unwrap();
+    v.set_lifecycle("dep", ArtifactStatus::Deprecated, None)
+        .await
+        .unwrap();
+    v.set_lifecycle("sup", ArtifactStatus::Superseded, Some("plain"))
+        .await
+        .unwrap();
+
+    let ids: Vec<String> = ["plain", "dep", "sup", "missing"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let out = v.lifecycle_of(&ids).await.unwrap();
+
+    assert_eq!(out.len(), 3, "a point that does not exist must be absent");
+    assert_eq!(out["plain"].status, ArtifactStatus::Active);
+    assert_eq!(out["dep"].status, ArtifactStatus::Deprecated);
+    assert_eq!(out["dep"].superseded_by, None);
+    assert_eq!(out["sup"].status, ArtifactStatus::Superseded);
+    assert_eq!(out["sup"].superseded_by.as_deref(), Some("plain"));
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn all_artifact_ids_pages_past_one_scroll() {
+    // The backfill subtracts this from SQLite to find points whose row is gone,
+    // so a single unpaged scroll would report most of a large base as orphaned
+    // and delete it. The page size is 1000; this crosses it.
+    let v = fresh("engram_it_all_ids", 4).await;
+    let points: Vec<VectorPoint> = (0..1_100)
+        .map(|i| point(&format!("a{i}"), "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"))
+        .collect();
+    for batch in points.chunks(500) {
+        v.upsert(batch.to_vec()).await.unwrap();
+    }
+
+    let mut ids = v.all_artifact_ids().await.unwrap();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), 1_100, "the scroll stopped at its first page");
     v.drop_collection().await.unwrap();
 }

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -2068,3 +2068,33 @@ async fn a_point_naming_no_artifact_does_not_keep_the_backfill_running_forever()
     );
     v.drop_collection().await.unwrap();
 }
+
+#[tokio::test]
+#[ignore]
+async fn an_unstamped_point_is_never_a_stale_candidate() {
+    // The list says "not confirmed accurate in a while", so a point that was
+    // never stamped at all must not appear: missing means unknown, not stale,
+    // and every point predates the backfill until it runs. A row reading
+    // "last verified: never" is this invariant breaking.
+    let v = fresh("engram_it_stale_unstamped", 4).await;
+    v.upsert(vec![
+        point("stamped", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+        point("unstamped", "s1", vec![0.0, 1.0, 0.0, 0.0], &[], "c"),
+    ])
+    .await
+    .unwrap();
+    v.set_last_verified_at("stamped", 1_000, false)
+        .await
+        .unwrap();
+
+    let ids: Vec<String> = v
+        .stale_candidates(i64::MAX, i64::MAX, 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|h| h.payload.artifact_id)
+        .collect();
+
+    assert_eq!(ids, vec!["stamped".to_string()], "{ids:?}");
+    v.drop_collection().await.unwrap();
+}

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -9,8 +9,9 @@
 //! `ENGRAM_TEST_QDRANT=http://localhost:16333`.
 
 use engram::config::VectorConfig;
+use engram::store::artifacts::ArtifactStatus;
 use engram::vector::{
-    SearchFilter, VectorPayload, VectorPoint, VectorStore, qdrant::QdrantVectors,
+    LifecycleRow, SearchFilter, VectorPayload, VectorPoint, VectorStore, qdrant::QdrantVectors,
 };
 
 fn cfg(collection: &str) -> VectorConfig {
@@ -178,8 +179,15 @@ async fn only_a_verify_clears_the_hit_counter() {
     )])
     .await
     .unwrap();
-    v.touch(&["a".to_string()], 1_000).await.unwrap();
-    v.touch(&["a".to_string()], 2_000).await.unwrap();
+    // A stamp first: `stale_candidates` only considers points that have one,
+    // since a missing stamp means unbackfilled rather than stale.
+    v.set_last_verified_at("a", 1, false).await.unwrap();
+    v.touch(&[engram::vector::Touch::unknown("a")], 1_000)
+        .await
+        .unwrap();
+    v.touch(&[engram::vector::Touch::unknown("a")], 2_000)
+        .await
+        .unwrap();
 
     let counted = |older: i64| {
         let v = &v;
@@ -1096,9 +1104,12 @@ async fn resurface_finds_the_old_and_unseen_and_skips_everything_else() {
     ])
     .await
     .unwrap();
-    v.touch(&["old_but_just_seen".to_string()], now_secs())
-        .await
-        .unwrap();
+    v.touch(
+        &[engram::vector::Touch::unknown("old_but_just_seen")],
+        now_secs(),
+    )
+    .await
+    .unwrap();
 
     let cutoff = now_secs() - month;
     let out = v.resurface(10, cutoff, cutoff).await.unwrap();
@@ -1110,7 +1121,7 @@ async fn resurface_finds_the_old_and_unseen_and_skips_everything_else() {
     );
 
     // Showing it counts as seeing it.
-    v.touch(&["forgotten".to_string()], now_secs())
+    v.touch(&[engram::vector::Touch::unknown("forgotten")], now_secs())
         .await
         .unwrap();
     assert!(
@@ -1136,7 +1147,9 @@ async fn touching_a_chunk_leaves_the_rest_of_its_payload_alone() {
     .await
     .unwrap();
 
-    v.touch(&["a".to_string()], 12_345).await.unwrap();
+    v.touch(&[engram::vector::Touch::unknown("a")], 12_345)
+        .await
+        .unwrap();
 
     let hits = v
         .search(
@@ -1166,7 +1179,9 @@ async fn editing_metadata_does_not_erase_when_a_chunk_was_last_seen() {
     v.upsert(vec![aged("a", vec![1.0, 0.0, 0.0, 0.0], 1, &["old"])])
         .await
         .unwrap();
-    v.touch(&["a".to_string()], 12_345).await.unwrap();
+    v.touch(&[engram::vector::Touch::unknown("a")], 12_345)
+        .await
+        .unwrap();
 
     let mut edited = aged("a", vec![], 1, &["fresh"]).payload;
     edited.last_seen_at = None;
@@ -1202,7 +1217,9 @@ async fn re_embedding_does_not_erase_when_a_chunk_was_last_seen() {
     v.upsert(vec![aged("a", vec![1.0, 0.0, 0.0, 0.0], 60, &["t"])])
         .await
         .unwrap();
-    v.touch(&["a".to_string()], now_secs()).await.unwrap();
+    v.touch(&[engram::vector::Touch::unknown("a")], now_secs())
+        .await
+        .unwrap();
 
     // The same chunk, embedded again after an edit.
     let mut again = aged("a", vec![0.0, 1.0, 0.0, 0.0], 60, &["t"]);
@@ -1536,6 +1553,120 @@ async fn a_superseded_point_is_offered_neither_as_forgotten_nor_as_related() {
         .collect();
     assert!(near.is_empty(), "a hidden artifact was related: {near:?}");
 
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn near_pairs_skips_a_deprecated_point() {
+    // A deprecated artifact in the sweep can win its cluster on being newer and
+    // hide a live one — and `set_superseded_by` would overwrite the operator's
+    // deprecation with `superseded` while doing it.
+    let v = fresh("engram_it_near_pairs_deprecated", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "procedure"),
+        point("b", "s1", vec![0.99, 0.01, 0.0, 0.0], &[], "procedure"),
+    ])
+    .await
+    .unwrap();
+    assert_eq!(v.near_pairs(100, 5, 0.9).await.unwrap().len(), 1);
+
+    v.set_lifecycle("b", ArtifactStatus::Deprecated, None)
+        .await
+        .unwrap();
+    assert!(
+        v.near_pairs(100, 5, 0.9).await.unwrap().is_empty(),
+        "a deprecated artifact is still a consolidation candidate"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn the_backfill_stamps_every_point_in_one_request() {
+    // What startup runs when it finds unstamped points, and what the sweep's
+    // drift repair reuses. Both directions of the repair need `non_active_ids`
+    // to report what the payloads actually say.
+    let v = fresh("engram_it_backfill", 4).await;
+    v.upsert(vec![
+        point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "procedure"),
+        point("b", "s1", vec![0.0, 1.0, 0.0, 0.0], &[], "procedure"),
+    ])
+    .await
+    .unwrap();
+    assert_eq!(v.unstamped_count().await.unwrap(), 2);
+
+    v.apply_lifecycle(&[
+        LifecycleRow {
+            artifact_id: "a".into(),
+            status: ArtifactStatus::Active,
+            superseded_by: None,
+            last_verified_at: 1_000,
+        },
+        LifecycleRow {
+            artifact_id: "b".into(),
+            status: ArtifactStatus::Deprecated,
+            superseded_by: None,
+            last_verified_at: 2_000,
+        },
+    ])
+    .await
+    .unwrap();
+
+    assert_eq!(v.unstamped_count().await.unwrap(), 0);
+    assert_eq!(v.non_active_ids(100).await.unwrap(), vec!["b".to_string()]);
+    // The deprecation reached search, which is the whole point of the pass.
+    let hits = v
+        .search(
+            &[0.0, 1.0, 0.0, 0.0],
+            &Default::default(),
+            5,
+            &Default::default(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        hits.iter().all(|h| h.payload.artifact_id != "b"),
+        "{hits:?}"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn payload_indexes_are_added_to_a_collection_that_already_exists() {
+    // A field this release filters on exists in no collection created before
+    // it, so every filtered search would run as a full scan until someone
+    // thought to `--reindex`.
+    let v = fresh("engram_it_index_backfill", 4).await;
+    let name = "engram_it_index_backfill_v1";
+    let indexed = || async {
+        let info: serde_json::Value = serde_json::from_str(
+            &raw(reqwest::Method::GET, &format!("/collections/{name}"), None).await,
+        )
+        .unwrap();
+        info["result"]["payload_schema"]
+            .as_object()
+            .map(|m| m.contains_key("status"))
+            .unwrap_or(false)
+    };
+    assert!(indexed().await, "a fresh collection is missing the index");
+
+    // What a collection created by an earlier release looks like.
+    raw(
+        reqwest::Method::DELETE,
+        &format!("/collections/{name}/index/status?wait=true"),
+        None,
+    )
+    .await;
+    assert!(!indexed().await, "the index was not actually removed");
+
+    // Re-running startup is what has to put it back.
+    v.ensure_collection(4).await.unwrap();
+    assert!(
+        indexed().await,
+        "an existing collection never got the index this release filters on"
+    );
     v.drop_collection().await.unwrap();
 }
 

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -22,6 +22,7 @@ fn cfg(collection: &str) -> VectorConfig {
         recency_weight: 0.05,
         recency_half_life_days: 180,
         pinned_boost: 0.15,
+        weak_below: 0.35,
     }
 }
 
@@ -2097,4 +2098,58 @@ async fn an_unstamped_point_is_never_a_stale_candidate() {
 
     assert_eq!(ids, vec!["stamped".to_string()], "{ids:?}");
     v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn search_reports_a_cosine_alongside_the_fused_rank() {
+    // The ranking score of a hybrid query is a reciprocal-rank fusion value: it
+    // says where a result placed, not how close it was, so the top hit for a
+    // typo scores like the top hit for a perfect question. The similarity is
+    // fetched in the same request by a second, dense-only search, and *that* is
+    // the number that means the same thing from one query to the next.
+    let v = fresh("engram_it_similarity", 4).await;
+    v.upsert(vec![
+        point("near", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c"),
+        point("far", "s1", vec![0.0, 0.0, 0.0, 1.0], &[], "c"),
+    ])
+    .await
+    .unwrap();
+
+    let hits = v
+        .search(
+            &[1.0, 0.0, 0.0, 0.0],
+            &engram::vector::sparse::encode_query("text near"),
+            10,
+            &SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+
+    let near = hits
+        .iter()
+        .find(|h| h.payload.artifact_id == "near")
+        .expect("the matching point was not returned");
+    let far = hits
+        .iter()
+        .find(|h| h.payload.artifact_id == "far")
+        .expect("the distant point was not returned");
+
+    assert!(
+        near.similarity.is_some_and(|s| s > 0.99),
+        "an identical vector should be maximally similar: {:?}",
+        near.similarity
+    );
+    assert!(
+        far.similarity.is_some_and(|s| s < 0.1),
+        "an orthogonal vector should be maximally dissimilar: {:?}",
+        far.similarity
+    );
+    // The whole reason the similarity is fetched separately: this number is not
+    // one, and comparing it against a threshold would be meaningless.
+    assert!(
+        near.score < 0.9,
+        "the fused rank looked like a similarity: {}",
+        near.score
+    );
 }

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -51,7 +51,11 @@ fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPo
             tags: tags.iter().map(|s| s.to_string()).collect(),
             created_at: 42,
             last_seen_at: None,
+            hit_count: None,
             superseded: None,
+            status: None,
+            last_verified_at: None,
+            superseded_by: None,
         },
     }
 }
@@ -116,6 +120,7 @@ async fn filtered_search_uses_payload_indexes() {
         tags: vec!["forensics".into()],
         category: None,
         include_superseded: false,
+        include_deprecated: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -128,6 +133,7 @@ async fn filtered_search_uses_payload_indexes() {
         tags: vec![],
         category: Some("concept".into()),
         include_superseded: false,
+        include_deprecated: false,
     };
     assert_eq!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -169,6 +175,7 @@ async fn multiple_tags_are_an_and_not_an_or() {
         tags: vec!["linux".into(), "forensics".into()],
         category: None,
         include_superseded: false,
+        include_deprecated: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -609,6 +616,7 @@ async fn set_payload_rewrites_metadata_without_touching_the_vector() {
         tags: vec!["fresh".into()],
         category: None,
         include_superseded: false,
+        include_deprecated: false,
     };
     assert_eq!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -621,6 +629,7 @@ async fn set_payload_rewrites_metadata_without_touching_the_vector() {
         tags: vec!["old".into()],
         category: None,
         include_superseded: false,
+        include_deprecated: false,
     };
     assert!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &stale)
@@ -651,7 +660,11 @@ fn hybrid_point(id: &str, text: &str, dense: Vec<f32>) -> VectorPoint {
             tags: vec![],
             created_at: 42,
             last_seen_at: None,
+            hit_count: None,
             superseded: None,
+            status: None,
+            last_verified_at: None,
+            superseded_by: None,
         },
     }
 }
@@ -742,6 +755,7 @@ async fn a_filter_still_applies_to_both_halves_of_a_hybrid_query() {
         tags: vec!["keep".into()],
         category: None,
         include_superseded: false,
+        include_deprecated: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 10, &f)
@@ -831,6 +845,7 @@ fn now_secs() -> i64 {
 }
 
 fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint {
+    let ts = now_secs() - days_old * 86_400;
     VectorPoint {
         vector: dense,
         sparse: Default::default(),
@@ -841,9 +856,16 @@ fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint 
             title: None,
             category: Some("c".into()),
             tags: tags.iter().map(|s| s.to_string()).collect(),
-            created_at: now_secs() - days_old * 86_400,
+            created_at: ts,
             last_seen_at: None,
+            hit_count: None,
             superseded: None,
+            status: None,
+            // Recency decay now reads `last_verified_at`, not `created_at` —
+            // this helper's whole point is controlling how "aged" a point
+            // scores, so it has to set the field the formula actually uses.
+            last_verified_at: Some(ts),
+            superseded_by: None,
         },
     }
 }
@@ -943,6 +965,7 @@ async fn scoring_leaves_the_filter_alone() {
         tags: vec!["keep".into()],
         category: None,
         include_superseded: false,
+        include_deprecated: false,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 10, &f)
@@ -1471,6 +1494,7 @@ async fn a_superseded_point_leaves_search_and_can_come_back() {
             5,
             &SearchFilter {
                 include_superseded: true,
+                include_deprecated: false,
                 ..Default::default()
             },
         )

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -1941,3 +1941,130 @@ async fn all_artifact_ids_pages_past_one_scroll() {
     assert_eq!(ids.len(), 1_100, "the scroll stopped at its first page");
     v.drop_collection().await.unwrap();
 }
+
+#[tokio::test]
+#[ignore]
+async fn the_stale_queue_is_the_same_list_twice_and_stalest_first() {
+    // It used to be a random sample. Acting on a candidate redirects back to
+    // Ops, which re-drew — so the queue an operator was working reshuffled under
+    // them on every press, and on a base with more candidates than the limit a
+    // given artifact might take many page loads to come back.
+    let v = fresh("engram_it_stale_order", 4).await;
+    let points: Vec<VectorPoint> = (0..40)
+        .map(|i| {
+            point(
+                &format!("a{i:02}"),
+                "s1",
+                vec![1.0, 0.0, 0.0, 0.0],
+                &[],
+                "c",
+            )
+        })
+        .collect();
+    v.upsert(points).await.unwrap();
+    // Stamped in the opposite order to the ids, so "stalest first" and "id
+    // order" cannot be confused for one another.
+    for i in 0..40 {
+        v.set_last_verified_at(&format!("a{i:02}"), 10_000 - i, false)
+            .await
+            .unwrap();
+    }
+
+    let first: Vec<String> = v
+        .stale_candidates(i64::MAX, i64::MAX, 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|h| h.payload.artifact_id)
+        .collect();
+    let again: Vec<String> = v
+        .stale_candidates(i64::MAX, i64::MAX, 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|h| h.payload.artifact_id)
+        .collect();
+
+    assert_eq!(first, again, "the queue reshuffled between two renders");
+    let expected: Vec<String> = (0..10).map(|i| format!("a{:02}", 39 - i)).collect();
+    assert_eq!(first, expected, "the queue did not lead with the stalest");
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn payloads_of_returns_everything_needed_to_rebuild_a_row() {
+    // What `Core::heal_store_drift` restores an artifact from. Unlike
+    // `lifecycle_of` it has to carry the text, title, tags and category, or the
+    // restored row is an empty artifact with the right id.
+    let v = fresh("engram_it_payloads_of", 4).await;
+    v.upsert(vec![point(
+        "a",
+        "s1",
+        vec![1.0, 0.0, 0.0, 0.0],
+        &["t1", "t2"],
+        "procedure",
+    )])
+    .await
+    .unwrap();
+    v.set_lifecycle("a", ArtifactStatus::Deprecated, None)
+        .await
+        .unwrap();
+
+    let found = v
+        .payloads_of(&["a".to_string(), "never-existed".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        found.len(),
+        1,
+        "an id with no point must be absent, not empty"
+    );
+    let p = &found["a"];
+    assert_eq!(p.text, "text a");
+    assert_eq!(p.corpus_id, "s1");
+    assert_eq!(p.title.as_deref(), Some("a"));
+    assert_eq!(p.category.as_deref(), Some("procedure"));
+    assert_eq!(p.tags, vec!["t1".to_string(), "t2".to_string()]);
+    assert_eq!(p.created_at, 42);
+    assert_eq!(
+        p.status,
+        Some(ArtifactStatus::Deprecated),
+        "a restored artifact would come back active and searchable"
+    );
+    v.drop_collection().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_point_naming_no_artifact_does_not_keep_the_backfill_running_forever() {
+    // The backfill stamps artifacts, so a point naming none can never be
+    // stamped by it — and startup decides whether to run the backfill by
+    // counting unstamped points. Counting these meant the number never reached
+    // zero and every process start kicked off another full-base rewrite.
+    let v = fresh("engram_it_unkeyed", 4).await;
+    v.upsert(vec![point("a", "s1", vec![1.0, 0.0, 0.0, 0.0], &[], "c")])
+        .await
+        .unwrap();
+    raw(
+        reqwest::Method::PUT,
+        "/collections/engram_it_unkeyed/points?wait=true",
+        Some(serde_json::json!({
+            "points": [{
+                "id": "11111111-1111-1111-1111-111111111111",
+                "vector": { "dense": [0.0, 0.0, 0.0, 1.0] },
+                "payload": { "something": "else" },
+            }],
+        })),
+    )
+    .await;
+    v.set_last_verified_at("a", 1, false).await.unwrap();
+
+    assert_eq!(
+        v.unstamped_count().await.unwrap(),
+        0,
+        "startup would run the whole backfill again on every single start"
+    );
+    v.drop_collection().await.unwrap();
+}


### PR DESCRIPTION
## Summary
- Adds a real lifecycle (`active`/`deprecated`/`superseded`) plus `last_verified_at` to both SQLite (source of truth) and the Qdrant payload — freshness is now tracked instead of implied by `created_at`.
- Search excludes deprecated/superseded artifacts by default; opt-in via `include_deprecated`/`include_superseded` on the search API and MCP tool.
- Recency-decay scoring now reads `last_verified_at` instead of `created_at`.
- The consolidation judge can propose a supersede direction (which artifact is obsolete) on a contradicting pair; an operator confirms it via a new Ops action before anything is actually hidden — nothing is auto-applied.
- New `Core::deprecate`/`reactivate`/`verify`/`supersede` actions, wired into the Ops page and the artifact detail page.
- Retrieval activity (`hit_count`) feeds a one-way "stale candidates" review list only — deliberately never live search scoring, to avoid a popularity feedback loop (frequently-shown results boosting themselves further).
- `--backfill-lifecycle` CLI flag pushes SQLite's lifecycle state into existing Qdrant points after deploying the migration.

## Test plan
- [x] `cargo check --all-targets` — clean
- [x] `cargo test --lib` — 463 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [ ] Run `migrations/0011_lifecycle.sql` against production (automatic on next startup via `Store::migrate`)
- [ ] Run `engram --backfill-lifecycle` once after deploy to populate `status`/`last_verified_at` on existing Qdrant points (otherwise they score as maximally stale under the new decay formula until backfilled)
- [ ] Manually verify: deprecate/reactivate/verify buttons on Ops and artifact detail pages; judge-proposed supersede shows on Ops with an "Apply supersede" confirmation button

🤖 Generated with [Claude Code](https://claude.com/claude-code)