### PR TITLE
A job becomes one inference call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ rmcp = { version = "3.1.2", features = ["server", "transport-streamable-http-ser
 schemars = "1.2.2"
 
 [dev-dependencies]
+# `test-util` is not part of tokio's `full`. It carries the pausable clock the
+# gate's tests run on, so a cooldown is asserted exactly rather than slept
+# through.
+tokio = { version = "1.53.1", features = ["full", "test-util"] }
 tempfile = "3"
 temp-env = "0.3"
 wiremock = "0.6.5"

--- a/config.example.toml
+++ b/config.example.toml
@@ -206,11 +206,15 @@ sweep_hours = 6
 
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share
-# one GPU, so a per-role cooldown could not bound total load.
+# one GPU, so a per-role cooldown could not bound total load. Upgrading: this
+# replaces `cooldown_secs` under `[infer.synthesize]`, which is now ignored —
+# engram says so at startup if it finds one.
 [pacing]
 # Minimum seconds between the end of one background call and the start of the
-# next. Zero disables pacing. A question asked through `ask` ignores it: someone
-# is waiting, and the pacer is there to protect the GPU from batch work.
+# next, and only one background call runs at a time however many workers are
+# configured, so this is the gap between calls rather than per worker. Zero
+# disables pacing. A question asked through `ask` ignores it: someone is
+# waiting, and the pacer is there to protect the GPU from batch work.
 cooldown_secs = 0
 # Consecutive transport failures before background calls are held back, and how
 # long to hold them for before letting one through to probe. Output the parser

--- a/config.example.toml
+++ b/config.example.toml
@@ -219,6 +219,8 @@ cooldown_secs = 0
 # Consecutive transport failures before background calls are held back, and how
 # long to hold them for before letting one through to probe. Output the parser
 # cannot read does not count: the endpoint answered, and the window's own text
-# is the problem.
+# is the problem. Zero disables the breaker. Once it has tripped, the single
+# call let through after the probe window re-trips it immediately if it fails
+# too; a call that succeeds closes it.
 breaker_after = 3
 breaker_probe_secs = 60

--- a/config.example.toml
+++ b/config.example.toml
@@ -63,20 +63,6 @@ max_output_tokens = 16384
 # parsing partway through wants a higher number, not a lower one: a shorter
 # segment is a shorter reply. Lower it (1.5-2.0) for a large hosted model.
 output_ratio = 8.0
-# Seconds before the client gives up on one call. Defaults to 900. A timeout
-# looks exactly like a dead endpoint to the job runner: the job retries and
-# fails at the same wall, so this must exceed the model's real worst case.
-# timeout_secs = 900
-# Sent as `reasoning_effort` when set. On a reasoning model the thinking comes
-# out of max_output_tokens, so suppressing it is what stops the artifact list
-# from being cut off. Unset by default: models that do not reason reject the field.
-# reasoning_effort = "none"
-# Seconds to idle between segments. Synthesising a long corpus is
-# otherwise minutes of unbroken generation, which is a sustained thermal load
-# on a desktop card rather than a burst. It does not save energy — the same
-# tokens are generated either way — so it is off by default and exists for the
-# machine sitting next to you.
-# cooldown_secs = 15
 # Tokens of the document's verbatim opening prepended to every window, so an
 # artifact from deep in a long document still knows what product, version and
 # platform it belongs to — which is what the caveats field asks for and what a
@@ -217,3 +203,18 @@ retain_days = 0
 # How often retention is enforced. A window measured in days does not need
 # checking more often than this, and the sweep is a single DELETE.
 sweep_hours = 6
+
+# ── Pacing ───────────────────────────────────────────────────────────────────
+# One gap in front of every inference call, whatever its role. The roles share
+# one GPU, so a per-role cooldown could not bound total load.
+[pacing]
+# Minimum seconds between the end of one background call and the start of the
+# next. Zero disables pacing. A question asked through `ask` ignores it: someone
+# is waiting, and the pacer is there to protect the GPU from batch work.
+cooldown_secs = 0
+# Consecutive transport failures before background calls are held back, and how
+# long to hold them for before letting one through to probe. Output the parser
+# cannot read does not count: the endpoint answered, and the window's own text
+# is the problem.
+breaker_after = 3
+breaker_probe_secs = 60

--- a/config.example.toml
+++ b/config.example.toml
@@ -63,6 +63,17 @@ max_output_tokens = 16384
 # parsing partway through wants a higher number, not a lower one: a shorter
 # segment is a shorter reply. Lower it (1.5-2.0) for a large hosted model.
 output_ratio = 8.0
+# Seconds before the client gives up on one call. Defaults to 900. A timeout
+# looks exactly like a dead endpoint to the job runner: the job retries and
+# fails at the same wall, so this must exceed the model's real worst case.
+# timeout_secs = 900
+# Sent as `reasoning_effort` when set. On a reasoning model the thinking comes
+# out of max_output_tokens, so suppressing it is what stops the artifact list
+# from being cut off. Unset by default: models that do not reason reject the field.
+# reasoning_effort = "none"
+# Pacing moved to `[pacing]` at the bottom of this file. A `cooldown_secs` here
+# is ignored, and engram says so at startup rather than letting the setting
+# quietly stop happening.
 # Tokens of the document's verbatim opening prepended to every window, so an
 # artifact from deep in a long document still knows what product, version and
 # platform it belongs to — which is what the caveats field asks for and what a

--- a/docs/superpowers/plans/2026-08-13-independently-schedulable-inference.md
+++ b/docs/superpowers/plans/2026-08-13-independently-schedulable-inference.md
@@ -1,0 +1,1637 @@
+# Independently Schedulable Inference — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every inference call in engram an independently schedulable queue unit with its own attempt budget and backoff, paced by one global gate that also carries the interactive lane and a circuit breaker.
+
+**Architecture:** A job becomes one inference call. `Synthesize` and `Consolidate` stop making calls and become local work that *arms* units (`SegmentWindow`, `Title`, `Judge`, `Embed`). Claim ordering gains a `seq` column so units round-robin across documents. One `InferenceGate` in `Core` sits in front of every call site.
+
+**Tech Stack:** Rust 2024 (rustc 1.94), tokio, sqlx/SQLite, async-trait, tracing. Tests use `#[tokio::test]`, `tokio::time::pause`, and the fakes in `src/infer/fake.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md`
+
+## Global Constraints
+
+- `MAX_ATTEMPTS` stays `5`; it now means five attempts at **one unit**.
+- Backoff is unchanged: `backoff_secs`, doubling to a 21,600s ceiling.
+- Circuit breaker: **3** consecutive `Error::Inference` failures; probe interval **60s**. `Error::MalformedLlmOutput` must **not** trip it.
+- `workers = 1`. Nothing in this plan may introduce concurrency between units.
+- `migrate()` runs `schema.sql` on every connect and **cannot alter a table**. Adding a column is safe; dropping one is not. `segments.attempts` is therefore left in place and unused, never dropped.
+- `CREATE INDEX IF NOT EXISTS` on an existing name is a silent no-op — index changes require `DROP INDEX IF EXISTS` by the old name first.
+- Every task ends green: `cargo test`, `cargo clippy --all-targets` (no warnings), `cargo fmt --check`.
+- Commit at the end of every task. Branch is `feat/independently-schedulable-inference`.
+
+## Task 0 (operator, not code): settle window size
+
+Spec §10. Not a coding task and **not a blocker** for Tasks 1–10 — the unit is one window and one call whether a window is 512 or 2048 tokens. Run it before tuning the scheduler.
+
+Baselines already recorded: coverage `0.5539`, literal-flag rate `8 of 277 (2.9%)` on corpus `019ff75a-61b1-7703-aea9-f2a3ae9a0ddd`.
+
+Re-ingest that document at `output_ratio` 8.0, 16.0, 32.0. Capture coverage, flag rate, malformed-output count (from a clean run — the 2026-08-12 journal double-counts via cache replays), and eval `recall@k`/MRR. **Decision rule:** adopt the largest ratio at which malformed-output count is near zero and coverage does not regress.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/infer/gate.rs` | **new** — `InferenceGate`: cooldown, interactive lease, circuit breaker |
+| `src/jobs/window.rs` | **new** — the `SegmentWindow` handler and the settle rule |
+| `src/jobs/judge.rs` | **new** — the `Judge` handler, moved out of `consolidate.rs` |
+| `src/infer/mod.rs` | add `pub mod gate;` |
+| `src/config.rs` | global `cooldown_secs`, breaker settings |
+| `src/store/schema.sql` | `jobs.seq`, rebuilt claim index |
+| `src/store/jobs.rs` | new `Stage` variants, `seq`, claim ordering, unit-target helpers |
+| `src/jobs/mod.rs` | dispatch for the new stages |
+| `src/jobs/synthesize.rs` | shrinks to planning + settle; loses the window loop |
+| `src/jobs/embed.rs` | one batch per run, re-arms |
+| `src/jobs/consolidate.rs` | local only; arms `Judge` units |
+| `src/jobs/reconcile.rs` | arms per-window units; the migration path |
+| `src/core/mod.rs` | holds `Arc<InferenceGate>` |
+| `src/core/ask.rs` | holds an interactive lease |
+
+`synthesize.rs` is already ~1500 lines. Moving the window handler to `window.rs` is a split by responsibility, not a unilateral restructure.
+
+---
+
+### Task 1: The inference gate
+
+**Files:**
+- Create: `src/infer/gate.rs`
+- Modify: `src/infer/mod.rs` (add `pub mod gate;`)
+- Modify: `src/config.rs`
+
+**Interfaces:**
+- Produces: `InferenceGate::new(cooldown: Duration) -> InferenceGate`; `.with_breaker(after: usize, probe: Duration) -> InferenceGate`; `async fn background(&self)`; `fn interactive(self: &Arc<Self>) -> InteractiveLease`; `fn call_succeeded(&self)`; `fn call_failed(&self, e: &Error)`. `InteractiveLease` releases on `Drop`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/infer/gate.rs` with only the test module and the `use` lines:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn gate(cooldown_secs: u64) -> Arc<InferenceGate> {
+        Arc::new(InferenceGate::new(Duration::from_secs(cooldown_secs)))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_idle_gate_with_no_cooldown_lets_work_through_at_once() {
+        let g = gate(0);
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_cooldown_is_measured_from_when_the_last_call_ended() {
+        let g = gate(5);
+        g.call_succeeded();
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn background_work_waits_while_an_interactive_call_holds_a_lease() {
+        let g = gate(0);
+        let lease = g.interactive();
+        let g2 = Arc::clone(&g);
+        let waiter = tokio::spawn(async move { g2.background().await });
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        assert!(!waiter.is_finished(), "background ran while an ask was in flight");
+
+        drop(lease);
+        waiter.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_interactive_call_never_waits_even_during_a_cooldown() {
+        // The point of the lane: a person is waiting, and the pacer exists to
+        // protect the GPU from batch work, not from them.
+        let g = gate(600);
+        g.call_succeeded();
+        let started = tokio::time::Instant::now();
+        let _lease = g.interactive();
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn three_transport_failures_in_a_row_open_the_breaker() {
+        let g = Arc::new(
+            InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)),
+        );
+        for _ in 0..3 {
+            g.call_failed(&Error::Inference { role: "chunk", detail: "502".into() });
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::from_secs(60));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_success_closes_the_breaker_again() {
+        let g = Arc::new(
+            InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)),
+        );
+        for _ in 0..2 {
+            g.call_failed(&Error::Inference { role: "chunk", detail: "502".into() });
+        }
+        g.call_succeeded();
+        g.call_failed(&Error::Inference { role: "chunk", detail: "502".into() });
+
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO, "the run was not reset");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unreadable_output_is_not_an_endpoint_failure() {
+        // The distinction the whole design rests on: the model answered, so the
+        // endpoint is fine. Tripping the breaker here would stop the queue over
+        // one document's punctuation.
+        let g = Arc::new(
+            InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)),
+        );
+        for _ in 0..5 {
+            g.call_failed(&Error::MalformedLlmOutput("duplicate field `tags`".into()));
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib infer::gate`
+Expected: FAIL to compile — `InferenceGate` not found.
+
+- [ ] **Step 3: Implement the gate**
+
+Prepend to `src/infer/gate.rs`:
+
+```rust
+//! One pacer in front of every inference call.
+//!
+//! Three jobs that all answer the same question — may a background call start
+//! now? The cooldown protects a desktop GPU from unbroken load. The interactive
+//! lease keeps the worker from piling work onto the endpoint while a person is
+//! waiting on `ask`. The breaker stops thirty-four units from each spending a
+//! fifteen-minute timeout discovering the same dead endpoint.
+//!
+//! It sits around calls rather than around jobs, so the two stages that make no
+//! inference call — planning a corpus into windows, and the consolidation sweep
+//! — never wait for a cooldown they did not earn.
+
+use crate::error::Error;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::time::Instant;
+
+#[derive(Default)]
+struct GateState {
+    /// Interactive calls in flight. Background work waits while this is above
+    /// zero; it is a count rather than a flag because `ask` makes more than one
+    /// call and the UI can have two queries open.
+    interactive: usize,
+    last_finished: Option<Instant>,
+    consecutive_transport_failures: usize,
+    breaker_open_until: Option<Instant>,
+}
+
+pub struct InferenceGate {
+    state: Mutex<GateState>,
+    resumed: Notify,
+    cooldown: Duration,
+    breaker_after: usize,
+    probe_after: Duration,
+}
+
+impl InferenceGate {
+    pub fn new(cooldown: Duration) -> Self {
+        Self {
+            state: Mutex::new(GateState::default()),
+            resumed: Notify::new(),
+            cooldown,
+            // Off unless configured, so a test that does not ask for a breaker
+            // cannot be surprised by one.
+            breaker_after: usize::MAX,
+            probe_after: Duration::ZERO,
+        }
+    }
+
+    pub fn with_breaker(mut self, after: usize, probe: Duration) -> Self {
+        self.breaker_after = after.max(1);
+        self.probe_after = probe;
+        self
+    }
+
+    /// Returns when a background inference call may start.
+    pub async fn background(&self) {
+        loop {
+            // The lock is never held across an await: the wait is computed,
+            // dropped, and only then slept on.
+            let wait = {
+                let st = self.state.lock().expect("gate state");
+                if st.interactive > 0 {
+                    None
+                } else {
+                    let now = Instant::now();
+                    let ready_at = [
+                        st.last_finished.map(|t| t + self.cooldown),
+                        st.breaker_open_until,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .max();
+                    match ready_at {
+                        Some(t) if t > now => Some(t - now),
+                        _ => return,
+                    }
+                }
+            };
+            match wait {
+                Some(d) => tokio::time::sleep(d).await,
+                // Held off by an interactive call, which has no deadline. The
+                // lease wakes us when it drops.
+                None => self.resumed.notified().await,
+            }
+        }
+    }
+
+    /// A lease for an interactive call. Returns immediately, always.
+    pub fn interactive(self: &Arc<Self>) -> InteractiveLease {
+        self.state.lock().expect("gate state").interactive += 1;
+        InteractiveLease {
+            gate: Arc::clone(self),
+        }
+    }
+
+    pub fn call_succeeded(&self) {
+        let mut st = self.state.lock().expect("gate state");
+        st.last_finished = Some(Instant::now());
+        st.consecutive_transport_failures = 0;
+        st.breaker_open_until = None;
+    }
+
+    /// A failed call still occupied the GPU, so it still starts the cooldown.
+    /// Only a transport failure counts toward the breaker: `MalformedLlmOutput`
+    /// means the endpoint answered and this window's text is the problem.
+    pub fn call_failed(&self, e: &Error) {
+        let mut st = self.state.lock().expect("gate state");
+        st.last_finished = Some(Instant::now());
+        if !matches!(e, Error::Inference { .. }) {
+            return;
+        }
+        st.consecutive_transport_failures += 1;
+        if st.consecutive_transport_failures >= self.breaker_after {
+            st.breaker_open_until = Some(Instant::now() + self.probe_after);
+            // Reset so one further failure after the probe re-opens it, rather
+            // than every subsequent call re-arming from an already-tripped count.
+            st.consecutive_transport_failures = 0;
+            tracing::warn!(
+                probe_secs = self.probe_after.as_secs(),
+                "inference endpoint failed repeatedly; holding background calls"
+            );
+        }
+    }
+}
+
+pub struct InteractiveLease {
+    gate: Arc<InferenceGate>,
+}
+
+impl Drop for InteractiveLease {
+    fn drop(&mut self) {
+        {
+            let mut st = self.gate.state.lock().expect("gate state");
+            st.interactive = st.interactive.saturating_sub(1);
+            st.last_finished = Some(Instant::now());
+        }
+        self.gate.resumed.notify_waiters();
+    }
+}
+```
+
+- [ ] **Step 4: Register the module**
+
+In `src/infer/mod.rs`, add after `pub mod facts;`:
+
+```rust
+pub mod gate;
+```
+
+- [ ] **Step 5: Add the configuration**
+
+In `src/config.rs`, move `cooldown_secs` out of `SynthesizeRole` into a top-level section. Add:
+
+```rust
+/// Pacing for every inference call, not just synthesis. The roles share one
+/// GPU, so a per-role gap could not bound total load.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PacingConfig {
+    /// Minimum seconds between the end of one background call and the start of
+    /// the next. Zero disables pacing. `ask` ignores it.
+    #[serde(default)]
+    pub cooldown_secs: u64,
+    #[serde(default = "default_breaker_after")]
+    pub breaker_after: usize,
+    #[serde(default = "default_breaker_probe_secs")]
+    pub breaker_probe_secs: u64,
+}
+
+fn default_breaker_after() -> usize {
+    3
+}
+
+fn default_breaker_probe_secs() -> u64 {
+    60
+}
+
+impl Default for PacingConfig {
+    fn default() -> Self {
+        Self {
+            cooldown_secs: 0,
+            breaker_after: default_breaker_after(),
+            breaker_probe_secs: default_breaker_probe_secs(),
+        }
+    }
+}
+```
+
+Add `#[serde(default)] pub pacing: PacingConfig,` to `Config`. Keep `SynthesizeRole::cooldown_secs` and `Synthesizer::cooldown()` for now — Task 5 removes them, and removing them here would break `synthesize.rs` before its replacement exists.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --lib infer::gate && cargo clippy --all-targets && cargo fmt --check`
+Expected: 7 passed; clippy silent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/infer/gate.rs src/infer/mod.rs src/config.rs
+git commit -m "feat: one pacer in front of every inference call"
+```
+
+---
+
+### Task 2: `seq` and round-robin claiming
+
+**Files:**
+- Modify: `src/store/schema.sql:113-140`
+- Modify: `src/store/jobs.rs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `Store::enqueue_seq(stage: Stage, target_kind: &str, target_id: &str, seq: i64) -> Result<()>`. `enqueue` keeps its signature and delegates with `seq = 0`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/store/jobs.rs`:
+
+```rust
+#[tokio::test]
+async fn units_of_two_documents_interleave_rather_than_queueing_behind_each_other() {
+    // A thirty-four window document takes thirty-four consecutive row ids. Under
+    // id ordering a capture made during that ingest waits for every one of them.
+    let s = Store::memory().await.unwrap();
+    for i in 0..3 {
+        s.enqueue_seq(Stage::SegmentWindow, "segment", &format!("doc-a#{i}"), i)
+            .await
+            .unwrap();
+    }
+    for i in 0..3 {
+        s.enqueue_seq(Stage::SegmentWindow, "segment", &format!("doc-b#{i}"), i)
+            .await
+            .unwrap();
+    }
+
+    let mut order = Vec::new();
+    while let Some(j) = s.claim_job().await.unwrap() {
+        order.push(j.target_id);
+        s.complete_job(j.id).await.unwrap();
+    }
+    assert_eq!(
+        order,
+        vec!["doc-a#0", "doc-b#0", "doc-a#1", "doc-b#1", "doc-a#2", "doc-b#2"],
+        "the second document waited for the whole of the first"
+    );
+}
+
+#[tokio::test]
+async fn attempts_still_outrank_seq() {
+    // The fairness fix must survive the interleaving one: a unit that keeps
+    // failing sinks below fresher work whatever its position in a document.
+    let s = Store::memory().await.unwrap();
+    s.enqueue_seq(Stage::SegmentWindow, "segment", "sore#0", 0)
+        .await
+        .unwrap();
+    let j = s.claim_job().await.unwrap().unwrap();
+    s.fail_job(j.id, 0, "malformed llm output").await.unwrap();
+
+    s.enqueue_seq(Stage::SegmentWindow, "segment", "fresh#9", 9)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE jobs SET run_after = 0")
+        .execute(&s.pool)
+        .await
+        .unwrap();
+
+    let next = s.claim_job().await.unwrap().unwrap();
+    assert_eq!(next.target_id, "fresh#9", "a failing unit kept the front");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib store::jobs`
+Expected: FAIL to compile — no `Stage::SegmentWindow`, no `enqueue_seq`.
+
+- [ ] **Step 3: Add the schema column and index**
+
+In `src/store/schema.sql`, add to the `jobs` table body, after `created_at`:
+
+```sql
+  -- Position within the batch of units armed together: the window index, the
+  -- judge pair's index, the embed batch number. Zero for singletons. Claiming
+  -- orders by it so every document's first window runs before any document's
+  -- second, which is what stops a large ingest from starving a small one.
+  seq         INTEGER NOT NULL DEFAULT 0,
+```
+
+Replace the claim index. Note `run_after` sits **last** on purpose: an inequality ends an index's usable ordering, so leading with it would force a temp B-tree on every poll.
+
+```sql
+DROP INDEX IF EXISTS idx_jobs_claim;
+CREATE INDEX IF NOT EXISTS idx_jobs_claim2  ON jobs(state, attempts, seq, id, run_after);
+```
+
+- [ ] **Step 4: Add the stage and the enqueue variant**
+
+In `src/store/jobs.rs`, extend `Stage` with `SegmentWindow`, `Title` and `Judge`, wiring `as_str`/`parse` to `"segment_window"`, `"title"`, `"judge"`.
+
+Add:
+
+```rust
+/// Arm a unit at a given position within its batch. `enqueue` is this with
+/// `seq = 0`, which is right for singletons and wrong for the thirty-four
+/// windows of one document.
+pub async fn enqueue_seq(
+    &self,
+    stage: Stage,
+    target_kind: &str,
+    target_id: &str,
+    seq: i64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq)
+         VALUES (?, ?, ?, 'pending', 0, 0, ?, ?)
+         ON CONFLICT(stage, target_id) DO UPDATE SET
+           state = 'pending', attempts = 0, run_after = 0, last_error = NULL,
+           claimed_at = NULL, created_at = excluded.created_at, seq = excluded.seq",
+    )
+    .bind(stage.as_str())
+    .bind(target_kind)
+    .bind(target_id)
+    .bind(now())
+    .bind(seq)
+    .execute(&self.pool)
+    .await?;
+    Ok(())
+}
+```
+
+Rewrite `enqueue` to delegate: `self.enqueue_seq(stage, target_kind, target_id, 0).await`.
+
+In `claim_job`, change the ordering clause to `ORDER BY attempts, seq, id`. Add `seq = excluded.seq` is **not** wanted in `enqueue_after` — a re-armed unit keeps its position.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test --lib store::jobs && cargo clippy --all-targets && cargo fmt --check`
+Expected: PASS, including the pre-existing claim tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/schema.sql src/store/jobs.rs
+git commit -m "feat: units of different documents interleave in the queue"
+```
+
+---
+
+### Task 3: The `SegmentWindow` handler
+
+**Files:**
+- Create: `src/jobs/window.rs`
+- Modify: `src/jobs/mod.rs`
+
+**Interfaces:**
+- Consumes: `Stage::SegmentWindow` (Task 2).
+- Produces: `window::unit_target(corpus_id: &str, idx: i64) -> String` (`"{corpus_id}#{idx}"`); `window::parse_target(t: &str) -> Option<(&str, i64)>`; `async fn window::run(core: &Core, target: &str) -> Result<()>`.
+
+Nothing arms these units yet, so the existing pipeline keeps working and this task lands green. Task 4 flips the pipeline over.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::segments::SegmentState;
+
+    #[test]
+    fn a_unit_target_round_trips() {
+        let t = unit_target("019ff75a-61b1-7703-aea9-f2a3ae9a0ddd", 17);
+        assert_eq!(t, "019ff75a-61b1-7703-aea9-f2a3ae9a0ddd#17");
+        assert_eq!(
+            parse_target(&t),
+            Some(("019ff75a-61b1-7703-aea9-f2a3ae9a0ddd", 17))
+        );
+        assert_eq!(parse_target("no-hash"), None);
+        assert_eq!(parse_target("bad#notanumber"), None);
+    }
+
+    #[tokio::test]
+    async fn a_unit_segments_exactly_its_own_window() {
+        let core = test_core().await;
+        let body = (0..400)
+            .map(|i| format!("paragraph number {i} with some filler text"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        run(&core, &unit_target(&out.id, 0)).await.unwrap();
+
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert_eq!(windows[0].state, SegmentState::Done);
+        assert!(
+            windows[1..].iter().all(|w| w.state == SegmentState::Pending),
+            "a unit segmented a window that was not its own"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_unit_whose_window_no_longer_exists_is_not_found() {
+        // Re-segmenting can shorten a document. The stale unit must be dropped
+        // by run_one's NotFound path rather than retried for six hours.
+        let core = test_core().await;
+        let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        let err = run(&core, &unit_target(&out.id, 99)).await.unwrap_err();
+        assert!(matches!(err, crate::error::Error::NotFound));
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_reply_fails_only_this_window() {
+        let mut core = test_core().await;
+        let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+        core.synthesizer =
+            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on("alpha"));
+
+        let err = run(&core, &unit_target(&out.id, 0)).await.unwrap_err();
+        assert!(err.retryable(), "the window is still owed a call");
+        let w = &core.store.segments_for_corpus(&out.id).await.unwrap()[0];
+        assert!(
+            w.last_error.as_deref().is_some_and(|e| e.contains("duplicate field")),
+            "the window must carry the parser's own complaint"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib jobs::window`
+Expected: FAIL to compile — module does not exist.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `src/jobs/window.rs`. Move `resolve_span`, `write_segment_artifacts`, `from_context_only`, `paraphrased` and `flag_unverified` here from `synthesize.rs` unchanged, then add:
+
+```rust
+//! One window, one inference call.
+//!
+//! This is the unit the whole job model is built around: the smallest thing the
+//! synthesizer can be asked to do. Below it there is nothing — one call returns
+//! every artifact a window yields, eight on average — and above it was a job
+//! covering a whole document, which is what gave thirty-four windows a shared
+//! attempt budget and cost one of them twelve rounds of a six-hour backoff.
+
+use crate::core::Core;
+use crate::error::{Error, Result};
+use crate::store::segments::SegmentState;
+
+pub fn unit_target(corpus_id: &str, idx: i64) -> String {
+    format!("{corpus_id}#{idx}")
+}
+
+pub fn parse_target(target: &str) -> Option<(&str, i64)> {
+    let (corpus_id, idx) = target.rsplit_once('#')?;
+    Some((corpus_id, idx.parse().ok()?))
+}
+
+pub async fn run(core: &Core, target: &str) -> Result<()> {
+    let (corpus_id, idx) = parse_target(target).ok_or(Error::NotFound)?;
+    let w = core
+        .store
+        .segments_for_corpus(corpus_id)
+        .await?
+        .into_iter()
+        .find(|s| s.idx == idx)
+        // The window was re-split out of existence. `run_one` drops the job
+        // rather than retrying something that can never come back.
+        .ok_or(Error::NotFound)?;
+
+    if w.state == SegmentState::Done {
+        return Ok(());
+    }
+
+    let all = core.store.segments_for_corpus(corpus_id).await?;
+    let all_texts: Vec<&str> = all.iter().map(|s| s.text.as_str()).collect();
+    let ctx = crate::infer::context::WindowContext::build(
+        &all_texts,
+        idx as usize,
+        core.synthesizer.budget().context,
+        &core.counter,
+    );
+    let text = w.text.clone();
+
+    core.gate.background().await;
+    let first = core
+        .synthesizer
+        .segment(crate::infer::SegmentInput { core: &text, context: &ctx })
+        .await;
+    match &first {
+        Ok(_) => core.gate.call_succeeded(),
+        Err(e) => core.gate.call_failed(e),
+    }
+    let mut chunks = match first {
+        Ok(c) => c,
+        Err(e) => {
+            let reason = e.to_string();
+            tracing::warn!(
+                corpus_id,
+                window = idx,
+                lines = format!("{}-{}", w.start_line, w.end_line),
+                reason,
+                "window could not be segmented"
+            );
+            core.store
+                .set_segment_state(corpus_id, idx, SegmentState::Failed, Some(&reason))
+                .await?;
+            settle(core, corpus_id).await?;
+            return Err(e);
+        }
+    };
+
+    if paraphrased(&chunks, &text) {
+        tracing::warn!(corpus_id, window = idx, "literals missing; re-segmenting once");
+        core.gate.background().await;
+        let second = core
+            .synthesizer
+            .segment(crate::infer::SegmentInput { core: &text, context: &ctx })
+            .await;
+        match second {
+            Ok(c) => {
+                core.gate.call_succeeded();
+                chunks = c;
+            }
+            // The first reply parsed; it merely paraphrased. Keeping it and
+            // letting `flag_unverified` mark what went missing beats losing a
+            // window we can already read.
+            Err(e) => {
+                core.gate.call_failed(&e);
+                tracing::warn!(corpus_id, window = idx, error = %e,
+                    "the re-segmentation failed; keeping the first reply");
+            }
+        }
+    }
+
+    if !ctx.is_empty() {
+        let before = chunks.len();
+        chunks.retain(|c| !from_context_only(&c.text, &text, &ctx));
+        let dropped = before - chunks.len();
+        if dropped > 0 {
+            tracing::info!(corpus_id, window = idx, dropped,
+                "artifacts drawn from context blocks were dropped");
+        }
+    }
+
+    let body: String = text
+        .lines()
+        .skip(w.carry_lines as usize)
+        .collect::<Vec<_>>()
+        .join("\n");
+    for c in &mut chunks {
+        c.corpus_lines = Some(resolve_span(&c.text, &body, &w, c.corpus_lines));
+    }
+
+    let written = write_segment_artifacts(core, corpus_id, idx, proposed_to_new(idx, chunks)).await?;
+    flag_unverified(core, &written, &text).await?;
+    core.store
+        .set_segment_state(corpus_id, idx, SegmentState::Done, None)
+        .await?;
+
+    settle(core, corpus_id).await
+}
+```
+
+Leave `settle` as a stub that Task 4 fills in — it must exist for this to compile:
+
+```rust
+/// Filled in by Task 4.
+async fn settle(_core: &Core, _corpus_id: &str) -> Result<()> {
+    Ok(())
+}
+```
+
+Add `pub mod window;` to `src/jobs/mod.rs` and route the stage:
+
+```rust
+(Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
+```
+
+Add `pub gate: Arc<InferenceGate>` to `Core` in `src/core/mod.rs`, built in `from_config` from `cfg.pacing`, and in `test_support` as `Arc::new(InferenceGate::new(Duration::ZERO))`.
+
+Add `pub async fn plan(core: &Core, corpus_id: &str) -> Result<()>` to `synthesize.rs` as the split-and-upsert half of the current `run` — everything before the `for w in ...` loop. Task 4 makes it arm units.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+Expected: PASS. The old `synthesize::run` still drives the pipeline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/window.rs src/jobs/mod.rs src/jobs/synthesize.rs src/core/mod.rs
+git commit -m "feat: a window is a schedulable unit"
+```
+
+---
+
+### Task 4: Planning, settling, and flipping the pipeline
+
+**Files:**
+- Modify: `src/jobs/synthesize.rs`
+- Modify: `src/jobs/window.rs`
+
+**Interfaces:**
+- Consumes: `window::unit_target`, `window::run`, `Store::enqueue_seq`.
+- Produces: `synthesize::plan` arms one `SegmentWindow` per pending window and makes **no** inference call. `window::settle` is real.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/jobs/synthesize.rs` tests:
+
+```rust
+#[tokio::test]
+async fn planning_makes_no_inference_call_and_arms_one_unit_per_window() {
+    use crate::infer::fake::RecordingSynthesizer;
+    let mut core = test_core().await;
+    let rec = std::sync::Arc::new(RecordingSynthesizer::new(context_budget(30, 20)));
+    core.synthesizer = rec.clone();
+    let body = multi_segment_body();
+    let out = core.ingest(&body, "web", None).await.unwrap();
+
+    plan(&core, &out.id).await.unwrap();
+
+    assert_eq!(rec.seen.lock().unwrap().len(), 0, "planning called the model");
+    let windows = core.store.segments_for_corpus(&out.id).await.unwrap().len();
+    let armed: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM jobs WHERE stage = 'segment_window' AND state = 'pending'",
+    )
+    .fetch_one(&core.store.pool)
+    .await
+    .unwrap();
+    assert_eq!(armed as usize, windows);
+}
+
+#[tokio::test]
+async fn a_poisoned_window_does_not_stop_another_document() {
+    // The 2026-08-12 incident as a test. Document A holds a window whose reply
+    // never parses; document B must still reach ready.
+    let mut core = test_core().await;
+    let a = core
+        .ingest(&format!("STOPHERE poison\n\n{}", multi_segment_body()), "web", None)
+        .await
+        .unwrap();
+    let b = core.ingest("bravo one\n\nbravo two", "web", None).await.unwrap();
+    core.synthesizer =
+        std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on("STOPHERE"));
+
+    for _ in 0..200 {
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        if !crate::jobs::run_one(&core).await.unwrap_or(false) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        core.store.get_corpus(&b.id).await.unwrap().status,
+        CorpusStatus::Ready,
+        "the healthy document waited on the poisoned one"
+    );
+    assert_eq!(
+        core.store.get_corpus(&a.id).await.unwrap().status,
+        CorpusStatus::Partial,
+        "a document with one refused window settles partial, not failed"
+    );
+}
+
+#[tokio::test]
+async fn a_corpus_settles_around_a_window_that_will_not_resolve() {
+    // Per-unit budgets could hang a corpus forever: if no unit terminates, the
+    // settle never fires and thirty-three good windows never become searchable.
+    let mut core = test_core().await;
+    let body = format!("STOPHERE poison\n\n{}", multi_segment_body());
+    let out = core.ingest(&body, "web", None).await.unwrap();
+    core.synthesizer =
+        std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on("STOPHERE"));
+
+    for _ in 0..200 {
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        if !crate::jobs::run_one(&core).await.unwrap_or(false) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        core.store.get_corpus(&out.id).await.unwrap().status,
+        CorpusStatus::Partial
+    );
+    assert!(
+        !core.store.artifacts_for_corpus(&out.id).await.unwrap().is_empty(),
+        "the good windows' artifacts were never written"
+    );
+    let embed_armed: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM jobs WHERE stage = 'embed' AND target_id = ?",
+    )
+    .bind(&out.id)
+    .fetch_one(&core.store.pool)
+    .await
+    .unwrap();
+    assert_eq!(embed_armed, 1, "the good artifacts were never queued to embed");
+}
+
+#[tokio::test]
+async fn a_recovered_window_settles_the_corpus_again() {
+    let mut core = test_core().await;
+    let body = format!("STOPHERE poison\n\n{}", multi_segment_body());
+    let out = core.ingest(&body, "web", None).await.unwrap();
+    core.synthesizer =
+        std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on("STOPHERE"));
+    for _ in 0..200 {
+        sqlx::query("UPDATE jobs SET run_after = 0").execute(&core.store.pool).await.unwrap();
+        if !crate::jobs::run_one(&core).await.unwrap_or(false) { break; }
+    }
+
+    core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::default());
+    for _ in 0..200 {
+        sqlx::query("UPDATE jobs SET run_after = 0").execute(&core.store.pool).await.unwrap();
+        if !crate::jobs::run_one(&core).await.unwrap_or(false) { break; }
+    }
+
+    let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
+    assert!(windows.iter().all(|w| w.state == SegmentState::Done));
+    assert_eq!(
+        core.store.get_corpus(&out.id).await.unwrap().status,
+        CorpusStatus::Ready
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::synthesize`
+Expected: FAIL — planning arms nothing; the poisoned document blocks the other.
+
+- [ ] **Step 3: Make `plan` arm units**
+
+At the end of `synthesize::plan`, after `upsert_segments`:
+
+```rust
+    // One unit per window that has not resolved. `seq` is the window index, so
+    // this document's window 0 is claimed before any document's window 1.
+    for w in core.store.pending_segments(corpus_id).await? {
+        core.store
+            .enqueue_seq(
+                Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(corpus_id, w.idx),
+                w.idx,
+            )
+            .await?;
+    }
+    Ok(())
+```
+
+Delete the window loop and the old `run`. Point the `Synthesize | Enrich` dispatch arm in `jobs/mod.rs` at `synthesize::plan`.
+
+- [ ] **Step 4: Implement `settle`**
+
+Replace the stub in `src/jobs/window.rs`:
+
+```rust
+/// Everything that can only be decided once every window has resolved.
+///
+/// "Resolved" has to include a window that has spent its attempts, or a corpus
+/// would hang forever on one the model will not read: engram never abandons
+/// work, so that unit stays queued at the backoff ceiling and would otherwise
+/// hold thirty-three good windows out of the index indefinitely. The corpus
+/// settles around it and reports `partial`. If it later succeeds, this runs
+/// again — every step here is idempotent for exactly that reason.
+async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
+    let windows = core.store.segments_for_corpus(corpus_id).await?;
+    let unresolved = windows.iter().any(|w| {
+        w.state == SegmentState::Pending
+            || (w.state == SegmentState::Failed && attempts_for(core, corpus_id, w.idx) < MAX_ATTEMPTS)
+    });
+    if unresolved {
+        return Ok(());
+    }
+    crate::jobs::synthesize::finish(core, corpus_id).await
+}
+```
+
+`attempts_for` reads the unit's own job row, since `jobs.attempts` is now the single counter:
+
+```rust
+async fn attempts_for(core: &Core, corpus_id: &str, idx: i64) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT attempts FROM jobs WHERE stage = 'segment_window' AND target_id = ?",
+    )
+    .bind(unit_target(corpus_id, idx))
+    .fetch_optional(&core.store.pool)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or(MAX_ATTEMPTS)
+}
+```
+
+Make the `unresolved` closure `async`-friendly by collecting attempts first:
+
+```rust
+    let mut unresolved = false;
+    for w in &windows {
+        unresolved |= match w.state {
+            SegmentState::Pending => true,
+            SegmentState::Failed => attempts_for(core, corpus_id, w.idx).await < MAX_ATTEMPTS,
+            SegmentState::Done => false,
+        };
+    }
+```
+
+In `synthesize::finish`, remove the title call (Task 6 makes it a unit) and arm it instead:
+
+```rust
+    if src.title_hint.is_none() {
+        core.store.enqueue(Stage::Title, "corpus", corpus_id).await?;
+    }
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+Expected: PASS. Some old `synthesize` tests now fail — Task 10 removes them. If any block this task, mark them `#[ignore]` with a `// removed in Task 10` comment rather than deleting them here.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/jobs/synthesize.rs src/jobs/window.rs src/jobs/mod.rs
+git commit -m "feat: planning arms window units and the corpus settles around them"
+```
+
+---
+
+### Task 5: Wire the gate into `ask` and retire the per-role cooldown
+
+**Files:**
+- Modify: `src/core/ask.rs`
+- Modify: `src/infer/mod.rs`, `src/infer/openai.rs`, `src/infer/fake.rs`, `src/config.rs`
+
+**Interfaces:**
+- Consumes: `Core::gate`.
+- Produces: `Synthesizer::cooldown()` and `SynthesizeRole::cooldown_secs` are gone.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/core/ask.rs` tests:
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn a_question_holds_the_interactive_lane_for_its_whole_answer() {
+    use std::time::Duration;
+    let core = crate::core::test_support::test_core().await;
+    let gate = std::sync::Arc::clone(&core.gate);
+
+    let asking = tokio::spawn({
+        let core = core.clone();
+        async move {
+            core.ask(&AskRequest { question: "what".into(), ..Default::default() }).await
+        }
+    });
+    tokio::time::advance(Duration::from_millis(1)).await;
+
+    let waiter = tokio::spawn(async move { gate.background().await });
+    tokio::time::advance(Duration::from_secs(5)).await;
+    assert!(!waiter.is_finished(), "background work ran during an ask");
+
+    asking.await.unwrap().unwrap();
+    waiter.await.unwrap();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib core::ask`
+Expected: FAIL — background work is not held off.
+
+- [ ] **Step 3: Take the lease**
+
+At the top of `Core::ask`, before any inference:
+
+```rust
+    // Held for the whole answer, not per call: `ask` makes more than one, and a
+    // gap between them is a gap the worker would fill with a window.
+    let _lane = self.gate.interactive();
+```
+
+- [ ] **Step 4: Remove the per-role cooldown**
+
+Delete `Synthesizer::cooldown()` from the trait in `src/infer/mod.rs` and its implementations in `openai.rs` and `fake.rs` (including `PacedSynthesizer`, whose only purpose was that hook — replace its test with the gate's cooldown test from Task 1). Delete `SynthesizeRole::cooldown_secs` and `cooldown_secs = 0` from `config.example.toml`, adding a `[pacing]` section documenting `cooldown_secs`, `breaker_after`, `breaker_probe_secs`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/ask.rs src/infer src/config.rs config.example.toml
+git commit -m "feat: ask holds the interactive lane; cooldown becomes global"
+```
+
+---
+
+### Task 6: `Title` as a unit
+
+**Files:**
+- Modify: `src/jobs/synthesize.rs`, `src/jobs/mod.rs`
+
+**Interfaces:**
+- Produces: `async fn synthesize::run_title(core: &Core, corpus_id: &str) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn naming_a_corpus_is_its_own_unit() {
+    let core = test_core().await;
+    let out = core.ingest("alpha line\n\nbravo line", "web", None).await.unwrap();
+    plan(&core, &out.id).await.unwrap();
+    while crate::jobs::run_one(&core).await.unwrap() {}
+    assert_eq!(
+        core.store.get_corpus(&out.id).await.unwrap().title_hint.as_deref(),
+        Some("Fake title: alpha line")
+    );
+}
+
+#[tokio::test]
+async fn a_corpus_the_model_will_not_name_still_reaches_ready() {
+    // A name is decoration. Retrying it forever spends real calls on it, and
+    // failing the corpus over it would be worse.
+    let mut core = test_core().await;
+    let out = core.ingest("alpha line\n\nbravo line", "web", None).await.unwrap();
+    plan(&core, &out.id).await.unwrap();
+    while crate::jobs::run_one(&core).await.unwrap() {}
+    core.synthesizer =
+        std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing("no title for you"));
+    core.store.enqueue(Stage::Title, "corpus", &out.id).await.unwrap();
+
+    for _ in 0..MAX_ATTEMPTS + 2 {
+        sqlx::query("UPDATE jobs SET run_after = 0").execute(&core.store.pool).await.unwrap();
+        let _ = crate::jobs::run_one(&core).await;
+    }
+
+    let queued: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM jobs WHERE stage = 'title' AND state = 'pending'",
+    )
+    .fetch_one(&core.store.pool)
+    .await
+    .unwrap();
+    assert_eq!(queued, 0, "a cosmetic failure is retried forever");
+    assert!(core.store.get_corpus(&out.id).await.unwrap().title_hint.is_none());
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::synthesize`
+Expected: FAIL — no `title` stage handler.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Name a document. A failure past the attempt budget closes the job rather
+/// than retrying at the ceiling: the corpus keeps the snippet the UI falls back
+/// to, and a name is not worth four model calls a day forever.
+pub async fn run_title(core: &Core, corpus_id: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    if src.title_hint.is_some() {
+        return Ok(());
+    }
+    let titles: Vec<String> = core
+        .store
+        .artifacts_for_corpus(corpus_id)
+        .await?
+        .iter()
+        .filter_map(|c| c.title.clone())
+        .collect();
+
+    core.gate.background().await;
+    match core.synthesizer.title(&src.raw_text, &titles).await {
+        Ok(Some(t)) => {
+            core.gate.call_succeeded();
+            core.store.set_title_hint(corpus_id, &t).await?;
+            Ok(())
+        }
+        Ok(None) => {
+            core.gate.call_succeeded();
+            Ok(())
+        }
+        Err(e) => {
+            core.gate.call_failed(&e);
+            Err(e)
+        }
+    }
+}
+```
+
+In `jobs/mod.rs`, dispatch `(Stage::Title, _) => synthesize::run_title(core, &job.target_id).await`, and in the retryable arm add the give-up case:
+
+```rust
+    // A name is decoration; the corpus already has its fallback.
+    (Stage::Title, _) if exhausted => {
+        tracing::warn!(error = %e, "could not name this corpus; leaving it unnamed");
+        core.store.complete_job(job.id).await?;
+    }
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/synthesize.rs src/jobs/mod.rs
+git commit -m "feat: naming a document is its own unit"
+```
+
+---
+
+### Task 7: One embed batch per unit
+
+**Files:**
+- Modify: `src/jobs/embed.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_large_corpus_embeds_one_batch_per_claim() {
+    let core = crate::core::test_support::test_core().await;
+    let body = (0..70)
+        .map(|i| format!("paragraph {i} with filler"))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let out = core.ingest(&body, "web", None).await.unwrap();
+    crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+    while crate::jobs::run_one(&core).await.unwrap() {}
+
+    let chunks = core.store.artifacts_for_corpus(&out.id).await.unwrap().len();
+    assert!(chunks > BATCH, "the fixture must exceed one batch");
+    assert!(
+        core.store.pending_artifacts_for_corpus(&out.id).await.unwrap().is_empty(),
+        "the re-arm did not drain the corpus"
+    );
+}
+
+#[tokio::test]
+async fn one_run_embeds_at_most_one_batch() {
+    let core = crate::core::test_support::test_core().await;
+    let body = (0..70).map(|i| format!("p {i}")).collect::<Vec<_>>().join("\n\n");
+    let out = core.ingest(&body, "web", None).await.unwrap();
+    crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+    while let Some(j) = core.store.claim_job().await.unwrap() {
+        if j.stage == crate::store::jobs::Stage::Embed { break; }
+        let _ = crate::jobs::run_one(&core).await;
+        core.store.complete_job(j.id).await.unwrap();
+    }
+    let before = core.store.pending_artifacts_for_corpus(&out.id).await.unwrap().len();
+    run_corpus(&core, &out.id).await.unwrap();
+    let after = core.store.pending_artifacts_for_corpus(&out.id).await.unwrap().len();
+    assert_eq!(before - after, BATCH, "a run embedded more than one batch");
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::embed`
+Expected: FAIL — `run_corpus` drains every batch in one call.
+
+- [ ] **Step 3: Implement**
+
+In `run_corpus_with_limit`, replace the `for (chunks, texts) in batch.chunks(BATCH)...` loop with a single batch plus a re-arm:
+
+```rust
+    let (chunks, texts) = match (batch.get(..BATCH.min(batch.len())), texts.get(..BATCH.min(texts.len()))) {
+        (Some(c), Some(t)) if !c.is_empty() => (c, t.to_vec()),
+        _ => return settle_corpus(core, corpus_id).await,
+    };
+
+    core.gate.background().await;
+    match embed_batch(core, chunks, texts).await {
+        Ok(()) => core.gate.call_succeeded(),
+        Err(e) if input_too_large(&e) => {
+            core.gate.call_failed(&e);
+            tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
+            return split_into_artifact_jobs(core, corpus_id).await;
+        }
+        Err(e) => {
+            core.gate.call_failed(&e);
+            return Err(e);
+        }
+    }
+
+    // More to do: come back as a fresh unit rather than draining the corpus in
+    // one job, so a large document cannot monopolise the worker and each batch
+    // is paced and preemptible. `seq` climbs so later batches sink below other
+    // documents' first ones.
+    if !core.store.pending_artifacts_for_corpus(corpus_id).await?.is_empty() {
+        let next_seq = core.store.job_seq(Stage::Embed, corpus_id).await?.unwrap_or(0) + 1;
+        core.store
+            .enqueue_seq(Stage::Embed, "corpus", corpus_id, next_seq)
+            .await?;
+        return Ok(());
+    }
+    settle_corpus(core, corpus_id).await
+```
+
+Add to `src/store/jobs.rs`:
+
+```rust
+/// The `seq` a job currently carries, so a re-arming unit can climb rather than
+/// re-entering at the front.
+pub async fn job_seq(&self, stage: Stage, target_id: &str) -> Result<Option<i64>> {
+    Ok(sqlx::query_scalar::<_, i64>(
+        "SELECT seq FROM jobs WHERE stage = ? AND target_id = ?",
+    )
+    .bind(stage.as_str())
+    .bind(target_id)
+    .fetch_optional(&self.pool)
+    .await?)
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/embed.rs src/store/jobs.rs
+git commit -m "feat: one embed batch per unit, re-arming while chunks remain"
+```
+
+---
+
+### Task 8: `Judge` as a unit
+
+**Files:**
+- Create: `src/jobs/judge.rs`
+- Modify: `src/jobs/consolidate.rs`, `src/jobs/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn the_sweep_makes_no_inference_call_and_arms_one_unit_per_pair() {
+    // Twenty judge calls in one job was the second-worst blocker in the system.
+    let core = crate::core::test_support::test_core_with_pairs().await;
+    let before = core.completer_calls();
+
+    crate::jobs::consolidate::run(&core).await.unwrap();
+
+    assert_eq!(core.completer_calls(), before, "the sweep called the model");
+    let armed: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM jobs WHERE stage = 'judge' AND state = 'pending'",
+    )
+    .fetch_one(&core.store.pool)
+    .await
+    .unwrap();
+    assert!(armed > 0, "no judge units were armed");
+}
+```
+
+`test_core_with_pairs` does not exist yet. Add it to `test_support` in `src/core/mod.rs`. `record_pair(a, b, score)` writes a `pending` row directly, so the helper does not need a similarity sweep to produce one:
+
+```rust
+/// A core holding two artifacts and one pending pair between them, plus a
+/// counting completer so a test can assert the sweep made no call.
+pub async fn test_core_with_pairs() -> (Core, Arc<ScriptedCompleter>) {
+    let completer = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"contradicts":false}"#.to_string(),
+    ]));
+    let mut core = build(Arc::new(FakeSynthesizer::default()), None).await;
+    core.completer = completer.clone();
+
+    let out = core
+        .ingest("alpha paragraph here\n\nbravo paragraph here", "web", None)
+        .await
+        .unwrap();
+    crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+    while crate::jobs::run_one(&core).await.unwrap() {}
+
+    let artifacts = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+    assert!(artifacts.len() >= 2, "the fixture needs two artifacts to pair");
+    core.store
+        .record_pair(&artifacts[0].id, &artifacts[1].id, 0.9)
+        .await
+        .unwrap();
+
+    (core, completer)
+}
+```
+
+`ScriptedCompleter::calls()` already exists (`src/infer/fake.rs:514`), so the test reads `completer.calls()` rather than a new `Core` method. Adjust the test's first and third lines to:
+
+```rust
+    let (core, completer) = crate::core::test_support::test_core_with_pairs().await;
+    let before = completer.calls();
+    // ...
+    assert_eq!(completer.calls(), before, "the sweep called the model");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib jobs::consolidate`
+Expected: FAIL — the sweep judges inline.
+
+- [ ] **Step 3: Implement**
+
+Move the body of `judge_pending`'s loop into `src/jobs/judge.rs`:
+
+```rust
+//! One pair, one call.
+//!
+//! The sweep used to make up to `max_judgements` of these in a single job, so a
+//! consolidation run blocked every capture behind it for as long as twenty
+//! model calls took. The sweep now arms them and the queue paces them.
+
+pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
+    let id: i64 = pair_id.parse().map_err(|_| Error::NotFound)?;
+    let Some(p) = core.store.pair(id).await? else {
+        return Err(Error::NotFound);
+    };
+    let (Ok(a), Ok(b)) = (
+        core.store.get_artifact(&p.a_id).await,
+        core.store.get_artifact(&p.b_id).await,
+    ) else {
+        // One side was deleted or superseded while the unit waited.
+        core.store.record_judge_attempt(id).await?;
+        return Ok(());
+    };
+
+    core.gate.background().await;
+    let out = core
+        .completer
+        .complete(
+            crate::infer::prompt::JUDGE_SYSTEM,
+            &crate::infer::prompt::judge_prompt(
+                (a.title.as_deref().unwrap_or(""), &a.text),
+                (b.title.as_deref().unwrap_or(""), &b.text),
+            ),
+        )
+        .await;
+    match &out {
+        Ok(_) => core.gate.call_succeeded(),
+        Err(e) => core.gate.call_failed(e),
+    }
+    let (contradicts, detail, obsolete) = crate::infer::prompt::parse_judgement(&out?)?;
+    core.store.record_judge_attempt(id).await?;
+    apply_judgement(core, &p, contradicts, detail, obsolete).await
+}
+```
+
+`apply_judgement` is the existing post-parse half of `judge_pending`, moved verbatim. Add `Store::pair(id) -> Result<Option<ArtifactPair>>` alongside `pairs_to_judge`.
+
+In `consolidate.rs`, replace the `judge_pending` call with:
+
+```rust
+    if cfg.judge {
+        for (n, p) in core.store.pairs_to_judge(200).await?.into_iter().enumerate() {
+            if n >= core.consolidate.max_judgements {
+                break;
+            }
+            core.store
+                .enqueue_seq(Stage::Judge, "pair", &p.id.to_string(), n as i64)
+                .await?;
+        }
+    }
+```
+
+`seq` is the pair's index in the sweep, so twenty judge units do not all sit at `seq = 0` and jump the whole window queue.
+
+Dispatch `(Stage::Judge, _) => judge::run(core, &job.target_id).await`, and give it the same give-up arm as `Title`: past `MAX_ATTEMPTS` complete the job and leave the pair pending for a later sweep.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/judge.rs src/jobs/consolidate.rs src/jobs/mod.rs src/store/pairs.rs src/core/mod.rs
+git commit -m "feat: a judgement is its own unit"
+```
+
+---
+
+### Task 9: Reconcile and the deployment path
+
+**Files:**
+- Modify: `src/jobs/reconcile.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn an_old_corpus_level_job_becomes_per_window_units() {
+    // The deployment path: a database written before this change holds one
+    // Synthesize row per unfinished corpus and no window units at all.
+    let core = crate::core::test_support::test_core().await;
+    let body = (0..400)
+        .map(|i| format!("paragraph {i} with filler text"))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let out = core.ingest(&body, "web", None).await.unwrap();
+    crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+    // Wind the clock back to the old shape.
+    sqlx::query("DELETE FROM jobs WHERE stage = 'segment_window'")
+        .execute(&core.store.pool)
+        .await
+        .unwrap();
+    core.store
+        .enqueue(crate::store::jobs::Stage::Synthesize, "corpus", &out.id)
+        .await
+        .unwrap();
+
+    run(&core).await.unwrap();
+
+    let armed: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM jobs WHERE stage = 'segment_window' AND state = 'pending'",
+    )
+    .fetch_one(&core.store.pool)
+    .await
+    .unwrap();
+    let windows = core.store.segments_for_corpus(&out.id).await.unwrap().len();
+    assert_eq!(armed as usize, windows, "the old job did not become units");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib jobs::reconcile`
+Expected: FAIL — reconcile arms a corpus-level `Synthesize` job only.
+
+- [ ] **Step 3: Implement**
+
+In `reconcile::run`, replace the unfinished-segments branch:
+
+```rust
+            let segments = core.store.segments_for_corpus(&c.id).await?;
+            if segments.is_empty() {
+                // Never planned. The planning stage splits and arms the units.
+                core.store.enqueue(Stage::Synthesize, "corpus", &c.id).await?;
+                armed += 1;
+                continue;
+            }
+            let unresolved: Vec<_> = segments
+                .iter()
+                .filter(|w| w.state != SegmentState::Done)
+                .collect();
+            if !unresolved.is_empty() {
+                // Windows exist but their units do not — either a database from
+                // before units existed, or a process killed between two writes.
+                for w in unresolved {
+                    core.store
+                        .enqueue_seq(
+                            Stage::SegmentWindow,
+                            "segment",
+                            &crate::jobs::window::unit_target(&c.id, w.idx),
+                            w.idx,
+                        )
+                        .await?;
+                    armed += 1;
+                }
+                continue;
+            }
+```
+
+`enqueue_seq` is idempotent per `(stage, target_id)`, so a sweep over a healthy base still costs one query per hundred corpora and changes nothing.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib && cargo clippy --all-targets && cargo fmt --check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/reconcile.rs
+git commit -m "feat: reconcile arms window units, which is the upgrade path"
+```
+
+---
+
+### Task 10: Delete what the granularity change made dead
+
+**Files:**
+- Modify: `src/jobs/synthesize.rs`, `src/jobs/mod.rs`, `src/store/segments.rs`, `src/store/schema.sql`
+
+- [ ] **Step 1: Delete the code**
+
+- `fail_pending_segments` and its call site in `jobs/mod.rs`, plus the `(Stage::Synthesize, _) if exhausted` arm. Planning makes no inference call, so it cannot exhaust anything.
+- `REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS` and the `in_a_row` counter.
+- `Store::bump_segment_attempts` and every caller. `jobs.attempts` is the single counter.
+
+In `schema.sql`, leave `segments.attempts` in place — `migrate()` cannot drop a column — and comment it:
+
+```sql
+  -- Dead since 2026-08-13: `jobs.attempts` is the per-window counter now that a
+  -- window is its own unit. Left in place because `migrate` cannot drop a
+  -- column; remove when the database is next recreated.
+  attempts   INTEGER NOT NULL DEFAULT 0,
+```
+
+- [ ] **Step 2: Delete or rewrite the obsolete tests**
+
+Delete, with their premises: `a_window_the_model_refuses_is_marked_failed_not_split`, `a_burst_of_endpoint_failures_does_not_condemn_untried_windows`, `a_source_with_untried_windows_still_has_a_job_after_a_failure`, `a_segment_the_endpoint_refused_is_queued_again`, `a_model_refusing_everything_costs_a_handful_of_calls_not_one_per_window`, `a_window_the_parser_chokes_on_does_not_hold_up_the_rest_of_the_document`, `a_cooldown_paces_the_windows_it_segments`. Each asserts behaviour that only exists with a shared attempt budget or a per-role cooldown; Tasks 1, 4 and 6 cover the same ground at the new granularity.
+
+Un-ignore anything marked `// removed in Task 10` in Task 4 and delete it.
+
+- [ ] **Step 3: Run the whole suite**
+
+Run: `cargo test && cargo clippy --all-targets && cargo fmt --check`
+Expected: PASS, no warnings.
+
+- [ ] **Step 4: Verify the schema applies to the real database**
+
+```bash
+cp engram.db /tmp/upgrade-check.db
+sqlite3 /tmp/upgrade-check.db < <(sed -n '/── Jobs/,/idx_jobs_created/p' src/store/schema.sql)
+sqlite3 /tmp/upgrade-check.db "EXPLAIN QUERY PLAN
+  SELECT id FROM jobs WHERE state='pending' AND run_after <= 9999999999
+  ORDER BY attempts, seq, id LIMIT 1;"
+```
+
+Expected: `SEARCH jobs USING COVERING INDEX idx_jobs_claim2`, with **no** `USE TEMP B-TREE FOR ORDER BY`. A temp B-tree means the index column order is wrong — `run_after` must be last.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: remove what a shared attempt budget needed"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §3 unit model → Tasks 3, 4, 6, 7, 8. §4 gate, breaker, claim ordering, reconcile → Tasks 1, 2, 5, 9. §5 budgets and settle → Task 4 (settle), Tasks 6 and 8 (Title/Judge give-up arms). §6 deletions → Task 10. §7 schema and deployment → Tasks 2, 9, 10. §8 affinity → no task; it is a decision not to build something. §9 tests → all sixteen are placed: gate 1–5 in Task 1, 6–8 in Task 4, 9 in Task 2, 10–11 in Task 4, 12 in Task 3, 13 in Task 6, 14 in Task 8, 15 in Task 7, 16 in Task 9. §10 → Task 0. §11 out of scope, no tasks.
+
+**Type consistency.** `unit_target`/`parse_target` defined in Task 3, used in Tasks 4 and 9. `enqueue_seq` defined in Task 2, used in Tasks 4, 7, 8, 9. `job_seq` defined in Task 7, used only there. `Core::gate` added in Task 3, used in Tasks 3, 5, 6, 7, 8. `synthesize::plan` introduced in Task 3, completed in Task 4, used in Tasks 6, 7, 9. `settle` stubbed in Task 3, implemented in Task 4.
+
+**Known rough edge, flagged rather than hidden.** Task 4 may leave a handful of old tests temporarily `#[ignore]`d until Task 10. That is deliberate: it lets the pipeline flip land green in one commit instead of dragging test deletion into it. Every such marker carries a `// removed in Task 10` comment, and Task 10 step 2 sweeps them.
+
+**Risk worth naming before execution.** Task 4 is the one that flips the pipeline, and it is the largest. If it does not land cleanly, the failure mode is a half-migrated system where planning arms units but the old loop still runs — so it must be reviewed as a whole and not split further at execution time. Tasks 1, 2, 3 are all additive and safe to land independently; Task 4 is the commit to be careful about.

--- a/docs/superpowers/plans/2026-08-13-pr11-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-13-pr11-review-fixes.md
@@ -1,0 +1,1122 @@
+# PR #11 Review Fixes Implementation Plan
+
+> **Executed 2026-08-13.** Three things diverged from the plan as written, each
+> recorded at the task it affected: the breaker test could not use a paused
+> clock (Task 1), `arm_seq` turned out to be dead and was removed outright
+> (Task 5), and finding #5 was largely unreachable so Task 3 shrank to the part
+> that was real. Final state: 659 tests passing, clippy clean.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the six defects the code review of PR #11 ("A job becomes one inference call") found, without weakening any of the invariants that PR established.
+
+**Architecture:** Six independent fixes across the inference gate, the embed stage, the judge stage, the reconciliation sweep, the synthesis planner, and the consolidation sweep's reporting. Each is small and local. Two of them (Tasks 1 and 2) both touch `src/jobs/embed.rs`, so they are ordered to avoid edit conflicts; the rest are independent and could in principle be done in any order.
+
+**Tech Stack:** Rust, tokio, sqlx over SQLite, `cargo test --lib` for the inline `#[cfg(test)] mod tests` blocks each file carries.
+
+## Global Constraints
+
+- Branch is `feat/independently-schedulable-inference`. Do not merge or push; commit only.
+- Every test lives in the inline `#[cfg(test)] mod tests` block at the bottom of the file it tests. There is no separate `tests/` file to add to for any task here.
+- Verification command for every task: `cargo test --lib` (currently 653 passing). Individual tests: `cargo test --lib <test_name>`.
+- **Comment style is load-bearing in this codebase.** Comments explain *why*, in prose, and usually name the concrete failure the code prevents. Match that register — every comment written in this plan is the comment to use, verbatim. Do not summarise them down to one line.
+- Do not add dependencies.
+- `MAX_ATTEMPTS`, `BATCH`, `SAFETY` and the other existing constants keep their current values.
+
+---
+
+### Task 1: An oversize refusal must not open the circuit breaker
+
+**Files:**
+- Modify: `src/infer/gate.rs:138-168` (add `call_refused`), `src/infer/gate.rs:182-190` (add `BackgroundPermit::refused`)
+- Modify: `src/jobs/embed.rs:74-92`, `src/jobs/embed.rs:141-145`, `src/jobs/embed.rs:320-344`
+- Test: `src/infer/gate.rs` tests module, `src/jobs/embed.rs` tests module
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `InferenceGate::call_refused(&self)` and `BackgroundPermit::refused(self)`. Both take no error argument — a refusal carries no information the gate acts on. Task 2 does not use them.
+
+**Background:** `gate.rs:151` counts every `Error::Inference` toward `consecutive_transport_failures`. `embed.rs`'s `input_too_large()` matches on `Error::Inference { role: "embed", .. }`, so a semantic refusal — the endpoint answered, saying the chunk exceeds its physical batch — is counted as a transport failure. Three unsplittable oversize chunks in one corpus trips the default `breaker_after = 3` and holds *all* background inference for `breaker_probe_secs` against a healthy endpoint. This is the same category as `MalformedLlmOutput`, which the gate already excludes.
+
+- [ ] **Step 1: Write the failing gate test**
+
+Add to the `mod tests` block in `src/infer/gate.rs`, after `unreadable_output_is_not_an_endpoint_failure`:
+
+```rust
+    #[tokio::test(start_paused = true)]
+    async fn a_refused_input_is_not_an_endpoint_failure() {
+        // The endpoint answered: this input is too big for it. That is a fact
+        // about the input, not about the endpoint's health — the same
+        // distinction `MalformedLlmOutput` gets, arriving here as an
+        // `Error::Inference` only because a size refusal is transport-shaped.
+        // Counted, three unsplittable oversize chunks in one document would
+        // hold every background call in the system — synthesis and judging
+        // included — against a server that is working perfectly.
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)));
+        for _ in 0..5 {
+            g.background().await.refused();
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cargo test --lib a_refused_input_is_not_an_endpoint_failure`
+Expected: compile error — `no method named 'refused' found for struct 'BackgroundPermit'`.
+
+- [ ] **Step 3: Add `call_refused` to the gate**
+
+In `src/infer/gate.rs`, insert immediately after the `call_failed` method (which ends at line 168, before the closing `}` of `impl InferenceGate`):
+
+```rust
+    /// A call the endpoint answered by refusing the input.
+    ///
+    /// It occupied the GPU, so it starts the cooldown like any other call. It
+    /// says nothing about whether the endpoint is well, so it must not count
+    /// toward the breaker — the same distinction `MalformedLlmOutput` gets, and
+    /// it has to be made by the caller because a size refusal arrives as an
+    /// `Error::Inference` and is indistinguishable here from a dead server.
+    pub fn call_refused(&self) {
+        let mut st = self.state.lock().expect("gate state");
+        st.last_finished = Some(Instant::now());
+    }
+```
+
+- [ ] **Step 4: Add `refused` to the permit**
+
+In `src/infer/gate.rs`, inside `impl BackgroundPermit<'_>`, after `failed`:
+
+```rust
+    /// The endpoint answered, refusing the input. Starts the cooldown and hands
+    /// the turn on, without counting against the endpoint.
+    pub fn refused(self) {
+        self.gate.call_refused();
+    }
+```
+
+- [ ] **Step 5: Run the gate test to verify it passes**
+
+Run: `cargo test --lib a_refused_input_is_not_an_endpoint_failure`
+Expected: PASS
+
+- [ ] **Step 6: Commit the gate half**
+
+```bash
+git add src/infer/gate.rs
+git commit -m "feat: a refusal is not the endpoint failing"
+```
+
+**Executed note:** Steps 7-8 below specify `#[tokio::test(start_paused = true)]`
+for the embed-level test. That does not work: building a `Core` opens an sqlx
+pool, and a pool acquired under a paused clock waits on a timer that never fires,
+so the test panics with `pool timed out while waiting for an open connection`.
+The shipped test is a plain `#[tokio::test]` asserting through
+`tokio::time::timeout(100ms, core.gate.background())`, the same real-time pattern
+`the_per_chunk_path_is_paced_like_every_other_call` already uses. The gate-level
+test in Steps 1-5 keeps `start_paused` — it builds no `Core`.
+
+- [ ] **Step 7: Write the failing embed test**
+
+Add to the `mod tests` block in `src/jobs/embed.rs`, after `a_refusal_during_the_as_is_attempt_still_ends_in_a_split`:
+
+```rust
+    #[tokio::test(start_paused = true)]
+    async fn a_size_refusal_does_not_hold_the_rest_of_the_queue() {
+        // Three unsplittable oversize chunks — code blocks, tables, the exact
+        // thing `split_oversize`'s hard path exists for — used to be three
+        // consecutive transport failures. At the default `breaker_after` that
+        // opened the breaker and stopped synthesis, judging and embedding alike
+        // for the whole probe window, against an endpoint that was answering
+        // every request it was given.
+        let mut core = crate::core::test_support::test_core().await;
+        core.gate = std::sync::Arc::new(
+            crate::infer::gate::InferenceGate::new(std::time::Duration::ZERO)
+                .with_breaker(1, std::time::Duration::from_secs(60)),
+        );
+        core.embedder = std::sync::Arc::new(crate::infer::fake::StrictEmbedder::new(
+            crate::core::test_support::TEST_DIM,
+            200,
+        ));
+
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let body = (0..40)
+            .map(|i| format!("paragraph {i} with a good deal of filler text in it"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: body,
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        // The configured limit is the lie; the endpoint's is what bites.
+        run_with_limit(&core, &made[0].id, 8192).await.unwrap();
+
+        let started = tokio::time::Instant::now();
+        core.gate.background().await;
+        assert_eq!(
+            started.elapsed(),
+            std::time::Duration::ZERO,
+            "a chunk the endpoint refused opened the breaker"
+        );
+    }
+```
+
+- [ ] **Step 8: Run it to make sure it fails**
+
+Run: `cargo test --lib a_size_refusal_does_not_hold_the_rest_of_the_queue`
+Expected: FAIL — `assertion 'left == right' failed: a chunk the endpoint refused opened the breaker`, left `60s`, right `0ns`.
+
+- [ ] **Step 9: Report the refusal as a refusal in `run_with_limit`**
+
+In `src/jobs/embed.rs`, in `run_with_limit`, change the `input_too_large` arm's first line. Replace:
+
+```rust
+        Err(e) if input_too_large(&e) => {
+            permit.failed(&e);
+```
+
+with:
+
+```rust
+        Err(e) if input_too_large(&e) => {
+            // Refused, not failed: the endpoint answered. Counting this toward
+            // the breaker let a handful of oversize chunks stop every
+            // background call in the system.
+            permit.refused();
+```
+
+- [ ] **Step 10: Report the refusal as a refusal in `run_corpus_with_limit`**
+
+In the same file, in `run_corpus_with_limit`, replace:
+
+```rust
+        Err(e) if input_too_large(&e) => {
+            permit.failed(&e);
+            tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
+```
+
+with:
+
+```rust
+        Err(e) if input_too_large(&e) => {
+            // Refused, not failed: the endpoint answered, and what it answered
+            // is about one chunk in this batch rather than about the endpoint.
+            permit.refused();
+            tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
+```
+
+- [ ] **Step 11: Report the refusal as a refusal in `split_oversize`, and cover the no-budget case with it**
+
+In `split_oversize`, the fall-through match currently has two error arms. Replace the whole `Err(e) if input_too_large(&e) && budget > 0 => { ... }` arm *and* leave the general `Err(e)` arm in place, so the two read:
+
+```rust
+        // Refused, not failed: the endpoint answered. This arm no longer tests
+        // `budget`, because a refusal we cannot act on is still a refusal —
+        // reporting it as a sick endpoint was how a single untouchable chunk
+        // could hold the breaker open on every retry of it.
+        Err(e) if input_too_large(&e) => {
+            permit.refused();
+            // Still nothing to cut with when the title alone fills the limit:
+            // `split_by_lines` at a budget of zero puts every line in a part of
+            // its own and then falls to the 64-character floor, which shreds the
+            // text into fragments that are each still oversize once they inherit
+            // the title. A refusal we cannot act on is reported as one.
+            if budget > 0 {
+                let parts = split_by_lines(&chunk.text, budget, &core.counter);
+                if parts.len() > 1 {
+                    tracing::warn!(artifact_id = %chunk.id, parts = parts.len(), "endpoint refused it whole; cutting on lines");
+                    return replace_with_siblings(core, chunk, parts).await;
+                }
+            }
+            return Err(e);
+        }
+        Err(e) => {
+            permit.failed(&e);
+            return Err(e);
+        }
+```
+
+- [ ] **Step 12: Run the embed test to verify it passes**
+
+Run: `cargo test --lib a_size_refusal_does_not_hold_the_rest_of_the_queue`
+Expected: PASS
+
+- [ ] **Step 13: Run the whole suite to check for regressions**
+
+Run: `cargo test --lib`
+Expected: PASS, 655 tests. `a_refusal_with_no_budget_left_is_reported_rather_than_shredded` must still pass — the restructured arm still returns `Err(e)` when `budget == 0`.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/jobs/embed.rs
+git commit -m "fix: a chunk the endpoint will not take is not a broken endpoint"
+```
+
+---
+
+### Task 2: A batch job makes one inference call, oversize chunks included
+
+**Files:**
+- Modify: `src/jobs/embed.rs:110-125` (the scan loop in `run_corpus_with_limit`)
+- Modify: `src/jobs/embed.rs:1189-1209` (the `an_oversize_chunk_does_not_block_its_siblings` test)
+- Test: `src/jobs/embed.rs` tests module
+
+**Interfaces:**
+- Consumes: `Store::rearm_idle_seq(stage, target_kind, target_id, seq)` — already exists at `src/store/jobs.rs:197`.
+- Produces: nothing new. `run_corpus_with_limit` keeps its signature.
+
+**Background:** `run_corpus_with_limit` now takes at most `BATCH` chunks per job, but the loop above it still calls `split_oversize` for *every* oversize pending chunk, and that function's fall-through path makes a gated inference call apiece. A corpus with 50 unsplittable oversize chunks makes 50 sequential model calls inside one job — exactly the head-of-line blocking this PR set out to remove, and with `pacing.cooldown_secs > 0` it holds the turn for `50 × cooldown`.
+
+The fix: the batch path stops splitting entirely. An oversize chunk gets its own per-artifact `Embed` unit, and `run_with_limit` — which already handles the oversize case at line 61 — splits it in a job of its own. This terminates: `rearm_if_more` stops re-arming the batch once `pending_artifacts_are_isolated` is true, and an exhausted per-artifact unit is marked embed-failed by `run_one` (`src/jobs/mod.rs:111-116`), which settles the corpus.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `src/jobs/embed.rs`, next to `one_run_embeds_at_most_one_batch`:
+
+```rust
+    #[tokio::test]
+    async fn oversize_chunks_do_not_turn_one_batch_into_many_calls() {
+        // `split_oversize` can cost a model call of its own — its fall-through
+        // embeds the chunk whole to find out whether our estimate was wrong —
+        // and the scan ran it once per oversize chunk. Fifty of them was fifty
+        // sequential calls inside a job that is allowed exactly one, holding the
+        // turn for fifty cooldowns before anything else could run.
+        let (core, embedder) = crate::core::test_support::test_core_counting_embed_calls().await;
+        let big = "alpha ".repeat(400);
+        let (src_id, _) = seed(&core, &[&big, &big, &big, "small"]).await;
+
+        run_corpus_with_limit(&core, &src_id, 200).await.unwrap();
+
+        assert_eq!(
+            embedder.calls(),
+            1,
+            "the batch job made more than one inference call"
+        );
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs
+              WHERE stage = 'embed' AND target_kind = 'artifact' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed, 3, "each oversize chunk should have got its own unit");
+    }
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cargo test --lib oversize_chunks_do_not_turn_one_batch_into_many_calls`
+Expected: FAIL — `embedder.calls()` is 4 (three fall-through splits plus the batch), and `armed` is 6 (the sibling units `replace_with_siblings` enqueued) rather than 3.
+
+- [ ] **Step 3: Arm a unit instead of splitting inline**
+
+In `src/jobs/embed.rs`, replace the scan loop in `run_corpus_with_limit`. The current body is:
+
+```rust
+    for chunk in pending {
+        let text = embed_text(&chunk);
+        if core.counter.count(&text) > limit {
+            split_oversize(core, &chunk, limit, false).await?;
+        } else {
+            texts.push(text);
+            batch.push(chunk);
+        }
+    }
+```
+
+Replace it with:
+
+```rust
+    for chunk in pending {
+        let text = embed_text(&chunk);
+        if core.counter.count(&text) > limit {
+            // Splitting is not free: `split_oversize` falls through to embedding
+            // the chunk whole when there is no boundary to cut on, and that is a
+            // model call. Doing it here made a job that is allowed one call make
+            // one per oversize chunk — fifty of them held the turn for fifty
+            // cooldowns, which is the head-of-line blocking one-batch-per-run
+            // exists to prevent. Its own unit instead, where `run_with_limit`
+            // splits it paced like everything else.
+            //
+            // Idle-only: `rearm_if_more` brings this job back for every batch of
+            // a long document, and `enqueue` would wind the attempts of a unit
+            // already queued back to zero on each of them.
+            core.store
+                .rearm_idle_seq(Stage::Embed, "artifact", &chunk.id, 0)
+                .await?;
+        } else {
+            texts.push(text);
+            batch.push(chunk);
+        }
+    }
+```
+
+Also update the comment directly above the loop. Replace:
+
+```rust
+    // An oversize chunk becomes siblings instead of a vector, so it cannot ride
+    // along in a batch. It leaves behind its own per-chunk jobs.
+```
+
+with:
+
+```rust
+    // An oversize chunk becomes siblings instead of a vector, so it cannot ride
+    // along in a batch — and finding out how to cut it can itself cost a call.
+    // It gets a unit of its own and this job goes on without it.
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `cargo test --lib oversize_chunks_do_not_turn_one_batch_into_many_calls`
+Expected: PASS
+
+- [ ] **Step 5: Run the suite and expect one existing test to fail**
+
+Run: `cargo test --lib`
+Expected: FAIL in `an_oversize_chunk_does_not_block_its_siblings` — it calls `run_corpus_with_limit` directly and asserts `chunks.len() > 3`, but the split now happens in a separate unit that this test never runs. This is the intended behaviour change, not a bug; the next step updates the test to assert the new seam.
+
+- [ ] **Step 6: Update `an_oversize_chunk_does_not_block_its_siblings`**
+
+Replace the body of that test (`src/jobs/embed.rs`, currently lines 1189-1209) with:
+
+```rust
+    #[tokio::test]
+    async fn an_oversize_chunk_does_not_block_its_siblings() {
+        // It becomes siblings rather than a vector, so it cannot ride along in
+        // the batch. The rest of the source must still be embedded, and the
+        // oversize one must be handed to a unit of its own rather than split
+        // here — splitting can cost a call this job has already spent.
+        let core = test_core().await;
+        let big = format!("{}\n\n{}", "alpha ".repeat(400), "beta ".repeat(400));
+        let (src_id, ids) = seed(&core, &["small one", &big, "small two"]).await;
+
+        run_corpus_with_limit(&core, &src_id, 200).await.unwrap();
+
+        assert_eq!(
+            core.vectors.count().await.unwrap(),
+            2,
+            "the two small chunks should be embedded"
+        );
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs
+              WHERE stage = 'embed' AND target_kind = 'artifact' AND target_id = ?
+                AND state = 'pending'",
+        )
+        .bind(&ids[1])
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed, 1, "the oversize chunk was not given its own unit");
+
+        // And that unit does the split, so nothing is lost by deferring it.
+        run_with_limit(&core, &ids[1], 200).await.unwrap();
+        let chunks = core.store.artifacts_for_corpus(&src_id).await.unwrap();
+        assert!(
+            chunks.len() > 3,
+            "the oversize chunk should have become siblings, got {}",
+            chunks.len()
+        );
+    }
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `cargo test --lib`
+Expected: PASS, 656 tests. Watch in particular that `a_long_document_re_arms_itself_until_it_is_drained` and `isolating_a_batch_does_not_put_the_batch_straight_back` still pass — both exercise the `rearm_if_more` termination this change relies on.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/jobs/embed.rs
+git commit -m "fix: an oversize chunk costs its own unit, not this job's turn"
+```
+
+---
+
+### Task 3: A pair whose artifact is gone is closed, not left pending
+
+**Files:**
+- Modify: `src/jobs/judge.rs:23-30`
+- Modify: `src/jobs/consolidate.rs:473-478` (the matching `continue` in `arm_judgements`)
+- Test: `src/jobs/judge.rs` tests module
+
+**Interfaces:**
+- Consumes: `Store::get_artifact` returns `Err(Error::NotFound)` for a missing row (`src/store/artifacts.rs:272`), `Store::set_pair_state(id, PairState, Option<&str>)`.
+- Produces: nothing new.
+
+**Executed note — this task shrank.** `artifact_pairs.a_id` and `b_id` are
+`REFERENCES artifacts(id) ON DELETE CASCADE` (`src/store/schema.sql:160-161`) and
+every pool sets `foreign_keys(true)` (`src/store/mod.rs:36,156,336`), so deleting
+an artifact takes its pairs with it. A pair naming an artifact that is gone is a
+state the schema forbids, which makes the permanent-pending leak this task was
+written for unreachable — the test in Step 1 fails at `get_pair`, not at the
+assertion. What was real is the error swallowing, so the shipped change is
+narrower than the steps below: both call sites use `?` on `get_artifact` and the
+deletion branch is deleted along with the comment claiming it happens. No
+`NotFound` arm, and no test — injecting a store failure needs scaffolding that
+does not exist. Steps 1-5 below are superseded; Step 5's `arm_judgements` edit
+was applied in the same narrowed form.
+
+**Background (as originally written):** The `let (Ok(a), Ok(b)) = … else` swallows *any* error from `get_artifact`, not just `NotFound`. It records an attempt and returns `Ok`, so `run_one` closes the unit while the pair stays `Pending`. `pairs_to_judge` (`src/store/pairs.rs:233`) has no attempts ceiling, and `arm_judgements` hits the same `continue` and never dismisses it either — so the pair sits in the review queue permanently. A transient store error is also miscategorised as a deletion.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `src/jobs/judge.rs`. If that file has no `mod tests` block yet, create one at the end of the file with `use super::*;` and `use crate::core::test_support::test_core;` at its top.
+
+```rust
+    #[tokio::test]
+    async fn a_pair_whose_artifact_is_gone_is_closed_rather_than_left_pending() {
+        // `pairs_to_judge` has no attempts ceiling, so a pair left pending here
+        // is pending for good: this unit closes without settling it, and the
+        // next sweep's `arm_judgements` skips it for exactly the same reason.
+        // It sits in the operator's review queue naming an artifact that does
+        // not exist, forever.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "the mount point is /srv".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(0),
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "the mount point is /mnt".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(0),
+                        caveats: vec![],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        core.store
+            .record_pair(&made[0].id, &made[1].id, 0.9)
+            .await
+            .unwrap();
+        let pair = core.store.pairs_to_judge(1).await.unwrap().remove(0);
+
+        // The half the unit will not find when it is finally claimed.
+        core.store.delete_artifact(&made[1].id).await.unwrap();
+
+        run(&core, &pair.id.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store.get_pair(pair.id).await.unwrap().state,
+            PairState::Dismissed,
+            "the pair was left pending with nothing left that could settle it"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cargo test --lib a_pair_whose_artifact_is_gone_is_closed_rather_than_left_pending`
+Expected: FAIL — state is `Pending`, not `Dismissed`.
+
+- [ ] **Step 3: Tell a deletion apart from a sick store in `judge::run`**
+
+In `src/jobs/judge.rs`, replace:
+
+```rust
+    let (Ok(a), Ok(b)) = (
+        core.store.get_artifact(&p.a_id).await,
+        core.store.get_artifact(&p.b_id).await,
+    ) else {
+        // One side was deleted while the unit waited. Nothing to compare.
+        core.store.record_judge_attempt(id).await?;
+        return Ok(());
+    };
+```
+
+with:
+
+```rust
+    let (a, b) = match (
+        core.store.get_artifact(&p.a_id).await,
+        core.store.get_artifact(&p.b_id).await,
+    ) {
+        (Ok(a), Ok(b)) => (a, b),
+        // One side was deleted while the unit waited. Dismissed rather than
+        // left pending: `pairs_to_judge` has no attempts ceiling, so a pending
+        // pair nothing can compare stays at the head of every sweep and in the
+        // operator's review queue for good — `arm_judgements` skips it for the
+        // same reason this unit does, so neither of them would ever close it.
+        (Err(Error::NotFound), _) | (_, Err(Error::NotFound)) => {
+            core.store
+                .set_pair_state(id, PairState::Dismissed, None)
+                .await?;
+            return Ok(());
+        }
+        // Any other error is the store being unwell, not an artifact being
+        // gone. Reporting it keeps the unit retryable instead of settling a
+        // pair on the strength of a failed read.
+        (Err(e), _) | (_, Err(e)) => return Err(e),
+    };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --lib a_pair_whose_artifact_is_gone_is_closed_rather_than_left_pending`
+Expected: PASS
+
+- [ ] **Step 5: Make the same distinction in `arm_judgements`**
+
+In `src/jobs/consolidate.rs`, in `arm_judgements`, replace:
+
+```rust
+        let (Ok(a), Ok(b)) = (
+            core.store.get_artifact(&p.a_id).await,
+            core.store.get_artifact(&p.b_id).await,
+        ) else {
+            continue;
+        };
+```
+
+with:
+
+```rust
+        let (a, b) = match (
+            core.store.get_artifact(&p.a_id).await,
+            core.store.get_artifact(&p.b_id).await,
+        ) {
+            (Ok(a), Ok(b)) => (a, b),
+            // Gone, so there is nothing to ask about and nothing a later sweep
+            // could do either. Dismissed rather than skipped: skipping left the
+            // pair pending, and a pending pair with no attempts against it
+            // leads `pairs_to_judge`'s ordering every sweep from here on.
+            (Err(Error::NotFound), _) | (_, Err(Error::NotFound)) => {
+                core.store
+                    .set_pair_state(p.id, crate::store::pairs::PairState::Dismissed, None)
+                    .await?;
+                continue;
+            }
+            (Err(e), _) | (_, Err(e)) => return Err(e),
+        };
+```
+
+If `src/jobs/consolidate.rs` does not already import `Error`, add it: change the existing `use crate::error::Result;` to `use crate::error::{Error, Result};`.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `cargo test --lib`
+Expected: PASS, 657 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jobs/judge.rs src/jobs/consolidate.rs
+git commit -m "fix: a pair with nothing left to compare stops waiting to be judged"
+```
+
+---
+
+### Task 4: The sweep heals a document that resolved every window but never finished
+
+**Files:**
+- Modify: `src/jobs/reconcile.rs:45-75`
+- Modify: `src/jobs/reconcile.rs:192-224` (the `a_corpus_whose_artifacts_never_embedded_gets_an_embed_job` test)
+- Test: `src/jobs/reconcile.rs` tests module
+
+**Interfaces:**
+- Consumes: `Corpus.coverage: Option<f64>` (`src/store/corpora.rs:83`), `crate::jobs::window::settle(core, corpus_id)` (`src/jobs/window.rs:212`), `Store::artifacts_for_corpus`.
+- Produces: nothing new.
+
+**Background:** On master the sweep enqueued `Stage::Synthesize`, whose `run()` ended in `finish()`. Now it only arms `SegmentWindow` units for *unresolved* windows. A process killed between the last `set_segment_state(Done)` and `settle()` leaves a corpus with every window `done` and no `finish`: `unresolved` is empty, so that branch is skipped. The embed branch below still fires — artifacts are pending — and `settle_corpus` eventually gives the corpus a status, so nothing looks wrong. But `renumber_artifacts`, `recompute_coverage` and the `Title` unit never ran for that document, and nothing will ever run them.
+
+`finish()` calls `recompute_coverage`, which always writes a value, on every path that produced artifacts — so a NULL `coverage` on a corpus that has artifacts and no unresolved windows is exactly the stuck state. The zero-chunk path in `finish()` sets `Failed` and writes no coverage, which is why the artifact check is part of the condition.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `src/jobs/reconcile.rs`, after `a_corpus_whose_artifacts_never_embedded_gets_an_embed_job`:
+
+```rust
+    #[tokio::test]
+    async fn a_corpus_that_resolved_every_window_but_never_finished_is_healed() {
+        // Killed between the last window's `Done` and the `settle` that
+        // follows it. Every window has resolved, so the branch above arms
+        // nothing, and the embed branch below gives the corpus a status anyway
+        // — which is what makes this invisible. The document was never
+        // renumbered, never measured and never named, and nothing else in the
+        // system would ever do it.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[seg(1, 10, "the window")])
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "the window".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        assert!(
+            core.store.get_corpus(&src.id).await.unwrap().coverage.is_none(),
+            "the fixture must start unmeasured"
+        );
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store.get_corpus(&src.id).await.unwrap().coverage.is_some(),
+            "the document was never measured, and nothing was left that would"
+        );
+        assert!(
+            core.store
+                .has_job(Stage::Title, &src.id)
+                .await
+                .unwrap(),
+            "the document was never handed to the namer"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cargo test --lib a_corpus_that_resolved_every_window_but_never_finished_is_healed`
+Expected: FAIL — `the document was never measured, and nothing was left that would`.
+
+- [ ] **Step 3: Add the branch**
+
+In `src/jobs/reconcile.rs`, insert between the `if !unresolved.is_empty() { … continue; }` block and the `if !core.store.pending_artifacts_for_corpus(...)` block:
+
+```rust
+            // Every window resolved and the document was still never finished.
+            // `finish` measures coverage on every path that produced artifacts,
+            // so a corpus with artifacts and none of it is one whose process
+            // died between the last window's `Done` and the `settle` that
+            // follows it. Nothing else would notice: the embed branch below
+            // still fires and `settle_corpus` gives it a status, while the
+            // renumbering, the coverage measure and the title unit never ran.
+            //
+            // `settle` rather than a job, because there is no inference here —
+            // it is the same local work `finish` does, and re-running it on a
+            // document that is fine is what the coverage test rules out.
+            if c.coverage.is_none() && !core.store.artifacts_for_corpus(&c.id).await?.is_empty() {
+                crate::jobs::window::settle(core, &c.id).await?;
+                armed += 1;
+                continue;
+            }
+```
+
+- [ ] **Step 4: Run the new test**
+
+Run: `cargo test --lib a_corpus_that_resolved_every_window_but_never_finished_is_healed`
+Expected: PASS
+
+- [ ] **Step 5: Run the suite and expect one existing test to fail**
+
+Run: `cargo test --lib`
+Expected: FAIL in `a_corpus_whose_artifacts_never_embedded_gets_an_embed_job` — its fixture is a corpus with a Done window, artifacts, and no coverage, so it now takes the new branch and `claim_job` may return the `Title` unit rather than the `Embed` one. The fixture, not the assertion, is what needs fixing: a corpus that reached the embed stage has been through `finish`, and so has a coverage value.
+
+- [ ] **Step 6: Give that fixture the coverage a finished document has**
+
+In `a_corpus_whose_artifacts_never_embedded_gets_an_embed_job`, immediately after the `insert_artifacts` call and before the `assert_eq!(run(&core).await.unwrap(), 1);`, add:
+
+```rust
+        // A corpus that got as far as embedding has been through `finish`, and
+        // `finish` measures it. Without this the fixture is indistinguishable
+        // from a document whose `finish` never ran, which is a different repair.
+        core.store.set_corpus_coverage(&src.id, 0.9).await.unwrap();
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `cargo test --lib`
+Expected: PASS, 658 tests. `a_finished_corpus_is_left_alone` must still return 0 — that fixture has a Done window and no artifacts, so the new branch's artifact check excludes it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/jobs/reconcile.rs
+git commit -m "fix: a document that resolved every window still gets finished"
+```
+
+---
+
+### Task 5: Planning a document does not wind back a queued window's attempts
+
+**Files:**
+- Modify: `src/jobs/synthesize.rs:66-75` (`arm_seq` → `rearm_idle_seq`)
+- Modify: `src/store/jobs.rs` (add `delete_window_jobs`)
+- Modify: `src/core/ingest.rs:639` (call it from `reprocess`)
+- Modify: `src/store/jobs.rs:175-177` (the `arm_seq` docstring, which still names planning as its caller)
+- Test: `src/jobs/synthesize.rs` tests module, `src/core/ingest.rs` tests module
+
+**Interfaces:**
+- Consumes: `Store::rearm_idle_seq`, `crate::jobs::window::unit_target(corpus_id, idx) -> String` which formats `"{corpus_id}#{idx}"` (`src/jobs/window.rs:21`).
+- Produces: `Store::delete_window_jobs(&self, corpus_id: &str) -> Result<()>`.
+
+**Background:** `plan()` arms window units with `arm_seq` (`Guard::NotRunning`), which resets `attempts` and `run_after` on units that are merely queued. Everything else that arms units automatically was moved to `rearm_idle_seq` for exactly this reason. `plan()` is reachable more than once per corpus — the comment at `synthesize.rs:47-53` describes the case itself: a process killed after planning leaves the plan row pending, startup re-arms it, the units run and fail while the stale plan waits, and re-arming them from zero when it is finally claimed keeps a window the model will not read forever young, so `settle` never counts it as spent.
+
+The one thing `arm_seq` was buying is the operator's reprocess, which today deletes the `Title` job and the window *rows* but not the window *units* — so with `rearm_idle_seq` alone, a rerun would inherit the previous run's attempt counts. `reprocess` deleting the units restores that, and is what it should have been doing anyway.
+
+- [ ] **Step 1: Write the failing planner test**
+
+Add to the `mod tests` block in `src/jobs/synthesize.rs`:
+
+```rust
+    #[tokio::test]
+    async fn re_planning_does_not_wind_back_a_queued_windows_attempts() {
+        // A plan job outlives the units it arms: killed after planning, its row
+        // stays pending, startup re-arms it, the units sort ahead of it and run
+        // and fail — and only then is the stale plan claimed. Re-arming them
+        // from zero there keeps a window the model will not read forever young,
+        // so `settle` never counts it as spent and the document never leaves
+        // `segmenting`. It is the failure the reconciliation sweep was already
+        // fixed for, reached by a second route.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        plan(&core, &out.id).await.unwrap();
+        sqlx::query("UPDATE jobs SET attempts = 4 WHERE stage = 'segment_window'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        plan(&core, &out.id).await.unwrap();
+
+        let attempts: Vec<i64> =
+            sqlx::query_scalar("SELECT attempts FROM jobs WHERE stage = 'segment_window'")
+                .fetch_all(&core.store.pool)
+                .await
+                .unwrap();
+        assert!(
+            attempts.iter().all(|&a| a == 4),
+            "re-planning reset a unit that was already queued: {attempts:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cargo test --lib re_planning_does_not_wind_back_a_queued_windows_attempts`
+Expected: FAIL — attempts are `[0, 0]` (or `[0]`, depending on how the fixture windows out).
+
+- [ ] **Step 3: Switch `plan()` to idle-only arming**
+
+In `src/jobs/synthesize.rs`, in the `for w in pending` loop, replace `arm_seq` with `rearm_idle_seq` and extend the comment above the loop. The loop's preceding comment currently reads:
+
+```rust
+    // One unit per window that has not resolved. `seq` is the window index, so
+    // this document's window 0 is claimed before any document's window 1 and a
+    // capture made during a long ingest does not wait for all of it.
+```
+
+Replace it with:
+
+```rust
+    // One unit per window that has not resolved. `seq` is the window index, so
+    // this document's window 0 is claimed before any document's window 1 and a
+    // capture made during a long ingest does not wait for all of it.
+    //
+    // Idle-only, like every other automatic arming in the system. A plan job
+    // outlives the units it arms — the case the comment above describes — so
+    // this runs again while those units are queued with attempts against them,
+    // and winding those back keeps a window the model will not read forever
+    // young. An operator's reprocess still gets a clean slate: it deletes the
+    // units outright, which is a decision a person made rather than a sweep.
+```
+
+and change the call itself to:
+
+```rust
+        core.store
+            .rearm_idle_seq(
+                Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(corpus_id, w.idx),
+                w.idx,
+            )
+            .await?;
+```
+
+- [ ] **Step 4: Run the planner test to verify it passes**
+
+Run: `cargo test --lib re_planning_does_not_wind_back_a_queued_windows_attempts`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing reprocess test**
+
+Add to the `mod tests` block in `src/core/ingest.rs`, next to `reprocessing_gives_a_corpus_that_was_never_named_another_chance`:
+
+```rust
+    #[tokio::test]
+    async fn reprocessing_gives_every_window_its_attempts_back() {
+        // Planning arms idle-only now, so the window units are the one piece of
+        // the previous run that a reprocess would otherwise inherit: a rerun
+        // asked for by a person would start its windows four attempts in and
+        // give up on them almost at once. `clear_segments` drops the rows the
+        // units name but not the units, which outlive them.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+        sqlx::query("UPDATE jobs SET attempts = 4 WHERE stage = 'segment_window'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        core.reprocess(&out.id, Stage::Synthesize).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        let attempts: Vec<i64> =
+            sqlx::query_scalar("SELECT attempts FROM jobs WHERE stage = 'segment_window'")
+                .fetch_all(&core.store.pool)
+                .await
+                .unwrap();
+        assert!(
+            !attempts.is_empty(),
+            "the rerun should have armed its windows again"
+        );
+        assert!(
+            attempts.iter().all(|&a| a == 0),
+            "the rerun inherited the previous run's attempts: {attempts:?}"
+        );
+    }
+```
+
+- [ ] **Step 6: Run it to make sure it fails**
+
+Run: `cargo test --lib reprocessing_gives_every_window_its_attempts_back`
+Expected: FAIL — attempts are `[4, 4]`.
+
+- [ ] **Step 7: Add `delete_window_jobs` to the store**
+
+In `src/store/jobs.rs`, add after `delete_job`:
+
+```rust
+    /// Forget every window unit of one document.
+    ///
+    /// The units are keyed `corpus#idx` and outlive the window rows they name,
+    /// so `clear_segments` on its own leaves a rerun sharing the attempt counts
+    /// of the run it replaces — and since planning arms idle-only, it would keep
+    /// them. Only an operator asking for the work again wants this, for the same
+    /// reason `delete_job` exists: a rerun a person asked for is a clean slate
+    /// or it is not one.
+    ///
+    /// Matched on the `corpus#` prefix rather than with `LIKE`, so an id
+    /// carrying a wildcard character cannot widen the delete.
+    pub async fn delete_window_jobs(&self, corpus_id: &str) -> Result<()> {
+        sqlx::query(
+            "DELETE FROM jobs
+              WHERE stage = 'segment_window'
+                AND substr(target_id, 1, length(?) + 1) = ? || '#'",
+        )
+        .bind(corpus_id)
+        .bind(corpus_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 8: Call it from `reprocess`**
+
+In `src/core/ingest.rs`, in the `Stage::Synthesize | Stage::Enrich` arm, immediately after the `self.store.clear_segments(&src.id).await?;` line and its comment, add:
+
+```rust
+                // And the units that name those windows, which outlive them.
+                // Planning arms idle-only, so a unit still queued from the run
+                // being replaced would carry its attempts into the rerun — the
+                // person who asked for another try would get a window that gives
+                // up after one.
+                self.store.delete_window_jobs(&src.id).await?;
+```
+
+- [ ] **Step 9: Run the reprocess test to verify it passes**
+
+Run: `cargo test --lib reprocessing_gives_every_window_its_attempts_back`
+Expected: PASS
+
+**Executed note:** the `rg` in Step 10 found `arm_seq`'s only remaining caller
+was its own test, so the delete branch was taken. That also removed
+`Guard::NotRunning` and its statement arm, since nothing else constructs the
+variant and it would have warned as dead. The test that covered it,
+`arming_a_unit_a_worker_is_already_inside_leaves_it_alone`, was pointed at
+`rearm_idle_seq` instead — `Guard::Closed` is strictly narrower than
+`NotRunning`, so it still holds the property the test is about. The two
+remaining tiers are `enqueue_seq` (an operator's reprocess) and `rearm_idle_seq`
+(everything automatic).
+
+- [ ] **Step 10: Correct the `arm_seq` docstring**
+
+`arm_seq` no longer has any caller. Confirm that first:
+
+Run: `rg 'arm_seq\(' src/ | rg -v 'rearm_idle_seq|enqueue_seq|fn arm_seq'`
+Expected: no output.
+
+If there are no callers, delete the `arm_seq` method from `src/store/jobs.rs` along with its docstring, since a method with no callers is a claim about the system that nothing checks. If `rg` shows callers, instead replace the misleading final paragraph of its docstring:
+
+```rust
+    /// Everything that arms units on its own — planning a document, a
+    /// consolidation sweep arming a judgement — wants this rather than
+    /// `enqueue_seq`.
+```
+
+with:
+
+```rust
+    /// Weaker than what automatic arming actually wants: a queued unit is
+    /// already going to run, and re-arming it winds its attempts back. Planning
+    /// a document and the consolidation sweep both use `rearm_idle_seq` below
+    /// for that reason.
+```
+
+- [ ] **Step 11: Run the full suite**
+
+Run: `cargo test --lib`
+Expected: PASS, 660 tests. `a_sweep_does_not_wind_back_a_failing_units_attempts` in `reconcile.rs` and `reprocessing_gives_a_corpus_that_was_never_named_another_chance` in `ingest.rs` both exercise neighbouring behaviour and must still pass.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/jobs/synthesize.rs src/store/jobs.rs src/core/ingest.rs
+git commit -m "fix: planning a document leaves its queued windows alone"
+```
+
+---
+
+### Task 6: Stop reporting a contradiction count the sweep cannot know
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs:32` (remove the field), `src/jobs/consolidate.rs:436` (remove the log field)
+- Test: none — this is the removal of a value that is never written.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Outcome` loses its `contradictions` field. Verified before writing this plan: nothing outside `consolidate.rs` reads it, and the `contradictions` key in `src/web/api.rs:235` comes from `pairs_by_state`, not from `Outcome`.
+
+**Background:** `arm_judgements` makes no model call, so `out.contradictions` is always 0, yet the sweep's summary line still logs it. An operator reading the journal concludes the judge found nothing, when in fact no judging happened in that sweep at all. The comment at `consolidate.rs:423-426` already says the number "is no longer knowable here"; the field and the log line are what is left of it.
+
+- [ ] **Step 1: Remove the field**
+
+In `src/jobs/consolidate.rs`, delete this line from `struct Outcome`:
+
+```rust
+    pub contradictions: usize,
+```
+
+- [ ] **Step 2: Remove it from the summary line**
+
+In the same file, delete this line from the `tracing::info!` call at the end of `run`:
+
+```rust
+            contradictions = out.contradictions,
+```
+
+- [ ] **Step 3: Extend the comment that explains the absence**
+
+The comment above `out.judged = arm_judgements(core).await?;` already explains why. Replace its last clause so it describes the current state rather than a field that no longer exists. The comment currently reads:
+
+```rust
+        // Armed, not asked. `judged` counts the calls this sweep is responsible
+        // for rather than the calls it made, since it now makes none;
+        // `contradictions` is no longer knowable here at all, because the answer
+        // arrives one unit at a time long after the sweep has returned.
+```
+
+Replace with:
+
+```rust
+        // Armed, not asked. `judged` counts the calls this sweep is responsible
+        // for rather than the calls it made, since it now makes none. There is
+        // deliberately no contradiction count beside it: the answers arrive one
+        // unit at a time long after the sweep has returned, and a zero logged
+        // here read as "the judge found nothing" rather than "the judge has not
+        // been asked yet". `pairs_by_state(Contradiction, ..)` is where that
+        // number actually lives, and the API and Ops both read it from there.
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test --lib`
+Expected: PASS, 660 tests. If any test constructs an `Outcome` literally with all fields named, the compiler will point at it; remove the `contradictions:` line there too. Tests that assert on `out.judged` and `out.queued` are unaffected.
+
+- [ ] **Step 5: Check nothing else referenced it**
+
+Run: `rg 'contradictions' src/`
+Expected: hits only in `src/infer/prompt.rs` (prompt text), `src/web/api.rs` (the `pairs_by_state` key), `src/web/ui.rs` (a comment), and the new comment in `consolidate.rs`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/jobs/consolidate.rs
+git commit -m "refactor: drop a count the sweep stopped being able to make"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run `cargo test --lib` — expect 660 passing.
+- [ ] Run `cargo check --all-targets` — expect clean.
+- [ ] Run `cargo clippy --all-targets -- -D warnings` — expect clean.
+- [ ] Run `git log --oneline origin/master..HEAD` and confirm the six fix commits are present on top of the PR's existing history.
+
+## Self-Review Notes
+
+Checked against the six review findings:
+
+| Finding | Task |
+|---|---|
+| #1 oversize refusals trip the breaker | Task 1 |
+| #2 oversize scan unbounded per run | Task 2 |
+| #3 resolved-but-never-finished corpus | Task 4 |
+| #4 `plan()` uses `arm_seq` | Task 5 |
+| #5 store error treated as deletion | Task 3 |
+| #6 dead `contradictions` counter | Task 6 |
+
+Two behaviour changes deliberately break an existing test, and each is handled in the task that causes it: `an_oversize_chunk_does_not_block_its_siblings` (Task 2, Step 6) and `a_corpus_whose_artifacts_never_embedded_gets_an_embed_job` (Task 4, Step 6). Both are fixture corrections, not weakened assertions.
+
+Test counts assume the suite is at 653 before Task 1 and that each task adds the tests it lists. If the running total differs, the number is the thing that is wrong, not the tasks.

--- a/docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md
+++ b/docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md
@@ -261,11 +261,25 @@ larger than the behaviour change is.
 | `jobs` | add `seq INTEGER NOT NULL DEFAULT 0` |
 | `segments` | drop `attempts` |
 
-`migrate()` applies `schema.sql` on every connect and cannot alter a table, so
-`seq` is additive (safe) while dropping `segments.attempts` is not. The column is
-therefore left in place and unused rather than dropped, and removed whenever the
-database is next recreated. This is recorded so the next reader does not mistake
-a dead column for live state.
+`migrate()` applies `schema.sql` on every connect and cannot alter a table.
+
+**Corrected during implementation.** This section originally claimed `seq` was
+"additive (safe)". It is not: `CREATE TABLE IF NOT EXISTS` is a no-op against a
+table that already exists, so a column added to `schema.sql` never reaches a
+deployed base — and the column check at the end of `migrate()` then refuses to
+start it. Deploying as originally specified would have taken engram down.
+
+`migrate()` therefore grows a short list of columns that arrived after their
+table was deployed, appended with `ALTER TABLE ... ADD COLUMN` when absent. Two
+constraints on that list, both learned the hard way: SQLite can only append, and
+only with a default; and the appends must run **before** `schema.sql`, because
+the file builds an index over `seq` and an index cannot name a column that does
+not exist yet.
+
+Dropping `segments.attempts` remains impossible, so the column is left in place
+and unused rather than dropped, and removed whenever the database is next
+recreated. Recorded so the next reader does not mistake a dead column for live
+state.
 
 Index: `idx_jobs_claim` becomes `(state, attempts, seq, id, run_after)`. As with
 the 2026-08-13 change, it is dropped by its old name first — `CREATE INDEX IF NOT

--- a/docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md
+++ b/docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md
@@ -118,20 +118,30 @@ jobs, so the two local stages never wait for a cooldown they do not earn.
 
 ```
 InferenceGate
-  ├─ background().await   → returns when no interactive call is in flight,
-  │                         AND cooldown has elapsed since the last call ended,
-  │                         AND the circuit breaker is closed
+  ├─ background().await   → a permit, returned when no interactive call is in
+  │                         flight, AND cooldown has elapsed since the last call
+  │                         ended, AND the circuit breaker is closed
   ├─ interactive()        → RAII lease, returns immediately, never waits
   └─ any call completing stamps `last_finished`
 ```
 
 `core.ask()` holds an `interactive()` lease for its whole duration, since it
-makes more than one call. The four inference-making handlers — window, title,
-embed batch, judge — await `background()` immediately before their call.
+makes more than one call. The five inference-making paths — window, title, embed
+batch, per-chunk embed, judge — await `background()` immediately before their
+call and report the outcome through the permit it returns.
+
+The permit is what makes the cooldown a property of the endpoint rather than of
+a worker. `server.workers` defaults to 2, and a gate that only *checks* lets
+both read the same unchanged `last_finished` — neither has finished — and put
+two generations on the one GPU. Only one background call runs at a time, and the
+next waiter measures its cooldown from when that call ended.
 
 `cooldown_secs` moves from `[infer.synthesize]` to a global setting: a minimum
 gap between any two background calls, whatever their role. The GPU does not care
-which role loaded it. `ask` ignores the gap entirely.
+which role loaded it. `ask` ignores the gap entirely. The old key is kept on
+`SynthesizeRole` purely so that startup can complain about it — unknown keys
+parse silently, and an operator's thermal pacing turning itself off across an
+upgrade is not something to find out about from a warm room.
 
 An `ask` arriving mid-window still waits out the in-flight call — up to ~73s,
 observed. Nothing cancels. What the gate buys is that the worker will not pile a

--- a/docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md
+++ b/docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md
@@ -1,0 +1,401 @@
+# Independently schedulable inference — Design
+
+Date: 2026-08-13
+Status: draft
+Refines the job model in `2026-08-09-engram-design.md`.
+Supersedes the corpus-level `Synthesize` job and `fail_pending_segments`.
+
+## 1. Why
+
+On 2026-08-12 a single document — `019ff75a`, "Fundamentals of Secure System
+Design" — took from roughly 19:00 to 22:27 to segment. Thirty-three of its
+thirty-four windows parsed on the first try. Window 3 needed twelve.
+
+The reason is granularity. One job covered the whole corpus, so one window the
+parser could not read consumed the corpus's entire attempt budget, and the pass
+stopped at the failure rather than continuing past it. Windows 4 to 33 were not
+attempted during any of those twelve rounds; the journal shows them starting at
+20:48, seconds after window 3 finally parsed at 20:47:35. Between attempts the
+whole document waited out a backoff that doubles toward a six-hour ceiling.
+
+Two smaller faults compounded it. `enqueue_after` re-arms the existing row, so
+the failing corpus kept its original row id and reclaimed the front of a
+strictly id-ordered queue every time its backoff expired, ahead of everything
+captured since. And several of those attempts cost nothing at all: the endpoint
+replayed cached completions — identical token counts, identical parser errors at
+identical byte offsets, 678 tokens "generated" in 33 ms — so the retry could not
+have produced a different answer.
+
+The 2026-08-13 changes (per-window step-over, `ORDER BY attempts, id`,
+`.instrument`) treat the symptom at corpus granularity. This design removes the
+cause: **a job becomes one inference call.**
+
+## 2. Goal
+
+Every inference call in the application is an independently schedulable unit:
+its own attempt budget, its own backoff, paced by one global cooldown, and
+yielding to interactive work. No unit can hold up another.
+
+Explicit non-goals, decided during design:
+
+- **Document affinity.** Measured and rejected. See §8.
+- **Aborting in-flight calls** to make `ask` faster. Rejected: no wasted work.
+- **Parallelism.** One worker, one GPU. The scheduler picks one unit at a time.
+- **Making retries differ** (seed/nonce) so a caching endpoint cannot replay a
+  failure. Real, and out of scope here; recorded in §10.
+
+## 3. The unit model
+
+One job is one inference call. Everything that is not an inference call becomes
+local work that *enqueues* units.
+
+| Stage | Target | Inference calls |
+|---|---|---|
+| `Synthesize` | corpus | **none** — splits text, upserts segments, enqueues one `SegmentWindow` per pending window |
+| `SegmentWindow` | `{corpus_id}#{idx}` | one window |
+| `Title` | corpus | one |
+| `Embed` | corpus | one batch, re-arms while chunks remain |
+| `Consolidate` | collection | **none** — scoring, clustering, auto-supersede are local; enqueues `Judge` units |
+| `Judge` | pair id | one pair |
+
+Two of these need justification.
+
+**`Embed` stays targeted at the corpus.** A batch is a set of up to 32 chunks,
+not an entity, so there is no row to carry scheduling state. The handler embeds
+one batch and re-enqueues itself if chunks remain, with `seq` incremented so
+successive batches of a large corpus interleave with other work rather than
+monopolising `seq = 0`. Each batch is then independently scheduled, paced and
+preemptible without inventing a batch entity.
+
+**`Consolidate` loses its inference.** Today one sweep makes up to
+`max_judgements` (20) judge calls in a loop — the second-worst blocker after
+synthesis. The sweep now does only local work and arms one `Judge` unit per
+pending pair. `max_judgements` stops being a loop bound and becomes a cap on how
+many units a sweep arms.
+
+**`Enrich` remains an alias for `Synthesize`.** It has no distinct behaviour
+today — `run_one` and `Core::reprocess` both match `Synthesize | Enrich` — and it
+stays an alias for the planning stage. It is the operator's "re-segment this
+document" verb.
+
+That interaction is worth pinning, because `reprocess` clears the segment rows.
+Planning then re-splits and enqueues units for `idx 0..M`. Since `enqueue` is
+idempotent per `(stage, target_id)`, units for indices that still exist re-arm
+the same rows rather than duplicating. Units for `idx M..N` from a longer
+previous split are left pointing at segments that no longer exist, and are
+dropped on their next claim by the `NotFound` path.
+
+The paraphrase retry stays inline, so a `SegmentWindow` unit may cost two calls
+back to back. It is bounded at two, and splitting it needs somewhere durable to
+stash the first reply — for a retry that, against a caching endpoint, currently
+returns the identical reply. See §10.
+
+### Lifecycle
+
+```
+ingest
+  └─ Synthesize (local)  ──enqueues──> SegmentWindow ×N
+                                          │
+                          each: 1 call, own attempts, own backoff
+                                          │
+                          last one to settle does the local work
+                          (renumber, coverage, status) and enqueues:
+                                          │
+                              ┌───────────┴───────────┐
+                            Title                   Embed
+                          (1 call)            (1 batch, re-arms)
+```
+
+The settle step is a query plus idempotent enqueues, so the last window
+triggering it is race-free under one worker.
+
+## 4. Claiming, pacing and priority
+
+### The gate
+
+One component in `Core`, acquired around **inference calls** rather than around
+jobs, so the two local stages never wait for a cooldown they do not earn.
+
+```
+InferenceGate
+  ├─ background().await   → returns when no interactive call is in flight,
+  │                         AND cooldown has elapsed since the last call ended,
+  │                         AND the circuit breaker is closed
+  ├─ interactive()        → RAII lease, returns immediately, never waits
+  └─ any call completing stamps `last_finished`
+```
+
+`core.ask()` holds an `interactive()` lease for its whole duration, since it
+makes more than one call. The four inference-making handlers — window, title,
+embed batch, judge — await `background()` immediately before their call.
+
+`cooldown_secs` moves from `[infer.synthesize]` to a global setting: a minimum
+gap between any two background calls, whatever their role. The GPU does not care
+which role loaded it. `ask` ignores the gap entirely.
+
+An `ask` arriving mid-window still waits out the in-flight call — up to ~73s,
+observed. Nothing cancels. What the gate buys is that the worker will not pile a
+new unit onto the endpoint in front of it.
+
+### The circuit breaker
+
+Removing the pass-abort (§6) introduces a regression: with the endpoint down,
+thirty-four units would each burn a 900-second timeout — 8½ hours of waiting
+where the old code stopped after one. The breaker is where that belongs.
+
+Three consecutive transport failures (`Error::Inference`, **not**
+`MalformedLlmOutput`) trip it; `background()` then holds everything for a probe
+interval of 60 seconds before letting a single call through. Any success resets
+it; a failure re-trips it. Three matches the reasoning behind the constant it
+replaces: one failure is noise, three in a row is a fact about the endpoint. The
+probe interval is short because `mikoshi` returns 502 while loading a model —
+the outage this most often is heals in minutes, and the per-unit backoff in §5
+already covers longer ones. This is strictly better than today, where
+a dead endpoint is handled inside `synthesize::run` and nowhere else — embed and
+judge each hammer it independently.
+
+### Claim ordering
+
+Plain `ORDER BY attempts, id` at unit granularity reproduces head-of-line
+blocking one level down: a 34-window document takes 34 consecutive row ids, so a
+capture behind it waits for all 34. Since affinity is worth nothing (§8),
+interleaving is free.
+
+One integer on the job row:
+
+```
+seq  = position within the batch of units enqueued together
+       (window index; judge-pair index; embed batch number; 0 for singletons)
+
+ORDER BY attempts, seq, id
+```
+
+This gives round-robin across documents with no GROUP BY and no rotation cursor:
+
+```
+A.w0  B.w0  A.w1  B.w1  A.w2  B.w2 ...
+```
+
+Every document's first window runs before any document's second, so a capture
+made during a large ingest produces artifacts within a call or two. `attempts`
+still leads, preserving the fairness fix: a unit that keeps failing sinks below
+fresher work but is never starved, since it runs as soon as nothing fresher is
+ready.
+
+`seq` matters for judge units too — a sweep arming twenty would otherwise put all
+twenty at `seq = 0` and jump the entire window queue.
+
+### Reconcile
+
+`reconcile.rs` gains one case: for a corpus whose segments exist but whose window
+units are missing, arm the per-window units directly. This is what makes a
+materialised queue safe — units stay derivable from domain state, so drift
+self-heals on the sweep exactly as it does today.
+
+## 5. Attempt budgets and settling
+
+Engram's principle is that there is no terminal state: work stays queued at the
+backoff ceiling so a healed endpoint is picked up. That holds. But per-unit
+budgets expose a problem the corpus-level design papered over — **if no unit ever
+terminates, the corpus never settles**, never embeds, and the artifacts from
+thirty-three good windows never become searchable.
+
+`MAX_ATTEMPTS` stays 5, but it now means five attempts *at one window* rather
+than five at a whole document. Window 3 would have had its own five before the
+corpus settled `partial`, instead of consuming the budget for thirty-four.
+
+So a window is *settled* when it is `done`, **or** `failed` with
+`attempts >= MAX_ATTEMPTS`. The job row stays queued at the six-hour ceiling —
+the work is never abandoned — but the corpus settles around it and reports
+`partial`. If that window later succeeds, the settle re-runs: renumber, recompute
+coverage, re-enqueue embed for the new artifacts.
+
+Every `SegmentWindow` handler evaluates the settle condition after writing its
+result. Idempotent, so a late recovery re-running it is harmless.
+
+### Per-stage exceptions
+
+Two units give up rather than retry forever, both matching existing behaviour:
+
+- **Title** — a name is cosmetic and the corpus keeps its snippet fallback.
+  Today the code logs the failure and moves on. As a unit: exhaust
+  `MAX_ATTEMPTS`, then complete the job. Retrying forever spends real calls on
+  decoration.
+- **Judge** — after `MAX_ATTEMPTS` the job completes and the pair stays pending,
+  so a later sweep re-arms it. Same as today's `record_judge_attempt`.
+
+`SegmentWindow` and `Embed` keep never-abandon: both carry knowledge that would
+otherwise be lost.
+
+### Stale units
+
+Re-segmenting can change the window count, leaving `corpus#idx` jobs pointing at
+windows that no longer exist. `run_one` already drops those —
+`Err(Error::NotFound)` completes the job instead of retrying it.
+
+## 6. What this deletes
+
+The granularity change removes code that exists only to ration a shared budget:
+
+- `fail_pending_segments` and the tried/untried partition. Its purpose was
+  rationing one attempt budget across windows the model never saw; per-window
+  budgets make the question meaningless.
+- `REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS` and the
+  `MalformedLlmOutput`-versus-endpoint branch inside `synthesize::run` (added
+  2026-08-13). Both exist because one job covered thirty-four windows and had to
+  choose between stepping over a failure and abandoning the pass. With per-unit
+  granularity there is no pass: each window fails on its own, backs off on its
+  own, and `attempts`-first ordering sinks it automatically. The endpoint-down
+  case moves to the breaker, where it covers all four call sites instead of one.
+- `segments.attempts`. `jobs.attempts` becomes the single counter per window.
+  Two counters for one thing is what produced the original confusion — the job
+  counted 13 attempts while window 3 counted 12.
+
+Roughly six to eight existing tests are deleted or rewritten. The diff will look
+larger than the behaviour change is.
+
+## 7. Schema
+
+| Table | Change |
+|---|---|
+| `jobs` | add `seq INTEGER NOT NULL DEFAULT 0` |
+| `segments` | drop `attempts` |
+
+`migrate()` applies `schema.sql` on every connect and cannot alter a table, so
+`seq` is additive (safe) while dropping `segments.attempts` is not. The column is
+therefore left in place and unused rather than dropped, and removed whenever the
+database is next recreated. This is recorded so the next reader does not mistake
+a dead column for live state.
+
+Index: `idx_jobs_claim` becomes `(state, attempts, seq, id, run_after)`. As with
+the 2026-08-13 change, it is dropped by its old name first — `CREATE INDEX IF NOT
+EXISTS` on an existing name is a silent no-op, so an existing deployment would
+otherwise keep the narrower index.
+
+### Deployment path
+
+Existing databases hold corpus-level `Synthesize` job rows. On start, `reconcile`
+sees corpora with unfinished segments and arms per-window units; the old
+corpus-level rows complete on their next claim, because the new `Synthesize`
+handler is the planning step and is idempotent. No manual SQL, no data migration
+— but §9 test 16 pins it rather than assuming it.
+
+## 8. Measured: affinity does not matter
+
+Design initially assumed that scheduling windows in document order preserved
+llama.cpp prefix reuse, and that interleaving would cost throughput. Measurement
+says otherwise:
+
+```
+per-call prompt: ~3203 tokens
+  shared by ALL documents (any order):  653  (20%)   system prompt
+  shared only within one document:      200  ( 6%)   document opening
+  unique to this call regardless:      2350  (73%)   window body + overlap
+```
+
+The 653-token system prompt is identical for every synthesize call in the
+application and stays warm under any ordering. Affinity protects only the
+200-token document opening — 6% of the prefill — and prefill is the cheap half:
+observed calls spend 20–73 seconds generating 400–3000 output tokens, so they are
+decode-bound. Affinity is worth a fraction of a percent of wall clock, and it is
+the single thing that would complicate the scheduler most. Dropped.
+
+## 9. Testing
+
+Virtual time throughout for the gate: `#[tokio::test(start_paused = true)]`. No
+wall-clock sleeps, and assertions become exact rather than "elapsed >= 40ms". The
+existing `a_cooldown_paces_the_windows_it_segments` converts to it.
+
+**Gate**
+
+1. `background()` returns immediately when idle and cooldown is zero.
+2. `background()` waits exactly the cooldown after a previous call ends.
+3. `background()` blocks while an `interactive()` lease is held; proceeds on drop.
+4. `interactive()` never waits — asserted during an active cooldown.
+5. Breaker trips after N consecutive `Error::Inference`; a success resets it;
+   `MalformedLlmOutput` does **not** trip it.
+
+**Unit model**
+
+6. `Synthesize` makes zero inference calls and enqueues one unit per window.
+7. Draining a multi-window corpus reaches `ready` with N window calls, one title,
+   and the expected embed batches.
+8. **Two corpora, one poisoned window**: the healthy corpus reaches `ready` while
+   the poisoned unit is still retrying. This is the journal incident as a test;
+   it cannot pass today.
+9. Claim order interleaves: `A.w0, B.w0, A.w1, B.w1`. Pure store test.
+10. A window past `MAX_ATTEMPTS` leaves the corpus `partial` **and the good
+    windows' artifacts still embed**.
+11. Settle re-runs: the stuck window later succeeds, corpus reaches `ready`, new
+    artifacts embed.
+12. A `corpus#idx` unit whose window no longer exists is dropped, not retried.
+13. Title exhausting its attempts leaves the corpus `ready` and unnamed.
+14. `Consolidate` makes zero inference calls and arms one `Judge` unit per pair.
+15. A corpus with >32 pending chunks yields multiple embed claims, one batch each.
+
+**Migration**
+
+16. Seed the old shape — corpus-level `Synthesize` row plus segment rows — run
+    `reconcile`, assert per-window units appear and the old row retires.
+
+## 10. Open: window size, to be settled by measurement
+
+Window size is arithmetic today: `max_output_tokens / output_ratio` =
+`16384 / 8.0` = 2048 input tokens, yielding ~8.1 artifacts per call (measured:
+34 windows, 277 artifacts on corpus `019ff75a`).
+
+Every structural failure in the 2026-08-12 journal is a long-output failure —
+truncation at the 16384 ceiling, and array corruption at columns 6720, 7822,
+11973. Short replies (176, 190, 211 tokens) show none. Much of `prompt.rs`
+(`salvage_truncated`, `salvage_objects`, the repair call) exists solely to
+survive this. Smaller windows should reduce it, and would also cut the worst-case
+`ask` wait from ~73s to ~25s.
+
+Cost is lower than it looks: total output tokens are roughly constant regardless
+of how they are split, so what multiplies is prefill — the cheap half. Estimated
++20–40% wall clock, not the 8× a naive reading suggests.
+
+**Before the scheduler is tuned, settle this by measurement, not argument.**
+Re-ingest corpus `019ff75a` at `output_ratio` 8.0, 16.0 and 32.0 and compare:
+
+| Signal | Source | Baseline at ratio 8.0 |
+|---|---|---|
+| coverage | `corpora.coverage` | **0.5539** |
+| literal-flag rate | artifacts carrying `FLAG_LITERALS` | **8 of 277 — 2.9%** |
+| malformed-output count | journal parse-failure lines per ingest | capture from a clean re-ingest |
+| retrieval | `recall@k` / MRR from the eval harness | run once against the current base |
+
+The first two are read off the current database and recorded here. The
+malformed-output count cannot be taken from the 2026-08-12 journal: cache
+replays duplicate several of its parse-failure lines, so the honest baseline is
+a clean re-ingest at ratio 8.0 rather than a count from that excerpt.
+
+Note the flag rate is already low at 2.9%, so it has little room to improve and
+is the weakest of the four signals. Coverage and malformed-output count are the
+ones that should decide the ratio.
+
+Decision rule: adopt the largest `output_ratio` at which malformed-output count
+is near zero and coverage does not regress. If coverage and flag rate do not move
+while malformed count drops, output length was a structural problem only — a
+useful negative result, and the ratio should then be chosen purely on structural
+reliability.
+
+Nothing in §3–§7 depends on the answer: the unit is one window and one call
+whether a window is 512 or 2048 tokens. Smaller windows mean more units, which
+makes independent scheduling more valuable, not less.
+
+## 11. Not in scope
+
+**Retries cannot differ.** `llm.mikoshi.de` serves cached completions: an
+identical prompt within roughly half an hour returns byte-for-byte, in
+single-digit milliseconds. Any retry re-sending the same prompt cannot produce a
+different result — it burns an attempt and doubles a backoff for nothing. This
+affects the inline paraphrase retry (§3), which is currently a guaranteed no-op.
+The fix is a seed or nonce on retry, or disabling response caching for the
+synthesize role. Deferred by decision on 2026-08-13; recorded here because the
+per-unit backoff in §5 will otherwise look inexplicably patient.
+
+**Duplicate JSON keys still cost a window.** `duplicate field \`tags\`` killed
+window 3 for twelve attempts. serde's derived `Deserialize` rejects repeated
+keys; routing each object through `serde_json::Value` first accepts them
+last-key-wins. Verified, deferred by the same decision.

--- a/src/bin/eval_prepare.rs
+++ b/src/bin/eval_prepare.rs
@@ -20,9 +20,8 @@ use engram::vector::memory::MemoryVectors;
 use std::sync::Arc;
 
 /// How many times the whole corpus is driven before its remaining segments are
-/// called hopeless. `synthesize::run` resumes from the first pending segment, so
-/// a pass is one attempt at each segment still outstanding — this stands in for
-/// the job runner's own attempt budget.
+/// called hopeless. A pass drains every unit the queue will hand over, so this
+/// stands in for the job runner's own attempt budget.
 const MAX_PASSES: usize = 4;
 
 #[tokio::main]
@@ -72,19 +71,23 @@ async fn main() -> Result<()> {
         tracing::info!(file = %name, bytes = text.len(), "synthesising");
         let out = core.ingest(&text, "eval", Some(&name)).await?;
 
-        // Stand in for the job runner: `synthesize::run` resumes from the first
-        // pending segment, so repeating it is what drives a multi-segment corpus
-        // to completion.
+        // Be the job runner. Planning arms one unit per window and the queue
+        // hands them over one at a time, so a pass here is "drain what is ready"
+        // rather than "one attempt at each outstanding segment". The backoff is
+        // wound back between passes: this is a batch tool with a whole corpus to
+        // get through, not a service pacing itself against a live endpoint.
+        engram::jobs::synthesize::plan(&core, &out.id).await?;
         let mut passes = 0;
         loop {
-            if let Err(e) = engram::jobs::synthesize::run(&core, &out.id).await {
-                tracing::warn!(error = %e, file = %name, "synthesis pass failed");
-            }
+            while engram::jobs::run_one(&core).await.unwrap_or(false) {}
             passes += 1;
             let pending = core.store.pending_segments(&out.id).await?;
             if pending.is_empty() {
                 break;
             }
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await?;
             if passes >= MAX_PASSES {
                 bail!(
                     "{name}: {} segment(s) still unsynthesised after {MAX_PASSES} passes. \

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,38 @@ pub struct Config {
     pub consolidate: ConsolidateConfig,
     #[serde(default)]
     pub feedback: FeedbackConfig,
+    #[serde(default)]
+    pub pacing: PacingConfig,
+}
+
+/// Pacing for every inference call, not just synthesis.
+///
+/// The roles share one GPU, so a per-role gap could not bound total load: three
+/// roles each honouring their own cooldown still interleave into unbroken work.
+/// One gap in front of all of them is the only version of this setting that
+/// means what it says.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PacingConfig {
+    /// Minimum seconds between the end of one background call and the start of
+    /// the next. Zero disables pacing. `ask` ignores it: a person is waiting,
+    /// and the pacer exists to protect the GPU from batch work, not from them.
+    pub cooldown_secs: u64,
+    /// Consecutive transport failures before background calls are held.
+    /// Unreadable model output does not count — the endpoint answered.
+    pub breaker_after: usize,
+    /// How long to hold them for before letting one through to probe.
+    pub breaker_probe_secs: u64,
+}
+
+impl Default for PacingConfig {
+    fn default() -> Self {
+        Self {
+            cooldown_secs: 0,
+            breaker_after: 3,
+            breaker_probe_secs: 60,
+        }
+    }
 }
 
 /// Recording real searches so they can be judged later.

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,13 +254,6 @@ pub struct SynthesizeRole {
     pub reasoning_effort: Option<String>,
     /// Seconds to idle between segmentation calls.
     ///
-    /// Segmenting a long source is minutes of uninterrupted generation, which
-    /// on a desktop GPU is a sustained thermal load rather than a burst. This
-    /// buys the card time to settle between windows. It does not save energy —
-    /// the same tokens are generated either way — so it is off by default and
-    /// exists for the machine sitting next to someone.
-    #[serde(default)]
-    pub cooldown_secs: u64,
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
     /// Tokens of the document's verbatim opening prepended to every window, so

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,10 +252,19 @@ pub struct SynthesizeRole {
     /// is what truncates the answer.
     #[serde(default)]
     pub reasoning_effort: Option<String>,
-    /// Seconds to idle between segmentation calls.
-    ///
+    /// Seconds to wait on one call before giving up on it.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+    /// Moved to `[pacing]`, and kept here only to be complained about.
+    ///
+    /// Pacing is one queue in front of one endpoint now, so a cooldown per role
+    /// could never bound the total load — several roles each honouring their own
+    /// still interleave into unbroken work. Nothing reads this, and without the
+    /// field the operator's thermal pacing would parse cleanly and silently stop
+    /// happening: unknown keys are ignored, which is right for forward
+    /// compatibility and wrong for a setting someone chose on purpose.
+    #[serde(default)]
+    pub cooldown_secs: Option<u64>,
     /// Tokens of the document's verbatim opening prepended to every window, so
     /// an artifact from deep in a long document still knows what product and
     /// version it belongs to. Zero disables it.
@@ -395,6 +404,7 @@ impl Config {
         cfg.normalize();
         cfg.validate()?;
         cfg.warn_on_file_secrets(path);
+        cfg.warn_on_moved_keys();
         Ok(cfg)
     }
 
@@ -456,6 +466,20 @@ impl Config {
             )));
         }
         Ok(())
+    }
+
+    /// A setting that moved is a setting that stopped working, and an unknown
+    /// key parses without complaint. Say so once at startup rather than letting
+    /// an operator discover the pacing they configured has been off since the
+    /// upgrade.
+    fn warn_on_moved_keys(&self) {
+        if self.infer.synthesize.cooldown_secs.is_some() {
+            tracing::warn!(
+                "infer.synthesize.cooldown_secs has moved to [pacing].cooldown_secs and is \
+                 being ignored; pacing is one gap in front of one endpoint now, so it can no \
+                 longer be set per role"
+            );
+        }
     }
 
     /// Secrets belong in the environment. A secret sitting in the config file

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,8 @@ pub struct PacingConfig {
     /// and the pacer exists to protect the GPU from batch work, not from them.
     pub cooldown_secs: u64,
     /// Consecutive transport failures before background calls are held.
-    /// Unreadable model output does not count — the endpoint answered.
+    /// Unreadable model output does not count — the endpoint answered. Zero
+    /// disables the breaker, as zero disables the cooldown above.
     pub breaker_after: usize,
     /// How long to hold them for before letting one through to probe.
     pub breaker_probe_secs: u64,

--- a/src/core/ask.rs
+++ b/src/core/ask.rs
@@ -34,6 +34,16 @@ impl Core {
             return Err(Error::Validation("question is empty".into()));
         }
 
+        // Held for the whole answer rather than around the completion, because
+        // a search embeds the query and that is a model call too. A gap between
+        // them is a gap the worker would fill with a window, and a window is
+        // twenty to seventy seconds of somebody waiting.
+        //
+        // Taking the lane does not make an in-flight call stop; nothing here
+        // cancels. It keeps the worker from putting anything new in front of
+        // this one.
+        let _lane = self.gate.interactive();
+
         // No per-source cap: an answer often lives in one document, and
         // withholding its paragraphs to keep the citation list varied would
         // make the answer worse, not fairer.
@@ -129,6 +139,82 @@ mod tests {
     use super::*;
     use crate::core::test_support::test_core;
     use crate::store::artifacts::NewArtifact;
+
+    /// A completer that asks, from inside the model call, whether background
+    /// work could start right now. That is the question the lane exists to
+    /// answer, and the only place it can be asked honestly.
+    struct LaneProbe {
+        gate: std::sync::Arc<crate::infer::gate::InferenceGate>,
+        background_was_held: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::infer::Completer for LaneProbe {
+        async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+            let held =
+                tokio::time::timeout(std::time::Duration::from_millis(50), self.gate.background())
+                    .await
+                    .is_err();
+            self.background_was_held
+                .store(held, std::sync::atomic::Ordering::SeqCst);
+            Ok("an answer".into())
+        }
+        fn context_tokens(&self) -> usize {
+            4096
+        }
+    }
+
+    #[tokio::test]
+    async fn a_question_holds_the_interactive_lane_for_its_whole_answer() {
+        // Priority, not preemption: the worker must not put a new window in
+        // front of someone who is waiting. What it cannot do is stop the window
+        // already running, which is the ~73s ceiling this deliberately accepts.
+        let mut core = test_core().await;
+        let probe = std::sync::Arc::new(LaneProbe {
+            gate: std::sync::Arc::clone(&core.gate),
+            background_was_held: std::sync::atomic::AtomicBool::new(false),
+        });
+        core.completer = probe.clone();
+        seed(&core, 3, 4).await;
+
+        core.ask(&AskRequest {
+            q: "chunk".into(),
+            limit: Some(3),
+            tags: vec![],
+            category: None,
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            probe
+                .background_was_held
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "a window could have started while the question was still being answered"
+        );
+    }
+
+    #[tokio::test]
+    async fn asking_a_question_leaves_the_lane_free_afterwards() {
+        // The lease is RAII, so the interesting failure is one that leaks: a
+        // single question would then hold background work off forever.
+        let core = test_core().await;
+        seed(&core, 3, 4).await;
+
+        core.ask(&AskRequest {
+            q: "chunk".into(),
+            limit: Some(3),
+            tags: vec![],
+            category: None,
+        })
+        .await
+        .unwrap();
+
+        // Returns immediately if the lane was released; hangs the test if not.
+        tokio::time::timeout(std::time::Duration::from_secs(5), core.gate.background())
+            .await
+            .expect("the interactive lane was never released");
+    }
 
     async fn seed(core: &crate::core::Core, n: usize, size: usize) {
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -637,6 +637,14 @@ impl Core {
                 // no chunks at all. Re-windowing is also the point of a
                 // reprocess after a model or budget change.
                 self.store.clear_segments(&src.id).await?;
+                // The title unit is armed once per corpus and never again, so
+                // that a document the model will not name stops costing calls.
+                // The row is what remembers that, which also means a corpus left
+                // unnamed by a transient failure could never be named again —
+                // including by the person who noticed and asked for the rerun.
+                // An explicit reprocess is exactly the case that rule is not
+                // meant to cover.
+                self.store.delete_job(Stage::Title, &src.id).await?;
                 // Reprocessing a parked capture is a decision to process it, so
                 // the park has to be lifted with it. Leaving the flag set means
                 // a fully synthesized and embedded corpus sits on the review
@@ -696,6 +704,38 @@ mod tests {
             .map(|i| format!("step {i}: run the {marker} command and read its output"))
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[tokio::test]
+    async fn reprocessing_gives_a_corpus_that_was_never_named_another_chance() {
+        // A title unit is armed once per corpus and never again, so that a
+        // document the model will not name stops costing four calls a day
+        // forever. The row is what remembers that — and it outlived a
+        // reprocess, so a corpus left unnamed by an endpoint that was briefly
+        // down could never be named again, including by the person who noticed
+        // and asked for the rerun.
+        let core = test_core().await;
+        let src = core.ingest(&manual("mount"), "web", None).await.unwrap();
+        for _ in 0..200 {
+            sqlx::query("UPDATE jobs SET run_after = 0 WHERE state = 'pending'")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            if !crate::jobs::run_one(&core).await.unwrap_or(false) {
+                break;
+            }
+        }
+        assert!(
+            core.store.has_job(Stage::Title, &src.id).await.unwrap(),
+            "the fixture must arm a title unit"
+        );
+
+        core.reprocess(&src.id, Stage::Synthesize).await.unwrap();
+
+        assert!(
+            !core.store.has_job(Stage::Title, &src.id).await.unwrap(),
+            "reprocess left the spent title unit behind, so the corpus can never be named"
+        );
     }
 
     #[tokio::test]

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -667,6 +667,16 @@ impl Core {
                     "consolidate is a collection-wide sweep, not a per-corpus stage".into(),
                 ));
             }
+            // Units the queue arms for itself, one per inference call. An
+            // operator reprocesses a document, not one of its windows: asking
+            // for `synthesize` re-windows the whole thing and arms them all.
+            Stage::SegmentWindow | Stage::Title | Stage::Judge => {
+                return Err(Error::Validation(
+                    "that stage is a single inference call the queue arms itself; \
+                     reprocess the document instead"
+                        .into(),
+                ));
+            }
         }
         Ok(())
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1040,7 +1040,7 @@ mod tests {
             .ingest("alpha para\n\nbeta para", "web", None)
             .await
             .unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         let first = core
             .store
             .artifacts_for_corpus(&out.id)
@@ -1059,7 +1059,7 @@ mod tests {
             "reprocess must forget the windowing so it can be redone"
         );
 
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         assert_eq!(
             core.store
                 .artifacts_for_corpus(&out.id)

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -637,6 +637,12 @@ impl Core {
                 // no chunks at all. Re-windowing is also the point of a
                 // reprocess after a model or budget change.
                 self.store.clear_segments(&src.id).await?;
+                // And the units that name those windows, which outlive them.
+                // Planning arms idle-only, so a unit still queued from the run
+                // being replaced would carry its attempts into the rerun — the
+                // person who asked for another try would get a window that gives
+                // up after one.
+                self.store.delete_window_jobs(&src.id).await?;
                 // The title unit is armed once per corpus and never again, so
                 // that a document the model will not name stops costing calls.
                 // The row is what remembers that, which also means a corpus left
@@ -704,6 +710,42 @@ mod tests {
             .map(|i| format!("step {i}: run the {marker} command and read its output"))
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[tokio::test]
+    async fn reprocessing_gives_every_window_its_attempts_back() {
+        // Planning arms idle-only now, so the window units are the one piece of
+        // the previous run that a reprocess would otherwise inherit: a rerun
+        // asked for by a person would start its windows four attempts in and
+        // give up on them almost at once. `clear_segments` drops the rows the
+        // units name but not the units, which outlive them.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+        sqlx::query("UPDATE jobs SET attempts = 4 WHERE stage = 'segment_window'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        core.reprocess(&out.id, Stage::Synthesize).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        let attempts: Vec<i64> =
+            sqlx::query_scalar("SELECT attempts FROM jobs WHERE stage = 'segment_window'")
+                .fetch_all(&core.store.pool)
+                .await
+                .unwrap();
+        assert!(
+            !attempts.is_empty(),
+            "the rerun should have armed its windows again"
+        );
+        assert!(
+            attempts.iter().all(|&a| a == 0),
+            "the rerun inherited the previous run's attempts: {attempts:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -637,6 +637,15 @@ impl Core {
                 // no chunks at all. Re-windowing is also the point of a
                 // reprocess after a model or budget change.
                 self.store.clear_segments(&src.id).await?;
+                // The measure those windows produced goes with them. It is not
+                // just stale: the reconciliation sweep identifies a document
+                // whose last window resolved but whose `settle` never ran by
+                // having no coverage, so a value left over from the previous run
+                // reads as "already finished". A rerun that dies in exactly that
+                // window would then be stuck in `segmenting` for good — nothing
+                // resolves again to trigger `settle`, and the one sweep that
+                // repairs it has been told there is nothing to repair.
+                self.store.clear_corpus_coverage(&src.id).await?;
                 // And the units that name those windows, which outlive them.
                 // Planning arms idle-only, so a unit still queued from the run
                 // being replaced would carry its attempts into the rerun — the
@@ -710,6 +719,36 @@ mod tests {
             .map(|i| format!("step {i}: run the {marker} command and read its output"))
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[tokio::test]
+    async fn reprocessing_forgets_the_previous_runs_coverage() {
+        // The reconciliation sweep identifies a document whose last window
+        // resolved but whose `settle` never ran by its having no coverage. A
+        // reprocess that left the previous run's measure behind made its own
+        // rerun the one case the repair could not see: if that rerun died in
+        // exactly that window, nothing would resolve again to trigger `settle`,
+        // and the sweep would read the stale number as "already finished". The
+        // document sits in `segmenting` for good — never renumbered, never
+        // embedded, never in search.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        core.store.set_corpus_coverage(&out.id, 0.87).await.unwrap();
+
+        core.reprocess(&out.id, Stage::Synthesize).await.unwrap();
+
+        assert!(
+            core.store
+                .get_corpus(&out.id)
+                .await
+                .unwrap()
+                .coverage
+                .is_none(),
+            "the rerun carried the previous run's coverage, hiding it from the repair sweep"
+        );
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -52,6 +52,12 @@ impl QueryCache {
     }
 }
 
+/// Live per-document locks, keyed by corpus id. Shared by every clone of
+/// `Core`: a per-clone map would lock nothing, the same way a per-clone gate
+/// would pace nothing.
+pub type CorpusLocks =
+    Arc<std::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>;
+
 #[derive(Clone)]
 pub struct Core {
     pub store: Store,
@@ -79,6 +85,9 @@ pub struct Core {
     /// because a per-clone gate would pace nothing: the point is one queue of
     /// calls in front of one GPU.
     pub gate: Arc<crate::infer::gate::InferenceGate>,
+    /// One lock per document, so the local writes that rearrange a document
+    /// cannot interleave with each other. Reach for it through `corpus_lock`.
+    pub corpus_locks: CorpusLocks,
 }
 
 impl Core {
@@ -122,7 +131,41 @@ impl Core {
                     std::time::Duration::from_secs(cfg.pacing.breaker_probe_secs),
                 ),
             ),
+            corpus_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
+    }
+
+    /// Exclusive access to one document's artifact rows, for as long as the
+    /// guard is held.
+    ///
+    /// Windows became independently schedulable units, which means two workers
+    /// can be inside two windows of one document at once — where before, one job
+    /// owned the whole thing. The two local writes that rearrange a document are
+    /// not safe against each other: `write_segment_artifacts` deletes a window's
+    /// artifacts and inserts their replacements, while `finish` renumbers every
+    /// ordinal in the document. Interleaved, they leave duplicate or gapped
+    /// ordinals and a status that depends on which finished last. It converges on
+    /// the next settle, and until then the document is wrong.
+    ///
+    /// Never hold this across an inference call. The whole point of splitting a
+    /// document into units was to stop one window blocking the rest, and a lock
+    /// held around `segment` would hand that back — serialised, and for minutes.
+    /// Every holder does local SQLite work, which SQLite serialises anyway.
+    ///
+    /// `tokio::sync::Mutex` because a waiter must yield its thread rather than
+    /// park a worker on it.
+    pub async fn corpus_lock(&self, corpus_id: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let lock = {
+            let mut locks = self.corpus_locks.lock().expect("corpus locks");
+            // Entries nobody is holding or waiting on are dropped rather than
+            // accumulating one per document for the life of the process. A
+            // holder's guard owns its `Arc`, and so does a task that has cloned
+            // one and not yet locked it, so anything still in use counts above
+            // one and survives.
+            locks.retain(|_, l| Arc::strong_count(l) > 1);
+            Arc::clone(locks.entry(corpus_id.to_string()).or_default())
+        };
+        lock.lock_owned().await
     }
 }
 
@@ -188,6 +231,7 @@ pub mod test_support {
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::ZERO,
             )),
+            corpus_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 }
@@ -212,6 +256,47 @@ mod tests {
             !cfg.consolidate.judge,
             "the only inference-costing stage must be opt-in"
         );
+    }
+
+    #[tokio::test]
+    async fn one_document_is_locked_at_a_time_and_two_documents_are_not() {
+        let core = test_support::test_core().await;
+
+        let held = core.corpus_lock("doc-a").await;
+        let core2 = core.clone();
+        let blocked = tokio::spawn(async move {
+            let _second = core2.corpus_lock("doc-a").await;
+        });
+
+        // Another document is a different lock, so it must not be behind this
+        // one: two workers segmenting two documents was the point of units.
+        let other = core.corpus_lock("doc-b").await;
+        drop(other);
+
+        tokio::task::yield_now().await;
+        assert!(
+            !blocked.is_finished(),
+            "two writers were let into one document at once"
+        );
+        drop(held);
+        blocked.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn locks_nobody_is_holding_do_not_accumulate() {
+        // One entry per document, kept for the life of the process, would be a
+        // slow leak on a base that ingests continuously.
+        let core = test_support::test_core().await;
+        for i in 0..50 {
+            drop(core.corpus_lock(&format!("doc-{i}")).await);
+        }
+        let held = core.corpus_lock("doc-held").await;
+        assert_eq!(
+            core.corpus_locks.lock().unwrap().len(),
+            1,
+            "released locks were kept"
+        );
+        drop(held);
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -75,6 +75,10 @@ pub struct Core {
     /// Whether and how real searches are recorded for later judging. Read on
     /// the search path, so it lives here rather than being threaded down.
     pub feedback: crate::config::FeedbackConfig,
+    /// The pacer every inference call passes through. Shared by every clone,
+    /// because a per-clone gate would pace nothing: the point is one queue of
+    /// calls in front of one GPU.
+    pub gate: Arc<crate::infer::gate::InferenceGate>,
 }
 
 impl Core {
@@ -109,6 +113,15 @@ impl Core {
             consolidate: cfg.consolidate.clone(),
             weak_below: cfg.vector.weak_below,
             feedback: cfg.feedback.clone(),
+            gate: Arc::new(
+                crate::infer::gate::InferenceGate::new(std::time::Duration::from_secs(
+                    cfg.pacing.cooldown_secs,
+                ))
+                .with_breaker(
+                    cfg.pacing.breaker_after,
+                    std::time::Duration::from_secs(cfg.pacing.breaker_probe_secs),
+                ),
+            ),
         }
     }
 }
@@ -170,6 +183,11 @@ pub mod test_support {
             weak_below: 0.0,
             // Off, like the shipped default. The capture tests switch it on.
             feedback: crate::config::FeedbackConfig::default(),
+            // No cooldown and no breaker: a test that wants pacing builds its
+            // own gate, and every other test would otherwise pay for one.
+            gate: Arc::new(crate::infer::gate::InferenceGate::new(
+                std::time::Duration::ZERO,
+            )),
         }
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -331,6 +331,15 @@ impl Core {
             n => n.min(MAX_LIMIT),
         };
 
+        // Embedding the query is a model call, and so is the reranker, so a
+        // search is a person waiting on the endpoint exactly as `ask` is — and
+        // it is the more common way in, through the UI and through MCP. Without
+        // the lane a worker is free to start a window the instant the query
+        // lands, and the query then waits out twenty to seventy seconds of it.
+        // `ask` takes one too and holds it across this; the lane is a count, so
+        // nesting is what it is built for.
+        let _lane = self.gate.interactive();
+
         let started = std::time::Instant::now();
         // Prefixes repeat constantly inside one search and whole queries repeat
         // across sessions, so this is the difference between one embedding call
@@ -576,6 +585,73 @@ mod tests {
                 crate::jobs::embed::run(core, &c.id).await.unwrap();
             }
         }
+    }
+
+    /// An embedder that stops inside the call, so a test can look at what the
+    /// rest of the system is doing while a search waits on the endpoint.
+    struct BlockingEmbedder {
+        inner: crate::infer::fake::FakeEmbedder,
+        started: std::sync::Arc<tokio::sync::Notify>,
+        release: std::sync::Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::infer::Embedder for BlockingEmbedder {
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            self.started.notify_one();
+            self.release.notified().await;
+            self.inner.embed(texts).await
+        }
+        fn dim(&self) -> usize {
+            self.inner.dim()
+        }
+        fn model(&self) -> &str {
+            self.inner.model()
+        }
+        fn max_input_tokens(&self) -> usize {
+            self.inner.max_input_tokens()
+        }
+    }
+
+    // Real time rather than `start_paused`: the SQLite pool's own timeouts are
+    // tokio timers too, and a paused clock auto-advances them the moment every
+    // task is idle, so the pool times out before the test starts.
+    #[tokio::test]
+    async fn a_search_holds_the_interactive_lane_while_it_runs() {
+        // `ask` took the lane and a plain search did not, which left the more
+        // common way in — the UI and MCP — free to be overtaken: a worker could
+        // start a window the instant the query landed, and the person waiting on
+        // their search then waited out twenty to seventy seconds of it. The
+        // query embed is a model call, and so is the reranker.
+        let mut core = test_core().await;
+        let started = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release = std::sync::Arc::new(tokio::sync::Notify::new());
+        core.embedder = std::sync::Arc::new(BlockingEmbedder {
+            inner: crate::infer::fake::FakeEmbedder::new(core.embedder.dim()),
+            started: started.clone(),
+            release: release.clone(),
+        });
+        let core = std::sync::Arc::new(core);
+
+        let searching = tokio::spawn({
+            let core = core.clone();
+            async move { core.search(&q("timeout"), Door::Api).await }
+        });
+        started.notified().await;
+
+        let gate = core.gate.clone();
+        let worker = tokio::spawn(async move {
+            gate.background().await;
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !worker.is_finished(),
+            "a background call started while a search was waiting on the endpoint"
+        );
+
+        release.notify_one();
+        searching.await.unwrap().unwrap();
+        worker.await.unwrap();
     }
 
     fn q(text: &str) -> SearchQuery {

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -306,35 +306,6 @@ impl Synthesizer for RecordingSynthesizer {
     }
 }
 
-/// Segments like `FakeSynthesizer` but reports a cooldown, so a test can assert
-/// the job actually paces itself instead of running flat out.
-pub struct PacedSynthesizer {
-    inner: FakeSynthesizer,
-    cooldown: std::time::Duration,
-}
-
-impl PacedSynthesizer {
-    pub fn new(cooldown: std::time::Duration) -> Self {
-        Self {
-            inner: FakeSynthesizer::default(),
-            cooldown,
-        }
-    }
-}
-
-#[async_trait]
-impl Synthesizer for PacedSynthesizer {
-    async fn segment(&self, input: SegmentInput<'_>) -> Result<Vec<ProposedArtifact>> {
-        self.inner.segment(input).await
-    }
-    fn budget(&self) -> SynthesisBudget {
-        self.inner.budget()
-    }
-    fn cooldown(&self) -> std::time::Duration {
-        self.cooldown
-    }
-}
-
 /// Claims every chunk came from lines far outside its window. The span check
 /// exists because the model's line numbers are taken on trust.
 #[derive(Default)]

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -66,6 +66,9 @@ pub struct FakeSynthesizer {
     /// Fail only on windows containing this marker. Lets a test model the
     /// realistic case — some windows succeed, one does not.
     fail_on_marker: Option<String>,
+    /// Answer, but with something the parser cannot read. Distinct from the
+    /// two above, which model an endpoint that never answered at all.
+    unparsable_on_marker: Option<String>,
 }
 
 impl FakeSynthesizer {
@@ -73,6 +76,7 @@ impl FakeSynthesizer {
         Self {
             fail_with: Some(msg.to_string()),
             fail_on_marker: None,
+            unparsable_on_marker: None,
         }
     }
 
@@ -80,6 +84,19 @@ impl FakeSynthesizer {
         Self {
             fail_with: None,
             fail_on_marker: Some(marker.to_string()),
+            unparsable_on_marker: None,
+        }
+    }
+
+    /// The model replies to every window and its reply for the marked one
+    /// cannot be parsed however often it is asked. This is what a duplicate
+    /// JSON key looks like from the caller's side, and it is a property of the
+    /// window's text rather than of the endpoint.
+    pub fn unparsable_on(marker: &str) -> Self {
+        Self {
+            fail_with: None,
+            fail_on_marker: None,
+            unparsable_on_marker: Some(marker.to_string()),
         }
     }
 }
@@ -95,6 +112,13 @@ impl Synthesizer for FakeSynthesizer {
                 role: "chunk",
                 detail: format!("refusing window containing {marker}"),
             });
+        }
+        if let Some(marker) = &self.unparsable_on_marker
+            && text.contains(marker.as_str())
+        {
+            return Err(Error::MalformedLlmOutput(
+                "duplicate field `tags` at line 1 column 630".into(),
+            ));
         }
         if let Some(m) = &self.fail_with {
             return Err(Error::Inference {

--- a/src/infer/gate.rs
+++ b/src/infer/gate.rs
@@ -216,7 +216,13 @@ impl Drop for InteractiveLease {
         {
             let mut st = self.gate.state.lock().expect("gate state");
             st.interactive = st.interactive.saturating_sub(1);
-            st.last_finished = Some(Instant::now());
+            // `last_finished` is deliberately not stamped. It was, and it made
+            // the cooldown restart on every interactive call — which for search
+            // means every keystroke's embed. A person paging through the UI held
+            // background work off forever: each page pushed the gap out again,
+            // and nothing here ages or bounds that. The cooldown paces batch
+            // work against the GPU, and the interactive lane is already the
+            // exception to it — `[pacing]` says so in as many words.
         }
         self.gate.resumed.notify_waiters();
     }
@@ -277,6 +283,40 @@ mod tests {
         let started = tokio::time::Instant::now();
         let _lease = g.interactive();
         assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_person_paging_through_the_ui_cannot_starve_background_work() {
+        // The lease used to stamp `last_finished` on the way out, so every
+        // interactive call restarted the cooldown — and for search that is every
+        // keystroke's embed. Each page pushed the gap out again, with nothing here
+        // ageing the background work that was waiting, so on a long enough
+        // browsing session it never ran at all.
+        let g = gate(600);
+        // A background call has just ended, so the cooldown is what the waiter
+        // below is waiting on.
+        g.call_succeeded();
+        let t0 = tokio::time::Instant::now();
+        let g2 = Arc::clone(&g);
+        let waiter = tokio::spawn(async move {
+            g2.background().await;
+            tokio::time::Instant::now()
+        });
+
+        // Ten pages of results, each one an interactive call that begins and
+        // ends, spread across the cooldown the waiter is already serving.
+        for _ in 0..10 {
+            let lease = g.interactive();
+            tokio::time::advance(Duration::from_secs(60)).await;
+            drop(lease);
+        }
+
+        let started_at = waiter.await.unwrap();
+        assert_eq!(
+            started_at.duration_since(t0),
+            Duration::from_secs(600),
+            "the searches pushed the cooldown out from under work that was already waiting"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/infer/gate.rs
+++ b/src/infer/gate.rs
@@ -59,8 +59,12 @@ impl InferenceGate {
         }
     }
 
+    /// `after = 0` turns the breaker off, the way `cooldown_secs = 0` turns the
+    /// cooldown off. Clamping it up to 1 instead would read the operator's
+    /// "don't do this" as the most aggressive setting there is — one failed call
+    /// holding every background call for the whole probe window.
     pub fn with_breaker(mut self, after: usize, probe: Duration) -> Self {
-        self.breaker_after = after.max(1);
+        self.breaker_after = if after == 0 { usize::MAX } else { after };
         self.probe_after = probe;
         self
     }
@@ -150,9 +154,12 @@ impl InferenceGate {
         st.consecutive_transport_failures += 1;
         if st.consecutive_transport_failures >= self.breaker_after {
             st.breaker_open_until = Some(Instant::now() + self.probe_after);
-            // Reset, so one further failure after the probe re-opens it rather
-            // than every subsequent call re-arming from an already-tripped count.
-            st.consecutive_transport_failures = 0;
+            // The count is left where it is rather than reset, so the one call
+            // let through after the probe window re-opens the breaker the moment
+            // it fails. Resetting cost `breaker_after` full timeouts — three
+            // quarters of an hour at the default `timeout_secs` — to rediscover
+            // the same dead endpoint on every probe cycle, which is the exact
+            // cost this exists to avoid. `call_succeeded` is what clears it.
             tracing::warn!(
                 probe_secs = self.probe_after.as_secs(),
                 "inference endpoint failed repeatedly; holding background calls"
@@ -331,6 +338,54 @@ mod tests {
         let started = tokio::time::Instant::now();
         g.background().await;
         assert_eq!(started.elapsed(), Duration::ZERO, "the run was not reset");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn one_failure_after_the_probe_window_re_opens_the_breaker() {
+        // The probe is one call let through to ask whether the endpoint is back.
+        // If it is not, the answer is already in — making the queue earn the
+        // whole run again spends `breaker_after` full timeouts, three quarters
+        // of an hour at the default, rediscovering it on every cycle.
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)));
+        for _ in 0..3 {
+            g.call_failed(&Error::Inference {
+                role: "chunk",
+                detail: "502".into(),
+            });
+        }
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        // The probe goes out, and the endpoint is still down.
+        g.background().await.failed(&Error::Inference {
+            role: "chunk",
+            detail: "502".into(),
+        });
+
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(
+            started.elapsed(),
+            Duration::from_secs(60),
+            "the queue was let back onto a dead endpoint"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_breaker_configured_to_zero_is_off() {
+        // Zero reads as "don't do this", the way `cooldown_secs = 0` does.
+        // Clamping it up to one made it the most aggressive setting there is.
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(0, Duration::from_secs(60)));
+        for _ in 0..10 {
+            g.call_failed(&Error::Inference {
+                role: "chunk",
+                detail: "502".into(),
+            });
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/infer/gate.rs
+++ b/src/infer/gate.rs
@@ -1,10 +1,11 @@
 //! One pacer in front of every inference call.
 //!
-//! Three jobs that all answer the same question — may a background call start
-//! now? The cooldown protects a desktop GPU from unbroken load. The interactive
-//! lease keeps the worker from piling work onto the endpoint while a person is
-//! waiting on `ask`. The breaker stops thirty-four units from each spending a
-//! fifteen-minute timeout discovering the same dead endpoint.
+//! Four jobs that all answer the same question — may a background call start
+//! now? The cooldown protects a desktop GPU from unbroken load. The turn keeps
+//! that answer true for the whole system rather than per worker. The
+//! interactive lease keeps the worker from piling work onto the endpoint while
+//! a person is waiting on `ask`. The breaker stops thirty-four units from each
+//! spending a fifteen-minute timeout discovering the same dead endpoint.
 //!
 //! It sits around calls rather than around jobs, so the two stages that make no
 //! inference call — planning a corpus into windows, and the consolidation sweep
@@ -13,7 +14,7 @@
 use crate::error::Error;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore, SemaphorePermit};
 use tokio::time::Instant;
 
 #[derive(Default)]
@@ -30,6 +31,15 @@ struct GateState {
 pub struct InferenceGate {
     state: Mutex<GateState>,
     resumed: Notify,
+    /// One background call at a time, held for the duration of the call.
+    ///
+    /// The cooldown on its own paces each worker without bounding the whole:
+    /// `server.workers` defaults to 2, and two workers read the same unchanged
+    /// `last_finished` in the same instant — neither has finished — and put two
+    /// generations on the one GPU. That is the load the cooldown is configured
+    /// to prevent, so the gap has to be between calls rather than between one
+    /// worker's calls.
+    turn: Semaphore,
     cooldown: Duration,
     breaker_after: usize,
     probe_after: Duration,
@@ -40,6 +50,7 @@ impl InferenceGate {
         Self {
             state: Mutex::new(GateState::default()),
             resumed: Notify::new(),
+            turn: Semaphore::new(1),
             cooldown,
             // Off unless configured, so a test that did not ask for a breaker
             // cannot be surprised by one.
@@ -54,14 +65,35 @@ impl InferenceGate {
         self
     }
 
-    /// Returns when a background inference call may start.
-    pub async fn background(&self) {
+    /// Returns the right to make one background inference call, once one may
+    /// start. Hold the permit for the duration of the call.
+    pub async fn background(&self) -> BackgroundPermit<'_> {
+        // The turn is taken before the wait rather than after it, so whoever
+        // holds it re-reads the cooldown once the call ahead has finished.
+        // Checking first and taking the turn afterwards would let every waiter
+        // clear the same stale `last_finished` and then merely queue up.
+        let turn = self
+            .turn
+            .acquire()
+            .await
+            .expect("the gate's turn is never closed");
         loop {
+            // Built before the lock is taken and registered before it is
+            // dropped. `notify_waiters` wakes only waiters that are already
+            // registered and leaves no permit behind, so a lease ending in the
+            // gap between dropping the guard and first polling this would have
+            // woken nobody — and background work would have waited for the
+            // *next* question instead of for this one to end, which on a
+            // single-user base can be hours.
+            let resumed = self.resumed.notified();
+            tokio::pin!(resumed);
+
             // The lock is never held across an await: the wait is computed, the
             // guard dropped, and only then slept on.
             let wait = {
                 let st = self.state.lock().expect("gate state");
                 if st.interactive > 0 {
+                    resumed.as_mut().enable();
                     None
                 } else {
                     let now = Instant::now();
@@ -74,7 +106,7 @@ impl InferenceGate {
                     .max();
                     match ready_at {
                         Some(t) if t > now => Some(t - now),
-                        _ => return,
+                        _ => break,
                     }
                 }
             };
@@ -82,8 +114,12 @@ impl InferenceGate {
                 Some(d) => tokio::time::sleep(d).await,
                 // Held off by an interactive call, which has no deadline. The
                 // lease wakes us when it drops.
-                None => self.resumed.notified().await,
+                None => resumed.await,
             }
+        }
+        BackgroundPermit {
+            gate: self,
+            _turn: turn,
         }
     }
 
@@ -122,6 +158,27 @@ impl InferenceGate {
                 "inference endpoint failed repeatedly; holding background calls"
             );
         }
+    }
+}
+
+/// The right to make one background inference call, held for as long as the
+/// call runs.
+///
+/// Report the outcome through it — both methods consume the permit, so the
+/// cooldown starts and the turn passes on at the moment the call ended rather
+/// than whenever the caller got around to saying so.
+pub struct BackgroundPermit<'a> {
+    gate: &'a InferenceGate,
+    _turn: SemaphorePermit<'a>,
+}
+
+impl BackgroundPermit<'_> {
+    pub fn succeeded(self) {
+        self.gate.call_succeeded();
+    }
+
+    pub fn failed(self, e: &Error) {
+        self.gate.call_failed(e);
     }
 }
 
@@ -172,7 +229,9 @@ mod tests {
         let g = gate(0);
         let lease = g.interactive();
         let g2 = Arc::clone(&g);
-        let waiter = tokio::spawn(async move { g2.background().await });
+        let waiter = tokio::spawn(async move {
+            g2.background().await;
+        });
 
         tokio::time::advance(Duration::from_secs(30)).await;
         assert!(
@@ -193,6 +252,49 @@ mod tests {
         let started = tokio::time::Instant::now();
         let _lease = g.interactive();
         assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn two_workers_do_not_put_two_generations_on_the_gpu_at_once() {
+        // `server.workers` defaults to 2, and the cooldown alone is a check
+        // rather than a turn: both workers read the same unchanged
+        // `last_finished` — neither has finished — and both proceed. The gap the
+        // operator configured then bounds each worker rather than the endpoint.
+        let g = gate(5);
+        let first = g.background().await;
+
+        let g2 = Arc::clone(&g);
+        let second = tokio::spawn(async move {
+            g2.background().await;
+            tokio::time::Instant::now()
+        });
+        tokio::time::advance(Duration::from_secs(3600)).await;
+        assert!(
+            !second.is_finished(),
+            "a second call started while the first was still running"
+        );
+
+        // And the waiter serves out the cooldown from when that call *ended*,
+        // rather than from a stamp it read before it started.
+        first.succeeded();
+        let released = tokio::time::Instant::now();
+        let acquired = second.await.unwrap();
+        assert_eq!(acquired - released, Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_failed_call_hands_the_turn_on() {
+        // The turn is released by the permit, so a call that errored must not
+        // hold the endpoint shut behind it.
+        let g = gate(0);
+        let permit = g.background().await;
+        permit.failed(&Error::Inference {
+            role: "chunk",
+            detail: "502".into(),
+        });
+        tokio::time::timeout(Duration::from_secs(1), g.background())
+            .await
+            .expect("the turn was never handed on");
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/infer/gate.rs
+++ b/src/infer/gate.rs
@@ -166,6 +166,18 @@ impl InferenceGate {
             );
         }
     }
+
+    /// A call the endpoint answered by refusing the input.
+    ///
+    /// It occupied the GPU, so it starts the cooldown like any other call. It
+    /// says nothing about whether the endpoint is well, so it must not count
+    /// toward the breaker — the same distinction `MalformedLlmOutput` gets, and
+    /// it has to be made by the caller because a size refusal arrives as an
+    /// `Error::Inference` and is indistinguishable here from a dead server.
+    pub fn call_refused(&self) {
+        let mut st = self.state.lock().expect("gate state");
+        st.last_finished = Some(Instant::now());
+    }
 }
 
 /// The right to make one background inference call, held for as long as the
@@ -186,6 +198,12 @@ impl BackgroundPermit<'_> {
 
     pub fn failed(self, e: &Error) {
         self.gate.call_failed(e);
+    }
+
+    /// The endpoint answered, refusing the input. Starts the cooldown and hands
+    /// the turn on, without counting against the endpoint.
+    pub fn refused(self) {
+        self.gate.call_refused();
     }
 }
 
@@ -369,6 +387,25 @@ mod tests {
             Duration::from_secs(60),
             "the queue was let back onto a dead endpoint"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_refused_input_is_not_an_endpoint_failure() {
+        // The endpoint answered: this input is too big for it. That is a fact
+        // about the input, not about the endpoint's health — the same
+        // distinction `MalformedLlmOutput` gets, arriving here as an
+        // `Error::Inference` only because a size refusal is transport-shaped.
+        // Counted, three unsplittable oversize chunks in one document would
+        // hold every background call in the system — synthesis and judging
+        // included — against a server that is working perfectly.
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)));
+        for _ in 0..5 {
+            g.background().await.refused();
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/infer/gate.rs
+++ b/src/infer/gate.rs
@@ -1,0 +1,248 @@
+//! One pacer in front of every inference call.
+//!
+//! Three jobs that all answer the same question — may a background call start
+//! now? The cooldown protects a desktop GPU from unbroken load. The interactive
+//! lease keeps the worker from piling work onto the endpoint while a person is
+//! waiting on `ask`. The breaker stops thirty-four units from each spending a
+//! fifteen-minute timeout discovering the same dead endpoint.
+//!
+//! It sits around calls rather than around jobs, so the two stages that make no
+//! inference call — planning a corpus into windows, and the consolidation sweep
+//! — never wait for a cooldown they did not earn.
+
+use crate::error::Error;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::time::Instant;
+
+#[derive(Default)]
+struct GateState {
+    /// Interactive calls in flight. Background work waits while this is above
+    /// zero; a count rather than a flag because `ask` makes more than one call
+    /// and the UI can have two queries open.
+    interactive: usize,
+    last_finished: Option<Instant>,
+    consecutive_transport_failures: usize,
+    breaker_open_until: Option<Instant>,
+}
+
+pub struct InferenceGate {
+    state: Mutex<GateState>,
+    resumed: Notify,
+    cooldown: Duration,
+    breaker_after: usize,
+    probe_after: Duration,
+}
+
+impl InferenceGate {
+    pub fn new(cooldown: Duration) -> Self {
+        Self {
+            state: Mutex::new(GateState::default()),
+            resumed: Notify::new(),
+            cooldown,
+            // Off unless configured, so a test that did not ask for a breaker
+            // cannot be surprised by one.
+            breaker_after: usize::MAX,
+            probe_after: Duration::ZERO,
+        }
+    }
+
+    pub fn with_breaker(mut self, after: usize, probe: Duration) -> Self {
+        self.breaker_after = after.max(1);
+        self.probe_after = probe;
+        self
+    }
+
+    /// Returns when a background inference call may start.
+    pub async fn background(&self) {
+        loop {
+            // The lock is never held across an await: the wait is computed, the
+            // guard dropped, and only then slept on.
+            let wait = {
+                let st = self.state.lock().expect("gate state");
+                if st.interactive > 0 {
+                    None
+                } else {
+                    let now = Instant::now();
+                    let ready_at = [
+                        st.last_finished.map(|t| t + self.cooldown),
+                        st.breaker_open_until,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .max();
+                    match ready_at {
+                        Some(t) if t > now => Some(t - now),
+                        _ => return,
+                    }
+                }
+            };
+            match wait {
+                Some(d) => tokio::time::sleep(d).await,
+                // Held off by an interactive call, which has no deadline. The
+                // lease wakes us when it drops.
+                None => self.resumed.notified().await,
+            }
+        }
+    }
+
+    /// A lease for an interactive call. Returns immediately, always.
+    pub fn interactive(self: &Arc<Self>) -> InteractiveLease {
+        self.state.lock().expect("gate state").interactive += 1;
+        InteractiveLease {
+            gate: Arc::clone(self),
+        }
+    }
+
+    pub fn call_succeeded(&self) {
+        let mut st = self.state.lock().expect("gate state");
+        st.last_finished = Some(Instant::now());
+        st.consecutive_transport_failures = 0;
+        st.breaker_open_until = None;
+    }
+
+    /// A failed call still occupied the GPU, so it still starts the cooldown.
+    /// Only a transport failure counts toward the breaker: `MalformedLlmOutput`
+    /// means the endpoint answered and this window's text is the problem.
+    pub fn call_failed(&self, e: &Error) {
+        let mut st = self.state.lock().expect("gate state");
+        st.last_finished = Some(Instant::now());
+        if !matches!(e, Error::Inference { .. }) {
+            return;
+        }
+        st.consecutive_transport_failures += 1;
+        if st.consecutive_transport_failures >= self.breaker_after {
+            st.breaker_open_until = Some(Instant::now() + self.probe_after);
+            // Reset, so one further failure after the probe re-opens it rather
+            // than every subsequent call re-arming from an already-tripped count.
+            st.consecutive_transport_failures = 0;
+            tracing::warn!(
+                probe_secs = self.probe_after.as_secs(),
+                "inference endpoint failed repeatedly; holding background calls"
+            );
+        }
+    }
+}
+
+pub struct InteractiveLease {
+    gate: Arc<InferenceGate>,
+}
+
+impl Drop for InteractiveLease {
+    fn drop(&mut self) {
+        {
+            let mut st = self.gate.state.lock().expect("gate state");
+            st.interactive = st.interactive.saturating_sub(1);
+            st.last_finished = Some(Instant::now());
+        }
+        self.gate.resumed.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn gate(cooldown_secs: u64) -> Arc<InferenceGate> {
+        Arc::new(InferenceGate::new(Duration::from_secs(cooldown_secs)))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_idle_gate_with_no_cooldown_lets_work_through_at_once() {
+        let g = gate(0);
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_cooldown_is_measured_from_when_the_last_call_ended() {
+        let g = gate(5);
+        g.call_succeeded();
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn background_work_waits_while_an_interactive_call_holds_a_lease() {
+        let g = gate(0);
+        let lease = g.interactive();
+        let g2 = Arc::clone(&g);
+        let waiter = tokio::spawn(async move { g2.background().await });
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        assert!(
+            !waiter.is_finished(),
+            "background ran while an ask was in flight"
+        );
+
+        drop(lease);
+        waiter.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_interactive_call_never_waits_even_during_a_cooldown() {
+        // The point of the lane: a person is waiting, and the pacer exists to
+        // protect the GPU from batch work, not from them.
+        let g = gate(600);
+        g.call_succeeded();
+        let started = tokio::time::Instant::now();
+        let _lease = g.interactive();
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn three_transport_failures_in_a_row_open_the_breaker() {
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)));
+        for _ in 0..3 {
+            g.call_failed(&Error::Inference {
+                role: "chunk",
+                detail: "502".into(),
+            });
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::from_secs(60));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_success_closes_the_breaker_again() {
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)));
+        for _ in 0..2 {
+            g.call_failed(&Error::Inference {
+                role: "chunk",
+                detail: "502".into(),
+            });
+        }
+        g.call_succeeded();
+        g.call_failed(&Error::Inference {
+            role: "chunk",
+            detail: "502".into(),
+        });
+
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO, "the run was not reset");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unreadable_output_is_not_an_endpoint_failure() {
+        // The distinction the whole design rests on: the model answered, so the
+        // endpoint is fine. Tripping the breaker here would stop the queue over
+        // one document's punctuation.
+        let g =
+            Arc::new(InferenceGate::new(Duration::ZERO).with_breaker(3, Duration::from_secs(60)));
+        for _ in 0..5 {
+            g.call_failed(&Error::MalformedLlmOutput("duplicate field `tags`".into()));
+        }
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+}

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -49,11 +49,6 @@ pub trait Synthesizer: Send + Sync {
     /// Segment one window of text. Windowing itself is the caller's job.
     async fn segment(&self, input: SegmentInput<'_>) -> Result<Vec<ProposedArtifact>>;
     fn budget(&self) -> SynthesisBudget;
-    /// How long to idle between windows, so a long source is not one
-    /// unbroken thermal load on a desktop GPU. Zero for anything remote.
-    fn cooldown(&self) -> std::time::Duration {
-        std::time::Duration::ZERO
-    }
     /// A short name for a whole document, given its opening and the titles of
     /// the artifacts drawn from it.
     ///

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -2,6 +2,7 @@ pub mod budget;
 pub mod context;
 pub mod facts;
 pub mod fake;
+pub mod gate;
 pub mod openai;
 pub mod prompt;
 pub mod split;

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -490,6 +490,7 @@ mod tests {
             reasoning_effort: None,
             context_opening_tokens: 200,
             context_overlap_tokens: 150,
+            cooldown_secs: None,
         }
     }
     fn embed_cfg(base: String) -> EmbedRole {

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -73,7 +73,6 @@ pub struct HttpSynthesizer {
     budget: SynthesisBudget,
     max_artifact_tokens: usize,
     reasoning_effort: Option<String>,
-    cooldown: std::time::Duration,
 }
 
 impl HttpSynthesizer {
@@ -94,7 +93,6 @@ impl HttpSynthesizer {
             },
             max_artifact_tokens: 1024,
             reasoning_effort: cfg.reasoning_effort.clone(),
-            cooldown: std::time::Duration::from_secs(cfg.cooldown_secs),
         }
     }
 
@@ -175,10 +173,6 @@ impl Synthesizer for HttpSynthesizer {
 
     fn budget(&self) -> SynthesisBudget {
         self.budget
-    }
-
-    fn cooldown(&self) -> std::time::Duration {
-        self.cooldown
     }
 
     async fn title(&self, text: &str, artifact_titles: &[String]) -> Result<Option<String>> {
@@ -494,7 +488,6 @@ mod tests {
             tokenizer_path: None,
             timeout_secs: crate::config::DEFAULT_TIMEOUT_SECS,
             reasoning_effort: None,
-            cooldown_secs: 0,
             context_opening_tokens: 200,
             context_overlap_tokens: 150,
         }

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -152,9 +152,23 @@ Reply with JSON only, no commentary, in exactly this shape:
 /// opens "32 Bit Clusternummern" and never says FAT32 again. Handed the bodies
 /// alone, the model saw two anonymous spec lists with different numbers and
 /// called them a contradiction — correctly, on the evidence it was given.
-pub fn judge_prompt(a: (&str, &str), b: (&str, &str)) -> String {
+/// `attempt` is how many times this pair has already been asked about, and it is
+/// in the prompt for one reason: the endpoint caches by exact prompt text and
+/// replays a cached reply in milliseconds. A retry of a reply the parser could
+/// not read would otherwise re-read the same unreadable bytes, five times, and
+/// call it five attempts.
+///
+/// Zero adds nothing at all, so a first ask stays byte-identical to what it has
+/// always been — and keeps hitting the cache when it should, on a pair the sweep
+/// re-arms after a settled verdict was lost.
+pub fn judge_prompt(a: (&str, &str), b: (&str, &str), attempt: i64) -> String {
+    let retry = if attempt > 0 {
+        format!("(attempt {})\n", attempt + 1)
+    } else {
+        String::new()
+    };
     format!(
-        "----- ARTIFACT A -----\nTitle: {}\n\n{}\n----- ARTIFACT B -----\nTitle: {}\n\n{}\n----- END -----",
+        "{retry}----- ARTIFACT A -----\nTitle: {}\n\n{}\n----- ARTIFACT B -----\nTitle: {}\n\n{}\n----- END -----",
         a.0, a.1, b.0, b.1
     )
 }
@@ -501,10 +515,30 @@ mod tests {
         let p = judge_prompt(
             ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
             ("FAT32 Specifications", "32 Bit Clusternummern."),
+            0,
         );
         assert!(p.contains("Title: FAT16 Specifications"), "{p}");
         assert!(p.contains("Title: FAT32 Specifications"), "{p}");
         assert!(p.contains("Die max. Partitionsgröße: 2 GB."));
+    }
+
+    #[test]
+    fn a_retry_does_not_ask_the_endpoint_the_question_it_has_cached() {
+        // The endpoint replays a cached reply for an identical prompt in
+        // milliseconds. A pair whose reply the parser could not read is retried
+        // up to `MAX_ATTEMPTS` times, and every one of those would have read the
+        // same unreadable bytes back.
+        let pair = (
+            ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
+            ("FAT32 Specifications", "32 Bit Clusternummern."),
+        );
+        let first = judge_prompt(pair.0, pair.1, 0);
+        let second = judge_prompt(pair.0, pair.1, 1);
+        assert_ne!(first, second);
+        assert_ne!(second, judge_prompt(pair.0, pair.1, 2));
+        // A first ask stays exactly what it was, so the cache still earns its
+        // keep on a pair the sweep re-arms after a verdict was lost.
+        assert!(first.starts_with("----- ARTIFACT A -----"), "{first}");
     }
 
     #[test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -507,10 +507,27 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
             continue;
         }
 
+        // A pair whose unit is still queued from an earlier sweep is already
+        // going to be judged. `pairs_to_judge` orders by `judge_attempts`, and a
+        // pair that has not run yet still has none, so it leads every sweep
+        // until it does — spending the budget on itself over and over while
+        // pairs recorded since never get a turn.
+        let target = p.id.to_string();
+        if core.store.live_job(Stage::Judge, &target).await? {
+            continue;
+        }
+
         // `seq` is the pair's position in this sweep. Left at zero, twenty
         // judge units would all sort ahead of every document's second window.
+        //
+        // Idle-only for the same reason the reconciliation sweep is: re-arming
+        // a queued unit winds its `attempts` back to zero, and a pair the model
+        // will not judge would then never reach `MAX_ATTEMPTS` — never reaching
+        // the close-out in `run_one` that hands it back to a later sweep. The
+        // guard above already skips those; this is what keeps it true if the
+        // two ever drift.
         core.store
-            .arm_seq(Stage::Judge, "pair", &p.id.to_string(), armed as i64)
+            .rearm_idle_seq(Stage::Judge, "pair", &target, armed as i64)
             .await?;
         armed += 1;
     }
@@ -1558,6 +1575,77 @@ mod tests {
                 .len(),
             1,
             "the second sweep never reached an unjudged pair"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_leaves_a_judge_unit_that_is_already_queued_alone() {
+        // Two ways this went wrong at once. Re-arming a queued unit wound its
+        // `attempts` back, so a pair the model will not judge never reached
+        // `MAX_ATTEMPTS` and never reached the close-out that hands it to a
+        // later sweep — forever young, exactly as the reconciliation sweep used
+        // to keep windows. And `pairs_to_judge` orders by `judge_attempts`, so a
+        // pair still waiting for its first call leads every sweep: the budget
+        // went on re-arming it while pairs recorded since never got a turn.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.consolidate.max_judgements = 1;
+        // Two pairs in the review band and nothing near enough to cluster, so
+        // the sweep has a second pair to reach once the first is spoken for.
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.0, 1.0]),
+                ("retry is 3 times", [-1.0, 0.0]),
+                ("retry is 9 times", [0.0, -1.0]),
+            ],
+        )
+        .await;
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        core.store
+            .record_pair(&ids[2], &ids[3], 0.90)
+            .await
+            .unwrap();
+
+        // A sweep arms one unit. Nothing runs it — the worker is busy.
+        run(&core).await.unwrap();
+        let first: (String, i64) =
+            sqlx::query_as("SELECT target_id, id FROM jobs WHERE stage = 'judge'")
+                .fetch_one(&core.store.pool)
+                .await
+                .unwrap();
+        let later = crate::store::now() + 3600;
+        sqlx::query("UPDATE jobs SET attempts = 2, run_after = ? WHERE id = ?")
+            .bind(later)
+            .bind(first.1)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let (attempts, run_after): (i64, i64) =
+            sqlx::query_as("SELECT attempts, run_after FROM jobs WHERE id = ?")
+                .bind(first.1)
+                .fetch_one(&core.store.pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            (attempts, run_after),
+            (2, later),
+            "the sweep wound a queued judge unit back to zero attempts"
+        );
+        let armed: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM jobs WHERE stage = 'judge'")
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            armed, 2,
+            "the second sweep spent its budget re-arming the pair it had already queued"
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -15,6 +15,7 @@
 use crate::core::Core;
 use crate::error::Result;
 use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::jobs::Stage;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Default, Clone, Copy, serde::Serialize)]
@@ -25,6 +26,8 @@ pub struct Outcome {
     /// Pairs settled without asking anyone, because the two artifacts state no
     /// value differently and so have nothing to disagree about.
     pub closed: usize,
+    /// Pairs this sweep armed a judge unit for. The calls happen later, one
+    /// unit at a time, so this counts what was asked for rather than answered.
     pub judged: usize,
     pub contradictions: usize,
 }
@@ -417,9 +420,11 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     }
 
     if cfg.judge {
-        let (judged, contradictions) = judge_pending(core).await?;
-        out.judged = judged;
-        out.contradictions = contradictions;
+        // Armed, not asked. `judged` counts the calls this sweep is responsible
+        // for rather than the calls it made, since it now makes none;
+        // `contradictions` is no longer knowable here at all, because the answer
+        // arrives one unit at a time long after the sweep has returned.
+        out.judged = arm_judgements(core).await?;
     }
 
     if out.superseded > 0 || out.queued > 0 || out.judged > 0 {
@@ -441,12 +446,24 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 /// Returns how many calls were made and how many found a contradiction. A
 /// failed call leaves its pair pending on purpose: a dead endpoint must never
 /// look like a clean bill of health.
-async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
+/// Decide which pending pairs are worth a model call, and arm one unit each.
+///
+/// Every filter here is local — an artifact's status, and the fact-token
+/// prefilter that is the whole economic argument for this feature: most near
+/// pairs have no value in common to disagree about, and a call is minutes on
+/// this hardware. What survives becomes a `Judge` unit. Nothing in this sweep
+/// talks to a model any more, which is what stops one consolidation run
+/// blocking every capture behind it for as long as twenty calls take.
+///
+/// Returns how many were armed. `max_judgements` is a cap on that rather than a
+/// loop bound, so the meaning of the setting is unchanged: the most model calls
+/// one sweep can be responsible for.
+async fn arm_judgements(core: &Core) -> Result<usize> {
     let pending = core.store.pairs_to_judge(200).await?;
 
-    let (mut judged, mut contradictions) = (0usize, 0usize);
+    let mut armed = 0usize;
     for p in pending {
-        if judged >= core.consolidate.max_judgements {
+        if armed >= core.consolidate.max_judgements {
             tracing::info!(
                 budget = core.consolidate.max_judgements,
                 "judge budget spent; the rest wait for the next sweep"
@@ -463,14 +480,15 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
         // A pair queued in the review band can have a member retired after the
         // fact: superseded by a later sweep once a re-embed moves the score
         // above `auto_supersede`, or deprecated by an operator. Judging it would
-        // spend the scarcest thing here — a model call — to post a
-        // contradiction about an artifact that is no longer in results.
+        // spend the scarcest thing here to post a contradiction about an
+        // artifact that is no longer in results.
         //
         // The status half matters beyond the wasted call. A judgement can
         // propose a supersede, which Ops renders as an "apply supersede" button
         // — and `Core::supersede` refuses a deprecated side, so pressing it
         // returns a validation error and the pair stays pending forever. The
-        // same guard runs in `run`'s cluster pass and review band.
+        // same guard runs in `run`'s cluster pass and review band, and again in
+        // the unit itself, because a pair can be retired while it waits.
         if a.status != ArtifactStatus::Active
             || b.status != ArtifactStatus::Active
             || a.superseded_by.is_some()
@@ -482,8 +500,6 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
             continue;
         }
 
-        // The whole economic argument: most near pairs have no value in common
-        // to disagree about, and a model call is minutes on this hardware.
         if !crate::infer::facts::may_disagree(&a.text, &b.text) {
             core.store
                 .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
@@ -491,89 +507,14 @@ async fn judge_pending(core: &Core) -> Result<(usize, usize)> {
             continue;
         }
 
-        judged += 1;
-        // Counted before the call and regardless of how it goes, so a pair the
-        // model keeps failing on drops behind the rest of the queue instead of
-        // absorbing this budget again on the next sweep.
-        core.store.record_judge_attempt(p.id).await?;
-        let reply = match core
-            .completer
-            .complete(
-                crate::infer::prompt::JUDGE_SYSTEM,
-                &crate::infer::prompt::judge_prompt(
-                    (a.title.as_deref().unwrap_or("untitled"), &a.text),
-                    (b.title.as_deref().unwrap_or("untitled"), &b.text),
-                ),
-            )
-            .await
-        {
-            Ok(r) => r,
-            // A transport failure is a statement about the endpoint, not about
-            // this pair: the next nineteen calls would fail the same way, and
-            // each one costs a full timeout. Stop, keep the pairs pending, and
-            // let the next sweep find out whether anything changed.
-            Err(e) => {
-                tracing::warn!(
-                    pair = p.id,
-                    error = %e,
-                    "judge call failed; pairs stay pending and this sweep stops judging"
-                );
-                break;
-            }
-        };
-
-        match crate::infer::prompt::parse_judgement(&reply) {
-            Ok((true, detail, obsolete)) => {
-                contradictions += 1;
-                // Trust the judge's named direction only when it agrees with
-                // the sweep's own newest-wins bias (see `keeper`): a call that
-                // names the *newer* artifact obsolete is exactly the failure
-                // mode worth guarding against, since it would otherwise
-                // propose hiding the side more likely to be current.
-                let obsolete_id = obsolete.and_then(|side| {
-                    let (named, other) = match side {
-                        'a' => (&a, &b),
-                        _ => (&b, &a),
-                    };
-                    (named.created_at <= other.created_at).then(|| named.id.clone())
-                });
-                match obsolete_id {
-                    Some(obsolete_id) => {
-                        // Proposed, not applied: an operator confirms via the
-                        // pair's "apply supersede" action before anything is
-                        // actually hidden.
-                        core.store
-                            .set_pair_superseded(p.id, &obsolete_id, detail.as_deref())
-                            .await?;
-                        tracing::info!(
-                            pair = p.id,
-                            obsolete = %obsolete_id,
-                            "judge proposed a supersede, pending operator confirmation"
-                        );
-                    }
-                    None => {
-                        core.store
-                            .set_pair_state(
-                                p.id,
-                                crate::store::pairs::PairState::Contradiction,
-                                detail.as_deref(),
-                            )
-                            .await?;
-                        tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
-                    }
-                }
-            }
-            Ok((false, _, _)) => {
-                core.store
-                    .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
-                    .await?;
-            }
-            Err(e) => {
-                tracing::warn!(pair = p.id, error = %e, "judge reply unreadable; pair stays pending");
-            }
-        }
+        // `seq` is the pair's position in this sweep. Left at zero, twenty
+        // judge units would all sort ahead of every document's second window.
+        core.store
+            .enqueue_seq(Stage::Judge, "pair", &p.id.to_string(), armed as i64)
+            .await?;
+        armed += 1;
     }
-    Ok((judged, contradictions))
+    Ok(armed)
 }
 
 #[cfg(test)]
@@ -583,6 +524,25 @@ mod tests {
     use crate::store::artifacts::NewArtifact;
     use crate::store::pairs::PairState;
     use crate::vector::{VectorPayload, VectorPoint};
+
+    /// Sweep, then work the judge units it armed.
+    ///
+    /// The sweep no longer calls the model: it decides which pairs are worth
+    /// asking about and arms a unit each. Tests about what the judge *said*
+    /// therefore have to drive the queue too, which is what a worker does.
+    async fn sweep_and_judge(core: &crate::core::Core) -> Outcome {
+        let out = run(core).await.unwrap();
+        for _ in 0..100 {
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            if !crate::jobs::run_one(core).await.unwrap_or(false) {
+                break;
+            }
+        }
+        out
+    }
 
     /// Seed artifacts with hand-placed vectors, so the test controls the exact
     /// similarity rather than depending on what the fake embedder produces.
@@ -1211,8 +1171,8 @@ mod tests {
         ]));
         disagreeing(&core).await;
 
-        let out = run(&core).await.unwrap();
-        assert_eq!((out.judged, out.contradictions), (1, 1), "{out:?}");
+        let out = sweep_and_judge(&core).await;
+        assert_eq!(out.judged, 1, "one pair should have been armed: {out:?}");
         let found = core
             .store
             .pairs_by_state(PairState::Contradiction, 10)
@@ -1233,8 +1193,8 @@ mod tests {
         ]));
         let ids = disagreeing(&core).await;
 
-        let out = run(&core).await.unwrap();
-        assert_eq!((out.judged, out.contradictions), (1, 1), "{out:?}");
+        let out = sweep_and_judge(&core).await;
+        assert_eq!(out.judged, 1, "one pair should have been armed: {out:?}");
         let found = core
             .store
             .pairs_by_state(PairState::Superseded, 10)
@@ -1346,7 +1306,7 @@ mod tests {
         )
         .await;
 
-        run(&core).await.unwrap();
+        sweep_and_judge(&core).await;
         assert_eq!(completer.calls(), 1, "the budget was ignored");
     }
 
@@ -1491,16 +1451,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_dead_endpoint_stops_the_judge_instead_of_spending_the_budget_on_it() {
-        // Every call would fail the same way, and each one costs a full
-        // timeout. The pairs stay pending either way; what this saves is
-        // twenty consecutive waits on an endpoint that is not there.
+    async fn the_sweep_makes_no_inference_call_and_arms_one_unit_per_pair() {
+        // Twenty judge calls in one job was the second-worst blocker in the
+        // system after synthesis: a consolidation run held every capture behind
+        // it for as long as twenty calls took. The sweep now decides which
+        // pairs are worth asking about — all of it local — and arms a unit each.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"contradicts":false}"#.into(),
+        ]));
+        core.completer = completer.clone();
+        disagreeing(&core).await;
+
+        let out = run(&core).await.unwrap();
+
+        assert_eq!(completer.calls(), 0, "the sweep called the model");
+        assert_eq!(out.judged, 1, "no judge unit was armed: {out:?}");
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs WHERE stage = 'judge' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed, 1);
+
+        // And the unit, when the queue gets to it, is what makes the call.
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert_eq!(completer.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_dead_endpoint_leaves_every_pair_pending() {
+        // This used to assert that the sweep stopped judging after the first
+        // transport failure, because the next nineteen calls would fail the
+        // same way and each cost a full timeout. That guard still exists, but it
+        // moved: the circuit breaker on the gate holds *all* background calls
+        // after three consecutive transport failures, which covers embedding and
+        // synthesis too rather than only this loop. It has its own test.
+        //
+        // What has to remain true here is the part that was never about calls:
+        // a dead endpoint must not silently clear a queue of real conflicts.
         let mut core = test_core().await;
         core.consolidate.judge = true;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
         core.completer = completer.clone();
-        // Two pairs, each inside the review band and nowhere near the other, so
-        // there really is a second call for the judge to skip.
         seed(
             &core,
             &[
@@ -1512,21 +1507,16 @@ mod tests {
         )
         .await;
 
-        let out = run(&core).await.unwrap();
+        let out = sweep_and_judge(&core).await;
         assert_eq!(out.queued, 2, "not enough pairs to prove anything: {out:?}");
-        assert_eq!(
-            completer.calls(),
-            1,
-            "the judge kept calling a dead endpoint"
-        );
         assert_eq!(
             core.store
                 .pairs_by_state(PairState::Pending, 10)
                 .await
                 .unwrap()
                 .len(),
-            out.queued,
-            "a failed call must never look like a clean bill of health"
+            2,
+            "a dead endpoint cleared pairs it never actually judged"
         );
     }
 
@@ -1552,8 +1542,8 @@ mod tests {
         )
         .await;
 
-        run(&core).await.unwrap();
-        run(&core).await.unwrap();
+        sweep_and_judge(&core).await;
+        sweep_and_judge(&core).await;
 
         let pending = core.store.pairs_to_judge(10).await.unwrap();
         assert!(

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -471,12 +471,15 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
             );
             break;
         }
-        let (Ok(a), Ok(b)) = (
-            core.store.get_artifact(&p.a_id).await,
-            core.store.get_artifact(&p.b_id).await,
-        ) else {
-            continue;
-        };
+        // Reported, not skipped. Skipping treated a store that was briefly
+        // unwell as a pair not worth arming, and since nothing recorded an
+        // attempt it led the next sweep's ordering all over again. There is no
+        // deletion to skip for: the pair rows are `ON DELETE CASCADE` on both
+        // members, so a pair naming an artifact that is gone cannot exist.
+        let (a, b) = (
+            core.store.get_artifact(&p.a_id).await?,
+            core.store.get_artifact(&p.b_id).await?,
+        );
 
         // A pair queued in the review band can have a member retired after the
         // fact: superseded by a later sweep once a re-embed moves the score

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -510,7 +510,7 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
         // `seq` is the pair's position in this sweep. Left at zero, twenty
         // judge units would all sort ahead of every document's second window.
         core.store
-            .enqueue_seq(Stage::Judge, "pair", &p.id.to_string(), armed as i64)
+            .arm_seq(Stage::Judge, "pair", &p.id.to_string(), armed as i64)
             .await?;
         armed += 1;
     }

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -29,7 +29,6 @@ pub struct Outcome {
     /// Pairs this sweep armed a judge unit for. The calls happen later, one
     /// unit at a time, so this counts what was asked for rather than answered.
     pub judged: usize,
-    pub contradictions: usize,
 }
 
 /// Disjoint-set over artifact ids, so a run of near-identical pairs collapses
@@ -421,9 +420,12 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 
     if cfg.judge {
         // Armed, not asked. `judged` counts the calls this sweep is responsible
-        // for rather than the calls it made, since it now makes none;
-        // `contradictions` is no longer knowable here at all, because the answer
-        // arrives one unit at a time long after the sweep has returned.
+        // for rather than the calls it made, since it now makes none. There is
+        // deliberately no contradiction count beside it: the answers arrive one
+        // unit at a time long after the sweep has returned, and a zero logged
+        // here read as "the judge found nothing" rather than "the judge has not
+        // been asked yet". `pairs_by_state(Contradiction, ..)` is where that
+        // number actually lives, and the API and Ops both read it from there.
         out.judged = arm_judgements(core).await?;
     }
 
@@ -433,7 +435,6 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             superseded = out.superseded,
             queued = out.queued,
             judged = out.judged,
-            contradictions = out.contradictions,
             "consolidation sweep finished"
         );
     }

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -13,7 +13,7 @@
 //! this design exists to avoid.
 
 use crate::core::Core;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::store::artifacts::{ArtifactStatus, Chunk};
 use crate::store::jobs::Stage;
 use std::collections::{HashMap, HashSet};
@@ -441,12 +441,6 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     Ok(out)
 }
 
-/// Ask the model about pending pairs, but only the ones that could possibly
-/// disagree, and only up to the sweep's budget.
-///
-/// Returns how many calls were made and how many found a contradiction. A
-/// failed call leaves its pair pending on purpose: a dead endpoint must never
-/// look like a clean bill of health.
 /// Decide which pending pairs are worth a model call, and arm one unit each.
 ///
 /// Every filter here is local — an artifact's status, and the fact-token
@@ -456,9 +450,15 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 /// talks to a model any more, which is what stops one consolidation run
 /// blocking every capture behind it for as long as twenty calls take.
 ///
-/// Returns how many were armed. `max_judgements` is a cap on that rather than a
-/// loop bound, so the meaning of the setting is unchanged: the most model calls
-/// one sweep can be responsible for.
+/// Returns how many were armed. `max_judgements` bounds what one sweep arms,
+/// and deliberately not judge units in flight: a pair whose unit an earlier
+/// sweep queued is skipped without spending the budget, so a sweep still reaches
+/// pairs recorded since. Counting those in flight instead would let one unit the
+/// queue cannot get through — an open breaker, a dead endpoint — stop every other
+/// pair from ever being judged, which is the head-of-line blocking that splitting
+/// the sweep into units was for. Nothing runs away: `live_job` arms a pair at
+/// most once, so the depth is bounded by the pairs that exist, and the call rate
+/// is the gate's job rather than this number's.
 async fn arm_judgements(core: &Core) -> Result<usize> {
     let pending = core.store.pairs_to_judge(200).await?;
 
@@ -471,15 +471,26 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
             );
             break;
         }
-        // Reported, not skipped. Skipping treated a store that was briefly
-        // unwell as a pair not worth arming, and since nothing recorded an
-        // attempt it led the next sweep's ordering all over again. There is no
-        // deletion to skip for: the pair rows are `ON DELETE CASCADE` on both
-        // members, so a pair naming an artifact that is gone cannot exist.
-        let (a, b) = (
-            core.store.get_artifact(&p.a_id).await?,
-            core.store.get_artifact(&p.b_id).await?,
-        );
+        // Reported, not skipped, with one exception. Skipping treated a store
+        // that was briefly unwell as a pair not worth arming, and since nothing
+        // recorded an attempt it led the next sweep's ordering all over again.
+        //
+        // A pair naming an artifact that is gone is the exception. The pair rows
+        // are `ON DELETE CASCADE` on both members, so the state does not persist
+        // — but `pairs_to_judge` handed us a snapshot, and this loop is full of
+        // awaits, so a re-segmentation or an operator's delete lands inside it
+        // and cascades a pair away between the read and here. Propagating that
+        // `NotFound` reaches `run_one`, which reads it as the sweep's own target
+        // being gone: it completes the job, and every pair behind this one waits
+        // for the next tick — up to `interval_hours` away.
+        let (a, b) = match (
+            core.store.get_artifact(&p.a_id).await,
+            core.store.get_artifact(&p.b_id).await,
+        ) {
+            (Ok(a), Ok(b)) => (a, b),
+            (Err(Error::NotFound), _) | (_, Err(Error::NotFound)) => continue,
+            (Err(e), _) | (_, Err(e)) => return Err(e),
+        };
 
         // A pair queued in the review band can have a member retired after the
         // fact: superseded by a later sweep once a re-embed moves the score
@@ -1580,6 +1591,76 @@ mod tests {
             1,
             "the second sweep never reached an unjudged pair"
         );
+    }
+
+    #[tokio::test]
+    async fn a_pair_whose_artifact_vanished_does_not_abandon_the_rest_of_the_sweep() {
+        // `pairs_to_judge` hands back a snapshot, and the arming loop is full of
+        // awaits: a re-segmentation of a window, or an operator deleting an
+        // artifact, lands inside it and cascades one of these pairs away between
+        // the read and the read of its members.
+        //
+        // Propagating that `NotFound` reached `run_one`, which reads it as the
+        // sweep's own target being gone — it logs the job as dropped and
+        // completes it. One pair that lost a race therefore cost every pair
+        // behind it a wait of up to `interval_hours`.
+        let mut core = test_core().await;
+        core.consolidate.judge = true;
+        core.consolidate.max_judgements = 5;
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.0, 1.0]),
+                ("retry is 3 times", [-1.0, 0.0]),
+                ("retry is 9 times", [0.0, -1.0]),
+            ],
+        )
+        .await;
+        // The higher score leads the snapshot, so the surviving pair is only
+        // reached if the missing one did not end the loop.
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.95)
+            .await
+            .unwrap();
+        core.store
+            .record_pair(&ids[2], &ids[3], 0.90)
+            .await
+            .unwrap();
+
+        // The state the sweep observes mid-loop, held still. The cascade would
+        // normally take the pair row along with the artifact, which is exactly
+        // why the pragma is needed to reproduce it: what the loop is holding is a
+        // pair it read *before* the delete.
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM artifacts WHERE id = ?")
+            .bind(&ids[0])
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let armed = arm_judgements(&core).await.unwrap();
+
+        assert_eq!(
+            armed, 1,
+            "the pair that lost the race took the whole sweep down with it"
+        );
+        let target: String = sqlx::query_scalar("SELECT target_id FROM jobs WHERE stage = 'judge'")
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap();
+        let surviving = core
+            .store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.a_id == ids[2])
+            .expect("the untouched pair is still pending");
+        assert_eq!(target, surviving.id.to_string());
     }
 
     #[tokio::test]

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -114,13 +114,27 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
     let pending = core.store.pending_artifacts_for_corpus(corpus_id).await?;
 
     // An oversize chunk becomes siblings instead of a vector, so it cannot ride
-    // along in a batch. It leaves behind its own per-chunk jobs.
+    // along in a batch — and finding out how to cut it can itself cost a call.
+    // It gets a unit of its own and this job goes on without it.
     let mut batch: Vec<Chunk> = Vec::with_capacity(pending.len());
     let mut texts: Vec<String> = Vec::with_capacity(pending.len());
     for chunk in pending {
         let text = embed_text(&chunk);
         if core.counter.count(&text) > limit {
-            split_oversize(core, &chunk, limit, false).await?;
+            // Splitting is not free: `split_oversize` falls through to embedding
+            // the chunk whole when there is no boundary to cut on, and that is a
+            // model call. Doing it here made a job that is allowed one call make
+            // one per oversize chunk — fifty of them held the turn for fifty
+            // cooldowns, which is the head-of-line blocking one-batch-per-run
+            // exists to prevent. Its own unit instead, where `run_with_limit`
+            // splits it paced like everything else.
+            //
+            // Idle-only: `rearm_if_more` brings this job back for every batch of
+            // a long document, and `enqueue` would wind the attempts of a unit
+            // already queued back to zero on each of them.
+            core.store
+                .rearm_idle_seq(Stage::Embed, "artifact", &chunk.id, 0)
+                .await?;
         } else {
             texts.push(text);
             batch.push(chunk);
@@ -1068,6 +1082,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn oversize_chunks_do_not_turn_one_batch_into_many_calls() {
+        // `split_oversize` can cost a model call of its own — its fall-through
+        // embeds the chunk whole to find out whether our estimate was wrong —
+        // and the scan ran it once per oversize chunk. Fifty of them was fifty
+        // sequential calls inside a job that is allowed exactly one, holding the
+        // turn for fifty cooldowns before anything else could run.
+        let (core, embedder) = crate::core::test_support::test_core_counting_embed_calls().await;
+        let big = "alpha ".repeat(400);
+        let (src_id, _) = seed(&core, &[&big, &big, &big, "small"]).await;
+
+        run_corpus_with_limit(&core, &src_id, 200).await.unwrap();
+
+        assert_eq!(
+            embedder.calls(),
+            1,
+            "the batch job made more than one inference call"
+        );
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs
+              WHERE stage = 'embed' AND target_kind = 'artifact' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed, 3, "each oversize chunk should have got its own unit");
+    }
+
+    #[tokio::test]
     async fn a_long_document_re_arms_itself_until_it_is_drained() {
         let core = test_core().await;
         let id = corpus_with_chunks(&core, BATCH * 2 + 5).await;
@@ -1259,10 +1301,12 @@ mod tests {
     #[tokio::test]
     async fn an_oversize_chunk_does_not_block_its_siblings() {
         // It becomes siblings rather than a vector, so it cannot ride along in
-        // the batch. The rest of the source must still be embedded.
+        // the batch. The rest of the source must still be embedded, and the
+        // oversize one must be handed to a unit of its own rather than split
+        // here — splitting can cost a call this job has already spent.
         let core = test_core().await;
         let big = format!("{}\n\n{}", "alpha ".repeat(400), "beta ".repeat(400));
-        let (src_id, _) = seed(&core, &["small one", &big, "small two"]).await;
+        let (src_id, ids) = seed(&core, &["small one", &big, "small two"]).await;
 
         run_corpus_with_limit(&core, &src_id, 200).await.unwrap();
 
@@ -1271,10 +1315,24 @@ mod tests {
             2,
             "the two small chunks should be embedded"
         );
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs
+              WHERE stage = 'embed' AND target_kind = 'artifact' AND target_id = ?
+                AND state = 'pending'",
+        )
+        .bind(&ids[1])
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed, 1, "the oversize chunk was not given its own unit");
+
+        // And that unit does the split, so nothing is lost by deferring it.
+        run_with_limit(&core, &ids[1], 200).await.unwrap();
         let chunks = core.store.artifacts_for_corpus(&src_id).await.unwrap();
         assert!(
             chunks.len() > 3,
-            "the oversize chunk should have become siblings"
+            "the oversize chunk should have become siblings, got {}",
+            chunks.len()
         );
     }
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -214,8 +214,18 @@ pub async fn rearm_if_more(core: &Core, corpus_id: &str) -> Result<()> {
         .await?
         .unwrap_or(0)
         + 1;
+    //
+    // Idle-only, and not merely because every automatic arming is. `run_one`
+    // calls this after `complete_job`, and between those two awaits another
+    // worker's `settle` can reach `finish`, whose own idle-only arming
+    // legitimately resurrects the row this just closed — at which point a second
+    // worker can claim it. A `Guard::Any` upsert would then flip that `running`
+    // row back to `pending` and put two workers into `run_corpus` for one
+    // corpus, where whichever finishes second closes the row the other re-armed
+    // and the source is left half-embedded. That is the trap the doc comment
+    // above describes, reached from the other side.
     core.store
-        .enqueue_seq(Stage::Embed, "corpus", corpus_id, next_seq)
+        .rearm_idle_seq(Stage::Embed, "corpus", corpus_id, next_seq)
         .await
 }
 
@@ -284,7 +294,16 @@ async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
 pub async fn split_into_artifact_jobs(core: &Core, corpus_id: &str) -> Result<()> {
     let pending = core.store.pending_artifacts_for_corpus(corpus_id).await?;
     for c in &pending {
-        core.store.enqueue(Stage::Embed, "artifact", &c.id).await?;
+        // Idle-only, like every other automatic arming. Two workers reach this
+        // for the same corpus whenever one batch meets a refused chunk while
+        // another worker is already inside the per-chunk unit an earlier batch
+        // armed — and a `Guard::Any` upsert would put that `running` row back to
+        // `pending` under it. A third claim then runs `split_oversize` on the
+        // same chunk beside the first, and one parent ends up with two full sets
+        // of siblings.
+        core.store
+            .rearm_idle_seq(Stage::Embed, "artifact", &c.id, 0)
+            .await?;
     }
     tracing::info!(
         corpus_id,
@@ -588,6 +607,105 @@ pub async fn settle_corpus(core: &Core, corpus_id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A corpus with `n` chunks, none of them embedded yet.
+    async fn corpus_with_pending_chunks(core: &Core, n: usize) -> (String, Vec<String>) {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<_> = (0..n)
+            .map(|i| NewArtifact {
+                ordinal: i as i64,
+                text: format!("chunk {i}"),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: Some(i as i64),
+                caveats: vec![],
+            })
+            .collect();
+        let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();
+        (src.id, made.iter().map(|c| c.id.clone()).collect())
+    }
+
+    async fn job_state(core: &Core, stage: Stage, target: &str) -> Option<String> {
+        sqlx::query_scalar::<_, String>("SELECT state FROM jobs WHERE stage = ? AND target_id = ?")
+            .bind(stage.as_str())
+            .bind(target)
+            .fetch_optional(&core.store.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn isolating_a_batch_leaves_a_chunk_already_being_split_alone() {
+        // Two workers reach this for one corpus: A is inside `split_oversize`
+        // for a chunk an earlier batch isolated, while B's batch meets a
+        // different refused chunk and isolates everything pending. Arming
+        // whatever state it found flipped A's row back to `pending`, a third
+        // claim ran `split_oversize` beside A, and one parent chunk ended up
+        // with two full sets of siblings.
+        let core = crate::core::test_support::test_core().await;
+        let (src, chunks) = corpus_with_pending_chunks(&core, 2).await;
+
+        core.store
+            .enqueue(Stage::Embed, "artifact", &chunks[0])
+            .await
+            .unwrap();
+        let claimed = core.store.claim_job().await.unwrap().unwrap();
+        assert_eq!(claimed.target_id, chunks[0]);
+
+        split_into_artifact_jobs(&core, &src).await.unwrap();
+
+        assert_eq!(
+            job_state(&core, Stage::Embed, &chunks[0]).await.as_deref(),
+            Some("running"),
+            "isolating the batch reset a chunk a worker was already splitting"
+        );
+        // Its sibling, which nothing was inside, is armed as it should be.
+        assert_eq!(
+            job_state(&core, Stage::Embed, &chunks[1]).await.as_deref(),
+            Some("pending")
+        );
+    }
+
+    #[tokio::test]
+    async fn coming_back_for_another_batch_does_not_disturb_a_running_row() {
+        // `run_one` calls this after `complete_job`, and in that gap another
+        // worker's `settle` can reach `finish`, whose idle-only arming
+        // legitimately reopens the row — and a second worker can claim it.
+        // Arming whatever state it found then put two workers into `run_corpus`
+        // for one corpus, and whichever finished second closed the row the other
+        // had re-armed, leaving the source half-embedded.
+        let core = crate::core::test_support::test_core().await;
+        let (src, _) = corpus_with_pending_chunks(&core, 2).await;
+
+        core.store
+            .enqueue(Stage::Embed, "corpus", &src)
+            .await
+            .unwrap();
+        core.store.claim_job().await.unwrap().unwrap();
+
+        rearm_if_more(&core, &src).await.unwrap();
+        assert_eq!(
+            job_state(&core, Stage::Embed, &src).await.as_deref(),
+            Some("running"),
+            "a second worker was let into run_corpus for a corpus already being embedded"
+        );
+
+        // The path this exists for is untouched: a row closed with chunks still
+        // pending comes back for the next batch.
+        sqlx::query("UPDATE jobs SET state = 'done' WHERE stage = 'embed' AND target_id = ?")
+            .bind(&src)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        rearm_if_more(&core, &src).await.unwrap();
+        assert_eq!(
+            job_state(&core, Stage::Embed, &src).await.as_deref(),
+            Some("pending"),
+            "a corpus with chunks left stopped half-embedded"
+        );
+    }
 
     #[tokio::test]
     async fn an_artifact_retired_before_its_first_embed_lands_retired() {

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -72,7 +72,10 @@ pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Res
     match embed_batch(core, std::slice::from_ref(&chunk), vec![text.clone()]).await {
         Ok(()) => permit.succeeded(),
         Err(e) if input_too_large(&e) => {
-            permit.failed(&e);
+            // Refused, not failed: the endpoint answered. Counting this toward
+            // the breaker let a handful of oversize chunks stop every
+            // background call in the system.
+            permit.refused();
             // The endpoint's real ceiling is lower than the configured one, so
             // halving the configured limit would change nothing. Halve what the
             // chunk actually measures instead: that shrinks on every refusal
@@ -139,7 +142,9 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
         // One oversize chunk fails the whole batch, and the batch cannot say
         // which. Per-chunk jobs isolate it, and that path splits it.
         Err(e) if input_too_large(&e) => {
-            permit.failed(&e);
+            // Refused, not failed: the endpoint answered, and what it answered
+            // is about one chunk in this batch rather than about the endpoint.
+            permit.refused();
             tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
             return split_into_artifact_jobs(core, corpus_id).await;
         }
@@ -323,17 +328,23 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
             permit.succeeded();
             v
         }
-        // Still nothing to cut with when the title alone fills the limit:
-        // `split_by_lines` at a budget of zero puts every line in a part of its
-        // own and then falls to the 64-character floor, which shreds the text
-        // into fragments that are each still oversize once they inherit the
-        // title. A refusal we cannot act on is reported as one.
-        Err(e) if input_too_large(&e) && budget > 0 => {
-            permit.failed(&e);
-            let parts = split_by_lines(&chunk.text, budget, &core.counter);
-            if parts.len() > 1 {
-                tracing::warn!(artifact_id = %chunk.id, parts = parts.len(), "endpoint refused it whole; cutting on lines");
-                return replace_with_siblings(core, chunk, parts).await;
+        // Refused, not failed: the endpoint answered. This arm no longer tests
+        // `budget`, because a refusal we cannot act on is still a refusal —
+        // reporting it as a sick endpoint was how a single untouchable chunk
+        // could hold the breaker open on every retry of it.
+        Err(e) if input_too_large(&e) => {
+            permit.refused();
+            // Still nothing to cut with when the title alone fills the limit:
+            // `split_by_lines` at a budget of zero puts every line in a part of
+            // its own and then falls to the 64-character floor, which shreds the
+            // text into fragments that are each still oversize once they inherit
+            // the title. A refusal we cannot act on is reported as one.
+            if budget > 0 {
+                let parts = split_by_lines(&chunk.text, budget, &core.counter);
+                if parts.len() > 1 {
+                    tracing::warn!(artifact_id = %chunk.id, parts = parts.len(), "endpoint refused it whole; cutting on lines");
+                    return replace_with_siblings(core, chunk, parts).await;
+                }
             }
             return Err(e);
         }
@@ -849,6 +860,65 @@ mod tests {
 
         let chunks = core.store.artifacts_for_corpus(&src.id).await.unwrap();
         assert!(chunks.len() > 1, "got {} chunks", chunks.len());
+    }
+
+    #[tokio::test]
+    async fn a_size_refusal_does_not_hold_the_rest_of_the_queue() {
+        // Three unsplittable oversize chunks — code blocks, tables, the exact
+        // thing `split_oversize`'s hard path exists for — used to be three
+        // consecutive transport failures. At the default `breaker_after` that
+        // opened the breaker and stopped synthesis, judging and embedding alike
+        // for the whole probe window, against an endpoint that was answering
+        // every request it was given.
+        let mut core = crate::core::test_support::test_core().await;
+        core.gate = std::sync::Arc::new(
+            crate::infer::gate::InferenceGate::new(std::time::Duration::ZERO)
+                .with_breaker(1, std::time::Duration::from_secs(60)),
+        );
+        core.embedder = std::sync::Arc::new(crate::infer::fake::StrictEmbedder::new(
+            crate::core::test_support::TEST_DIM,
+            200,
+        ));
+
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let body = (0..40)
+            .map(|i| format!("paragraph {i} with a good deal of filler text in it"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: body,
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        // The configured limit is the lie; the endpoint's is what bites.
+        run_with_limit(&core, &made[0].id, 8192).await.unwrap();
+
+        // Asked in real time rather than on a paused clock: building a `Core`
+        // opens a pool, and a pool acquired under `start_paused` waits on a
+        // timer that never fires. An open breaker would hold this for the whole
+        // probe window, so a short timeout tells the two apart.
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                core.gate.background()
+            )
+            .await
+            .is_ok(),
+            "a chunk the endpoint refused opened the breaker"
+        );
     }
 
     #[test]

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -64,9 +64,15 @@ pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Res
         return split_oversize(core, &chunk, limit, false).await;
     }
 
+    // Paced like every other inference call. `split_into_artifact_jobs` can
+    // leave hundreds of these behind for one document, and against a dead
+    // endpoint an ungated path spends a timeout apiece without any of those
+    // failures ever reaching the breaker.
+    let permit = core.gate.background().await;
     match embed_batch(core, std::slice::from_ref(&chunk), vec![text.clone()]).await {
-        Ok(()) => {}
+        Ok(()) => permit.succeeded(),
         Err(e) if input_too_large(&e) => {
+            permit.failed(&e);
             // The endpoint's real ceiling is lower than the configured one, so
             // halving the configured limit would change nothing. Halve what the
             // chunk actually measures instead: that shrinks on every refusal
@@ -84,7 +90,10 @@ pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Res
             // this split has to succeed whatever the text looks like.
             return split_oversize(core, &chunk, smaller, true).await;
         }
-        Err(e) => return Err(e),
+        Err(e) => {
+            permit.failed(&e);
+            return Err(e);
+        }
     }
     settle_corpus(core, &chunk.corpus_id).await
 }
@@ -124,18 +133,18 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
         return settle_corpus(core, corpus_id).await;
     }
 
-    core.gate.background().await;
+    let permit = core.gate.background().await;
     match embed_batch(core, &batch[..take], texts[..take].to_vec()).await {
-        Ok(()) => core.gate.call_succeeded(),
+        Ok(()) => permit.succeeded(),
         // One oversize chunk fails the whole batch, and the batch cannot say
         // which. Per-chunk jobs isolate it, and that path splits it.
         Err(e) if input_too_large(&e) => {
-            core.gate.call_failed(&e);
+            permit.failed(&e);
             tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
             return split_into_artifact_jobs(core, corpus_id).await;
         }
         Err(e) => {
-            core.gate.call_failed(&e);
+            permit.failed(&e);
             return Err(e);
         }
     }
@@ -167,6 +176,14 @@ pub async fn rearm_if_more(core: &Core, corpus_id: &str) -> Result<()> {
         .await?
         .is_empty()
     {
+        return Ok(());
+    }
+    // What is left may not be batch work any more. A batch that met a chunk the
+    // endpoint refuses gives way to one unit per chunk and returns `Ok`, so this
+    // runs straight afterwards and would put the same doomed batch back beside
+    // the units that replaced it — converging, since those carry `seq = 0` and
+    // win the ordering, but a wasted call and a reset attempt count per round.
+    if core.store.pending_artifacts_are_isolated(corpus_id).await? {
         return Ok(());
     }
     // `seq` climbs, so later batches of a long document sink below the first
@@ -300,14 +317,19 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         title_cost,
         "oversize chunk has nothing left to cut on; embedding as-is"
     );
+    let permit = core.gate.background().await;
     let vectors = match core.embedder.embed(std::slice::from_ref(&chunk.text)).await {
-        Ok(v) => v,
+        Ok(v) => {
+            permit.succeeded();
+            v
+        }
         // Still nothing to cut with when the title alone fills the limit:
         // `split_by_lines` at a budget of zero puts every line in a part of its
         // own and then falls to the 64-character floor, which shreds the text
         // into fragments that are each still oversize once they inherit the
         // title. A refusal we cannot act on is reported as one.
         Err(e) if input_too_large(&e) && budget > 0 => {
+            permit.failed(&e);
             let parts = split_by_lines(&chunk.text, budget, &core.counter);
             if parts.len() > 1 {
                 tracing::warn!(artifact_id = %chunk.id, parts = parts.len(), "endpoint refused it whole; cutting on lines");
@@ -315,7 +337,10 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
             }
             return Err(e);
         }
-        Err(e) => return Err(e),
+        Err(e) => {
+            permit.failed(&e);
+            return Err(e);
+        }
     };
     core.vectors
         .upsert(vec![VectorPoint {
@@ -908,6 +933,68 @@ mod tests {
             .len();
 
         assert_eq!(before - after, BATCH, "a run embedded more than one batch");
+    }
+
+    #[tokio::test]
+    async fn the_per_chunk_path_is_paced_like_every_other_call() {
+        // `split_into_artifact_jobs` can leave hundreds of these behind for one
+        // document. Ungated they ran back to back at the endpoint, and against a
+        // dead one they each spent a timeout without a single failure ever
+        // reaching the breaker that exists to stop exactly that.
+        let core = test_core().await;
+        let (_src, ids) = seed(&core, &["one"]).await;
+
+        // Holding the turn is the question asked directly: a path that goes
+        // through the gate cannot start while another call has it.
+        let permit = core.gate.background().await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), run(&core, &ids[0]))
+                .await
+                .is_err(),
+            "the per-chunk embed path went straight to the endpoint"
+        );
+
+        permit.succeeded();
+        run(&core, &ids[0]).await.unwrap();
+        assert_eq!(
+            core.store.get_artifact(&ids[0]).await.unwrap().embed_state,
+            EmbedState::Embedded
+        );
+    }
+
+    #[tokio::test]
+    async fn isolating_a_batch_does_not_put_the_batch_straight_back() {
+        // The batch meets a chunk the endpoint refuses, gives way to one unit
+        // per chunk, and returns `Ok` — so `run_one` completes it and re-arms
+        // it, beside the units that just replaced it. It converges, because
+        // those carry `seq = 0` and win the ordering, but every round costs
+        // another call that can only fail the same way.
+        let mut core = test_core().await;
+        core.embedder = std::sync::Arc::new(crate::infer::fake::StrictEmbedder::new(
+            crate::core::test_support::TEST_DIM,
+            20,
+        ));
+        let big = "alpha ".repeat(200);
+        let (src_id, _) = seed(&core, &["small", &big]).await;
+        core.store
+            .enqueue(Stage::Embed, "corpus", &src_id)
+            .await
+            .unwrap();
+
+        // One claim: the re-arm happens in `run_one` after the job is closed.
+        crate::jobs::run_one(&core).await.unwrap();
+
+        let batch_armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs
+              WHERE stage = 'embed' AND target_kind = 'corpus' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            batch_armed, 0,
+            "the batch was re-armed beside the per-chunk units that replaced it"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -115,19 +115,72 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
         }
     }
 
-    for (chunks, texts) in batch.chunks(BATCH).zip(texts.chunks(BATCH)) {
-        match embed_batch(core, chunks, texts.to_vec()).await {
-            Ok(()) => {}
-            // One oversize chunk fails the whole batch, and the batch cannot
-            // say which. Per-chunk jobs isolate it, and that path splits it.
-            Err(e) if input_too_large(&e) => {
-                tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
-                return split_into_artifact_jobs(core, corpus_id).await;
-            }
-            Err(e) => return Err(e),
+    // One batch per run, not every batch. A document with 277 chunks is nine
+    // calls, and doing them in one job puts nine of them in front of everything
+    // else the queue holds — unpaced, and with no chance for a question to slip
+    // between them.
+    let take = BATCH.min(batch.len());
+    if take == 0 {
+        return settle_corpus(core, corpus_id).await;
+    }
+
+    core.gate.background().await;
+    match embed_batch(core, &batch[..take], texts[..take].to_vec()).await {
+        Ok(()) => core.gate.call_succeeded(),
+        // One oversize chunk fails the whole batch, and the batch cannot say
+        // which. Per-chunk jobs isolate it, and that path splits it.
+        Err(e) if input_too_large(&e) => {
+            core.gate.call_failed(&e);
+            tracing::warn!(corpus_id, error = %e, "batch held a chunk the endpoint will not take; isolating");
+            return split_into_artifact_jobs(core, corpus_id).await;
+        }
+        Err(e) => {
+            core.gate.call_failed(&e);
+            return Err(e);
         }
     }
-    settle_corpus(core, corpus_id).await
+
+    // Settling only once nothing is left. Whether to come back for another
+    // batch is the caller's to decide and act on — see `rearm_if_more`.
+    if core
+        .store
+        .pending_artifacts_for_corpus(corpus_id)
+        .await?
+        .is_empty()
+    {
+        return settle_corpus(core, corpus_id).await;
+    }
+    Ok(())
+}
+
+/// Queue the next batch of a corpus that is not finished embedding.
+///
+/// Called by `run_one` *after* the job is completed, never from inside the
+/// handler. The queue is keyed by `(stage, target)`, so re-arming from within
+/// would upsert the very row the `complete_job` that follows then marks done —
+/// and the corpus would silently stop half-embedded. The same trap took the
+/// untried windows of a source once already.
+pub async fn rearm_if_more(core: &Core, corpus_id: &str) -> Result<()> {
+    if core
+        .store
+        .pending_artifacts_for_corpus(corpus_id)
+        .await?
+        .is_empty()
+    {
+        return Ok(());
+    }
+    // `seq` climbs, so later batches of a long document sink below the first
+    // batches of documents captured since, instead of one source owning the
+    // embedder until it is finished.
+    let next_seq = core
+        .store
+        .job_seq(Stage::Embed, corpus_id)
+        .await?
+        .unwrap_or(0)
+        + 1;
+    core.store
+        .enqueue_seq(Stage::Embed, "corpus", corpus_id, next_seq)
+        .await
 }
 
 /// One inference call and one upsert for the whole slice. Chunks are marked
@@ -814,6 +867,98 @@ mod tests {
     use crate::store::artifacts::{EmbedState, NewArtifact};
     use crate::store::corpora::CorpusStatus;
 
+    /// A corpus with `n` chunks already written and none embedded.
+    async fn corpus_with_chunks(core: &Core, n: usize) -> String {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..n)
+            .map(|i| NewArtifact {
+                ordinal: i as i64,
+                text: format!("chunk number {i}"),
+                corpus_span: None,
+                title: Some(format!("t{i}")),
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+                segment_idx: Some(0),
+            })
+            .collect();
+        core.store.insert_artifacts(&src.id, &new).await.unwrap();
+        src.id
+    }
+
+    #[tokio::test]
+    async fn one_run_embeds_at_most_one_batch() {
+        // Nine calls in one job is nine calls in front of everything else the
+        // queue is holding, with no chance for a question to slip between them.
+        let core = test_core().await;
+        let id = corpus_with_chunks(&core, BATCH + 10).await;
+
+        let before = core
+            .store
+            .pending_artifacts_for_corpus(&id)
+            .await
+            .unwrap()
+            .len();
+        run_corpus(&core, &id).await.unwrap();
+        let after = core
+            .store
+            .pending_artifacts_for_corpus(&id)
+            .await
+            .unwrap()
+            .len();
+
+        assert_eq!(before - after, BATCH, "a run embedded more than one batch");
+    }
+
+    #[tokio::test]
+    async fn a_long_document_re_arms_itself_until_it_is_drained() {
+        let core = test_core().await;
+        let id = corpus_with_chunks(&core, BATCH * 2 + 5).await;
+        core.store
+            .enqueue(Stage::Embed, "corpus", &id)
+            .await
+            .unwrap();
+
+        let mut claims = 0;
+        while crate::jobs::run_one(&core).await.unwrap() {
+            claims += 1;
+            assert!(claims < 20, "the re-arm never terminated");
+        }
+
+        assert!(
+            core.store
+                .pending_artifacts_for_corpus(&id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the re-arm did not drain the corpus"
+        );
+        assert_eq!(claims, 3, "expected one claim per batch");
+    }
+
+    #[tokio::test]
+    async fn a_re_armed_batch_sinks_below_a_fresher_document() {
+        // The point of climbing `seq`: batch two of a long document must not
+        // outrank batch one of a document captured since.
+        let core = test_core().await;
+        let long = corpus_with_chunks(&core, BATCH * 2).await;
+        core.store
+            .enqueue(Stage::Embed, "corpus", &long)
+            .await
+            .unwrap();
+        // One claim: the re-arm happens in `run_one` after the job is closed,
+        // so calling the handler directly would show nothing.
+        crate::jobs::run_one(&core).await.unwrap();
+
+        let seq = core
+            .store
+            .job_seq(Stage::Embed, &long)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(seq, 1, "the re-armed batch stayed at the front");
+    }
+
     async fn seed(core: &crate::core::Core, texts: &[&str]) -> (String, Vec<String>) {
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let new: Vec<NewArtifact> = texts
@@ -923,12 +1068,18 @@ mod tests {
     #[tokio::test]
     async fn a_batch_larger_than_the_request_limit_is_split_across_calls() {
         // Endpoints cap how many inputs they accept, so the batch is bounded.
+        // The split is across units now rather than within one job, so the
+        // corpus is driven through the queue to see both calls.
         let (core, embedder) = crate::core::test_support::test_core_counting_embed_calls().await;
         let texts: Vec<String> = (0..BATCH + 5).map(|i| format!("chunk {i}")).collect();
         let refs: Vec<&str> = texts.iter().map(String::as_str).collect();
         let (src_id, _) = seed(&core, &refs).await;
 
-        run_corpus(&core, &src_id).await.unwrap();
+        core.store
+            .enqueue(Stage::Embed, "corpus", &src_id)
+            .await
+            .unwrap();
+        while crate::jobs::run_one(&core).await.unwrap() {}
 
         assert_eq!(embedder.calls(), 2, "the batch was not bounded");
         assert_eq!(core.vectors.count().await.unwrap(), (BATCH + 5) as u64);

--- a/src/jobs/judge.rs
+++ b/src/jobs/judge.rs
@@ -49,7 +49,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     // the budget again on the next sweep.
     core.store.record_judge_attempt(id).await?;
 
-    core.gate.background().await;
+    let permit = core.gate.background().await;
     let reply = match core
         .completer
         .complete(
@@ -62,11 +62,11 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         .await
     {
         Ok(r) => {
-            core.gate.call_succeeded();
+            permit.succeeded();
             r
         }
         Err(e) => {
-            core.gate.call_failed(&e);
+            permit.failed(&e);
             return Err(e);
         }
     };

--- a/src/jobs/judge.rs
+++ b/src/jobs/judge.rs
@@ -20,14 +20,16 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         return Ok(());
     }
 
-    let (Ok(a), Ok(b)) = (
-        core.store.get_artifact(&p.a_id).await,
-        core.store.get_artifact(&p.b_id).await,
-    ) else {
-        // One side was deleted while the unit waited. Nothing to compare.
-        core.store.record_judge_attempt(id).await?;
-        return Ok(());
-    };
+    // Reported, not swallowed. This read used to treat any failure as "one side
+    // was deleted while the unit waited" — it recorded an attempt and returned
+    // `Ok`, so a store that was briefly unwell closed the unit and counted the
+    // pair as having had its turn. There is no deletion to handle: `a_id` and
+    // `b_id` are `ON DELETE CASCADE` and every pool sets `foreign_keys`, so a
+    // pair naming an artifact that is gone is a state the schema does not allow.
+    let (a, b) = (
+        core.store.get_artifact(&p.a_id).await?,
+        core.store.get_artifact(&p.b_id).await?,
+    );
 
     // Re-checked here and not only when the unit was armed. A pair can wait out
     // a backoff, and in that time a member can be superseded by a later sweep or

--- a/src/jobs/judge.rs
+++ b/src/jobs/judge.rs
@@ -1,0 +1,134 @@
+//! One pair, one call.
+//!
+//! The sweep used to make up to `max_judgements` of these in a single job, so a
+//! consolidation run blocked every capture behind it for as long as twenty model
+//! calls took — the second-worst blocker in the system after synthesis. The
+//! sweep now decides *which* pairs are worth asking about, which costs nothing,
+//! and arms one unit per pair. The queue paces them and interleaves them with
+//! everything else.
+
+use crate::core::Core;
+use crate::error::{Error, Result};
+use crate::store::artifacts::ArtifactStatus;
+use crate::store::pairs::{ArtifactPair, PairState};
+
+pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
+    let id: i64 = pair_id.parse().map_err(|_| Error::NotFound)?;
+    let p = core.store.get_pair(id).await?;
+    if p.state != PairState::Pending {
+        // Settled by an operator, or by a later sweep, while this waited.
+        return Ok(());
+    }
+
+    let (Ok(a), Ok(b)) = (
+        core.store.get_artifact(&p.a_id).await,
+        core.store.get_artifact(&p.b_id).await,
+    ) else {
+        // One side was deleted while the unit waited. Nothing to compare.
+        core.store.record_judge_attempt(id).await?;
+        return Ok(());
+    };
+
+    // Re-checked here and not only when the unit was armed. A pair can wait out
+    // a backoff, and in that time a member can be superseded by a later sweep or
+    // deprecated by an operator — spending the scarcest thing here to post a
+    // contradiction about an artifact no longer in results.
+    if a.status != ArtifactStatus::Active
+        || b.status != ArtifactStatus::Active
+        || a.superseded_by.is_some()
+        || b.superseded_by.is_some()
+    {
+        core.store
+            .set_pair_state(id, PairState::Dismissed, None)
+            .await?;
+        return Ok(());
+    }
+
+    // Counted before the call and regardless of how it goes, so a pair the model
+    // keeps failing on drops behind the rest of the queue rather than absorbing
+    // the budget again on the next sweep.
+    core.store.record_judge_attempt(id).await?;
+
+    core.gate.background().await;
+    let reply = match core
+        .completer
+        .complete(
+            crate::infer::prompt::JUDGE_SYSTEM,
+            &crate::infer::prompt::judge_prompt(
+                (a.title.as_deref().unwrap_or("untitled"), &a.text),
+                (b.title.as_deref().unwrap_or("untitled"), &b.text),
+            ),
+        )
+        .await
+    {
+        Ok(r) => {
+            core.gate.call_succeeded();
+            r
+        }
+        Err(e) => {
+            core.gate.call_failed(&e);
+            return Err(e);
+        }
+    };
+
+    apply(core, &p, &a, &b, &reply).await
+}
+
+/// Record what the judge said. Split out because it is the half that has
+/// nothing to do with the endpoint, and the half worth reading on its own.
+async fn apply(
+    core: &Core,
+    p: &ArtifactPair,
+    a: &crate::store::artifacts::Chunk,
+    b: &crate::store::artifacts::Chunk,
+    reply: &str,
+) -> Result<()> {
+    match crate::infer::prompt::parse_judgement(reply) {
+        Ok((true, detail, obsolete)) => {
+            // Trust the judge's named direction only when it agrees with the
+            // sweep's own newest-wins bias (see `keeper`): a call that names the
+            // *newer* artifact obsolete is exactly the failure mode worth
+            // guarding against, since it would otherwise propose hiding the side
+            // more likely to be current.
+            let obsolete_id = obsolete.and_then(|side| {
+                let (named, other) = match side {
+                    'a' => (a, b),
+                    _ => (b, a),
+                };
+                (named.created_at <= other.created_at).then(|| named.id.clone())
+            });
+            match obsolete_id {
+                Some(obsolete_id) => {
+                    // Proposed, not applied: an operator confirms via the pair's
+                    // "apply supersede" action before anything is hidden.
+                    core.store
+                        .set_pair_superseded(p.id, &obsolete_id, detail.as_deref())
+                        .await?;
+                    tracing::info!(
+                        pair = p.id,
+                        obsolete = %obsolete_id,
+                        "judge proposed a supersede, pending operator confirmation"
+                    );
+                }
+                None => {
+                    core.store
+                        .set_pair_state(p.id, PairState::Contradiction, detail.as_deref())
+                        .await?;
+                    tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
+                }
+            }
+        }
+        Ok((false, _, _)) => {
+            core.store
+                .set_pair_state(p.id, PairState::NoConflict, None)
+                .await?;
+        }
+        // A reply that cannot be read is an error, not a verdict: the pair stays
+        // pending and a later sweep asks again.
+        Err(e) => {
+            tracing::warn!(pair = p.id, error = %e, "judge reply unreadable; pair stays pending");
+            return Err(e);
+        }
+    }
+    Ok(())
+}

--- a/src/jobs/judge.rs
+++ b/src/jobs/judge.rs
@@ -135,7 +135,14 @@ async fn apply(
         // unchanged prompt would replay the same unreadable bytes for every one
         // of `MAX_ATTEMPTS`. One varying byte is what makes the second ask a
         // second ask.
+        //
+        // Counted here and not beside `record_judge_attempt`, because this is
+        // the only failure that says anything about the pair. A call the
+        // endpoint never answered says something about the endpoint, and
+        // letting an outage count against every pending pair would take the
+        // whole review queue out of the judge's reach on its way past.
         Err(e) => {
+            core.store.record_unreadable_judgement(p.id).await?;
             tracing::warn!(
                 pair = p.id,
                 attempt = p.judge_attempts,

--- a/src/jobs/judge.rs
+++ b/src/jobs/judge.rs
@@ -59,6 +59,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
             &crate::infer::prompt::judge_prompt(
                 (a.title.as_deref().unwrap_or("untitled"), &a.text),
                 (b.title.as_deref().unwrap_or("untitled"), &b.text),
+                p.judge_attempts,
             ),
         )
         .await
@@ -126,9 +127,21 @@ async fn apply(
                 .await?;
         }
         // A reply that cannot be read is an error, not a verdict: the pair stays
-        // pending and a later sweep asks again.
+        // pending, and the unit retries under the queue's backoff.
+        //
+        // Retrying is only worth anything because `judge_prompt` carries the
+        // attempt number. `MalformedLlmOutput` is retryable, so this re-queues
+        // the unit — and against an endpoint that caches by exact prompt, an
+        // unchanged prompt would replay the same unreadable bytes for every one
+        // of `MAX_ATTEMPTS`. One varying byte is what makes the second ask a
+        // second ask.
         Err(e) => {
-            tracing::warn!(pair = p.id, error = %e, "judge reply unreadable; pair stays pending");
+            tracing::warn!(
+                pair = p.id,
+                attempt = p.judge_attempts,
+                error = %e,
+                "judge reply unreadable; pair stays pending"
+            );
             return Err(e);
         }
     }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -75,6 +75,12 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                 // sweep decides again whether it is worth asking about. Holding
                 // a unit at the six-hour ceiling for it would keep re-asking a
                 // question the sweep may no longer want answered.
+                //
+                // That later decision is `pairs_to_judge`'s
+                // `MAX_UNREADABLE_JUDGEMENTS` test. Without one, closing the
+                // unit here is not a hand-off but a loop: the next sweep finds
+                // the pair pending with no live job and arms it for another
+                // `MAX_ATTEMPTS`, forever.
                 (Stage::Judge, _) if exhausted => {
                     tracing::warn!(error = %e, "could not judge this pair; leaving it for a later sweep");
                     core.store.complete_job(job.id).await?;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -37,7 +37,7 @@ pub async fn run_one(core: &Core) -> Result<bool> {
 
 async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
     let result = match (job.stage, job.target_kind.as_str()) {
-        (Stage::Synthesize | Stage::Enrich, _) => synthesize::run(core, &job.target_id).await,
+        (Stage::Synthesize | Stage::Enrich, _) => synthesize::plan(core, &job.target_id).await,
         // Embedding is batched per source; the per-chunk path is for edits,
         // for oversize splits, and for isolating a chunk the batch chokes on.
         (Stage::Embed, "corpus") => embed::run_corpus(core, &job.target_id).await,
@@ -69,41 +69,6 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         Err(e) if e.retryable() => {
             let exhausted = job.attempts >= MAX_ATTEMPTS;
             match (job.stage, job.target_kind.as_str()) {
-                // Out of attempts against the synthesizer. The windows that were
-                // actually tried are recorded as failed; the ones that never
-                // ran go back in the queue.
-                (Stage::Synthesize, _) if exhausted => {
-                    tracing::warn!(error = %e, "segmentation is not getting through; backing off");
-                    match synthesize::fail_pending_segments(core, &job.target_id, &e.to_string())
-                        .await
-                    {
-                        Ok(_) => {
-                            core.store.complete_job(job.id).await?;
-                            // Always, not only when a window went untried. A
-                            // segment the endpoint refused is not a verdict on
-                            // the text — the endpoint was loading a model, or
-                            // the machine was asleep — and the state it records
-                            // is what the next attempt starts from rather than
-                            // where it stops. After closing this job, never
-                            // before: the queue is keyed by (stage, target), so
-                            // an earlier enqueue would be the very row
-                            // `complete_job` then marks done.
-                            core.store
-                                .enqueue_after(
-                                    Stage::Synthesize,
-                                    "corpus",
-                                    &job.target_id,
-                                    job.attempts,
-                                )
-                                .await?;
-                        }
-                        Err(fe) => {
-                            core.store
-                                .fail_job(job.id, job.attempts, &fe.to_string())
-                                .await?;
-                        }
-                    }
-                }
                 // A whole source failing together usually means the endpoint is
                 // down, but it can also be one chunk the embedder rejects.
                 // Retrying chunk by chunk isolates the culprit either way.

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,5 +1,6 @@
 pub mod consolidate;
 pub mod embed;
+pub mod judge;
 pub mod reconcile;
 pub mod synthesize;
 pub mod window;
@@ -46,13 +47,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
         (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
-        // The handler lands in the task that introduces it; nothing arms this
-        // stage yet, so the arm is unreachable until then. `NotFound` is the
-        // safe shape: `run_one` closes such a job rather than retrying it.
-        (Stage::Judge, _) => {
-            tracing::error!(stage = job.stage.as_str(), "no handler for this stage yet");
-            Err(Error::NotFound)
-        }
+        (Stage::Judge, _) => judge::run(core, &job.target_id).await,
     };
 
     match result {
@@ -76,6 +71,14 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         Err(e) if e.retryable() => {
             let exhausted = job.attempts >= MAX_ATTEMPTS;
             match (job.stage, job.target_kind.as_str()) {
+                // A pair the model will not judge stays pending, and a later
+                // sweep decides again whether it is worth asking about. Holding
+                // a unit at the six-hour ceiling for it would keep re-asking a
+                // question the sweep may no longer want answered.
+                (Stage::Judge, _) if exhausted => {
+                    tracing::warn!(error = %e, "could not judge this pair; leaving it for a later sweep");
+                    core.store.complete_job(job.id).await?;
+                }
                 // A name is decoration and the corpus already has its fallback,
                 // so this is the one unit that stops asking. Everything else
                 // stays queued at the backoff ceiling, because everything else

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -2,6 +2,7 @@ pub mod consolidate;
 pub mod embed;
 pub mod reconcile;
 pub mod synthesize;
+pub mod window;
 
 use crate::core::Core;
 use crate::error::{Error, Result};
@@ -43,10 +44,11 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Embed, _) => embed::run(core, &job.target_id).await,
         // The sweep looks at the whole collection, so it ignores the target.
         (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
+        (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
         // Handlers land in the tasks that introduce them; nothing arms these
         // stages yet, so this arm is unreachable until then. `NotFound` is the
         // safe shape: `run_one` closes such a job rather than retrying it.
-        (Stage::SegmentWindow | Stage::Title | Stage::Judge, _) => {
+        (Stage::Title | Stage::Judge, _) => {
             tracing::error!(stage = job.stage.as_str(), "no handler for this stage yet");
             Err(Error::NotFound)
         }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -58,6 +58,12 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
     match result {
         Ok(()) => {
             core.store.complete_job(job.id).await?;
+            // After completing, never before: the queue is keyed by (stage,
+            // target), so a handler that re-armed itself would be upserting the
+            // very row this `complete_job` then closes.
+            if job.stage == Stage::Embed && job.target_kind == "corpus" {
+                embed::rearm_if_more(core, &job.target_id).await?;
+            }
             Ok(true)
         }
         // The target was deleted while the job waited. Retrying can never

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -43,6 +43,13 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Embed, _) => embed::run(core, &job.target_id).await,
         // The sweep looks at the whole collection, so it ignores the target.
         (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
+        // Handlers land in the tasks that introduce them; nothing arms these
+        // stages yet, so this arm is unreachable until then. `NotFound` is the
+        // safe shape: `run_one` closes such a job rather than retrying it.
+        (Stage::SegmentWindow | Stage::Title | Stage::Judge, _) => {
+            tracing::error!(stage = job.stage.as_str(), "no handler for this stage yet");
+            Err(Error::NotFound)
+        }
     };
 
     match result {

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -45,10 +45,11 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         // The sweep looks at the whole collection, so it ignores the target.
         (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
         (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
-        // Handlers land in the tasks that introduce them; nothing arms these
-        // stages yet, so this arm is unreachable until then. `NotFound` is the
+        (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
+        // The handler lands in the task that introduces it; nothing arms this
+        // stage yet, so the arm is unreachable until then. `NotFound` is the
         // safe shape: `run_one` closes such a job rather than retrying it.
-        (Stage::Title | Stage::Judge, _) => {
+        (Stage::Judge, _) => {
             tracing::error!(stage = job.stage.as_str(), "no handler for this stage yet");
             Err(Error::NotFound)
         }
@@ -69,6 +70,14 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         Err(e) if e.retryable() => {
             let exhausted = job.attempts >= MAX_ATTEMPTS;
             match (job.stage, job.target_kind.as_str()) {
+                // A name is decoration and the corpus already has its fallback,
+                // so this is the one unit that stops asking. Everything else
+                // stays queued at the backoff ceiling, because everything else
+                // carries knowledge that would otherwise be lost.
+                (Stage::Title, _) if exhausted => {
+                    tracing::warn!(error = %e, "could not name this corpus; leaving it unnamed");
+                    core.store.complete_job(job.id).await?;
+                }
                 // A whole source failing together usually means the endpoint is
                 // down, but it can also be one chunk the embedder rejects.
                 // Retrying chunk by chunk isolates the culprit either way.

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -5,8 +5,9 @@ pub mod synthesize;
 
 use crate::core::Core;
 use crate::error::{Error, Result};
-use crate::store::jobs::{MAX_ATTEMPTS, Stage};
+use crate::store::jobs::{Job, MAX_ATTEMPTS, Stage};
 use std::time::Duration;
+use tracing::Instrument;
 
 pub const POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// A job still marked `running` after this long belonged to a process that died.
@@ -26,8 +27,14 @@ pub async fn run_one(core: &Core) -> Result<bool> {
         target = %job.target_id,
         attempt = job.attempts
     );
-    let _guard = span.enter();
+    // `.instrument`, not `span.enter()`: a guard held across an `.await` does
+    // not travel with the future, so every line logged after the first
+    // suspension point lost its `job{...}` prefix — which in a journal full of
+    // interleaved windows is the only thing saying which job spoke.
+    run_claimed(core, job).instrument(span).await
+}
 
+async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
     let result = match (job.stage, job.target_kind.as_str()) {
         (Stage::Synthesize | Stage::Enrich, _) => synthesize::run(core, &job.target_id).await,
         // Embedding is batched per source; the per-chunk path is for edits,

--- a/src/jobs/reconcile.rs
+++ b/src/jobs/reconcile.rs
@@ -73,7 +73,21 @@ pub async fn run(core: &Core) -> Result<usize> {
             // `settle` rather than a job, because there is no inference here —
             // it is the same local work `finish` does, and re-running it on a
             // document that is fine is what the coverage test rules out.
-            if c.coverage.is_none() && !core.store.artifacts_for_corpus(&c.id).await?.is_empty() {
+            //
+            // Windowless corpora are excluded here for the same reason they are
+            // excluded from planning above, and it has to be said twice because
+            // the coverage test does not imply it: artifacts that pre-date
+            // windows have no coverage either, and so do the placeholder corpora
+            // `heal_dangling_supersessions` writes to give an orphaned artifact a
+            // parent. Settling one finds zero windows, decides everything is
+            // resolved, and runs `finish` — which measures coverage against a
+            // placeholder's empty source, logs that most of it is unclaimed, and
+            // arms a `Title` unit. That last part is the expensive half: a model
+            // call to name a document that has no text to name it from.
+            if !segments.is_empty()
+                && c.coverage.is_none()
+                && !core.store.artifacts_for_corpus(&c.id).await?.is_empty()
+            {
                 crate::jobs::window::settle(core, &c.id).await?;
                 armed += 1;
                 continue;
@@ -302,6 +316,54 @@ mod tests {
         assert!(
             core.store.has_job(Stage::Title, &src.id).await.unwrap(),
             "the document was never handed to the namer"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_corpus_with_no_windows_at_all_is_not_settled_or_named() {
+        // The mirror of the repair above, and the reason it needs a second
+        // condition rather than only the coverage test. A corpus with artifacts
+        // and no window rows is either older than windows or one of the
+        // placeholders `heal_dangling_supersessions` writes to give an orphaned
+        // artifact a parent — and neither has coverage, so coverage alone reads
+        // both as a document whose `finish` never ran.
+        //
+        // Settling one finds no windows, decides everything is resolved, and
+        // measures a placeholder's empty source before arming a `Title` unit: a
+        // model call to name a document that has no text to name it from.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "an artifact older than windows".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_corpus(&src.id)
+                .await
+                .unwrap()
+                .coverage
+                .is_none(),
+            "a document with no windows was measured against a source it never had"
+        );
+        assert!(
+            !core.store.has_job(Stage::Title, &src.id).await.unwrap(),
+            "a model call was spent naming a document with nothing to name it from"
         );
     }
 

--- a/src/jobs/reconcile.rs
+++ b/src/jobs/reconcile.rs
@@ -30,12 +30,33 @@ pub async fn run(core: &Core) -> Result<usize> {
             if c.near_dupe_of.is_some() {
                 continue;
             }
+            // A corpus with no window rows at all is deliberately left alone:
+            // its artifacts pre-date windows, and planning it would re-segment
+            // a document that is already fine. Capture arms the planning job;
+            // this sweep is for work that started and stopped.
             let segments = core.store.segments_for_corpus(&c.id).await?;
-            if segments.iter().any(|w| w.state != SegmentState::Done) {
-                core.store
-                    .enqueue(Stage::Synthesize, "corpus", &c.id)
-                    .await?;
-                armed += 1;
+            let unresolved: Vec<_> = segments
+                .iter()
+                .filter(|w| w.state != SegmentState::Done)
+                .collect();
+            if !unresolved.is_empty() {
+                // Windows exist but their units may not: a database written
+                // before units existed has none at all, and a process killed
+                // between two writes can be missing one. This is what makes a
+                // materialised queue safe — the units stay derivable from the
+                // rows that describe the work, so drift heals on a sweep rather
+                // than needing to be noticed.
+                for w in unresolved {
+                    core.store
+                        .enqueue_seq(
+                            Stage::SegmentWindow,
+                            "segment",
+                            &crate::jobs::window::unit_target(&c.id, w.idx),
+                            w.idx,
+                        )
+                        .await?;
+                    armed += 1;
+                }
                 continue;
             }
             if !core
@@ -61,6 +82,42 @@ mod tests {
     use crate::core::test_support::test_core;
     use crate::store::artifacts::NewArtifact;
     use crate::store::segments::NewSegment;
+
+    #[tokio::test]
+    async fn an_old_corpus_level_job_becomes_per_window_units() {
+        // The upgrade path. A database written before units existed holds one
+        // Synthesize row per unfinished corpus and no window units at all, so
+        // without this the windows would sit unsegmented until someone noticed.
+        let core = test_core().await;
+        let body = (0..400)
+            .map(|i| format!("paragraph {i} with filler text"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        // Wind the clock back to the old shape: windows, no units.
+        sqlx::query("DELETE FROM jobs WHERE stage = 'segment_window'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        core.store
+            .enqueue(Stage::Synthesize, "corpus", &out.id)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap().len();
+        assert!(windows > 2, "the fixture must span several windows");
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs WHERE stage = 'segment_window' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed as usize, windows, "the old job did not become units");
+    }
 
     fn seg(start_line: i64, end_line: i64, text: &str) -> NewSegment<'_> {
         NewSegment {
@@ -88,10 +145,12 @@ mod tests {
             .unwrap();
 
         // Segment 1 never ran and nothing is queued: the crack this closes.
+        // One unit, addressed to that window — not a job for the whole corpus,
+        // which would re-plan a document whose other window is already done.
         assert_eq!(run(&core).await.unwrap(), 1);
         let job = core.store.claim_job().await.unwrap().expect("a job");
-        assert_eq!(job.stage, Stage::Synthesize);
-        assert_eq!(job.target_id, src.id);
+        assert_eq!(job.stage, Stage::SegmentWindow);
+        assert_eq!(job.target_id, crate::jobs::window::unit_target(&src.id, 1));
     }
 
     #[tokio::test]

--- a/src/jobs/reconcile.rs
+++ b/src/jobs/reconcile.rs
@@ -6,9 +6,12 @@
 //! bug in it. Without it, "the system repairs itself" holds only for the
 //! failures the system happened to be watching at the time.
 //!
-//! Cheap and idempotent: `enqueue` is keyed by (stage, target), so re-arming
-//! something already queued changes nothing, and a base with nothing wrong
-//! costs one query per hundred corpora.
+//! Cheap and idempotent: the queue is keyed by (stage, target), and this arms
+//! only units nothing is going to run — a base with nothing wrong costs one
+//! query per hundred corpora and changes not a row. Deliberately *not*
+//! `enqueue`: that resets attempts, and a sweep that keeps winding a failing
+//! unit's attempts back to zero is a sweep that stops its document ever
+//! settling.
 
 use crate::core::Core;
 use crate::error::Result;
@@ -48,7 +51,7 @@ pub async fn run(core: &Core) -> Result<usize> {
                 // than needing to be noticed.
                 for w in unresolved {
                     core.store
-                        .enqueue_seq(
+                        .rearm_idle_seq(
                             Stage::SegmentWindow,
                             "segment",
                             &crate::jobs::window::unit_target(&c.id, w.idx),
@@ -65,7 +68,9 @@ pub async fn run(core: &Core) -> Result<usize> {
                 .await?
                 .is_empty()
             {
-                core.store.enqueue(Stage::Embed, "corpus", &c.id).await?;
+                core.store
+                    .rearm_idle_seq(Stage::Embed, "corpus", &c.id, 0)
+                    .await?;
                 armed += 1;
             }
         }
@@ -82,6 +87,37 @@ mod tests {
     use crate::core::test_support::test_core;
     use crate::store::artifacts::NewArtifact;
     use crate::store::segments::NewSegment;
+
+    #[tokio::test]
+    async fn a_sweep_does_not_wind_back_a_failing_units_attempts() {
+        // A window the model will not read has to reach the ceiling before its
+        // document can settle around it. A sweep that re-armed every unresolved
+        // window from zero kept such a unit forever young, so `settle` never
+        // counted it as spent and the corpus never left `segmenting` — the sweep
+        // meant to heal the base was the thing holding it open.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+        sqlx::query("UPDATE jobs SET attempts = 4 WHERE stage = 'segment_window'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let attempts: Vec<i64> =
+            sqlx::query_scalar("SELECT attempts FROM jobs WHERE stage = 'segment_window'")
+                .fetch_all(&core.store.pool)
+                .await
+                .unwrap();
+        assert!(
+            attempts.iter().all(|&a| a == 4),
+            "the sweep reset a unit that was already queued: {attempts:?}"
+        );
+    }
 
     #[tokio::test]
     async fn an_old_corpus_level_job_becomes_per_window_units() {

--- a/src/jobs/reconcile.rs
+++ b/src/jobs/reconcile.rs
@@ -62,6 +62,22 @@ pub async fn run(core: &Core) -> Result<usize> {
                 }
                 continue;
             }
+            // Every window resolved and the document was still never finished.
+            // `finish` measures coverage on every path that produced artifacts,
+            // so a corpus with artifacts and none of it is one whose process
+            // died between the last window's `Done` and the `settle` that
+            // follows it. Nothing else would notice: the embed branch below
+            // still fires and `settle_corpus` gives it a status, while the
+            // renumbering, the coverage measure and the title unit never ran.
+            //
+            // `settle` rather than a job, because there is no inference here —
+            // it is the same local work `finish` does, and re-running it on a
+            // document that is fine is what the coverage test rules out.
+            if c.coverage.is_none() && !core.store.artifacts_for_corpus(&c.id).await?.is_empty() {
+                crate::jobs::window::settle(core, &c.id).await?;
+                armed += 1;
+                continue;
+            }
             if !core
                 .store
                 .pending_artifacts_for_corpus(&c.id)
@@ -218,9 +234,75 @@ mod tests {
             .await
             .unwrap();
 
+        // A corpus that got as far as embedding has been through `finish`, and
+        // `finish` measures it. Without this the fixture is indistinguishable
+        // from a document whose `finish` never ran, which is a different repair.
+        core.store.set_corpus_coverage(&src.id, 0.9).await.unwrap();
+
         assert_eq!(run(&core).await.unwrap(), 1);
         let job = core.store.claim_job().await.unwrap().expect("a job");
         assert_eq!(job.stage, Stage::Embed);
+    }
+
+    #[tokio::test]
+    async fn a_corpus_that_resolved_every_window_but_never_finished_is_healed() {
+        // Killed between the last window's `Done` and the `settle` that
+        // follows it. Every window has resolved, so the branch above arms
+        // nothing, and the embed branch below gives the corpus a status anyway
+        // — which is what makes this invisible. The document was never
+        // renumbered, never measured and never named, and nothing else in the
+        // system would ever do it.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[seg(1, 10, "the window")])
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "the window".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .get_corpus(&src.id)
+                .await
+                .unwrap()
+                .coverage
+                .is_none(),
+            "the fixture must start unmeasured"
+        );
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_corpus(&src.id)
+                .await
+                .unwrap()
+                .coverage
+                .is_some(),
+            "the document was never measured, and nothing was left that would"
+        );
+        assert!(
+            core.store.has_job(Stage::Title, &src.id).await.unwrap(),
+            "the document was never handed to the namer"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -5,24 +5,6 @@ use crate::infer::split::split_into_segments;
 use crate::store::corpora::CorpusStatus;
 use crate::store::jobs::Stage;
 use crate::store::segments::SegmentState;
-// Scaffolding, gone with `run` in the next commit: these moved to `window`
-// alongside the handler that owns them, and the loop below is the last caller.
-use crate::jobs::window::{
-    flag_unverified, from_context_only, paraphrased, proposed_to_new, resolve_span,
-    write_segment_artifacts,
-};
-
-/// Unreadable replies in a row before the pass stops working through the
-/// document.
-///
-/// One window the model will not produce readable JSON for says something about
-/// that window; the pass steps over it and keeps going, which is the whole point
-/// of stepping over it at all. Several in a row says something about the model
-/// or the endpoint, and every further window costs a full call — the slowest,
-/// most expensive thing engram does — to arrive back at the same answer. Three
-/// is far enough to clear a bad patch of a document and short enough that a
-/// broken model costs a handful of calls rather than one per window.
-const REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS: usize = 3;
 
 /// Tokens consumed by the system prompt and scaffolding. Measured from the
 /// real prompt rather than guessed.
@@ -65,218 +47,21 @@ pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
         })
         .collect();
     core.store.upsert_segments(corpus_id, &rows).await?;
-    Ok(())
-}
 
-/// LLM-assisted segmentation, one window at a time.
-///
-/// Superseded by the per-window units `plan` will arm, and kept only until the
-/// pipeline is flipped over to them.
-pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
-    plan(core, corpus_id).await?;
-    if core.store.segments_for_corpus(corpus_id).await?.is_empty() {
-        return Ok(());
-    }
-
-    // Every window of the corpus, in order, for the neighbouring context. The
-    // rows are authoritative rather than the freshly split `windows`: a corpus
-    // whose windows were written by an earlier run keeps the text that run
-    // produced, which is what makes a retry reproduce the same prompt.
-    let all = core.store.segments_for_corpus(corpus_id).await?;
-    let all_texts: Vec<&str> = all.iter().map(|s| s.text.as_str()).collect();
-
-    // The first unreadable reply of this pass, kept so the job still ends in an
-    // error and comes back for the windows it could not segment. The rest of
-    // the document is worked through first.
-    let mut refused: Option<crate::error::Error> = None;
-    let mut in_a_row = 0usize;
-
+    // One unit per window that has not resolved. `seq` is the window index, so
+    // this document's window 0 is claimed before any document's window 1 and a
+    // capture made during a long ingest does not wait for all of it.
     for w in core.store.pending_segments(corpus_id).await? {
-        core.store.bump_segment_attempts(corpus_id, w.idx).await?;
-        // The stored text, not a re-derivation from the line range: line
-        // numbers cannot address a unit smaller than a line, so a corpus with
-        // no newlines re-derived to the whole document for window 0 and to
-        // nothing at all for every window after it.
-        let text = w.text.clone();
-
-        // The failure this catches is a job retrying an over-context window
-        // against the endpoint with growing backoff and no terminal state, so
-        // it is worth an assertion even though it cannot fire today.
-        //
-        // The ceiling is twice the budget rather than the budget itself,
-        // because that is what the splitter actually promises: it flushes once
-        // the buffer has *reached* the budget, and `flush` then prepends the
-        // carried heading, so a window legitimately lands somewhat over. Twice
-        // is the bound `text_with_no_structure_still_splits_by_line_cap` has
-        // always asserted. What must never happen is unbounded — the corpus
-        // that came back fifteen times its budget.
-        let window_budget = segment_tokens(core.synthesizer.budget(), prompt_overhead(core));
-        let window_tokens = core.counter.count(&text);
-        debug_assert!(
-            window_tokens <= window_budget * 2,
-            "window {} is {window_tokens} tokens against a budget of {window_budget}",
-            w.idx
-        );
-        if window_tokens > window_budget * 2 {
-            tracing::error!(
-                corpus_id,
-                window = w.idx,
-                window_tokens,
-                window_budget,
-                "window is far over its budget; the splitter did not shrink it"
-            );
-        }
-
-        let ctx = crate::infer::context::WindowContext::build(
-            &all_texts,
-            w.idx as usize,
-            core.synthesizer.budget().context,
-            &core.counter,
-        );
-        let mut chunks = match core
-            .synthesizer
-            .segment(crate::infer::SegmentInput {
-                core: &text,
-                context: &ctx,
-            })
-            .await
-        {
-            Ok(chunks) => chunks,
-            // The model answered and we could not read the answer. That is a
-            // property of this window's text, not of the endpoint, so the
-            // windows after it are still worth calling for — and before this,
-            // they were not called at all until the bad one got through. One
-            // duplicate JSON key cost a real document thirty untried windows
-            // and twelve rounds of backoff, hours of waiting for work that was
-            // never going to be attempted in those passes anyway.
-            Err(e @ crate::error::Error::MalformedLlmOutput(_)) => {
-                let reason = e.to_string();
-                tracing::warn!(
-                    corpus_id,
-                    window = w.idx,
-                    lines = format!("{}-{}", w.start_line, w.end_line),
-                    reason,
-                    "window could not be segmented; moving on to the next one"
-                );
-                core.store
-                    .set_segment_state(corpus_id, w.idx, SegmentState::Failed, Some(&reason))
-                    .await?;
-                in_a_row += 1;
-                refused.get_or_insert(e);
-                // Carrying on past one bad window is what this arm is for.
-                // Carrying on past a run of them is just paying a full call to
-                // learn the same thing again: a model garbling this many in a
-                // row is garbling all of them, and the windows left untried
-                // stay pending for a pass that can actually use them.
-                if in_a_row >= REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS {
-                    tracing::warn!(
-                        corpus_id,
-                        windows = in_a_row,
-                        "the model is refusing every window; stopping this pass"
-                    );
-                    break;
-                }
-                continue;
-            }
-            // Anything else — a timeout, a 502, a refused connection — says the
-            // endpoint is unwell. Putting thirty more windows to it costs one
-            // timeout each and learns nothing, so the pass still stops here.
-            Err(e) => return Err(e),
-        };
-        // A window the model read fine says the last refusal was about that
-        // window rather than about the model, so the run starts over.
-        in_a_row = 0;
-
-        // The model was told to keep commands, paths and flags verbatim. If it
-        // did not, one more attempt usually gets it right; a second failure is
-        // stored with a flag rather than dropped, because a visible warning
-        // beats losing the chapter.
-        if paraphrased(&chunks, &text) {
-            tracing::warn!(
-                corpus_id,
-                window = w.idx,
-                "literals missing; re-segmenting once"
-            );
-            match core
-                .synthesizer
-                .segment(crate::infer::SegmentInput {
-                    core: &text,
-                    context: &ctx,
-                })
-                .await
-            {
-                Ok(second) => chunks = second,
-                // The first reply parsed; it merely paraphrased. Keeping it and
-                // letting `flag_unverified` mark what went missing beats losing
-                // a window we can already read.
-                Err(e) => tracing::warn!(
-                    corpus_id,
-                    window = w.idx,
-                    error = %e,
-                    "the re-segmentation failed; keeping the first reply"
-                ),
-            }
-        }
-
-        if !ctx.is_empty() {
-            let before = chunks.len();
-            chunks.retain(|c| !from_context_only(&c.text, &text, &ctx));
-            let dropped = before - chunks.len();
-            if dropped > 0 {
-                // A rising count here means the configured model is ignoring
-                // the prompt's context-only instruction. Better as a number in
-                // the log than as duplicates in the base.
-                tracing::info!(
-                    corpus_id,
-                    window = w.idx,
-                    dropped,
-                    "artifacts drawn from context blocks were dropped"
-                );
-            }
-        }
-
-        // The span is ours to compute.
-        //
-        // Without the carried heading, which is prepended text from further up
-        // the document and occupies none of the window's lines.
-        let body: String = text
-            .lines()
-            .skip(w.carry_lines as usize)
-            .collect::<Vec<_>>()
-            .join("\n");
-        for c in &mut chunks {
-            c.corpus_lines = Some(resolve_span(&c.text, &body, &w, c.corpus_lines));
-        }
-
-        let written =
-            write_segment_artifacts(core, corpus_id, w.idx, proposed_to_new(w.idx, chunks)).await?;
-        flag_unverified(core, &written, &text).await?;
         core.store
-            .set_segment_state(corpus_id, w.idx, SegmentState::Done, None)
+            .enqueue_seq(
+                Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(corpus_id, w.idx),
+                w.idx,
+            )
             .await?;
-
-        // Idle between windows if asked to. A long source is otherwise minutes
-        // of unbroken generation, which on a desktop GPU is a sustained load
-        // rather than a burst. The window is already committed, so a pause here
-        // costs nothing if the process dies during it.
-        let cooldown = core.synthesizer.cooldown();
-        if !cooldown.is_zero() {
-            tracing::debug!(
-                secs = cooldown.as_secs(),
-                "cooling down before the next window"
-            );
-            tokio::time::sleep(cooldown).await;
-        }
     }
-
-    // Windows the model refused are still owed a call, so the job has to fail
-    // for the queue to bring it back. `finish` is left to the caller's
-    // exhausted path, which settles the source once the attempts run out.
-    if let Some(e) = refused {
-        return Err(e);
-    }
-
-    finish(core, corpus_id).await
+    Ok(())
 }
 
 /// Measure how much of a corpus survived into its artifacts, and store it.
@@ -381,83 +166,47 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Settle the windows a spent job leaves behind.
+/// Plan a corpus and work its queue to a standstill — what a worker does,
+/// compressed into one call.
 ///
-/// The model is a hard dependency: a window it will not segment stays
-/// unsegmented and records why. There is no structural split to fall back on,
-/// because paragraphs stored verbatim are not what the rest of the system means
-/// by a chunk — no title, no category, no tags, and not rewritten to stand
-/// alone — and they would compete for queries against chunks that are.
-///
-/// Only windows that have actually been tried get a verdict. A local endpoint
-/// fails in bursts — the model is loading, or something else took the VRAM —
-/// and the job's attempt count is shared by every window, so an outage during
-/// window 1 must not condemn windows 2 onward that the model never saw. Those
-/// go back in the queue instead. "Tried at least once" is the line rather than
-/// "spent every attempt", because the attempt count belongs to the job, which
-/// covers the whole source.
-///
-/// Returns whether windows are still waiting for their first attempt, which the
-/// caller answers with a fresh job. It cannot be enqueued here: the caller's own
-/// job row is keyed `(stage, target_id)`, so enqueuing the same source would
-/// reuse that row and the `complete_job` that follows would close it again — the
-/// untried windows would be left with nothing to come back to.
-///
-/// Either way the source is settled for now: whatever windows did succeed are
-/// embedded and the corpus reports `partial`. Settled is not finished — a failed
-/// window is still owed a model call, and the caller queues one at the backoff's
-/// distance.
-pub async fn fail_pending_segments(core: &Core, corpus_id: &str, reason: &str) -> Result<bool> {
-    let pending = core.store.pending_segments(corpus_id).await?;
-    if pending.is_empty() {
-        finish(core, corpus_id).await?;
-        return Ok(false);
-    }
+/// Segmentation is no longer a function that takes a document and returns it
+/// segmented: it is a plan plus N units the queue delivers. Tests across the
+/// tree that care about the outcome rather than the schedule say so with this.
+/// The backoff is wound back each round because a delay is not what any of them
+/// are asserting.
+#[cfg(test)]
+pub async fn segment_all(core: &Core, corpus_id: &str) {
+    plan(core, corpus_id).await.unwrap();
+    for _ in 0..500 {
+        // Embedding is held back rather than run. This helper stands in for the
+        // old whole-corpus `run`, which segmented a document and left an embed
+        // job queued behind it — several tests are about the state in exactly
+        // that gap, and draining through it would erase what they check.
+        sqlx::query(
+            "UPDATE jobs SET run_after = CASE WHEN stage = 'embed' THEN ? ELSE 0 END
+              WHERE state = 'pending'",
+        )
+        .bind(crate::store::now() + 86_400)
+        .execute(&core.store.pool)
+        .await
+        .unwrap();
 
-    let (tried, untried): (Vec<_>, Vec<_>) = pending
-        .into_iter()
-        .partition(|w| w.attempts > 0 || w.state == SegmentState::Failed);
-
-    if !untried.is_empty() {
-        tracing::info!(
-            corpus_id,
-            windows = untried.len(),
-            "leaving untried windows queued rather than failing them"
-        );
+        if !crate::jobs::run_one(core).await.unwrap_or(false) {
+            break;
+        }
+        // A window the model will never read stays claimable forever — engram
+        // has no terminal state — so "the queue is empty" cannot be the end
+        // condition here. The corpus leaving `segmenting` is: that is precisely
+        // the moment `settle` decided every window had resolved, whether by
+        // succeeding or by spending its attempts.
+        if core.store.get_corpus(corpus_id).await.unwrap().status != CorpusStatus::Segmenting {
+            break;
+        }
     }
-
-    if tried.is_empty() {
-        // Nothing has earned a verdict yet; the caller queues another attempt.
-        return Ok(true);
-    }
-
-    for w in tried {
-        core.store
-            .set_segment_state(corpus_id, w.idx, SegmentState::Failed, Some(reason))
-            .await?;
-        tracing::warn!(
-            corpus_id,
-            window = w.idx,
-            lines = format!("{}-{}", w.start_line, w.end_line),
-            reason,
-            "window could not be segmented; its lines have no chunk"
-        );
-    }
-    // Windows still waiting for their first attempt mean the source is not
-    // settled yet; finishing here would enqueue embedding for half a document.
-    // A window already marked failed does not hold it up — it is owed another
-    // call, not a first one, and the next job brings that.
-    let untried_left = core
-        .store
-        .pending_segments(corpus_id)
-        .await?
-        .into_iter()
-        .any(|w| w.state == SegmentState::Pending);
-    if !untried_left {
-        finish(core, corpus_id).await?;
-        return Ok(false);
-    }
-    Ok(true)
+    sqlx::query("UPDATE jobs SET run_after = 0 WHERE stage = 'embed'")
+        .execute(&core.store.pool)
+        .await
+        .unwrap();
 }
 
 #[cfg(test)]
@@ -465,7 +214,6 @@ mod tests {
     use super::*;
     use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
     use crate::store::corpora::CorpusStatus;
-    use crate::store::jobs::{MAX_ATTEMPTS, Stage};
 
     /// A budget with room for several windows and an output ceiling that never
     /// binds, so the context blocks are what shape the windowing.
@@ -496,7 +244,7 @@ mod tests {
         for raw in [lines.join("\n"), "word ".repeat(8000)] {
             let src = core.store.insert_corpus(&raw, "web", None).await.unwrap();
 
-            run(&core, &src.id).await.unwrap();
+            segment_all(&core, &src.id).await;
 
             let segments = core.store.segments_for_corpus(&src.id).await.unwrap();
             assert!(!segments.is_empty(), "a corpus must produce windows");
@@ -513,38 +261,6 @@ mod tests {
                 assert!(!s.text.is_empty(), "window {} was stored empty", s.idx);
             }
         }
-    }
-
-    #[test]
-    fn an_artifact_found_only_in_context_is_recognised() {
-        use crate::infer::context::WindowContext;
-
-        let core_text = "the window says something quite specific here\nand more of it";
-        let ctx = WindowContext {
-            opening: Some("the document opening states the version clearly".into()),
-            before: None,
-            after: Some("the following window describes another procedure".into()),
-        };
-
-        // Drawn from the window itself: keep.
-        assert!(!from_context_only(
-            "the window says something quite specific here",
-            core_text,
-            &ctx
-        ));
-        // Drawn from a context block and nowhere in the window: drop.
-        assert!(from_context_only(
-            "the following window describes another procedure",
-            core_text,
-            &ctx
-        ));
-        // Located nowhere at all — a heavily reworded artifact. Keep it, so it
-        // reaches flag_unverified the way it does today instead of vanishing.
-        assert!(!from_context_only(
-            "an entirely reworded statement about unrelated matters",
-            core_text,
-            &ctx
-        ));
     }
 
     #[tokio::test]
@@ -565,7 +281,7 @@ mod tests {
             .await
             .unwrap();
 
-        run(&core, &src.id).await.unwrap();
+        segment_all(&core, &src.id).await;
 
         let written = core.store.artifacts_for_corpus(&src.id).await.unwrap();
         let mut texts: Vec<&str> = written.iter().map(|c| c.text.as_str()).collect();
@@ -599,7 +315,7 @@ mod tests {
             .await
             .unwrap();
 
-        run(&core, &src.id).await.unwrap();
+        segment_all(&core, &src.id).await;
 
         let seen = rec.seen.lock().unwrap();
         assert!(seen.len() > 1, "the fixture must produce several windows");
@@ -642,7 +358,7 @@ mod tests {
             .await
             .unwrap();
 
-        run(&core, &src.id).await.unwrap();
+        segment_all(&core, &src.id).await;
 
         let seen = rec.seen.lock().unwrap();
         // Window 1's preceding context must be the literal end of window 0's
@@ -680,7 +396,7 @@ mod tests {
                 .is_none()
         );
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let named = core.store.get_corpus(&out.id).await.unwrap();
         assert_eq!(named.title_hint.as_deref(), Some("Fake title: alpha line"));
@@ -696,7 +412,7 @@ mod tests {
             .await
             .unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let got = core.store.get_corpus(&out.id).await.unwrap();
         assert_eq!(got.title_hint.as_deref(), Some("My own label"));
@@ -712,7 +428,7 @@ mod tests {
             .ingest("alpha line\n\nbravo line", "web", None)
             .await
             .unwrap();
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         // A synthesizer that fails every call cannot produce artifacts either,
         // so naming is exercised through `finish` on a corpus that already has
@@ -722,7 +438,7 @@ mod tests {
             .ingest("alpha line\n\nbravo line", "web", None)
             .await
             .unwrap();
-        let _ = run(&failing, &hurt.id).await;
+        segment_all(&failing, &hurt.id).await;
         assert!(
             failing
                 .store
@@ -753,6 +469,149 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn planning_makes_no_inference_call_and_arms_one_unit_per_window() {
+        use crate::infer::fake::RecordingSynthesizer;
+        let mut core = test_core().await;
+        let rec = std::sync::Arc::new(RecordingSynthesizer::new(context_budget(30, 20)));
+        core.synthesizer = rec.clone();
+        let body = multi_segment_body();
+        let out = core.ingest(&body, "web", None).await.unwrap();
+
+        plan(&core, &out.id).await.unwrap();
+
+        assert_eq!(
+            rec.seen.lock().unwrap().len(),
+            0,
+            "planning called the model; it is meant to be arithmetic over text"
+        );
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap().len();
+        assert!(windows > 2, "the fixture must span several windows");
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs WHERE stage = 'segment_window' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed as usize, windows);
+    }
+
+    #[tokio::test]
+    async fn a_poisoned_window_does_not_stop_another_document() {
+        // The 2026-08-12 incident, as a test. One window of document A carries a
+        // reply that never parses; document B must still reach ready. Before the
+        // units existed this could not pass: A held the queue for hours.
+        let mut core = test_core().await;
+        let a = core
+            .ingest(
+                &format!("STOPHERE poison\n\n{}", multi_segment_body()),
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+        let b = core
+            .ingest("bravo one\n\nbravo two", "web", None)
+            .await
+            .unwrap();
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
+            "STOPHERE",
+        ));
+
+        plan(&core, &a.id).await.unwrap();
+        plan(&core, &b.id).await.unwrap();
+        for _ in 0..400 {
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            if !crate::jobs::run_one(&core).await.unwrap_or(false) {
+                break;
+            }
+        }
+
+        assert_eq!(
+            core.store.get_corpus(&b.id).await.unwrap().status,
+            CorpusStatus::Ready,
+            "the healthy document waited on the poisoned one"
+        );
+        assert_eq!(
+            core.store.get_corpus(&a.id).await.unwrap().status,
+            CorpusStatus::Partial,
+            "a document with one refused window settles partial, not failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_corpus_settles_around_a_window_that_will_not_resolve() {
+        // Per-unit budgets could hang a document forever: engram never abandons
+        // work, so a window the model will not read stays queued at the ceiling
+        // — and if settling waited for it, the windows that came back perfectly
+        // would never be embedded and never become searchable.
+        let mut core = test_core().await;
+        let body = format!("STOPHERE poison\n\n{}", multi_segment_body());
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
+            "STOPHERE",
+        ));
+
+        segment_all(&core, &out.id).await;
+
+        assert_eq!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Partial
+        );
+        assert!(
+            !core
+                .store
+                .artifacts_for_corpus(&out.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the good windows' artifacts were never written"
+        );
+        let embed_armed: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM jobs WHERE stage = 'embed' AND target_id = ?")
+                .bind(&out.id)
+                .fetch_one(&core.store.pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            embed_armed, 1,
+            "the good artifacts were never queued to embed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_recovered_window_settles_the_corpus_again() {
+        let mut core = test_core().await;
+        let body = format!("STOPHERE poison\n\n{}", multi_segment_body());
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
+            "STOPHERE",
+        ));
+        segment_all(&core, &out.id).await;
+        assert_eq!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Partial
+        );
+
+        // The endpoint comes back to its senses. Settling has to run again, or
+        // the document would stay `partial` with a window that is now fine.
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::default());
+        segment_all(&core, &out.id).await;
+
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(
+            windows.iter().all(|w| w.state == SegmentState::Done),
+            "the retried window never recovered"
+        );
+        assert_eq!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Embedding
+        );
+    }
+
+    #[tokio::test]
     async fn segments_a_source_into_chunks_and_queues_embedding() {
         let core = test_core().await;
         let out = core
@@ -760,7 +619,7 @@ mod tests {
             .await
             .unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let chunks = core.store.artifacts_for_corpus(&out.id).await.unwrap();
         assert_eq!(chunks.len(), 2);
@@ -772,17 +631,19 @@ mod tests {
         );
 
         // One embed job for the whole source, not one per chunk: the point of
-        // batching is a single inference call.
-        core.store.claim_job().await.unwrap(); // segment
-        let mut embed_jobs = Vec::new();
-        while let Some(j) = core.store.claim_job().await.unwrap() {
-            if j.stage == Stage::Embed {
-                embed_jobs.push(j);
-            }
-        }
+        // batching is a single inference call. Read off the table rather than
+        // claimed, because the units this document was segmented by are already
+        // done and claiming would say nothing about how many there were.
+        let embed_jobs: Vec<(String, String)> = sqlx::query_as(
+            "SELECT target_kind, target_id FROM jobs
+              WHERE stage = 'embed' AND state = 'pending'",
+        )
+        .fetch_all(&core.store.pool)
+        .await
+        .unwrap();
         assert_eq!(embed_jobs.len(), 1, "expected one batched embed job");
-        assert_eq!(embed_jobs[0].target_kind, "corpus");
-        assert_eq!(embed_jobs[0].target_id, out.id);
+        assert_eq!(embed_jobs[0].0, "corpus");
+        assert_eq!(embed_jobs[0].1, out.id);
     }
 
     #[tokio::test]
@@ -797,7 +658,7 @@ mod tests {
             "test body must span multiple windows or it proves nothing"
         );
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let chunks = core.store.artifacts_for_corpus(&out.id).await.unwrap();
         assert!(chunks.len() > 1);
@@ -807,87 +668,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_segment_the_endpoint_refused_is_queued_again() {
-        // The failure that lost a quarter of a document: the endpoint was
-        // loading a model and returned 502 for ten minutes, the job spent its
-        // attempts inside the first minute, and nothing ever tried the segment
-        // again. `failed` has to mean "waiting to be tried", not "gone".
-        let core = test_core_with_failing_synthesizer().await;
-        let out = core
-            .ingest("alpha para\n\nbeta para", "web", None)
-            .await
-            .unwrap();
-
-        for _ in 0..MAX_ATTEMPTS + 2 {
-            sqlx::query("UPDATE jobs SET run_after = 0")
-                .execute(&core.store.pool)
-                .await
-                .unwrap();
-            crate::jobs::run_one(&core).await.unwrap();
-        }
-
-        assert!(
-            core.store.failed_jobs(10).await.unwrap().is_empty(),
-            "the corpus was abandoned"
-        );
-        // Directly, because `finish` also queues an embed job for the corpus
-        // and `claim_job` may hand that one over first.
-        let queued: i64 = sqlx::query_scalar(
-            "SELECT count(*) FROM jobs
-              WHERE stage = 'synthesize' AND target_id = ? AND state = 'pending'",
-        )
-        .bind(&out.id)
-        .fetch_one(&core.store.pool)
-        .await
-        .unwrap();
-        assert_eq!(queued, 1, "no job is left to retry the segment");
-    }
-
-    #[tokio::test]
-    async fn a_window_the_model_refuses_is_marked_failed_not_split() {
-        let core = test_core_with_failing_synthesizer().await;
-        let out = core
-            .ingest("alpha para\n\nbeta para", "web", None)
-            .await
-            .unwrap();
-
-        let err = run(&core, &out.id).await.unwrap_err();
-        assert!(
-            err.retryable(),
-            "a dead endpoint deserves a retry, not a verdict"
-        );
-
-        let requeue = fail_pending_segments(&core, &out.id, "endpoint down")
-            .await
-            .unwrap();
-
-        assert!(!requeue, "nothing is left waiting when every window failed");
-        let w = &core.store.segments_for_corpus(&out.id).await.unwrap()[0];
-        assert_eq!(w.state, SegmentState::Failed);
-        assert_eq!(w.last_error.as_deref(), Some("endpoint down"));
-
-        // The point of the change: no paragraph-shaped debris competing for
-        // queries against chunks that were actually written to stand alone.
-        assert!(
-            core.store
-                .artifacts_for_corpus(&out.id)
-                .await
-                .unwrap()
-                .is_empty(),
-            "a refused window must produce no chunks at all"
-        );
-        assert_eq!(
-            core.store.get_corpus(&out.id).await.unwrap().status,
-            CorpusStatus::Failed
-        );
-    }
-
-    #[tokio::test]
     async fn re_running_segmentation_replaces_rather_than_appends() {
         let core = test_core().await;
         let out = core.ingest("one\n\ntwo", "web", None).await.unwrap();
-        run(&core, &out.id).await.unwrap();
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
+        segment_all(&core, &out.id).await;
         assert_eq!(
             core.store
                 .artifacts_for_corpus(&out.id)
@@ -915,7 +700,7 @@ Then run sync.";
         core.synthesizer = synthesizer.clone();
         let out = core.ingest(COMMAND_BODY, "web", None).await.unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         assert_eq!(synthesizer.calls(), 2, "exactly one re-segmentation");
         let chunks = core.store.artifacts_for_corpus(&out.id).await.unwrap();
@@ -933,7 +718,7 @@ Then run sync.";
         );
         let out = core.ingest(COMMAND_BODY, "web", None).await.unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let chunks = core.store.artifacts_for_corpus(&out.id).await.unwrap();
         assert!(!chunks.is_empty(), "flagged chunks are still stored");
@@ -968,7 +753,7 @@ Then run sync.";
             .await
             .unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let c = &core.store.artifacts_for_corpus(&out.id).await.unwrap()[0];
         let span = c.corpus_span.as_ref().unwrap();
@@ -995,7 +780,7 @@ Then run sync.";
             .await
             .unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         for c in core.store.artifacts_for_corpus(&out.id).await.unwrap() {
             assert!(
@@ -1018,7 +803,7 @@ Then run sync.";
             .ingest("first para\n\nsecond para", "web", None)
             .await
             .unwrap();
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
         let cov = core
             .store
             .get_corpus(&out.id)
@@ -1027,276 +812,6 @@ Then run sync.";
             .coverage
             .unwrap();
         assert!(cov > 0.0 && cov <= 1.0);
-    }
-
-    #[tokio::test]
-    async fn a_burst_of_endpoint_failures_does_not_condemn_untried_windows() {
-        // The job's attempt count is shared by every window of a source, so an
-        // outage while window 0 is running used to condemn the whole rest of
-        // the document without ever calling the model for it. Locally that
-        // outage is usually the model still loading.
-        let mut core = test_core().await;
-        let body = multi_segment_body();
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        assert!(segment_count(&core, &body) > 2);
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing("502"));
-
-        // The endpoint refuses while the first window is running; the rest of
-        // the source never gets a call at all.
-        assert!(run(&core, &out.id).await.is_err());
-        let requeue = fail_pending_segments(&core, &out.id, "502 Bad Gateway")
-            .await
-            .unwrap();
-
-        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
-        assert_eq!(
-            windows
-                .iter()
-                .filter(|w| w.state == SegmentState::Failed)
-                .count(),
-            1,
-            "only the window that spent its attempts may be given a verdict"
-        );
-        assert!(
-            windows
-                .iter()
-                .filter(|w| w.state == SegmentState::Pending)
-                .count()
-                > 1,
-            "untried windows must stay queued for the model"
-        );
-
-        assert!(
-            requeue,
-            "the untried windows need a job to come back to, and only the \
-             caller can enqueue it without its own row being closed underneath"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_source_with_untried_windows_still_has_a_job_after_a_failure() {
-        // Settling the windows used to enqueue the retry itself. The queue is keyed by
-        // (stage, target), so that reused the very row the worker was running,
-        // and the `complete_job` that followed closed it again: the untried
-        // windows were abandoned and the source sat in `segmenting` forever.
-        let mut core = test_core().await;
-        let body = multi_segment_body();
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        assert!(segment_count(&core, &body) > 2);
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing("502"));
-
-        for _ in 0..=crate::store::jobs::MAX_ATTEMPTS {
-            sqlx::query("UPDATE jobs SET run_after = 0")
-                .execute(&core.store.pool)
-                .await
-                .unwrap();
-            let _ = crate::jobs::run_one(&core).await;
-        }
-
-        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
-        assert!(
-            windows.iter().any(|w| w.state == SegmentState::Pending),
-            "this test only proves anything while windows are still untried"
-        );
-        // Past the backoff the last failure set, which is a delay rather than
-        // the question here.
-        sqlx::query("UPDATE jobs SET run_after = 0")
-            .execute(&core.store.pool)
-            .await
-            .unwrap();
-        let job = core.store.claim_job().await.unwrap();
-        let job = job.expect("the untried windows were left with no job at all");
-        assert_eq!(job.stage, Stage::Synthesize);
-        assert_eq!(job.target_id, out.id);
-    }
-
-    #[tokio::test]
-    async fn windows_that_succeeded_keep_their_chunks_when_a_later_one_fails() {
-        let mut core = test_core().await;
-        let body = format!("{}\n\nSTOPHERE marker paragraph\n", multi_segment_body());
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        core.synthesizer =
-            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing_on("STOPHERE"));
-
-        // First pass records the good windows and raises on the bad one.
-        assert!(run(&core, &out.id).await.is_err());
-        let llm_artifacts = core
-            .store
-            .artifacts_for_corpus(&out.id)
-            .await
-            .unwrap()
-            .len();
-        assert!(llm_artifacts > 0);
-
-        fail_pending_segments(&core, &out.id, "endpoint refused the window")
-            .await
-            .unwrap();
-
-        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
-        assert!(
-            windows.iter().any(|w| w.state == SegmentState::Done),
-            "successful windows must stay done"
-        );
-        let failed: Vec<_> = windows
-            .iter()
-            .filter(|w| w.state == SegmentState::Failed)
-            .collect();
-        assert_eq!(failed.len(), 1);
-        assert_eq!(
-            failed[0].last_error.as_deref(),
-            Some("endpoint refused the window")
-        );
-
-        assert_eq!(
-            core.store
-                .artifacts_for_corpus(&out.id)
-                .await
-                .unwrap()
-                .len(),
-            llm_artifacts,
-            "a failed window must not disturb the chunks another window earned"
-        );
-        assert_eq!(
-            core.store.get_corpus(&out.id).await.unwrap().status,
-            CorpusStatus::Partial,
-            "a window with no chunks makes the source partial, not ready"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_window_the_parser_chokes_on_does_not_hold_up_the_rest_of_the_document() {
-        // The production failure this exists for: one window's reply carried a
-        // duplicate JSON key, and because the pass stopped at the first error,
-        // the thirty windows after it were not attempted for over an hour —
-        // they waited out the job's backoff twelve times over. A reply we
-        // cannot read says something about that window's text, not about the
-        // endpoint, so the rest of the document still deserves its calls.
-        let mut core = test_core().await;
-        let body = format!("STOPHERE marker paragraph\n\n{}", multi_segment_body());
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        assert!(segment_count(&core, &body) > 2);
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
-            "STOPHERE",
-        ));
-
-        let err = run(&core, &out.id).await.unwrap_err();
-        assert!(err.retryable(), "the refused window is still owed a call");
-
-        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
-        let refused: Vec<_> = windows
-            .iter()
-            .filter(|w| w.state == SegmentState::Failed)
-            .collect();
-        assert_eq!(refused.len(), 1, "only the unreadable window may fail");
-        assert_eq!(refused[0].idx, 0);
-        assert!(
-            refused[0]
-                .last_error
-                .as_deref()
-                .is_some_and(|e| e.contains("duplicate field")),
-            "the window must carry the parser's own complaint"
-        );
-
-        // The point of the change: every window after the bad one was tried in
-        // this same pass rather than waiting for the next.
-        assert!(
-            windows
-                .iter()
-                .skip(1)
-                .all(|w| w.state == SegmentState::Done),
-            "windows after the refused one were left unattempted: {:?}",
-            windows.iter().map(|w| (w.idx, w.state)).collect::<Vec<_>>()
-        );
-        assert!(
-            !core
-                .store
-                .artifacts_for_corpus(&out.id)
-                .await
-                .unwrap()
-                .is_empty(),
-            "the readable windows must have produced chunks"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_model_refusing_everything_costs_a_handful_of_calls_not_one_per_window() {
-        // Stepping over a bad window must not turn a broken model into a full
-        // document's worth of calls every pass. Inference is the scarcest thing
-        // here, and three refusals in a row already answer the question.
-        let mut core = test_core().await;
-        let body = multi_segment_body();
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        let windows = segment_count(&core, &body);
-        assert!(
-            windows > REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS + 2,
-            "the fixture must have more windows than the pass will try"
-        );
-        // Unparsable for every window, since every window contains the marker.
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
-            "paragraph",
-        ));
-
-        assert!(run(&core, &out.id).await.is_err());
-
-        let tried = core
-            .store
-            .segments_for_corpus(&out.id)
-            .await
-            .unwrap()
-            .iter()
-            .filter(|w| w.attempts > 0)
-            .count();
-        assert_eq!(
-            tried, REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS,
-            "the pass kept calling a model that had already refused three times"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_refused_window_is_retried_on_the_next_pass_and_can_still_succeed() {
-        // `pending_segments` covers failed windows too, so the next pass owes
-        // the refused one another call — and a window that fails only because
-        // the endpoint garbled one reply must be able to recover.
-        let mut core = test_core().await;
-        let body = format!("STOPHERE marker paragraph\n\n{}", multi_segment_body());
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
-            "STOPHERE",
-        ));
-        assert!(run(&core, &out.id).await.is_err());
-
-        // The endpoint comes back to its senses.
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::default());
-        run(&core, &out.id).await.unwrap();
-
-        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
-        assert!(
-            windows.iter().all(|w| w.state == SegmentState::Done),
-            "the retried window never recovered"
-        );
-        assert_eq!(
-            core.store.get_corpus(&out.id).await.unwrap().status,
-            CorpusStatus::Embedding
-        );
-    }
-
-    #[tokio::test]
-    async fn a_cooldown_paces_the_windows_it_segments() {
-        let mut core = test_core().await;
-        let body = multi_segment_body();
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        let windows = segment_count(&core, &body);
-        assert!(windows > 1);
-
-        let pause = std::time::Duration::from_millis(40);
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::PacedSynthesizer::new(pause));
-
-        let started = std::time::Instant::now();
-        run(&core, &out.id).await.unwrap();
-        assert!(
-            started.elapsed() >= pause * (windows as u32 - 1),
-            "each window but the last should have been followed by a pause"
-        );
     }
 
     #[tokio::test]
@@ -1309,7 +824,7 @@ Then run sync.";
             .ingest("one para\n\ntwo para", "web", None)
             .await
             .unwrap();
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
         let before = core
             .store
             .artifacts_for_corpus(&out.id)
@@ -1330,7 +845,7 @@ Then run sync.";
             .await
             .unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         assert_eq!(
             core.store
@@ -1350,7 +865,7 @@ Then run sync.";
         let out = core.ingest(&body, "web", None).await.unwrap();
         assert!(segment_count(&core, &body) > 1);
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
         let (resolved, total) = core.store.segment_progress(&out.id).await.unwrap();
         assert_eq!(resolved, total, "every window should have resolved");
 
@@ -1362,7 +877,7 @@ Then run sync.";
             .len();
         // Nothing is pending, so a second run must be a no-op rather than a
         // second full pass that doubles the chunk count.
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
         let after = core
             .store
             .artifacts_for_corpus(&out.id)
@@ -1373,33 +888,6 @@ Then run sync.";
     }
 
     #[tokio::test]
-    async fn a_failing_window_leaves_earlier_windows_intact() {
-        // Fails only on the window containing the marker, so window 0 succeeds
-        // and a later one raises — the shape a flaky endpoint produces.
-        let mut core = test_core().await;
-        let body = format!("{}\n\nSTOPHERE marker paragraph\n", multi_segment_body());
-        let out = core.ingest(&body, "web", None).await.unwrap();
-        core.synthesizer =
-            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing_on("STOPHERE"));
-
-        let err = run(&core, &out.id).await.unwrap_err();
-        assert!(err.retryable(), "a synthesizer error must stay retryable");
-
-        let (resolved, total) = core.store.segment_progress(&out.id).await.unwrap();
-        assert!(resolved > 0, "windows before the failure must be recorded");
-        assert!(resolved < total, "the failing window must stay pending");
-        assert!(
-            !core
-                .store
-                .artifacts_for_corpus(&out.id)
-                .await
-                .unwrap()
-                .is_empty(),
-            "chunks from the successful windows must survive the error"
-        );
-    }
-
-    #[tokio::test]
     async fn empty_source_is_marked_failed_not_left_pending() {
         let core = test_core().await;
         let src = core
@@ -1407,77 +895,11 @@ Then run sync.";
             .insert_corpus("\n\n  \n", "web", None)
             .await
             .unwrap();
-        run(&core, &src.id).await.unwrap();
+        segment_all(&core, &src.id).await;
         assert_eq!(
             core.store.get_corpus(&src.id).await.unwrap().status,
             CorpusStatus::Failed
         );
-    }
-
-    fn window(start_line: i64, end_line: i64, carry_lines: i64) -> crate::store::segments::Segment {
-        crate::store::segments::Segment {
-            corpus_id: "c".into(),
-            idx: 1,
-            start_line,
-            end_line,
-            text: String::new(),
-            carry_lines,
-            state: SegmentState::Pending,
-            attempts: 0,
-            last_error: None,
-        }
-    }
-
-    #[test]
-    fn a_hinted_span_discounts_the_carried_heading_too() {
-        // The window covers source lines 50-60 and opens with one heading
-        // carried from further up, so the model's line 2 is source line 50.
-        // The artifact is reworded past recognition, which is exactly when the
-        // hint is all there is — and the path that used it was the one place
-        // the carried heading was still being counted.
-        let w = window(50, 60, 1);
-        let body = "first body line\nsecond body line";
-        assert_eq!(
-            resolve_span(
-                "nothing here matches the source at all",
-                body,
-                &w,
-                Some((2, 3))
-            ),
-            (50, 51)
-        );
-    }
-
-    #[test]
-    fn a_window_carrying_nothing_reads_the_hint_straight_through() {
-        let w = window(50, 60, 0);
-        assert_eq!(
-            resolve_span("unlocatable", "a\nb", &w, Some((2, 3))),
-            (51, 52)
-        );
-    }
-
-    #[test]
-    fn the_artifacts_own_text_beats_the_hint() {
-        // `locate_span` reads the artifact; the hint is only a claim about it.
-        let w = window(50, 60, 1);
-        let body = "first body line\nsecond body line";
-        assert_eq!(
-            resolve_span("second body line", body, &w, Some((9, 9))),
-            (51, 51)
-        );
-    }
-
-    #[test]
-    fn a_hint_pointing_outside_the_window_falls_back_to_the_whole_window() {
-        let w = window(50, 60, 1);
-        // Discounting the carry can push a hint of line 1 — the heading
-        // itself — below the window's first line. Clamping keeps it inside.
-        assert_eq!(
-            resolve_span("unlocatable", "a\nb", &w, Some((1, 1))),
-            (50, 50)
-        );
-        assert_eq!(resolve_span("unlocatable", "a\nb", &w, None), (50, 60));
     }
 
     #[tokio::test]
@@ -1495,7 +917,7 @@ Then run sync.";
         let body = lines.join("\n");
         let out = core.ingest(&body, "web", None).await.unwrap();
 
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
         assert!(
@@ -1526,7 +948,7 @@ Then run sync.";
         let body = multi_segment_body();
         let out = core.ingest(&body, "web", None).await.unwrap();
         assert!(segment_count(&core, &body) > 1);
-        run(&core, &out.id).await.unwrap();
+        segment_all(&core, &out.id).await;
 
         let chunks = core.store.artifacts_for_corpus(&out.id).await.unwrap();
         let last = chunks.last().unwrap();

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -8,7 +8,7 @@ use crate::store::segments::SegmentState;
 
 /// Tokens consumed by the system prompt and scaffolding. Measured from the
 /// real prompt rather than guessed.
-fn prompt_overhead(core: &Core) -> usize {
+pub(super) fn prompt_overhead(core: &Core) -> usize {
     core.counter.count(crate::infer::prompt::SYNTHESIZER_SYSTEM) + 200
 }
 
@@ -161,6 +161,10 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     // unit's attempts each time and spend another `MAX_ATTEMPTS` calls on a name
     // that has already been given up on, forever. That is the exact opposite of
     // what makes this the one unit allowed to stop asking.
+    //
+    // The one way back is an operator's reprocess, which deletes the row — the
+    // rule is about repeated settles of one document, not about refusing a
+    // person who asked for another try.
     if src.title_hint.is_none() && !core.store.has_job(Stage::Title, corpus_id).await? {
         core.store
             .enqueue(Stage::Title, "corpus", corpus_id)
@@ -169,8 +173,20 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
 
     // One job for the whole source: every chunk was just written, and embedding
     // them together is one inference call instead of `chunks.len()`.
+    //
+    // Idle-only, because settling runs afresh every time a window resolves and
+    // this is reached on every one of them. Re-arming a *running* embed job puts
+    // it back in the queue for a second worker while the first is still inside
+    // the embedder — two workers embedding the same batch, and whichever
+    // finishes second closing the row the other's `rearm_if_more` had just
+    // re-armed, leaving the corpus half-embedded. Re-arming a *pending* one is
+    // quieter and no better: it winds `attempts` and `run_after` back every
+    // thirty seconds, so a dead embedder is hammered with no backoff, and resets
+    // the `seq` that `rearm_if_more` climbs. A job already queued will pick up
+    // the chunks this settle just wrote; only one that already finished needs
+    // arming again.
     core.store
-        .enqueue(Stage::Embed, "corpus", corpus_id)
+        .rearm_idle_seq(Stage::Embed, "corpus", corpus_id, 0)
         .await?;
     let status = if degraded {
         CorpusStatus::Partial
@@ -297,6 +313,100 @@ mod tests {
             output_ratio: 1.0,
             context: crate::infer::context::ContextBudget { opening, overlap },
         }
+    }
+
+    /// (state, attempts, run_after, seq) of one job row.
+    async fn job_row(core: &Core, stage: Stage, target: &str) -> (String, i64, i64, i64) {
+        sqlx::query_as(
+            "SELECT state, attempts, run_after, seq FROM jobs WHERE stage = ? AND target_id = ?",
+        )
+        .bind(stage.as_str())
+        .bind(target)
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap()
+    }
+
+    /// A corpus with its windows resolved and one embed job queued behind them.
+    async fn segmented(core: &Core) -> String {
+        let lines: Vec<String> = (0..40)
+            .map(|i| format!("body line {i} with enough words to cost real tokens"))
+            .collect();
+        let src = core
+            .store
+            .insert_corpus(&lines.join("\n"), "web", None)
+            .await
+            .unwrap();
+        segment_all(core, &src.id).await;
+        src.id
+    }
+
+    #[tokio::test]
+    async fn settling_again_does_not_disturb_an_embed_job_a_worker_is_inside() {
+        // Settling runs afresh every time a window resolves, and a document with
+        // one window the model will not read settles on every failed retry of
+        // it. Re-arming here put a *running* embed job back in the queue for a
+        // second worker: two workers embedding the same batch, and whichever
+        // finished second closed the row the other had just re-armed for the
+        // rest of the chunks — a corpus left half-embedded.
+        let core = test_core().await;
+        let id = segmented(&core).await;
+
+        sqlx::query("UPDATE jobs SET state = 'running', claimed_at = ? WHERE stage = 'embed'")
+            .bind(crate::store::now())
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        finish(&core, &id).await.unwrap();
+
+        let (state, ..) = job_row(&core, Stage::Embed, &id).await;
+        assert_eq!(state, "running", "a settle re-armed an embed job mid-call");
+    }
+
+    #[tokio::test]
+    async fn settling_again_does_not_reset_a_backing_off_embed_job() {
+        // The quieter half of the same bug. A queued job is already going to run
+        // and will pick up everything written since, so winding it back gains
+        // nothing — and costs the backoff that keeps a dead embedder from being
+        // asked every thirty seconds, plus the `seq` that `rearm_if_more` climbs
+        // to walk a corpus through its chunks.
+        let core = test_core().await;
+        let id = segmented(&core).await;
+
+        let later = crate::store::now() + 3600;
+        sqlx::query("UPDATE jobs SET state = 'pending', attempts = 4, run_after = ?, seq = 7 WHERE stage = 'embed'")
+            .bind(later)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        finish(&core, &id).await.unwrap();
+
+        let (state, attempts, run_after, seq) = job_row(&core, Stage::Embed, &id).await;
+        assert_eq!(
+            (state.as_str(), attempts, run_after, seq),
+            ("pending", 4, later, 7),
+            "a settle wound a queued embed job back to the front"
+        );
+    }
+
+    #[tokio::test]
+    async fn settling_after_an_embed_finished_arms_it_again() {
+        // The case the arming is actually for: the chunks this settle just wrote
+        // are not in the batch the finished job embedded.
+        let core = test_core().await;
+        let id = segmented(&core).await;
+
+        sqlx::query("UPDATE jobs SET state = 'done' WHERE stage = 'embed'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        finish(&core, &id).await.unwrap();
+
+        let (state, ..) = job_row(&core, Stage::Embed, &id).await;
+        assert_eq!(state, "pending", "new chunks were left unembedded");
     }
 
     #[tokio::test]

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -63,9 +63,16 @@ pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
     // One unit per window that has not resolved. `seq` is the window index, so
     // this document's window 0 is claimed before any document's window 1 and a
     // capture made during a long ingest does not wait for all of it.
+    //
+    // Idle-only, like every other automatic arming in the system. A plan job
+    // outlives the units it arms — the case the comment above describes — so
+    // this runs again while those units are queued with attempts against them,
+    // and winding those back keeps a window the model will not read forever
+    // young. An operator's reprocess still gets a clean slate: it deletes the
+    // units outright, which is a decision a person made rather than a sweep.
     for w in pending {
         core.store
-            .arm_seq(
+            .rearm_idle_seq(
                 Stage::SegmentWindow,
                 "segment",
                 &crate::jobs::window::unit_target(corpus_id, w.idx),
@@ -303,6 +310,39 @@ mod tests {
     use super::*;
     use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
     use crate::store::corpora::CorpusStatus;
+
+    #[tokio::test]
+    async fn re_planning_does_not_wind_back_a_queued_windows_attempts() {
+        // A plan job outlives the units it arms: killed after planning, its row
+        // stays pending, startup re-arms it, the units sort ahead of it and run
+        // and fail — and only then is the stale plan claimed. Re-arming them
+        // from zero there keeps a window the model will not read forever young,
+        // so `settle` never counts it as spent and the document never leaves
+        // `segmenting`. It is the failure the reconciliation sweep was already
+        // fixed for, reached by a second route.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        plan(&core, &out.id).await.unwrap();
+        sqlx::query("UPDATE jobs SET attempts = 4 WHERE stage = 'segment_window'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        plan(&core, &out.id).await.unwrap();
+
+        let attempts: Vec<i64> =
+            sqlx::query_scalar("SELECT attempts FROM jobs WHERE stage = 'segment_window'")
+                .fetch_all(&core.store.pool)
+                .await
+                .unwrap();
+        assert!(
+            attempts.iter().all(|&a| a == 4),
+            "re-planning reset a unit that was already queued: {attempts:?}"
+        );
+    }
 
     /// A budget with room for several windows and an output ceiling that never
     /// binds, so the context blocks are what shape the windowing.

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -7,6 +7,18 @@ use crate::store::corpora::CorpusStatus;
 use crate::store::jobs::Stage;
 use crate::store::segments::SegmentState;
 
+/// Unreadable replies in a row before the pass stops working through the
+/// document.
+///
+/// One window the model will not produce readable JSON for says something about
+/// that window; the pass steps over it and keeps going, which is the whole point
+/// of stepping over it at all. Several in a row says something about the model
+/// or the endpoint, and every further window costs a full call — the slowest,
+/// most expensive thing engram does — to arrive back at the same answer. Three
+/// is far enough to clear a bad patch of a document and short enough that a
+/// broken model costs a handful of calls rather than one per window.
+const REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS: usize = 3;
+
 /// Tokens consumed by the system prompt and scaffolding. Measured from the
 /// real prompt rather than guessed.
 fn prompt_overhead(core: &Core) -> usize {
@@ -55,9 +67,15 @@ fn resolve_span(
 /// LLM-assisted segmentation, one window at a time.
 ///
 /// The window rows are the job's memory. A window that succeeds is written and
-/// marked `done` before the next is attempted, so an error here costs the
-/// windows that had not started yet and nothing else — the job retries and
-/// resumes from the first pending window.
+/// marked `done` before the next is attempted, so the job retries and resumes
+/// from the first window that has not resolved.
+///
+/// What a failure costs depends on whose failure it is. A reply the parser
+/// cannot read is the window's own problem — the pass records it against that
+/// window and carries on through the document, and the job ends in an error so
+/// the queue brings it back for another try. An endpoint that will not answer
+/// at all is everyone's problem, and the pass stops on the spot rather than
+/// spending a timeout per remaining window to learn the same thing again.
 pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
     core.store
@@ -95,6 +113,12 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
     // produced, which is what makes a retry reproduce the same prompt.
     let all = core.store.segments_for_corpus(corpus_id).await?;
     let all_texts: Vec<&str> = all.iter().map(|s| s.text.as_str()).collect();
+
+    // The first unreadable reply of this pass, kept so the job still ends in an
+    // error and comes back for the windows it could not segment. The rest of
+    // the document is worked through first.
+    let mut refused: Option<crate::error::Error> = None;
+    let mut in_a_row = 0usize;
 
     for w in core.store.pending_segments(corpus_id).await? {
         core.store.bump_segment_attempts(corpus_id, w.idx).await?;
@@ -138,13 +162,60 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
             core.synthesizer.budget().context,
             &core.counter,
         );
-        let mut chunks = core
+        let mut chunks = match core
             .synthesizer
             .segment(crate::infer::SegmentInput {
                 core: &text,
                 context: &ctx,
             })
-            .await?;
+            .await
+        {
+            Ok(chunks) => chunks,
+            // The model answered and we could not read the answer. That is a
+            // property of this window's text, not of the endpoint, so the
+            // windows after it are still worth calling for — and before this,
+            // they were not called at all until the bad one got through. One
+            // duplicate JSON key cost a real document thirty untried windows
+            // and twelve rounds of backoff, hours of waiting for work that was
+            // never going to be attempted in those passes anyway.
+            Err(e @ crate::error::Error::MalformedLlmOutput(_)) => {
+                let reason = e.to_string();
+                tracing::warn!(
+                    corpus_id,
+                    window = w.idx,
+                    lines = format!("{}-{}", w.start_line, w.end_line),
+                    reason,
+                    "window could not be segmented; moving on to the next one"
+                );
+                core.store
+                    .set_segment_state(corpus_id, w.idx, SegmentState::Failed, Some(&reason))
+                    .await?;
+                in_a_row += 1;
+                refused.get_or_insert(e);
+                // Carrying on past one bad window is what this arm is for.
+                // Carrying on past a run of them is just paying a full call to
+                // learn the same thing again: a model garbling this many in a
+                // row is garbling all of them, and the windows left untried
+                // stay pending for a pass that can actually use them.
+                if in_a_row >= REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS {
+                    tracing::warn!(
+                        corpus_id,
+                        windows = in_a_row,
+                        "the model is refusing every window; stopping this pass"
+                    );
+                    break;
+                }
+                continue;
+            }
+            // Anything else — a timeout, a 502, a refused connection — says the
+            // endpoint is unwell. Putting thirty more windows to it costs one
+            // timeout each and learns nothing, so the pass still stops here.
+            Err(e) => return Err(e),
+        };
+        // A window the model read fine says the last refusal was about that
+        // window rather than about the model, so the run starts over.
+        in_a_row = 0;
+
         // The model was told to keep commands, paths and flags verbatim. If it
         // did not, one more attempt usually gets it right; a second failure is
         // stored with a flag rather than dropped, because a visible warning
@@ -155,13 +226,25 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
                 window = w.idx,
                 "literals missing; re-segmenting once"
             );
-            chunks = core
+            match core
                 .synthesizer
                 .segment(crate::infer::SegmentInput {
                     core: &text,
                     context: &ctx,
                 })
-                .await?;
+                .await
+            {
+                Ok(second) => chunks = second,
+                // The first reply parsed; it merely paraphrased. Keeping it and
+                // letting `flag_unverified` mark what went missing beats losing
+                // a window we can already read.
+                Err(e) => tracing::warn!(
+                    corpus_id,
+                    window = w.idx,
+                    error = %e,
+                    "the re-segmentation failed; keeping the first reply"
+                ),
+            }
         }
 
         if !ctx.is_empty() {
@@ -213,6 +296,13 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
             );
             tokio::time::sleep(cooldown).await;
         }
+    }
+
+    // Windows the model refused are still owed a call, so the job has to fail
+    // for the queue to bring it back. `finish` is left to the caller's
+    // exhausted path, which settles the source once the attempts run out.
+    if let Some(e) = refused {
+        return Err(e);
     }
 
     finish(core, corpus_id).await
@@ -1213,6 +1303,123 @@ Then run sync.";
             core.store.get_corpus(&out.id).await.unwrap().status,
             CorpusStatus::Partial,
             "a window with no chunks makes the source partial, not ready"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_window_the_parser_chokes_on_does_not_hold_up_the_rest_of_the_document() {
+        // The production failure this exists for: one window's reply carried a
+        // duplicate JSON key, and because the pass stopped at the first error,
+        // the thirty windows after it were not attempted for over an hour —
+        // they waited out the job's backoff twelve times over. A reply we
+        // cannot read says something about that window's text, not about the
+        // endpoint, so the rest of the document still deserves its calls.
+        let mut core = test_core().await;
+        let body = format!("STOPHERE marker paragraph\n\n{}", multi_segment_body());
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        assert!(segment_count(&core, &body) > 2);
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
+            "STOPHERE",
+        ));
+
+        let err = run(&core, &out.id).await.unwrap_err();
+        assert!(err.retryable(), "the refused window is still owed a call");
+
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
+        let refused: Vec<_> = windows
+            .iter()
+            .filter(|w| w.state == SegmentState::Failed)
+            .collect();
+        assert_eq!(refused.len(), 1, "only the unreadable window may fail");
+        assert_eq!(refused[0].idx, 0);
+        assert!(
+            refused[0]
+                .last_error
+                .as_deref()
+                .is_some_and(|e| e.contains("duplicate field")),
+            "the window must carry the parser's own complaint"
+        );
+
+        // The point of the change: every window after the bad one was tried in
+        // this same pass rather than waiting for the next.
+        assert!(
+            windows
+                .iter()
+                .skip(1)
+                .all(|w| w.state == SegmentState::Done),
+            "windows after the refused one were left unattempted: {:?}",
+            windows.iter().map(|w| (w.idx, w.state)).collect::<Vec<_>>()
+        );
+        assert!(
+            !core
+                .store
+                .artifacts_for_corpus(&out.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the readable windows must have produced chunks"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_model_refusing_everything_costs_a_handful_of_calls_not_one_per_window() {
+        // Stepping over a bad window must not turn a broken model into a full
+        // document's worth of calls every pass. Inference is the scarcest thing
+        // here, and three refusals in a row already answer the question.
+        let mut core = test_core().await;
+        let body = multi_segment_body();
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        let windows = segment_count(&core, &body);
+        assert!(
+            windows > REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS + 2,
+            "the fixture must have more windows than the pass will try"
+        );
+        // Unparsable for every window, since every window contains the marker.
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
+            "paragraph",
+        ));
+
+        assert!(run(&core, &out.id).await.is_err());
+
+        let tried = core
+            .store
+            .segments_for_corpus(&out.id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|w| w.attempts > 0)
+            .count();
+        assert_eq!(
+            tried, REFUSALS_BEFORE_GIVING_UP_ON_THE_PASS,
+            "the pass kept calling a model that had already refused three times"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_window_is_retried_on_the_next_pass_and_can_still_succeed() {
+        // `pending_segments` covers failed windows too, so the next pass owes
+        // the refused one another call — and a window that fails only because
+        // the endpoint garbled one reply must be able to recover.
+        let mut core = test_core().await;
+        let body = format!("STOPHERE marker paragraph\n\n{}", multi_segment_body());
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
+            "STOPHERE",
+        ));
+        assert!(run(&core, &out.id).await.is_err());
+
+        // The endpoint comes back to its senses.
+        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::default());
+        run(&core, &out.id).await.unwrap();
+
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(
+            windows.iter().all(|w| w.state == SegmentState::Done),
+            "the retried window never recovered"
+        );
+        assert_eq!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Embedding
         );
     }
 

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -135,20 +135,17 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
         );
     }
 
-    // Named here rather than at capture, which makes no inference call by
-    // design. The artifact titles are the cheapest description of what the
-    // document turned out to be about, and they only exist now.
+    // Armed rather than called. Naming is a model call like any other, and
+    // making it here would put it inside whichever window happened to finish
+    // last — uncounted, unpaced, and in front of work the queue had ordered.
     //
-    // A failure is logged and dropped: the corpus keeps the snippet the UI
-    // falls back to, and losing a document over a missing name would be a bad
-    // trade. A name given at capture is left alone — someone chose it.
+    // Named at all only now: the artifact titles are the cheapest description
+    // of what the document turned out to be about, and they only exist once its
+    // windows have run. A name given at capture is left alone — someone chose it.
     if src.title_hint.is_none() {
-        let titles: Vec<String> = chunks.iter().filter_map(|c| c.title.clone()).collect();
-        match core.synthesizer.title(&src.raw_text, &titles).await {
-            Ok(Some(t)) => core.store.set_title_hint(corpus_id, &t).await?,
-            Ok(None) => {}
-            Err(e) => tracing::warn!(corpus_id, error = %e, "could not name this corpus"),
-        }
+        core.store
+            .enqueue(Stage::Title, "corpus", corpus_id)
+            .await?;
     }
 
     // One job for the whole source: every chunk was just written, and embedding
@@ -164,6 +161,47 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     core.store.set_corpus_status(corpus_id, status).await?;
     tracing::info!(corpus_id, chunks = chunks.len(), degraded, "segmented");
     Ok(())
+}
+
+/// Name a document, given its opening and the titles of the artifacts drawn
+/// from it.
+///
+/// The only unit whose failure is not worth retrying to the ceiling. A name is
+/// decoration: the corpus keeps the snippet the UI falls back to, and spending
+/// four model calls a day forever on a document the model will not name is a
+/// bad trade against every other thing those calls could do. `run_one` closes
+/// this job once its attempts are spent.
+pub async fn run_title(core: &Core, corpus_id: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    if src.title_hint.is_some() {
+        return Ok(());
+    }
+    let titles: Vec<String> = core
+        .store
+        .artifacts_for_corpus(corpus_id)
+        .await?
+        .iter()
+        .filter_map(|c| c.title.clone())
+        .collect();
+
+    core.gate.background().await;
+    match core.synthesizer.title(&src.raw_text, &titles).await {
+        Ok(Some(t)) => {
+            core.gate.call_succeeded();
+            core.store.set_title_hint(corpus_id, &t).await?;
+            Ok(())
+        }
+        // The synthesizer has no opinion about titles. Not a failure, and not
+        // worth another call.
+        Ok(None) => {
+            core.gate.call_succeeded();
+            Ok(())
+        }
+        Err(e) => {
+            core.gate.call_failed(&e);
+            Err(e)
+        }
+    }
 }
 
 /// Plan a corpus and work its queue to a standstill — what a worker does,
@@ -203,6 +241,22 @@ pub async fn segment_all(core: &Core, corpus_id: &str) {
             break;
         }
     }
+
+    // Settling arms the title unit, so the corpus leaves `segmenting` with one
+    // still queued. The old whole-corpus `run` named the document before it
+    // returned, and these tests were written against that. Settling also arms
+    // embedding, with a fresh `run_after`, so the hold has to be reapplied.
+    for _ in 0..20 {
+        sqlx::query("UPDATE jobs SET run_after = ? WHERE stage = 'embed' AND state = 'pending'")
+            .bind(crate::store::now() + 86_400)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        if !crate::jobs::run_one(core).await.unwrap_or(false) {
+            break;
+        }
+    }
+
     sqlx::query("UPDATE jobs SET run_after = 0 WHERE stage = 'embed'")
         .execute(&core.store.pool)
         .await
@@ -466,6 +520,87 @@ mod tests {
             segment_tokens(core.synthesizer.budget(), prompt_overhead(core)),
         )
         .len()
+    }
+
+    #[tokio::test]
+    async fn naming_a_corpus_is_its_own_unit() {
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+
+        segment_all(&core, &out.id).await;
+        // The title unit is armed by the settle, so it is still queued here.
+        while crate::jobs::run_one(&core).await.unwrap() {}
+
+        assert_eq!(
+            core.store
+                .get_corpus(&out.id)
+                .await
+                .unwrap()
+                .title_hint
+                .as_deref(),
+            Some("Fake title: alpha line")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_corpus_the_model_will_not_name_still_reaches_ready() {
+        // A name is decoration. Retrying it to the six-hour ceiling forever
+        // spends real calls on it, and failing the document over it is worse.
+        let mut core = test_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+        segment_all(&core, &out.id).await;
+
+        // Put the document back in the state settling leaves it in — named by
+        // nobody, with a title unit queued — and then break the model.
+        sqlx::query("UPDATE corpora SET title_hint = NULL WHERE id = ?")
+            .bind(&out.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        core.store
+            .enqueue(Stage::Title, "corpus", &out.id)
+            .await
+            .unwrap();
+        core.synthesizer =
+            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing("no title"));
+        for _ in 0..crate::store::jobs::MAX_ATTEMPTS + 3 {
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            let _ = crate::jobs::run_one(&core).await;
+        }
+
+        let still_queued: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs WHERE stage = 'title' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(still_queued, 0, "a cosmetic failure is retried forever");
+        assert!(
+            core.store
+                .get_corpus(&out.id)
+                .await
+                .unwrap()
+                .title_hint
+                .is_none()
+        );
+        assert!(
+            !core
+                .store
+                .artifacts_for_corpus(&out.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the document itself must be unharmed by an unnameable title"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -19,10 +19,6 @@ fn prompt_overhead(core: &Core) -> usize {
 /// units it arms.
 pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
-    core.store
-        .set_corpus_status(corpus_id, CorpusStatus::Segmenting)
-        .await?;
-
     let windows = split_into_segments(
         &src.raw_text,
         &core.counter,
@@ -48,12 +44,28 @@ pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
         .collect();
     core.store.upsert_segments(corpus_id, &rows).await?;
 
+    // A document whose windows have all resolved arms nothing, and declaring it
+    // `segmenting` would park it there for good — nothing would be left to run
+    // that could call `settle` and move it on. Reachable whenever a plan job
+    // outlives the units it armed: a process killed after planning leaves the
+    // row pending, startup re-arms it, the units (attempts 0) sort ahead of it
+    // and drive the document all the way to `ready`, and only then is the stale
+    // plan claimed. Settling instead is idempotent and says the same thing.
+    let pending = core.store.pending_segments(corpus_id).await?;
+    if pending.is_empty() {
+        return crate::jobs::window::settle(core, corpus_id).await;
+    }
+
+    core.store
+        .set_corpus_status(corpus_id, CorpusStatus::Segmenting)
+        .await?;
+
     // One unit per window that has not resolved. `seq` is the window index, so
     // this document's window 0 is claimed before any document's window 1 and a
     // capture made during a long ingest does not wait for all of it.
-    for w in core.store.pending_segments(corpus_id).await? {
+    for w in pending {
         core.store
-            .enqueue_seq(
+            .arm_seq(
                 Stage::SegmentWindow,
                 "segment",
                 &crate::jobs::window::unit_target(corpus_id, w.idx),
@@ -142,7 +154,14 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     // Named at all only now: the artifact titles are the cheapest description
     // of what the document turned out to be about, and they only exist once its
     // windows have run. A name given at capture is left alone — someone chose it.
-    if src.title_hint.is_none() {
+    //
+    // Armed once, and never again. Settling runs afresh every time a window
+    // resolves, so a document with one window the model will not read settles
+    // on every failed retry of it — and re-arming here would reset the title
+    // unit's attempts each time and spend another `MAX_ATTEMPTS` calls on a name
+    // that has already been given up on, forever. That is the exact opposite of
+    // what makes this the one unit allowed to stop asking.
+    if src.title_hint.is_none() && !core.store.has_job(Stage::Title, corpus_id).await? {
         core.store
             .enqueue(Stage::Title, "corpus", corpus_id)
             .await?;
@@ -184,21 +203,21 @@ pub async fn run_title(core: &Core, corpus_id: &str) -> Result<()> {
         .filter_map(|c| c.title.clone())
         .collect();
 
-    core.gate.background().await;
+    let permit = core.gate.background().await;
     match core.synthesizer.title(&src.raw_text, &titles).await {
         Ok(Some(t)) => {
-            core.gate.call_succeeded();
+            permit.succeeded();
             core.store.set_title_hint(corpus_id, &t).await?;
             Ok(())
         }
         // The synthesizer has no opinion about titles. Not a failure, and not
         // worth another call.
         Ok(None) => {
-            core.gate.call_succeeded();
+            permit.succeeded();
             Ok(())
         }
         Err(e) => {
-            core.gate.call_failed(&e);
+            permit.failed(&e);
             Err(e)
         }
     }
@@ -601,6 +620,64 @@ mod tests {
                 .is_empty(),
             "the document itself must be unharmed by an unnameable title"
         );
+    }
+
+    #[tokio::test]
+    async fn planning_a_document_whose_windows_all_finished_does_not_park_it() {
+        // `segmenting` says work is in flight, and only a settle moves a corpus
+        // out of it. A plan that arms nothing has nothing left to settle it, so
+        // declaring `segmenting` first left the document there permanently —
+        // reachable from a plan job that outlived the units it armed.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        segment_all(&core, &out.id).await;
+        let (resolved, total) = core.store.segment_progress(&out.id).await.unwrap();
+        assert_eq!(resolved, total, "the fixture must start fully segmented");
+
+        plan(&core, &out.id).await.unwrap();
+
+        assert_ne!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Segmenting,
+            "a finished document was parked in segmenting with nothing to run"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_name_already_given_up_on_is_not_asked_for_again() {
+        // Settling runs afresh every time a window resolves, so a document with
+        // one window the model will not read settles on every failed retry of
+        // it — once every six hours, forever. Re-arming the title unit there
+        // reset its attempts and spent another `MAX_ATTEMPTS` calls each time on
+        // a name that had already been given up on.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+        segment_all(&core, &out.id).await;
+        while crate::jobs::run_one(&core).await.unwrap() {}
+
+        // What a corpus the model would not name looks like afterwards: no
+        // title, and a title unit that has been closed.
+        sqlx::query("UPDATE corpora SET title_hint = NULL WHERE id = ?")
+            .bind(&out.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        finish(&core, &out.id).await.unwrap();
+
+        let armed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM jobs WHERE stage = 'title' AND state = 'pending'",
+        )
+        .fetch_one(&core.store.pool)
+        .await
+        .unwrap();
+        assert_eq!(armed, 0, "a name already given up on was asked for again");
     }
 
     #[tokio::test]

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -2,10 +2,15 @@ use crate::core::Core;
 use crate::error::Result;
 use crate::infer::budget::segment_tokens;
 use crate::infer::split::split_into_segments;
-use crate::store::artifacts::{CorpusSpan, NewArtifact};
 use crate::store::corpora::CorpusStatus;
 use crate::store::jobs::Stage;
 use crate::store::segments::SegmentState;
+// Scaffolding, gone with `run` in the next commit: these moved to `window`
+// alongside the handler that owns them, and the loop below is the last caller.
+use crate::jobs::window::{
+    flag_unverified, from_context_only, paraphrased, proposed_to_new, resolve_span,
+    write_segment_artifacts,
+};
 
 /// Unreadable replies in a row before the pass stops working through the
 /// document.
@@ -25,58 +30,12 @@ fn prompt_overhead(core: &Core) -> usize {
     core.counter.count(crate::infer::prompt::SYNTHESIZER_SYSTEM) + 200
 }
 
-/// Where an artifact sits in the source document.
+/// Split a document into windows and record them. No inference call.
 ///
-/// Asking the model for `corpus_lines`, checking the answer, and having a third
-/// outcome for a claim that fails the check produced a flag on the artifact and
-/// a button offering to re-synthesise an entire segment over a line number.
-/// Since `locate_span` finds an artifact's own text even where the source is
-/// hard-wrapped and synthesis reflowed it, the claim is worth what it is: a
-/// hint for the case where nothing matches at all. Nothing here can disagree
-/// with the artifact, so nothing here has anything to report.
-///
-/// `body` is the window without its carried heading — text prepended from
-/// further up the document, occupying none of the window's own lines. Both
-/// paths have to discount it: `locate_span` because it searches `body`, and the
-/// hint because the model numbered its lines from the top of what it was shown,
-/// and line 1 of that is the carried heading. Correcting only the first left
-/// every hinted span in a continuing section `carry_lines` too far down.
-fn resolve_span(
-    artifact: &str,
-    body: &str,
-    w: &crate::store::segments::Segment,
-    hint: Option<(i64, i64)>,
-) -> (i64, i64) {
-    let shift = w.start_line - 1 - w.carry_lines;
-    let hinted = hint.map(|(a, b)| (a + shift, b + shift));
-    let span = crate::infer::verify::locate_span(artifact, body, w.start_line)
-        .or(hinted)
-        .unwrap_or((w.start_line, w.end_line));
-    // A span outside its own window would render as the wrong text.
-    let clamped = (
-        span.0.clamp(w.start_line, w.end_line),
-        span.1.clamp(w.start_line, w.end_line),
-    );
-    if clamped.0 <= clamped.1 {
-        clamped
-    } else {
-        (w.start_line, w.end_line)
-    }
-}
-
-/// LLM-assisted segmentation, one window at a time.
-///
-/// The window rows are the job's memory. A window that succeeds is written and
-/// marked `done` before the next is attempted, so the job retries and resumes
-/// from the first window that has not resolved.
-///
-/// What a failure costs depends on whose failure it is. A reply the parser
-/// cannot read is the window's own problem — the pass records it against that
-/// window and carries on through the document, and the job ends in an error so
-/// the queue brings it back for another try. An endpoint that will not answer
-/// at all is everyone's problem, and the pass stops on the spot rather than
-/// spending a timeout per remaining window to learn the same thing again.
-pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
+/// This is the whole of the `Synthesize` stage now: deciding what the units of
+/// work are, which is local arithmetic over the text. The calls belong to the
+/// units it arms.
+pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
     core.store
         .set_corpus_status(corpus_id, CorpusStatus::Segmenting)
@@ -106,6 +65,18 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
         })
         .collect();
     core.store.upsert_segments(corpus_id, &rows).await?;
+    Ok(())
+}
+
+/// LLM-assisted segmentation, one window at a time.
+///
+/// Superseded by the per-window units `plan` will arm, and kept only until the
+/// pipeline is flipped over to them.
+pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
+    plan(core, corpus_id).await?;
+    if core.store.segments_for_corpus(corpus_id).await?.is_empty() {
+        return Ok(());
+    }
 
     // Every window of the corpus, in order, for the neighbouring context. The
     // rows are authoritative rather than the freshly split `windows`: a corpus
@@ -308,97 +279,6 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
     finish(core, corpus_id).await
 }
 
-/// Replace the chunks of one window. Same "replace, never append" guarantee as
-/// before; the key is the window rather than the whole source, so a retry of
-/// window 4 cannot disturb windows 0 to 3.
-async fn write_segment_artifacts(
-    core: &Core,
-    corpus_id: &str,
-    segment_idx: i64,
-    new: Vec<NewArtifact>,
-) -> Result<Vec<crate::store::artifacts::Chunk>> {
-    let old = core
-        .store
-        .artifact_ids_for_segment(corpus_id, segment_idx)
-        .await?;
-    if !old.is_empty() {
-        core.vectors.delete_artifacts(&old).await?;
-        for id in &old {
-            core.store.delete_artifact(id).await?;
-        }
-    }
-    core.store.insert_artifacts(corpus_id, &new).await
-}
-
-/// Did this artifact come from a context block rather than from the window?
-///
-/// The prompt says not to extract from context, and a small local model obeys
-/// that unevenly, so the check is structural. Three outcomes matter and only
-/// the middle one is a duplicate: located in the window, keep; located only in
-/// context, drop, because the window that owns the material will emit it
-/// properly; located nowhere, keep — that is an artifact the model reworded
-/// hard, which flag_unverified has always handled and which must not start
-/// silently disappearing.
-fn from_context_only(
-    text: &str,
-    core_text: &str,
-    ctx: &crate::infer::context::WindowContext,
-) -> bool {
-    if crate::infer::verify::locate_span(text, core_text, 1).is_some() {
-        return false;
-    }
-    ctx.blocks()
-        .any(|b| crate::infer::verify::locate_span(text, b, 1).is_some())
-}
-
-/// Did any proposed chunk lose a literal its window contains?
-///
-/// The chunk body only, deliberately — this gates a second synthesis call over
-/// the whole window, the most expensive thing here. A caveat is prose the model
-/// is asked to write freely ("only on `/dev/sd*` devices", "requires `sudo`"),
-/// so a path it names in passing need not appear verbatim in the source, and
-/// re-synthesising a window over one is paying the largest cost in the system
-/// for the smallest reason. `flag_unverified` still checks caveats: a command
-/// invented in one is flagged for the reader like any other.
-fn paraphrased(chunks: &[crate::infer::ProposedArtifact], window: &str) -> bool {
-    chunks
-        .iter()
-        .any(|c| !crate::infer::verify::missing_literals(&c.text, &[], window).is_empty())
-}
-
-/// Mark what verification could not vouch for. The chunk is kept — a warning
-/// the reader can see beats a chapter silently missing from the base.
-///
-/// One check, not two. A span is derived rather than adjudicated, so there is
-/// nothing left to disbelieve about it; what remains is the literal check,
-/// which is about the text itself and speaks to whoever reads the artifact.
-async fn flag_unverified(
-    core: &Core,
-    written: &[crate::store::artifacts::Chunk],
-    segment_body: &str,
-) -> Result<()> {
-    use crate::infer::verify;
-
-    for c in written {
-        let mut flags = Vec::new();
-        let mut detail: Option<String> = None;
-
-        let missing = verify::missing_literals(&c.text, &c.caveats, segment_body);
-        if let Some(first) = missing.first() {
-            flags.push(verify::FLAG_LITERALS.to_string());
-            detail = Some(format!("missing literal: {first}"));
-            tracing::warn!(artifact_id = %c.id, literal = %first, "literal not found in source window");
-        }
-
-        if !flags.is_empty() {
-            core.store
-                .set_artifact_flags(&c.id, &flags, detail.as_deref())
-                .await?;
-        }
-    }
-    Ok(())
-}
-
 /// Measure how much of a corpus survived into its artifacts, and store it.
 ///
 /// Pure local work over rows that are already there — no inference and no
@@ -578,29 +458,6 @@ pub async fn fail_pending_segments(core: &Core, corpus_id: &str, reason: &str) -
         return Ok(false);
     }
     Ok(true)
-}
-
-fn proposed_to_new(
-    segment_idx: i64,
-    proposed: Vec<crate::infer::ProposedArtifact>,
-) -> Vec<NewArtifact> {
-    proposed
-        .into_iter()
-        .enumerate()
-        .map(|(i, p)| NewArtifact {
-            ordinal: i as i64,
-            text: p.text,
-            corpus_span: p.corpus_lines.map(|(a, b)| CorpusSpan {
-                start_line: a,
-                end_line: b,
-            }),
-            title: p.title,
-            category: p.category,
-            tags: p.tags,
-            caveats: p.caveats,
-            segment_idx: Some(segment_idx),
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -216,7 +216,25 @@ pub(crate) async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
             // `jobs.attempts` rather than a counter on the segment: the unit is
             // the job now, and two counters for one thing is what made the
             // original incident so hard to read.
-            SegmentState::Failed => attempts_for(core, corpus_id, w.idx).await >= MAX_ATTEMPTS,
+            SegmentState::Failed => match attempts_for(core, corpus_id, w.idx).await {
+                Ok(n) => n >= MAX_ATTEMPTS,
+                // A query that failed says nothing about the window, and now
+                // that two workers can be in one corpus at once, `SQLITE_BUSY`
+                // here is routine. Reading it as "spent" would settle a document
+                // that still has retries left and report it `partial`. Deferring
+                // costs one settle: the next window to resolve runs this again,
+                // and the reconciliation sweep finishes the document if none
+                // does.
+                Err(e) => {
+                    tracing::warn!(
+                        corpus_id,
+                        window = w.idx,
+                        error = %e,
+                        "could not read the window's attempts; deferring the settle"
+                    );
+                    false
+                }
+            },
             SegmentState::Pending => false,
         };
         if !resolved {
@@ -230,17 +248,17 @@ pub(crate) async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
 ///
 /// A missing row means the unit is gone — dropped as stale, or never armed —
 /// and nothing is going to try that window again, so it counts as spent rather
-/// than holding up the document forever.
-async fn attempts_for(core: &Core, corpus_id: &str, idx: i64) -> i64 {
-    sqlx::query_scalar::<_, i64>(
+/// than holding up the document forever. That default belongs to the missing
+/// row alone: a failed query is not an answer, and the caller decides what to do
+/// about not having one.
+async fn attempts_for(core: &Core, corpus_id: &str, idx: i64) -> Result<i64> {
+    Ok(sqlx::query_scalar::<_, i64>(
         "SELECT attempts FROM jobs WHERE stage = 'segment_window' AND target_id = ?",
     )
     .bind(unit_target(corpus_id, idx))
     .fetch_optional(&core.store.pool)
-    .await
-    .ok()
-    .flatten()
-    .unwrap_or(MAX_ATTEMPTS)
+    .await?
+    .unwrap_or(MAX_ATTEMPTS))
 }
 
 /// Where an artifact sits in the source document.

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -210,6 +210,12 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
 /// idempotent: ordinals are renumbered, coverage recomputed, the embed job
 /// re-armed for the artifacts that have appeared since.
 pub(crate) async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
+    // Held for the whole read-then-finish, so no window's artifacts can be
+    // rewritten underneath the decision or the renumbering it leads to. Taken
+    // here rather than at each caller: this and `write_segment_artifacts` are the
+    // only two holders, neither is reachable from inside the other, and a lock
+    // acquired at call sites is one somebody eventually forgets to acquire.
+    let _corpus = core.corpus_lock(corpus_id).await;
     for w in core.store.segments_for_corpus(corpus_id).await? {
         let resolved = match w.state {
             SegmentState::Done => true,
@@ -303,12 +309,17 @@ pub(crate) fn resolve_span(
 /// Replace the chunks of one window. Same "replace, never append" guarantee as
 /// before; the key is the window rather than the whole source, so a retry of
 /// window 4 cannot disturb windows 0 to 3.
+///
+/// The delete and the insert are one unit against the rest of the document: a
+/// `settle` running between them would renumber a document that is missing a
+/// window's worth of artifacts and hand out ordinals this insert then duplicates.
 pub(crate) async fn write_segment_artifacts(
     core: &Core,
     corpus_id: &str,
     segment_idx: i64,
     new: Vec<NewArtifact>,
 ) -> Result<Vec<crate::store::artifacts::Chunk>> {
+    let _corpus = core.corpus_lock(corpus_id).await;
     let old = core
         .store
         .artifact_ids_for_segment(corpus_id, segment_idx)

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -1,0 +1,395 @@
+//! One window, one inference call.
+//!
+//! This is the unit the whole job model is built around: the smallest thing the
+//! synthesizer can be asked to do. Below it there is nothing — one call returns
+//! every artifact a window yields, eight on average, and a window cannot be
+//! subdivided without asking for artifacts nobody has enumerated yet. Above it
+//! used to be a job covering a whole document, which is what gave thirty-four
+//! windows one attempt budget between them and cost a single unreadable reply
+//! twelve rounds of a six-hour backoff while the other thirty-three waited.
+
+use crate::core::Core;
+use crate::error::{Error, Result};
+use crate::store::artifacts::{CorpusSpan, NewArtifact};
+use crate::store::segments::SegmentState;
+
+/// A window's address in the queue.
+///
+/// The corpus id is a UUID and cannot contain `#`, so the split is unambiguous
+/// from the right.
+pub fn unit_target(corpus_id: &str, idx: i64) -> String {
+    format!("{corpus_id}#{idx}")
+}
+
+pub fn parse_target(target: &str) -> Option<(&str, i64)> {
+    let (corpus_id, idx) = target.rsplit_once('#')?;
+    Some((corpus_id, idx.parse().ok()?))
+}
+
+pub async fn run(core: &Core, target: &str) -> Result<()> {
+    let (corpus_id, idx) = parse_target(target).ok_or(Error::NotFound)?;
+    let all = core.store.segments_for_corpus(corpus_id).await?;
+    let w = all
+        .iter()
+        .find(|s| s.idx == idx)
+        // Re-segmenting can shorten a document, leaving a unit addressed to a
+        // window that no longer exists. `run_one` closes a NotFound job rather
+        // than retrying something that can never come back.
+        .ok_or(Error::NotFound)?
+        .clone();
+
+    if w.state == SegmentState::Done {
+        return Ok(());
+    }
+
+    let all_texts: Vec<&str> = all.iter().map(|s| s.text.as_str()).collect();
+    let ctx = crate::infer::context::WindowContext::build(
+        &all_texts,
+        idx as usize,
+        core.synthesizer.budget().context,
+        &core.counter,
+    );
+    // The stored text, not a re-derivation from the line range: line numbers
+    // cannot address a unit smaller than a line, so a corpus with no newlines
+    // re-derived to the whole document for window 0 and to nothing at all for
+    // every window after it.
+    let text = w.text.clone();
+
+    core.gate.background().await;
+    let first = core
+        .synthesizer
+        .segment(crate::infer::SegmentInput {
+            core: &text,
+            context: &ctx,
+        })
+        .await;
+    match &first {
+        Ok(_) => core.gate.call_succeeded(),
+        Err(e) => core.gate.call_failed(e),
+    }
+    let mut chunks = match first {
+        Ok(c) => c,
+        Err(e) => {
+            let reason = e.to_string();
+            tracing::warn!(
+                corpus_id,
+                window = idx,
+                lines = format!("{}-{}", w.start_line, w.end_line),
+                reason,
+                "window could not be segmented"
+            );
+            core.store
+                .set_segment_state(corpus_id, idx, SegmentState::Failed, Some(&reason))
+                .await?;
+            settle(core, corpus_id).await?;
+            return Err(e);
+        }
+    };
+
+    // The model was told to keep commands, paths and flags verbatim. If it did
+    // not, one more attempt sometimes gets it right; a second failure is stored
+    // with a flag rather than dropped, because a visible warning beats losing
+    // the chapter.
+    if paraphrased(&chunks, &text) {
+        tracing::warn!(
+            corpus_id,
+            window = idx,
+            "literals missing; re-segmenting once"
+        );
+        core.gate.background().await;
+        match core
+            .synthesizer
+            .segment(crate::infer::SegmentInput {
+                core: &text,
+                context: &ctx,
+            })
+            .await
+        {
+            Ok(second) => {
+                core.gate.call_succeeded();
+                chunks = second;
+            }
+            // The first reply parsed; it merely paraphrased. Keeping it and
+            // letting `flag_unverified` mark what went missing beats losing a
+            // window we can already read.
+            Err(e) => {
+                core.gate.call_failed(&e);
+                tracing::warn!(
+                    corpus_id,
+                    window = idx,
+                    error = %e,
+                    "the re-segmentation failed; keeping the first reply"
+                );
+            }
+        }
+    }
+
+    if !ctx.is_empty() {
+        let before = chunks.len();
+        chunks.retain(|c| !from_context_only(&c.text, &text, &ctx));
+        let dropped = before - chunks.len();
+        if dropped > 0 {
+            // A rising count here means the configured model is ignoring the
+            // prompt's context-only instruction. Better as a number in the log
+            // than as duplicates in the base.
+            tracing::info!(
+                corpus_id,
+                window = idx,
+                dropped,
+                "artifacts drawn from context blocks were dropped"
+            );
+        }
+    }
+
+    // The span is ours to compute. Without the carried heading, which is
+    // prepended text from further up the document and occupies none of this
+    // window's lines.
+    let body: String = text
+        .lines()
+        .skip(w.carry_lines as usize)
+        .collect::<Vec<_>>()
+        .join("\n");
+    for c in &mut chunks {
+        c.corpus_lines = Some(resolve_span(&c.text, &body, &w, c.corpus_lines));
+    }
+
+    let written =
+        write_segment_artifacts(core, corpus_id, idx, proposed_to_new(idx, chunks)).await?;
+    flag_unverified(core, &written, &text).await?;
+    core.store
+        .set_segment_state(corpus_id, idx, SegmentState::Done, None)
+        .await?;
+
+    settle(core, corpus_id).await
+}
+
+/// Filled in by the task that makes the corpus settle around its windows.
+async fn settle(_core: &Core, _corpus_id: &str) -> Result<()> {
+    Ok(())
+}
+
+/// Where an artifact sits in the source document.
+///
+/// Asking the model for `corpus_lines`, checking the answer, and having a third
+/// outcome for a claim that fails the check produced a flag on the artifact and
+/// a button offering to re-synthesise an entire segment over a line number.
+/// Since `locate_span` finds an artifact's own text even where the source is
+/// hard-wrapped and synthesis reflowed it, the claim is worth what it is: a
+/// hint for the case where nothing matches at all. Nothing here can disagree
+/// with the artifact, so nothing here has anything to report.
+///
+/// `body` is the window without its carried heading — text prepended from
+/// further up the document, occupying none of the window's own lines. Both
+/// paths have to discount it: `locate_span` because it searches `body`, and the
+/// hint because the model numbered its lines from the top of what it was shown,
+/// and line 1 of that is the carried heading. Correcting only the first left
+/// every hinted span in a continuing section `carry_lines` too far down.
+pub(crate) fn resolve_span(
+    artifact: &str,
+    body: &str,
+    w: &crate::store::segments::Segment,
+    hint: Option<(i64, i64)>,
+) -> (i64, i64) {
+    let shift = w.start_line - 1 - w.carry_lines;
+    let hinted = hint.map(|(a, b)| (a + shift, b + shift));
+    let span = crate::infer::verify::locate_span(artifact, body, w.start_line)
+        .or(hinted)
+        .unwrap_or((w.start_line, w.end_line));
+    // A span outside its own window would render as the wrong text.
+    let clamped = (
+        span.0.clamp(w.start_line, w.end_line),
+        span.1.clamp(w.start_line, w.end_line),
+    );
+    if clamped.0 <= clamped.1 {
+        clamped
+    } else {
+        (w.start_line, w.end_line)
+    }
+}
+
+/// Replace the chunks of one window. Same "replace, never append" guarantee as
+/// before; the key is the window rather than the whole source, so a retry of
+/// window 4 cannot disturb windows 0 to 3.
+pub(crate) async fn write_segment_artifacts(
+    core: &Core,
+    corpus_id: &str,
+    segment_idx: i64,
+    new: Vec<NewArtifact>,
+) -> Result<Vec<crate::store::artifacts::Chunk>> {
+    let old = core
+        .store
+        .artifact_ids_for_segment(corpus_id, segment_idx)
+        .await?;
+    if !old.is_empty() {
+        core.vectors.delete_artifacts(&old).await?;
+        for id in &old {
+            core.store.delete_artifact(id).await?;
+        }
+    }
+    core.store.insert_artifacts(corpus_id, &new).await
+}
+
+/// Did this artifact come from a context block rather than from the window?
+///
+/// The prompt says not to extract from context, and a small local model obeys
+/// that unevenly, so the check is structural. Three outcomes matter and only
+/// the middle one is a duplicate: located in the window, keep; located only in
+/// context, drop, because the window that owns the material will emit it
+/// properly; located nowhere, keep — that is an artifact the model reworded
+/// hard, which flag_unverified has always handled and which must not start
+/// silently disappearing.
+pub(crate) fn from_context_only(
+    text: &str,
+    core_text: &str,
+    ctx: &crate::infer::context::WindowContext,
+) -> bool {
+    if crate::infer::verify::locate_span(text, core_text, 1).is_some() {
+        return false;
+    }
+    ctx.blocks()
+        .any(|b| crate::infer::verify::locate_span(text, b, 1).is_some())
+}
+
+/// Did any proposed chunk lose a literal its window contains?
+///
+/// The chunk body only, deliberately — this gates a second synthesis call over
+/// the whole window, the most expensive thing here. A caveat is prose the model
+/// is asked to write freely ("only on `/dev/sd*` devices", "requires `sudo`"),
+/// so a path it names in passing need not appear verbatim in the source, and
+/// re-synthesising a window over one is paying the largest cost in the system
+/// for the smallest reason. `flag_unverified` still checks caveats: a command
+/// invented in one is flagged for the reader like any other.
+pub(crate) fn paraphrased(chunks: &[crate::infer::ProposedArtifact], window: &str) -> bool {
+    chunks
+        .iter()
+        .any(|c| !crate::infer::verify::missing_literals(&c.text, &[], window).is_empty())
+}
+
+/// Mark what verification could not vouch for. The chunk is kept — a warning
+/// the reader can see beats a chapter silently missing from the base.
+///
+/// One check, not two. A span is derived rather than adjudicated, so there is
+/// nothing left to disbelieve about it; what remains is the literal check,
+/// which is about the text itself and speaks to whoever reads the artifact.
+pub(crate) async fn flag_unverified(
+    core: &Core,
+    written: &[crate::store::artifacts::Chunk],
+    segment_body: &str,
+) -> Result<()> {
+    use crate::infer::verify;
+
+    for c in written {
+        let mut flags = Vec::new();
+        let mut detail: Option<String> = None;
+
+        let missing = verify::missing_literals(&c.text, &c.caveats, segment_body);
+        if let Some(first) = missing.first() {
+            flags.push(verify::FLAG_LITERALS.to_string());
+            detail = Some(format!("missing literal: {first}"));
+            tracing::warn!(artifact_id = %c.id, literal = %first, "literal not found in source window");
+        }
+
+        if !flags.is_empty() {
+            core.store
+                .set_artifact_flags(&c.id, &flags, detail.as_deref())
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn proposed_to_new(
+    segment_idx: i64,
+    proposed: Vec<crate::infer::ProposedArtifact>,
+) -> Vec<NewArtifact> {
+    proposed
+        .into_iter()
+        .enumerate()
+        .map(|(i, p)| NewArtifact {
+            ordinal: i as i64,
+            text: p.text,
+            corpus_span: p.corpus_lines.map(|(a, b)| CorpusSpan {
+                start_line: a,
+                end_line: b,
+            }),
+            title: p.title,
+            category: p.category,
+            tags: p.tags,
+            caveats: p.caveats,
+            segment_idx: Some(segment_idx),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+
+    #[test]
+    fn a_unit_target_round_trips() {
+        let t = unit_target("019ff75a-61b1-7703-aea9-f2a3ae9a0ddd", 17);
+        assert_eq!(t, "019ff75a-61b1-7703-aea9-f2a3ae9a0ddd#17");
+        assert_eq!(
+            parse_target(&t),
+            Some(("019ff75a-61b1-7703-aea9-f2a3ae9a0ddd", 17))
+        );
+        assert_eq!(parse_target("no-hash"), None);
+        assert_eq!(parse_target("bad#notanumber"), None);
+    }
+
+    #[tokio::test]
+    async fn a_unit_segments_exactly_its_own_window() {
+        let core = test_core().await;
+        let body = (0..400)
+            .map(|i| format!("paragraph number {i} with some filler text"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        run(&core, &unit_target(&out.id, 0)).await.unwrap();
+
+        let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(windows.len() > 1, "the fixture must span several windows");
+        assert_eq!(windows[0].state, SegmentState::Done);
+        assert!(
+            windows[1..]
+                .iter()
+                .all(|w| w.state == SegmentState::Pending),
+            "a unit segmented a window that was not its own"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_unit_whose_window_no_longer_exists_is_not_found() {
+        // Re-segmenting can shorten a document. The stale unit must be dropped
+        // by run_one's NotFound path rather than retried for six hours.
+        let core = test_core().await;
+        let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+
+        let err = run(&core, &unit_target(&out.id, 99)).await.unwrap_err();
+        assert!(matches!(err, Error::NotFound));
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_reply_fails_only_this_window() {
+        let mut core = test_core().await;
+        let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+        core.synthesizer =
+            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on("alpha"));
+
+        let err = run(&core, &unit_target(&out.id, 0)).await.unwrap_err();
+        assert!(err.retryable(), "the window is still owed a call");
+        let w = &core.store.segments_for_corpus(&out.id).await.unwrap()[0];
+        assert_eq!(w.state, SegmentState::Failed);
+        assert!(
+            w.last_error
+                .as_deref()
+                .is_some_and(|e| e.contains("duplicate field")),
+            "the window must carry the parser's own complaint"
+        );
+    }
+}

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -11,6 +11,7 @@
 use crate::core::Core;
 use crate::error::{Error, Result};
 use crate::store::artifacts::{CorpusSpan, NewArtifact};
+use crate::store::jobs::MAX_ATTEMPTS;
 use crate::store::segments::SegmentState;
 
 /// A window's address in the queue.
@@ -163,9 +164,50 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
     settle(core, corpus_id).await
 }
 
-/// Filled in by the task that makes the corpus settle around its windows.
-async fn settle(_core: &Core, _corpus_id: &str) -> Result<()> {
-    Ok(())
+/// Everything that can only be decided once every window has resolved.
+///
+/// "Resolved" has to include a window that has spent its attempts, and that is
+/// the whole subtlety here. Engram never abandons work, so a window the model
+/// will not read stays queued at the six-hour ceiling forever — and if settling
+/// waited for it, the thirty-three windows that came back perfectly would never
+/// be embedded, never be searchable, and the document would sit in `segmenting`
+/// for good. The corpus settles around such a window and reports `partial`.
+///
+/// If it later succeeds this runs again, which is why every step of `finish` is
+/// idempotent: ordinals are renumbered, coverage recomputed, the embed job
+/// re-armed for the artifacts that have appeared since.
+async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
+    for w in core.store.segments_for_corpus(corpus_id).await? {
+        let resolved = match w.state {
+            SegmentState::Done => true,
+            // `jobs.attempts` rather than a counter on the segment: the unit is
+            // the job now, and two counters for one thing is what made the
+            // original incident so hard to read.
+            SegmentState::Failed => attempts_for(core, corpus_id, w.idx).await >= MAX_ATTEMPTS,
+            SegmentState::Pending => false,
+        };
+        if !resolved {
+            return Ok(());
+        }
+    }
+    crate::jobs::synthesize::finish(core, corpus_id).await
+}
+
+/// How many times this window's unit has been claimed.
+///
+/// A missing row means the unit is gone — dropped as stale, or never armed —
+/// and nothing is going to try that window again, so it counts as spent rather
+/// than holding up the document forever.
+async fn attempts_for(core: &Core, corpus_id: &str, idx: i64) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT attempts FROM jobs WHERE stage = 'segment_window' AND target_id = ?",
+    )
+    .bind(unit_target(corpus_id, idx))
+    .fetch_optional(&core.store.pool)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or(MAX_ATTEMPTS)
 }
 
 /// Where an artifact sits in the source document.
@@ -391,5 +433,105 @@ mod tests {
                 .is_some_and(|e| e.contains("duplicate field")),
             "the window must carry the parser's own complaint"
         );
+    }
+
+    /// A window fixture for the span tests: the text is irrelevant to them, the
+    /// line range and the carried heading are the whole point.
+    fn window(start_line: i64, end_line: i64, carry_lines: i64) -> crate::store::segments::Segment {
+        crate::store::segments::Segment {
+            corpus_id: "c".into(),
+            idx: 1,
+            start_line,
+            end_line,
+            text: String::new(),
+            carry_lines,
+            state: SegmentState::Pending,
+            attempts: 0,
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn a_hinted_span_discounts_the_carried_heading_too() {
+        // The window covers source lines 50-60 and opens with one heading
+        // carried from further up, so the model's line 2 is source line 50.
+        // The artifact is reworded past recognition, which is exactly when the
+        // hint is all there is — and the path that used it was the one place
+        // the carried heading was still being counted.
+        let w = window(50, 60, 1);
+        let body = "first body line\nsecond body line";
+        assert_eq!(
+            resolve_span(
+                "nothing here matches the source at all",
+                body,
+                &w,
+                Some((2, 3))
+            ),
+            (50, 51)
+        );
+    }
+
+    #[test]
+    fn a_window_carrying_nothing_reads_the_hint_straight_through() {
+        let w = window(50, 60, 0);
+        assert_eq!(
+            resolve_span("unlocatable", "a\nb", &w, Some((2, 3))),
+            (51, 52)
+        );
+    }
+
+    #[test]
+    fn the_artifacts_own_text_beats_the_hint() {
+        // `locate_span` reads the artifact; the hint is only a claim about it.
+        let w = window(50, 60, 1);
+        let body = "first body line\nsecond body line";
+        assert_eq!(
+            resolve_span("second body line", body, &w, Some((9, 9))),
+            (51, 51)
+        );
+    }
+
+    #[test]
+    fn a_hint_pointing_outside_the_window_falls_back_to_the_whole_window() {
+        let w = window(50, 60, 1);
+        // Discounting the carry can push a hint of line 1 — the heading
+        // itself — below the window's first line. Clamping keeps it inside.
+        assert_eq!(
+            resolve_span("unlocatable", "a\nb", &w, Some((1, 1))),
+            (50, 50)
+        );
+        assert_eq!(resolve_span("unlocatable", "a\nb", &w, None), (50, 60));
+    }
+
+    #[test]
+    fn an_artifact_found_only_in_context_is_recognised() {
+        use crate::infer::context::WindowContext;
+
+        let core_text = "the window says something quite specific here\nand more of it";
+        let ctx = WindowContext {
+            opening: Some("the document opening states the version clearly".into()),
+            before: None,
+            after: Some("the following window describes another procedure".into()),
+        };
+
+        // Drawn from the window itself: keep.
+        assert!(!from_context_only(
+            "the window says something quite specific here",
+            core_text,
+            &ctx
+        ));
+        // Drawn from a context block and nowhere in the window: drop.
+        assert!(from_context_only(
+            "the following window describes another procedure",
+            core_text,
+            &ctx
+        ));
+        // Located nowhere at all — a heavily reworded artifact. Keep it, so it
+        // reaches flag_unverified the way it does today instead of vanishing.
+        assert!(!from_context_only(
+            "an entirely reworded statement about unrelated matters",
+            core_text,
+            &ctx
+        ));
     }
 }

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -56,6 +56,39 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
     // every window after it.
     let text = w.text.clone();
 
+    // The failure this catches is a unit retrying an over-context window against
+    // the endpoint with growing backoff and no terminal state. Per-unit budgets
+    // made it quieter than it used to be, not rarer: the other thirty-three
+    // windows now finish and the document settles `partial`, while the one
+    // window that can never fit keeps asking at the six-hour ceiling with
+    // nothing in the journal naming the cause.
+    //
+    // The ceiling is twice the budget rather than the budget itself, because
+    // that is what the splitter actually promises: it flushes once the buffer
+    // has *reached* the budget, and `flush` then prepends the carried heading,
+    // so a window legitimately lands somewhat over. Twice is the bound
+    // `text_with_no_structure_still_splits_by_line_cap` has always asserted.
+    // What must never happen is unbounded — the corpus that came back fifteen
+    // times its budget.
+    let window_budget = crate::infer::budget::segment_tokens(
+        core.synthesizer.budget(),
+        super::synthesize::prompt_overhead(core),
+    );
+    let window_tokens = core.counter.count(&text);
+    debug_assert!(
+        window_tokens <= window_budget * 2,
+        "window {idx} is {window_tokens} tokens against a budget of {window_budget}"
+    );
+    if window_tokens > window_budget * 2 {
+        tracing::error!(
+            corpus_id,
+            window = idx,
+            window_tokens,
+            window_budget,
+            "window is far over its budget; the splitter did not shrink it"
+        );
+    }
+
     let permit = core.gate.background().await;
     let first = core
         .synthesizer

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -56,7 +56,7 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
     // every window after it.
     let text = w.text.clone();
 
-    core.gate.background().await;
+    let permit = core.gate.background().await;
     let first = core
         .synthesizer
         .segment(crate::infer::SegmentInput {
@@ -65,8 +65,8 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
         })
         .await;
     match &first {
-        Ok(_) => core.gate.call_succeeded(),
-        Err(e) => core.gate.call_failed(e),
+        Ok(_) => permit.succeeded(),
+        Err(e) => permit.failed(e),
     }
     let mut chunks = match first {
         Ok(c) => c,
@@ -97,7 +97,7 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
             window = idx,
             "literals missing; re-segmenting once"
         );
-        core.gate.background().await;
+        let permit = core.gate.background().await;
         match core
             .synthesizer
             .segment(crate::infer::SegmentInput {
@@ -107,14 +107,14 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
             .await
         {
             Ok(second) => {
-                core.gate.call_succeeded();
+                permit.succeeded();
                 chunks = second;
             }
             // The first reply parsed; it merely paraphrased. Keeping it and
             // letting `flag_unverified` mark what went missing beats losing a
             // window we can already read.
             Err(e) => {
-                core.gate.call_failed(&e);
+                permit.failed(&e);
                 tracing::warn!(
                     corpus_id,
                     window = idx,
@@ -176,7 +176,7 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
 /// If it later succeeds this runs again, which is why every step of `finish` is
 /// idempotent: ordinals are renumbered, coverage recomputed, the embed job
 /// re-armed for the artifacts that have appeared since.
-async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
+pub(crate) async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
     for w in core.store.segments_for_corpus(corpus_id).await? {
         let resolved = match w.state {
             SegmentState::Done => true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,7 +365,6 @@ mod startup_tests {
                     tokenizer_path: None,
                     timeout_secs: engram::config::DEFAULT_TIMEOUT_SECS,
                     reasoning_effort: None,
-                    cooldown_secs: 0,
                     context_opening_tokens: 200,
                     context_overlap_tokens: 150,
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,7 @@ mod startup_tests {
                     reasoning_effort: None,
                     context_opening_tokens: 200,
                     context_overlap_tokens: 150,
+                    cooldown_secs: None,
                 },
                 embed: EmbedRole {
                     base_url: "http://localhost:8000/v1".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,7 @@ mod startup_tests {
             },
             consolidate: ConsolidateConfig::default(),
             feedback: FeedbackConfig::default(),
+            pacing: engram::config::PacingConfig::default(),
         }
     }
 

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -326,6 +326,25 @@ impl Store {
         Ok(rows.iter().map(row_to_artifact).collect())
     }
 
+    /// Is every chunk still waiting to be embedded already armed as its own
+    /// unit? True means the source has been taken off the batch path and onto
+    /// the per-chunk one, and re-arming its batch would only spend another call
+    /// discovering the same refusal.
+    pub async fn pending_artifacts_are_isolated(&self, corpus_id: &str) -> Result<bool> {
+        let unarmed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM artifacts a
+              WHERE a.corpus_id = ? AND a.embed_state = 'pending'
+                AND NOT EXISTS (
+                  SELECT 1 FROM jobs j
+                   WHERE j.stage = 'embed' AND j.target_id = a.id AND j.state != 'done'
+                )",
+        )
+        .bind(corpus_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(unarmed == 0)
+    }
+
     /// Put every chunk of a source back in the embed queue's path. Re-embedding
     /// only happens for rows that say they still need it, so asking for it has
     /// to say so first.

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -304,6 +304,20 @@ impl Store {
         Ok(())
     }
 
+    /// Forget what the last run measured, so the next one is measured against
+    /// its own windows. Also what the reconciliation sweep reads as "this
+    /// document never finished": a stale value there is indistinguishable from a
+    /// document that finished cleanly, which is the wrong answer for a source
+    /// whose windows are being thrown away and re-cut.
+    pub async fn clear_corpus_coverage(&self, corpus_id: &str) -> Result<()> {
+        sqlx::query("UPDATE corpora SET coverage = NULL, updated_at = ? WHERE id = ?")
+            .bind(now())
+            .bind(corpus_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// The stored corpus most like this signature, if any clears `min`.
     ///
     /// A full scan of the signature column. A single-operator base holds

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -280,38 +280,6 @@ impl Store {
         Ok(self.job_seq(stage, target_id).await?.is_some())
     }
 
-    /// Queue work that has already been tried, so the next attempt waits.
-    ///
-    /// `enqueue` resets `attempts` to zero, which is right for a reprocess a
-    /// person asked for and wrong for a stage re-arming itself: a synthesize
-    /// job that keeps failing would come straight back with a two-second
-    /// delay and hammer an endpoint that is down. This keeps the attempt count
-    /// climbing so the backoff means something.
-    pub async fn enqueue_after(
-        &self,
-        stage: Stage,
-        target_kind: &str,
-        target_id: &str,
-        attempts: i64,
-    ) -> Result<()> {
-        sqlx::query(
-            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at)
-             VALUES (?, ?, ?, 'pending', ?, ?, ?)
-             ON CONFLICT(stage, target_id) DO UPDATE SET
-               state = 'pending', attempts = excluded.attempts,
-               run_after = excluded.run_after, claimed_at = NULL",
-        )
-        .bind(stage.as_str())
-        .bind(target_kind)
-        .bind(target_id)
-        .bind(attempts)
-        .bind(now() + backoff_secs(attempts))
-        .bind(now())
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
     /// Atomic claim. The UPDATE ... WHERE id = (SELECT ...) RETURNING form runs
     /// as one statement under SQLite's write lock, so two workers can never
     /// take the same row.
@@ -319,7 +287,7 @@ impl Store {
     /// Least-tried first, then earliest position in its batch, then oldest.
     ///
     /// Ordering by id alone made the queue strictly sequential in the one case
-    /// where that hurts: `enqueue_after` re-arms the existing row, so a job that
+    /// where that hurts: `fail_job` re-arms the row in place, so a job that
     /// cannot get through keeps its original id and reclaims the front of the
     /// queue every time its backoff expires, ahead of everything captured since.
     /// One document the model would not parse therefore held up every document
@@ -597,7 +565,7 @@ mod tests {
 
     #[tokio::test]
     async fn work_that_keeps_failing_stops_holding_the_head_of_the_queue() {
-        // `enqueue_after` re-arms the existing row, so a job that fails over and
+        // `fail_job` re-arms the row in place, so a job that fails over and
         // over keeps its original id. Ordering by id alone therefore handed the
         // queue's front to the one target that could not make progress, every
         // time its backoff expired, ahead of everything captured since.

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -11,13 +11,21 @@ pub const MAX_ATTEMPTS: i64 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Stage {
+    /// Splits a corpus into windows and arms one `SegmentWindow` per window.
+    /// Makes no inference call itself.
     Synthesize,
     Enrich,
+    /// One window, one call. The unit the job model is built around.
+    SegmentWindow,
+    /// Naming one document. One call.
+    Title,
     Embed,
     /// The periodic consolidation sweep. Its target is the collection rather
     /// than any one corpus, so there is exactly one of these in the queue at a
-    /// time.
+    /// time. Local work: it arms `Judge` units rather than calling the model.
     Consolidate,
+    /// One pair, one call.
+    Judge,
 }
 
 impl Stage {
@@ -25,16 +33,22 @@ impl Stage {
         match self {
             Stage::Synthesize => "synthesize",
             Stage::Enrich => "enrich",
+            Stage::SegmentWindow => "segment_window",
+            Stage::Title => "title",
             Stage::Embed => "embed",
             Stage::Consolidate => "consolidate",
+            Stage::Judge => "judge",
         }
     }
     pub fn parse(s: &str) -> Option<Stage> {
         match s {
             "synthesize" => Some(Stage::Synthesize),
             "enrich" => Some(Stage::Enrich),
+            "segment_window" => Some(Stage::SegmentWindow),
+            "title" => Some(Stage::Title),
             "embed" => Some(Stage::Embed),
             "consolidate" => Some(Stage::Consolidate),
+            "judge" => Some(Stage::Judge),
             _ => None,
         }
     }
@@ -85,23 +99,52 @@ pub fn backoff_secs(attempts: i64) -> i64 {
 
 impl Store {
     pub async fn enqueue(&self, stage: Stage, target_kind: &str, target_id: &str) -> Result<()> {
-        // Idempotent per (stage, target). A conflicting row that already
-        // finished or failed is re-armed, which is exactly what a manual
-        // reprocess needs.
+        self.enqueue_seq(stage, target_kind, target_id, 0).await
+    }
+
+    /// Arm a unit at a given position within its batch.
+    ///
+    /// `enqueue` is this with `seq = 0`, which is right for a singleton and
+    /// wrong for the thirty-four windows of one document: left at zero they
+    /// would sort among themselves by row id, and a document captured later
+    /// would wait behind all of them.
+    ///
+    /// Idempotent per (stage, target). A conflicting row that already finished
+    /// or failed is re-armed, which is exactly what a manual reprocess needs.
+    pub async fn enqueue_seq(
+        &self,
+        stage: Stage,
+        target_kind: &str,
+        target_id: &str,
+        seq: i64,
+    ) -> Result<()> {
         sqlx::query(
-            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at)
-             VALUES (?, ?, ?, 'pending', 0, 0, ?)
+            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq)
+             VALUES (?, ?, ?, 'pending', 0, 0, ?, ?)
              ON CONFLICT(stage, target_id) DO UPDATE SET
                state = 'pending', attempts = 0, run_after = 0, last_error = NULL,
-               claimed_at = NULL, created_at = excluded.created_at",
+               claimed_at = NULL, created_at = excluded.created_at, seq = excluded.seq",
         )
         .bind(stage.as_str())
         .bind(target_kind)
         .bind(target_id)
         .bind(now())
+        .bind(seq)
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// The `seq` a job currently carries, so a unit that re-arms itself can
+    /// climb rather than re-entering at the front of its batch.
+    pub async fn job_seq(&self, stage: Stage, target_id: &str) -> Result<Option<i64>> {
+        Ok(
+            sqlx::query_scalar::<_, i64>("SELECT seq FROM jobs WHERE stage = ? AND target_id = ?")
+                .bind(stage.as_str())
+                .bind(target_id)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
     }
 
     /// Queue work that has already been tried, so the next attempt waits.
@@ -140,15 +183,20 @@ impl Store {
     /// as one statement under SQLite's write lock, so two workers can never
     /// take the same row.
     ///
-    /// Least-tried first, then oldest. Ordering by id alone made the queue
-    /// strictly sequential in the one case where that hurts: `enqueue_after`
-    /// re-arms the existing row, so a job that cannot get through keeps its
-    /// original id and reclaims the front of the queue every time its backoff
-    /// expires, ahead of everything captured since. One document the model
-    /// would not parse therefore held up every document behind it. Sorting by
-    /// `attempts` puts work that has already had its turn behind work that has
-    /// not — a reordering rather than a demotion, since the sore thumb still
-    /// runs as soon as nothing fresher is ready.
+    /// Least-tried first, then earliest position in its batch, then oldest.
+    ///
+    /// Ordering by id alone made the queue strictly sequential in the one case
+    /// where that hurts: `enqueue_after` re-arms the existing row, so a job that
+    /// cannot get through keeps its original id and reclaims the front of the
+    /// queue every time its backoff expires, ahead of everything captured since.
+    /// One document the model would not parse therefore held up every document
+    /// behind it. Sorting by `attempts` puts work that has already had its turn
+    /// behind work that has not — a reordering rather than a demotion, since the
+    /// sore thumb still runs as soon as nothing fresher is ready.
+    ///
+    /// `seq` then interleaves whole documents. Without it, a corpus armed as
+    /// thirty-four units takes thirty-four consecutive ids and reproduces the
+    /// same head-of-line blocking one level down.
     pub async fn claim_job(&self) -> Result<Option<Job>> {
         let row = sqlx::query(
             "UPDATE jobs
@@ -156,7 +204,7 @@ impl Store {
               WHERE id = (
                 SELECT id FROM jobs
                  WHERE state = 'pending' AND run_after <= ?
-                 ORDER BY attempts, id LIMIT 1
+                 ORDER BY attempts, seq, id LIMIT 1
               )
               RETURNING id, stage, target_kind, target_id, attempts",
         )
@@ -479,6 +527,60 @@ mod tests {
             next.expect("the failing job was abandoned").target_id,
             "sore-thumb"
         );
+    }
+
+    #[tokio::test]
+    async fn units_of_two_documents_interleave_rather_than_queueing_behind_each_other() {
+        // A thirty-four window document takes thirty-four consecutive row ids.
+        // Under id ordering a capture made during that ingest waits for every
+        // one of them before producing a single artifact.
+        let s = Store::memory().await.unwrap();
+        for i in 0..3 {
+            s.enqueue_seq(Stage::SegmentWindow, "segment", &format!("doc-a#{i}"), i)
+                .await
+                .unwrap();
+        }
+        for i in 0..3 {
+            s.enqueue_seq(Stage::SegmentWindow, "segment", &format!("doc-b#{i}"), i)
+                .await
+                .unwrap();
+        }
+
+        let mut order = Vec::new();
+        while let Some(j) = s.claim_job().await.unwrap() {
+            order.push(j.target_id);
+            s.complete_job(j.id).await.unwrap();
+        }
+        assert_eq!(
+            order,
+            vec![
+                "doc-a#0", "doc-b#0", "doc-a#1", "doc-b#1", "doc-a#2", "doc-b#2"
+            ],
+            "the second document waited for the whole of the first"
+        );
+    }
+
+    #[tokio::test]
+    async fn attempts_still_outrank_seq() {
+        // The fairness fix must survive the interleaving one: a unit that keeps
+        // failing sinks below fresher work whatever its position in a document.
+        let s = Store::memory().await.unwrap();
+        s.enqueue_seq(Stage::SegmentWindow, "segment", "sore#0", 0)
+            .await
+            .unwrap();
+        let j = s.claim_job().await.unwrap().unwrap();
+        s.fail_job(j.id, 0, "malformed llm output").await.unwrap();
+
+        s.enqueue_seq(Stage::SegmentWindow, "segment", "fresh#9", 9)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        let next = s.claim_job().await.unwrap().unwrap();
+        assert_eq!(next.target_id, "fresh#9", "a failing unit kept the front");
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -105,8 +105,6 @@ pub fn backoff_secs(attempts: i64) -> i64 {
 enum Guard {
     /// Anything, running included. An operator's reprocess.
     Any,
-    /// Anything a worker is not inside right now.
-    NotRunning,
     /// Only a row closed while its work was not.
     Closed,
 }
@@ -130,7 +128,6 @@ impl Guard {
     fn statement(self) -> &'static str {
         match self {
             Guard::Any => arm_job!(""),
-            Guard::NotRunning => arm_job!("WHERE jobs.state != 'running'"),
             Guard::Closed => arm_job!("WHERE jobs.state = 'done'"),
         }
     }
@@ -163,37 +160,17 @@ impl Store {
             .await
     }
 
-    /// Arm a unit without disturbing one that is already running.
-    ///
-    /// It is one row per unit, so re-arming one mid-call put it back in the
-    /// queue for a second worker to claim while the first was still inside the
-    /// model call — two workers segmenting the same window, each deleting the
-    /// artifacts the other had just written, and both then settling the corpus.
-    /// Nothing is lost by waiting: the running attempt either finishes the work
-    /// or fails and re-queues itself.
-    ///
-    /// Everything that arms units on its own — planning a document, a
-    /// consolidation sweep arming a judgement — wants this rather than
-    /// `enqueue_seq`.
-    pub async fn arm_seq(
-        &self,
-        stage: Stage,
-        target_kind: &str,
-        target_id: &str,
-        seq: i64,
-    ) -> Result<()> {
-        self.upsert_job(stage, target_kind, target_id, seq, Guard::NotRunning)
-            .await
-    }
-
     /// Arm a unit only if nothing is going to run it.
     ///
-    /// What the reconciliation sweep wants, and neither of the above is it: a
-    /// unit already queued is already going to run, and winding its `attempts`
-    /// back to zero on every sweep is how a window the model will not read never
-    /// reaches the ceiling that lets its document settle — the sweep would keep
-    /// it forever young and the corpus forever `segmenting`. Only a row closed
-    /// while its work was not is resurrected.
+    /// What every automatic arming wants, and `enqueue_seq` is not it: a unit
+    /// already queued is already going to run, and winding its `attempts` back
+    /// to zero is how a window the model will not read never reaches the ceiling
+    /// that lets its document settle — forever young, and its corpus forever
+    /// `segmenting`. Only a row closed while its work was not is resurrected.
+    ///
+    /// There was once a middle tier that armed anything a worker was not inside,
+    /// on the reasoning that a merely *queued* unit is safe to disturb. It is
+    /// not, for the reason above, and every caller it had has moved here.
     pub async fn rearm_idle_seq(
         &self,
         stage: Stage,
@@ -268,6 +245,30 @@ impl Store {
             .bind(target_id)
             .execute(&self.pool)
             .await?;
+        Ok(())
+    }
+
+    /// Forget every window unit of one document.
+    ///
+    /// The units are keyed `corpus#idx` and outlive the window rows they name,
+    /// so `clear_segments` on its own leaves a rerun sharing the attempt counts
+    /// of the run it replaces — and since planning arms idle-only, it would keep
+    /// them. Only an operator asking for the work again wants this, for the same
+    /// reason `delete_job` exists: a rerun a person asked for is a clean slate
+    /// or it is not one.
+    ///
+    /// Matched on the `corpus#` prefix rather than with `LIKE`, so an id
+    /// carrying a wildcard character cannot widen the delete.
+    pub async fn delete_window_jobs(&self, corpus_id: &str) -> Result<()> {
+        sqlx::query(
+            "DELETE FROM jobs
+              WHERE stage = 'segment_window'
+                AND substr(target_id, 1, length(?) + 1) = ? || '#'",
+        )
+        .bind(corpus_id)
+        .bind(corpus_id)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
@@ -727,7 +728,7 @@ mod tests {
             .unwrap();
         s.claim_job().await.unwrap().unwrap();
 
-        s.arm_seq(Stage::SegmentWindow, "segment", "src-1#0", 0)
+        s.rearm_idle_seq(Stage::SegmentWindow, "segment", "src-1#0", 0)
             .await
             .unwrap();
         assert!(

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -97,6 +97,45 @@ pub fn backoff_secs(attempts: i64) -> i64 {
     2i64.saturating_pow(exp).min(21_600)
 }
 
+/// Which existing rows an arming upsert may disturb.
+///
+/// Each carries its whole statement rather than a fragment to paste in, so
+/// there is no construction step for anything to be smuggled through.
+#[derive(Clone, Copy)]
+enum Guard {
+    /// Anything, running included. An operator's reprocess.
+    Any,
+    /// Anything a worker is not inside right now.
+    NotRunning,
+    /// Only a row closed while its work was not.
+    Closed,
+}
+
+/// The upsert the three guards share, spelled out once per guard because a
+/// statement assembled at runtime is a statement nobody can read in the source.
+macro_rules! arm_job {
+    ($guard:literal) => {
+        concat!(
+            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq)
+             VALUES (?, ?, ?, 'pending', 0, 0, ?, ?)
+             ON CONFLICT(stage, target_id) DO UPDATE SET
+               state = 'pending', attempts = 0, run_after = 0, last_error = NULL,
+               claimed_at = NULL, created_at = excluded.created_at, seq = excluded.seq ",
+            $guard
+        )
+    };
+}
+
+impl Guard {
+    fn statement(self) -> &'static str {
+        match self {
+            Guard::Any => arm_job!(""),
+            Guard::NotRunning => arm_job!("WHERE jobs.state != 'running'"),
+            Guard::Closed => arm_job!("WHERE jobs.state = 'done'"),
+        }
+    }
+}
+
 impl Store {
     pub async fn enqueue(&self, stage: Stage, target_kind: &str, target_id: &str) -> Result<()> {
         self.enqueue_seq(stage, target_kind, target_id, 0).await
@@ -109,8 +148,10 @@ impl Store {
     /// would sort among themselves by row id, and a document captured later
     /// would wait behind all of them.
     ///
-    /// Idempotent per (stage, target). A conflicting row that already finished
-    /// or failed is re-armed, which is exactly what a manual reprocess needs.
+    /// Idempotent per (stage, target). A conflicting row is re-armed whatever
+    /// state it is in, running included — which is what an operator's reprocess
+    /// needs and what nothing automatic should do. Automatic arming wants
+    /// `arm_seq` or `rearm_idle_seq` below.
     pub async fn enqueue_seq(
         &self,
         stage: Stage,
@@ -118,20 +159,69 @@ impl Store {
         target_id: &str,
         seq: i64,
     ) -> Result<()> {
-        sqlx::query(
-            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq)
-             VALUES (?, ?, ?, 'pending', 0, 0, ?, ?)
-             ON CONFLICT(stage, target_id) DO UPDATE SET
-               state = 'pending', attempts = 0, run_after = 0, last_error = NULL,
-               claimed_at = NULL, created_at = excluded.created_at, seq = excluded.seq",
-        )
-        .bind(stage.as_str())
-        .bind(target_kind)
-        .bind(target_id)
-        .bind(now())
-        .bind(seq)
-        .execute(&self.pool)
-        .await?;
+        self.upsert_job(stage, target_kind, target_id, seq, Guard::Any)
+            .await
+    }
+
+    /// Arm a unit without disturbing one that is already running.
+    ///
+    /// It is one row per unit, so re-arming one mid-call put it back in the
+    /// queue for a second worker to claim while the first was still inside the
+    /// model call — two workers segmenting the same window, each deleting the
+    /// artifacts the other had just written, and both then settling the corpus.
+    /// Nothing is lost by waiting: the running attempt either finishes the work
+    /// or fails and re-queues itself.
+    ///
+    /// Everything that arms units on its own — planning a document, a
+    /// consolidation sweep arming a judgement — wants this rather than
+    /// `enqueue_seq`.
+    pub async fn arm_seq(
+        &self,
+        stage: Stage,
+        target_kind: &str,
+        target_id: &str,
+        seq: i64,
+    ) -> Result<()> {
+        self.upsert_job(stage, target_kind, target_id, seq, Guard::NotRunning)
+            .await
+    }
+
+    /// Arm a unit only if nothing is going to run it.
+    ///
+    /// What the reconciliation sweep wants, and neither of the above is it: a
+    /// unit already queued is already going to run, and winding its `attempts`
+    /// back to zero on every sweep is how a window the model will not read never
+    /// reaches the ceiling that lets its document settle — the sweep would keep
+    /// it forever young and the corpus forever `segmenting`. Only a row closed
+    /// while its work was not is resurrected.
+    pub async fn rearm_idle_seq(
+        &self,
+        stage: Stage,
+        target_kind: &str,
+        target_id: &str,
+        seq: i64,
+    ) -> Result<()> {
+        self.upsert_job(stage, target_kind, target_id, seq, Guard::Closed)
+            .await
+    }
+
+    /// The one upsert the three above differ only in the guard on.
+    async fn upsert_job(
+        &self,
+        stage: Stage,
+        target_kind: &str,
+        target_id: &str,
+        seq: i64,
+        guard: Guard,
+    ) -> Result<()> {
+        sqlx::query(guard.statement())
+            .bind(stage.as_str())
+            .bind(target_kind)
+            .bind(target_id)
+            .bind(now())
+            .bind(seq)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -145,6 +235,14 @@ impl Store {
                 .fetch_optional(&self.pool)
                 .await?,
         )
+    }
+
+    /// Has this unit ever been armed? A row survives being completed, so this
+    /// distinguishes "never asked" from "asked, and done asking" — which is the
+    /// only thing separating a first settle from the fiftieth for a stage that
+    /// is allowed to give up.
+    pub async fn has_job(&self, stage: Stage, target_id: &str) -> Result<bool> {
+        Ok(self.job_seq(stage, target_id).await?.is_some())
     }
 
     /// Queue work that has already been tried, so the next attempt waits.
@@ -581,6 +679,67 @@ mod tests {
 
         let next = s.claim_job().await.unwrap().unwrap();
         assert_eq!(next.target_id, "fresh#9", "a failing unit kept the front");
+    }
+
+    #[tokio::test]
+    async fn arming_a_unit_a_worker_is_already_inside_leaves_it_alone() {
+        // One row per unit, so putting a running one back in the queue hands the
+        // same window to a second worker while the first is still inside the
+        // model call — and `write_segment_artifacts` has each of them deleting
+        // the artifacts the other just wrote.
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::SegmentWindow, "segment", "src-1#0")
+            .await
+            .unwrap();
+        s.claim_job().await.unwrap().unwrap();
+
+        s.arm_seq(Stage::SegmentWindow, "segment", "src-1#0", 0)
+            .await
+            .unwrap();
+        assert!(
+            s.claim_job().await.unwrap().is_none(),
+            "a second worker could claim a window already being segmented"
+        );
+
+        // An operator's reprocess still gets through: they are asking for the
+        // work to be redone, having presumably changed what it would produce.
+        s.enqueue(Stage::SegmentWindow, "segment", "src-1#0")
+            .await
+            .unwrap();
+        assert!(s.claim_job().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn the_sweeps_arming_only_resurrects_a_closed_unit() {
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::SegmentWindow, "segment", "src-1#0")
+            .await
+            .unwrap();
+        let j = s.claim_job().await.unwrap().unwrap();
+        s.fail_job(j.id, 4, "unreadable reply").await.unwrap();
+
+        // Queued and waiting out a backoff: already going to run, so the sweep
+        // has nothing to add and must not wind it back.
+        s.rearm_idle_seq(Stage::SegmentWindow, "segment", "src-1#0", 0)
+            .await
+            .unwrap();
+        let (attempts, run_after): (i64, i64) =
+            sqlx::query_as("SELECT attempts, run_after FROM jobs WHERE target_id = 'src-1#0'")
+                .fetch_one(&s.pool)
+                .await
+                .unwrap();
+        assert_eq!(attempts, 1, "the sweep reset a unit's attempt count");
+        assert!(run_after > now(), "the sweep cleared a unit's backoff");
+
+        // Closed while its work was not: exactly what the sweep exists for.
+        s.complete_job(j.id).await.unwrap();
+        s.rearm_idle_seq(Stage::SegmentWindow, "segment", "src-1#0", 0)
+            .await
+            .unwrap();
+        assert!(
+            s.claim_job().await.unwrap().is_some(),
+            "the sweep left a closed unit's unfinished work unarmed"
+        );
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -139,6 +139,16 @@ impl Store {
     /// Atomic claim. The UPDATE ... WHERE id = (SELECT ...) RETURNING form runs
     /// as one statement under SQLite's write lock, so two workers can never
     /// take the same row.
+    ///
+    /// Least-tried first, then oldest. Ordering by id alone made the queue
+    /// strictly sequential in the one case where that hurts: `enqueue_after`
+    /// re-arms the existing row, so a job that cannot get through keeps its
+    /// original id and reclaims the front of the queue every time its backoff
+    /// expires, ahead of everything captured since. One document the model
+    /// would not parse therefore held up every document behind it. Sorting by
+    /// `attempts` puts work that has already had its turn behind work that has
+    /// not — a reordering rather than a demotion, since the sore thumb still
+    /// runs as soon as nothing fresher is ready.
     pub async fn claim_job(&self) -> Result<Option<Job>> {
         let row = sqlx::query(
             "UPDATE jobs
@@ -146,7 +156,7 @@ impl Store {
               WHERE id = (
                 SELECT id FROM jobs
                  WHERE state = 'pending' AND run_after <= ?
-                 ORDER BY id LIMIT 1
+                 ORDER BY attempts, id LIMIT 1
               )
               RETURNING id, stage, target_kind, target_id, attempts",
         )
@@ -402,6 +412,73 @@ mod tests {
             "the work was abandoned; an endpoint that comes back would never be noticed"
         );
         assert!(s.failed_jobs(10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn work_that_keeps_failing_stops_holding_the_head_of_the_queue() {
+        // `enqueue_after` re-arms the existing row, so a job that fails over and
+        // over keeps its original id. Ordering by id alone therefore handed the
+        // queue's front to the one target that could not make progress, every
+        // time its backoff expired, ahead of everything captured since.
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::Synthesize, "corpus", "sore-thumb")
+            .await
+            .unwrap();
+        for _ in 0..4 {
+            let j = s.claim_job().await.unwrap().unwrap();
+            s.fail_job(j.id, 0, "malformed llm output").await.unwrap();
+            // Past the backoff it just set; the delay is not what this test is
+            // about.
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&s.pool)
+                .await
+                .unwrap();
+        }
+
+        // Captured long after, and with a lower row id nowhere in sight.
+        s.enqueue(Stage::Synthesize, "corpus", "fresh")
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        let next = s.claim_job().await.unwrap().unwrap();
+        assert_eq!(
+            next.target_id, "fresh",
+            "the failing job kept the front of the queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_job_that_yielded_is_not_starved_once_it_is_the_only_work_left() {
+        // Yielding must be a reordering, not a demotion: the sore thumb still
+        // runs when nothing fresher is ready.
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::Synthesize, "corpus", "sore-thumb")
+            .await
+            .unwrap();
+        for _ in 0..4 {
+            let j = s.claim_job().await.unwrap().unwrap();
+            s.fail_job(j.id, 0, "malformed llm output").await.unwrap();
+            // Past the backoff it just set; the delay is not what this test is
+            // about.
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&s.pool)
+                .await
+                .unwrap();
+        }
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        let next = s.claim_job().await.unwrap();
+        assert_eq!(
+            next.expect("the failing job was abandoned").target_id,
+            "sore-thumb"
+        );
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -237,6 +237,40 @@ impl Store {
         )
     }
 
+    /// Is anything going to run this unit? `Some` for a row that is queued or
+    /// that a worker is inside, `None` for one that is closed or was never
+    /// armed.
+    ///
+    /// What a sweep needs before spending budget on a unit: a pair whose
+    /// judgement is already queued is already going to be judged, and arming it
+    /// again is a no-op that costs another pair its turn.
+    pub async fn live_job(&self, stage: Stage, target_id: &str) -> Result<bool> {
+        Ok(sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM jobs
+              WHERE stage = ? AND target_id = ? AND state IN ('pending', 'running')",
+        )
+        .bind(stage.as_str())
+        .bind(target_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some())
+    }
+
+    /// Forget that this unit was ever armed.
+    ///
+    /// Only an operator asking for the work again wants this. A row surviving
+    /// its completion is what lets a stage give up for good, so removing one
+    /// undoes exactly that — which is the point when the person who owns the
+    /// collection has asked for another try.
+    pub async fn delete_job(&self, stage: Stage, target_id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM jobs WHERE stage = ? AND target_id = ?")
+            .bind(stage.as_str())
+            .bind(target_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Has this unit ever been armed? A row survives being completed, so this
     /// distinguishes "never asked" from "asked, and done asking" — which is the
     /// only thing separating a first settle from the fiftieth for a stage that

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -53,16 +53,66 @@ impl Store {
     /// One statement of what the schema *is*, rather than a chain of diffs
     /// describing how it came to be. Every object is `IF NOT EXISTS`, so this
     /// creates what is missing on a fresh database and is a no-op on one that
-    /// already has it. It deliberately cannot alter an existing table: while
-    /// the project is in testing, changing a column means editing `schema.sql`
-    /// and recreating the database.
+    /// already has it — then `ADDED_COLUMNS` appends the few columns that
+    /// arrived after a table was already deployed, since `IF NOT EXISTS` cannot.
     ///
-    /// Which is exactly why it then checks. A table that already exists is left
+    /// It still checks afterwards. A table that already exists is otherwise left
     /// as it is, columns and all, so a database from before a column was added
-    /// survives this call and fails much later, in a request, with a bare
+    /// would survive this call and fail much later, in a request, with a bare
     /// `ColumnNotFound` panic that says nothing about the real cause.
     pub async fn migrate(&self) -> Result<()> {
         const SCHEMA: &str = include_str!("schema.sql");
+
+        // Columns that arrived after their table was already deployed.
+        //
+        // `schema.sql` says what the schema *is*, and `CREATE TABLE IF NOT
+        // EXISTS` is a no-op against a table that is already there — so a column
+        // added to that file never reaches a running base, and the check below
+        // then refuses to start, correctly, saying the database is older than
+        // the schema. That is the right answer while nothing is deployed and the
+        // wrong one afterwards: it asks an operator to recreate a knowledge base
+        // to gain a column with a default.
+        //
+        // So each such column is named here once. SQLite's `ALTER TABLE` can
+        // only append, and only with a default, which is exactly the shape of
+        // every entry this list is allowed to hold. Adding one is safe; changing
+        // or reordering one is not. A column needing more than an append does
+        // not belong here — it belongs in a recreate.
+        const ADDED_COLUMNS: &[(&str, &str, &str)] =
+            &[("jobs", "seq", "INTEGER NOT NULL DEFAULT 0")];
+
+        // Before the schema, not after. `schema.sql` builds an index over `seq`,
+        // and an index cannot name a column that is not there yet — applying the
+        // file first fails on exactly the databases this list exists to rescue.
+        // On a fresh one the table does not exist yet, the loop skips, and the
+        // schema creates it with the column already in place.
+        for (table, column, decl) in ADDED_COLUMNS {
+            let have: Vec<String> = sqlx::query("SELECT name FROM pragma_table_info(?)")
+                .bind(table)
+                .fetch_all(&self.pool)
+                .await?
+                .iter()
+                .map(|r| r.get::<String, _>("name"))
+                .collect();
+            // An empty list means the table does not exist yet, in which case
+            // `schema.sql` just created it with the column already in place.
+            if have.is_empty() || have.iter().any(|h| h.eq_ignore_ascii_case(column)) {
+                continue;
+            }
+            // A table name cannot be a bind parameter, so this statement has to
+            // be built as a string, and sqlx rightly demands the assertion be
+            // made explicitly. The audit it asks for: all three parts come from
+            // `ADDED_COLUMNS` above, which is a compile-time constant in this
+            // file. No caller, request or database value reaches it.
+            sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+                "ALTER TABLE {table} ADD COLUMN {column} {decl}"
+            )))
+            .execute(&self.pool)
+            .await
+            .map_err(|e| crate::error::Error::Store(e.to_string()))?;
+            tracing::info!(table, column, "added a column to an existing database");
+        }
+
         sqlx::raw_sql(SCHEMA)
             .execute(&self.pool)
             .await
@@ -172,6 +222,51 @@ pub fn new_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn a_column_added_after_deployment_reaches_a_database_that_predates_it() {
+        // The upgrade path, and the trap in it. `CREATE TABLE IF NOT EXISTS` is
+        // a no-op against a table that already exists, so a column added to
+        // schema.sql never reaches a running base — and the check at the end of
+        // migrate() then refuses to start it. An operator would have been asked
+        // to recreate a knowledge base to gain a column with a default.
+        let store = Store::memory().await.unwrap();
+        // The index names the column, so it goes first — which is the same
+        // ordering constraint migrate() itself has to respect.
+        sqlx::query("DROP INDEX IF EXISTS idx_jobs_claim2")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        sqlx::query("ALTER TABLE jobs DROP COLUMN seq")
+            .execute(&store.pool)
+            .await
+            .expect("the fixture needs a jobs table without seq");
+
+        store
+            .migrate()
+            .await
+            .expect("migrate refused an older base");
+
+        let has_seq: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM pragma_table_info('jobs') WHERE name = 'seq'")
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert_eq!(has_seq, 1, "seq was never added to the existing table");
+
+        // And the default has to be usable, or every pre-existing row would sort
+        // as NULL and the claim ordering would be undefined for them.
+        store
+            .enqueue(jobs::Stage::Embed, "corpus", "c-1")
+            .await
+            .unwrap();
+        let seq = store
+            .job_seq(jobs::Stage::Embed, "c-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(seq, 0);
+    }
 
     #[tokio::test]
     async fn applying_the_schema_twice_changes_nothing() {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -78,8 +78,14 @@ impl Store {
         // every entry this list is allowed to hold. Adding one is safe; changing
         // or reordering one is not. A column needing more than an append does
         // not belong here — it belongs in a recreate.
-        const ADDED_COLUMNS: &[(&str, &str, &str)] =
-            &[("jobs", "seq", "INTEGER NOT NULL DEFAULT 0")];
+        const ADDED_COLUMNS: &[(&str, &str, &str)] = &[
+            ("jobs", "seq", "INTEGER NOT NULL DEFAULT 0"),
+            (
+                "artifact_pairs",
+                "judge_unreadable",
+                "INTEGER NOT NULL DEFAULT 0",
+            ),
+        ];
 
         // Before the schema, not after. `schema.sql` builds an index over `seq`,
         // and an index cannot name a column that is not there yet — applying the

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -9,6 +9,21 @@ use super::{Store, now};
 use crate::error::Result;
 use sqlx::Row;
 
+/// How many unreadable replies a pair is worth before the judge stops being
+/// offered it.
+///
+/// One unit's full retry lifetime, which is already the most varied asking the
+/// prompt can do: `judge_prompt` carries the attempt number precisely so those
+/// retries are not the same question replayed out of the endpoint's cache. If
+/// five differently-phrased asks about the same two artifacts all come back
+/// unreadable, a sixth is not a better bet than the one after it, and the
+/// close-out in `run_one` hands the pair to the next sweep — which without this
+/// ceiling would arm it for five more, every sweep, forever.
+///
+/// The pair stays `pending`, so nothing is lost: it is still on the review
+/// queue, and an operator settles it by hand.
+pub const MAX_UNREADABLE_JUDGEMENTS: i64 = super::jobs::MAX_ATTEMPTS;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PairState {
@@ -60,6 +75,10 @@ pub struct ArtifactPair {
     /// Model calls this pair has already cost, successful or not. Orders the
     /// judge's queue so a pair it cannot read does not starve the rest.
     pub judge_attempts: i64,
+    /// How many of those calls came back with something that could not be
+    /// parsed as a verdict. The ceiling that stops asking is on this and not on
+    /// `judge_attempts` — see `MAX_UNREADABLE_JUDGEMENTS`.
+    pub judge_unreadable: i64,
     /// Which artifact the judge named obsolete, when `state` is `Superseded`.
     /// Lets the review UI offer "apply supersede" without asking the model
     /// again.
@@ -76,6 +95,7 @@ fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
         detail: r.get("detail"),
         created_at: r.get("created_at"),
         judge_attempts: r.get("judge_attempts"),
+        judge_unreadable: r.get("judge_unreadable"),
         obsolete_id: r.get("obsolete_id"),
     }
 }
@@ -230,11 +250,19 @@ impl Store {
     /// parsed stays pending on purpose, and under a plain `score DESC` the same
     /// top-scoring handful would absorb every sweep's budget forever while the
     /// rest of the queue is never reached.
+    ///
+    /// Pairs past `MAX_UNREADABLE_JUDGEMENTS` are held back. Staying pending is
+    /// what keeps them on an operator's review queue; being handed to the judge
+    /// again is what would make them cost model calls forever, since a unit that
+    /// exhausts its retries is closed rather than parked and the next sweep
+    /// would find the pair pending, idle, and first in line all over again.
     pub async fn pairs_to_judge(&self, limit: i64) -> Result<Vec<ArtifactPair>> {
         let rows = sqlx::query(
-            "SELECT * FROM artifact_pairs WHERE state = 'pending'
+            "SELECT * FROM artifact_pairs
+              WHERE state = 'pending' AND judge_unreadable < ?
               ORDER BY judge_attempts ASC, score DESC, created_at DESC LIMIT ?",
         )
+        .bind(MAX_UNREADABLE_JUDGEMENTS)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -249,6 +277,20 @@ impl Store {
             .bind(id)
             .execute(&self.pool)
             .await?;
+        Ok(())
+    }
+
+    /// Count one reply that came back unreadable. Only this counter gates
+    /// whether the pair is ever asked about again, so it is stepped where the
+    /// parse fails and nowhere else — an endpoint that is down must not shelve
+    /// the whole review queue on its way past.
+    pub async fn record_unreadable_judgement(&self, id: i64) -> Result<()> {
+        sqlx::query(
+            "UPDATE artifact_pairs SET judge_unreadable = judge_unreadable + 1 WHERE id = ?",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 }
@@ -290,6 +332,69 @@ mod tests {
             .await
             .unwrap();
         (made[0].id.clone(), made[1].id.clone())
+    }
+
+    #[tokio::test]
+    async fn a_pair_the_judge_can_never_read_stops_costing_calls() {
+        // The unit closes itself at `MAX_ATTEMPTS` so a later sweep can decide
+        // again whether the pair is worth asking about. Nothing implemented that
+        // decision: the pair was still pending with no live job, so every sweep
+        // armed it for another five calls — and the attempt counter in the
+        // prompt means all five are full-cost generations rather than replays
+        // out of the endpoint's cache. This is the decision.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_to_judge(10).await.unwrap()[0].id;
+
+        for _ in 0..MAX_UNREADABLE_JUDGEMENTS - 1 {
+            s.record_judge_attempt(id).await.unwrap();
+            s.record_unreadable_judgement(id).await.unwrap();
+        }
+        assert_eq!(
+            s.pairs_to_judge(10).await.unwrap().len(),
+            1,
+            "a pair short of the ceiling was already being held back"
+        );
+
+        s.record_judge_attempt(id).await.unwrap();
+        s.record_unreadable_judgement(id).await.unwrap();
+        assert!(
+            s.pairs_to_judge(10).await.unwrap().is_empty(),
+            "a pair the judge has never once been able to read is still being asked about"
+        );
+        // Held back from the judge, not settled: it is still on the queue an
+        // operator works through by hand.
+        assert_eq!(
+            s.pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "holding a pair back from the judge took it off the review queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_endpoint_outage_does_not_shelve_the_review_queue() {
+        // Attempts are counted before the call, so a run of failures against a
+        // dead endpoint walks `judge_attempts` to the ceiling for every pending
+        // pair at once. Gating on that counter would mean one outage emptied the
+        // judge's queue permanently, which is why the ceiling is on replies that
+        // came back and could not be read.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_to_judge(10).await.unwrap()[0].id;
+
+        for _ in 0..MAX_UNREADABLE_JUDGEMENTS * 3 {
+            s.record_judge_attempt(id).await.unwrap();
+        }
+        assert_eq!(
+            s.pairs_to_judge(10).await.unwrap().len(),
+            1,
+            "an endpoint outage put the pair permanently out of the judge's reach"
+        );
     }
 
     #[tokio::test]

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -164,6 +164,12 @@ CREATE TABLE IF NOT EXISTS artifact_pairs (
   detail         TEXT,
   created_at     INTEGER NOT NULL,
   judge_attempts INTEGER NOT NULL DEFAULT 0,
+  -- Of those attempts, the ones the endpoint answered and the answer could not
+  -- be read. Counted apart from `judge_attempts` because only this half says
+  -- anything about the pair: a call an outage ate says something about the
+  -- endpoint, and shelving a pair for that would empty the review queue every
+  -- time the model is down.
+  judge_unreadable INTEGER NOT NULL DEFAULT 0,
   obsolete_id    TEXT REFERENCES artifacts(id),
   UNIQUE(a_id, b_id)
 );

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -121,6 +121,11 @@ CREATE TABLE IF NOT EXISTS jobs (
   last_error  TEXT,
   claimed_at  INTEGER,
   created_at  INTEGER NOT NULL DEFAULT 0,
+  -- Position within the batch of units armed together: the window index, the
+  -- judge pair's index, the embed batch number. Zero for singletons. Claiming
+  -- orders by it, so every document's first window runs before any document's
+  -- second — which is what stops a large ingest starving a small one behind it.
+  seq         INTEGER NOT NULL DEFAULT 0,
   UNIQUE(stage, target_id)
 );
 -- Ready work in the order `claim_job` takes it: least-tried first, then oldest.
@@ -134,11 +139,12 @@ CREATE TABLE IF NOT EXISTS jobs (
 --
 -- Dropped by its old name rather than widened in place. `migrate` applies this
 -- file to every database on every start, and `CREATE INDEX IF NOT EXISTS` on a
--- name that already exists is a silent no-op, so a deployment carrying the old
--- two-column `idx_jobs_ready` would have kept it. The drop is how an existing
--- base actually picks this up.
+-- name that already exists is a silent no-op, so a deployment carrying an
+-- earlier version of this index would have kept it. The drop is how an existing
+-- base actually picks the new one up.
 DROP INDEX IF EXISTS idx_jobs_ready;
-CREATE INDEX IF NOT EXISTS idx_jobs_claim   ON jobs(state, attempts, id, run_after);
+DROP INDEX IF EXISTS idx_jobs_claim;
+CREATE INDEX IF NOT EXISTS idx_jobs_claim2  ON jobs(state, attempts, seq, id, run_after);
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at);
 
 -- ── Consolidation ────────────────────────────────────────────────────────────

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -123,7 +123,22 @@ CREATE TABLE IF NOT EXISTS jobs (
   created_at  INTEGER NOT NULL DEFAULT 0,
   UNIQUE(stage, target_id)
 );
-CREATE INDEX IF NOT EXISTS idx_jobs_ready   ON jobs(state, run_after);
+-- Ready work in the order `claim_job` takes it: least-tried first, then oldest.
+--
+-- The column order is the query's, not the filter's. `run_after` last looks
+-- wrong until you try it the other way round: an inequality ends an index's
+-- usable ordering, so `(state, run_after, attempts, id)` finds the ready rows
+-- and then sorts them in a temp B-tree on every poll. This walks `state`,
+-- `attempts`, `id` in claim order, tests `run_after` on each entry, and stops
+-- at the first row that is ready — covering, and no sort.
+--
+-- Dropped by its old name rather than widened in place. `migrate` applies this
+-- file to every database on every start, and `CREATE INDEX IF NOT EXISTS` on a
+-- name that already exists is a silent no-op, so a deployment carrying the old
+-- two-column `idx_jobs_ready` would have kept it. The drop is how an existing
+-- base actually picks this up.
+DROP INDEX IF EXISTS idx_jobs_ready;
+CREATE INDEX IF NOT EXISTS idx_jobs_claim   ON jobs(state, attempts, id, run_after);
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at);
 
 -- ── Consolidation ────────────────────────────────────────────────────────────

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -81,10 +81,10 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_superseded ON artifacts(superseded_by);
 CREATE INDEX IF NOT EXISTS idx_artifacts_status     ON artifacts(status);
 
 -- ── Segments ─────────────────────────────────────────────────────────────────
--- The windows a corpus was split into for synthesis. These rows are the job's
--- memory: a window that succeeds is written and marked done before the next is
--- attempted, so a failure costs the windows that had not started and nothing
--- else.
+-- The windows a corpus was split into for synthesis. One window is one
+-- inference call and one queue unit, so these rows say what the units are and
+-- which of them have resolved; the attempt count and the backoff belong to the
+-- job, not here.
 CREATE TABLE IF NOT EXISTS segments (
   corpus_id  TEXT    NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
   idx        INTEGER NOT NULL,
@@ -100,6 +100,11 @@ CREATE TABLE IF NOT EXISTS segments (
   -- An offset measured inside the window is that much too high without it.
   carry_lines INTEGER NOT NULL DEFAULT 0,
   state      TEXT    NOT NULL DEFAULT 'pending',  -- pending | done | failed
+  -- Dead since 2026-08-13. A window is its own queue unit now, so `jobs.attempts`
+  -- is the count that governs its backoff and its settling, and two counters for
+  -- one thing is exactly what made the incident behind that change so hard to
+  -- read. Left in place because `migrate` cannot drop a column; remove it
+  -- whenever the database is next recreated, and do not start writing to it.
   attempts   INTEGER NOT NULL DEFAULT 0,
   last_error TEXT,
   PRIMARY KEY (corpus_id, idx)

--- a/src/store/segments.rs
+++ b/src/store/segments.rs
@@ -196,23 +196,6 @@ impl Store {
         Ok(())
     }
 
-    pub async fn bump_segment_attempts(&self, corpus_id: &str, idx: i64) -> Result<i64> {
-        sqlx::query(
-            "UPDATE segments SET attempts = attempts + 1
-             WHERE corpus_id = ? AND idx = ?",
-        )
-        .bind(corpus_id)
-        .bind(idx)
-        .execute(&self.pool)
-        .await?;
-        let row = sqlx::query("SELECT attempts FROM segments WHERE corpus_id = ? AND idx = ?")
-            .bind(corpus_id)
-            .bind(idx)
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(row.get("attempts"))
-    }
-
     /// Put a window back in the queue's path. The operator's "re-segment this
     /// window" button, and nothing else, calls this.
     pub async fn reset_segment(&self, corpus_id: &str, idx: i64) -> Result<()> {
@@ -431,15 +414,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn attempts_accumulate_and_a_reset_clears_them() {
+    async fn a_reset_clears_a_window_back_to_pending() {
         let s = Store::memory().await.unwrap();
         let src = s.insert_corpus("raw", "web", None).await.unwrap();
         s.upsert_segments(&src.id, &[seg(1, 5, "window 0")])
             .await
             .unwrap();
 
-        assert_eq!(s.bump_segment_attempts(&src.id, 0).await.unwrap(), 1);
-        assert_eq!(s.bump_segment_attempts(&src.id, 0).await.unwrap(), 2);
         s.set_segment_state(&src.id, 0, SegmentState::Failed, Some("boom"))
             .await
             .unwrap();

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1450,7 +1450,7 @@ mod tests {
             .ingest("alpha line\n\nbravo line", "web", None)
             .await
             .unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         crate::jobs::embed::run_corpus(&core, &out.id)
             .await
             .unwrap();
@@ -1490,7 +1490,7 @@ mod tests {
             .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
             .await
             .unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         let c = core
             .store
             .artifacts_for_corpus(&out.id)
@@ -1520,7 +1520,7 @@ mod tests {
     async fn a_chunk_whose_source_vanished_is_not_a_500() {
         let core = crate::core::test_support::test_core().await;
         let out = core.ingest("alpha\n\nbravo", "web", None).await.unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         let c = core
             .store
             .artifacts_for_corpus(&out.id)
@@ -1545,7 +1545,7 @@ mod tests {
             .ingest("first para\n\nsecond para", "web", None)
             .await
             .unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         core.store
             .set_segment_state(
                 &out.id,
@@ -1639,7 +1639,7 @@ mod tests {
             .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
             .await
             .unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         crate::jobs::embed::run_corpus(&core, &out.id)
             .await
             .unwrap();
@@ -1866,7 +1866,7 @@ mod tests {
             .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
             .await
             .unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         crate::jobs::embed::run_corpus(&core, &out.id)
             .await
             .unwrap();
@@ -2004,7 +2004,7 @@ mod tests {
         // beside its source and simply offer no neighbours.
         let core = crate::core::test_support::test_core().await;
         let out = core.ingest("alpha\n\nbravo", "web", None).await.unwrap();
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         let c = core
             .store
             .artifacts_for_corpus(&out.id)
@@ -2381,7 +2381,7 @@ mod tests {
         );
         assert!(body.contains("every 3s"), "work in flight keeps polling");
 
-        crate::jobs::synthesize::run(&core, &out.id).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
         crate::jobs::embed::run_corpus(&core, &out.id)
             .await
             .unwrap();

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1559,8 +1559,9 @@ mod tests {
 
         assert_eq!(crate::jobs::reconcile::run(&core).await.unwrap(), 1);
         let mut found = false;
+        let want = crate::jobs::window::unit_target(&out.id, 0);
         while let Some(j) = core.store.claim_job().await.unwrap() {
-            if j.stage == crate::store::jobs::Stage::Synthesize && j.target_id == out.id {
+            if j.stage == crate::store::jobs::Stage::SegmentWindow && j.target_id == want {
                 found = true;
             }
         }

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -287,6 +287,11 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         consolidate: engram::config::ConsolidateConfig::default(),
         weak_below: 0.0,
         feedback: engram::config::FeedbackConfig::default(),
+        // The benchmark makes no background inference call, so the pacer never
+        // has anything to hold back.
+        gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(
+            std::time::Duration::ZERO,
+        )),
     };
     let translated = index(&core, &artifacts).await;
 

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -292,6 +292,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(
             std::time::Duration::ZERO,
         )),
+        corpus_locks: Default::default(),
     };
     let translated = index(&core, &artifacts).await;
 


### PR DESCRIPTION
## Why

On 2026-08-12 one document took three and a half hours to segment. Thirty-three of its thirty-four windows parsed on the first try; window 3 needed twelve, because its reply carried a duplicate JSON key. One job covered the whole corpus, so that one window consumed the document's entire attempt budget, and the pass stopped at the failure rather than continuing past it. Windows 4–33 were not attempted during any of those twelve rounds — the journal shows them starting seconds after window 3 finally parsed.

Two smaller faults compounded it. `enqueue_after` re-arms the existing row, so the failing corpus kept its original row id and reclaimed the front of a strictly id-ordered queue every time its backoff expired. And several of those attempts cost nothing at all: the endpoint replayed cached completions — identical token counts, identical parser errors at identical byte offsets, 678 tokens "generated" in 33 ms — so the retry could not have produced a different answer.

## What changed

A job is now one inference call.

| | before | after |
|---|---|---|
| synthesis | 1 job / document, 34 windows sharing one budget | 1 job / window |
| naming | inline, inside whichever window finished last | its own unit |
| embedding | 9 calls in one job | 1 batch per unit, re-arming |
| judging | up to 20 calls in one sweep | 1 unit per pair; the sweep makes none |
| pacing | per-role, synthesis only | one gate in front of every call |
| `ask` | queued behind background work | priority lane, ignores the cooldown |

The two stages that make no inference call — planning a document into windows, and the consolidation sweep — became local work that *arms* units. `seq` records a unit's position within the batch it was armed with, so claiming interleaves whole documents: every document's first window runs before any document's second.

The incident is now a test. `a_poisoned_window_does_not_stop_another_document` ingests two documents, poisons one window of the first, and asserts the second still reaches `ready`. It could not have passed before this branch.

## The settling rule, which is the subtle part

Engram never abandons work, so a window the model will not read stays claimable forever. That means "every window is done" can never be the condition for finishing a document, or the thirty-three windows that came back perfectly would never be embedded and the corpus would sit in `segmenting` for good.

A window counts as resolved when it is **done, or failed with its attempts spent**. The corpus settles around it and reports `partial`. If it later succeeds, settling runs again — which is why every step of `finish` had to already be idempotent.

## Migration

**The spec was wrong about this and it would have taken the deployment down on startup.** `CREATE TABLE IF NOT EXISTS` is a no-op against an existing table, so `seq` would never have reached a running database — and `migrate()`'s own column check would then have refused to start, asking an operator to recreate a knowledge base to gain a column with a default.

`migrate()` now carries a short list of columns that arrived after their table was deployed, appended with `ALTER TABLE`. The ordering matters and cost a test failure to find: the appends must run **before** `schema.sql`, because the file builds an index over `seq` and an index cannot name a column that is not there yet.

Verified against a copy of the production database: migrate succeeds, the column lands with existing rows defaulting to 0, the claim uses the new index as a **covering index with no temp B-tree**, and a second connect changes nothing. No manual SQL, no data migration — build and restart.

## One deliberate behaviour change

The judge sweep used to stop after the first transport failure. That guard moved to the circuit breaker on the gate, which trips at three consecutive transport failures and covers embedding and synthesis too, rather than only that loop. A dead endpoint therefore costs up to three wasted judge calls instead of one, bought in exchange for the same protection everywhere else. Unreadable model output deliberately does **not** trip it: the endpoint answered, and the window's text is the problem.

## Measured, and it changed the design

Document affinity was considered and dropped. The 653-token system prompt is identical for every synthesize call in the application and stays warm under any ordering; affinity protects only the 200-token document opening — 6% of a prefill on a call that is decode-bound at 20–73 seconds. It would have complicated the scheduler most and bought least.

## Still open

- **Window size** (spec §10) — every structural failure in that journal is a long-output failure. Left to measurement against recorded baselines (coverage 0.5539, literal-flag rate 8/277) rather than argument. Nothing here depends on the answer.
- **Retry caching and duplicate JSON keys** (spec §11) — deferred by decision. They are why window 3 needed twelve attempts rather than two. This branch makes that failure cheap for the *document*; it does not make it cheap for the window.

## Testing

636 tests passing, clippy silent, fmt clean. Ten tests were deleted whose premises — a shared attempt budget, a pass that steps over windows, a per-role cooldown — describe a system that no longer exists; what replaces them asserts the same properties one level down, where they are now true.

Spec: `docs/superpowers/specs/2026-08-13-independently-schedulable-inference-design.md`
Plan: `docs/superpowers/plans/2026-08-13-independently-schedulable-inference.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFQDg8mfkioRcictepwY8
