### PR TITLE
Duplicates find each other, and settle themselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.db
 *.db-wal
 *.db-shm
+# A copy kept aside before a schema change is still the knowledge base, and
+# `*.db` does not cover a suffixed name. One such file reached this repository
+# once; the pattern is here so the next one cannot.
+*.db.*
 
 # Evaluation corpus. Whatever documents the operator actually wants to search,
 # and never publishable by default — the harness reads it from ENGRAM_EVAL_DIR,

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ the file — the loader warns if it finds one.
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`. |
 | `infer.ask.*` | Completion model, used only by `ask`. Same timeout and reasoning keys. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
-| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `autonomous`, `max_judgements`. |
+| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `autonomous`, `max_judgements`, `merge_max_roots`. |
 | `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. Off by default. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails` / `allowed_groups`. |

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ the file — the loader warns if it finds one.
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`. |
 | `infer.ask.*` | Completion model, used only by `ask`. Same timeout and reasoning keys. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
-| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `autonomous`, `max_judgements`, `merge_max_roots`. |
+| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `autonomous`, `dedupe_interval_mins`, `max_dedupe_per_tick`, `merge_max_roots`. |
 | `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. Off by default. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails` / `allowed_groups`. |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ stand on its own, with a title, a category and tags. Artifacts are what gets
 embedded, ranked, read and edited. One call turns one segment into several
 artifacts; no artifact spans two segments.
 
+Most artifacts are *captured* — written from one segment of one corpus, with the
+lines they came from shown beside them. A few are *merged*: written by
+consolidation out of two or more captured artifacts that said the same thing,
+and listing what they were written from instead of corpus lines. The originals
+are hidden rather than deleted, one button restores them, and no merge is
+written that would drop a number, command or path any of its sources carried.
+Consolidation prefers to keep an original wherever one will do, so merging is
+what happens when neither artifact alone was sufficient.
+
 ## Asking for something
 
 Type the situation, not the keywords. The query is embedded whole and matched

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ the file — the loader warns if it finds one.
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`. |
 | `infer.ask.*` | Completion model, used only by `ask`. Same timeout and reasoning keys. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
-| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `judge`, `max_judgements`. |
+| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `sample`, `per_point`, `interval_hours`, `autonomous`, `max_judgements`. |
 | `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. Off by default. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails` / `allowed_groups`. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,8 +21,18 @@ means making the background job do more, never adding a model call to the query
 path.
 
 **Fidelity outranks convenience.** Retrieval returns the exact source artifact.
-A paraphrase or a synthetic summary must never silently replace or outrank the
+A paraphrase or a synthetic summary must never *silently* replace or outrank the
 original wording — that is the one failure mode this design exists to avoid.
+
+Consolidation may write a merged artifact out of several others, and the word
+doing the work above is "silently". Four conditions make it an application of
+this principle rather than an exception to it: superseding is preferred wherever
+one stored original suffices, so most groups produce no synthetic text at all; a
+merged artifact is a distinct provenance kind that names what it was written
+from; the originals are superseded rather than deleted, still stored and one
+button from restored; and no merge may drop a value, command or path any source
+carried. A disagreement about a value is never settled this way — it goes to a
+person. See `docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md`.
 
 **Lean beats clever.** Anything that adds a storage tier, a model dependency or
 a layer crossing without a measured retrieval gain does not go in.
@@ -85,12 +95,24 @@ to the query path.
   loses to C, leaving A pointing at something hidden. Between `review_min`
   (0.88) and that, the pair goes on the `artifact_pairs` queue instead — 0.88 is
   where two genuinely distinct artifacts about one subsystem routinely sit.
-  The staleness half is the opt-in `consolidate.judge`: queued pairs are
-  filtered on fact-shaped tokens (`src/infer/facts.rs`) with no inference at
-  all, and only a pair whose values actually differ reaches the model, which is
-  asked one yes/no question under a per-sweep budget. Nothing is ever merged or
-  deleted, and which of two contradictory artifacts is current stays the
-  reader's judgement.
+  Which of two contradictory artifacts is current stays the reader's judgement.
+- ~~**Autonomous consolidation.**~~ Done — detection no longer samples: a
+  `Stage::Relate` unit asks each artifact for its own neighbours when it is
+  embedded (`VectorStore::neighbours`, one query, no embedding call), so
+  coverage is complete regardless of how large the base has grown. The sampled
+  sweep kept needing both members of a pair in one draw, a probability decaying
+  as (sample/N)² — years per pair at a hundred thousand artifacts.
+  `Stage::Dedupe` then settles a whole connected component in one call, with
+  four verdicts: distinct, conflict, replaced, duplicate. `replaced` is
+  preferred wherever it applies, because the survivor is then a stored original
+  with a valid span. `duplicate` writes a merged artifact — a distinct
+  `provenance` kind naming its sources through `artifact_sources` — and
+  supersedes what it replaced; a re-merge is always written from the captured
+  roots, so information loss stays one generation deep however often a group is
+  merged. Two free checks refuse any merge that would drop a value or a literal
+  (`jobs::merge::losses`). A value conflict is escalated to a person and never
+  merged, and every merge is undoable. See
+  `docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md`.
 - **Caveats on artifacts.** Done as part of the above, and worth naming
   separately: the synthesis call now also returns the conditions under which an
   artifact does not apply. It costs output tokens on a call already being made,

--- a/config.example.toml
+++ b/config.example.toml
@@ -181,10 +181,19 @@ interval_hours = 24
 # conflicts queue on Ops, because deciding which of two facts is current is the
 # judgement a model is worst at.
 autonomous = false
-max_judgements = 20
+# How often the dedupe pass arms model calls, and how many per tick. Together
+# these are a rate — twenty an hour by default — and a rate is the right shape
+# because the fixed quantity is what the hardware gets through, not how big the
+# knowledge base has grown. The old per-sweep ceiling was a queue that only grew.
+#
+# Set max_dedupe_per_tick = 0 to switch the model off entirely. Duplicates are
+# still found, recorded and clustered, all of which costs no inference; nothing
+# is ever asked about.
+dedupe_interval_mins = 15
+max_dedupe_per_tick = 5
 # How many captured artifacts one merged artifact may be written from. Above
-# this the group is surfaced on Ops instead of merged: a merge of forty sources
-# stops being one atomic piece of knowledge, which is what an artifact is.
+# this the group is surfaced for a person instead of merged: a merge of forty
+# sources stops being one atomic piece of knowledge, which is what an artifact is.
 merge_max_roots = 8
 
 # Recording real searches so they can be judged later, and turned into the

--- a/config.example.toml
+++ b/config.example.toml
@@ -182,6 +182,10 @@ interval_hours = 24
 # judgement a model is worst at.
 autonomous = false
 max_judgements = 20
+# How many captured artifacts one merged artifact may be written from. Above
+# this the group is surfaced on Ops instead of merged: a merge of forty sources
+# stops being one atomic piece of knowledge, which is what an artifact is.
+merge_max_roots = 8
 
 # Recording real searches so they can be judged later, and turned into the
 # query/artifact pairs the evaluation harness scores against. Off by default: a

--- a/config.example.toml
+++ b/config.example.toml
@@ -173,14 +173,17 @@ per_point = 5
 interval_hours = 24
 # Let the dedupe pass act on what it decides: superseding where one stored
 # artifact plainly replaces another, and writing one merged artifact where each
-# side carries something the other lacks. Off by default for now — the verdicts
-# are recorded either way, so the queue can be read before the system is allowed
-# to act on it.
+# side carries something the other lacks. On by default.
 #
-# A disagreement about a value is never settled this way. It goes to the
-# conflicts queue on Ops, because deciding which of two facts is current is the
-# judgement a model is worst at.
-autonomous = false
+# Turning it off does not stop the pass asking — the verdicts are recorded
+# either way, so you can read what it would have done before letting it do it.
+# `max_dedupe_per_tick = 0` is what switches the model off entirely.
+#
+# A disagreement about a value is never settled this way. It goes to the review
+# queue on Capture, because deciding which of two facts is current is the
+# judgement a model is worst at. Nothing is deleted, no merge that would drop a
+# number, command or path is written, and every merge has an undo on Ops.
+autonomous = true
 # How often the dedupe pass arms model calls, and how many per tick. Together
 # these are a rate — twenty an hour by default — and a rate is the right shape
 # because the fixed quantity is what the hardware gets through, not how big the

--- a/config.example.toml
+++ b/config.example.toml
@@ -171,10 +171,16 @@ auto_supersede = 0.95
 sample = 2000
 per_point = 5
 interval_hours = 24
-# Ask the completion model whether a queued pair actually disagrees. Off by
-# default: it is the only part of consolidation that costs inference, and it
-# only ever sees pairs whose numbers, versions or dates already differ.
-judge = false
+# Let the dedupe pass act on what it decides: superseding where one stored
+# artifact plainly replaces another, and writing one merged artifact where each
+# side carries something the other lacks. Off by default for now — the verdicts
+# are recorded either way, so the queue can be read before the system is allowed
+# to act on it.
+#
+# A disagreement about a value is never settled this way. It goes to the
+# conflicts queue on Ops, because deciding which of two facts is current is the
+# judgement a model is worst at.
+autonomous = false
 max_judgements = 20
 
 # Recording real searches so they can be judged later, and turned into the

--- a/docs/superpowers/plans/2026-08-14-autonomous-consolidation.md
+++ b/docs/superpowers/plans/2026-08-14-autonomous-consolidation.md
@@ -1,0 +1,3483 @@
+# Autonomous Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Duplicate hygiene detects, judges and settles near-duplicate artifacts without an operator, on a base that grows, while every decision stays reversible and no stored value is ever lost.
+
+**Architecture:** Detection moves from a sampled sweep to a per-artifact `Relate` unit armed when an artifact finishes embedding, which makes coverage complete instead of probabilistic. A `Dedupe` unit then settles a whole connected component of pending pairs in one model call, choosing between four verdicts; `duplicate` writes a new artifact with `provenance = 'merged'` and explicit lineage rows, superseding its roots. Two local verification passes refuse any merge that would drop a fact token or a literal. Value conflicts are escalated to a person and never merged.
+
+**Tech Stack:** Rust, `sqlx` (SQLite), Qdrant REST, `tokio`, `serde_json`, `tracing`. Tests are `#[tokio::test]` in-module, using `crate::core::test_support::test_core()`, `Store::memory()`, and `crate::infer::fake::ScriptedCompleter`.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md`
+
+## Global Constraints
+
+- **SQLite is the source of truth.** Qdrant is derived. Every lifecycle change writes SQLite first, then the payload. Never the reverse.
+- **`src/store/schema.sql` is applied on every connect and cannot alter a table.** `migrate` parses **one column per line** and checks the columns back against the database. Keep one column per line. Changing `corpus_id` to nullable requires recreating the database (`schema.sql:9–12`).
+- **A model call is the scarcest resource in the system.** No code path may spend one where a local rule already answers the question. Pairs at or above `auto_supersede` must never reach a `Dedupe` unit.
+- **No artifact text is ever rewritten in place, and nothing is ever deleted on a similarity score.** Merging writes a *new* artifact and supersedes the originals.
+- **A value conflict is never settled autonomously.** It becomes `PairState::Contradiction` and goes to Ops.
+- **Test names are sentences** and carry the bug they pin in a comment above the assertions. Follow the existing style in `src/jobs/consolidate.rs`.
+- **Every commit message ends with** `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.
+- Run the full suite with `cargo test` before each commit; run a single test with `cargo test <test_name>`.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/store/schema.sql` | whole schema | Modify: `provenance`, `lifecycle_dirty`, nullable `corpus_id`, `artifact_sources` |
+| `src/store/artifacts.rs` | artifact rows | Modify: `Provenance`, `Chunk.provenance`, `insert_merged_artifact`, dirty marking |
+| `src/store/lineage.rs` | `artifact_sources` reads/writes | **Create** |
+| `src/store/pairs.rs` | review queue | Modify: `NearIdentical`, `Oversized`, component expansion |
+| `src/jobs/classify.rs` | the one place a scored pair is turned into a pair row | **Create** |
+| `src/jobs/relate.rs` | per-artifact neighbour discovery | **Create** |
+| `src/jobs/dedupe.rs` | one component, one call, one verdict | **Create** (replaces `judge.rs`) |
+| `src/jobs/merge.rs` | writing and undoing a merge | **Create** |
+| `src/jobs/consolidate.rs` | the sweep: backlog, backstop, clustering, repairs | Modify |
+| `src/infer/prompt.rs` | prompts and parsers | Modify: `DEDUPE_SYSTEM`, `dedupe_prompt`, `parse_dedupe` |
+| `src/infer/verify.rs` | literal checks | Reused unmodified; new caller |
+| `src/config.rs` | `ConsolidateConfig` | Modify |
+| `src/core/background.rs` | tickers | Modify: `spawn_dedupe_ticker` |
+| `src/web/ui.rs` | Ops and detail pane | Modify |
+| `tests/eval.rs` | retrieval scoring | Modify |
+
+`judge.rs`, `relate.rs`, `dedupe.rs`, `merge.rs` and `classify.rs` are split by responsibility rather than folded into `consolidate.rs`, which is already 1745 lines. Each is one unit of the pipeline with one entry point.
+
+---
+
+## Phase 1 — Schema and data model
+
+### Task 1: Artifacts gain a provenance kind
+
+**Files:**
+- Modify: `src/store/schema.sql:54-85`
+- Modify: `src/store/artifacts.rs:34-103` (`Provenance`, `Chunk`), `:171` (`insert_artifacts`), `row_to_artifact`
+- Modify: `src/vector/mod.rs` (`VectorPayload`), `src/vector/qdrant.rs`, `src/vector/memory.rs`, `src/jobs/embed.rs` (`payload_of`)
+- Test: `src/store/artifacts.rs` (in-module `mod tests`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Provenance::{Captured, Merged}` with `as_str(&self) -> &'static str` and `parse(s: &str) -> Provenance`; `Chunk.provenance: Provenance`; `Chunk.corpus_id: Option<String>`; `VectorPayload.provenance: Option<String>`.
+
+**Note on `corpus_id`.** It becomes `Option<String>` on `Chunk`. Every existing reader of `chunk.corpus_id` must be updated; there are roughly two dozen. `VectorPayload.corpus_id` stays `String` and carries `""` for a merged artifact, because making it optional ripples through search filters for no gain — a corpus filter genuinely should not match an artifact that belongs to no corpus. `restore_artifact` reads `provenance` from the payload to decide whether `""` means "merged" or is a bug.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/store/artifacts.rs`, inside `mod tests`:
+
+```rust
+#[tokio::test]
+async fn a_captured_artifact_is_captured_and_names_its_corpus() {
+    // `provenance` is the discriminator every consumer branches on, never
+    // `corpus_id IS NULL`. A null is an absence; a kind is an assertion, and
+    // the failure modes merging can produce want to hang off an assertion.
+    let s = Store::memory().await.unwrap();
+    let src = s.insert_corpus("x", "web", None).await.unwrap();
+    let made = s
+        .insert_artifacts(
+            &src.id,
+            &[NewArtifact {
+                ordinal: 0,
+                text: "one".into(),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            }],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(made[0].provenance, Provenance::Captured);
+    assert_eq!(made[0].corpus_id.as_deref(), Some(src.id.as_str()));
+
+    let read = s.get_artifact(&made[0].id).await.unwrap();
+    assert_eq!(read.provenance, Provenance::Captured);
+    assert_eq!(read.corpus_id.as_deref(), Some(src.id.as_str()));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test a_captured_artifact_is_captured_and_names_its_corpus`
+Expected: FAIL — `Provenance` not found, `corpus_id` type mismatch.
+
+- [ ] **Step 3: Add the schema columns**
+
+In `src/store/schema.sql`, change the `artifacts` table. One column per line — `migrate` parses it that way:
+
+```sql
+CREATE TABLE IF NOT EXISTS artifacts (
+  id               TEXT PRIMARY KEY,
+  -- NULL for a merged artifact, which belongs to no single corpus. Claiming a
+  -- corpus it did not come from would put wrong lines beside it in the detail
+  -- pane, which is the specific dishonesty merging must not commit.
+  corpus_id        TEXT REFERENCES corpora(id) ON DELETE CASCADE,
+  -- 'captured' | 'merged'. The discriminator every consumer branches on.
+  provenance       TEXT NOT NULL DEFAULT 'captured',
+  -- Set in the same SQLite write that changes status/superseded_by, cleared
+  -- once the payload write is acknowledged. The lifecycle repair reads this
+  -- instead of scanning, so its cost is the open writes and not the (forever
+  -- growing) set of hidden artifacts.
+  lifecycle_dirty  INTEGER NOT NULL DEFAULT 0,
+  ordinal          INTEGER NOT NULL,
+  text             TEXT NOT NULL,
+  ...
+);
+CREATE INDEX IF NOT EXISTS idx_artifacts_dirty ON artifacts(lifecycle_dirty) WHERE lifecycle_dirty = 1;
+```
+
+Leave every other column exactly as it is.
+
+- [ ] **Step 4: Add the Rust type**
+
+In `src/store/artifacts.rs`, beside `ArtifactStatus`:
+
+```rust
+/// Where an artifact's text came from.
+///
+/// `Captured` text was written by synthesis over one window of one corpus, so
+/// it has a span, a segment, and corpus lines to render beside it. `Merged`
+/// text was written by the dedupe pass out of two or more captured artifacts;
+/// it has no corpus and no span, and names its roots through
+/// `artifact_sources` instead. Nothing may treat the two alike — see
+/// `verify`, which cannot check a merged artifact against a segment that does
+/// not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+    Captured,
+    Merged,
+}
+
+impl Provenance {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Provenance::Captured => "captured",
+            Provenance::Merged => "merged",
+        }
+    }
+    pub fn parse(s: &str) -> Provenance {
+        match s {
+            "merged" => Provenance::Merged,
+            _ => Provenance::Captured,
+        }
+    }
+}
+```
+
+Change `Chunk`:
+
+```rust
+pub struct Chunk {
+    pub id: String,
+    /// `None` for a merged artifact. See `Provenance`.
+    pub corpus_id: Option<String>,
+    pub provenance: Provenance,
+    ...
+}
+```
+
+In `row_to_artifact`, read both: `corpus_id: r.get("corpus_id")` (sqlx maps a nullable TEXT to `Option<String>`) and `provenance: Provenance::parse(r.get::<String, _>("provenance").as_str())`.
+
+In `insert_artifacts`, set `corpus_id: Some(corpus_id.to_string())`, `provenance: Provenance::Captured`, and add `provenance` to the INSERT column list bound to `"captured"`.
+
+- [ ] **Step 5: Update every reader of `corpus_id`**
+
+Run `cargo build` and fix each error. The mechanical fix is `.as_deref()` or `.clone().unwrap_or_default()` at the call site. Two need judgement:
+
+- `src/jobs/embed.rs`'s `payload_of`: `corpus_id: c.corpus_id.clone().unwrap_or_default()` and add `provenance: Some(c.provenance.as_str().to_string())`.
+- `src/store/artifacts.rs`'s `restore_artifact`: when the payload says `provenance == "merged"`, write `corpus_id` as NULL rather than `""`.
+
+Add `provenance: Option<String>` to `VectorPayload` in `src/vector/mod.rs`, defaulting to `None`, and carry it through `src/vector/qdrant.rs` and `src/vector/memory.rs` beside the existing `status` field.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS, including `a_captured_artifact_is_captured_and_names_its_corpus`. The database must be recreated first: `rm -f engram.db`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/schema.sql src/store/artifacts.rs src/vector/ src/jobs/embed.rs
+git commit -m "feat(store): artifacts carry a provenance kind
+
+A merged artifact belongs to no corpus, so corpus_id becomes nullable and
+provenance says which kind a row is. Consumers branch on the kind rather
+than on the null: an absence is not an assertion, and the failure modes
+merging can produce need one.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Lineage, stored as the transitive closure
+
+**Files:**
+- Modify: `src/store/schema.sql` (append after `artifacts`)
+- Create: `src/store/lineage.rs`
+- Modify: `src/store/mod.rs` (add `pub mod lineage;`)
+- Test: `src/store/lineage.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `Provenance` from Task 1.
+- Produces on `Store`:
+  - `record_lineage(&self, child_id: &str, roots: &[(String, String)]) -> Result<()>` — pairs are `(root_id, via_id)`.
+  - `roots_of(&self, artifact_ids: &[String]) -> Result<BTreeMap<String, Vec<String>>>` — for a captured artifact the answer is itself; for a merged one, its stored roots. Keyed by the input id.
+  - `merged_with_active_roots(&self, limit: i64) -> Result<Vec<String>>` — merged artifact ids at least one of whose roots is still `active`.
+  - `children_of_root(&self, root_id: &str) -> Result<Vec<String>>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/store/lineage.rs`:
+
+```rust
+//! Which captured artifacts a merged artifact is made of.
+//!
+//! Stored as the resolved closure rather than as parent edges. The re-merge
+//! rule in the dedupe pass needs the *captured* roots of every candidate on
+//! every decision, and walking edges with a recursive CTE would put a graph
+//! traversal on the sweep's hot path. The fan-in cap bounds how much this
+//! duplicates.
+//!
+//! The cost of the denormalisation is that a deleted root removes closure rows
+//! an edge table could have recomputed. `merge.rs` flags the child rather than
+//! pretending the source was never there.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+use std::collections::BTreeMap;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use crate::store::artifacts::{NewArtifact, Provenance};
+
+    async fn three(s: &Store) -> (String, String, String) {
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..3)
+            .map(|i| NewArtifact {
+                ordinal: i,
+                text: format!("artifact {i}"),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        let made = s.insert_artifacts(&src.id, &new).await.unwrap();
+        (made[0].id.clone(), made[1].id.clone(), made[2].id.clone())
+    }
+
+    #[tokio::test]
+    async fn a_captured_artifact_is_its_own_root() {
+        // The dedupe pass asks for the roots of every component member without
+        // caring which kind it is. Answering "none" for a captured artifact
+        // would silently drop it from the prompt it is supposed to be in.
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let roots = s.roots_of(&[a.clone(), b.clone()]).await.unwrap();
+        assert_eq!(roots[&a], vec![a.clone()]);
+        assert_eq!(roots[&b], vec![b.clone()]);
+    }
+
+    #[tokio::test]
+    async fn a_merged_artifact_resolves_to_its_captured_roots() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m = s
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    text: "both".into(),
+                    title: Some("both".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[a.clone(), b.clone()],
+            )
+            .await
+            .unwrap();
+
+        let roots = s.roots_of(std::slice::from_ref(&m.id)).await.unwrap();
+        let mut got = roots[&m.id].clone();
+        got.sort();
+        let mut want = vec![a, b];
+        want.sort();
+        assert_eq!(got, want);
+        assert_eq!(m.provenance, Provenance::Merged);
+        assert_eq!(m.corpus_id, None);
+    }
+
+    #[tokio::test]
+    async fn deleting_a_root_takes_its_lineage_rows_with_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m = s
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    text: "both".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[a.clone(), b.clone()],
+            )
+            .await
+            .unwrap();
+
+        s.delete_artifact(&a).await.unwrap();
+        let roots = s.roots_of(std::slice::from_ref(&m.id)).await.unwrap();
+        assert_eq!(roots[&m.id], vec![b], "the cascade left a dangling root");
+    }
+
+    #[tokio::test]
+    async fn a_merge_whose_roots_are_still_active_is_findable() {
+        // The write path embeds a merged artifact before superseding its
+        // roots, so a crash in between leaves exactly this state. Nothing else
+        // in the system would ever notice it.
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m = s
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    text: "both".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[a.clone(), b.clone()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(s.merged_with_active_roots(10).await.unwrap(), vec![m.id.clone()]);
+
+        s.set_superseded_by(&a, Some(&m.id)).await.unwrap();
+        s.set_superseded_by(&b, Some(&m.id)).await.unwrap();
+        assert!(
+            s.merged_with_active_roots(10).await.unwrap().is_empty(),
+            "a finished merge is still reported as unfinished"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib lineage`
+Expected: FAIL — `roots_of` and `insert_merged_artifact` do not exist.
+
+- [ ] **Step 3: Add the table**
+
+In `src/store/schema.sql`, after the `artifacts` indexes:
+
+```sql
+-- ── Lineage ──────────────────────────────────────────────────────────────────
+-- What a merged artifact is made of, as resolved captured roots rather than as
+-- parent edges. `root_id` always names a `provenance = 'captured'` artifact, so
+-- a re-merge reads the leaves in one query and never rewrites from text that
+-- was itself written by a model.
+CREATE TABLE IF NOT EXISTS artifact_sources (
+  child_id   TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  root_id    TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- The direct parent through which root_id entered this child; equal to
+  -- root_id for a first-generation merge. Rendering only. SET NULL because a
+  -- deleted intermediate does not invalidate the root relationship.
+  via_id     TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (child_id, root_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sources_root ON artifact_sources(root_id);
+```
+
+- [ ] **Step 4: Implement `NewMerged` and `insert_merged_artifact`**
+
+In `src/store/artifacts.rs`:
+
+```rust
+/// A merged artifact being created. Deliberately not `NewArtifact`: there is no
+/// corpus, no span, no segment and no ordinal within a document, and a struct
+/// that carries those fields as `None` invites a caller to fill them in.
+#[derive(Debug, Clone)]
+pub struct NewMerged {
+    pub text: String,
+    pub title: Option<String>,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub caveats: Vec<String>,
+}
+
+impl Store {
+    /// Write a merged artifact and its lineage in one transaction.
+    ///
+    /// One transaction because an artifact with no lineage rows is one whose
+    /// detail pane can render nothing and whose roots nobody can recover — and
+    /// the re-merge rule reads exactly those rows. Splitting the two writes
+    /// makes that state reachable by a crash.
+    ///
+    /// `roots` may name merged artifacts; they are flattened to their own
+    /// captured roots here, so `artifact_sources.root_id` is only ever
+    /// captured.
+    pub async fn insert_merged_artifact(
+        &self,
+        new: &NewMerged,
+        roots: &[String],
+    ) -> Result<Chunk> {
+        let resolved = self.roots_of(roots).await?;
+        let mut tx = self.pool.begin().await?;
+        let created_at = now();
+        let c = Chunk {
+            id: new_id(),
+            corpus_id: None,
+            provenance: Provenance::Merged,
+            ordinal: 0,
+            text: new.text.clone(),
+            corpus_span: None,
+            title: new.title.clone(),
+            category: new.category.clone(),
+            tags: new.tags.clone(),
+            embed_state: EmbedState::Pending,
+            embed_model: None,
+            created_at,
+            embed_rev: 0,
+            segment_idx: None,
+            flags: vec![],
+            flag_detail: None,
+            superseded_by: None,
+            caveats: new.caveats.clone(),
+            status: ArtifactStatus::Active,
+            last_verified_at: Some(created_at),
+        };
+        sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
+             VALUES (?, NULL, 'merged', 0, ?, NULL, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)",
+        )
+        .bind(&c.id)
+        .bind(&c.text)
+        .bind(&c.title)
+        .bind(&c.category)
+        .bind(serde_json::to_string(&c.tags).unwrap())
+        .bind(c.embed_state.as_str())
+        .bind(c.created_at)
+        .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
+        .bind(c.status.as_str())
+        .bind(c.last_verified_at)
+        .execute(&mut *tx)
+        .await?;
+
+        for (via, roots) in &resolved {
+            for root in roots {
+                sqlx::query(
+                    "INSERT OR IGNORE INTO artifact_sources (child_id, root_id, via_id, created_at)
+                     VALUES (?, ?, ?, ?)",
+                )
+                .bind(&c.id)
+                .bind(root)
+                .bind(via)
+                .bind(created_at)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(c)
+    }
+}
+```
+
+- [ ] **Step 5: Implement the lineage reads**
+
+In `src/store/lineage.rs`, above the tests:
+
+```rust
+impl Store {
+    /// The captured roots of each of `artifact_ids`, keyed by the input id.
+    ///
+    /// A captured artifact is its own root. A merged one resolves through
+    /// `artifact_sources`, which already holds the closure, so this is one
+    /// query and not a traversal.
+    pub async fn roots_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<BTreeMap<String, Vec<String>>> {
+        let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for id in artifact_ids {
+            let rows = sqlx::query(
+                "SELECT root_id FROM artifact_sources WHERE child_id = ? ORDER BY root_id",
+            )
+            .bind(id)
+            .fetch_all(&self.pool)
+            .await?;
+            let roots: Vec<String> = rows.iter().map(|r| r.get("root_id")).collect();
+            // No lineage rows means this is a captured artifact — or a merged
+            // one every root of which has since been deleted, which
+            // `merge::flag_orphans` is what notices.
+            out.insert(id.clone(), if roots.is_empty() { vec![id.clone()] } else { roots });
+        }
+        Ok(out)
+    }
+
+    /// Merged artifacts at least one of whose roots is still active.
+    ///
+    /// The write path embeds a merged artifact before superseding its roots, so
+    /// this is the state a crash between those two steps leaves. It is
+    /// invisible to everything else: the merge looks complete from the artifact
+    /// side and absent from the pair side.
+    pub async fn merged_with_active_roots(&self, limit: i64) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT DISTINCT s.child_id FROM artifact_sources s
+               JOIN artifacts child ON child.id = s.child_id
+               JOIN artifacts root  ON root.id  = s.root_id
+              WHERE child.provenance = 'merged'
+                AND child.status = 'active'
+                AND root.status = 'active'
+                AND root.superseded_by IS NULL
+              LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("child_id")).collect())
+    }
+
+    pub async fn children_of_root(&self, root_id: &str) -> Result<Vec<String>> {
+        let rows = sqlx::query("SELECT child_id FROM artifact_sources WHERE root_id = ?")
+            .bind(root_id)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(|r| r.get("child_id")).collect())
+    }
+}
+```
+
+Add `pub mod lineage;` to `src/store/mod.rs`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib lineage && cargo test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/schema.sql src/store/lineage.rs src/store/mod.rs src/store/artifacts.rs
+git commit -m "feat(store): lineage for merged artifacts
+
+artifact_sources holds resolved captured roots rather than parent edges.
+The re-merge rule needs the leaves on every decision, and a recursive CTE
+would put a graph walk on the sweep's hot path; the fan-in cap bounds the
+duplication that buys.
+
+insert_merged_artifact writes the artifact and its lineage in one
+transaction: a merged artifact with no roots is one whose detail pane can
+render nothing and whose sources nobody can recover.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 2 — Detection and lifecycle repair
+
+### Task 3: Two new pair states
+
+**Files:**
+- Modify: `src/store/pairs.rs:27-64` (`PairState`), `:259` (`pairs_to_judge`)
+- Test: `src/store/pairs.rs` (in-module)
+
+**Interfaces:**
+- Produces: `PairState::NearIdentical`, `PairState::Oversized`; `Store::pairs_by_state` and `count_pairs_by_state` accept both.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_near_identical_pair_is_never_offered_to_the_model() {
+    // The >= auto_supersede band is settled for free by clustering. A pair
+    // filed there that reached the dedupe queue would spend a model call on
+    // exactly the case where the cheap rule is already correct — the free path
+    // quietly becoming a paid one, which is the expensive regression.
+    let s = Store::memory().await.unwrap();
+    let (a, b) = two_artifacts(&s).await;
+    s.record_settled_pair(&a, &b, 0.99, PairState::NearIdentical)
+        .await
+        .unwrap();
+
+    assert!(s.pairs_to_judge(10).await.unwrap().is_empty());
+    assert_eq!(
+        s.pairs_by_state(PairState::NearIdentical, 10).await.unwrap().len(),
+        1
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test a_near_identical_pair_is_never_offered_to_the_model`
+Expected: FAIL — no variant `NearIdentical`.
+
+- [ ] **Step 3: Add the variants**
+
+```rust
+pub enum PairState {
+    Pending,
+    NoConflict,
+    Contradiction,
+    Superseded,
+    Dismissed,
+    /// Scored at or above `auto_supersede`. Settled by the sweep's free
+    /// clustering pass, and never armed for a model call: that band is
+    /// answered correctly by a rule that costs nothing.
+    NearIdentical,
+    /// The component this pair belongs to has more captured roots than
+    /// `merge_max_roots`. Not merged — a merge of forty roots is no longer one
+    /// atomic piece of knowledge, which is what an artifact is defined to be.
+    Oversized,
+}
+```
+
+Extend `as_str` with `"near_identical"` and `"oversized"`, and `parse` with the two matching arms. `pairs_to_judge` already filters `state = 'pending'`, so no change is needed there — but add the assertion above to prove it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib pairs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/pairs.rs
+git commit -m "feat(store): NearIdentical and Oversized pair states
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: One place that classifies a scored pair
+
+**Files:**
+- Create: `src/jobs/classify.rs`
+- Modify: `src/jobs/consolidate.rs:317-419` (delete the inline body, call the new function), `src/jobs/mod.rs`
+- Test: `src/jobs/classify.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `PairState` (Task 3), `Chunk`, `Provenance` (Task 1).
+- Produces: `pub async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<Verdict>` where
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Nothing was written: one side is not active, or the two are the same
+    /// artifact.
+    Skipped,
+    /// Filed at or above `auto_supersede` for the sweep's clustering pass.
+    NearIdentical,
+    /// One text is wholly inside the other and both came from one corpus.
+    /// Superseded here, with no call and no queue slot.
+    Contained,
+    /// Filed as `Pending` — a dedupe unit will decide.
+    Queued,
+    /// Already on the queue, or already answered. Nothing changed.
+    Unchanged,
+}
+```
+
+Also `pub fn contains_normalized(long: &str, short: &str) -> bool`, moved here from `consolidate.rs:77`.
+
+**Why this task exists.** Detection gains a second producer in Task 5. Two discovery paths with two copies of these rules is the kind of divergence you only notice when the outcome starts depending on which path saw a pair first.
+
+**Behaviour change from today.** The `may_disagree` gate is *removed* from this function. Under the old contract a pair with no differing values was filed `NoConflict` and both artifacts stayed active; under the new one it is the cleanest merge candidate and must reach the model. See spec §6.5.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/jobs/classify.rs` with the module doc and this test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::pairs::PairState;
+
+    // Reuses the `seed` helper from consolidate.rs's tests, made
+    // `pub(crate)` in this task.
+    use crate::jobs::consolidate::tests::seed;
+
+    #[tokio::test]
+    async fn a_pair_with_no_differing_values_is_queued_not_closed() {
+        // The polarity change. `may_disagree` admits a pair only when both
+        // sides state values AND those values differ, which is backwards for
+        // deduplication: the pairs it discarded are the cleanest merge
+        // candidates. Two artifacts at 0.93 saying the same thing used to be
+        // filed "nothing to decide" and both stayed in every result set.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let a = core.store.get_artifact(&ids[0]).await.unwrap();
+        let b = core.store.get_artifact(&ids[1]).await.unwrap();
+
+        assert_eq!(classify_pair(&core, &a, &b, 0.93).await.unwrap(), Verdict::Queued);
+        assert_eq!(
+            core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_at_auto_supersede_is_filed_for_the_cluster_pass() {
+        // It must not reach the dedupe queue: that band is answered by a rule
+        // that costs nothing, and a model call there is pure waste. It must
+        // also not be superseded here — pairwise resolution is what `Clusters`
+        // exists to avoid, because A loses to B and B then loses to C.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        let a = core.store.get_artifact(&ids[0]).await.unwrap();
+        let b = core.store.get_artifact(&ids[1]).await.unwrap();
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.999).await.unwrap(),
+            Verdict::NearIdentical
+        );
+        assert!(a.superseded_by.is_none() && b.superseded_by.is_none());
+        assert!(core.store.pairs_to_judge(10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_synthesis_call_emitting_a_passage_twice_resolves_itself() {
+        // Same corpus, one text wholly inside the other: a defect in one
+        // artifact rather than two sources saying different things. Nothing is
+        // lost by hiding it, and it costs no call.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Bind mounts attach a directory elsewhere. Use mount --bind.", [1.0, 0.0]),
+                ("Bind mounts attach a directory elsewhere.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let a = core.store.get_artifact(&ids[0]).await.unwrap();
+        let b = core.store.get_artifact(&ids[1]).await.unwrap();
+
+        assert_eq!(classify_pair(&core, &a, &b, 0.93).await.unwrap(), Verdict::Contained);
+        assert_eq!(
+            core.store.get_artifact(&ids[1]).await.unwrap().superseded_by.as_deref(),
+            Some(ids[0].as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_naming_a_hidden_artifact_is_skipped() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.deprecate(&ids[0]).await.unwrap();
+        let a = core.store.get_artifact(&ids[0]).await.unwrap();
+        let b = core.store.get_artifact(&ids[1]).await.unwrap();
+
+        assert_eq!(classify_pair(&core, &a, &b, 0.93).await.unwrap(), Verdict::Skipped);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib classify`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```rust
+//! Turning one scored pair into one decision.
+//!
+//! Two things discover near pairs now — the per-artifact `Relate` unit and the
+//! sweep's backlog scan — and both must reach the same conclusion about the
+//! same pair. Keeping these rules in the sweep's body meant the second producer
+//! would have arrived with a copy, and a copy diverges silently: you notice
+//! when the outcome starts depending on which path saw a pair first.
+//!
+//! Nothing here calls a model. Every rule is local, and the two that settle a
+//! pair outright — containment, and the `auto_supersede` band — are the reason
+//! most near pairs never cost anything at all.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::pairs::PairState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict { Skipped, NearIdentical, Contained, Queued, Unchanged }
+
+/// Is the whole of one artifact inside the other, whitespace aside?
+///
+/// Not a similarity — containment. A score says two texts are alike; this says
+/// one of them adds nothing.
+pub fn contains_normalized(long: &str, short: &str) -> bool {
+    let n = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+    !short.trim().is_empty() && n(long).contains(&n(short))
+}
+
+pub async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<Verdict> {
+    if a.id == b.id {
+        return Ok(Verdict::Skipped);
+    }
+    // Only two live artifacts have a question worth a queue slot, a call, or a
+    // supersede. A retired artifact must not win, and a resolved pair has
+    // nothing left to decide.
+    if [a, b].iter().any(|c| c.status != ArtifactStatus::Active || c.superseded_by.is_some()) {
+        return Ok(Verdict::Skipped);
+    }
+
+    // The free band. Filed rather than acted on: resolving pairwise leaves A
+    // pointing at a B that is itself hidden, which is what the sweep's
+    // union-find exists to prevent. The cluster pass reads these rows.
+    if score >= core.consolidate.auto_supersede {
+        let changed = core
+            .store
+            .record_settled_pair(&a.id, &b.id, score, PairState::NearIdentical)
+            .await?;
+        return Ok(if changed { Verdict::NearIdentical } else { Verdict::Unchanged });
+    }
+
+    // One synthesis call emitting the same passage twice. Same corpus is the
+    // whole of the condition: two documents that share a sentence are two
+    // sources, and hiding one of those on a 0.9 similarity is exactly what
+    // `auto_supersede` refuses to do.
+    if a.corpus_id.is_some() && a.corpus_id == b.corpus_id {
+        let (long, short) = if a.text.len() >= b.text.len() { (a, b) } else { (b, a) };
+        if contains_normalized(&long.text, &short.text) {
+            if let Err(e) = core.supersede(&short.id, &long.id).await {
+                tracing::warn!(superseded = %short.id, by = %long.id, error = %e,
+                    "could not hide a duplicated passage; it stays active");
+                return Ok(Verdict::Skipped);
+            }
+            tracing::info!(superseded = %short.id, by = %long.id,
+                "hid a passage one synthesis call emitted twice");
+            return Ok(Verdict::Contained);
+        }
+    }
+
+    // Everything else is a question for the dedupe pass. `may_disagree` used to
+    // gate this, filing a pair with no differing values as `NoConflict` — which
+    // is backwards for deduplication: those are the cleanest merge candidates.
+    // It survives as a prior in the prompt and as the input to the merge
+    // verification, not as an admission gate. See the spec, §6.5.
+    let changed = core.store.record_pair(&a.id, &b.id, score).await?;
+    Ok(if changed { Verdict::Queued } else { Verdict::Unchanged })
+}
+```
+
+- [ ] **Step 4: Rewrite the sweep's review band to call it**
+
+In `src/jobs/consolidate.rs`, replace lines 317–419 with:
+
+```rust
+    for p in pairs.iter().filter(|p| p.score < cfg.auto_supersede) {
+        if hidden.contains(&p.a) || hidden.contains(&p.b) {
+            continue;
+        }
+        let (Ok(a), Ok(b)) = (
+            core.store.get_artifact(&p.a).await,
+            core.store.get_artifact(&p.b).await,
+        ) else {
+            continue;
+        };
+        // Warn and carry on: a pair is one row about two artifacts, and a
+        // transient BUSY on it is no reason to abandon the rest of the band.
+        // The sweep re-finds the pair next run.
+        match crate::jobs::classify::classify_pair(core, &a, &b, p.score).await {
+            Ok(crate::jobs::classify::Verdict::Queued) => out.queued += 1,
+            Ok(crate::jobs::classify::Verdict::Contained) => out.superseded += 1,
+            Ok(_) => {}
+            Err(e) => tracing::warn!(a = %p.a, b = %p.b, error = %e,
+                "could not classify a pair; it will be re-examined next sweep"),
+        }
+    }
+```
+
+Delete `contains_normalized` from `consolidate.rs` (it now lives in `classify.rs`). Make the test helpers `seed` and `seed_into_new_corpus` `pub(crate)` and the test module `pub(crate) mod tests` so `classify.rs` can use them. Add `pub mod classify;` to `src/jobs/mod.rs`.
+
+- [ ] **Step 5: Rewrite the two tests the polarity change invalidates**
+
+In `src/jobs/consolidate.rs`, replace `a_pair_with_nothing_to_disagree_about_never_reaches_the_queue` (`:1432`) and `a_pair_with_no_facts_to_disagree_about_never_reaches_the_model` (`:1285`) with:
+
+```rust
+    #[tokio::test]
+    async fn a_pair_with_no_differing_values_reaches_the_queue() {
+        // This used to assert the opposite. `may_disagree` admits a pair only
+        // when both sides state values and those values differ — right for
+        // "do these contradict?", backwards for "are these duplicates?". Two
+        // artifacts at 0.93 saying the same thing in different words are the
+        // best merge candidate there is, and the old rule filed them as
+        // settled and left both in every result set.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.queued, 1, "{out:?}");
+        // Queued is not hidden: nothing about either artifact changes until a
+        // dedupe unit has ruled.
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().superseded_by.is_none());
+        }
+    }
+```
+
+Remove the `closed` field from `Outcome` and every reference to it; no path files `NoConflict` from the sweep any more.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jobs/classify.rs src/jobs/consolidate.rs src/jobs/mod.rs
+git commit -m "refactor(jobs): one place that classifies a scored pair
+
+Detection is about to gain a second producer, and two copies of these
+rules would diverge silently. Also inverts the prefilter: may_disagree
+gated the queue on values *differing*, which discards exactly the pairs
+that are cleanest to merge. It survives as a prompt prior and as the
+merge verification, not as an admission gate.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Per-artifact neighbour discovery
+
+**Files:**
+- Create: `src/jobs/relate.rs`
+- Modify: `src/store/jobs.rs:13-53` (`Stage::Relate`), `src/jobs/mod.rs:40-52` (dispatch), `src/jobs/embed.rs:277-290` (`mark_indexed`)
+- Test: `src/jobs/relate.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `classify_pair` (Task 4), `VectorStore::neighbours(artifact_id, limit) -> Result<Vec<SearchHit>>`.
+- Produces: `Stage::Relate` (`as_str` → `"relate"`); `pub async fn run(core: &Core, artifact_id: &str) -> Result<()>`; `pub async fn arm(core: &Core, artifact_id: &str, seq: i64) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::jobs::consolidate::tests::seed;
+    use crate::store::pairs::PairState;
+
+    #[tokio::test]
+    async fn an_artifact_finds_its_duplicate_the_moment_it_is_embedded() {
+        // The sweep samples 2000 points and needs both members of a pair in the
+        // same draw, so coverage decays as (sample/N)^2 — at 100k artifacts a
+        // given pair waits years. Asking one artifact for its own neighbours
+        // costs one Qdrant query, no embedding call, and is exact.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        run(&core, &ids[1]).await.unwrap();
+
+        let pending = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        assert_eq!(pending.len(), 1, "the unit found no duplicate");
+        assert!(
+            [&pending[0].a_id, &pending[0].b_id].contains(&&ids[0])
+                && [&pending[0].a_id, &pending[0].b_id].contains(&&ids[1])
+        );
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_neighbour_never_costs_a_model_call() {
+        // >= auto_supersede is settled for free by clustering. Filing it as an
+        // ordinary pending pair would arm a dedupe unit and spend a call on the
+        // one case where the cheap rule is already right.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+
+        run(&core, &ids[1]).await.unwrap();
+
+        assert!(core.store.pairs_to_judge(10).await.unwrap().is_empty());
+        assert_eq!(
+            core.store.pairs_by_state(PairState::NearIdentical, 10).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_neighbour_is_left_entirely_alone() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        run(&core, &ids[1]).await.unwrap();
+        assert!(core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn an_artifact_that_is_no_longer_active_asks_for_nothing() {
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        core.deprecate(&ids[1]).await.unwrap();
+
+        run(&core, &ids[1]).await.unwrap();
+
+        assert!(core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_found_by_whichever_member_is_embedded_second() {
+        // The completeness argument. When X's unit runs, Y is either already
+        // indexed — X finds it — or not, and Y finds X later. There is no
+        // window in which a pair falls through.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        run(&core, &ids[0]).await.unwrap();
+        let from_a = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len();
+        run(&core, &ids[1]).await.unwrap();
+        let after_b = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len();
+
+        assert_eq!(from_a, 1);
+        assert_eq!(after_b, 1, "the second member filed the same pair twice");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib relate`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Add the stage**
+
+In `src/store/jobs.rs`, add to `Stage`:
+
+```rust
+    /// One artifact, one neighbour query. No inference: `neighbours` looks the
+    /// vector up by point id, so this costs a round trip and nothing else.
+    /// It is what makes duplicate detection complete rather than sampled.
+    Relate,
+```
+
+with `"relate"` in `as_str` and `parse`.
+
+- [ ] **Step 4: Implement the unit**
+
+Create `src/jobs/relate.rs`:
+
+```rust
+//! What else is this artifact already saying?
+//!
+//! Duplicate detection used to be a sampled sweep: 2000 points drawn per run,
+//! pairs computed only within the draw, so both members of a pair had to land
+//! in the same sample. The probability of that is (sample/N)^2 and it decays
+//! quadratically — at a hundred thousand artifacts a given duplicate pair waits
+//! years for its turn.
+//!
+//! This asks the opposite question. One artifact, its own neighbours, one
+//! query. `neighbours` addresses the point by id, so Qdrant looks the vector up
+//! itself and no embedding call is paid, and it already excludes superseded and
+//! deprecated points. Coverage becomes 1, independent of N.
+//!
+//! A separate unit rather than a tail on `embed_batch`: a failing Qdrant query
+//! would otherwise fail the embed job, whose retry pays for the embedding
+//! again. Two failure domains, two units.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::ArtifactStatus;
+use crate::store::jobs::Stage;
+
+pub async fn arm(core: &Core, artifact_id: &str, seq: i64) -> Result<()> {
+    core.store
+        .rearm_idle_seq(Stage::Relate, "artifact", artifact_id, seq)
+        .await
+}
+
+pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
+    let me = core.store.get_artifact(artifact_id).await?;
+    // A retired artifact has no duplicates worth recording: every pair naming
+    // it would be skipped by `classify_pair` anyway, and the query is wasted.
+    if me.status != ArtifactStatus::Active || me.superseded_by.is_some() {
+        return Ok(());
+    }
+
+    let hits = core
+        .vectors
+        .neighbours(artifact_id, core.consolidate.per_point)
+        .await?;
+
+    for h in hits {
+        if h.score < core.consolidate.review_min {
+            continue;
+        }
+        // Ordinary: the vector store can list a point SQLite has dropped, a
+        // delete lags. Not an error.
+        let Ok(other) = core.store.get_artifact(&h.payload.artifact_id).await else {
+            tracing::debug!(artifact_id = %h.payload.artifact_id, "neighbour is gone");
+            continue;
+        };
+        // Warn and carry on, as the sweep does: one unwritable pair row is no
+        // reason to drop the other neighbours.
+        if let Err(e) = crate::jobs::classify::classify_pair(core, &me, &other, h.score).await {
+            tracing::warn!(a = %me.id, b = %other.id, error = %e, "could not classify a neighbour");
+        }
+    }
+    Ok(())
+}
+```
+
+`SearchHit`'s similarity field is `score`; confirm against `src/vector/mod.rs` and use the actual field name.
+
+- [ ] **Step 5: Wire the dispatch and the arming**
+
+In `src/jobs/mod.rs`, add `pub mod relate;` and a dispatch arm:
+
+```rust
+        (Stage::Relate, _) => relate::run(core, &job.target_id).await,
+```
+
+In `src/jobs/embed.rs`, in `mark_indexed`, after a successful mark:
+
+```rust
+    if !landed {
+        tracing::info!(
+            artifact_id = %chunk.id,
+            "chunk was edited while it was being embedded; leaving it pending"
+        );
+        return Ok(());
+    }
+    // Only now: the vector is in the index, so the neighbour query has
+    // something to find. Armed rather than run inline — a failing Qdrant query
+    // must not fail the embed job, whose retry would pay for the embedding
+    // again.
+    crate::jobs::relate::arm(core, &chunk.id, 0).await?;
+    Ok(())
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jobs/relate.rs src/jobs/mod.rs src/jobs/embed.rs src/store/jobs.rs
+git commit -m "feat(jobs): find duplicates when an artifact is embedded
+
+near_pairs samples 2000 points and needs both members of a pair in the
+same draw, so coverage decays as (sample/N)^2 -- at 100k artifacts a
+given pair waits years. neighbours() asks one artifact for its own
+neighbours by point id: no embedding call, lifecycle already filtered,
+coverage 1 regardless of N. The sweep keeps the backlog and the backstop.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: The cluster pass reads stored pairs too
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs:247-254` (cluster construction)
+- Test: `src/jobs/consolidate.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `PairState::NearIdentical` (Task 3), `Store::pairs_by_state`.
+- Produces: no new API. The sweep's union-find input becomes `near_pairs(...) ∪ pairs_by_state(NearIdentical, ...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn the_cluster_pass_settles_a_pair_the_relate_unit_filed() {
+        // The relate unit files >= auto_supersede pairs rather than acting on
+        // them, because resolving pairwise leaves A pointing at a B that is
+        // itself hidden. Nothing would ever settle them if the cluster pass
+        // read only what one sampled round trip happened to return.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        core.store
+            .record_settled_pair(&ids[0], &ids[1], 0.999, PairState::NearIdentical)
+            .await
+            .unwrap();
+        // Empty the vector store's view so `near_pairs` cannot supply the pair
+        // and only the stored row can.
+        core.vectors.delete_artifacts(&ids).await.unwrap();
+
+        let out = run(&core).await.unwrap();
+
+        assert_eq!(out.superseded, 1, "{out:?}");
+        assert_eq!(
+            core.store.get_artifact(&ids[0]).await.unwrap().superseded_by.as_deref(),
+            Some(ids[1].as_str())
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test the_cluster_pass_settles_a_pair_the_relate_unit_filed`
+Expected: FAIL — `out.superseded` is 0.
+
+- [ ] **Step 3: Implement**
+
+In `src/jobs/consolidate.rs`, replace the cluster construction:
+
+```rust
+    // Group everything near-identical first, and only then decide who wins.
+    //
+    // Two inputs. `near_pairs` is one sampled round trip, which is all this had
+    // when the sweep was the only producer; the stored `NearIdentical` rows are
+    // what the per-artifact relate units have filed since, and they are exact
+    // rather than sampled. Reading only the first would leave every pair a
+    // relate unit found above `auto_supersede` unsettled forever, because
+    // nothing else acts on that band.
+    let mut clusters = Clusters::default();
+    let mut in_a_cluster: HashSet<String> = HashSet::new();
+    let filed = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::NearIdentical, 500)
+        .await?;
+    let from_sweep = pairs
+        .iter()
+        .filter(|p| p.score >= cfg.auto_supersede)
+        .map(|p| (p.a.clone(), p.b.clone()));
+    let from_store = filed.iter().map(|p| (p.a_id.clone(), p.b_id.clone()));
+    for (a, b) in from_sweep.chain(from_store) {
+        clusters.union(&a, &b);
+        in_a_cluster.insert(a);
+        in_a_cluster.insert(b);
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/consolidate.rs
+git commit -m "feat(consolidate): cluster from stored pairs as well as the sample
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Lifecycle repair reads a marker instead of scanning
+
+**Files:**
+- Modify: `src/store/artifacts.rs:541-575` (`set_superseded_by`, `set_artifact_status`), add `dirty_lifecycle_artifacts`, `clear_lifecycle_dirty`
+- Modify: `src/core/ingest.rs:274-366` (`supersede`, `unsupersede`, `deprecate`, `reactivate`)
+- Modify: `src/jobs/consolidate.rs:121-190` (`repair_lifecycle_drift`)
+- Test: `src/jobs/consolidate.rs` (in-module)
+
+**Interfaces:**
+- Produces: `Store::dirty_lifecycle_artifacts(&self, limit: usize) -> Result<Vec<Chunk>>`, `Store::clear_lifecycle_dirty(&self, ids: &[String]) -> Result<()>`.
+
+**Why.** `DRIFT_SCAN = 5000` caps both scans. Autonomous merging makes hidden artifacts grow monotonically — every merge hides at least two, forever — so the cap is permanently reached and the repair degrades into sampling an ever-growing set.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn a_lifecycle_write_that_lost_its_payload_is_repaired_from_the_marker() {
+        // The scan-based repair is capped at DRIFT_SCAN from both sides, and
+        // merging makes hidden artifacts grow without bound, so past the cap it
+        // repairs a random window of an ever-growing set. The marker is set in
+        // the same SQLite write that hides an artifact and cleared once the
+        // payload write lands, so the repair costs the open writes and nothing
+        // else.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+
+        // Row written, payload not — exactly what a crash between the two
+        // leaves behind.
+        core.store.set_artifact_status(&ids[0], ArtifactStatus::Deprecated).await.unwrap();
+
+        assert_eq!(
+            core.store.dirty_lifecycle_artifacts(10).await.unwrap().len(),
+            1,
+            "the write left no marker"
+        );
+        assert_eq!(repair_lifecycle_drift(&core).await.unwrap(), 1);
+        assert!(
+            core.store.dirty_lifecycle_artifacts(10).await.unwrap().is_empty(),
+            "the marker outlived the repair, so every sweep will redo it"
+        );
+
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(!hits.iter().any(|h| h.payload.artifact_id == ids[0]));
+    }
+
+    #[tokio::test]
+    async fn a_completed_lifecycle_change_leaves_no_marker() {
+        // If `Core::supersede` did not clear it, the repair would rewrite every
+        // payload it ever touched, on every sweep, forever.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.supersede(&ids[0], &ids[1]).await.unwrap();
+
+        assert!(core.store.dirty_lifecycle_artifacts(10).await.unwrap().is_empty());
+        assert_eq!(
+            repair_lifecycle_drift(&core).await.unwrap(),
+            0,
+            "the repair fired on a base that agrees with itself"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test a_lifecycle_write_that_lost_its_payload_is_repaired_from_the_marker`
+Expected: FAIL — `dirty_lifecycle_artifacts` does not exist.
+
+- [ ] **Step 3: Set the marker where the row changes**
+
+In `src/store/artifacts.rs`, add `lifecycle_dirty = 1` to both writes:
+
+```rust
+    pub async fn set_superseded_by(&self, artifact_id: &str, by: Option<&str>) -> Result<()> {
+        // The marker rides the same statement as the change it describes: two
+        // statements could be interrupted between, which is the exact failure
+        // this is meant to catch.
+        sqlx::query(
+            "UPDATE artifacts SET superseded_by = ?, status = ?, lifecycle_dirty = 1 WHERE id = ?",
+        )
+        // ... existing binds
+    }
+
+    pub async fn set_artifact_status(&self, id: &str, status: ArtifactStatus) -> Result<()> {
+        sqlx::query("UPDATE artifacts SET status = ?, lifecycle_dirty = 1 WHERE id = ?")
+        // ... existing binds
+    }
+```
+
+Add the reads:
+
+```rust
+    /// Artifacts whose lifecycle row has changed since the payload was last
+    /// written. The repair's whole work list.
+    pub async fn dirty_lifecycle_artifacts(&self, limit: usize) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE lifecycle_dirty = 1 ORDER BY id LIMIT ?",
+        )
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
+    /// Clear the marker once the payload write is acknowledged. Never before:
+    /// clearing first turns a failed payload write into permanent drift that
+    /// nothing is left to notice.
+    pub async fn clear_lifecycle_dirty(&self, ids: &[String]) -> Result<()> {
+        for id in ids {
+            sqlx::query("UPDATE artifacts SET lifecycle_dirty = 0 WHERE id = ?")
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Clear the marker where the payload write succeeds**
+
+In `src/core/ingest.rs`, at the end of each of `supersede`, `unsupersede`, `deprecate` and `reactivate` — after the `self.vectors.set_lifecycle(...)` call returns `Ok` — add:
+
+```rust
+        self.store.clear_lifecycle_dirty(std::slice::from_ref(&id.to_string())).await?;
+```
+
+using whichever id that function just wrote. Where a function writes two artifacts, clear both.
+
+- [ ] **Step 5: Rewrite the repair**
+
+In `src/jobs/consolidate.rs`, replace the body of `repair_lifecycle_drift`:
+
+```rust
+/// Make the vector store's lifecycle payloads agree with SQLite, which is the
+/// source of truth for all of them.
+///
+/// Reads `lifecycle_dirty` rather than scanning. The scan version capped both
+/// sides at `DRIFT_SCAN` and, because autonomous merging makes hidden artifacts
+/// grow monotonically, was permanently past that cap — repairing a random
+/// window of an ever-growing set while reporting success. It also had to
+/// reconcile two differently-ordered truncated lists, which is what made
+/// "absent from the other list" read as drift.
+///
+/// Returns how many artifacts it rewrote, which is worth asserting on: a repair
+/// that fires on a base in agreement is a bug hiding behind a correct end state.
+async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
+    let dirty = core.store.dirty_lifecycle_artifacts(DRIFT_SCAN).await?;
+    if dirty.is_empty() {
+        return Ok(0);
+    }
+    let rows: Vec<crate::vector::LifecycleRow> = dirty.iter().map(lifecycle_row_of).collect();
+    core.vectors.apply_lifecycle(&rows).await?;
+    let ids: Vec<String> = dirty.iter().map(|c| c.id.clone()).collect();
+    core.store.clear_lifecycle_dirty(&ids).await?;
+    tracing::info!(repaired = rows.len(), "reconciled lifecycle state with the vector store");
+    Ok(rows.len())
+}
+```
+
+Keep `repair_lifecycle_drift_scanning` under a new name, `full_lifecycle_reconcile`, and call it from `Core::backfill_lifecycle` only — it still catches drift that arose with no SQLite write behind it, but it no longer runs every sweep. Update `the_drift_repair_rewrites_nothing_when_the_two_stores_agree` and `a_scan_cap_reached_from_both_sides_is_not_drift` to call `full_lifecycle_reconcile`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/artifacts.rs src/core/ingest.rs src/jobs/consolidate.rs
+git commit -m "fix(consolidate): repair lifecycle drift from a marker, not a scan
+
+Both scans were capped at DRIFT_SCAN and autonomous merging makes hidden
+artifacts grow without bound, so the repair was about to become a random
+sample of an ever-growing set that reported success either way. The
+marker rides the same UPDATE as the change it describes and is cleared
+only once the payload write is acknowledged.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 3 — The dedupe contract, recording only
+
+### Task 8: Rename judge to dedupe
+
+**Files:**
+- Rename: `src/jobs/judge.rs` → `src/jobs/dedupe.rs`
+- Modify: `src/store/jobs.rs` (`Stage::Judge` → `Stage::Dedupe`), `src/jobs/mod.rs`, `src/jobs/consolidate.rs`, `src/config.rs`, `src/web/api.rs`, `src/web/ui.rs`, `config.example.toml`, `README.md`
+
+**Interfaces:**
+- Produces: `Stage::Dedupe` (`as_str` → `"dedupe"`), `consolidate.autonomous: bool`, `crate::jobs::dedupe::run`.
+
+**Why.** `/ui/judge` and `src/web/judge.rs` are the relevance-feedback evaluation surface. Two unrelated things called "judge", one of which is being extended.
+
+- [ ] **Step 1: Rename and rewire**
+
+```bash
+git mv src/jobs/judge.rs src/jobs/dedupe.rs
+```
+
+Then, mechanically: `Stage::Judge` → `Stage::Dedupe`; `"judge"` → `"dedupe"` in `as_str`/`parse`; `judge::run` → `dedupe::run`; `pub mod judge;` → `pub mod dedupe;` in `src/jobs/mod.rs`; `arm_judgements` → `arm_dedupe`; `ConsolidateConfig.judge` → `.autonomous`; `JUDGE_SYSTEM` → `DEDUPE_SYSTEM`; `judge_prompt` → `dedupe_prompt`. Leave `src/web/judge.rs` and `/ui/judge` untouched — they are the other thing.
+
+Keep `pairs.judge_attempts`, `judge_unreadable` and `MAX_UNREADABLE_JUDGEMENTS` as they are: renaming a column means recreating the database, and the names are unambiguous in context.
+
+- [ ] **Step 2: Run tests to verify nothing broke**
+
+Run: `cargo test`
+Expected: PASS — this task changes no behaviour.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A src/ config.example.toml README.md
+git commit -m "refactor: rename the consolidation judge to dedupe
+
+/ui/judge is the relevance-feedback surface. Two unrelated things called
+judge, one of them about to grow, is one too many.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: The four-verdict prompt and parser
+
+**Files:**
+- Modify: `src/infer/prompt.rs:124-238`
+- Test: `src/infer/prompt.rs` (in-module)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+
+```rust
+pub enum Relation { Distinct, Conflict, Replaced, Duplicate }
+
+pub struct MergedDraft {
+    pub title: Option<String>,
+    pub text: String,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub caveats: Vec<String>,
+}
+
+pub struct Dedupe {
+    pub relation: Relation,
+    pub detail: Option<String>,
+    /// 'a' or 'b', only meaningful when `relation` is `Replaced`.
+    pub supersedes: Option<char>,
+    /// `Some` if and only if `relation` is `Duplicate`.
+    pub merged: Option<MergedDraft>,
+}
+
+pub const DEDUPE_SYSTEM: &str;
+pub fn dedupe_prompt(members: &[(&str, &str)], differing_values: &[String], attempt: i64) -> String;
+pub fn parse_dedupe(body: &str) -> Result<Dedupe>;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn a_duplicate_verdict_carries_a_merged_draft() {
+        let d = parse_dedupe(
+            r#"{"relation":"duplicate","detail":"same command, different detail",
+                "merged":{"title":"Bind mounts","text":"Use mount --bind.","tags":["mount"],
+                          "caveats":[],"category":"howto"}}"#,
+        )
+        .unwrap();
+        assert_eq!(d.relation, Relation::Duplicate);
+        assert_eq!(d.merged.as_ref().unwrap().text, "Use mount --bind.");
+        assert_eq!(d.merged.as_ref().unwrap().title.as_deref(), Some("Bind mounts"));
+    }
+
+    #[test]
+    fn a_merged_block_on_a_non_duplicate_verdict_is_unreadable() {
+        // `merged` belongs to `duplicate` and to nothing else. Accepting it
+        // elsewhere would let a reply that classified a pair as a conflict
+        // still hand us text to write, which is the one outcome the conflict
+        // verdict exists to prevent.
+        for relation in ["conflict", "replaced", "distinct"] {
+            let body = format!(
+                r#"{{"relation":"{relation}","supersedes":"a",
+                     "merged":{{"text":"x","tags":[],"caveats":[]}}}}"#
+            );
+            assert!(
+                matches!(parse_dedupe(&body), Err(crate::error::Error::MalformedLlmOutput(_))),
+                "a {relation} verdict was allowed to carry a merge"
+            );
+        }
+    }
+
+    #[test]
+    fn a_duplicate_verdict_without_a_merged_block_is_unreadable() {
+        assert!(matches!(
+            parse_dedupe(r#"{"relation":"duplicate","detail":"x"}"#),
+            Err(crate::error::Error::MalformedLlmOutput(_))
+        ));
+    }
+
+    #[test]
+    fn a_replaced_verdict_names_a_side() {
+        let d = parse_dedupe(r#"{"relation":"replaced","supersedes":"B","detail":"old flag"}"#).unwrap();
+        assert_eq!(d.relation, Relation::Replaced);
+        assert_eq!(d.supersedes, Some('b'));
+    }
+
+    #[test]
+    fn a_replaced_verdict_naming_no_side_is_a_conflict() {
+        // A direction the model would not name is not a direction. Treating it
+        // as one would pick a side by accident.
+        let d = parse_dedupe(r#"{"relation":"replaced","detail":"one of them is old"}"#).unwrap();
+        assert_eq!(d.relation, Relation::Conflict);
+    }
+
+    #[test]
+    fn the_dedupe_prompt_keeps_the_subject_rule() {
+        // FAT12, FAT16 and FAT32 are near-identical in form and deliberately
+        // different in content: they sit at 0.91 and every number in them
+        // differs. Without the subject-first rule the autonomous path merges a
+        // reference document into mush.
+        assert!(DEDUPE_SYSTEM.contains("same subject"));
+        assert!(DEDUPE_SYSTEM.contains("different things"));
+    }
+
+    #[test]
+    fn the_prompt_varies_with_the_attempt() {
+        // The endpoint replays identical output for identical prompts, so an
+        // unchanged retry returns the same unreadable bytes every time.
+        let a = dedupe_prompt(&[("t", "one"), ("t", "two")], &[], 0);
+        let b = dedupe_prompt(&[("t", "one"), ("t", "two")], &[], 1);
+        assert_ne!(a, b);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib prompt`
+Expected: FAIL — `parse_dedupe` does not exist.
+
+- [ ] **Step 3: Write the system prompt**
+
+```rust
+pub const DEDUPE_SYSTEM: &str = r#"You compare two or more knowledge artifacts about possibly the same thing, and decide what should happen to them.
+
+First decide whether they are about the same subject. Their titles say what each one is about, and the body may never repeat it — an artifact titled "FAT32 Specifications" can open with "32 Bit Clusternummern" and never name FAT32 again.
+
+If the titles name different things — two versions, two variants, two products, two filesystems, two commands — then they are not duplicates and not in conflict, no matter how far apart their numbers are. Different things have different numbers; that is what makes them different things. Answer "distinct" and stop.
+
+Only when they describe the same subject, choose one of:
+
+- "replaced" — one artifact plainly supersedes another: a deprecated flag, step or default versus its current replacement. Prefer this whenever it applies. It keeps the original wording of the survivor, which is always better than rewriting.
+- "duplicate" — they make the same claim, and each carries some detail the other lacks. Write one artifact that says everything all of them said.
+- "conflict" — they give a different value for the same detail of the same subject, and you cannot tell which is current. Do not choose a side and do not merge; a person decides this one.
+- "distinct" — different subjects, or one covers something the other simply does not.
+
+When you answer "duplicate", the merged text must contain every number, version, date, path, flag, command and error string that appeared in any input. If you cannot write one that does, the answer is "conflict", not "duplicate".
+
+Reply with JSON only, no commentary, in exactly this shape:
+
+{"relation": "duplicate", "detail": "...", "supersedes": "a", "merged": {"title": "...", "text": "...", "category": "...", "tags": [], "caveats": []}}
+
+- relation: one of "duplicate", "replaced", "conflict", "distinct".
+- detail: one short sentence saying why. Always.
+- supersedes: the letter of the artifact that is obsolete. Only with "replaced"; omit it otherwise.
+- merged: only with "duplicate"; omit it entirely otherwise. `text` stands alone without its sources. `caveats` are the conditions under which it does not apply."#;
+```
+
+- [ ] **Step 4: Write the user prompt and the parser**
+
+```rust
+/// The artifacts, each under its title and a letter.
+///
+/// The title is not decoration, it is the subject: synthesis writes a body that
+/// stands alone within its segment, which is not the same as naming what it is
+/// about. Handed bodies alone, the model saw two anonymous spec lists with
+/// different numbers and called them a contradiction — correctly, on the
+/// evidence it was given.
+///
+/// `differing_values` is what `facts::fact_tokens` found on more than one side
+/// with different values. It is a prior, not a verdict: it cannot tell a
+/// conflict from two levels of detail about one subject, which is the whole
+/// reason a model is asked.
+///
+/// `attempt` varies the wording. The endpoint replays identical output for
+/// identical prompts, so without it a retry is the same unreadable bytes again.
+pub fn dedupe_prompt(members: &[(&str, &str)], differing_values: &[String], attempt: i64) -> String {
+    let mut s = String::new();
+    for (i, (title, text)) in members.iter().enumerate() {
+        let letter = (b'a' + i as u8) as char;
+        s.push_str(&format!("Artifact {letter} — {title}\n{text}\n\n"));
+    }
+    if !differing_values.is_empty() {
+        s.push_str(&format!(
+            "These values appear with different readings across the artifacts: {}. \
+             They may be a real disagreement, or the same subject described at \
+             different levels of detail. Decide which.\n\n",
+            differing_values.join(", ")
+        ));
+    }
+    s.push_str(match attempt {
+        0 => "Answer with the JSON object and nothing else.",
+        1 => "Reply with only the JSON object described above. No prose.",
+        2 => "Output the JSON object. Do not explain it.",
+        3 => "Return the JSON object alone, starting with { and ending with }.",
+        _ => "JSON object only. No commentary, no code fence.",
+    });
+    s
+}
+
+pub fn parse_dedupe(body: &str) -> Result<Dedupe> {
+    #[derive(serde::Deserialize)]
+    struct Raw {
+        relation: String,
+        #[serde(default)]
+        detail: Option<String>,
+        #[serde(default)]
+        supersedes: Option<String>,
+        #[serde(default)]
+        merged: Option<RawMerged>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawMerged {
+        text: String,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        category: Option<String>,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        caveats: Vec<String>,
+    }
+
+    let r: Raw = serde_json::from_str(extract_json(body)).map_err(|e| {
+        Error::MalformedLlmOutput(format!("dedupe reply was not the expected JSON: {e}"))
+    })?;
+
+    let side = r.supersedes.as_deref().and_then(|s| match s.trim() {
+        "a" | "A" => Some('a'),
+        "b" | "B" => Some('b'),
+        _ => None,
+    });
+
+    let relation = match r.relation.trim().to_ascii_lowercase().as_str() {
+        "duplicate" => Relation::Duplicate,
+        // A direction the model would not name is not a direction. Falling back
+        // to a conflict is what stops this picking a side by accident.
+        "replaced" if side.is_some() => Relation::Replaced,
+        "replaced" | "conflict" => Relation::Conflict,
+        "distinct" => Relation::Distinct,
+        other => {
+            return Err(Error::MalformedLlmOutput(format!(
+                "dedupe reply named an unknown relation {other:?}"
+            )));
+        }
+    };
+
+    // `merged` belongs to `duplicate` and to nothing else. A conflict verdict
+    // that still handed us text to write would defeat the one outcome that
+    // verdict exists to produce.
+    match (&relation, &r.merged) {
+        (Relation::Duplicate, None) => {
+            return Err(Error::MalformedLlmOutput(
+                "dedupe reply said duplicate but wrote no merged artifact".into(),
+            ));
+        }
+        (rel, Some(_)) if *rel != Relation::Duplicate => {
+            return Err(Error::MalformedLlmOutput(
+                "dedupe reply carried a merged artifact on a non-duplicate verdict".into(),
+            ));
+        }
+        _ => {}
+    }
+
+    Ok(Dedupe {
+        relation,
+        detail: r.detail.map(|d| d.trim().to_string()).filter(|d| !d.is_empty()),
+        supersedes: side,
+        merged: r.merged.map(|m| MergedDraft {
+            title: m.title,
+            text: m.text,
+            category: m.category,
+            tags: m.tags,
+            caveats: m.caveats,
+        }),
+    })
+}
+```
+
+Keep `JUDGE_SYSTEM`/`parse_judgement` deleted — Task 8 renamed them and nothing else calls them.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib prompt`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/infer/prompt.rs
+git commit -m "feat(infer): four-verdict dedupe prompt and parser
+
+replaced is preferred over duplicate: a superseded original keeps its
+stored wording and its span, which is strictly better than a rewrite.
+merged belongs to the duplicate verdict and to nothing else, so a
+conflict cannot hand us text to write.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Component expansion and the fan-in cap
+
+**Files:**
+- Modify: `src/store/pairs.rs` (add `open_component`)
+- Modify: `src/config.rs` (`merge_max_roots`)
+- Test: `src/store/pairs.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `Clusters` from `src/jobs/consolidate.rs:42` — make it `pub(crate)`.
+- Produces: `Store::open_component(&self, pair_id: i64) -> Result<Vec<ArtifactPair>>` — every `Pending` pair reachable from `pair_id` through shared artifact ids, including itself. `ConsolidateConfig.merge_max_roots: usize` (default 8).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn a_component_gathers_every_pending_pair_that_shares_an_artifact() {
+        // Merging a three-artifact group pairwise costs two calls and produces
+        // a merged artifact that is superseded almost immediately. One
+        // component, one call.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("four", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..4)
+            .map(|i| NewArtifact {
+                ordinal: i,
+                text: format!("artifact {i}"),
+                corpus_span: None, title: None, category: None,
+                tags: vec![], segment_idx: None, caveats: vec![],
+            })
+            .collect();
+        let m = s.insert_artifacts(&src.id, &new).await.unwrap();
+
+        s.record_pair(&m[0].id, &m[1].id, 0.91).await.unwrap();
+        s.record_pair(&m[1].id, &m[2].id, 0.90).await.unwrap();
+        s.record_pair(&m[3].id, &m[0].id, 0.89).await.unwrap();
+        let seed = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+        let comp = s.open_component(seed).await.unwrap();
+        assert_eq!(comp.len(), 3, "the component stopped short: {comp:?}");
+    }
+
+    #[tokio::test]
+    async fn a_settled_pair_never_drags_an_answered_artifact_into_a_component() {
+        // Pending only. A dismissed or near-identical pair carries a decision,
+        // and following it would pull an already-answered artifact back into a
+        // group that is about to be rewritten.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("three", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..3)
+            .map(|i| NewArtifact {
+                ordinal: i, text: format!("artifact {i}"),
+                corpus_span: None, title: None, category: None,
+                tags: vec![], segment_idx: None, caveats: vec![],
+            })
+            .collect();
+        let m = s.insert_artifacts(&src.id, &new).await.unwrap();
+
+        s.record_pair(&m[0].id, &m[1].id, 0.91).await.unwrap();
+        s.record_pair(&m[1].id, &m[2].id, 0.90).await.unwrap();
+        let all = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        let (seed, other) = (all[0].id, all[1].id);
+        s.set_pair_state(other, PairState::Dismissed, None).await.unwrap();
+
+        assert_eq!(s.open_component(seed).await.unwrap().len(), 1);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test a_component_gathers_every_pending_pair_that_shares_an_artifact`
+Expected: FAIL — `open_component` does not exist.
+
+- [ ] **Step 3: Implement**
+
+In `src/store/pairs.rs`:
+
+```rust
+    /// Every `Pending` pair reachable from this one through a shared artifact.
+    ///
+    /// Computed at the moment of use rather than snapshotted when the unit was
+    /// armed: membership changes while a unit waits out a backoff, and acting
+    /// on a stale group would rewrite artifacts that have since been answered.
+    ///
+    /// `Pending` only. A dismissed or near-identical row carries a decision,
+    /// and following it would pull an already-settled artifact into a group
+    /// that is about to be superseded.
+    pub async fn open_component(&self, pair_id: i64) -> Result<Vec<ArtifactPair>> {
+        let open = self.pairs_by_state(PairState::Pending, 5_000).await?;
+        let Some(seed) = open.iter().find(|p| p.id == pair_id) else {
+            return Ok(vec![]);
+        };
+
+        let mut members: std::collections::HashSet<String> =
+            [seed.a_id.clone(), seed.b_id.clone()].into_iter().collect();
+        let mut picked: std::collections::HashSet<i64> = [seed.id].into_iter().collect();
+        // Fixed point rather than one pass: a pair joins the component only
+        // once one of its artifacts is already in it, and the pair that brings
+        // that artifact in may come later in the list.
+        loop {
+            let mut grew = false;
+            for p in &open {
+                if picked.contains(&p.id) {
+                    continue;
+                }
+                if members.contains(&p.a_id) || members.contains(&p.b_id) {
+                    members.insert(p.a_id.clone());
+                    members.insert(p.b_id.clone());
+                    picked.insert(p.id);
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+        Ok(open.into_iter().filter(|p| picked.contains(&p.id)).collect())
+    }
+```
+
+In `src/config.rs`, add to `ConsolidateConfig` and its `Default`:
+
+```rust
+    /// How many captured roots one merged artifact may draw on. Above this the
+    /// component is left alone and surfaced instead: a merge of forty sources
+    /// is no longer one atomic piece of knowledge, which is what an artifact is
+    /// defined to be.
+    pub merge_max_roots: usize,
+```
+
+with `merge_max_roots: 8`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib pairs && cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/pairs.rs src/config.rs
+git commit -m "feat(store): expand a pair into its open component
+
+Three related artifacts merged pairwise cost two calls and produce a
+merged artifact that is superseded almost immediately. Computed fresh at
+run time, not snapshotted at arming: membership changes while a unit
+waits out a backoff.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: The two verification passes
+
+**Files:**
+- Create: the `verify` section of `src/jobs/merge.rs`
+- Modify: `src/jobs/mod.rs`
+- Test: `src/jobs/merge.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `crate::infer::facts::fact_tokens`, `crate::infer::verify::missing_literals`, `MergedDraft` (Task 9).
+- Produces:
+
+```rust
+/// What a merged draft would have lost. Empty means it may be written.
+pub fn losses(roots: &[Chunk], draft: &MergedDraft) -> Vec<String>;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infer::prompt::MergedDraft;
+
+    fn draft(text: &str) -> MergedDraft {
+        MergedDraft {
+            title: None, text: text.into(), category: None,
+            tags: vec![], caveats: vec![],
+        }
+    }
+
+    fn root(text: &str) -> Chunk { /* build a Chunk with this text; helper */ }
+
+    #[test]
+    fn a_merge_that_keeps_both_values_is_allowed() {
+        let roots = [root("The timeout is 30 seconds."), root("The timeout is 90 seconds.")];
+        let d = draft("Sources differ on the timeout: an earlier capture gives 30 seconds, a later one 90 seconds.");
+        assert!(losses(&roots, &d).is_empty(), "{:?}", losses(&roots, &d));
+    }
+
+    #[test]
+    fn a_merge_that_drops_a_value_is_refused() {
+        // The one way this feature can destroy knowledge without anyone
+        // noticing: the model answers "duplicate" and quietly picks a side
+        // while writing. Nothing downstream would ever see the missing number.
+        let roots = [root("The timeout is 30 seconds."), root("The timeout is 90 seconds.")];
+        let d = draft("The timeout is 90 seconds.");
+        assert_eq!(losses(&roots, &d), vec!["30".to_string()]);
+    }
+
+    #[test]
+    fn a_merge_that_paraphrases_a_command_is_refused() {
+        // A paraphrased command is a command that later gets pasted into a
+        // root shell.
+        let roots = [
+            root("Attach it with `mount --bind /src /dst`."),
+            root("Bind mounts attach a directory elsewhere."),
+        ];
+        let d = draft("Bind mounts attach a directory elsewhere; use the bind mount option.");
+        assert!(
+            losses(&roots, &d).iter().any(|l| l.contains("mount --bind")),
+            "the literal check let a paraphrased command through: {:?}",
+            losses(&roots, &d)
+        );
+    }
+
+    #[test]
+    fn a_value_that_moved_into_the_caveats_is_not_lost() {
+        // Caveats are stored and rendered. A value demoted there is still
+        // recoverable, which is the whole test: this checks for loss, not for
+        // prominence.
+        let roots = [root("The timeout is 30 seconds."), root("The timeout is 90 seconds.")];
+        let mut d = draft("The timeout is 90 seconds.");
+        d.caveats = vec!["An earlier capture gave 30 seconds.".into()];
+        assert!(losses(&roots, &d).is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib merge`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `src/jobs/merge.rs` with:
+
+```rust
+//! Writing, verifying and undoing a merge.
+//!
+//! Merging is the one thing in this system that puts model-written text where
+//! stored text used to be, so it is also the one thing that can lose knowledge
+//! silently: a plausible paragraph reads exactly as well without the number it
+//! dropped. `losses` is what stands between a verdict and a write, and it is
+//! free — a scan of two token sets and one substring pass.
+
+use crate::infer::prompt::MergedDraft;
+use crate::store::artifacts::Chunk;
+
+/// Every value and literal in `roots` that `draft` does not carry.
+///
+/// Both halves search the draft's text *and* its caveats: a caveat is stored,
+/// rendered and recoverable, so a value demoted there has not been lost. This
+/// checks for loss, not for prominence.
+pub fn losses(roots: &[Chunk], draft: &MergedDraft) -> Vec<String> {
+    let mut haystack = draft.text.clone();
+    for c in &draft.caveats {
+        haystack.push(' ');
+        haystack.push_str(c);
+    }
+
+    let have = crate::infer::facts::fact_tokens(&haystack);
+    let mut out: Vec<String> = Vec::new();
+
+    for r in roots {
+        for tok in crate::infer::facts::fact_tokens(&r.text) {
+            if !have.contains(&tok) && !out.contains(&tok) {
+                out.push(tok);
+            }
+        }
+        // The existing check, with the merged text as the haystack instead of
+        // the segment: `missing_literals(artifact_text, caveats, haystack)`
+        // asks which literals of the first argument are absent from the third,
+        // which is exactly the question here with the arguments in this order.
+        for lit in crate::infer::verify::missing_literals(&r.text, &r.caveats, &haystack) {
+            if !out.contains(&lit) {
+                out.push(lit);
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+```
+
+Add `pub mod merge;` to `src/jobs/mod.rs`. Write the `root` test helper to construct a `Chunk` with the given text and defaults for everything else.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib merge`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/merge.rs src/jobs/mod.rs
+git commit -m "feat(jobs): refuse a merge that would lose a value or a literal
+
+Merging is the one thing that puts model-written text where stored text
+was, so it is the one thing that can lose knowledge silently: a plausible
+paragraph reads just as well without the number it dropped. Both checks
+are local and free, and both search the caveats too -- a value demoted
+there is stored and recoverable, so it is not lost.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: The dedupe unit, recording verdicts only
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (rewrite `run` and `apply`)
+- Modify: `src/jobs/consolidate.rs` (`arm_dedupe` skips the `may_disagree` gate)
+- Test: `src/jobs/dedupe.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `open_component` (Task 10), `parse_dedupe`/`dedupe_prompt` (Task 9), `losses` (Task 11), `roots_of` (Task 2).
+- Produces: `pub async fn run(core: &Core, pair_id: &str) -> Result<()>`; `pub struct Settlement { pub relation: Relation, pub merged: Option<MergedDraft>, pub roots: Vec<Chunk> }` returned by an inner `decide` so Task 14 can apply it.
+
+With `autonomous = false` this task records `Contradiction`, `NoConflict`, `Superseded` (proposal) and `Oversized`, and for `duplicate` records `Contradiction` with a detail naming the merge it would have written. Task 14 turns that last branch into a real merge.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn two_artifacts_about_different_subjects_are_never_merged() {
+        // FAT12, FAT16 and FAT32 are near-identical in form and deliberately
+        // different in content: 0.91 similarity, every number different. This
+        // is the failure mode that turns a reference document into mush, and
+        // it is the reason the prompt checks the subject before anything else.
+        let mut core = test_core().await;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"two different filesystems"}"#.into(),
+        ]));
+        let ids = seed_titled(
+            &core,
+            &[
+                ("FAT16 Specifications", "65524 clusters, 16 bit numbers.", [1.0, 0.0]),
+                ("FAT32 Specifications", "268435445 clusters, 28 bit numbers.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let pair = queue_pair(&core, &ids).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store.pairs_by_state(PairState::NoConflict, 10).await.unwrap().len(),
+            1
+        );
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().superseded_by.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn a_value_conflict_is_escalated_and_never_merged() {
+        // Deciding which of two contradictory facts is true stays a person's
+        // job. This is the one queue that expects a human, and autonomy does
+        // not empty it.
+        let mut core = test_core().await;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"conflict","detail":"1.21.4 versus 1.30.0"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let found = core.store.pairs_by_state(PairState::Contradiction, 10).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].detail.as_deref(), Some("1.21.4 versus 1.30.0"));
+        for id in &ids {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().status,
+                ArtifactStatus::Active,
+                "a conflict hid an artifact"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_plain_replacement_supersedes_rather_than_merging() {
+        // The survivor is a stored original with a valid span. That is
+        // strictly better than a rewrite, and it is the path by which fidelity
+        // keeps holding under autonomy — so the prompt prefers it and this
+        // pins that the code does too.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store.get_artifact(&ids[0]).await.unwrap().superseded_by.as_deref(),
+            Some(ids[1].as_str())
+        );
+        assert_eq!(
+            core.store.get_artifact(&ids[1]).await.unwrap().provenance,
+            Provenance::Captured,
+            "a replacement wrote synthetic text"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_replacement_naming_the_newer_artifact_is_not_trusted() {
+        // A miscalibrated call proposing to hide the *newer* side disagrees
+        // with the sweep's own newest-wins bias, so it falls back to a
+        // conflict rather than being applied.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        let ids = disagreeing(&core).await;
+        sqlx::query("UPDATE artifacts SET created_at = created_at + 100 WHERE id = ?")
+            .bind(&ids[1])
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"b","detail":"x"}"#.into(),
+        ]));
+        let pair = queue_pair(&core, &ids).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().superseded_by.is_none());
+        }
+        assert_eq!(
+            core.store.pairs_by_state(PairState::Contradiction, 10).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_component_past_the_fan_in_cap_is_surfaced_and_never_called_about() {
+        let mut core = test_core().await;
+        core.consolidate.merge_max_roots = 2;
+        let completer = std::sync::Arc::new(ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
+        core.store.record_pair(&ids[1], &ids[2], 0.90).await.unwrap();
+        let pair = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(completer.calls(), 0, "an oversized component cost a call");
+        assert_eq!(
+            core.store.pairs_by_state(PairState::Oversized, 10).await.unwrap().len(),
+            2,
+            "every pair in the component must leave the pending queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_dedupe_leaves_the_component_pending() {
+        // A dead endpoint must not silently clear a queue of real duplicates.
+        let mut core = test_core().await;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec!["not json".into()]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids).await;
+
+        assert!(run(&core, &pair.to_string()).await.is_err());
+        assert_eq!(
+            core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+            1
+        );
+        assert_eq!(core.store.get_pair(pair).await.unwrap().judge_unreadable, 1);
+    }
+```
+
+Add the helpers `seed_titled` (like `seed` but taking a title) and `queue_pair` (records a pair for two ids and returns its row id) to `src/jobs/consolidate.rs`'s `pub(crate) mod tests`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib dedupe`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Rewrite `src/jobs/dedupe.rs`:
+
+```rust
+//! One component, one call.
+//!
+//! The sweep decides which pairs are worth asking about, which costs nothing,
+//! and arms one unit each. The unit then expands its pair into the connected
+//! component of still-open pairs around it — three related artifacts settled
+//! pairwise cost two calls and produce a merged artifact that is superseded
+//! almost immediately.
+
+use crate::core::Core;
+use crate::error::{Error, Result};
+use crate::infer::prompt::{Dedupe, MergedDraft, Relation};
+use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::pairs::{ArtifactPair, PairState};
+
+/// What the model decided, with everything the write path needs already read.
+pub struct Settlement {
+    pub relation: Relation,
+    pub detail: Option<String>,
+    /// The artifact named obsolete, already checked against newest-wins.
+    pub obsolete: Option<String>,
+    pub merged: Option<MergedDraft>,
+    /// The component's members, active at the time of the call.
+    pub members: Vec<Chunk>,
+    /// Their captured roots, flattened. What the model was actually shown.
+    pub roots: Vec<Chunk>,
+    pub pairs: Vec<ArtifactPair>,
+}
+
+pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
+    let id: i64 = pair_id.parse().map_err(|_| Error::NotFound)?;
+    let p = core.store.get_pair(id).await?;
+    if p.state != PairState::Pending {
+        // Settled by an operator, by a later sweep, or by a sibling unit that
+        // already merged this component while this one waited.
+        return Ok(());
+    }
+
+    let pairs = core.store.open_component(id).await?;
+    let mut member_ids: Vec<String> = pairs
+        .iter()
+        .flat_map(|p| [p.a_id.clone(), p.b_id.clone()])
+        .collect();
+    member_ids.sort();
+    member_ids.dedup();
+
+    let mut members = Vec::new();
+    for mid in &member_ids {
+        let c = core.store.get_artifact(mid).await?;
+        // Re-checked here and not only at arming: a member can be superseded
+        // or deprecated while the unit waits out a backoff.
+        if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
+            settle_all(core, &pairs, PairState::Dismissed, None).await?;
+            return Ok(());
+        }
+        members.push(c);
+    }
+    if members.len() < 2 {
+        settle_all(core, &pairs, PairState::Dismissed, None).await?;
+        return Ok(());
+    }
+
+    // Flatten to captured roots before anything else. A merged member's own
+    // text is never shown to the model: rewriting from a rewrite is how
+    // generational drift starts, and the closure is stored precisely so this
+    // costs one query.
+    let root_map = core.store.roots_of(&member_ids).await?;
+    let mut root_ids: Vec<String> = root_map.values().flatten().cloned().collect();
+    root_ids.sort();
+    root_ids.dedup();
+
+    if root_ids.len() > core.consolidate.merge_max_roots {
+        tracing::info!(
+            pair = id,
+            roots = root_ids.len(),
+            cap = core.consolidate.merge_max_roots,
+            "component is past the fan-in cap; surfacing instead of merging"
+        );
+        settle_all(core, &pairs, PairState::Oversized, None).await?;
+        return Ok(());
+    }
+
+    let mut roots = Vec::new();
+    for rid in &root_ids {
+        roots.push(core.store.get_artifact(rid).await?);
+    }
+
+    for p in &pairs {
+        core.store.record_judge_attempt(p.id).await?;
+    }
+
+    let shown: Vec<(&str, &str)> = roots
+        .iter()
+        .map(|c| (c.title.as_deref().unwrap_or("untitled"), c.text.as_str()))
+        .collect();
+    let differing = differing_values(&roots);
+
+    let permit = core.gate.background().await;
+    let reply = match core
+        .completer
+        .complete(
+            crate::infer::prompt::DEDUPE_SYSTEM,
+            &crate::infer::prompt::dedupe_prompt(&shown, &differing, p.judge_attempts),
+        )
+        .await
+    {
+        Ok(r) => {
+            permit.succeeded();
+            r
+        }
+        Err(e) => {
+            permit.failed(&e);
+            return Err(e);
+        }
+    };
+
+    let verdict = match crate::infer::prompt::parse_dedupe(&reply) {
+        Ok(v) => v,
+        // A reply that cannot be read is an error, not a verdict: the component
+        // stays pending and the unit retries under the queue's backoff.
+        Err(e) => {
+            for p in &pairs {
+                core.store.record_unreadable_judgement(p.id).await?;
+            }
+            tracing::warn!(pair = id, attempt = p.judge_attempts, error = %e,
+                "dedupe reply unreadable; component stays pending");
+            return Err(e);
+        }
+    };
+
+    let settlement = interpret(verdict, members, roots, pairs);
+    apply(core, settlement).await
+}
+
+/// Values that appear with different readings across the roots. A prior for the
+/// prompt, never a verdict: it cannot tell a conflict from two levels of detail
+/// about one subject, which is the whole reason a model is asked.
+fn differing_values(roots: &[Chunk]) -> Vec<String> {
+    let sets: Vec<_> = roots
+        .iter()
+        .map(|r| crate::infer::facts::fact_tokens(&r.text))
+        .collect();
+    let mut all: std::collections::BTreeSet<String> = Default::default();
+    for s in &sets {
+        all.extend(s.iter().cloned());
+    }
+    all.into_iter()
+        .filter(|t| !sets.iter().all(|s| s.contains(t)))
+        .collect()
+}
+
+/// Turn a parsed reply into what the write path will do, applying the two
+/// guards that do not need the store: newest-wins on a named direction, and the
+/// loss check on a merged draft.
+fn interpret(
+    v: Dedupe,
+    members: Vec<Chunk>,
+    roots: Vec<Chunk>,
+    pairs: Vec<ArtifactPair>,
+) -> Settlement {
+    let mut relation = v.relation;
+    let mut detail = v.detail;
+    let mut merged = v.merged;
+    let mut obsolete = None;
+
+    if relation == Relation::Replaced {
+        // Trust a named direction only when it agrees with the newest-wins
+        // bias: a call naming the *newer* artifact obsolete would propose
+        // hiding the side more likely to be current.
+        let named = match v.supersedes {
+            Some('a') => members.first(),
+            _ => members.get(1),
+        };
+        let other = match v.supersedes {
+            Some('a') => members.get(1),
+            _ => members.first(),
+        };
+        obsolete = match (named, other) {
+            (Some(n), Some(o)) if n.created_at <= o.created_at => Some(n.id.clone()),
+            _ => None,
+        };
+        if obsolete.is_none() {
+            relation = Relation::Conflict;
+        }
+    }
+
+    if relation == Relation::Duplicate {
+        if let Some(d) = &merged {
+            let lost = crate::jobs::merge::losses(&roots, d);
+            if !lost.is_empty() {
+                // Escalate rather than retry: the merge is the thing that was
+                // wrong, and a person can read what it would have cost.
+                detail = Some(format!("the merge would have lost {}", lost.join(", ")));
+                relation = Relation::Conflict;
+                merged = None;
+            }
+        }
+    }
+
+    Settlement { relation, detail, obsolete, merged, members, roots, pairs }
+}
+
+async fn apply(core: &Core, s: Settlement) -> Result<()> {
+    match s.relation {
+        Relation::Distinct => settle_all(core, &s.pairs, PairState::NoConflict, s.detail.as_deref()).await,
+        Relation::Conflict => settle_all(core, &s.pairs, PairState::Contradiction, s.detail.as_deref()).await,
+        Relation::Replaced => {
+            let obsolete = s.obsolete.clone().expect("interpret guarantees it");
+            let winner = s
+                .members
+                .iter()
+                .find(|m| m.id != obsolete)
+                .expect("a component has at least two members");
+            for p in &s.pairs {
+                core.store.set_pair_superseded(p.id, &obsolete, s.detail.as_deref()).await?;
+            }
+            if core.consolidate.autonomous {
+                core.supersede(&obsolete, &winner.id).await?;
+                tracing::info!(superseded = %obsolete, by = %winner.id, "applied a replacement");
+            } else {
+                tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
+            }
+            Ok(())
+        }
+        // Task 14 replaces this branch with the merge write path. Until then a
+        // duplicate is recorded, not applied: the verdict is worth reading
+        // before anything acts on it.
+        Relation::Duplicate => {
+            let d = s.detail.or_else(|| Some("would merge".into()));
+            settle_all(core, &s.pairs, PairState::Contradiction, d.as_deref()).await
+        }
+    }
+}
+
+async fn settle_all(
+    core: &Core,
+    pairs: &[ArtifactPair],
+    state: PairState,
+    detail: Option<&str>,
+) -> Result<()> {
+    for p in pairs {
+        core.store.set_pair_state(p.id, state, detail).await?;
+    }
+    Ok(())
+}
+```
+
+In `src/jobs/consolidate.rs`'s `arm_dedupe`, delete the `may_disagree` block (lines 518–523): the gate is gone, and the prefilter now lives in the prompt and the verification.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/dedupe.rs src/jobs/consolidate.rs
+git commit -m "feat(jobs): settle a whole component in one call
+
+Four verdicts. A conflict is escalated and never merged; a replacement
+keeps a stored original rather than writing synthetic text; a duplicate
+is recorded but not yet applied. Members are flattened to captured roots
+before the call, so a re-merge never rewrites from a rewrite.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 4 — The merge write path
+
+### Task 13: Write a merge, embed it, then supersede its roots
+
+**Files:**
+- Modify: `src/jobs/merge.rs` (add `write`), `src/jobs/dedupe.rs` (`apply`'s `Duplicate` branch), `src/jobs/embed.rs` (`mark_indexed`)
+- Test: `src/jobs/merge.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `insert_merged_artifact` (Task 2), `Settlement` (Task 12).
+- Produces: `pub async fn write(core: &Core, draft: &MergedDraft, roots: &[String]) -> Result<Chunk>`; `pub async fn finish(core: &Core, merged_id: &str) -> Result<()>` — supersedes the roots of an already-embedded merged artifact.
+
+**Order matters.** `write` creates the artifact and its lineage and arms an embed job. `finish` runs when that embed completes. Superseding before the merged artifact is indexed would leave a window in which the roots are out of search and the merge is not yet in it — the knowledge temporarily unreachable, which is the failure class `heal_dangling_supersessions` exists to prevent.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn knowledge_is_never_unreachable_during_a_merge() {
+        // The write path is five steps over two stores that cannot be written
+        // atomically. Embedding before superseding means the worst state a
+        // crash can leave is redundancy -- the merge and its roots both in
+        // search -- rather than a gap. Redundancy is the state the system is
+        // coming from anyway; a gap is knowledge nobody can find.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let draft = MergedDraft {
+            title: Some("Mounting".into()),
+            text: "Mount the filesystem, or attach the volume, before writing.".into(),
+            category: None, tags: vec![], caveats: vec![],
+        };
+
+        // Step 1+2: the merge exists, nothing is hidden yet.
+        let m = write(&core, &draft, &ids).await.unwrap();
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().superseded_by.is_none());
+        }
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.payload.artifact_id == ids[0]),
+            "the roots left search before the merge was indexed"
+        );
+
+        // Step 3: embed the merge. Step 4 follows from `mark_indexed`.
+        crate::jobs::embed::run(&core, &m.id).await.unwrap();
+        for id in &ids {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().superseded_by.as_deref(),
+                Some(m.id.as_str()),
+                "the roots were never superseded"
+            );
+        }
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.payload.artifact_id == m.id),
+            "the merge never reached search"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_whose_roots_were_never_superseded_is_finished_by_the_next_sweep() {
+        // Crash between embedding the merge and hiding its roots. The merge
+        // looks complete from the artifact side and absent from the pair side,
+        // so only a join over the lineage would ever notice.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let draft = MergedDraft {
+            title: None,
+            text: "Mount the filesystem, or attach the volume, before writing.".into(),
+            category: None, tags: vec![], caveats: vec![],
+        };
+        let m = write(&core, &draft, &ids).await.unwrap();
+        // Embed without the arming hook, as an interrupted run would leave it.
+        core.store.mark_embedded(&m.id, "fake-embed", 0).await.unwrap();
+
+        crate::jobs::consolidate::run(&core).await.unwrap();
+
+        for id in &ids {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().superseded_by.as_deref(),
+                Some(m.id.as_str())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_merge_of_a_merge_is_written_from_the_captured_roots() {
+        // The anti-drift rule. M1(a,b) merged with c must be written from a, b
+        // and c -- never from M1's text, which is itself a rewrite. Otherwise
+        // every generation paraphrases a paraphrase and the originals drift
+        // further away with each one.
+        let core = test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+        let draft = MergedDraft {
+            title: None, text: "a text and b text".into(),
+            category: None, tags: vec![], caveats: vec![],
+        };
+        let m1 = write(&core, &draft, &ids).await.unwrap();
+
+        let c = seed_into_new_corpus(&core, "c text", [0.94, 0.34]).await;
+        let m2_draft = MergedDraft {
+            title: None, text: "a text and b text and c text".into(),
+            category: None, tags: vec![], caveats: vec![],
+        };
+        let m2 = write(&core, &m2_draft, &[m1.id.clone(), c.clone()]).await.unwrap();
+
+        let roots = core.store.roots_of(std::slice::from_ref(&m2.id)).await.unwrap();
+        let mut got = roots[&m2.id].clone();
+        got.sort();
+        let mut want = vec![ids[0].clone(), ids[1].clone(), c];
+        want.sort();
+        assert_eq!(got, want, "the second merge did not flatten to captured roots");
+        assert!(
+            !got.contains(&m1.id),
+            "a merged artifact was recorded as a root of another merge"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib merge`
+Expected: FAIL — `write` does not exist.
+
+- [ ] **Step 3: Implement `write` and `finish`**
+
+Append to `src/jobs/merge.rs`:
+
+```rust
+/// Create a merged artifact and arm its embedding. Its roots are **not**
+/// superseded here.
+///
+/// Superseding before the merge is indexed opens a window in which the roots
+/// are out of search and the merge is not yet in it — the knowledge temporarily
+/// unreachable. In this order the worst a crash can leave is the merge and its
+/// roots both in search, which is redundancy, which is the state the system was
+/// already in. `finish` closes it once the embedding lands.
+pub async fn write(core: &Core, draft: &MergedDraft, roots: &[String]) -> Result<Chunk> {
+    let m = core
+        .store
+        .insert_merged_artifact(
+            &crate::store::artifacts::NewMerged {
+                text: draft.text.clone(),
+                title: draft.title.clone(),
+                category: draft.category.clone(),
+                tags: draft.tags.clone(),
+                caveats: draft.caveats.clone(),
+            },
+            roots,
+        )
+        .await?;
+    core.store.enqueue(Stage::Embed, "artifact", &m.id).await?;
+    tracing::info!(merged = %m.id, roots = roots.len(), "wrote a merged artifact");
+    Ok(m)
+}
+
+/// Supersede the roots of an already-indexed merged artifact.
+///
+/// Called from `mark_indexed` when a `merged` artifact finishes embedding, and
+/// again from the sweep for merges whose process died in between.
+pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
+    let m = core.store.get_artifact(merged_id).await?;
+    if m.provenance != Provenance::Merged || m.status != ArtifactStatus::Active {
+        return Ok(());
+    }
+    let roots = core.store.roots_of(std::slice::from_ref(&m.id.clone())).await?;
+    for root in roots.get(&m.id).into_iter().flatten() {
+        let Ok(r) = core.store.get_artifact(root).await else {
+            continue;
+        };
+        if r.status != ArtifactStatus::Active || r.superseded_by.is_some() {
+            continue;
+        }
+        // One failure does not abandon the rest: an operator deprecating a root
+        // between the read and here is an ordinary race, and the sweep's repair
+        // reaches whatever is left.
+        if let Err(e) = core.supersede(root, &m.id).await {
+            tracing::warn!(root = %root, merged = %m.id, error = %e,
+                "could not hide a merged artifact's root; it stays active");
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Hook it into embedding and the sweep**
+
+In `src/jobs/embed.rs`'s `mark_indexed`, after the `relate::arm` call from Task 5:
+
+```rust
+    // A merged artifact hides its roots only once it is indexed itself, so the
+    // knowledge is never out of search on both sides at once.
+    if chunk.provenance == crate::store::artifacts::Provenance::Merged {
+        crate::jobs::merge::finish(core, &chunk.id).await?;
+    }
+```
+
+In `src/jobs/consolidate.rs`'s `run`, beside the other repairs:
+
+```rust
+    // A merge whose process died between embedding and superseding. Invisible
+    // to everything else: complete from the artifact side, absent from the pair
+    // side. Warn and carry on, like the repairs above.
+    match core.store.merged_with_active_roots(200).await {
+        Ok(unfinished) => {
+            for id in unfinished {
+                if let Err(e) = crate::jobs::merge::finish(core, &id).await {
+                    tracing::warn!(merged = %id, error = %e, "could not finish a merge");
+                }
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "could not look for unfinished merges"),
+    }
+```
+
+- [ ] **Step 5: Turn the `Duplicate` branch into a real merge**
+
+In `src/jobs/dedupe.rs`'s `apply`:
+
+```rust
+        Relation::Duplicate => {
+            let draft = s.merged.as_ref().expect("interpret guarantees it");
+            if !core.consolidate.autonomous {
+                // Recorded, not applied. Reading the verdicts before letting
+                // the system act on them is the cheapest evidence available
+                // about whether the contract holds on real data.
+                let d = s.detail.clone().or_else(|| Some("would merge".into()));
+                return settle_all(core, &s.pairs, PairState::Contradiction, d.as_deref()).await;
+            }
+            let root_ids: Vec<String> = s.roots.iter().map(|c| c.id.clone()).collect();
+            let m = crate::jobs::merge::write(core, draft, &root_ids).await?;
+            settle_all(core, &s.pairs, PairState::NoConflict, Some(&format!("merged into {}", m.id))).await?;
+            Ok(())
+        }
+```
+
+**Subsumed merges.** A component's members may include a merged artifact, and `finish` as written above hides only *roots*. Merging M1(a,b) with c produces M2 with roots {a,b,c}; a, b and c are hidden, and M1 is left active — where it is a near-duplicate of M2, so the next relate unit files the pair again and the two churn against each other forever.
+
+The rule that closes it needs no extra column and survives a crash, because it is derivable from what is already stored: **`finish` also supersedes any active merged artifact whose root set is a subset of this merge's root set.** If M2 was written from everything M1 was made of, M1 is subsumed by construction. Add to `src/store/lineage.rs`:
+
+```rust
+    /// Active merged artifacts, other than `child_id`, every root of which is
+    /// also a root of `child_id`.
+    ///
+    /// A merge written from everything an earlier merge was made of subsumes
+    /// it. Superseding the roots alone would leave that earlier merge active
+    /// and near-identical to the new one, and the two would be re-paired on
+    /// every sweep for as long as they both existed.
+    pub async fn subsumed_merges(&self, child_id: &str) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT other.id FROM artifacts other
+              WHERE other.provenance = 'merged'
+                AND other.status = 'active'
+                AND other.superseded_by IS NULL
+                AND other.id != ?1
+                AND EXISTS (SELECT 1 FROM artifact_sources WHERE child_id = other.id)
+                AND NOT EXISTS (
+                      SELECT 1 FROM artifact_sources mine
+                       WHERE mine.child_id = other.id
+                         AND mine.root_id NOT IN (
+                               SELECT root_id FROM artifact_sources WHERE child_id = ?1))",
+        )
+        .bind(child_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("id")).collect())
+    }
+```
+
+and in `finish`, after the root loop:
+
+```rust
+    for older in core.store.subsumed_merges(&m.id).await? {
+        if let Err(e) = core.supersede(&older, &m.id).await {
+            tracing::warn!(subsumed = %older, by = %m.id, error = %e,
+                "could not hide a merge this one subsumes; it stays active");
+        }
+    }
+```
+
+The `EXISTS` guard matters: a merged artifact whose roots have all been deleted has no lineage rows left, and without it the `NOT EXISTS` clause would call it a subset of everything and hide it behind an unrelated merge. That artifact is `flag_orphans`' business (Task 14), not this function's.
+
+Add the covering test to `src/jobs/merge.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_merge_that_subsumes_an_earlier_one_hides_it() {
+        // Superseding only the roots leaves the earlier merge active and
+        // near-identical to the new one, so the relate unit re-pairs them on
+        // every sweep and the two churn against each other forever.
+        let core = test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+        let m1 = write(
+            &core,
+            &MergedDraft {
+                title: None, text: "a text and b text".into(),
+                category: None, tags: vec![], caveats: vec![],
+            },
+            &ids,
+        )
+        .await
+        .unwrap();
+        crate::jobs::embed::run(&core, &m1.id).await.unwrap();
+
+        let c = seed_into_new_corpus(&core, "c text", [0.94, 0.34]).await;
+        let m2 = write(
+            &core,
+            &MergedDraft {
+                title: None, text: "a text and b text and c text".into(),
+                category: None, tags: vec![], caveats: vec![],
+            },
+            &[m1.id.clone(), c.clone()],
+        )
+        .await
+        .unwrap();
+        crate::jobs::embed::run(&core, &m2.id).await.unwrap();
+
+        assert_eq!(
+            core.store.get_artifact(&m1.id).await.unwrap().superseded_by.as_deref(),
+            Some(m2.id.as_str()),
+            "the subsumed merge is still active and will be re-paired forever"
+        );
+        for id in ids.iter().chain(std::iter::once(&c)) {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().superseded_by.as_deref(),
+                Some(m2.id.as_str())
+            );
+        }
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jobs/merge.rs src/jobs/dedupe.rs src/jobs/embed.rs src/jobs/consolidate.rs
+git commit -m "feat(jobs): write a merge, index it, then hide its roots
+
+Embedding before superseding means the worst a crash can leave is the
+merge and its roots both in search. The other order leaves a window in
+which neither is findable, which is the failure class
+heal_dangling_supersessions exists to prevent. The sweep gains a repair
+for merges whose process died in between -- a state complete from the
+artifact side and absent from the pair side, so nothing else would see it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Undo, and the pairs that must stay dismissed
+
+**Files:**
+- Modify: `src/jobs/merge.rs` (add `undo`, `flag_orphans`)
+- Modify: `src/jobs/consolidate.rs` (call `flag_orphans`)
+- Test: `src/jobs/merge.rs` (in-module)
+
+**Interfaces:**
+- Produces: `pub async fn undo(core: &Core, merged_id: &str) -> Result<()>`; `pub async fn flag_orphans(core: &Core) -> Result<usize>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn undoing_a_merge_survives_the_next_sweep() {
+        // Reactivating the roots alone accomplishes nothing: the next sweep
+        // re-finds them, the model says duplicate again, and the operator's
+        // decision is silently undone. Literally the same bug as
+        // reactivating_a_superseded_artifact_survives_the_next_sweep.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = std::sync::Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"duplicate","detail":"same claim",
+                "merged":{"text":"Mount the filesystem, or attach the volume, before writing.",
+                          "tags":[],"caveats":[]}}"#
+                .into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let pair = queue_pair(&core, &ids).await;
+        crate::jobs::dedupe::run(&core, &pair.to_string()).await.unwrap();
+        let m = core.store.merged_with_active_roots(10).await.unwrap();
+        let merged_id = if m.is_empty() {
+            // already finished
+            core.store.get_artifact(&ids[0]).await.unwrap().superseded_by.unwrap()
+        } else {
+            m[0].clone()
+        };
+        crate::jobs::embed::run(&core, &merged_id).await.ok();
+
+        undo(&core, &merged_id).await.unwrap();
+
+        for id in &ids {
+            let c = core.store.get_artifact(id).await.unwrap();
+            assert_eq!(c.status, ArtifactStatus::Active);
+            assert!(c.superseded_by.is_none());
+        }
+        assert_eq!(
+            core.store.get_artifact(&merged_id).await.unwrap().status,
+            ArtifactStatus::Deprecated,
+            "the merged artifact was deleted, taking its lineage with it"
+        );
+        assert_eq!(
+            core.store.pairs_by_state(PairState::Dismissed, 10).await.unwrap().len(),
+            1,
+            "the pair was left answerable, so the sweep will merge it again"
+        );
+
+        crate::jobs::consolidate::run(&core).await.unwrap();
+        for id in &ids {
+            assert!(
+                core.store.get_artifact(id).await.unwrap().superseded_by.is_none(),
+                "the sweep merged the pair again after an explicit undo"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn deleting_a_root_flags_the_merged_artifact_rather_than_hiding_the_loss() {
+        // The cascade removes the lineage row while the merged text still
+        // carries that root's content, so the artifact claims less provenance
+        // than it has. Not data loss, but a silent untruth.
+        let core = test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+        let draft = MergedDraft {
+            title: None, text: "a text and b text".into(),
+            category: None, tags: vec![], caveats: vec![],
+        };
+        let m = write(&core, &draft, &ids).await.unwrap();
+
+        core.store.delete_artifact(&ids[0]).await.unwrap();
+        assert_eq!(flag_orphans(&core).await.unwrap(), 1);
+
+        let flagged = core.store.get_artifact(&m.id).await.unwrap();
+        assert!(flagged.flags.iter().any(|f| f == "orphaned_source"), "{flagged:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test undoing_a_merge_survives_the_next_sweep`
+Expected: FAIL — `undo` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Take a merge back: the roots return, the merged artifact is retired, and the
+/// pairs that produced it are dismissed.
+///
+/// The last of those three is the one that is easy to leave out and useless to
+/// leave out. Reactivating the roots alone accomplishes nothing: the sweep
+/// re-finds them, the model reaches the same verdict, and the decision is
+/// silently undone. `record_pair` is INSERT OR IGNORE, so a dismissed row is
+/// respected forever — the mechanism exists and only needs to be used.
+///
+/// The merged artifact is deprecated rather than deleted: `artifact_sources`
+/// cascades away with a delete, taking the record of what was attempted.
+///
+/// This is for an *explicit* undo. A merged artifact that is simply deleted is
+/// handled by `heal_dangling_supersessions`, which restores the roots — and a
+/// fresh merge is then correct, because the duplication is genuinely back. A
+/// decision may overrule the sweep; a deletion may not.
+pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
+    let m = core.store.get_artifact(merged_id).await?;
+    if m.provenance != Provenance::Merged {
+        return Err(Error::Validation(format!("{merged_id} is not a merged artifact")));
+    }
+
+    let roots = core.store.roots_of(std::slice::from_ref(&m.id.clone())).await?;
+    let members: Vec<String> = roots.get(&m.id).cloned().unwrap_or_default();
+
+    for r in &members {
+        if let Err(e) = core.reactivate(r).await {
+            tracing::warn!(root = %r, error = %e, "could not reactivate a merged artifact's root");
+        }
+    }
+
+    // Deprecate only after the roots are back: the other order leaves a window
+    // with nothing in search at all.
+    core.deprecate(&m.id).await?;
+
+    // Every pair among the restored members. Without this the undo lasts until
+    // the next sweep and no longer.
+    for pair in core.store.pairs_among(&members).await? {
+        core.store.set_pair_state(pair.id, PairState::Dismissed, Some("merge undone")).await?;
+    }
+    tracing::info!(merged = %m.id, roots = members.len(), "undid a merge");
+    Ok(())
+}
+
+/// Flag merged artifacts that have lost a source to a delete.
+///
+/// The text still carries what the deleted root said, so this is not data loss
+/// — it is a claim of provenance the artifact can no longer support, and the
+/// detail pane says so rather than quietly showing one fewer source.
+pub async fn flag_orphans(core: &Core) -> Result<usize> {
+    let mut n = 0;
+    for id in core.store.merged_missing_a_source(500).await? {
+        core.store
+            .set_artifact_flags(
+                &id,
+                &["orphaned_source".to_string()],
+                Some("one of this artifact's sources has been deleted"),
+            )
+            .await?;
+        n += 1;
+    }
+    Ok(n)
+}
+```
+
+Add two store reads in `src/store/lineage.rs`:
+
+```rust
+    /// Every pair, in any state, both of whose artifacts are in this set.
+    pub async fn pairs_among(&self, ids: &[String]) -> Result<Vec<ArtifactPair>> { /* ... */ }
+
+    /// Merged artifacts whose stored lineage is smaller than the number of
+    /// sources they were written from. Recorded as a count on the artifact at
+    /// write time, so this is a comparison rather than a guess.
+    pub async fn merged_missing_a_source(&self, limit: i64) -> Result<Vec<String>> { /* ... */ }
+```
+
+`merged_missing_a_source` needs a `source_count` column on `artifacts`, written by `insert_merged_artifact` as `roots.len()`. Add it to `schema.sql` beside `provenance` (one column per line) and to `Chunk`.
+
+Call `flag_orphans` from `consolidate::run` beside the other repairs, warn-and-carry-on.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/merge.rs src/store/lineage.rs src/store/schema.sql src/store/artifacts.rs src/jobs/consolidate.rs
+git commit -m "feat(jobs): undo a merge, and make the undo stick
+
+Reactivating the roots alone accomplishes nothing -- the sweep re-finds
+them and reaches the same verdict, so the decision is silently undone.
+Dismissing the pairs is what makes it permanent. The merged artifact is
+deprecated rather than deleted, because a delete cascades the lineage
+away with it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 5 — Surface, pacing, measurement
+
+### Task 15: Ops and the detail pane
+
+**Files:**
+- Modify: `src/web/ui.rs`, `src/web/templates/` (artifact detail, ops), `src/web/api.rs`
+- Test: `src/web/ui.rs` (in-module)
+
+**Interfaces:**
+- Consumes: `roots_of`, `pairs_by_state`, `merge::undo`.
+- Produces: routes `POST /ui/merge/{id}/undo`; Ops sections **Merged**, **Conflicts**, **Oversized**.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn a_merged_artifact_renders_its_roots_instead_of_corpus_lines() {
+        // A captured artifact renders the corpus lines its span claims. A
+        // merged one has no span and no corpus, so the pane must show what it
+        // is actually made of -- and each root must link to its own corpus,
+        // because that is where the wording it was built from still lives.
+        let core = test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+        let draft = MergedDraft {
+            title: None, text: "a text and b text".into(),
+            category: None, tags: vec![], caveats: vec![],
+        };
+        let m = crate::jobs::merge::write(&core, &draft, &ids).await.unwrap();
+
+        let html = render_artifact_detail(&core, &m.id).await.unwrap();
+        for id in &ids {
+            assert!(html.contains(id.as_str()), "the pane does not name root {id}");
+        }
+        assert!(!html.contains("corpus lines"), "a merged artifact claimed a span");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test a_merged_artifact_renders_its_roots_instead_of_corpus_lines`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In the artifact detail handler, branch on `chunk.provenance`: `Captured` keeps the existing corpus-lines path; `Merged` loads `roots_of` and renders each root with its title, its corpus link, and its status. Add the **Undo merge** button, posting to `/ui/merge/{id}/undo`, which calls `crate::jobs::merge::undo`.
+
+On the Ops page add three sections beside the existing ones: **Merged** (`artifacts_by_status` filtered to `provenance = 'merged'`), **Conflicts** (`pairs_by_state(Contradiction, ..)`), **Oversized** (`pairs_by_state(Oversized, ..)`), each with its `count_pairs_by_state` total so the page can say how many it is not showing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/
+git commit -m "feat(ui): render merged artifacts by their roots, and undo a merge
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: Pace dedupe by a rate, not by a sweep
+
+**Files:**
+- Modify: `src/core/background.rs` (add `spawn_dedupe_ticker`), `src/main.rs:286-296`, `src/jobs/consolidate.rs` (`arm_dedupe`), `src/config.rs`, `config.example.toml`, `README.md:158`
+- Test: `src/core/background.rs`, `src/jobs/consolidate.rs`
+
+**Interfaces:**
+- Produces: `ConsolidateConfig.dedupe_interval_mins: u64` (15), `.max_dedupe_per_tick: usize` (5); `pub fn spawn_dedupe_ticker(core: Core, shutdown: watch::Receiver<bool>) -> JoinHandle<()>`. `max_judgements` is removed.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn dedupe_units_sort_behind_capture_work() {
+        // A large ingest may delay hygiene; hygiene may not delay an ingest.
+        // jobs.seq and idx_jobs_claim2 already order the queue this way -- this
+        // pins that dedupe actually uses it.
+        let core = test_core().await;
+        core.store.enqueue(Stage::SegmentWindow, "segment", "w0").await.unwrap();
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids).await;
+        crate::jobs::consolidate::arm_dedupe_for_test(&core, pair).await.unwrap();
+
+        let first = core.store.claim_job().await.unwrap().unwrap();
+        assert_eq!(first.stage, Stage::SegmentWindow, "dedupe ran ahead of capture");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test dedupe_units_sort_behind_capture_work`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `src/config.rs`, replace `max_judgements` with the two new fields and defaults. In `arm_dedupe`, use `core.consolidate.max_dedupe_per_tick` as the budget and arm with a high `seq`:
+
+```rust
+/// Dedupe units sort behind synthesis and embedding of equal attempt count, so
+/// hygiene consumes what capture leaves over rather than the other way round.
+/// `claim_job` orders by (state, attempts, seq, id), and a window's seq is its
+/// index within a document — a few hundred at most.
+const DEDUPE_SEQ_BASE: i64 = 1_000_000;
+```
+
+`rearm_idle_seq(Stage::Dedupe, "pair", &target, DEDUPE_SEQ_BASE + armed as i64)`.
+
+Add `spawn_dedupe_ticker` modelled on `spawn_retention_ticker`, firing every `dedupe_interval_mins`, calling `arm_dedupe(&core)`. Wire it in `src/main.rs` beside the other two and push its handle. Leave the in-flight rule alone: `live_job` still skips a pair whose unit is queued, and nothing counts units in flight — an unreachable unit must not be able to block every other pair.
+
+Expose `arm_dedupe_for_test` as `#[cfg(test)] pub(crate)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.rs src/core/background.rs src/main.rs src/jobs/consolidate.rs config.example.toml README.md
+git commit -m "feat(consolidate): pace dedupe by a rate, not by a sweep
+
+max_judgements bounded what one sweep armed, which was right while the
+sweep was the only producer. Relate units now file pairs continuously, so
+a number per 24-hour tick is a queue that only grows. The fixed quantity
+is hardware throughput, so the budget becomes calls per hour. Units sort
+behind capture work: a large ingest may delay hygiene, not the reverse.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 17: Teach the evaluation harness about merges
+
+**Files:**
+- Modify: `tests/eval.rs`, `src/eval/metrics.rs`
+- Test: `tests/eval.rs`
+
+**Interfaces:**
+- Consumes: `roots_of`, `Chunk.superseded_by`.
+- Produces: a graded pair whose target artifact has since been superseded by a merge scores as a hit on the merged artifact.
+
+**Why.** Merging changes what is retrievable at all. Without this the score collapses for a reason that says nothing about retrieval, and the number that would tell us whether the feature helps becomes unreadable.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_graded_artifact_that_was_merged_still_counts_as_a_hit() {
+    // A judged pair names the artifact that answered the query. When a merge
+    // supersedes it, the knowledge lives in the merged artifact and search
+    // correctly returns that instead. Scoring it as a miss would report a
+    // retrieval regression that did not happen.
+    let core = test_core().await;
+    let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+    let draft = MergedDraft {
+        title: None, text: "a text and b text".into(),
+        category: None, tags: vec![], caveats: vec![],
+    };
+    let m = crate::jobs::merge::write(&core, &draft, &ids).await.unwrap();
+    engram::jobs::embed::run(&core, &m.id).await.unwrap();
+
+    // The graded pair names ids[0], which is now superseded by m.
+    assert!(
+        resolve_expected(&core, &ids[0]).await.unwrap().contains(&m.id),
+        "a merged artifact does not satisfy a grade against its root"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test eval a_graded_artifact_that_was_merged_still_counts_as_a_hit`
+Expected: FAIL — `resolve_expected` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Add to the eval harness:
+
+```rust
+/// The artifact ids that satisfy a grade naming `expected`.
+///
+/// Itself, plus anything that superseded it. A merge moves the knowledge into a
+/// new artifact and search correctly returns that one; without this the harness
+/// reports a retrieval regression that is really a bookkeeping change.
+async fn resolve_expected(core: &Core, expected: &str) -> Result<Vec<String>> {
+    let mut out = vec![expected.to_string()];
+    let mut cursor = expected.to_string();
+    // Chains are short by construction — a merge supersedes onto a live
+    // artifact — but bound it anyway rather than trusting that.
+    for _ in 0..8 {
+        let c = core.store.get_artifact(&cursor).await?;
+        match c.superseded_by {
+            Some(next) => {
+                out.push(next.clone());
+                cursor = next;
+            }
+            None => break,
+        }
+    }
+    Ok(out)
+}
+```
+
+Use it wherever the harness compares a returned artifact id against a graded expectation.
+
+- [ ] **Step 4: Run the harness and record the delta**
+
+Run: `cargo test --test eval`
+Expected: PASS. Record the scores before and after a merge run over the same corpus in the commit message. A drop is a finding about the feature, not about the harness.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/eval.rs src/eval/
+git commit -m "test(eval): a merged artifact satisfies a grade against its root
+
+Merging changes what is retrievable at all. Without this the score
+collapses for a bookkeeping reason and the one number that says whether
+the feature helps becomes unreadable.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 18: Turn it on
+
+**Files:**
+- Modify: `src/config.rs` (`autonomous` default), `config.example.toml`, `README.md`, `ROADMAP.md`, `src/store/schema.sql:51-53`, `src/jobs/consolidate.rs:1-13`
+
+**Why last.** The gap between Task 12 (`autonomous = false`, verdicts recorded) and this task is the cheapest evidence available about whether the contract holds on real data. Do not close it in the same sitting.
+
+- [ ] **Step 1: Read the recorded verdicts**
+
+Run the instance with `autonomous = false` over a real corpus. On Ops, read the `Contradiction` rows whose detail begins `would merge` — those are the merges that would have been written. Confirm the subject rule held: no two artifacts about different subjects proposed as duplicates.
+
+- [ ] **Step 2: Flip the default**
+
+In `src/config.rs`, `autonomous: true`. In `config.example.toml`:
+
+```toml
+# Let consolidation settle duplicate groups by itself: superseding where one
+# stored artifact plainly replaces another, and writing one merged artifact
+# where each side carries something the other lacks. On by default.
+#
+# A disagreement about a value is never settled this way. It is escalated to
+# the conflicts queue on Ops, because deciding which of two facts is current is
+# the judgement a model is worst at.
+#
+# Every merge is undoable, and no merge is written that would drop a number,
+# version, date, path, command or error string that appeared in any source.
+autonomous = true
+```
+
+- [ ] **Step 3: Correct the four places that state the old invariant**
+
+- `src/store/schema.sql:51-53`: replace "nothing is ever merged or rewritten in place" with a sentence that says a merged artifact is a distinct `provenance` kind with lineage rows, and that a captured artifact's text is still never rewritten in place.
+- `src/jobs/consolidate.rs:1-13`: rewrite the module header to describe the four outcomes and name the two verification passes.
+- `ROADMAP.md:23-24`: keep the fidelity principle and add the narrow exception with its four conditions, referencing the spec.
+- `README.md:21` and the config table: same, plus the new keys.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(consolidate): autonomous duplicate hygiene on by default
+
+Four places said nothing is ever merged. They now say what is: merging is
+permitted narrowly, and the four conditions that make it safe are part of
+the fidelity thesis rather than exceptions to it -- superseding is
+preferred wherever a stored original suffices, merged artifacts are a
+distinct provenance kind with explicit lineage, originals are hidden and
+never destroyed, and no merge may drop a value or a literal. A value
+conflict is still a person's decision.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review notes
+
+Checked against the spec, section by section.
+
+- §3's four mechanisms: Tasks 12 (`replaced` preferred), 1+2 (provenance and lineage), 13 (`supersede`, never delete), 11 (`losses`).
+- §4.1's `lifecycle_dirty` lands in Task 1's schema but is only *used* in Task 7 — deliberate, so the column exists before the one database recreation.
+- §6.1's four verdicts: Task 9 parses them, Task 12 applies three, Task 13 the fourth.
+- §8.3's `orphaned_source` needs a `source_count` column, which §4 did not name. Added in Task 14 with the reason: without it "missing a source" cannot be distinguished from "had two sources".
+- **Found during self-review and fixed in Task 13:** the spec's §6.6 re-merge rule flattens a component to captured roots, and §8's write path supersedes those roots — which leaves an *earlier merged artifact* in the component active. It is then near-identical to the new merge, so the relate unit re-pairs them every sweep and the two churn indefinitely. `subsumed_merges` closes it from data already stored, so it survives a crash: a merge written from everything an earlier merge was made of subsumes it.
+- **Known gap, deliberate:** a corpus filter does not match merged artifacts, because `VectorPayload.corpus_id` carries `""` for them. Making it optional ripples through every search filter for little gain, and an artifact belonging to no corpus arguably should not match a corpus filter. If it turns out to matter, the fix is a `root_corpus_ids` payload array — not in this plan.
+- Type consistency: `Provenance`, `NewMerged`, `MergedDraft`, `Relation`, `Dedupe`, `Settlement`, `Verdict`, `losses`, `write`, `finish`, `undo`, `flag_orphans`, `classify_pair`, `open_component`, `roots_of`, `merged_with_active_roots` are each defined in exactly one task and referenced by name thereafter.

--- a/docs/superpowers/plans/2026-08-14-pr14-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-14-pr14-review-fixes.md
@@ -1,1541 +1,1093 @@
-# PR #14 Review Fixes Implementation Plan
+# PR 14 Review Fixes Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Fix all 14 confirmed findings from the multi-agent review of PR #14 (`feat/autonomous-consolidation`), on that branch.
+**Goal:** Fix every confirmed finding from the multi-agent review of PR 14 (feat/autonomous-consolidation), including the minor reuse/efficiency ones.
 
-**Architecture:** The load-bearing principle across the dedupe fixes: a pair-state write may only become terminal *after* the fallible side effect it describes (supersede, merge-embed) is durable — or the settled state must be recoverable by a sweep repair. Three product decisions are already made by the user: (1) observation-mode merge verdicts get a new honest `WouldMerge` pair state, draft still discarded; (2) unsuperseding a merge source is honored as a partial restore via a `restored` marker on lineage rows; (3) merges whose embed permanently fails are auto-undone by the sweep, reopening their pairs for a person.
+**Architecture:** All fixes are local repairs to the consolidation subsystem introduced by this branch: the dedupe judge unit (`src/jobs/dedupe.rs`), merge lifecycle (`src/jobs/merge.rs`), the consolidation sweep (`src/jobs/consolidate.rs`), the pair and lineage stores, and the Ops UI. No schema changes; two new store methods.
 
-**Tech Stack:** Rust (tokio, sqlx/SQLite, axum, askama templates), Qdrant + in-memory vector store. Tests are `#[tokio::test]` colocated in each module.
+**Tech Stack:** Rust, sqlx/SQLite, tokio, axum. Tests are in-file `#[cfg(test)] mod tests` using `crate::core::test_support::test_core()`, `crate::infer::fake::ScriptedCompleter`, and `crate::jobs::consolidate::tests::{seed, seed_titled}`.
 
-**Spec:** The 14 findings, restated one line each in "Findings Index" below. Full failure scenarios are in the PR #14 review report (delivered in-session); each task's rationale section repeats what its finding claims.
+**Spec:** The findings come from the code review recorded in this plan's "Findings and decisions" section below (verifier transcripts under the session's task outputs). The branch's own design spec is `docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md`.
 
 ## Global Constraints
 
-- Work on branch `feat/autonomous-consolidation` (PR #14). Do not merge or rebase onto master.
-- Every task: `cargo test` must pass and `cargo fmt` must be clean before its commit.
-- Commit style (from repo history): `fix(scope): lowercase clause describing the behavior`, e.g. `fix(dedupe): a retired member dismisses only its own pairs`. End every commit message with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
-- Comment style: this codebase writes long "why" comments. When you change behavior a nearby comment describes, update the comment in the same edit — several findings are precisely stale comments.
-- Schema changes go in BOTH places: the fresh-DB schema (`src/store/schema.sql` — locate the `artifact_pairs` / `artifact_sources` CREATE TABLE there) AND the `ADDED_COLUMNS` list in `src/store/mod.rs` (append-only, with a default; never reorder).
-- SQLite `now()` helper and test idioms (`test_core()`, `seed`, `queue_pair`, `ScriptedCompleter`, direct `sqlx::query(...).execute(&core.store.pool)` for state surgery) already exist — use them, do not invent new harnesses.
+- Run `cargo test` after every implementation step; run `cargo fmt` before every commit.
+- Comment style: comments state constraints the code cannot show, in the codebase's essay style. Never "fixed per review".
+- Test names are full snake_case sentences (`a_retired_member_dismisses_only_its_own_pairs`), matching the existing suites.
+- Commit after each task with a conventional-commit message.
 
-## Findings Index
+## Findings and decisions
 
-| # | Where | One-line claim |
-|---|-------|----------------|
-| F1 | `src/jobs/dedupe.rs:294-327` | Replaced verdict settles pairs terminally before the fallible `core.supersede`; picks obsolete/winner from roots with no status check; failure is unretryable (run() skips non-Pending). |
-| F2 | `src/jobs/dedupe.rs:78-81` | One retired component member dismisses the entire component, killing sibling pairs between still-active duplicates forever. |
-| F3 | `src/jobs/consolidate.rs:307` | Sweep's unfinished-merge repair silently reverts an operator's unsupersede of a merge source, every sweep. |
-| F4 | `src/jobs/consolidate.rs:446-470` | Closing pass treats any `get_artifact` error (transient BUSY) as "artifact gone" and permanently closes a live pair as NoConflict. |
-| F5 | `src/jobs/dedupe.rs:357-365` | Duplicate verdict settles pairs as NoConflict before the merge is embedded; a permanently failing embed strands an invisible merge, duplicates unmergeable forever. |
-| F6 | `src/jobs/dedupe.rs:321` | Autonomous applied replacement leaves its pair in `Superseded` (= "awaiting confirmation"); its buttons then always return a validation error. |
-| F7 | `src/jobs/dedupe.rs:334-350` | Autonomy-off duplicate verdict filed as `Contradiction`; UI lies ("These two disagree"), offers only lossy keep-one buttons, draft discarded. |
-| F8 | `src/store/lineage.rs:43-55` | `roots_of` self-root fallback fires for an orphaned merge; its synthesized text is shown to the model as a captured original and can become a `root_id`. |
-| F9 | `src/store/artifacts.rs:407` | `restore_artifact` loses `source_count`/lineage, so a merge restored from its vector payload silently defeats the anti-drift invariant. |
-| F10 | `src/jobs/consolidate.rs:153-169` | `repair_lifecycle_drift` racing a payload-first reveal can re-hide the payload, then the reveal clears the marker: row Active, payload Superseded, no marker. |
-| F11 | `src/store/jobs.rs:330` | Legacy `'judge'` job rows parse as `None` → `unwrap_or(Stage::Synthesize)` misroute. |
-| F12 | `src/jobs/consolidate.rs:549-560` | `arm_dedupe` does a 200-row query + loop every tick even when `max_dedupe_per_tick == 0`. |
-| F13 | `src/store/pairs.rs:350-366` | `open_component` fixed-point loop rescans the whole window per growth pass — quadratic on the 5 000-row window. |
-| F14 | `src/jobs/consolidate.rs:148,175` | Comments claim `full_lifecycle_reconcile` "no longer runs every sweep" / is "behind the marker" while `run()` calls it unconditionally at line 298. |
+Confirmed findings fixed by this plan (task number in parentheses):
+
+1. Stale `member_ids` in the dedupe unit leaks retired members' roots into the prompt, the fan-in cap, `losses()`, and the Replaced-verdict resolution (Task 2).
+2. `merge::undo` pressed before the embed lands dismisses nothing and strands the merge's pairs settled forever — silent permanent duplication (Task 4).
+3. Proposal-mode sibling pairs record "`X` was superseded" when the supersede was only proposed and may be rejected (Task 3).
+4. `WouldMerge` doc promises re-judging on autonomy flip; no code path provides it (Task 5).
+5. `flag_orphans` starves: no flag filter / ORDER BY in `merged_missing_a_source`, so 500 permanently-orphaned old merges block new ones forever, and "mark reviewed" is undone next sweep (Task 6).
+6. `merge_max_roots = 0` or `1` silently settles every component `Oversized`; `normalize()` doesn't touch it (Task 7).
+7. `full_lifecycle_reconcile_scanning` runs outside `lifecycle_lock`, races a concurrent reveal, and writes the corrupted state with no marker left to find it by (Task 8).
+8. `heal_dangling_supersessions` takes no lock and never marks dirty; interleaved with `repair_lifecycle_drift` it produces row-Active/payload-Superseded/marker-clear (Task 9).
+9. The liveness predicate `status == Active && superseded_by.is_none()` is hand-spelled at 12 production sites (Task 1).
+10. `ops()` and `build_artifact_detail()` duplicate the source-rows loop verbatim, and `ops()` is an N+1 over a batch API (Task 10).
+11. `open_component`'s `let Some(seed) ... else` arm is unreachable (Task 11).
+12. `arm_dedupe` pays two full-row `get_artifact` fetches per pair before the cheap already-queued skip, re-checking the same in-flight pairs every tick (Task 12).
+
+Declined by the user (2026-08-14, "prototype, only used by me — legacy doesn't exist"):
+
+- **Legacy-DB startup refusal stays.** `migrate()`'s hard error on a pre-PR `corpus_id NOT NULL` schema is deliberate and keeps its test. No automated rebuild.
+- **The autonomy default flip on upgrade stays.** No carry for configs that never wrote `judge`; fresh-install `autonomous: true` is the spec's choice.
+- **Legacy `no_conflict` prefilter pairs stay settled.** No migration reopens them.
+
+Deferred (not in this plan): the altitude finding proposing a single `Core::lifecycle_write` helper owning the lock/marker/ordering protocol. Tasks 8 and 9 fix the two concrete protocol violations; the full refactor of five working mutators is follow-up work, not a review fix.
 
 ---
 
-### Task 1: Pair-state groundwork — `WouldMerge` state and `merged_into` column
+### Task 1: `Chunk::in_results()` — one owner for the liveness predicate
 
 **Files:**
-- Modify: `src/store/pairs.rs` (PairState enum, `ArtifactPair`, `row_to_pair`, `set_pair_state`, `set_pair_superseded`; new fns `set_pair_merged`, `reopen_pairs_merged_into`)
-- Modify: `src/store/mod.rs` (`ADDED_COLUMNS`)
-- Modify: `src/store/schema.sql` (or wherever `CREATE TABLE artifact_pairs` lives — find with `grep -rn "CREATE TABLE artifact_pairs" src/`)
-- Test: `src/store/pairs.rs` tests module
+- Modify: `src/store/artifacts.rs` (impl block for `Chunk`, after the struct around line 99)
+- Modify: `src/jobs/dedupe.rs:79`, `src/jobs/dedupe.rs:345`
+- Modify: `src/jobs/classify.rs:54`
+- Modify: `src/jobs/relate.rs:50`
+- Modify: `src/jobs/consolidate.rs:440`, `src/jobs/consolidate.rs:657-661`
+- Modify: `src/jobs/merge.rs:61-64`, `src/jobs/merge.rs:76`, `src/jobs/merge.rs:184-187`
+- Modify: `src/core/ingest.rs:314`
+- Modify: `src/web/judge.rs:174`, `src/web/judge.rs:363`
+- Test: `src/store/artifacts.rs` tests module
 
 **Interfaces:**
-- Consumes: existing `Store` pair API.
-- Produces (later tasks rely on these exact names):
-  - `PairState::WouldMerge` with `as_str() == "would_merge"`, `parse("would_merge")`.
-  - `ArtifactPair.merged_into: Option<String>`.
-  - `Store::set_pair_merged(&self, id: i64, merged_into: &str, detail: Option<&str>) -> Result<()>` — writes `state = 'no_conflict'`, `detail`, `merged_into`, `obsolete_id = NULL`; `Err(NotFound)` when 0 rows affected.
-  - `Store::reopen_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64>` — `state = 'contradiction'`, given detail, `merged_into = NULL` for all rows whose `merged_into = merged_id`; returns rows affected.
-  - `set_pair_state` and `set_pair_superseded` both additionally set `merged_into = NULL` (same rule as `obsolete_id`: the column belongs to the merged-settlement and to nothing else).
+- Produces: `impl Chunk { pub fn in_results(&self) -> bool }` — later tasks (2, 12) call it.
 
-- [ ] **Step 1: Write the failing tests** (append to `src/store/pairs.rs` tests)
+- [ ] **Step 1: Write the failing test** (in `src/store/artifacts.rs` tests)
 
 ```rust
 #[tokio::test]
-async fn a_merged_settlement_records_which_merge_answered_it() {
+async fn in_results_means_active_and_not_superseded() {
     let s = Store::memory().await.unwrap();
-    let (a, b) = two_artifacts(&s).await;
-    s.record_pair(&a, &b, 0.91).await.unwrap();
-    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    let src = s.insert_corpus("raw", "web", None).await.unwrap();
+    let made = s
+        .insert_artifacts(&src.id, &[nc(0, "one"), nc(1, "two")])
+        .await
+        .unwrap();
 
-    s.set_pair_merged(id, "merge-1", Some("same claim")).await.unwrap();
-
-    let p = s.get_pair(id).await.unwrap();
-    assert_eq!(p.state, PairState::NoConflict);
-    assert_eq!(p.merged_into.as_deref(), Some("merge-1"));
-
-    // Leaving the settlement drops the record, exactly as obsolete_id does.
-    s.set_pair_state(id, PairState::Dismissed, None).await.unwrap();
-    assert_eq!(s.get_pair(id).await.unwrap().merged_into, None);
-}
-
-#[tokio::test]
-async fn reopening_a_stranded_merge_s_pairs_touches_only_its_own() {
-    let s = Store::memory().await.unwrap();
-    let (a, b) = two_artifacts(&s).await;
-    s.record_pair(&a, &b, 0.91).await.unwrap();
-    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-    s.set_pair_merged(id, "merge-1", None).await.unwrap();
-
-    assert_eq!(
-        s.reopen_pairs_merged_into("merge-other", "unrelated").await.unwrap(),
-        0,
-        "another merge's undo reopened this pair"
-    );
-    assert_eq!(s.reopen_pairs_merged_into("merge-1", "the merged text could not be indexed").await.unwrap(), 1);
-    let p = s.get_pair(id).await.unwrap();
-    assert_eq!(p.state, PairState::Contradiction);
-    assert_eq!(p.merged_into, None);
-}
-
-#[tokio::test]
-async fn would_merge_is_a_state_of_its_own() {
-    let s = Store::memory().await.unwrap();
-    let (a, b) = two_artifacts(&s).await;
-    s.record_pair(&a, &b, 0.91).await.unwrap();
-    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-    s.set_pair_state(id, PairState::WouldMerge, Some("same claim")).await.unwrap();
-    assert_eq!(s.pairs_by_state(PairState::WouldMerge, 10).await.unwrap().len(), 1);
-    assert_eq!(PairState::parse("would_merge"), PairState::WouldMerge);
+    assert!(s.get_artifact(&made[0].id).await.unwrap().in_results());
+    s.set_superseded_by(&made[0].id, Some(&made[1].id)).await.unwrap();
+    assert!(!s.get_artifact(&made[0].id).await.unwrap().in_results());
+    s.set_artifact_status(&made[1].id, ArtifactStatus::Deprecated)
+        .await
+        .unwrap();
+    assert!(!s.get_artifact(&made[1].id).await.unwrap().in_results());
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+(`Store::memory()` and the `nc` helper are the module's existing test fixtures.)
 
-Run: `cargo test -p engram a_merged_settlement_records reopening_a_stranded would_merge_is_a_state 2>&1 | tail -20`
-Expected: compile errors — `WouldMerge`, `merged_into`, `set_pair_merged` do not exist.
+- [ ] **Step 2: Run it — expect FAIL** with "no method named `in_results`": `cargo test in_results_means`
 
-- [ ] **Step 3: Implement**
-
-In `src/store/pairs.rs`:
-- Add `WouldMerge` variant with doc comment: the model answered "duplicate" while autonomy is off — recorded so an operator can read the verdicts before letting the system act on them; the draft is not kept, and flipping autonomy on lets a later unit re-judge and merge.
-- Extend `as_str`/`parse` with `"would_merge"`.
-- Add `pub merged_into: Option<String>` to `ArtifactPair` (doc: which merged artifact answered this pair, when the settlement was an applied merge; what the stranded-merge reap uses to reopen exactly the pairs a failed merge closed). Read it in `row_to_pair`.
-- In `set_pair_state` and `set_pair_superseded` SQL, add `, merged_into = NULL` next to the existing `obsolete_id` handling (extend `set_pair_state`'s doc comment to name both columns).
-- New functions:
+- [ ] **Step 3: Implement** in `src/store/artifacts.rs`, next to the `Chunk` struct:
 
 ```rust
-/// Settle a pair as answered by an applied merge. `merged_into` names the
-/// merged artifact, which is what lets the stranded-merge reap reopen exactly
-/// the pairs a merge that never embedded had closed.
-pub async fn set_pair_merged(&self, id: i64, merged_into: &str, detail: Option<&str>) -> Result<()> {
-    let res = sqlx::query(
-        "UPDATE artifact_pairs
-            SET state = 'no_conflict', detail = ?, merged_into = ?, obsolete_id = NULL
-          WHERE id = ?",
-    )
-    .bind(detail)
-    .bind(merged_into)
-    .bind(id)
-    .execute(&self.pool)
-    .await?;
-    if res.rows_affected() == 0 {
-        return Err(crate::error::Error::NotFound);
+impl Chunk {
+    /// Whether search may return this artifact: active and not hidden behind
+    /// a winner. This is the predicate every consolidation decision gates on —
+    /// what may win a cluster, be shown to the model, or be superseded — so it
+    /// has exactly one spelling. A third lifecycle state changes this method,
+    /// not twelve call sites.
+    pub fn in_results(&self) -> bool {
+        self.status == ArtifactStatus::Active && self.superseded_by.is_none()
     }
-    Ok(())
-}
-
-/// Reopen every pair a now-dead merge had settled, handing them to a person.
-/// Contradiction rather than Pending on purpose: re-arming the model would
-/// regenerate the same unembeddable draft and loop forever.
-pub async fn reopen_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
-    let res = sqlx::query(
-        "UPDATE artifact_pairs
-            SET state = 'contradiction', detail = ?, merged_into = NULL
-          WHERE merged_into = ?",
-    )
-    .bind(detail)
-    .bind(merged_id)
-    .execute(&self.pool)
-    .await?;
-    Ok(res.rows_affected())
 }
 ```
 
-In `src/store/mod.rs` `ADDED_COLUMNS`, append (comment: arrived with the stranded-merge reap; NULL on every pair predating it, which is correct — those settlements predate the column and are not reopenable by merge id):
+- [ ] **Step 4: Replace every inline spelling.** Positive form `c.status == ArtifactStatus::Active && c.superseded_by.is_none()` becomes `c.in_results()`; negated form becomes `!c.in_results()`. Exact sites:
+  - `src/jobs/dedupe.rs:79` → `if !c.in_results() {`
+  - `src/jobs/dedupe.rs:345` → delete the `live` closure; use `c.in_results()` at its two call sites (lines 346, 352)
+  - `src/jobs/classify.rs:54` → `.any(|c| !c.in_results())`
+  - `src/jobs/relate.rs:50` → `if !me.in_results() {`
+  - `src/jobs/consolidate.rs:440` → negated call
+  - `src/jobs/consolidate.rs:657-661` → `if !a.in_results() || !b.in_results() {`
+  - `src/jobs/merge.rs:61-64` (`finish`) → `if m.provenance != Provenance::Merged || !m.in_results() { return Ok(()); }`
+  - `src/jobs/merge.rs:76` → `if !r.in_results() { continue; }`
+  - `src/jobs/merge.rs:184-187` (`reap_stranded`) → `if m.provenance != Provenance::Merged || !m.in_results() || m.embed_state == EmbedState::Embedded {`
+  - `src/core/ingest.rs:314` (`repoint_supersession`) → `if !winner.in_results() {`
+  - `src/web/judge.rs:174` → `usable: a.in_results(),`
+  - `src/web/judge.rs:363` → negated call
 
-```rust
-("artifact_pairs", "merged_into", "TEXT"),
-```
+  Leave the single-condition `superseded_by.is_none()` payload checks (vector/memory.rs, qdrant.rs, embed.rs, ingest.rs:389/427) alone — they ask a different question.
 
-In the schema file, add `merged_into TEXT` to the `artifact_pairs` CREATE TABLE.
+- [ ] **Step 5: Run the full suite** — `cargo test`. Expected: PASS (pure extraction, zero behavior change).
 
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `cargo test -p engram a_merged_settlement_records reopening_a_stranded would_merge_is_a_state` — Expected: PASS. Then full `cargo test` (the `PairState` match in `as_str` is exhaustive; the compiler will point at any consumer that needs the new arm — fix those `match`es by adding the arm, nothing else).
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add -A && git commit -m "feat(pairs): a would_merge state and a merged_into column for settlements"
+git add -A && git commit -m "refactor(core): the liveness predicate has one owner, Chunk::in_results"
 ```
 
 ---
 
-### Task 2: F7 — observation-mode merge verdicts land as `WouldMerge`, rendered honestly
+### Task 2: Recompute `member_ids` after retired members are dropped
 
 **Files:**
-- Modify: `src/jobs/dedupe.rs` (Duplicate arm, non-autonomous branch, ~line 334)
-- Modify: `src/web/ui.rs` (`PAIR_STATES`, `PairRow`, `pair_rows`)
-- Modify: `templates/_decide.html`
-- Modify: `src/web/api.rs` (`consolidation` handler)
-- Test: `src/jobs/dedupe.rs` tests
+- Modify: `src/jobs/dedupe.rs:120-122`
+- Test: `src/jobs/dedupe.rs` tests module
 
 **Interfaces:**
-- Consumes: `PairState::WouldMerge` (Task 1).
-- Produces: `PairRow.would_merge: bool`; API key `"merge_proposals"`.
+- Consumes: `Chunk::in_results()` from Task 1 (only incidentally; the fix itself is one line).
 
-- [ ] **Step 1: Write the failing test** (in `src/jobs/dedupe.rs` tests; copy the seeding idiom from the existing duplicate-verdict test around line 720)
+The bug: `member_ids` is built at line 60 from the pre-partition pairs and never rebuilt after lines 85–113 drop retired members, so `roots_of(&member_ids)` at line 122 resolves roots of artifacts no longer in the question — they reach the prompt, the `merge_max_roots` cap, `losses()`, and the Replaced-verdict resolution.
 
-```rust
-#[tokio::test]
-async fn with_autonomy_off_a_duplicate_verdict_is_filed_as_would_merge() {
-    // It used to be filed as Contradiction, so the UI said "These two
-    // disagree" about a pair the model judged complementary, and offered only
-    // the lossy keep-one buttons for it.
-    let mut core = test_core().await;
-    core.consolidate.autonomous = false;
-    core.completer = Arc::new(ScriptedCompleter::new(vec![
-        r#"{"relation":"duplicate","detail":"same claim",
-            "merged":{"text":"engram needs Rust 1.21.4 and 1.30.0 to build.","tags":[],"caveats":[]}}"#
-            .into(),
-    ]));
-    let ids = disagreeing(&core).await;
-    let pair = queue_pair(&core, &ids[0], &ids[1]).await;
-
-    run(&core, &pair.to_string()).await.unwrap();
-
-    let found = core.store.pairs_by_state(PairState::WouldMerge, 10).await.unwrap();
-    assert_eq!(found.len(), 1, "the verdict must land as its own state");
-    assert_eq!(found[0].detail.as_deref(), Some("same claim"));
-    assert!(
-        core.store.pairs_by_state(PairState::Contradiction, 10).await.unwrap().is_empty(),
-        "a mergeable pair was filed among genuine conflicts"
-    );
-    // Recorded, not applied: no merge written, nothing hidden.
-    for id in &ids {
-        let c = core.store.get_artifact(id).await.unwrap();
-        assert!(c.superseded_by.is_none());
-    }
-    assert!(core.store.merged_artifacts(10).await.unwrap().is_empty());
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p engram with_autonomy_off_a_duplicate_verdict` — Expected: FAIL (pair lands in Contradiction).
-
-- [ ] **Step 3: Implement**
-
-`src/jobs/dedupe.rs`, Duplicate arm, non-autonomous branch: replace the `Contradiction` settle (and its `"would merge: {detail}"` prefix hack) with:
-
-```rust
-if !core.consolidate.autonomous {
-    // Recorded, not applied. Reading the verdicts before letting the
-    // system act on them is the cheapest evidence available about
-    // whether the contract holds on real data. Its own state rather
-    // than Contradiction: filing a mergeable pair among genuine
-    // conflicts made the UI claim the two disagree, and steered the
-    // operator toward hiding a side the model judged complementary.
-    // The draft is discarded — once autonomy is on, the unit re-judges
-    // and merges then.
-    return settle_all(core, &s.pairs, PairState::WouldMerge, s.detail.as_deref()).await;
-}
-```
-
-`src/web/ui.rs`:
-- `PAIR_STATES` becomes 5 entries; insert `WouldMerge` after `Oversized` with a comment (a verdict recorded in observation mode: worth a person's read, less urgent than a contradiction):
-
-```rust
-const PAIR_STATES: [crate::store::pairs::PairState; 5] = [
-    crate::store::pairs::PairState::Contradiction,
-    crate::store::pairs::PairState::Superseded,
-    crate::store::pairs::PairState::Oversized,
-    crate::store::pairs::PairState::WouldMerge,
-    crate::store::pairs::PairState::Pending,
-];
-```
-
-- Add `pub would_merge: bool` to `PairRow` (doc: the model would merge these; rendered with its own header so the page never claims a disagreement it did not find). In `pair_rows`, next to the existing `contradiction:` field init, add `would_merge: state == crate::store::pairs::PairState::WouldMerge,`.
-
-`templates/_decide.html` head line — three-way branch:
-
-```html
-{% if p.contradiction %}<b>These two disagree</b>{% else %}{% if p.would_merge %}<b>The model would merge these</b>{% else %}<b>These two cover the same ground</b>{% endif %}{% endif %}
-```
-
-(Keep the existing keep-one and Dismiss forms for all states — that is the chosen scope: honest header, existing actions.)
-
-`src/web/api.rs` `consolidation` handler: after `"supersede_proposals"`, add:
-
-```rust
-// Merge verdicts recorded while autonomy is off. Their own key for the
-// same reason they are their own state: an API consumer counting
-// `contradictions` must not see pairs the model judged complementary.
-"merge_proposals": st
-    .core
-    .store
-    .pairs_by_state(PairState::WouldMerge, 100)
-    .await?,
-```
-
-- [ ] **Step 4: Run tests**
-
-Run: `cargo test -p engram` — Expected: PASS, including the existing autonomy-off dedupe tests (any asserting Contradiction + `"would merge:"` prefix must be updated to assert `WouldMerge` — that assertion was pinning the bug).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(dedupe): an observation-mode merge verdict is not a contradiction"
-```
-
----
-
-### Task 3: F1 + F6 — Replaced verdict: validate, apply, then settle
-
-**Files:**
-- Modify: `src/jobs/dedupe.rs` (`apply`, `Relation::Replaced` arm, ~lines 281-328)
-- Test: `src/jobs/dedupe.rs` tests
-
-**Interfaces:**
-- Consumes: `Core::supersede`, `ArtifactStatus`, `settle_all`.
-- Produces: new arm behavior — later tasks do not depend on its internals.
-
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Write the failing test** (in `src/jobs/dedupe.rs` tests):
 
 ```rust
 #[tokio::test]
-async fn an_applied_replacement_does_not_wait_for_an_operator() {
-    // F6: the pair used to stay in Superseded — the state every consumer
-    // reads as "awaiting confirmation" — with buttons that could only
-    // return a validation error.
+async fn a_retired_members_roots_do_not_count_against_the_cap() {
+    // C is deprecated while the unit waits. Its pair is dismissed and it is
+    // dropped from the component — but its root must also leave the question,
+    // or a two-root component at the cap is settled Oversized for fan-in it
+    // does not have, and C's text is shown to the model as an original.
     let mut core = test_core().await;
     core.consolidate.autonomous = true;
-    core.completer = Arc::new(ScriptedCompleter::new(vec![
-        r#"{"relation":"replaced","detail":"old flag vs new flag","supersedes":"a"}"#.into(),
-    ]));
-    let ids = disagreeing(&core).await;
-    // Make ids[0] strictly older so the newest-wins guard accepts "a".
-    sqlx::query("UPDATE artifacts SET created_at = created_at - 100 WHERE id = ?")
-        .bind(&ids[0]).execute(&core.store.pool).await.unwrap();
-    let pair = queue_pair(&core, &ids[0], &ids[1]).await;
-
-    run(&core, &pair.to_string()).await.unwrap();
-
-    assert!(
-        core.store.get_artifact(&ids[0]).await.unwrap().superseded_by.is_some(),
-        "the replacement was not applied"
-    );
-    assert!(
-        core.store.pairs_by_state(PairState::Superseded, 10).await.unwrap().is_empty(),
-        "an applied replacement is still listed as awaiting confirmation"
-    );
-    assert_eq!(
-        core.store.pairs_by_state(PairState::Dismissed, 10).await.unwrap().len(),
-        1,
-        "the applied pair should be settled the way the manual apply settles it"
-    );
-}
-
-#[tokio::test]
-async fn a_replacement_naming_a_root_already_out_of_results_settles_cleanly() {
-    // F1: a component holding a finished merge flattens to roots that are
-    // already superseded. Applying blindly errored *after* the pairs were
-    // settled, and run()'s Pending guard made the error unretryable.
-    let mut core = test_core().await;
-    core.consolidate.autonomous = true;
-    // First call merges a+b; second call answers the (merge, c) pair.
-    core.completer = Arc::new(ScriptedCompleter::new(vec![
-        r#"{"relation":"duplicate","detail":"same claim",
-            "merged":{"text":"engram needs Rust 1.21.4 to build.","tags":[],"caveats":[]}}"#.into(),
-        r#"{"relation":"replaced","detail":"superseded by the merge","supersedes":"c"}"#.into(),
-    ]));
-    let ids = seed(
-        &core,
-        &[
-            ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
-            ("engram needs Rust 1.21.4 to compile.", [0.999, 0.02]),
-            ("engram wants Rust 1.20 or so to build.", [0.97, 0.2]),
-        ],
-    )
-    .await;
-    // Oldest so the newest-wins guard accepts it as obsolete. Its letter
-    // among the sorted roots must be computed, not assumed — see step 3
-    // note; if the sorted position of ids[2] is not 'c', adjust the
-    // scripted letter accordingly by sorting [&ids[0], &ids[1], &ids[2]].
-    sqlx::query("UPDATE artifacts SET created_at = created_at - 100 WHERE id = ?")
-        .bind(&ids[2]).execute(&core.store.pool).await.unwrap();
-
-    // Merge a and b, then drive the queue so finish() supersedes the roots.
-    let p1 = queue_pair(&core, &ids[0], &ids[1]).await;
-    run(&core, &p1.to_string()).await.unwrap();
-    drive_queue(&core).await; // embed lands, merge::finish hides ids[0], ids[1]
-    let m = &core.store.merged_artifacts(10).await.unwrap()[0].id;
-
-    let p2 = queue_pair(&core, m, &ids[2]).await;
-    run(&core, &p2.to_string()).await.unwrap();
-
-    // The winner among the roots is superseded, so the live carrier (the
-    // merge, a member) wins instead — and the settle happens after.
-    assert_eq!(
-        core.store.get_artifact(&ids[2]).await.unwrap().superseded_by.as_deref(),
-        Some(m.as_str()),
-        "the replacement was not applied against the live carrier"
-    );
-    assert!(core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
-}
-```
-
-Add the small queue driver next to the tests if none exists in this module (the consolidate tests have `sweep_and_judge`/`sweep_and_dedupe` — reuse the same body):
-
-```rust
-async fn drive_queue(core: &Core) {
-    for _ in 0..100 {
-        sqlx::query("UPDATE jobs SET run_after = 0")
-            .execute(&core.store.pool).await.unwrap();
-        if !crate::jobs::run_one(core).await.unwrap_or(false) { break; }
-    }
-}
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `cargo test -p engram an_applied_replacement_does_not_wait a_replacement_naming_a_root_already` — Expected: first FAILS on the `Superseded`-empty assertion; second FAILS (error propagates or pair left half-settled). If the second fails only because the letter `"c"` maps to a different sorted root, fix the test's scripted letter first (sort the three ids; the letter is the index of `ids[2]` in that order) — then confirm it fails for the real reason.
-
-- [ ] **Step 3: Implement** — replace the whole `Relation::Replaced` arm of `apply`:
-
-```rust
-Relation::Replaced => {
-    let obsolete = s
-        .obsolete
-        .clone()
-        .expect("interpret sets this or downgrades to Conflict");
-    // Fresh statuses, not the snapshot `interpret` saw. The roots of a
-    // member that is itself a finished merge are already superseded, and
-    // a component can change while the unit waits out a backoff.
-    let mut fresh = Vec::new();
-    for r in &s.roots {
-        match core.store.get_artifact(&r.id).await {
-            Ok(c) => fresh.push(c),
-            Err(Error::NotFound) => {}
-            Err(e) => return Err(e),
-        }
-    }
-    let live = |c: &Chunk| c.status == ArtifactStatus::Active && c.superseded_by.is_none();
-    let obsolete_live = fresh.iter().any(|c| c.id == obsolete && live(c));
-    // A live root wins if one exists; otherwise the live member that
-    // carries the surviving roots — a finished merge's own sources are
-    // superseded, and the merge is the one thing still in results.
-    let winner = fresh
-        .iter()
-        .find(|c| c.id != obsolete && live(c))
-        .map(|c| c.id.clone())
-        .or_else(|| s.members.iter().find(|m| m.id != obsolete).map(|m| m.id.clone()));
-    let (Some(winner), true) = (winner, obsolete_live) else {
-        // Nothing to apply: the named side is already out of results, so
-        // the replacement has in effect already happened.
-        return settle_all(
-            core,
-            &s.pairs,
-            PairState::NoConflict,
-            Some("the named replacement is already out of results"),
-        )
-        .await;
-    };
-
-    if core.consolidate.autonomous {
-        // The side effect FIRST. A failure here leaves every pair
-        // pending, so the unit retries under the queue's backoff — the
-        // reverse order left the verdict recorded but never applied,
-        // permanently, because run() skips non-Pending pairs.
-        core.supersede(&obsolete, &winner).await?;
-        tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
-        for pr in &s.pairs {
-            if pr.a_id == obsolete || pr.b_id == obsolete {
-                // As the manual apply settles it (`apply_pair_supersede_ui`):
-                // done, with the model's reasoning kept as the record of why.
-                core.store
-                    .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
-                    .await?;
-            } else {
-                // Both sides of this pair survived; see the comment below.
-                core.store
-                    .set_pair_state(
-                        pr.id,
-                        PairState::Contradiction,
-                        Some(&format!("{obsolete} was superseded; these two were not separated")),
-                    )
-                    .await?;
-            }
-        }
-        return Ok(());
-    }
-
-    // Proposal mode: nothing is hidden, the pair carries the direction
-    // and an operator confirms via "apply supersede".
-    for pr in &s.pairs {
-        if pr.a_id == obsolete || pr.b_id == obsolete {
-            core.store
-                .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
-                .await?;
-        } else {
-            core.store
-                .set_pair_state(
-                    pr.id,
-                    PairState::Contradiction,
-                    Some(&format!("{obsolete} was superseded; these two were not separated")),
-                )
-                .await?;
-        }
-    }
-    Ok(())
-}
-```
-
-Carry over (do not lose) the two existing long comments in that arm — the "letter indexes `roots`" comment stays on `interpret`, and the "Both sides survived…" comment moves onto the Contradiction branch. The `winner`-from-roots comment is superseded by the new "live root wins…" comment.
-
-- [ ] **Step 4: Run tests**
-
-Run: `cargo test -p engram` — Expected: PASS. The existing test `a_confident_direction_proposes_a_supersede_but_does_not_apply_it` must still pass unchanged (proposal path preserved).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(dedupe): a replacement is applied before its pairs are settled"
-```
-
----
-
-### Task 4: F2 — a retired member dismisses only the pairs that name it
-
-**Files:**
-- Modify: `src/jobs/dedupe.rs` (`run`, member-gathering loop, ~lines 67-87)
-- Test: `src/jobs/dedupe.rs` tests
-
-**Interfaces:** none new.
-
-- [ ] **Step 1: Write the failing test**
-
-```rust
-#[tokio::test]
-async fn a_retired_member_dismisses_only_its_own_pairs() {
-    // Dismissing the whole component killed sibling pairs between
-    // still-active duplicates permanently: record_pair is INSERT OR
-    // IGNORE and Dismissed appears on no list, so the A/B duplication
-    // became invisible forever.
-    let mut core = test_core().await;
-    core.consolidate.autonomous = true;
+    core.consolidate.merge_max_roots = 2;
     core.completer = Arc::new(ScriptedCompleter::new(vec![
         r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
     ]));
     let ids = seed(
         &core,
         &[
-            ("the timeout is 30 seconds", [1.0, 0.0]),
-            ("the timeout is 90 seconds", [0.93, 0.37]),
-            ("the timeout is 120 seconds", [0.94, 0.34]),
+            ("a text", [1.0, 0.0]),
+            ("b text", [0.93, 0.37]),
+            ("c text", [0.90, 0.44]),
         ],
     )
     .await;
-    let p_ab = queue_pair(&core, &ids[0], &ids[1]).await;
-    let p_bc = queue_pair(&core, &ids[1], &ids[2]).await;
+    let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+    queue_pair(&core, &ids[1], &ids[2]).await;
     core.deprecate(&ids[2]).await.unwrap();
 
-    run(&core, &p_ab.to_string()).await.unwrap();
+    run(&core, &seed_pair.to_string()).await.unwrap();
 
-    assert_eq!(
-        core.store.get_pair(p_bc).await.unwrap().state,
-        PairState::Dismissed,
-        "the pair naming the retired artifact should be dismissed"
+    assert!(
+        core.store
+            .pairs_by_state(PairState::Oversized, 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a retired member's root was counted against merge_max_roots"
     );
+    // The live pair reached the model and took its verdict.
     assert_eq!(
-        core.store.get_pair(p_ab).await.unwrap().state,
-        PairState::NoConflict,
-        "the pair between two live artifacts must still be judged, not dismissed"
+        core.store
+            .pairs_by_state(PairState::NoConflict, 10)
+            .await
+            .unwrap()
+            .len(),
+        1
     );
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run it — expect FAIL**: the pair settles `Oversized` (3 roots > cap 2). `cargo test a_retired_members_roots`
 
-Run: `cargo test -p engram a_retired_member_dismisses_only_its_own_pairs` — Expected: FAIL — `p_ab` is Dismissed.
-
-- [ ] **Step 3: Implement** — in `run`, replace the retired-member early-out. `pairs` must become `let mut pairs = …`:
+- [ ] **Step 3: Implement.** In `src/jobs/dedupe.rs`, immediately before line 122 (`let root_map = ...`), rebind `member_ids` from the surviving members so the two can never disagree:
 
 ```rust
-let mut members = Vec::new();
-let mut retired: std::collections::HashSet<String> = Default::default();
-for mid in &member_ids {
-    // (keep the existing "Reported, not swallowed" comment here)
-    let c = core.store.get_artifact(mid).await?;
-    if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
-        // Only the pairs naming this member are answered by its
-        // retirement. Dismissing the whole component killed sibling
-        // pairs between still-active duplicates — record_pair is
-        // INSERT OR IGNORE, so nothing could ever re-file them.
-        retired.insert(c.id);
-        continue;
-    }
-    members.push(c);
-}
-if !retired.is_empty() {
-    let (dead, live): (Vec<_>, Vec<_>) = pairs
-        .into_iter()
-        .partition(|pr| retired.contains(&pr.a_id) || retired.contains(&pr.b_id));
-    settle_all(core, &dead, PairState::Dismissed, Some("a member is no longer in results")).await?;
-    pairs = live;
-    // Dropping a member can strand others with no surviving pair; they
-    // are simply not part of this unit's question any more.
-    let named: std::collections::HashSet<&str> = pairs
-        .iter()
-        .flat_map(|pr| [pr.a_id.as_str(), pr.b_id.as_str()])
-        .collect();
-    members.retain(|c| named.contains(c.id.as_str()));
-    // The seed pair itself may be among the dead; the survivors keep
-    // their own units and nothing further is owed here.
-    if !pairs.iter().any(|pr| pr.id == id) {
-        return Ok(());
-    }
-}
-if members.len() < 2 {
-    settle_all(core, &pairs, PairState::Dismissed, None).await?;
-    return Ok(());
-}
+    // Flatten before anything else, and never show the model a merged member's
+    // own text.
+    //
+    // From `members`, not the list the component arrived with: the partition
+    // above drops retired members and their pairs, and roots resolved from the
+    // stale list would put a retired artifact back into the prompt, the fan-in
+    // cap, and the loss check — the question this unit is no longer asking.
+    let member_ids: Vec<String> = members.iter().map(|c| c.id.clone()).collect();
+    let root_map = core.store.roots_of(&member_ids).await?;
 ```
 
-Also move the existing re-check comment ("Re-checked here and not only when the unit was armed…") onto the retired-branch.
+Also change line 60's binding from `let mut member_ids` to `let member_ids` if the shadowing makes the `mut` unused (the compiler will say).
 
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS (the existing dismissal tests for fully-retired components still pass: with every pair dead, the seed pair is dismissed and the unit returns).
+- [ ] **Step 4: Run** `cargo test` (whole dedupe suite — `a_retired_member_dismisses_only_its_own_pairs` must still pass). Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add -A && git commit -m "fix(dedupe): a retired member dismisses only the pairs that name it"
+git add -A && git commit -m "fix(dedupe): roots are resolved from the surviving members, not the stale list"
 ```
 
 ---
 
-### Task 5: F5 — stranded merges are reaped by the sweep
+### Task 3: Truthful survivor-pair detail, written once
 
 **Files:**
-- Modify: `src/jobs/dedupe.rs` (Duplicate arm, autonomous settle, ~line 357)
-- Modify: `src/store/lineage.rs` (new query `stranded_merges`)
-- Modify: `src/jobs/merge.rs` (new fn `reap_stranded`)
-- Modify: `src/jobs/consolidate.rs` (`run`, after the `merged_with_active_roots` block, ~line 316)
-- Test: `src/jobs/consolidate.rs` tests
+- Modify: `src/jobs/dedupe.rs:372-438` (the `Relation::Replaced` arm of `apply`)
+- Test: `src/jobs/dedupe.rs` tests module
 
-**Interfaces:**
-- Consumes: `set_pair_merged`, `reopen_pairs_merged_into` (Task 1), `MAX_ATTEMPTS` (`crate::store::jobs`), `delete_job`.
-- Produces:
-  - `Store::stranded_merges(&self, limit: i64) -> Result<Vec<String>>`
-  - `merge::reap_stranded(core: &Core, merged_id: &str) -> Result<()>`
+Two findings, one edit: (a) in proposal mode the sibling pair's detail claims "`X` was superseded" before any supersede happened; (b) the survivor-Contradiction block is byte-identical in both branches, so a future edit lands in one copy. Partition the pairs once; branch on `autonomous` only where the modes actually differ.
 
-- [ ] **Step 1: Write the failing test** (in `src/jobs/consolidate.rs` tests)
+- [ ] **Step 1: Write the failing test:**
 
 ```rust
 #[tokio::test]
-async fn a_merge_that_can_never_embed_is_reaped_and_its_pairs_reopened() {
-    // The pairs were settled "merged into m" the moment the merge was
-    // written. If the embed then fails permanently the merge is stranded
-    // active-but-unindexed, the roots are never superseded, and the
-    // NoConflict pairs mean the duplicates can never be merged again.
-    use crate::store::artifacts::NewMerged;
-    let core = test_core().await;
-    let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
-    let m = core
-        .store
-        .insert_merged_artifact(
-            &NewMerged {
-                text: "both".into(), title: None, category: None,
-                tags: vec![], caveats: vec![],
-            },
-            &[ids[0].clone(), ids[1].clone()],
-        )
-        .await
-        .unwrap();
-    core.store.enqueue(crate::store::jobs::Stage::Embed, "artifact", &m.id).await.unwrap();
-    core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
-    let pid = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-    core.store.set_pair_merged(pid, &m.id, Some("same claim")).await.unwrap();
-    // The embed job has exhausted its retries and cannot succeed.
-    sqlx::query("UPDATE jobs SET attempts = ? WHERE target_id = ?")
-        .bind(crate::store::jobs::MAX_ATTEMPTS)
-        .bind(&m.id)
-        .execute(&core.store.pool)
-        .await
-        .unwrap();
-
-    run(&core).await.unwrap();
-
-    assert_eq!(
-        core.store.get_artifact(&m.id).await.unwrap().status,
-        ArtifactStatus::Deprecated,
-        "the stranded merge should be retired"
-    );
-    let p = core.store.get_pair(pid).await.unwrap();
-    assert_eq!(p.state, crate::store::pairs::PairState::Contradiction, "the pair goes back to a person");
-    for id in &ids {
-        assert_eq!(core.store.get_artifact(id).await.unwrap().status, ArtifactStatus::Active);
-    }
-    // And a healthy in-flight merge is left alone.
-    let m2 = core.store.insert_merged_artifact(
-        &NewMerged { text: "x".into(), title: None, category: None, tags: vec![], caveats: vec![] },
-        &[ids[0].clone(), ids[1].clone()],
-    ).await.unwrap();
-    core.store.enqueue(crate::store::jobs::Stage::Embed, "artifact", &m2.id).await.unwrap();
-    run(&core).await.unwrap();
-    assert_eq!(core.store.get_artifact(&m2.id).await.unwrap().status, ArtifactStatus::Active);
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p engram a_merge_that_can_never_embed` — Expected: compile FAIL (`stranded_merges` missing) or assertion FAIL (merge still active).
-
-- [ ] **Step 3: Implement**
-
-`src/store/lineage.rs`:
-
-```rust
-/// Active merged artifacts whose embedding can no longer arrive: no live
-/// embed job below the retry ceiling. The write path settles the pairs the
-/// moment the merge is written, so a merge stuck here is invisible to
-/// search, its roots were never superseded, and nothing else would notice.
-pub async fn stranded_merges(&self, limit: i64) -> Result<Vec<String>> {
-    let rows = sqlx::query(
-        "SELECT a.id FROM artifacts a
-          WHERE a.provenance = 'merged'
-            AND a.status = 'active'
-            AND a.superseded_by IS NULL
-            AND a.embed_state != 'embedded'
-            AND NOT EXISTS (
-                  SELECT 1 FROM jobs j
-                   WHERE j.stage = 'embed'
-                     AND j.target_id = a.id
-                     AND j.state IN ('pending', 'running')
-                     AND j.attempts < ?)
-          LIMIT ?",
+async fn a_proposed_supersede_is_not_recorded_as_a_done_one() {
+    // Proposal mode: the supersede is a proposal an operator may reject. The
+    // sibling pair's record must not assert an event that has not happened.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = false;
+    core.completer = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"replaced","supersedes":"a","detail":"a is stale"}"#.into(),
+    ]));
+    let ids = seed(
+        &core,
+        &[
+            ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
+            ("engram needs Rust 1.30.0 to build.", [0.93, 0.37]),
+            ("engram builds with stable Rust.", [0.90, 0.44]),
+        ],
     )
-    .bind(crate::store::jobs::MAX_ATTEMPTS)
-    .bind(limit)
-    .fetch_all(&self.pool)
-    .await?;
-    Ok(rows.iter().map(|r| r.get("id")).collect())
-}
-```
+    .await;
+    let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+    queue_pair(&core, &ids[1], &ids[2]).await;
 
-`src/jobs/merge.rs`:
+    run(&core, &seed_pair.to_string()).await.unwrap();
 
-```rust
-/// Retire a merge whose embedding can never arrive, and hand its pairs back
-/// to a person.
-///
-/// Safe by the write path's own ordering: the roots are superseded only
-/// after the embed lands, so a stranded merge has hidden nothing — the base
-/// is exactly what it was before the verdict, plus one unindexed artifact.
-/// Deprecated rather than deleted for the same reason `undo` deprecates:
-/// the lineage is the record of what was attempted.
-///
-/// Contradiction rather than Pending for the reopened pairs: re-arming the
-/// model would regenerate the same unembeddable draft, at full price,
-/// forever.
-pub async fn reap_stranded(core: &Core, merged_id: &str) -> Result<()> {
-    let m = core.store.get_artifact(merged_id).await?;
-    if m.provenance != Provenance::Merged
-        || m.status != ArtifactStatus::Active
-        || m.superseded_by.is_some()
-        || m.embed_state == crate::store::artifacts::EmbedState::Embedded
-    {
-        // The embed landed (or someone else acted) between the scan and
-        // here. Nothing is stranded any more.
-        return Ok(());
-    }
-    core.deprecate(&m.id).await?;
-    let reopened = core
+    let contradictions = core
         .store
-        .reopen_pairs_merged_into(&m.id, "the merged text could not be indexed; resolve by hand")
-        .await?;
-    // The forever-retrying job is the only signal this state used to have;
-    // with the merge retired it is pure noise.
-    core.store.delete_job(Stage::Embed, &m.id).await?;
-    tracing::warn!(merged = %m.id, reopened, "reaped a merge that could not be embedded");
-    Ok(())
-}
-```
-
-`src/jobs/dedupe.rs` Duplicate arm, autonomous branch — replace the `settle_all(NoConflict, "merged into …")` with per-pair stamping so the reap can find them:
-
-```rust
-let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
-let m = crate::jobs::merge::write(core, draft, &sources).await?;
-// `merged_into` rather than a detail string: if the embed never lands,
-// the sweep's reap has to find exactly these pairs and reopen them.
-for pr in &s.pairs {
-    core.store
-        .set_pair_merged(pr.id, &m.id, s.detail.as_deref())
-        .await?;
-}
-Ok(())
-```
-
-`src/jobs/consolidate.rs` `run`, directly after the `merged_with_active_roots` repair block:
-
-```rust
-// The opposite failure: a merge that will never be embedded. Its pairs
-// are already settled, its roots were never superseded, and its only
-// signal was a forever-retrying embed job.
-match core.store.stranded_merges(50).await {
-    Ok(stranded) => {
-        for id in stranded {
-            if let Err(e) = crate::jobs::merge::reap_stranded(core, &id).await {
-                tracing::warn!(merged = %id, error = %e, "could not reap a stranded merge");
-            }
-        }
+        .pairs_by_state(PairState::Contradiction, 10)
+        .await
+        .unwrap();
+    assert_eq!(contradictions.len(), 1, "the survivor pair escalates");
+    let detail = contradictions[0].detail.clone().unwrap_or_default();
+    assert!(
+        !detail.contains("was superseded"),
+        "the record asserts a supersession that is only proposed: {detail}"
+    );
+    // Nothing was hidden in proposal mode.
+    for id in &ids {
+        assert!(core.store.get_artifact(id).await.unwrap().in_results());
     }
-    Err(e) => tracing::warn!(error = %e, "could not look for stranded merges"),
 }
 ```
 
-- [ ] **Step 4: Run tests**
+Note: `supersedes` letters index the *roots* list, ordered by sorted root id; if the scripted letter doesn't resolve to the oldest artifact the guard downgrades to Conflict and the test still sees a Contradiction — but then the pair naming the obsolete isn't `Superseded`. If the assertion setup proves fragile, pin creation order by seeding the "stale" artifact first (seed inserts in order, `created_at` ascending) and letter `"a"` = lexicographically first root id; adjust the letter after printing `roots` once in a debug run. The behavioral assertions above (no "was superseded" text; nothing hidden) are the contract.
 
-Run: `cargo test -p engram` — Expected: PASS. Any existing test asserting the `"merged into {id}"` detail on settled pairs should be updated to assert `merged_into == Some(m.id)` instead.
+- [ ] **Step 2: Run it — expect FAIL** on the detail assertion. `cargo test a_proposed_supersede_is_not_recorded`
+
+- [ ] **Step 3: Implement.** In `apply`'s `Relation::Replaced` arm, after the `(Some(winner), true)` destructure, replace both per-mode loops with one partition:
+
+```rust
+            let (touching, survivors): (Vec<&ArtifactPair>, Vec<&ArtifactPair>) = s
+                .pairs
+                .iter()
+                .partition(|pr| pr.a_id == obsolete || pr.b_id == obsolete);
+
+            if core.consolidate.autonomous {
+                // The side effect FIRST. A failure here leaves every pair
+                // pending, so the unit retries under the queue's backoff — the
+                // reverse order left the verdict recorded on the pairs but
+                // never applied, permanently, because run() skips a component
+                // whose seed is no longer Pending.
+                core.supersede(&obsolete, &winner).await?;
+                tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
+                for pr in &touching {
+                    // As the manual apply settles it (`apply_pair_supersede_ui`):
+                    // done, with the model's reasoning kept as the record of why.
+                    core.store
+                        .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
+                        .await?;
+                }
+            } else {
+                // Proposal mode: nothing is hidden, the pair carries the
+                // direction and an operator confirms via "apply supersede".
+                for pr in &touching {
+                    core.store
+                        .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
+                        .await?;
+                }
+                tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
+            }
+
+            // Both sides survived these pairs. Writing the direction on them
+            // named an artifact the pair does not contain. Not left pending
+            // either: the roots this verdict was drawn from are unchanged, so
+            // re-arming would build the identical prompt and receive the
+            // identical answer forever. An unanswered question goes where the
+            // others go: to a person.
+            //
+            // Past tense only where the supersede actually ran. In proposal
+            // mode it may yet be rejected, and a record asserting it happened
+            // would outlive the rejection.
+            let survivor_detail = if core.consolidate.autonomous {
+                format!("{obsolete} was superseded; these two were not separated")
+            } else {
+                format!("superseding {obsolete} was proposed; these two were not separated")
+            };
+            for pr in &survivors {
+                core.store
+                    .set_pair_state(pr.id, PairState::Contradiction, Some(&survivor_detail))
+                    .await?;
+            }
+            Ok(())
+```
+
+Keep the surrounding rationale comments that still apply; the two deleted copies' comments are consolidated above.
+
+- [ ] **Step 4: Run** `cargo test` (the whole dedupe suite — the autonomous Replaced tests must still pass). Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add -A && git commit -m "fix(consolidate): a merge that can never embed is reaped, not stranded"
+git add -A && git commit -m "fix(dedupe): a proposal-mode survivor pair records a proposal, not a fait accompli"
 ```
 
 ---
 
-### Task 6: F4 — a transient read error must not close a filed pair
+### Task 4: `merge::undo` before the embed lands reopens the pairs it settled
 
 **Files:**
-- Modify: `src/jobs/consolidate.rs` (member-read loop ~line 376, closing pass ~line 446; extract pure helper)
-- Test: `src/jobs/consolidate.rs` tests
+- Modify: `src/store/pairs.rs` (new method, next to `reopen_pairs_merged_into` at line 324)
+- Modify: `src/jobs/merge.rs:156-165` (`undo`)
+- Test: `src/jobs/merge.rs` tests module
+
+The bug: pairs are settled `no_conflict, merged_into = M` at write time, but roots are superseded only at embed time. `undo` pressed in between finds `artifacts_superseded_by(M)` empty, dismisses nothing, deprecates M — and the pairs stay settled forever pointing at a deprecated merge, with both duplicates active side by side.
 
 **Interfaces:**
-- Produces: `fn close_filed_pair(a_known: bool, b_known: bool, a_live: bool, b_live: bool, a_id: &str, b_id: &str) -> Option<String>` — `None` = leave the pair filed; `Some(detail)` = close as NoConflict with that detail.
+- Produces: `Store::dismiss_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64>`
 
-- [ ] **Step 1: Write the failing test** (pure-function test; store-level fault injection isn't feasible with SQLite here, so the decision is extracted and tested directly)
+- [ ] **Step 1: Write the failing test** (in `src/jobs/merge.rs` tests; `write` + `draft` helpers already exist there):
+
+```rust
+#[tokio::test]
+async fn undoing_a_merge_before_its_embed_lands_still_releases_its_pairs() {
+    // Pairs are settled at write time; roots are superseded at embed time.
+    // An undo in between used to find nothing superseded, dismiss nothing,
+    // and leave the pairs no_conflict behind a deprecated merge — both
+    // duplicates active, and record_pair unable to ever re-file them.
+    let core = crate::core::test_support::test_core().await;
+    let ids = crate::jobs::consolidate::tests::seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+    )
+    .await;
+    core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
+    let pair = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+        .await
+        .unwrap()[0]
+        .id;
+
+    let m = write(&core, &draft("a text and b text"), &ids).await.unwrap();
+    core.store
+        .set_pair_merged(pair, &m.id, Some("duplicate"))
+        .await
+        .unwrap();
+    // No embed ran: nothing is superseded by m yet.
+
+    undo(&core, &m.id).await.unwrap();
+
+    let p = core.store.get_pair(pair).await.unwrap();
+    assert_eq!(
+        p.state,
+        crate::store::pairs::PairState::Dismissed,
+        "the pair stayed settled behind a deprecated merge: {p:?}"
+    );
+    assert_eq!(p.merged_into, None);
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (state stays `NoConflict`). `cargo test undoing_a_merge_before_its_embed`
+
+- [ ] **Step 3: Implement the store method** in `src/store/pairs.rs`, after `reopen_pairs_merged_into`:
+
+```rust
+    /// Dismiss every pair a merge being undone had settled, by the lineage the
+    /// settlement recorded. `pairs_among` covers only what the merge had
+    /// already hidden — before the embed lands that is nothing, while the
+    /// pairs were settled the moment the merge was written. Dismissed, not
+    /// Contradiction: an undo is an operator overruling the verdict, and
+    /// `record_pair` respecting dismissed rows is what makes that last.
+    pub async fn dismiss_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs
+                SET state = 'dismissed', detail = ?, merged_into = NULL
+              WHERE merged_into = ?",
+        )
+        .bind(detail)
+        .bind(merged_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+```
+
+- [ ] **Step 4: Call it from `undo`** in `src/jobs/merge.rs`, after the existing `pairs_among` loop (keep that loop — it also catches pairs between restored artifacts that never carried `merged_into`):
+
+```rust
+    // And by lineage, for an undo that outran the embed: before `finish` runs,
+    // nothing is superseded by this merge, so `restored` above is empty — but
+    // the pairs were settled the moment the merge was written, and leaving
+    // them would keep the duplicates invisible to every later sweep.
+    core.store
+        .dismiss_pairs_merged_into(&m.id, "merge undone")
+        .await?;
+```
+
+- [ ] **Step 5: Run** `cargo test` (the post-embed undo test in merge.rs must still pass). Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "fix(merge): undo before the embed lands releases the pairs the write settled"
+```
+
+---
+
+### Task 5: Flipping autonomy on re-arms `WouldMerge` verdicts
+
+**Files:**
+- Modify: `src/store/pairs.rs` (new method)
+- Modify: `src/jobs/consolidate.rs:606-613` (`arm_dedupe`)
+- Test: `src/jobs/consolidate.rs` tests module (or pairs.rs for the store half)
+
+The `WouldMerge` doc (pairs.rs:68-74) promises "flipping autonomy on lets a later unit re-judge and merge"; nothing implements it. User chose: implement the re-arm.
+
+**Interfaces:**
+- Produces: `Store::reopen_would_merge_pairs(&self) -> Result<u64>`
+
+- [ ] **Step 1: Write the failing test** (in `src/jobs/consolidate.rs` tests):
+
+```rust
+#[tokio::test]
+async fn would_merge_verdicts_are_re_armed_once_autonomy_is_on() {
+    // Recorded while autonomy was off, the verdict's whole point is to be
+    // acted on once the switch flips — the variant's own doc says so. The
+    // ticker's arming pass is where the flip becomes visible.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = true;
+    core.consolidate.max_dedupe_per_tick = 5;
+    let ids = seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+    )
+    .await;
+    core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
+    let pair = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+        .await
+        .unwrap()[0]
+        .id;
+    core.store
+        .set_pair_state(pair, crate::store::pairs::PairState::WouldMerge, Some("same claim"))
+        .await
+        .unwrap();
+
+    arm_dedupe(&core).await.unwrap();
+
+    assert_eq!(
+        core.store.get_pair(pair).await.unwrap().state,
+        crate::store::pairs::PairState::Pending,
+        "a would_merge verdict stayed stranded after autonomy came on"
+    );
+}
+```
+
+(If `arm_dedupe` and `seed` aren't importable in that tests module, follow how neighbouring `arm_dedupe` tests there reference them.)
+
+- [ ] **Step 2: Run it — expect FAIL** (state stays `WouldMerge`). `cargo test would_merge_verdicts_are_re_armed`
+
+- [ ] **Step 3: Implement the store method** in `src/store/pairs.rs`:
+
+```rust
+    /// Hand every recorded would-merge verdict back to the judge queue.
+    ///
+    /// `would_merge` exists only as a note taken while autonomy is off — the
+    /// draft was discarded, so there is nothing to apply directly; the unit
+    /// re-judges and merges at the queue's own pace. The detail is kept: it is
+    /// the model's recorded reasoning, and `pending` reads it never.
+    pub async fn reopen_would_merge_pairs(&self) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs SET state = 'pending' WHERE state = 'would_merge'",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+```
+
+- [ ] **Step 4: Call it from `arm_dedupe`** in `src/jobs/consolidate.rs`, after the `max_dedupe_per_tick == 0` early return and before `pairs_to_judge`:
+
+```rust
+    // Verdicts recorded while autonomy was off go back into the queue now
+    // that it is on. Idempotent and normally free: with autonomy on, no unit
+    // writes would_merge, so this touches rows exactly once per flip.
+    if core.consolidate.autonomous {
+        let reopened = core.store.reopen_would_merge_pairs().await?;
+        if reopened > 0 {
+            tracing::info!(reopened, "re-armed would-merge verdicts recorded before autonomy");
+        }
+    }
+```
+
+- [ ] **Step 5: Run** `cargo test`. Expected: PASS (including `would_merge_is_a_state_of_its_own` in pairs.rs).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(consolidate): flipping autonomy on re-arms recorded would-merge verdicts"
+```
+
+---
+
+### Task 6: `flag_orphans` stops starving, and "reviewed" sticks
+
+**Files:**
+- Modify: `src/store/lineage.rs:223-235` (`merged_missing_a_source`)
+- Modify: `src/jobs/merge.rs:218-238` (`flag_orphans`)
+- Modify: `src/store/artifacts.rs` (new method near `clear_artifact_flags`, line 935)
+- Modify: `src/web/ui.rs:1529-1536` (`mark_artifact_reviewed`)
+- Test: `src/jobs/merge.rs` tests module
+
+Two halves. (a) Starvation: the SQL has no flag filter and no ORDER BY, so once 500 old merges are permanently orphaned the same rows fill the LIMIT every sweep and new orphans are never flagged; each sweep also burns one `get_artifact` per already-flagged row. (b) The operator's "reviewed" clears the flag, but the row still matches the query, so the next sweep re-flags it — the dismissal doesn't stick.
+
+For (b): reviewing an orphaned merge means the operator accepts it as a merge of what remains, so the review also syncs `source_count` down to the surviving lineage count. The row then leaves the query's result set permanently.
+
+**Interfaces:**
+- Produces: `Store::accept_source_loss(&self, id: &str) -> Result<()>`
+
+- [ ] **Step 1: Write the failing tests** (in `src/jobs/merge.rs` tests):
+
+```rust
+#[tokio::test]
+async fn an_already_flagged_merge_does_not_occupy_the_orphan_scan() {
+    let core = crate::core::test_support::test_core().await;
+    let ids = crate::jobs::consolidate::tests::seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+    )
+    .await;
+    write(&core, &draft("a text and b text"), &ids).await.unwrap();
+    core.store.delete_artifact(&ids[0]).await.unwrap();
+    assert_eq!(flag_orphans(&core).await.unwrap(), 1);
+    // Flagged rows leave the scan entirely — not fetched and skipped in Rust,
+    // which is what let 500 of them starve every newer orphan out of the LIMIT.
+    assert!(
+        core.store.merged_missing_a_source(500).await.unwrap().is_empty(),
+        "a flagged merge still occupies a scan slot"
+    );
+}
+
+#[tokio::test]
+async fn reviewing_an_orphaned_merge_is_not_undone_by_the_next_sweep() {
+    let core = crate::core::test_support::test_core().await;
+    let ids = crate::jobs::consolidate::tests::seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+    )
+    .await;
+    let m = write(&core, &draft("a text and b text"), &ids).await.unwrap();
+    core.store.delete_artifact(&ids[0]).await.unwrap();
+    assert_eq!(flag_orphans(&core).await.unwrap(), 1);
+
+    // What mark_artifact_reviewed does for an orphaned merge.
+    core.store.accept_source_loss(&m.id).await.unwrap();
+    core.store.clear_artifact_flags(&m.id).await.unwrap();
+
+    assert_eq!(
+        flag_orphans(&core).await.unwrap(),
+        0,
+        "the sweep re-flagged a merge the operator had reviewed"
+    );
+    assert!(core.store.get_artifact(&m.id).await.unwrap().flags.is_empty());
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (first test: `merged_missing_a_source` still returns the flagged row; second: `flag_orphans` returns 1 again). `cargo test orphan`
+
+- [ ] **Step 3: Fix the SQL** in `src/store/lineage.rs` (`merged_missing_a_source`). Flags are stored as a JSON array in the `flags` TEXT column, so a LIKE exclusion is exact enough (no other flag contains the substring):
+
+```rust
+    /// Merged artifacts holding fewer lineage rows than the number of sources
+    /// they were written from — and not yet flagged for it. The exclusion is
+    /// in the SQL, not the caller: membership in this set is permanent
+    /// (deletes are hard), so without it the oldest flagged rows fill the
+    /// LIMIT forever and a newly orphaned merge past the five-hundredth is
+    /// never seen. Newest first for the same reason.
+    ///
+    /// A comparison rather than a guess, which is what `source_count` is for:
+    /// without it, "lost a source" cannot be told from "only ever had two".
+    pub async fn merged_missing_a_source(&self, limit: i64) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT a.id FROM artifacts a
+              WHERE a.provenance = 'merged'
+                AND a.source_count >
+                    (SELECT COUNT(*) FROM artifact_sources WHERE child_id = a.id)
+                AND (a.flags IS NULL OR a.flags NOT LIKE '%orphaned_source%')
+              ORDER BY a.created_at DESC, a.id
+              LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("id")).collect())
+    }
+```
+
+- [ ] **Step 4: Slim `flag_orphans`** in `src/jobs/merge.rs` — the per-row fetch-and-skip is now dead weight:
+
+```rust
+pub async fn flag_orphans(core: &Core) -> Result<usize> {
+    let mut n = 0;
+    // The scan already excludes flagged rows, so every id here is new work.
+    for id in core.store.merged_missing_a_source(500).await? {
+        core.store
+            .set_artifact_flags(
+                &id,
+                &["orphaned_source".to_string()],
+                Some("one of the artifacts this was written from has been deleted"),
+            )
+            .await?;
+        n += 1;
+    }
+    if n > 0 {
+        tracing::info!(flagged = n, "merged artifacts have lost a source");
+    }
+    Ok(n)
+}
+```
+
+- [ ] **Step 5: Add `accept_source_loss`** in `src/store/artifacts.rs`, next to `clear_artifact_flags`:
+
+```rust
+    /// Record that an operator reviewed a merge's lost sources and accepted it
+    /// as a merge of what remains. `source_count` comes down to the surviving
+    /// lineage count, so the orphan scan's comparison goes quiet — without
+    /// this, clearing the flag lasts exactly one sweep, because the row still
+    /// answers "lost a source" and is flagged all over again.
+    pub async fn accept_source_loss(&self, id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE artifacts
+                SET source_count = (SELECT COUNT(*) FROM artifact_sources WHERE child_id = ?)
+              WHERE id = ? AND provenance = 'merged'",
+        )
+        .bind(id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 6: Wire the handler** in `src/web/ui.rs` (`mark_artifact_reviewed`):
+
+```rust
+async fn mark_artifact_reviewed(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(cid): Path<String>,
+) -> Result<Response> {
+    // For an orphaned merge, "reviewed" means accepted as a merge of what
+    // remains — recorded on source_count, or the next sweep re-flags it and
+    // the operator's judgement lasts one tick.
+    let c = st.core.store.get_artifact(&cid).await?;
+    if c.flags.iter().any(|f| f == "orphaned_source") {
+        st.core.store.accept_source_loss(&cid).await?;
+    }
+    st.core.store.clear_artifact_flags(&cid).await?;
+    Ok(axum::response::Html(String::new()).into_response())
+}
+```
+
+- [ ] **Step 7: Run** `cargo test` — including `deleting_a_source_flags_the_merge_rather_than_hiding_the_loss`, whose "does not re-flag" assertion now holds via the SQL exclusion. Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "fix(merge): the orphan scan skips flagged rows in SQL, and a review sticks"
+```
+
+---
+
+### Task 7: `merge_max_roots` below 2 goes back to the default
+
+**Files:**
+- Modify: `src/config.rs:546-566` (`normalize`)
+- Test: `src/config.rs` tests module
+
+A cap of 0 or 1 settles every judgeable component `Oversized` before any model call — merging silently off from a number nobody types meaning that. The codebase's own pattern for this is `normalize()`'s put-back (see `feedback.candidates`).
+
+- [ ] **Step 1: Write the failing test** (in `src/config.rs` tests, following how the existing `feedback.candidates` normalize tests build a `Config`):
 
 ```rust
 #[test]
-fn an_unreadable_member_leaves_the_filed_pair_alone() {
-    // A transient BUSY on one member used to read as "gone", closing the
-    // pair as NoConflict while both artifacts were live — permanently,
-    // because record_settled_pair only updates pending rows.
-    assert_eq!(close_filed_pair(false, true, false, true, "a", "b"), None);
-    assert_eq!(close_filed_pair(true, false, true, false, "a", "b"), None);
-    // Both readable and live: genuinely unanswered, stays filed.
-    assert_eq!(close_filed_pair(true, true, true, true, "a", "b"), None);
-    // Known-gone or known-hidden sides do close.
-    assert_eq!(
-        close_filed_pair(true, true, true, false, "a", "b").as_deref(),
-        Some("near-identical; a kept")
+fn a_merge_cap_below_two_goes_back_to_the_default() {
+    // The same put-back as feedback.candidates: every judgeable component
+    // flattens to at least two roots, so a cap of 0 or 1 settles all of them
+    // Oversized before any call — merging silently off.
+    let dir = tempfile::tempdir().unwrap();
+    let p = write(
+        &dir,
+        &format!("{MINIMAL}\n[consolidate]\nmerge_max_roots = 1\n"),
     );
+    let cfg = Config::load(Some(&p)).unwrap();
     assert_eq!(
-        close_filed_pair(true, true, false, false, "a", "b").as_deref(),
-        Some("near-identical; neither side is in results any more")
+        cfg.consolidate.merge_max_roots,
+        ConsolidateConfig::default().merge_max_roots
     );
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+(`write` and `MINIMAL` are the config test module's existing fixtures; check whether `MINIMAL` already contains a `[consolidate]` section — if it does, append the key inside that section instead of opening a second one, since TOML rejects duplicate tables.)
 
-Run: `cargo test -p engram an_unreadable_member_leaves` — Expected: compile FAIL — `close_filed_pair` does not exist.
+- [ ] **Step 2: Run — expect FAIL.** `cargo test a_merge_cap_below_two`
 
-- [ ] **Step 3: Implement**
-
-Pure helper in `src/jobs/consolidate.rs`:
+- [ ] **Step 3: Implement** in `normalize()`, after the `feedback.candidates` blocks:
 
 ```rust
-/// Whether the clustering pass answered a filed near-identical pair, and
-/// with what record. `known` is false when the member's row could not be
-/// read this sweep — an unreadable member is not a gone member, and closing
-/// on a transient store error would settle a live pair permanently
-/// (`record_settled_pair` only updates pending rows).
-fn close_filed_pair(
-    a_known: bool,
-    b_known: bool,
-    a_live: bool,
-    b_live: bool,
-    a_id: &str,
-    b_id: &str,
-) -> Option<String> {
-    if !a_known || !b_known {
-        return None;
-    }
-    match (a_live, b_live) {
-        (true, true) => None,
-        (true, false) => Some(format!("near-identical; {a_id} kept")),
-        (false, true) => Some(format!("near-identical; {b_id} kept")),
-        (false, false) => Some("near-identical; neither side is in results any more".to_string()),
-    }
-}
+        // Same argument as above: every judgeable component flattens to at
+        // least two roots, so a cap of zero or one settles all of them
+        // Oversized before any call — merging silently off from a number
+        // nobody types meaning that.
+        if self.consolidate.merge_max_roots < 2 {
+            let d = ConsolidateConfig::default().merge_max_roots;
+            tracing::warn!(
+                configured = self.consolidate.merge_max_roots,
+                using = d,
+                "consolidate.merge_max_roots below 2 would settle every component \
+                 as oversized; using the default"
+            );
+            self.consolidate.merge_max_roots = d;
+        }
 ```
 
-Member-read loop: add `let mut unknown: HashSet<String> = HashSet::new();` beside `live`, and split the error cases:
-
-```rust
-let c = match core.store.get_artifact(id).await {
-    Ok(c) => c,
-    Err(Error::NotFound) => {
-        tracing::debug!(artifact_id = %id, "pair names an artifact that is gone");
-        continue;
-    }
-    Err(e) => {
-        // Unreadable is not gone. The closing pass must not settle a
-        // pair on the strength of a store that was briefly unwell.
-        tracing::warn!(artifact_id = %id, error = %e, "could not read a clustered artifact this sweep");
-        unknown.insert(id.clone());
-        continue;
-    }
-};
-```
-
-Closing pass body becomes:
-
-```rust
-for p in &filed {
-    let alive = |id: &String| live.contains(id) && !hidden.contains(id);
-    let Some(detail) = close_filed_pair(
-        !unknown.contains(&p.a_id),
-        !unknown.contains(&p.b_id),
-        alive(&p.a_id),
-        alive(&p.b_id),
-        &p.a_id,
-        &p.b_id,
-    ) else {
-        continue;
-    };
-    if let Err(e) = core
-        .store
-        .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, Some(&detail))
-        .await
-    {
-        tracing::warn!(pair = p.id, error = %e, "could not close a settled near-identical pair");
-    }
-}
-```
-
-Keep the existing block comment above the pass; extend it with one line: an unreadable member leaves the pair filed for the next sweep.
-
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
-
+- [ ] **Step 4: Run** `cargo test`. Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add -A && git commit -m "fix(consolidate): an unreadable member does not close a filed pair"
+git add -A && git commit -m "fix(config): a merge cap below two goes back to the default instead of disabling merges"
 ```
 
 ---
 
-### Task 7: F3 — an operator's partial restore survives the sweep
+### Task 8: The full lifecycle reconcile scan runs under `lifecycle_lock` and marks what it repairs
 
 **Files:**
-- Modify: `src/store/mod.rs` (`ADDED_COLUMNS`) + schema file (`artifact_sources` CREATE TABLE)
-- Modify: `src/store/lineage.rs` (`merged_with_active_roots`; new fns `mark_source_restored`, `roots_to_hide`)
-- Modify: `src/jobs/merge.rs` (`finish` uses `roots_to_hide`)
-- Modify: `src/core/ingest.rs` (`unsupersede`)
-- Test: `src/jobs/merge.rs` tests
+- Modify: `src/jobs/consolidate.rs:223-286` (`full_lifecycle_reconcile_scanning`)
+- Test: `src/jobs/consolidate.rs` tests module
 
-**Interfaces:**
-- Produces:
-  - `artifact_sources.restored INTEGER NOT NULL DEFAULT 0` (schema + `ADDED_COLUMNS`).
-  - `Store::mark_source_restored(&self, root_id: &str) -> Result<()>` — sets `restored = 1` on every lineage row naming that root.
-  - `Store::roots_to_hide(&self, child_id: &str) -> Result<Vec<String>>` — `SELECT root_id FROM artifact_sources WHERE child_id = ? AND restored = 0 ORDER BY root_id`.
-- `roots_of` is deliberately unchanged: flattening for the model must still see the true captured roots.
+The race: the scan reads the SQLite row snapshot and the payload at different times with no lock; a concurrent `unsupersede` completing in between makes the scan write the *stale hidden state* back over the fresh payload, and because the scan's write marks nothing dirty, the corrupted state (row Active, payload Superseded, marker clear) is invisible to the complete marker pass.
 
-- [ ] **Step 1: Write the failing test** (in `src/jobs/merge.rs` tests; mirror the setup of the existing `undoing_a_merge_survives_the_next_sweep` test at ~line 596, which already builds a finished merge — reuse its seeding verbatim up to the point where the merge's roots are superseded)
+- [ ] **Step 1: Write the test** (deterministic protocol test — the race itself needs a scheduler; assert the protocol instead):
 
 ```rust
 #[tokio::test]
-async fn restoring_one_merge_source_survives_the_next_sweep() {
-    // "Put it back" on a merge-hidden artifact used to last exactly one
-    // sweep: merged_with_active_roots cannot tell a crash-interrupted
-    // merge from an operator's explicit restore, and finish re-hid it.
-    // <seeding: as in undoing_a_merge_survives_the_next_sweep — build a
-    //  finished merge m over roots [a, b], both superseded by m>
-    core.unsupersede(&a).await.unwrap();
-
-    crate::jobs::consolidate::run(&core).await.unwrap();
-
-    let back = core.store.get_artifact(&a).await.unwrap();
-    assert!(
-        back.superseded_by.is_none(),
-        "the sweep re-hid an artifact an operator had explicitly restored"
-    );
-    // The rest of the merge is untouched: b stays hidden, m stays active.
-    assert!(core.store.get_artifact(&b).await.unwrap().superseded_by.is_some());
-    assert_eq!(core.store.get_artifact(&m).await.unwrap().status, ArtifactStatus::Active);
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p engram restoring_one_merge_source_survives` — Expected: FAIL — `a.superseded_by` is `Some(m)` again after the sweep.
-
-- [ ] **Step 3: Implement**
-
-Schema: `ADDED_COLUMNS` append (comment: the operator's partial restore; `0` on every existing row, which is correct — nothing predating the column was explicitly restored):
-
-```rust
-("artifact_sources", "restored", "INTEGER NOT NULL DEFAULT 0"),
-```
-
-plus `restored INTEGER NOT NULL DEFAULT 0` in the `artifact_sources` CREATE TABLE.
-
-`src/store/lineage.rs`:
-
-```rust
-/// Record that an operator explicitly restored this captured root: no
-/// repair may hide it behind a merge again. Every merge naming it, not one
-/// — the operator's decision is about the root, not about a lineage edge.
-/// A *new* merge decision may still hide it: `insert_merged_artifact`
-/// writes fresh rows with `restored = 0`, and that is new evidence rather
-/// than a repair of old state.
-pub async fn mark_source_restored(&self, root_id: &str) -> Result<()> {
-    sqlx::query("UPDATE artifact_sources SET restored = 1 WHERE root_id = ?")
-        .bind(root_id)
-        .execute(&self.pool)
-        .await?;
-    Ok(())
-}
-
-/// The roots `finish` is allowed to hide: the lineage minus every root an
-/// operator explicitly restored. Distinct from `roots_of`, which answers
-/// "what was this written from" and must keep seeing the true closure.
-pub async fn roots_to_hide(&self, child_id: &str) -> Result<Vec<String>> {
-    let rows = sqlx::query(
-        "SELECT root_id FROM artifact_sources
-          WHERE child_id = ? AND restored = 0 ORDER BY root_id",
-    )
-    .bind(child_id)
-    .fetch_all(&self.pool)
-    .await?;
-    Ok(rows.iter().map(|r| r.get("root_id")).collect())
-}
-```
-
-`merged_with_active_roots`: add `AND s.restored = 0` to the WHERE clause, and extend its doc comment: a root an operator explicitly restored is not an unfinished merge, and the repair must not see it.
-
-`src/jobs/merge.rs` `finish`: replace the `roots_of` read with:
-
-```rust
-for root in core.store.roots_to_hide(&m.id).await? {
-    let Ok(r) = core.store.get_artifact(&root).await else {
-        continue;
-    };
-    ...
-    if let Err(e) = core.supersede(&root, &m.id).await {
-```
-
-(loop body otherwise unchanged; adjust for `root: String` instead of `&String`).
-
-`src/core/ingest.rs` `unsupersede` — read the winner before clearing, mark after both stores agree:
-
-```rust
-pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
-    let winner = self.store.get_artifact(artifact_id).await?.superseded_by;
-    // (existing body: mark dirty, payload, row, clear marker)
-    ...
-    // A restore out of a merge is an operator overruling the merge for
-    // this one source. Recorded on the lineage, or the sweep's
-    // unfinished-merge repair re-hides it on the next tick, every tick.
-    if let Some(w) = winner
-        && let Ok(wc) = self.store.get_artifact(&w).await
-        && wc.provenance == crate::store::artifacts::Provenance::Merged
-    {
-        self.store.mark_source_restored(artifact_id).await?;
-    }
-    tracing::info!(artifact_id, "restored a superseded artifact to search");
-    Ok(())
-}
-```
-
-(`reactivate` routes merge-hidden artifacts through `unsupersede`, so both buttons are covered. `merge::undo` deprecates the merge itself, so stray `restored = 1` rows under a deprecated merge are inert.)
-
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS, including `a_merge_whose_roots_were_never_superseded_is_finished_by_the_next_sweep` (fresh lineage rows have `restored = 0`, so `finish` still hides them).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(merge): an operator's restore of a merge source survives the sweep"
-```
-
----
-
-### Task 8: F8 — an orphaned merge is never its own root
-
-**Files:**
-- Modify: `src/store/lineage.rs` (`roots_of`)
-- Modify: `src/jobs/dedupe.rs` (`run`, after `roots_of`, ~line 91)
-- Test: `src/jobs/dedupe.rs` tests
-
-**Interfaces:**
-- Changed contract: `roots_of` returns an **empty** `Vec` for a merged artifact with no lineage rows (previously: the artifact itself). Captured artifacts keep the self-root fallback. Before relying on this, `grep -rn "roots_of" src/` and check every caller tolerates an empty entry (`merge::finish` no longer calls it after Task 7; `insert_merged_artifact`'s flattening treats "no rows" per its own logic — verify it maps a rootless merged member to nothing rather than to itself; if it self-roots there too, apply the same provenance check in that flattening).
-
-- [ ] **Step 1: Write the failing test**
-
-```rust
-#[tokio::test]
-async fn a_merge_that_lost_its_sources_is_never_shown_as_an_original() {
-    // The self-root fallback put a model-synthesized paraphrase in the
-    // prompt as a captured original, and a Duplicate verdict would then
-    // record a merged artifact as root_id — paraphrase drift, one
-    // generation per merge, which the lineage design exists to prevent.
-    let mut core = test_core().await;
-    core.consolidate.autonomous = true;
-    let completer = Arc::new(ScriptedCompleter::new(vec![]));
-    core.completer = completer.clone();
-    let ids = disagreeing(&core).await;
-    let m = core
-        .store
-        .insert_merged_artifact(
-            &crate::store::artifacts::NewMerged {
-                text: "a paraphrase".into(), title: None, category: None,
-                tags: vec![], caveats: vec![],
-            },
-            &[ids[0].clone()],
-        )
+async fn the_scan_repair_leaves_no_repaired_id_unmarked_midway() {
+    // The scan writes payloads from row state. An interrupted write must be
+    // findable by the complete marker pass, so the ids are marked dirty
+    // before the payload write and cleared only after it returns — the same
+    // contract every lifecycle mutator honours.
+    let core = test_core().await;
+    let ids = seed(&core, &[("a text", [1.0, 0.0])]).await;
+    // Drift no SQLite write produced: the payload hides what the row shows.
+    core.vectors
+        .set_lifecycle(&ids[0], crate::store::artifacts::ArtifactStatus::Deprecated, None)
         .await
         .unwrap();
-    // Its every source cascades away, as a corpus deletion does.
-    sqlx::query("DELETE FROM artifact_sources WHERE child_id = ?")
-        .bind(&m.id).execute(&core.store.pool).await.unwrap();
 
-    let pair = queue_pair(&core, &m.id, &ids[1]).await;
-    run(&core, &pair.to_string()).await.unwrap();
+    let repaired = full_lifecycle_reconcile(&core).await.unwrap();
 
-    assert_eq!(completer.calls(), 0, "a rootless merge reached the model as an original");
-    assert_eq!(
-        core.store.get_pair(pair).await.unwrap().state,
-        PairState::Contradiction,
-        "the component goes to a person rather than being judged on a paraphrase"
-    );
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p engram a_merge_that_lost_its_sources` — Expected: FAIL — the completer is called (empty script panics or call count is 1).
-
-- [ ] **Step 3: Implement**
-
-`roots_of` fallback branch:
-
-```rust
-let entry = if roots.is_empty() {
-    // No lineage rows means a captured artifact — or a merged one every
-    // root of which has since been deleted. A captured artifact is its
-    // own root; a merged one is nobody's: its text is a synthesis, and
-    // handing it back as a root is how a paraphrase of a paraphrase
-    // ends up in a prompt as an original. The empty answer makes that
-    // state visible to the caller instead.
-    let provenance: String =
-        sqlx::query_scalar("SELECT provenance FROM artifacts WHERE id = ?")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?
-            .unwrap_or_else(|| "captured".to_string());
-    if provenance == "merged" { vec![] } else { vec![id.clone()] }
-} else {
-    roots
-};
-out.insert(id.clone(), entry);
-```
-
-`src/jobs/dedupe.rs` `run`, right after `let root_map = …`:
-
-```rust
-// A member with no roots at all is a merge whose sources were deleted
-// out from under it. Its text is a paraphrase with nothing behind it —
-// not something to show the model as an original, and not something a
-// rule can settle. A person decides.
-if member_ids.iter().any(|mid| root_map.get(mid).is_none_or(|r| r.is_empty())) {
-    settle_all(
-        core,
-        &pairs,
-        PairState::Contradiction,
-        Some("a merged member has lost its sources; resolve by hand"),
-    )
-    .await?;
-    return Ok(());
-}
-```
-
-Update the `roots_of` doc comment (its current text explains the old fallback) and the module-header sentence in `lineage.rs` that describes it.
-
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(lineage): a merge that lost every source is nobody's root"
-```
-
----
-
-### Task 9: F9 — a merge restored from the index is flagged as having lost its lineage
-
-**Files:**
-- Modify: `src/core/ingest.rs` (`heal_store_drift` restore loop, ~line 647)
-- Test: `src/core/ingest.rs` tests (or wherever `heal_store_drift` tests live — `grep -rn "heal_store_drift" src/ --include=*.rs -l`)
-
-**Interfaces:**
-- Consumes: `set_artifact_flags` (exists), `Provenance::Merged`, flag string `"orphaned_source"` (the one `flag_orphans` and the UI already read).
-
-- [ ] **Step 1: Write the failing test** (place beside the existing `heal_store_drift` tests, reusing their vector-point seeding idiom — the test around `ingest.rs:1580` restores an artifact from a surviving payload; copy its setup with `provenance: Some("merged".into())` in the payload)
-
-```rust
-#[tokio::test]
-async fn a_merge_restored_from_the_index_is_flagged_as_orphaned() {
-    // restore_artifact cannot recreate lineage rows and leaves
-    // source_count at 0, so 0 > COUNT(*) never fires and nothing ever
-    // flagged the restored merge — it became its own root silently.
-    // <setup: as in the existing restore test, but the payload's
-    //  provenance is "merged" and corpus_id handling follows the
-    //  Provenance::Merged branch>
-    core.heal_store_drift().await.unwrap();
-
-    let c = core.store.get_artifact(&artifact_id).await.unwrap();
+    assert_eq!(repaired, 1);
+    // Repair complete: payload agrees with the row again and no marker is left.
     assert!(
-        c.flags.iter().any(|f| f == "orphaned_source"),
-        "a restored merge must say it cannot support its provenance claim"
+        core.store.dirty_lifecycle_artifacts(10).await.unwrap().is_empty(),
+        "the scan left markers standing on a base in agreement"
     );
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+(Adapt the drift seeding and assertions to the existing reconcile tests in that module — several already seed payload-side drift; follow their pattern. If `dirty_lifecycle_artifacts` has a different name/signature, use whatever `repair_lifecycle_drift` reads.)
 
-Run: `cargo test -p engram a_merge_restored_from_the_index` — Expected: FAIL — no flag set.
+- [ ] **Step 2: Run** — this passes or fails depending on current marker behavior; its job is to pin the contract. Note the result.
 
-- [ ] **Step 3: Implement** — in the restore loop, after `if self.store.restore_artifact(&restored).await? {`:
-
-```rust
-if self.store.restore_artifact(&restored).await? {
-    out.rows_restored += 1;
-    // A payload records neither source_count nor lineage rows, so a
-    // restored merge definitionally cannot support its provenance
-    // claim — and `merged_missing_a_source` (0 > 0) will never say
-    // so. Said here instead, with the flag that pass would have set.
-    if provenance == crate::store::artifacts::Provenance::Merged {
-        self.store
-            .set_artifact_flags(
-                &p.artifact_id,
-                &["orphaned_source".to_string()],
-                Some("restored from the index; the record of its sources was lost"),
-            )
-            .await?;
-    }
-    self.store
-        .enqueue(Stage::Embed, "artifact", &p.artifact_id)
-        .await?;
-}
-```
-
-(With Task 8 in place, such a merge also never self-roots — the flag is the operator-visible half, `roots_of` is the invariant half.)
-
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(ingest): a merge restored from the index is flagged as orphaned"
-```
-
----
-
-### Task 10: F10 — lifecycle writes are serialized against the marker repair
-
-**Files:**
-- Modify: `src/core/mod.rs` (`Core` struct + its constructor(s))
-- Modify: `src/core/ingest.rs` (`supersede`, `unsupersede`, `deprecate`, `reactivate`, `repoint_supersession`)
-- Modify: `src/jobs/consolidate.rs` (`repair_lifecycle_drift`)
-
-**Interfaces:**
-- Produces: `Core.lifecycle_lock: Arc<tokio::sync::Mutex<()>>` (constructed as `Arc::new(tokio::sync::Mutex::new(()))` wherever `Core` is built — `grep -rn "Core {" src/` for every literal, including `test_support`).
-
-No new deterministic test: the race needs two tasks interleaved between specific awaits, which nothing in this test harness can schedule reliably. The fix is structural (mutual exclusion); the existing lifecycle test suite guards against regressions in each path's behavior. State this in the commit message body.
-
-- [ ] **Step 1: Implement**
-
-`Core`:
+- [ ] **Step 3: Implement.** At the top of `full_lifecycle_reconcile_scanning`, before `list_non_active_artifacts`:
 
 ```rust
-/// Serializes every lifecycle transition against the sweep's marker
-/// repair. Each transition is two writes to two stores plus a dirty
-/// marker, none of it atomic; without mutual exclusion the repair can
-/// read a stale row mid-reveal, write the old state back over the new
-/// payload, and the reveal then clears the marker — row active, payload
-/// hidden, and nothing left that would ever notice. Shared by every
-/// clone, like the background queue.
-pub lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
-```
-
-In `ingest.rs`, split `unsupersede` into a public locking wrapper and a private body so `reactivate` never locks twice:
-
-```rust
-pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
-    let _guard = self.lifecycle_lock.lock().await;
-    self.unsupersede_locked(artifact_id).await
-}
-
-async fn unsupersede_locked(&self, artifact_id: &str) -> Result<()> {
-    // (entire current body, including Task 7's restored-marking)
-}
-```
-
-`reactivate`:
-
-```rust
-pub async fn reactivate(&self, id: &str) -> Result<()> {
-    let _guard = self.lifecycle_lock.lock().await;
-    if self.store.get_artifact(id).await?.superseded_by.is_some() {
-        return self.unsupersede_locked(id).await;
-    }
-    // (rest of current body)
-}
-```
-
-`supersede`, `deprecate`, `repoint_supersession`: `let _guard = self.lifecycle_lock.lock().await;` as the first line (none of them calls another locked fn — verify by reading each body before adding the guard; `merge::finish` and the sweep call them from *outside*, which is fine, the guard is per-call).
-
-`repair_lifecycle_drift` in `consolidate.rs`:
-
-```rust
-async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
-    // Under the same lock as every lifecycle transition: the repair
-    // reads rows, writes payloads and clears markers, and interleaving
-    // that with a payload-first reveal is exactly the sequence that
-    // hides an artifact with no marker left to find it by.
+    // Under the same lock as every lifecycle transition. The scan reads the
+    // row side and the payload side at different moments and then writes
+    // payloads from the row snapshot; interleaved with a payload-first reveal
+    // it would write the stale hidden state back over the fresh payload —
+    // and, writing with no marker, leave nothing behind for the complete
+    // marker pass to find it by. The scan is capped at `DRIFT_SCAN`, so the
+    // hold is bounded.
     let _guard = core.lifecycle_lock.lock().await;
-    let dirty = core.store.dirty_lifecycle_artifacts(DRIFT_SCAN).await?;
-    // (rest unchanged)
 ```
 
-- [ ] **Step 2: Run tests** — `cargo test -p engram` — Expected: PASS (behavior unchanged single-threaded; watch for a deadlock-shaped test hang, which would mean a locked fn calls another locked fn — re-check call graphs).
+And wrap the write at the bottom in the marker protocol:
 
-- [ ] **Step 3: Commit**
+```rust
+    if !rows.is_empty() {
+        tracing::info!(
+            repaired = rows.len(),
+            "lifecycle state disagreed between sqlite and the vector store"
+        );
+        // Marked before the payload write, cleared only after it returns: an
+        // interrupted repair is then ordinary marked drift the next marker
+        // pass finishes, instead of a best-effort scan's private problem.
+        let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+        for id in &ids {
+            core.store.mark_lifecycle_dirty(id).await?;
+        }
+        core.vectors.apply_lifecycle(&rows).await?;
+        core.store.clear_lifecycle_dirty(&ids).await?;
+    }
+    Ok(rows.len())
+```
+
+(Check the actual field name for the id on `LifecycleRow` — `lifecycle_row_of` builds it; adjust `r.id` accordingly. If `mark_lifecycle_dirty` only takes `&str` one at a time, the loop above is the call shape.)
+
+- [ ] **Step 4: Verify no caller holds the lock** (tokio Mutex deadlocks silently):
+
+Run: `grep -n "full_lifecycle_reconcile\|lifecycle_lock" src/jobs/consolidate.rs src/core/*.rs`
+Expected: `run()` calls `repair_lifecycle_drift` (locks and releases) and then `full_lifecycle_reconcile` as a *separate* call; no call path enters the scan with the lock held. If any does, restructure as `_locked` variants the way `unsupersede`/`unsupersede_locked` do.
+
+- [ ] **Step 5: Run** `cargo test` (the reconcile suite has several scan tests — all must pass). Expected: PASS.
+- [ ] **Step 6: Commit**
 
 ```bash
-git add -A && git commit -m "fix(core): lifecycle transitions and the marker repair exclude each other"
+git add -A && git commit -m "fix(consolidate): the reconcile scan takes the lifecycle lock and marks its writes"
 ```
-
-Body: note that the interleaving (repair reads stale row → reveal writes payload → repair writes stale payload → reveal clears marker) is unreproducible deterministically in tests, so the fix is mutual exclusion with no new test; existing lifecycle tests cover each path.
 
 ---
 
-### Task 11: F11 — legacy `'judge'` job rows
+### Task 9: `heal_dangling_supersessions` honours the lifecycle lock and marker
 
 **Files:**
-- Modify: `src/store/mod.rs` (migration section — near the existing one-off `ALTER TABLE`/cleanup statements, `grep -n "DROP COLUMN" src/store/mod.rs` for the spot)
-- Test: `src/store/jobs.rs` tests
+- Modify: `src/core/ingest.rs:756-793`
+- Test: `src/core/ingest.rs` tests module (or wherever the heal's existing tests live — find with `grep -rn "heal_dangling" src --include=*.rs`)
 
-**Interfaces:** none new.
+Same failure class as Task 8: heal writes payload → row → clear-marker with no lock and no pre-mark; interleaved with `repair_lifecycle_drift` it produces row Active / payload Superseded / marker clear.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the test** (protocol pin, same shape as Task 8's):
 
 ```rust
 #[tokio::test]
-async fn a_legacy_judge_row_is_not_claimed_as_something_else() {
-    // Stage::parse has no 'judge' arm and claim_job falls back to
-    // Synthesize, so a leftover row from the branch this replaced was
-    // claimed as a synthesize job aimed at a pair id.
-    let s = Store::memory().await.unwrap();
-    sqlx::query(
-        "INSERT INTO jobs (stage, target_kind, target_id, state, run_after, attempts, seq)
-         VALUES ('judge', 'pair', '17', 'pending', 0, 0, 0)",
-    )
-    .execute(&s.pool)
-    .await
-    .unwrap();
+async fn the_heal_reveals_under_the_lifecycle_lock_with_the_marker_raised_first() {
+    // Payload-first direction, so the contract is unsupersede's: mark before
+    // the payload write, clear only once both stores agree. Without the mark,
+    // a crash between the two writes is drift no marker ever announced; and
+    // without the lock, the sweep's repair can interleave and write the stale
+    // hidden state back with nothing left to notice.
+    let core = test_core().await;
+    let ids = seed(&core, &[("a", [1.0, 0.0]), ("b", [0.93, 0.37])]).await;
+    core.supersede(&ids[0], &ids[1]).await.unwrap();
+    core.delete_artifact(&ids[1]).await.unwrap(); // runs the heal
 
-    s.migrate().await.unwrap();
-
+    let a = core.store.get_artifact(&ids[0]).await.unwrap();
+    assert!(a.in_results(), "the heal did not restore the dangling loser");
     assert!(
-        s.claim_job().await.unwrap().is_none(),
-        "a legacy judge row survived migration and was claimed"
+        core.store.dirty_lifecycle_artifacts(10).await.unwrap().is_empty(),
+        "the heal left a marker on a base in agreement"
     );
 }
 ```
 
-(If the migration entry point is not named `migrate`, find the fn that runs `ADDED_COLUMNS` — the test calls that. If it is private, make the test a sibling in `store/mod.rs` tests instead.)
+(This may already pass end-state-wise; it pins the marker end state while Step 3 fixes the ordering and locking. Keep it regardless.)
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run it**, note the result.
 
-Run: `cargo test -p engram a_legacy_judge_row` — Expected: FAIL — the row is claimed (as Synthesize).
-
-- [ ] **Step 3: Implement** — in the migration path, after the `ADDED_COLUMNS` loop:
+- [ ] **Step 3: Implement.** In `heal_dangling_supersessions`:
 
 ```rust
-// The judge became the dedupe unit on this branch and its stage name
-// went with it. A leftover row would otherwise be claimed under
-// `Stage::parse`'s Synthesize fallback and aimed at a pair id. Deleted
-// rather than renamed: the pair is still pending, so the next sweep
-// re-arms it under its real stage, and a rename could collide with a
-// dedupe row the sweep has already written for the same pair.
-sqlx::query("DELETE FROM jobs WHERE stage = 'judge'")
-    .execute(&self.pool)
-    .await?;
-```
-
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(store): a legacy judge job row is deleted, not misrouted"
-```
-
----
-
-### Task 12: F12 — `arm_dedupe` does nothing when its budget is zero
-
-**Files:**
-- Modify: `src/jobs/consolidate.rs` (`arm_dedupe`, ~line 549)
-- Test: `src/jobs/consolidate.rs` tests
-
-- [ ] **Step 1: Write the failing test**
-
-```rust
-#[tokio::test]
-async fn a_zero_dedupe_budget_arms_nothing_and_reads_nothing() {
-    // With the budget at zero every tick still ran the 200-row query and
-    // logged "budget spent" — dead work on the sweep's hot path, and a
-    // misleading log line. The observable half: nothing is armed and no
-    // pair is touched.
-    let mut core = test_core().await;
-    core.consolidate.max_dedupe_per_tick = 0;
-    disagreeing(&core).await;
-    let out = run(&core).await.unwrap();
-    assert_eq!(out.judged, 0);
-    assert_eq!(
-        core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
-        1,
-        "the pending pair must be left exactly as it was"
-    );
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails or passes vacuously**
-
-Run: `cargo test -p engram a_zero_dedupe_budget` — This may already PASS behaviorally (the waste is the query, not the outcome). Either way it pins the contract; proceed.
-
-- [ ] **Step 3: Implement** — first lines of `arm_dedupe`:
-
-```rust
-// `max_dedupe_per_tick = 0` is the off switch for the model (see run's
-// comment on the `autonomous` flag). Off means off: no 200-row read per
-// tick, and no "budget spent" log line implying a budget was spent.
-if core.consolidate.max_dedupe_per_tick == 0 {
-    return Ok(0);
-}
-```
-
-- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add -A && git commit -m "fix(consolidate): a zero dedupe budget arms nothing and reads nothing"
-```
-
----
-
-### Task 13: F13 — `open_component` grows by worklist, not by rescan
-
-**Files:**
-- Modify: `src/store/pairs.rs` (`open_component` fixed-point loop, ~lines 342-366)
-
-Behavior is unchanged (same members, same picked set), so the existing `open_component` tests are the spec — no new test.
-
-- [ ] **Step 1: Implement** — replace the loop with an adjacency-indexed worklist:
-
-```rust
-// Adjacency once, then a worklist. The fixed point rescanned the whole
-// window per growth pass — quadratic at the 5 000-row window for a
-// long chain — for an answer a plain flood fill gives in one pass over
-// the edges.
-let mut by_artifact: std::collections::HashMap<&str, Vec<usize>> = Default::default();
-for (i, p) in open.iter().enumerate() {
-    by_artifact.entry(p.a_id.as_str()).or_default().push(i);
-    by_artifact.entry(p.b_id.as_str()).or_default().push(i);
-}
-let mut picked: std::collections::HashSet<i64> = [seed.id].into_iter().collect();
-let mut queue: Vec<&str> = vec![seed.a_id.as_str(), seed.b_id.as_str()];
-let mut seen: std::collections::HashSet<&str> = queue.iter().copied().collect();
-while let Some(id) = queue.pop() {
-    for &i in by_artifact.get(id).into_iter().flatten() {
-        let p = &open[i];
-        picked.insert(p.id);
-        for other in [p.a_id.as_str(), p.b_id.as_str()] {
-            if seen.insert(other) {
-                queue.push(other);
+    pub(crate) async fn heal_dangling_supersessions(&self) -> Result<()> {
+        // Under the lifecycle lock like every other transition: this path
+        // reveals payload-first, and interleaving with the sweep's repair —
+        // which reads rows and writes payloads — is exactly the sequence that
+        // hides an artifact with no marker left to find it by.
+        let _guard = self.lifecycle_lock.lock().await;
+        let mut first_err = None;
+        for id in self.store.dangling_superseded().await? {
+            // Marked before the payload write, as `unsupersede` does and for
+            // the same reason: this direction writes the payload first, so
+            // without it a crash between the two stores would leave drift no
+            // row write ever announced.
+            self.store.mark_lifecycle_dirty(&id).await?;
+            if let Err(e) = self
+                .vectors
+                .set_lifecycle(&id, ArtifactStatus::Active, None)
+                .await
+            {
+                tracing::warn!(
+                    artifact_id = %id,
+                    error = %e,
+                    "could not clear the hidden flag; the artifact stays listed on Ops"
+                );
+                first_err.get_or_insert(e);
+                continue;
             }
+            self.store.set_superseded_by(&id, None).await?;
+            // ... keep the existing clear_lifecycle_dirty call and its comment ...
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
         }
     }
-}
-Ok(open.into_iter().filter(|p| picked.contains(&p.id)).collect())
 ```
 
-(Delete the now-dead `members` set and the old loop; keep the surrounding comments about the seed always being in the component.)
+One subtlety the implementer must preserve: on the `continue` (payload write failed), the marker now stays raised — that is correct and is the point: the failed reveal is findable drift. But `repair_lifecycle_drift` repairs *row → payload*, and here the row still says superseded, so the marker pass would just rewrite "superseded" into the payload — harmless (that is the current true state) and the heal retries next sweep anyway.
 
-- [ ] **Step 2: Run tests** — `cargo test -p engram open_component` then full `cargo test -p engram` — Expected: PASS.
+- [ ] **Step 4: Verify no caller holds the lock:**
 
+Run: `grep -rn "heal_dangling_supersessions" src --include=*.rs`
+Expected callers: `delete_artifact`, `delete_corpus`, `reprocess` (ingest.rs), `embed.rs`, `consolidate::run` — read each call site and confirm none holds `lifecycle_lock` at the call. `delete_artifact`/`delete_corpus`/`reprocess` do not lock; check `embed.rs:582`'s enclosing function. If any holds it, add a `_locked` variant per the `unsupersede_locked` pattern.
+
+- [ ] **Step 5: Run** `cargo test`. Expected: PASS.
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "fix(core): the dangling-supersession heal takes the lifecycle lock and marks first"
+```
+
+---
+
+### Task 10: One `source_rows` helper; Ops batches `roots_of`
+
+**Files:**
+- Modify: `src/web/ui.rs:1043-1075` (`ops()`), `src/web/ui.rs:1412-1435` (`build_artifact_detail`)
+- Test: existing UI/store tests only (this is an extraction; `cargo test` guards it)
+
+The loop `roots_of(one id)` → skip self → `get_artifact(rid)` → push `SourceRow` is copy-pasted verbatim in both functions, and `ops()` runs it once per merged artifact — an N+1 over an API whose signature `&[String]` exists for batching.
+
+- [ ] **Step 1: Extract the helper** in `src/web/ui.rs`, near `SourceRow`:
+
+```rust
+/// The source list a merge renders: its lineage roots, fetched and titled.
+/// One shape for Ops and the detail pane — the two must stay behaviorally
+/// identical (same self-guard, same tolerance for deleted sources, same
+/// corpus fallback), and a copy in each is how they come to disagree about
+/// what a merge was made of.
+async fn source_rows(store: &crate::store::Store, merged_id: &str, roots: &[String]) -> Vec<SourceRow> {
+    let mut sources = Vec::new();
+    for rid in roots {
+        // `roots_of` answers an empty list for a merge that lost every source;
+        // the self guard stays as defense against a base written before that
+        // change.
+        if rid == merged_id {
+            continue;
+        }
+        if let Ok(r) = store.get_artifact(rid).await {
+            sources.push(SourceRow {
+                corpus_id: r.corpus_id.clone().unwrap_or_default(),
+                title: title_of(&r),
+                id: r.id,
+            });
+        }
+    }
+    sources
+}
+```
+
+- [ ] **Step 2: Rewrite `ops()`'s merged loop** — one batched `roots_of` for all listed merges:
+
+```rust
+    let mut merged = Vec::new();
+    let merged_chunks = st.core.store.merged_artifacts(50).await?;
+    // One lineage query per page, not one per row: `roots_of` takes the batch.
+    let merged_ids: Vec<String> = merged_chunks.iter().map(|c| c.id.clone()).collect();
+    let roots = st.core.store.roots_of(&merged_ids).await.unwrap_or_default();
+    for c in merged_chunks {
+        let sources = source_rows(
+            &st.core.store,
+            &c.id,
+            roots.get(&c.id).map(Vec::as_slice).unwrap_or_default(),
+        )
+        .await;
+        merged.push(MergedRow {
+            orphaned: c.flags.iter().any(|f| f == "orphaned_source"),
+            title: title_of(&c),
+            id: c.id,
+            sources,
+        });
+    }
+```
+
+(If `st.core.store` is not a plain `crate::store::Store`, match the helper's parameter type to whatever both call sites can hand over — the detail pane has `core.store`, ops has `st.core.store`.)
+
+- [ ] **Step 3: Rewrite `build_artifact_detail`'s block** to use the same helper:
+
+```rust
+    let mut sources = Vec::new();
+    if c.provenance == crate::store::artifacts::Provenance::Merged {
+        let roots = core
+            .store
+            .roots_of(std::slice::from_ref(&c.id))
+            .await
+            .unwrap_or_default();
+        sources = source_rows(
+            &core.store,
+            &c.id,
+            roots.get(&c.id).map(Vec::as_slice).unwrap_or_default(),
+        )
+        .await;
+    }
+```
+
+- [ ] **Step 4: Run** `cargo test`. Expected: PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "refactor(ui): one source_rows helper, one batched roots_of per Ops page"
+```
+
+---
+
+### Task 11: Remove `open_component`'s unreachable empty-component arm
+
+**Files:**
+- Modify: `src/store/pairs.rs:399-401`
+
+The block above guarantees the seed is in `open` (pushed if Pending, early-returned if settled), so the `else` arm can never run — yet it returns the same empty vec that has a *documented meaning* ("settled while the unit waited"), forcing readers to reason about a phantom third case.
+
+- [ ] **Step 1: Replace the let-else** at pairs.rs:399:
+
+```rust
+        let seed = open
+            .iter()
+            .find(|p| p.id == pair_id)
+            .expect("the block above put the seed in the window or returned");
+```
+
+- [ ] **Step 2: Run** `cargo test` (pairs suite). Expected: PASS.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add -A && git commit -m "perf(pairs): open_component flood-fills instead of rescanning the window"
+git add -A && git commit -m "refactor(pairs): open_component has two empty-component cases, not a phantom third"
 ```
 
 ---
 
-### Task 14: F14 — comments stop claiming the full reconcile is gated
+### Task 12: `arm_dedupe` skips in-flight pairs before fetching their artifacts
 
 **Files:**
-- Modify: `src/jobs/consolidate.rs` (doc comment of `repair_lifecycle_drift` ~line 143-148, doc comment of `full_lifecycle_reconcile` ~line 173-179)
+- Modify: `src/jobs/consolidate.rs:636-688` (inside `arm_dedupe`'s loop)
 
-The code is right (the reconcile's own rationale at lines 180-184 argues for keeping it); the comments are wrong.
+Each tick reads up to 200 pending pairs and pays two full-row `get_artifact` fetches per pair *before* the cheap `live_job` skip — and in-flight pairs sort first (`judge_attempts = 0`), so the same rows are re-fetched every 15 minutes for nothing.
 
-- [ ] **Step 1: Implement** — two wording fixes:
+- [ ] **Step 1: Reorder.** Move the `live_job` check (the block at lines 680-688 beginning `// A pair whose unit is still queued from an earlier sweep...` through `if core.store.live_job(Stage::Dedupe, &target).await? { continue; }`) to directly *above* the `let (a, b) = match (...)` artifact fetch at line 636. Keep both comment blocks with their code. The retired-member dismissal stays where it is — it needs the artifacts.
 
-In `repair_lifecycle_drift`'s doc, replace "`full_lifecycle_reconcile` keeps that scan for the drift that arises with no SQLite write behind it, but it no longer runs every sweep." with:
+- [ ] **Step 2: Check nothing between the two blocks depended on order.** The moved check reads only `p.id`; the fetch reads only `p.a_id`/`p.b_id`. Nothing in between mutates state. Confirm by reading the final loop top-to-bottom: budget check → live_job skip → artifact fetch → retired dismissal → re-arm.
 
-```
-/// `full_lifecycle_reconcile` keeps that scan for the drift that arises with
-/// no SQLite write behind it; it still runs every sweep, after this pass.
-```
-
-In `full_lifecycle_reconcile`'s doc, replace "Still on the sweep, behind the marker, and the division of labour is the point." with:
-
-```
-/// Still on every sweep, after the marker pass, and the division of labour
-/// is the point.
-```
-
-- [ ] **Step 2: Verify and commit**
-
-Run: `cargo build 2>&1 | tail -3` (comments only; build proves nothing broke) and `cargo fmt`.
+- [ ] **Step 3: Run** `cargo test` (the arm_dedupe tests). Expected: PASS.
+- [ ] **Step 4: Commit**
 
 ```bash
-git add -A && git commit -m "docs(consolidate): the full reconcile runs every sweep, and says so"
+git add -A && git commit -m "perf(consolidate): arm_dedupe skips queued pairs before fetching their artifacts"
 ```
 
 ---
 
-## Final verification (after Task 14)
+## Final verification
 
 - [ ] `cargo test` — full suite green.
-- [ ] `cargo fmt --check` and (if the repo uses it — check CI config) `cargo clippy` — clean.
-- [ ] Re-read the Findings Index: each of F1-F14 maps to a merged commit. F1→T3, F2→T4, F3→T7, F4→T6, F5→T1+T5, F6→T3, F7→T1+T2, F8→T8, F9→T9, F10→T10, F11→T11, F12→T12, F13→T13, F14→T14.
-- [ ] `git push` to `feat/autonomous-consolidation` only when the user asks.
+- [ ] `cargo fmt --check` and `cargo clippy` (fix anything the tasks introduced).
+- [ ] Re-read the Findings list at the top: every numbered finding maps to a landed commit; the three declined ones and the deferred refactor are recorded there.

--- a/docs/superpowers/plans/2026-08-14-pr14-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-14-pr14-review-fixes.md
@@ -32,7 +32,7 @@ Confirmed findings fixed by this plan (task number in parentheses):
 9. The liveness predicate `status == Active && superseded_by.is_none()` is hand-spelled at 12 production sites (Task 1).
 10. `ops()` and `build_artifact_detail()` duplicate the source-rows loop verbatim, and `ops()` is an N+1 over a batch API (Task 10).
 11. `open_component`'s `let Some(seed) ... else` arm is unreachable (Task 11).
-12. `arm_dedupe` pays two full-row `get_artifact` fetches per pair before the cheap already-queued skip, re-checking the same in-flight pairs every tick (Task 12).
+12. `arm_dedupe` pays two full-row `get_artifact` fetches per pair before the cheap already-queued skip, re-checking the same in-flight pairs every tick (Task 12). **Outcome: invalid — reverted.** The order is load-bearing: the retired-member dismissal must run even for pairs whose unit is still queued, which `a_pair_whose_member_was_deprecated_never_reaches_the_dedupe_pass` and `a_pair_whose_member_was_since_hidden_never_reaches_the_model` pin. The reorder landed as 603b4ef and was reverted in the next commit.
 
 Declined by the user (2026-08-14, "prototype, only used by me — legacy doesn't exist"):
 

--- a/docs/superpowers/plans/2026-08-14-pr14-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-14-pr14-review-fixes.md
@@ -1,0 +1,1541 @@
+# PR #14 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all 14 confirmed findings from the multi-agent review of PR #14 (`feat/autonomous-consolidation`), on that branch.
+
+**Architecture:** The load-bearing principle across the dedupe fixes: a pair-state write may only become terminal *after* the fallible side effect it describes (supersede, merge-embed) is durable — or the settled state must be recoverable by a sweep repair. Three product decisions are already made by the user: (1) observation-mode merge verdicts get a new honest `WouldMerge` pair state, draft still discarded; (2) unsuperseding a merge source is honored as a partial restore via a `restored` marker on lineage rows; (3) merges whose embed permanently fails are auto-undone by the sweep, reopening their pairs for a person.
+
+**Tech Stack:** Rust (tokio, sqlx/SQLite, axum, askama templates), Qdrant + in-memory vector store. Tests are `#[tokio::test]` colocated in each module.
+
+**Spec:** The 14 findings, restated one line each in "Findings Index" below. Full failure scenarios are in the PR #14 review report (delivered in-session); each task's rationale section repeats what its finding claims.
+
+## Global Constraints
+
+- Work on branch `feat/autonomous-consolidation` (PR #14). Do not merge or rebase onto master.
+- Every task: `cargo test` must pass and `cargo fmt` must be clean before its commit.
+- Commit style (from repo history): `fix(scope): lowercase clause describing the behavior`, e.g. `fix(dedupe): a retired member dismisses only its own pairs`. End every commit message with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Comment style: this codebase writes long "why" comments. When you change behavior a nearby comment describes, update the comment in the same edit — several findings are precisely stale comments.
+- Schema changes go in BOTH places: the fresh-DB schema (`src/store/schema.sql` — locate the `artifact_pairs` / `artifact_sources` CREATE TABLE there) AND the `ADDED_COLUMNS` list in `src/store/mod.rs` (append-only, with a default; never reorder).
+- SQLite `now()` helper and test idioms (`test_core()`, `seed`, `queue_pair`, `ScriptedCompleter`, direct `sqlx::query(...).execute(&core.store.pool)` for state surgery) already exist — use them, do not invent new harnesses.
+
+## Findings Index
+
+| # | Where | One-line claim |
+|---|-------|----------------|
+| F1 | `src/jobs/dedupe.rs:294-327` | Replaced verdict settles pairs terminally before the fallible `core.supersede`; picks obsolete/winner from roots with no status check; failure is unretryable (run() skips non-Pending). |
+| F2 | `src/jobs/dedupe.rs:78-81` | One retired component member dismisses the entire component, killing sibling pairs between still-active duplicates forever. |
+| F3 | `src/jobs/consolidate.rs:307` | Sweep's unfinished-merge repair silently reverts an operator's unsupersede of a merge source, every sweep. |
+| F4 | `src/jobs/consolidate.rs:446-470` | Closing pass treats any `get_artifact` error (transient BUSY) as "artifact gone" and permanently closes a live pair as NoConflict. |
+| F5 | `src/jobs/dedupe.rs:357-365` | Duplicate verdict settles pairs as NoConflict before the merge is embedded; a permanently failing embed strands an invisible merge, duplicates unmergeable forever. |
+| F6 | `src/jobs/dedupe.rs:321` | Autonomous applied replacement leaves its pair in `Superseded` (= "awaiting confirmation"); its buttons then always return a validation error. |
+| F7 | `src/jobs/dedupe.rs:334-350` | Autonomy-off duplicate verdict filed as `Contradiction`; UI lies ("These two disagree"), offers only lossy keep-one buttons, draft discarded. |
+| F8 | `src/store/lineage.rs:43-55` | `roots_of` self-root fallback fires for an orphaned merge; its synthesized text is shown to the model as a captured original and can become a `root_id`. |
+| F9 | `src/store/artifacts.rs:407` | `restore_artifact` loses `source_count`/lineage, so a merge restored from its vector payload silently defeats the anti-drift invariant. |
+| F10 | `src/jobs/consolidate.rs:153-169` | `repair_lifecycle_drift` racing a payload-first reveal can re-hide the payload, then the reveal clears the marker: row Active, payload Superseded, no marker. |
+| F11 | `src/store/jobs.rs:330` | Legacy `'judge'` job rows parse as `None` → `unwrap_or(Stage::Synthesize)` misroute. |
+| F12 | `src/jobs/consolidate.rs:549-560` | `arm_dedupe` does a 200-row query + loop every tick even when `max_dedupe_per_tick == 0`. |
+| F13 | `src/store/pairs.rs:350-366` | `open_component` fixed-point loop rescans the whole window per growth pass — quadratic on the 5 000-row window. |
+| F14 | `src/jobs/consolidate.rs:148,175` | Comments claim `full_lifecycle_reconcile` "no longer runs every sweep" / is "behind the marker" while `run()` calls it unconditionally at line 298. |
+
+---
+
+### Task 1: Pair-state groundwork — `WouldMerge` state and `merged_into` column
+
+**Files:**
+- Modify: `src/store/pairs.rs` (PairState enum, `ArtifactPair`, `row_to_pair`, `set_pair_state`, `set_pair_superseded`; new fns `set_pair_merged`, `reopen_pairs_merged_into`)
+- Modify: `src/store/mod.rs` (`ADDED_COLUMNS`)
+- Modify: `src/store/schema.sql` (or wherever `CREATE TABLE artifact_pairs` lives — find with `grep -rn "CREATE TABLE artifact_pairs" src/`)
+- Test: `src/store/pairs.rs` tests module
+
+**Interfaces:**
+- Consumes: existing `Store` pair API.
+- Produces (later tasks rely on these exact names):
+  - `PairState::WouldMerge` with `as_str() == "would_merge"`, `parse("would_merge")`.
+  - `ArtifactPair.merged_into: Option<String>`.
+  - `Store::set_pair_merged(&self, id: i64, merged_into: &str, detail: Option<&str>) -> Result<()>` — writes `state = 'no_conflict'`, `detail`, `merged_into`, `obsolete_id = NULL`; `Err(NotFound)` when 0 rows affected.
+  - `Store::reopen_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64>` — `state = 'contradiction'`, given detail, `merged_into = NULL` for all rows whose `merged_into = merged_id`; returns rows affected.
+  - `set_pair_state` and `set_pair_superseded` both additionally set `merged_into = NULL` (same rule as `obsolete_id`: the column belongs to the merged-settlement and to nothing else).
+
+- [ ] **Step 1: Write the failing tests** (append to `src/store/pairs.rs` tests)
+
+```rust
+#[tokio::test]
+async fn a_merged_settlement_records_which_merge_answered_it() {
+    let s = Store::memory().await.unwrap();
+    let (a, b) = two_artifacts(&s).await;
+    s.record_pair(&a, &b, 0.91).await.unwrap();
+    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+    s.set_pair_merged(id, "merge-1", Some("same claim")).await.unwrap();
+
+    let p = s.get_pair(id).await.unwrap();
+    assert_eq!(p.state, PairState::NoConflict);
+    assert_eq!(p.merged_into.as_deref(), Some("merge-1"));
+
+    // Leaving the settlement drops the record, exactly as obsolete_id does.
+    s.set_pair_state(id, PairState::Dismissed, None).await.unwrap();
+    assert_eq!(s.get_pair(id).await.unwrap().merged_into, None);
+}
+
+#[tokio::test]
+async fn reopening_a_stranded_merge_s_pairs_touches_only_its_own() {
+    let s = Store::memory().await.unwrap();
+    let (a, b) = two_artifacts(&s).await;
+    s.record_pair(&a, &b, 0.91).await.unwrap();
+    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    s.set_pair_merged(id, "merge-1", None).await.unwrap();
+
+    assert_eq!(
+        s.reopen_pairs_merged_into("merge-other", "unrelated").await.unwrap(),
+        0,
+        "another merge's undo reopened this pair"
+    );
+    assert_eq!(s.reopen_pairs_merged_into("merge-1", "the merged text could not be indexed").await.unwrap(), 1);
+    let p = s.get_pair(id).await.unwrap();
+    assert_eq!(p.state, PairState::Contradiction);
+    assert_eq!(p.merged_into, None);
+}
+
+#[tokio::test]
+async fn would_merge_is_a_state_of_its_own() {
+    let s = Store::memory().await.unwrap();
+    let (a, b) = two_artifacts(&s).await;
+    s.record_pair(&a, &b, 0.91).await.unwrap();
+    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    s.set_pair_state(id, PairState::WouldMerge, Some("same claim")).await.unwrap();
+    assert_eq!(s.pairs_by_state(PairState::WouldMerge, 10).await.unwrap().len(), 1);
+    assert_eq!(PairState::parse("would_merge"), PairState::WouldMerge);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p engram a_merged_settlement_records reopening_a_stranded would_merge_is_a_state 2>&1 | tail -20`
+Expected: compile errors — `WouldMerge`, `merged_into`, `set_pair_merged` do not exist.
+
+- [ ] **Step 3: Implement**
+
+In `src/store/pairs.rs`:
+- Add `WouldMerge` variant with doc comment: the model answered "duplicate" while autonomy is off — recorded so an operator can read the verdicts before letting the system act on them; the draft is not kept, and flipping autonomy on lets a later unit re-judge and merge.
+- Extend `as_str`/`parse` with `"would_merge"`.
+- Add `pub merged_into: Option<String>` to `ArtifactPair` (doc: which merged artifact answered this pair, when the settlement was an applied merge; what the stranded-merge reap uses to reopen exactly the pairs a failed merge closed). Read it in `row_to_pair`.
+- In `set_pair_state` and `set_pair_superseded` SQL, add `, merged_into = NULL` next to the existing `obsolete_id` handling (extend `set_pair_state`'s doc comment to name both columns).
+- New functions:
+
+```rust
+/// Settle a pair as answered by an applied merge. `merged_into` names the
+/// merged artifact, which is what lets the stranded-merge reap reopen exactly
+/// the pairs a merge that never embedded had closed.
+pub async fn set_pair_merged(&self, id: i64, merged_into: &str, detail: Option<&str>) -> Result<()> {
+    let res = sqlx::query(
+        "UPDATE artifact_pairs
+            SET state = 'no_conflict', detail = ?, merged_into = ?, obsolete_id = NULL
+          WHERE id = ?",
+    )
+    .bind(detail)
+    .bind(merged_into)
+    .bind(id)
+    .execute(&self.pool)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(crate::error::Error::NotFound);
+    }
+    Ok(())
+}
+
+/// Reopen every pair a now-dead merge had settled, handing them to a person.
+/// Contradiction rather than Pending on purpose: re-arming the model would
+/// regenerate the same unembeddable draft and loop forever.
+pub async fn reopen_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
+    let res = sqlx::query(
+        "UPDATE artifact_pairs
+            SET state = 'contradiction', detail = ?, merged_into = NULL
+          WHERE merged_into = ?",
+    )
+    .bind(detail)
+    .bind(merged_id)
+    .execute(&self.pool)
+    .await?;
+    Ok(res.rows_affected())
+}
+```
+
+In `src/store/mod.rs` `ADDED_COLUMNS`, append (comment: arrived with the stranded-merge reap; NULL on every pair predating it, which is correct — those settlements predate the column and are not reopenable by merge id):
+
+```rust
+("artifact_pairs", "merged_into", "TEXT"),
+```
+
+In the schema file, add `merged_into TEXT` to the `artifact_pairs` CREATE TABLE.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p engram a_merged_settlement_records reopening_a_stranded would_merge_is_a_state` — Expected: PASS. Then full `cargo test` (the `PairState` match in `as_str` is exhaustive; the compiler will point at any consumer that needs the new arm — fix those `match`es by adding the arm, nothing else).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(pairs): a would_merge state and a merged_into column for settlements"
+```
+
+---
+
+### Task 2: F7 — observation-mode merge verdicts land as `WouldMerge`, rendered honestly
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (Duplicate arm, non-autonomous branch, ~line 334)
+- Modify: `src/web/ui.rs` (`PAIR_STATES`, `PairRow`, `pair_rows`)
+- Modify: `templates/_decide.html`
+- Modify: `src/web/api.rs` (`consolidation` handler)
+- Test: `src/jobs/dedupe.rs` tests
+
+**Interfaces:**
+- Consumes: `PairState::WouldMerge` (Task 1).
+- Produces: `PairRow.would_merge: bool`; API key `"merge_proposals"`.
+
+- [ ] **Step 1: Write the failing test** (in `src/jobs/dedupe.rs` tests; copy the seeding idiom from the existing duplicate-verdict test around line 720)
+
+```rust
+#[tokio::test]
+async fn with_autonomy_off_a_duplicate_verdict_is_filed_as_would_merge() {
+    // It used to be filed as Contradiction, so the UI said "These two
+    // disagree" about a pair the model judged complementary, and offered only
+    // the lossy keep-one buttons for it.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = false;
+    core.completer = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"duplicate","detail":"same claim",
+            "merged":{"text":"engram needs Rust 1.21.4 and 1.30.0 to build.","tags":[],"caveats":[]}}"#
+            .into(),
+    ]));
+    let ids = disagreeing(&core).await;
+    let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    let found = core.store.pairs_by_state(PairState::WouldMerge, 10).await.unwrap();
+    assert_eq!(found.len(), 1, "the verdict must land as its own state");
+    assert_eq!(found[0].detail.as_deref(), Some("same claim"));
+    assert!(
+        core.store.pairs_by_state(PairState::Contradiction, 10).await.unwrap().is_empty(),
+        "a mergeable pair was filed among genuine conflicts"
+    );
+    // Recorded, not applied: no merge written, nothing hidden.
+    for id in &ids {
+        let c = core.store.get_artifact(id).await.unwrap();
+        assert!(c.superseded_by.is_none());
+    }
+    assert!(core.store.merged_artifacts(10).await.unwrap().is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram with_autonomy_off_a_duplicate_verdict` — Expected: FAIL (pair lands in Contradiction).
+
+- [ ] **Step 3: Implement**
+
+`src/jobs/dedupe.rs`, Duplicate arm, non-autonomous branch: replace the `Contradiction` settle (and its `"would merge: {detail}"` prefix hack) with:
+
+```rust
+if !core.consolidate.autonomous {
+    // Recorded, not applied. Reading the verdicts before letting the
+    // system act on them is the cheapest evidence available about
+    // whether the contract holds on real data. Its own state rather
+    // than Contradiction: filing a mergeable pair among genuine
+    // conflicts made the UI claim the two disagree, and steered the
+    // operator toward hiding a side the model judged complementary.
+    // The draft is discarded — once autonomy is on, the unit re-judges
+    // and merges then.
+    return settle_all(core, &s.pairs, PairState::WouldMerge, s.detail.as_deref()).await;
+}
+```
+
+`src/web/ui.rs`:
+- `PAIR_STATES` becomes 5 entries; insert `WouldMerge` after `Oversized` with a comment (a verdict recorded in observation mode: worth a person's read, less urgent than a contradiction):
+
+```rust
+const PAIR_STATES: [crate::store::pairs::PairState; 5] = [
+    crate::store::pairs::PairState::Contradiction,
+    crate::store::pairs::PairState::Superseded,
+    crate::store::pairs::PairState::Oversized,
+    crate::store::pairs::PairState::WouldMerge,
+    crate::store::pairs::PairState::Pending,
+];
+```
+
+- Add `pub would_merge: bool` to `PairRow` (doc: the model would merge these; rendered with its own header so the page never claims a disagreement it did not find). In `pair_rows`, next to the existing `contradiction:` field init, add `would_merge: state == crate::store::pairs::PairState::WouldMerge,`.
+
+`templates/_decide.html` head line — three-way branch:
+
+```html
+{% if p.contradiction %}<b>These two disagree</b>{% else %}{% if p.would_merge %}<b>The model would merge these</b>{% else %}<b>These two cover the same ground</b>{% endif %}{% endif %}
+```
+
+(Keep the existing keep-one and Dismiss forms for all states — that is the chosen scope: honest header, existing actions.)
+
+`src/web/api.rs` `consolidation` handler: after `"supersede_proposals"`, add:
+
+```rust
+// Merge verdicts recorded while autonomy is off. Their own key for the
+// same reason they are their own state: an API consumer counting
+// `contradictions` must not see pairs the model judged complementary.
+"merge_proposals": st
+    .core
+    .store
+    .pairs_by_state(PairState::WouldMerge, 100)
+    .await?,
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p engram` — Expected: PASS, including the existing autonomy-off dedupe tests (any asserting Contradiction + `"would merge:"` prefix must be updated to assert `WouldMerge` — that assertion was pinning the bug).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(dedupe): an observation-mode merge verdict is not a contradiction"
+```
+
+---
+
+### Task 3: F1 + F6 — Replaced verdict: validate, apply, then settle
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (`apply`, `Relation::Replaced` arm, ~lines 281-328)
+- Test: `src/jobs/dedupe.rs` tests
+
+**Interfaces:**
+- Consumes: `Core::supersede`, `ArtifactStatus`, `settle_all`.
+- Produces: new arm behavior — later tasks do not depend on its internals.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn an_applied_replacement_does_not_wait_for_an_operator() {
+    // F6: the pair used to stay in Superseded — the state every consumer
+    // reads as "awaiting confirmation" — with buttons that could only
+    // return a validation error.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = true;
+    core.completer = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"replaced","detail":"old flag vs new flag","supersedes":"a"}"#.into(),
+    ]));
+    let ids = disagreeing(&core).await;
+    // Make ids[0] strictly older so the newest-wins guard accepts "a".
+    sqlx::query("UPDATE artifacts SET created_at = created_at - 100 WHERE id = ?")
+        .bind(&ids[0]).execute(&core.store.pool).await.unwrap();
+    let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    assert!(
+        core.store.get_artifact(&ids[0]).await.unwrap().superseded_by.is_some(),
+        "the replacement was not applied"
+    );
+    assert!(
+        core.store.pairs_by_state(PairState::Superseded, 10).await.unwrap().is_empty(),
+        "an applied replacement is still listed as awaiting confirmation"
+    );
+    assert_eq!(
+        core.store.pairs_by_state(PairState::Dismissed, 10).await.unwrap().len(),
+        1,
+        "the applied pair should be settled the way the manual apply settles it"
+    );
+}
+
+#[tokio::test]
+async fn a_replacement_naming_a_root_already_out_of_results_settles_cleanly() {
+    // F1: a component holding a finished merge flattens to roots that are
+    // already superseded. Applying blindly errored *after* the pairs were
+    // settled, and run()'s Pending guard made the error unretryable.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = true;
+    // First call merges a+b; second call answers the (merge, c) pair.
+    core.completer = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"duplicate","detail":"same claim",
+            "merged":{"text":"engram needs Rust 1.21.4 to build.","tags":[],"caveats":[]}}"#.into(),
+        r#"{"relation":"replaced","detail":"superseded by the merge","supersedes":"c"}"#.into(),
+    ]));
+    let ids = seed(
+        &core,
+        &[
+            ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
+            ("engram needs Rust 1.21.4 to compile.", [0.999, 0.02]),
+            ("engram wants Rust 1.20 or so to build.", [0.97, 0.2]),
+        ],
+    )
+    .await;
+    // Oldest so the newest-wins guard accepts it as obsolete. Its letter
+    // among the sorted roots must be computed, not assumed — see step 3
+    // note; if the sorted position of ids[2] is not 'c', adjust the
+    // scripted letter accordingly by sorting [&ids[0], &ids[1], &ids[2]].
+    sqlx::query("UPDATE artifacts SET created_at = created_at - 100 WHERE id = ?")
+        .bind(&ids[2]).execute(&core.store.pool).await.unwrap();
+
+    // Merge a and b, then drive the queue so finish() supersedes the roots.
+    let p1 = queue_pair(&core, &ids[0], &ids[1]).await;
+    run(&core, &p1.to_string()).await.unwrap();
+    drive_queue(&core).await; // embed lands, merge::finish hides ids[0], ids[1]
+    let m = &core.store.merged_artifacts(10).await.unwrap()[0].id;
+
+    let p2 = queue_pair(&core, m, &ids[2]).await;
+    run(&core, &p2.to_string()).await.unwrap();
+
+    // The winner among the roots is superseded, so the live carrier (the
+    // merge, a member) wins instead — and the settle happens after.
+    assert_eq!(
+        core.store.get_artifact(&ids[2]).await.unwrap().superseded_by.as_deref(),
+        Some(m.as_str()),
+        "the replacement was not applied against the live carrier"
+    );
+    assert!(core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().is_empty());
+}
+```
+
+Add the small queue driver next to the tests if none exists in this module (the consolidate tests have `sweep_and_judge`/`sweep_and_dedupe` — reuse the same body):
+
+```rust
+async fn drive_queue(core: &Core) {
+    for _ in 0..100 {
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&core.store.pool).await.unwrap();
+        if !crate::jobs::run_one(core).await.unwrap_or(false) { break; }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p engram an_applied_replacement_does_not_wait a_replacement_naming_a_root_already` — Expected: first FAILS on the `Superseded`-empty assertion; second FAILS (error propagates or pair left half-settled). If the second fails only because the letter `"c"` maps to a different sorted root, fix the test's scripted letter first (sort the three ids; the letter is the index of `ids[2]` in that order) — then confirm it fails for the real reason.
+
+- [ ] **Step 3: Implement** — replace the whole `Relation::Replaced` arm of `apply`:
+
+```rust
+Relation::Replaced => {
+    let obsolete = s
+        .obsolete
+        .clone()
+        .expect("interpret sets this or downgrades to Conflict");
+    // Fresh statuses, not the snapshot `interpret` saw. The roots of a
+    // member that is itself a finished merge are already superseded, and
+    // a component can change while the unit waits out a backoff.
+    let mut fresh = Vec::new();
+    for r in &s.roots {
+        match core.store.get_artifact(&r.id).await {
+            Ok(c) => fresh.push(c),
+            Err(Error::NotFound) => {}
+            Err(e) => return Err(e),
+        }
+    }
+    let live = |c: &Chunk| c.status == ArtifactStatus::Active && c.superseded_by.is_none();
+    let obsolete_live = fresh.iter().any(|c| c.id == obsolete && live(c));
+    // A live root wins if one exists; otherwise the live member that
+    // carries the surviving roots — a finished merge's own sources are
+    // superseded, and the merge is the one thing still in results.
+    let winner = fresh
+        .iter()
+        .find(|c| c.id != obsolete && live(c))
+        .map(|c| c.id.clone())
+        .or_else(|| s.members.iter().find(|m| m.id != obsolete).map(|m| m.id.clone()));
+    let (Some(winner), true) = (winner, obsolete_live) else {
+        // Nothing to apply: the named side is already out of results, so
+        // the replacement has in effect already happened.
+        return settle_all(
+            core,
+            &s.pairs,
+            PairState::NoConflict,
+            Some("the named replacement is already out of results"),
+        )
+        .await;
+    };
+
+    if core.consolidate.autonomous {
+        // The side effect FIRST. A failure here leaves every pair
+        // pending, so the unit retries under the queue's backoff — the
+        // reverse order left the verdict recorded but never applied,
+        // permanently, because run() skips non-Pending pairs.
+        core.supersede(&obsolete, &winner).await?;
+        tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
+        for pr in &s.pairs {
+            if pr.a_id == obsolete || pr.b_id == obsolete {
+                // As the manual apply settles it (`apply_pair_supersede_ui`):
+                // done, with the model's reasoning kept as the record of why.
+                core.store
+                    .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
+                    .await?;
+            } else {
+                // Both sides of this pair survived; see the comment below.
+                core.store
+                    .set_pair_state(
+                        pr.id,
+                        PairState::Contradiction,
+                        Some(&format!("{obsolete} was superseded; these two were not separated")),
+                    )
+                    .await?;
+            }
+        }
+        return Ok(());
+    }
+
+    // Proposal mode: nothing is hidden, the pair carries the direction
+    // and an operator confirms via "apply supersede".
+    for pr in &s.pairs {
+        if pr.a_id == obsolete || pr.b_id == obsolete {
+            core.store
+                .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
+                .await?;
+        } else {
+            core.store
+                .set_pair_state(
+                    pr.id,
+                    PairState::Contradiction,
+                    Some(&format!("{obsolete} was superseded; these two were not separated")),
+                )
+                .await?;
+        }
+    }
+    Ok(())
+}
+```
+
+Carry over (do not lose) the two existing long comments in that arm — the "letter indexes `roots`" comment stays on `interpret`, and the "Both sides survived…" comment moves onto the Contradiction branch. The `winner`-from-roots comment is superseded by the new "live root wins…" comment.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p engram` — Expected: PASS. The existing test `a_confident_direction_proposes_a_supersede_but_does_not_apply_it` must still pass unchanged (proposal path preserved).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(dedupe): a replacement is applied before its pairs are settled"
+```
+
+---
+
+### Task 4: F2 — a retired member dismisses only the pairs that name it
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (`run`, member-gathering loop, ~lines 67-87)
+- Test: `src/jobs/dedupe.rs` tests
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_retired_member_dismisses_only_its_own_pairs() {
+    // Dismissing the whole component killed sibling pairs between
+    // still-active duplicates permanently: record_pair is INSERT OR
+    // IGNORE and Dismissed appears on no list, so the A/B duplication
+    // became invisible forever.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = true;
+    core.completer = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+    ]));
+    let ids = seed(
+        &core,
+        &[
+            ("the timeout is 30 seconds", [1.0, 0.0]),
+            ("the timeout is 90 seconds", [0.93, 0.37]),
+            ("the timeout is 120 seconds", [0.94, 0.34]),
+        ],
+    )
+    .await;
+    let p_ab = queue_pair(&core, &ids[0], &ids[1]).await;
+    let p_bc = queue_pair(&core, &ids[1], &ids[2]).await;
+    core.deprecate(&ids[2]).await.unwrap();
+
+    run(&core, &p_ab.to_string()).await.unwrap();
+
+    assert_eq!(
+        core.store.get_pair(p_bc).await.unwrap().state,
+        PairState::Dismissed,
+        "the pair naming the retired artifact should be dismissed"
+    );
+    assert_eq!(
+        core.store.get_pair(p_ab).await.unwrap().state,
+        PairState::NoConflict,
+        "the pair between two live artifacts must still be judged, not dismissed"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram a_retired_member_dismisses_only_its_own_pairs` — Expected: FAIL — `p_ab` is Dismissed.
+
+- [ ] **Step 3: Implement** — in `run`, replace the retired-member early-out. `pairs` must become `let mut pairs = …`:
+
+```rust
+let mut members = Vec::new();
+let mut retired: std::collections::HashSet<String> = Default::default();
+for mid in &member_ids {
+    // (keep the existing "Reported, not swallowed" comment here)
+    let c = core.store.get_artifact(mid).await?;
+    if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
+        // Only the pairs naming this member are answered by its
+        // retirement. Dismissing the whole component killed sibling
+        // pairs between still-active duplicates — record_pair is
+        // INSERT OR IGNORE, so nothing could ever re-file them.
+        retired.insert(c.id);
+        continue;
+    }
+    members.push(c);
+}
+if !retired.is_empty() {
+    let (dead, live): (Vec<_>, Vec<_>) = pairs
+        .into_iter()
+        .partition(|pr| retired.contains(&pr.a_id) || retired.contains(&pr.b_id));
+    settle_all(core, &dead, PairState::Dismissed, Some("a member is no longer in results")).await?;
+    pairs = live;
+    // Dropping a member can strand others with no surviving pair; they
+    // are simply not part of this unit's question any more.
+    let named: std::collections::HashSet<&str> = pairs
+        .iter()
+        .flat_map(|pr| [pr.a_id.as_str(), pr.b_id.as_str()])
+        .collect();
+    members.retain(|c| named.contains(c.id.as_str()));
+    // The seed pair itself may be among the dead; the survivors keep
+    // their own units and nothing further is owed here.
+    if !pairs.iter().any(|pr| pr.id == id) {
+        return Ok(());
+    }
+}
+if members.len() < 2 {
+    settle_all(core, &pairs, PairState::Dismissed, None).await?;
+    return Ok(());
+}
+```
+
+Also move the existing re-check comment ("Re-checked here and not only when the unit was armed…") onto the retired-branch.
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS (the existing dismissal tests for fully-retired components still pass: with every pair dead, the seed pair is dismissed and the unit returns).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(dedupe): a retired member dismisses only the pairs that name it"
+```
+
+---
+
+### Task 5: F5 — stranded merges are reaped by the sweep
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (Duplicate arm, autonomous settle, ~line 357)
+- Modify: `src/store/lineage.rs` (new query `stranded_merges`)
+- Modify: `src/jobs/merge.rs` (new fn `reap_stranded`)
+- Modify: `src/jobs/consolidate.rs` (`run`, after the `merged_with_active_roots` block, ~line 316)
+- Test: `src/jobs/consolidate.rs` tests
+
+**Interfaces:**
+- Consumes: `set_pair_merged`, `reopen_pairs_merged_into` (Task 1), `MAX_ATTEMPTS` (`crate::store::jobs`), `delete_job`.
+- Produces:
+  - `Store::stranded_merges(&self, limit: i64) -> Result<Vec<String>>`
+  - `merge::reap_stranded(core: &Core, merged_id: &str) -> Result<()>`
+
+- [ ] **Step 1: Write the failing test** (in `src/jobs/consolidate.rs` tests)
+
+```rust
+#[tokio::test]
+async fn a_merge_that_can_never_embed_is_reaped_and_its_pairs_reopened() {
+    // The pairs were settled "merged into m" the moment the merge was
+    // written. If the embed then fails permanently the merge is stranded
+    // active-but-unindexed, the roots are never superseded, and the
+    // NoConflict pairs mean the duplicates can never be merged again.
+    use crate::store::artifacts::NewMerged;
+    let core = test_core().await;
+    let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+    let m = core
+        .store
+        .insert_merged_artifact(
+            &NewMerged {
+                text: "both".into(), title: None, category: None,
+                tags: vec![], caveats: vec![],
+            },
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await
+        .unwrap();
+    core.store.enqueue(crate::store::jobs::Stage::Embed, "artifact", &m.id).await.unwrap();
+    core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
+    let pid = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    core.store.set_pair_merged(pid, &m.id, Some("same claim")).await.unwrap();
+    // The embed job has exhausted its retries and cannot succeed.
+    sqlx::query("UPDATE jobs SET attempts = ? WHERE target_id = ?")
+        .bind(crate::store::jobs::MAX_ATTEMPTS)
+        .bind(&m.id)
+        .execute(&core.store.pool)
+        .await
+        .unwrap();
+
+    run(&core).await.unwrap();
+
+    assert_eq!(
+        core.store.get_artifact(&m.id).await.unwrap().status,
+        ArtifactStatus::Deprecated,
+        "the stranded merge should be retired"
+    );
+    let p = core.store.get_pair(pid).await.unwrap();
+    assert_eq!(p.state, crate::store::pairs::PairState::Contradiction, "the pair goes back to a person");
+    for id in &ids {
+        assert_eq!(core.store.get_artifact(id).await.unwrap().status, ArtifactStatus::Active);
+    }
+    // And a healthy in-flight merge is left alone.
+    let m2 = core.store.insert_merged_artifact(
+        &NewMerged { text: "x".into(), title: None, category: None, tags: vec![], caveats: vec![] },
+        &[ids[0].clone(), ids[1].clone()],
+    ).await.unwrap();
+    core.store.enqueue(crate::store::jobs::Stage::Embed, "artifact", &m2.id).await.unwrap();
+    run(&core).await.unwrap();
+    assert_eq!(core.store.get_artifact(&m2.id).await.unwrap().status, ArtifactStatus::Active);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram a_merge_that_can_never_embed` — Expected: compile FAIL (`stranded_merges` missing) or assertion FAIL (merge still active).
+
+- [ ] **Step 3: Implement**
+
+`src/store/lineage.rs`:
+
+```rust
+/// Active merged artifacts whose embedding can no longer arrive: no live
+/// embed job below the retry ceiling. The write path settles the pairs the
+/// moment the merge is written, so a merge stuck here is invisible to
+/// search, its roots were never superseded, and nothing else would notice.
+pub async fn stranded_merges(&self, limit: i64) -> Result<Vec<String>> {
+    let rows = sqlx::query(
+        "SELECT a.id FROM artifacts a
+          WHERE a.provenance = 'merged'
+            AND a.status = 'active'
+            AND a.superseded_by IS NULL
+            AND a.embed_state != 'embedded'
+            AND NOT EXISTS (
+                  SELECT 1 FROM jobs j
+                   WHERE j.stage = 'embed'
+                     AND j.target_id = a.id
+                     AND j.state IN ('pending', 'running')
+                     AND j.attempts < ?)
+          LIMIT ?",
+    )
+    .bind(crate::store::jobs::MAX_ATTEMPTS)
+    .bind(limit)
+    .fetch_all(&self.pool)
+    .await?;
+    Ok(rows.iter().map(|r| r.get("id")).collect())
+}
+```
+
+`src/jobs/merge.rs`:
+
+```rust
+/// Retire a merge whose embedding can never arrive, and hand its pairs back
+/// to a person.
+///
+/// Safe by the write path's own ordering: the roots are superseded only
+/// after the embed lands, so a stranded merge has hidden nothing — the base
+/// is exactly what it was before the verdict, plus one unindexed artifact.
+/// Deprecated rather than deleted for the same reason `undo` deprecates:
+/// the lineage is the record of what was attempted.
+///
+/// Contradiction rather than Pending for the reopened pairs: re-arming the
+/// model would regenerate the same unembeddable draft, at full price,
+/// forever.
+pub async fn reap_stranded(core: &Core, merged_id: &str) -> Result<()> {
+    let m = core.store.get_artifact(merged_id).await?;
+    if m.provenance != Provenance::Merged
+        || m.status != ArtifactStatus::Active
+        || m.superseded_by.is_some()
+        || m.embed_state == crate::store::artifacts::EmbedState::Embedded
+    {
+        // The embed landed (or someone else acted) between the scan and
+        // here. Nothing is stranded any more.
+        return Ok(());
+    }
+    core.deprecate(&m.id).await?;
+    let reopened = core
+        .store
+        .reopen_pairs_merged_into(&m.id, "the merged text could not be indexed; resolve by hand")
+        .await?;
+    // The forever-retrying job is the only signal this state used to have;
+    // with the merge retired it is pure noise.
+    core.store.delete_job(Stage::Embed, &m.id).await?;
+    tracing::warn!(merged = %m.id, reopened, "reaped a merge that could not be embedded");
+    Ok(())
+}
+```
+
+`src/jobs/dedupe.rs` Duplicate arm, autonomous branch — replace the `settle_all(NoConflict, "merged into …")` with per-pair stamping so the reap can find them:
+
+```rust
+let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
+let m = crate::jobs::merge::write(core, draft, &sources).await?;
+// `merged_into` rather than a detail string: if the embed never lands,
+// the sweep's reap has to find exactly these pairs and reopen them.
+for pr in &s.pairs {
+    core.store
+        .set_pair_merged(pr.id, &m.id, s.detail.as_deref())
+        .await?;
+}
+Ok(())
+```
+
+`src/jobs/consolidate.rs` `run`, directly after the `merged_with_active_roots` repair block:
+
+```rust
+// The opposite failure: a merge that will never be embedded. Its pairs
+// are already settled, its roots were never superseded, and its only
+// signal was a forever-retrying embed job.
+match core.store.stranded_merges(50).await {
+    Ok(stranded) => {
+        for id in stranded {
+            if let Err(e) = crate::jobs::merge::reap_stranded(core, &id).await {
+                tracing::warn!(merged = %id, error = %e, "could not reap a stranded merge");
+            }
+        }
+    }
+    Err(e) => tracing::warn!(error = %e, "could not look for stranded merges"),
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p engram` — Expected: PASS. Any existing test asserting the `"merged into {id}"` detail on settled pairs should be updated to assert `merged_into == Some(m.id)` instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(consolidate): a merge that can never embed is reaped, not stranded"
+```
+
+---
+
+### Task 6: F4 — a transient read error must not close a filed pair
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs` (member-read loop ~line 376, closing pass ~line 446; extract pure helper)
+- Test: `src/jobs/consolidate.rs` tests
+
+**Interfaces:**
+- Produces: `fn close_filed_pair(a_known: bool, b_known: bool, a_live: bool, b_live: bool, a_id: &str, b_id: &str) -> Option<String>` — `None` = leave the pair filed; `Some(detail)` = close as NoConflict with that detail.
+
+- [ ] **Step 1: Write the failing test** (pure-function test; store-level fault injection isn't feasible with SQLite here, so the decision is extracted and tested directly)
+
+```rust
+#[test]
+fn an_unreadable_member_leaves_the_filed_pair_alone() {
+    // A transient BUSY on one member used to read as "gone", closing the
+    // pair as NoConflict while both artifacts were live — permanently,
+    // because record_settled_pair only updates pending rows.
+    assert_eq!(close_filed_pair(false, true, false, true, "a", "b"), None);
+    assert_eq!(close_filed_pair(true, false, true, false, "a", "b"), None);
+    // Both readable and live: genuinely unanswered, stays filed.
+    assert_eq!(close_filed_pair(true, true, true, true, "a", "b"), None);
+    // Known-gone or known-hidden sides do close.
+    assert_eq!(
+        close_filed_pair(true, true, true, false, "a", "b").as_deref(),
+        Some("near-identical; a kept")
+    );
+    assert_eq!(
+        close_filed_pair(true, true, false, false, "a", "b").as_deref(),
+        Some("near-identical; neither side is in results any more")
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram an_unreadable_member_leaves` — Expected: compile FAIL — `close_filed_pair` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Pure helper in `src/jobs/consolidate.rs`:
+
+```rust
+/// Whether the clustering pass answered a filed near-identical pair, and
+/// with what record. `known` is false when the member's row could not be
+/// read this sweep — an unreadable member is not a gone member, and closing
+/// on a transient store error would settle a live pair permanently
+/// (`record_settled_pair` only updates pending rows).
+fn close_filed_pair(
+    a_known: bool,
+    b_known: bool,
+    a_live: bool,
+    b_live: bool,
+    a_id: &str,
+    b_id: &str,
+) -> Option<String> {
+    if !a_known || !b_known {
+        return None;
+    }
+    match (a_live, b_live) {
+        (true, true) => None,
+        (true, false) => Some(format!("near-identical; {a_id} kept")),
+        (false, true) => Some(format!("near-identical; {b_id} kept")),
+        (false, false) => Some("near-identical; neither side is in results any more".to_string()),
+    }
+}
+```
+
+Member-read loop: add `let mut unknown: HashSet<String> = HashSet::new();` beside `live`, and split the error cases:
+
+```rust
+let c = match core.store.get_artifact(id).await {
+    Ok(c) => c,
+    Err(Error::NotFound) => {
+        tracing::debug!(artifact_id = %id, "pair names an artifact that is gone");
+        continue;
+    }
+    Err(e) => {
+        // Unreadable is not gone. The closing pass must not settle a
+        // pair on the strength of a store that was briefly unwell.
+        tracing::warn!(artifact_id = %id, error = %e, "could not read a clustered artifact this sweep");
+        unknown.insert(id.clone());
+        continue;
+    }
+};
+```
+
+Closing pass body becomes:
+
+```rust
+for p in &filed {
+    let alive = |id: &String| live.contains(id) && !hidden.contains(id);
+    let Some(detail) = close_filed_pair(
+        !unknown.contains(&p.a_id),
+        !unknown.contains(&p.b_id),
+        alive(&p.a_id),
+        alive(&p.b_id),
+        &p.a_id,
+        &p.b_id,
+    ) else {
+        continue;
+    };
+    if let Err(e) = core
+        .store
+        .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, Some(&detail))
+        .await
+    {
+        tracing::warn!(pair = p.id, error = %e, "could not close a settled near-identical pair");
+    }
+}
+```
+
+Keep the existing block comment above the pass; extend it with one line: an unreadable member leaves the pair filed for the next sweep.
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(consolidate): an unreadable member does not close a filed pair"
+```
+
+---
+
+### Task 7: F3 — an operator's partial restore survives the sweep
+
+**Files:**
+- Modify: `src/store/mod.rs` (`ADDED_COLUMNS`) + schema file (`artifact_sources` CREATE TABLE)
+- Modify: `src/store/lineage.rs` (`merged_with_active_roots`; new fns `mark_source_restored`, `roots_to_hide`)
+- Modify: `src/jobs/merge.rs` (`finish` uses `roots_to_hide`)
+- Modify: `src/core/ingest.rs` (`unsupersede`)
+- Test: `src/jobs/merge.rs` tests
+
+**Interfaces:**
+- Produces:
+  - `artifact_sources.restored INTEGER NOT NULL DEFAULT 0` (schema + `ADDED_COLUMNS`).
+  - `Store::mark_source_restored(&self, root_id: &str) -> Result<()>` — sets `restored = 1` on every lineage row naming that root.
+  - `Store::roots_to_hide(&self, child_id: &str) -> Result<Vec<String>>` — `SELECT root_id FROM artifact_sources WHERE child_id = ? AND restored = 0 ORDER BY root_id`.
+- `roots_of` is deliberately unchanged: flattening for the model must still see the true captured roots.
+
+- [ ] **Step 1: Write the failing test** (in `src/jobs/merge.rs` tests; mirror the setup of the existing `undoing_a_merge_survives_the_next_sweep` test at ~line 596, which already builds a finished merge — reuse its seeding verbatim up to the point where the merge's roots are superseded)
+
+```rust
+#[tokio::test]
+async fn restoring_one_merge_source_survives_the_next_sweep() {
+    // "Put it back" on a merge-hidden artifact used to last exactly one
+    // sweep: merged_with_active_roots cannot tell a crash-interrupted
+    // merge from an operator's explicit restore, and finish re-hid it.
+    // <seeding: as in undoing_a_merge_survives_the_next_sweep — build a
+    //  finished merge m over roots [a, b], both superseded by m>
+    core.unsupersede(&a).await.unwrap();
+
+    crate::jobs::consolidate::run(&core).await.unwrap();
+
+    let back = core.store.get_artifact(&a).await.unwrap();
+    assert!(
+        back.superseded_by.is_none(),
+        "the sweep re-hid an artifact an operator had explicitly restored"
+    );
+    // The rest of the merge is untouched: b stays hidden, m stays active.
+    assert!(core.store.get_artifact(&b).await.unwrap().superseded_by.is_some());
+    assert_eq!(core.store.get_artifact(&m).await.unwrap().status, ArtifactStatus::Active);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram restoring_one_merge_source_survives` — Expected: FAIL — `a.superseded_by` is `Some(m)` again after the sweep.
+
+- [ ] **Step 3: Implement**
+
+Schema: `ADDED_COLUMNS` append (comment: the operator's partial restore; `0` on every existing row, which is correct — nothing predating the column was explicitly restored):
+
+```rust
+("artifact_sources", "restored", "INTEGER NOT NULL DEFAULT 0"),
+```
+
+plus `restored INTEGER NOT NULL DEFAULT 0` in the `artifact_sources` CREATE TABLE.
+
+`src/store/lineage.rs`:
+
+```rust
+/// Record that an operator explicitly restored this captured root: no
+/// repair may hide it behind a merge again. Every merge naming it, not one
+/// — the operator's decision is about the root, not about a lineage edge.
+/// A *new* merge decision may still hide it: `insert_merged_artifact`
+/// writes fresh rows with `restored = 0`, and that is new evidence rather
+/// than a repair of old state.
+pub async fn mark_source_restored(&self, root_id: &str) -> Result<()> {
+    sqlx::query("UPDATE artifact_sources SET restored = 1 WHERE root_id = ?")
+        .bind(root_id)
+        .execute(&self.pool)
+        .await?;
+    Ok(())
+}
+
+/// The roots `finish` is allowed to hide: the lineage minus every root an
+/// operator explicitly restored. Distinct from `roots_of`, which answers
+/// "what was this written from" and must keep seeing the true closure.
+pub async fn roots_to_hide(&self, child_id: &str) -> Result<Vec<String>> {
+    let rows = sqlx::query(
+        "SELECT root_id FROM artifact_sources
+          WHERE child_id = ? AND restored = 0 ORDER BY root_id",
+    )
+    .bind(child_id)
+    .fetch_all(&self.pool)
+    .await?;
+    Ok(rows.iter().map(|r| r.get("root_id")).collect())
+}
+```
+
+`merged_with_active_roots`: add `AND s.restored = 0` to the WHERE clause, and extend its doc comment: a root an operator explicitly restored is not an unfinished merge, and the repair must not see it.
+
+`src/jobs/merge.rs` `finish`: replace the `roots_of` read with:
+
+```rust
+for root in core.store.roots_to_hide(&m.id).await? {
+    let Ok(r) = core.store.get_artifact(&root).await else {
+        continue;
+    };
+    ...
+    if let Err(e) = core.supersede(&root, &m.id).await {
+```
+
+(loop body otherwise unchanged; adjust for `root: String` instead of `&String`).
+
+`src/core/ingest.rs` `unsupersede` — read the winner before clearing, mark after both stores agree:
+
+```rust
+pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+    let winner = self.store.get_artifact(artifact_id).await?.superseded_by;
+    // (existing body: mark dirty, payload, row, clear marker)
+    ...
+    // A restore out of a merge is an operator overruling the merge for
+    // this one source. Recorded on the lineage, or the sweep's
+    // unfinished-merge repair re-hides it on the next tick, every tick.
+    if let Some(w) = winner
+        && let Ok(wc) = self.store.get_artifact(&w).await
+        && wc.provenance == crate::store::artifacts::Provenance::Merged
+    {
+        self.store.mark_source_restored(artifact_id).await?;
+    }
+    tracing::info!(artifact_id, "restored a superseded artifact to search");
+    Ok(())
+}
+```
+
+(`reactivate` routes merge-hidden artifacts through `unsupersede`, so both buttons are covered. `merge::undo` deprecates the merge itself, so stray `restored = 1` rows under a deprecated merge are inert.)
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS, including `a_merge_whose_roots_were_never_superseded_is_finished_by_the_next_sweep` (fresh lineage rows have `restored = 0`, so `finish` still hides them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(merge): an operator's restore of a merge source survives the sweep"
+```
+
+---
+
+### Task 8: F8 — an orphaned merge is never its own root
+
+**Files:**
+- Modify: `src/store/lineage.rs` (`roots_of`)
+- Modify: `src/jobs/dedupe.rs` (`run`, after `roots_of`, ~line 91)
+- Test: `src/jobs/dedupe.rs` tests
+
+**Interfaces:**
+- Changed contract: `roots_of` returns an **empty** `Vec` for a merged artifact with no lineage rows (previously: the artifact itself). Captured artifacts keep the self-root fallback. Before relying on this, `grep -rn "roots_of" src/` and check every caller tolerates an empty entry (`merge::finish` no longer calls it after Task 7; `insert_merged_artifact`'s flattening treats "no rows" per its own logic — verify it maps a rootless merged member to nothing rather than to itself; if it self-roots there too, apply the same provenance check in that flattening).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_merge_that_lost_its_sources_is_never_shown_as_an_original() {
+    // The self-root fallback put a model-synthesized paraphrase in the
+    // prompt as a captured original, and a Duplicate verdict would then
+    // record a merged artifact as root_id — paraphrase drift, one
+    // generation per merge, which the lineage design exists to prevent.
+    let mut core = test_core().await;
+    core.consolidate.autonomous = true;
+    let completer = Arc::new(ScriptedCompleter::new(vec![]));
+    core.completer = completer.clone();
+    let ids = disagreeing(&core).await;
+    let m = core
+        .store
+        .insert_merged_artifact(
+            &crate::store::artifacts::NewMerged {
+                text: "a paraphrase".into(), title: None, category: None,
+                tags: vec![], caveats: vec![],
+            },
+            &[ids[0].clone()],
+        )
+        .await
+        .unwrap();
+    // Its every source cascades away, as a corpus deletion does.
+    sqlx::query("DELETE FROM artifact_sources WHERE child_id = ?")
+        .bind(&m.id).execute(&core.store.pool).await.unwrap();
+
+    let pair = queue_pair(&core, &m.id, &ids[1]).await;
+    run(&core, &pair.to_string()).await.unwrap();
+
+    assert_eq!(completer.calls(), 0, "a rootless merge reached the model as an original");
+    assert_eq!(
+        core.store.get_pair(pair).await.unwrap().state,
+        PairState::Contradiction,
+        "the component goes to a person rather than being judged on a paraphrase"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram a_merge_that_lost_its_sources` — Expected: FAIL — the completer is called (empty script panics or call count is 1).
+
+- [ ] **Step 3: Implement**
+
+`roots_of` fallback branch:
+
+```rust
+let entry = if roots.is_empty() {
+    // No lineage rows means a captured artifact — or a merged one every
+    // root of which has since been deleted. A captured artifact is its
+    // own root; a merged one is nobody's: its text is a synthesis, and
+    // handing it back as a root is how a paraphrase of a paraphrase
+    // ends up in a prompt as an original. The empty answer makes that
+    // state visible to the caller instead.
+    let provenance: String =
+        sqlx::query_scalar("SELECT provenance FROM artifacts WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?
+            .unwrap_or_else(|| "captured".to_string());
+    if provenance == "merged" { vec![] } else { vec![id.clone()] }
+} else {
+    roots
+};
+out.insert(id.clone(), entry);
+```
+
+`src/jobs/dedupe.rs` `run`, right after `let root_map = …`:
+
+```rust
+// A member with no roots at all is a merge whose sources were deleted
+// out from under it. Its text is a paraphrase with nothing behind it —
+// not something to show the model as an original, and not something a
+// rule can settle. A person decides.
+if member_ids.iter().any(|mid| root_map.get(mid).is_none_or(|r| r.is_empty())) {
+    settle_all(
+        core,
+        &pairs,
+        PairState::Contradiction,
+        Some("a merged member has lost its sources; resolve by hand"),
+    )
+    .await?;
+    return Ok(());
+}
+```
+
+Update the `roots_of` doc comment (its current text explains the old fallback) and the module-header sentence in `lineage.rs` that describes it.
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(lineage): a merge that lost every source is nobody's root"
+```
+
+---
+
+### Task 9: F9 — a merge restored from the index is flagged as having lost its lineage
+
+**Files:**
+- Modify: `src/core/ingest.rs` (`heal_store_drift` restore loop, ~line 647)
+- Test: `src/core/ingest.rs` tests (or wherever `heal_store_drift` tests live — `grep -rn "heal_store_drift" src/ --include=*.rs -l`)
+
+**Interfaces:**
+- Consumes: `set_artifact_flags` (exists), `Provenance::Merged`, flag string `"orphaned_source"` (the one `flag_orphans` and the UI already read).
+
+- [ ] **Step 1: Write the failing test** (place beside the existing `heal_store_drift` tests, reusing their vector-point seeding idiom — the test around `ingest.rs:1580` restores an artifact from a surviving payload; copy its setup with `provenance: Some("merged".into())` in the payload)
+
+```rust
+#[tokio::test]
+async fn a_merge_restored_from_the_index_is_flagged_as_orphaned() {
+    // restore_artifact cannot recreate lineage rows and leaves
+    // source_count at 0, so 0 > COUNT(*) never fires and nothing ever
+    // flagged the restored merge — it became its own root silently.
+    // <setup: as in the existing restore test, but the payload's
+    //  provenance is "merged" and corpus_id handling follows the
+    //  Provenance::Merged branch>
+    core.heal_store_drift().await.unwrap();
+
+    let c = core.store.get_artifact(&artifact_id).await.unwrap();
+    assert!(
+        c.flags.iter().any(|f| f == "orphaned_source"),
+        "a restored merge must say it cannot support its provenance claim"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram a_merge_restored_from_the_index` — Expected: FAIL — no flag set.
+
+- [ ] **Step 3: Implement** — in the restore loop, after `if self.store.restore_artifact(&restored).await? {`:
+
+```rust
+if self.store.restore_artifact(&restored).await? {
+    out.rows_restored += 1;
+    // A payload records neither source_count nor lineage rows, so a
+    // restored merge definitionally cannot support its provenance
+    // claim — and `merged_missing_a_source` (0 > 0) will never say
+    // so. Said here instead, with the flag that pass would have set.
+    if provenance == crate::store::artifacts::Provenance::Merged {
+        self.store
+            .set_artifact_flags(
+                &p.artifact_id,
+                &["orphaned_source".to_string()],
+                Some("restored from the index; the record of its sources was lost"),
+            )
+            .await?;
+    }
+    self.store
+        .enqueue(Stage::Embed, "artifact", &p.artifact_id)
+        .await?;
+}
+```
+
+(With Task 8 in place, such a merge also never self-roots — the flag is the operator-visible half, `roots_of` is the invariant half.)
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(ingest): a merge restored from the index is flagged as orphaned"
+```
+
+---
+
+### Task 10: F10 — lifecycle writes are serialized against the marker repair
+
+**Files:**
+- Modify: `src/core/mod.rs` (`Core` struct + its constructor(s))
+- Modify: `src/core/ingest.rs` (`supersede`, `unsupersede`, `deprecate`, `reactivate`, `repoint_supersession`)
+- Modify: `src/jobs/consolidate.rs` (`repair_lifecycle_drift`)
+
+**Interfaces:**
+- Produces: `Core.lifecycle_lock: Arc<tokio::sync::Mutex<()>>` (constructed as `Arc::new(tokio::sync::Mutex::new(()))` wherever `Core` is built — `grep -rn "Core {" src/` for every literal, including `test_support`).
+
+No new deterministic test: the race needs two tasks interleaved between specific awaits, which nothing in this test harness can schedule reliably. The fix is structural (mutual exclusion); the existing lifecycle test suite guards against regressions in each path's behavior. State this in the commit message body.
+
+- [ ] **Step 1: Implement**
+
+`Core`:
+
+```rust
+/// Serializes every lifecycle transition against the sweep's marker
+/// repair. Each transition is two writes to two stores plus a dirty
+/// marker, none of it atomic; without mutual exclusion the repair can
+/// read a stale row mid-reveal, write the old state back over the new
+/// payload, and the reveal then clears the marker — row active, payload
+/// hidden, and nothing left that would ever notice. Shared by every
+/// clone, like the background queue.
+pub lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
+```
+
+In `ingest.rs`, split `unsupersede` into a public locking wrapper and a private body so `reactivate` never locks twice:
+
+```rust
+pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+    let _guard = self.lifecycle_lock.lock().await;
+    self.unsupersede_locked(artifact_id).await
+}
+
+async fn unsupersede_locked(&self, artifact_id: &str) -> Result<()> {
+    // (entire current body, including Task 7's restored-marking)
+}
+```
+
+`reactivate`:
+
+```rust
+pub async fn reactivate(&self, id: &str) -> Result<()> {
+    let _guard = self.lifecycle_lock.lock().await;
+    if self.store.get_artifact(id).await?.superseded_by.is_some() {
+        return self.unsupersede_locked(id).await;
+    }
+    // (rest of current body)
+}
+```
+
+`supersede`, `deprecate`, `repoint_supersession`: `let _guard = self.lifecycle_lock.lock().await;` as the first line (none of them calls another locked fn — verify by reading each body before adding the guard; `merge::finish` and the sweep call them from *outside*, which is fine, the guard is per-call).
+
+`repair_lifecycle_drift` in `consolidate.rs`:
+
+```rust
+async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
+    // Under the same lock as every lifecycle transition: the repair
+    // reads rows, writes payloads and clears markers, and interleaving
+    // that with a payload-first reveal is exactly the sequence that
+    // hides an artifact with no marker left to find it by.
+    let _guard = core.lifecycle_lock.lock().await;
+    let dirty = core.store.dirty_lifecycle_artifacts(DRIFT_SCAN).await?;
+    // (rest unchanged)
+```
+
+- [ ] **Step 2: Run tests** — `cargo test -p engram` — Expected: PASS (behavior unchanged single-threaded; watch for a deadlock-shaped test hang, which would mean a locked fn calls another locked fn — re-check call graphs).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(core): lifecycle transitions and the marker repair exclude each other"
+```
+
+Body: note that the interleaving (repair reads stale row → reveal writes payload → repair writes stale payload → reveal clears marker) is unreproducible deterministically in tests, so the fix is mutual exclusion with no new test; existing lifecycle tests cover each path.
+
+---
+
+### Task 11: F11 — legacy `'judge'` job rows
+
+**Files:**
+- Modify: `src/store/mod.rs` (migration section — near the existing one-off `ALTER TABLE`/cleanup statements, `grep -n "DROP COLUMN" src/store/mod.rs` for the spot)
+- Test: `src/store/jobs.rs` tests
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_legacy_judge_row_is_not_claimed_as_something_else() {
+    // Stage::parse has no 'judge' arm and claim_job falls back to
+    // Synthesize, so a leftover row from the branch this replaced was
+    // claimed as a synthesize job aimed at a pair id.
+    let s = Store::memory().await.unwrap();
+    sqlx::query(
+        "INSERT INTO jobs (stage, target_kind, target_id, state, run_after, attempts, seq)
+         VALUES ('judge', 'pair', '17', 'pending', 0, 0, 0)",
+    )
+    .execute(&s.pool)
+    .await
+    .unwrap();
+
+    s.migrate().await.unwrap();
+
+    assert!(
+        s.claim_job().await.unwrap().is_none(),
+        "a legacy judge row survived migration and was claimed"
+    );
+}
+```
+
+(If the migration entry point is not named `migrate`, find the fn that runs `ADDED_COLUMNS` — the test calls that. If it is private, make the test a sibling in `store/mod.rs` tests instead.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p engram a_legacy_judge_row` — Expected: FAIL — the row is claimed (as Synthesize).
+
+- [ ] **Step 3: Implement** — in the migration path, after the `ADDED_COLUMNS` loop:
+
+```rust
+// The judge became the dedupe unit on this branch and its stage name
+// went with it. A leftover row would otherwise be claimed under
+// `Stage::parse`'s Synthesize fallback and aimed at a pair id. Deleted
+// rather than renamed: the pair is still pending, so the next sweep
+// re-arms it under its real stage, and a rename could collide with a
+// dedupe row the sweep has already written for the same pair.
+sqlx::query("DELETE FROM jobs WHERE stage = 'judge'")
+    .execute(&self.pool)
+    .await?;
+```
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(store): a legacy judge job row is deleted, not misrouted"
+```
+
+---
+
+### Task 12: F12 — `arm_dedupe` does nothing when its budget is zero
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs` (`arm_dedupe`, ~line 549)
+- Test: `src/jobs/consolidate.rs` tests
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_zero_dedupe_budget_arms_nothing_and_reads_nothing() {
+    // With the budget at zero every tick still ran the 200-row query and
+    // logged "budget spent" — dead work on the sweep's hot path, and a
+    // misleading log line. The observable half: nothing is armed and no
+    // pair is touched.
+    let mut core = test_core().await;
+    core.consolidate.max_dedupe_per_tick = 0;
+    disagreeing(&core).await;
+    let out = run(&core).await.unwrap();
+    assert_eq!(out.judged, 0);
+    assert_eq!(
+        core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+        1,
+        "the pending pair must be left exactly as it was"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes vacuously**
+
+Run: `cargo test -p engram a_zero_dedupe_budget` — This may already PASS behaviorally (the waste is the query, not the outcome). Either way it pins the contract; proceed.
+
+- [ ] **Step 3: Implement** — first lines of `arm_dedupe`:
+
+```rust
+// `max_dedupe_per_tick = 0` is the off switch for the model (see run's
+// comment on the `autonomous` flag). Off means off: no 200-row read per
+// tick, and no "budget spent" log line implying a budget was spent.
+if core.consolidate.max_dedupe_per_tick == 0 {
+    return Ok(0);
+}
+```
+
+- [ ] **Step 4: Run tests** — `cargo test -p engram` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "fix(consolidate): a zero dedupe budget arms nothing and reads nothing"
+```
+
+---
+
+### Task 13: F13 — `open_component` grows by worklist, not by rescan
+
+**Files:**
+- Modify: `src/store/pairs.rs` (`open_component` fixed-point loop, ~lines 342-366)
+
+Behavior is unchanged (same members, same picked set), so the existing `open_component` tests are the spec — no new test.
+
+- [ ] **Step 1: Implement** — replace the loop with an adjacency-indexed worklist:
+
+```rust
+// Adjacency once, then a worklist. The fixed point rescanned the whole
+// window per growth pass — quadratic at the 5 000-row window for a
+// long chain — for an answer a plain flood fill gives in one pass over
+// the edges.
+let mut by_artifact: std::collections::HashMap<&str, Vec<usize>> = Default::default();
+for (i, p) in open.iter().enumerate() {
+    by_artifact.entry(p.a_id.as_str()).or_default().push(i);
+    by_artifact.entry(p.b_id.as_str()).or_default().push(i);
+}
+let mut picked: std::collections::HashSet<i64> = [seed.id].into_iter().collect();
+let mut queue: Vec<&str> = vec![seed.a_id.as_str(), seed.b_id.as_str()];
+let mut seen: std::collections::HashSet<&str> = queue.iter().copied().collect();
+while let Some(id) = queue.pop() {
+    for &i in by_artifact.get(id).into_iter().flatten() {
+        let p = &open[i];
+        picked.insert(p.id);
+        for other in [p.a_id.as_str(), p.b_id.as_str()] {
+            if seen.insert(other) {
+                queue.push(other);
+            }
+        }
+    }
+}
+Ok(open.into_iter().filter(|p| picked.contains(&p.id)).collect())
+```
+
+(Delete the now-dead `members` set and the old loop; keep the surrounding comments about the seed always being in the component.)
+
+- [ ] **Step 2: Run tests** — `cargo test -p engram open_component` then full `cargo test -p engram` — Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "perf(pairs): open_component flood-fills instead of rescanning the window"
+```
+
+---
+
+### Task 14: F14 — comments stop claiming the full reconcile is gated
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs` (doc comment of `repair_lifecycle_drift` ~line 143-148, doc comment of `full_lifecycle_reconcile` ~line 173-179)
+
+The code is right (the reconcile's own rationale at lines 180-184 argues for keeping it); the comments are wrong.
+
+- [ ] **Step 1: Implement** — two wording fixes:
+
+In `repair_lifecycle_drift`'s doc, replace "`full_lifecycle_reconcile` keeps that scan for the drift that arises with no SQLite write behind it, but it no longer runs every sweep." with:
+
+```
+/// `full_lifecycle_reconcile` keeps that scan for the drift that arises with
+/// no SQLite write behind it; it still runs every sweep, after this pass.
+```
+
+In `full_lifecycle_reconcile`'s doc, replace "Still on the sweep, behind the marker, and the division of labour is the point." with:
+
+```
+/// Still on every sweep, after the marker pass, and the division of labour
+/// is the point.
+```
+
+- [ ] **Step 2: Verify and commit**
+
+Run: `cargo build 2>&1 | tail -3` (comments only; build proves nothing broke) and `cargo fmt`.
+
+```bash
+git add -A && git commit -m "docs(consolidate): the full reconcile runs every sweep, and says so"
+```
+
+---
+
+## Final verification (after Task 14)
+
+- [ ] `cargo test` — full suite green.
+- [ ] `cargo fmt --check` and (if the repo uses it — check CI config) `cargo clippy` — clean.
+- [ ] Re-read the Findings Index: each of F1-F14 maps to a merged commit. F1→T3, F2→T4, F3→T7, F4→T6, F5→T1+T5, F6→T3, F7→T1+T2, F8→T8, F9→T9, F10→T10, F11→T11, F12→T12, F13→T13, F14→T14.
+- [ ] `git push` to `feat/autonomous-consolidation` only when the user asks.

--- a/docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md
+++ b/docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md
@@ -1,0 +1,705 @@
+# Autonomous consolidation — Design
+
+Date: 2026-08-14
+Status: draft
+Extends `src/jobs/consolidate.rs`, `src/jobs/judge.rs`, `src/store/pairs.rs`.
+Overturns one stated invariant. See §3.
+
+## 1. Why
+
+Consolidation today finds duplicates and then asks a person about them. That is
+two different jobs, and both of them scale badly.
+
+**Detection is a lottery.** `near_pairs` draws a random sample of
+`consolidate.sample` (2000) points per sweep and computes the distance matrix
+only *within* that sample. For a given duplicate pair to be found, both members
+must land in the same draw — probability ≈ (s/N)². At `interval_hours = 24`:
+
+| Artifacts | P(pair found per sweep) | Expected wait |
+|---|---|---|
+| 5,000 | ~16 % | ~6 days |
+| 20,000 | ~1 % | ~3 months |
+| 100,000 | ~0.04 % | ~7 years |
+
+This decays quadratically. Nothing downstream can fix it: a judge that never
+sees a pair cannot rule on it.
+
+**The queue has no consumer that scales.** Pairs that survive the prefilter go
+to `artifact_pairs` and wait for an operator. The queue grows with the base; the
+operator does not.
+
+**The prefilter has the wrong polarity for deduplication.** `may_disagree`
+(`src/infer/facts.rs:103`) admits a pair only when both sides state values *and
+those values differ*. That was exactly right for the question it was written
+for — "do these two contradict each other?" It is backwards for deduplication.
+The pairs it discards are the cleanest merge candidates:
+
+```
+"Mount the filesystem before writing to it."   ->  fact_tokens: {}
+"Attach the volume before writing."            ->  fact_tokens: {}
+   may_disagree = false  ->  NoConflict  ->  both stay active, both in search
+```
+
+Two artifacts at ~0.93 similarity saying the same thing are filed as "nothing to
+decide" and both remain in every result set. That is the duplication this
+subsystem exists to remove, and today it is structurally invisible to it. The
+test at `src/infer/facts.rs:122` states the behaviour plainly.
+
+## 2. Goal
+
+Duplicate hygiene runs without an operator, on a base that grows, while every
+decision stays reversible and every value stays recoverable.
+
+Concretely:
+
+1. Detection is complete rather than sampled: a pair of near-identical artifacts
+   is found once both are indexed, not eventually.
+2. A near-duplicate group settles itself — superseded where an original
+   suffices, merged into one rewritten artifact where both sides carry something
+   the other lacks.
+3. A genuine disagreement about a value is **not** settled autonomously. It goes
+   to a person, as today.
+4. Nothing a merge produces can silently lose a value, a command, or a path.
+5. Every merge is undoable, and the undo survives the next sweep.
+
+### Non-goals
+
+- **Deciding which of two contradictory facts is true.** Explicitly out. This
+  stays the reader's judgement and keeps its existing escalation path.
+- **Merging as the preferred outcome.** Where one original plainly replaces the
+  other, superseding is better and is chosen first. See §6.
+- **Retrieval-time inference.** Unchanged: a query costs one embedding and one
+  vector search. Everything here happens in the background.
+- **Removing the review queue.** It shrinks to conflicts and refusals. It does
+  not disappear.
+
+## 3. The invariant this overturns, and what replaces it
+
+Four places in the repository state that artifacts are never merged:
+
+- `src/store/schema.sql:51` — "Superseding hides an artifact and names its
+  replacement; nothing is ever merged or rewritten in place."
+- `src/jobs/consolidate.rs:10` — "A merged artifact would be synthetic text
+  standing where a stored passage used to, with no segment to verify it against
+  and no corpus lines to show beside it, which is the one failure mode this
+  design exists to avoid."
+- `ROADMAP.md:23` — "Fidelity outranks convenience… A paraphrase or a synthetic
+  summary must never silently replace or outrank the original wording."
+- The ROADMAP `CUT` block, which killed precomputed answer cards for exactly
+  this reason.
+
+The prohibition is deliberate and load-bearing. It is lifted here **narrowly**,
+and the four mechanisms below are what stand in its place. All four are
+non-negotiable parts of this design; dropping any one of them turns the feature
+back into the thing the prohibition was protecting against.
+
+1. **Synthetic text is the last resort, not the default.** A group where one
+   artifact plainly replaces the other is superseded, keeping stored wording
+   with a valid span. A merge happens only when both sides carry information the
+   other lacks — the case where *neither* original is sufficient and the
+   pre-merge state was already losing something.
+2. **Provenance is explicit and structural.** `provenance = 'merged'`, and every
+   merged artifact carries rows naming the captured artifacts it came from. It
+   is never mistakable for a captured passage, in the store or in the UI.
+3. **The originals are never destroyed.** They are superseded — hidden, still
+   stored, still readable, one write from being back. Same mechanism, same undo
+   as today.
+4. **The merge is verified against the originals.** No value and no literal may
+   disappear (§6.4). A merge that would lose one is refused, not applied.
+
+What remains true and is not weakened: retrieval returns whole artifacts, never
+generated prose; a captured artifact is never rewritten in place; nothing is
+deleted on a similarity score.
+
+## 4. Data model
+
+### 4.1 Artifacts gain a kind
+
+```sql
+-- artifacts
+provenance      TEXT NOT NULL DEFAULT 'captured',   -- 'captured' | 'merged'
+corpus_id       TEXT NULL REFERENCES corpora(id) ON DELETE CASCADE,  -- was NOT NULL
+lifecycle_dirty INTEGER NOT NULL DEFAULT 0
+```
+
+`provenance` is the discriminator every consumer branches on — never
+`corpus_id IS NULL`. A null is an absence; a kind is an assertion, and the
+failure modes this feature can produce want to hang off an assertion.
+
+A merged artifact has `corpus_id`, `corpus_span` and `segment_idx` all NULL. It
+belongs to no corpus because it came from more than one, and claiming a span it
+does not have is the specific dishonesty §3 exists to prevent.
+
+**Consequence for deployment.** `src/store/schema.sql` is applied on every
+connect and cannot alter an existing table (`schema.sql:9–12`); `migrate` reads
+the columns back and checks them. Adding `provenance` and `lifecycle_dirty` is
+additive and safe. Dropping `NOT NULL` from `corpus_id` is a column *change* and
+therefore means **recreating the database**. The schema header names this as the
+intended path during testing. Recorded here so it is a decision and not a
+surprise.
+
+### 4.2 Lineage, stored as the transitive closure
+
+```sql
+CREATE TABLE IF NOT EXISTS artifact_sources (
+  child_id   TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  root_id    TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- The direct parent through which root_id entered this child. Equal to
+  -- root_id for a first-generation merge. Rendering only.
+  via_id     TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (child_id, root_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sources_root ON artifact_sources(root_id);
+```
+
+Resolved roots, not edges. `root_id` always names an artifact with
+`provenance = 'captured'` — this is an invariant with a test (§11).
+
+The denormalisation is what makes re-merge cheap at scale: a candidate group's
+roots are one `SELECT ... WHERE child_id IN (...)`, with no recursive CTE on the
+sweep's hot path, and the fan-in cap is `COUNT(DISTINCT root_id)` — checkable
+*before* a model call is spent.
+
+The redundancy is real and is the price: a deleted root removes closure rows
+that an edge table would have let us recompute. §8.3 says what happens then.
+
+### 4.3 What `superseded_by` keeps doing
+
+Nothing new. A merge calls `Core::supersede` per root, with the same guards
+(refuses a deprecated side, SQLite first, payload second) and the same Ops undo.
+`artifact_sources` is additive: `superseded_by` answers "where do I look
+instead", `artifact_sources` answers "what is this made of".
+
+No merge-log table is needed. `superseded_by` + `artifact_sources` +
+`artifacts.created_at` reconstruct any merge. An Ops view over that is a query,
+not a write path.
+
+### 4.4 Pair states
+
+`PairState` gains two variants:
+
+- `Oversized` — the group exceeds `merge_max_roots`. Not merged, surfaced to
+  Ops.
+- `NearIdentical` — the pair scored at or above `auto_supersede`. It is settled
+  by the sweep's free clustering pass and **never** arms a dedupe unit. See
+  §5.2, which is where this variant becomes necessary.
+
+`Superseded` keeps its meaning (a proposed direction, `obsolete_id` set) and
+gains an applied form under autonomy. `Contradiction` becomes the sole human
+queue.
+
+## 5. Detection
+
+### 5.1 The primitive already exists
+
+`VectorStore::neighbours(artifact_id, limit)` (`src/vector/qdrant.rs:1826`)
+queries Qdrant **by point id**, so the vector is looked up in the index and no
+embedding call is paid. It already filters `superseded`/`deprecated` correctly
+and returns scores. Both backends implement it. Its only caller today is the
+detail pane's related list (`src/web/ui.rs:1301`).
+
+No new vector capability is needed — only a new caller.
+
+### 5.2 One unit per artifact, triggered by embedding
+
+```
+Stage::Relate, target_kind = "artifact"
+```
+
+Armed where `mark_embedded` runs (`src/jobs/embed.rs:280`), i.e. only once the
+vector is actually in the index. The unit:
+
+1. calls `neighbours(id, per_point)` — one HTTP call, no inference;
+2. drops hits below `review_min`;
+3. passes the rest through `classify_pair(core, &a, &b, score)`.
+
+**A pair at or above `auto_supersede` must not reach the dedupe queue.** That
+band is settled for free by clustering, and letting the relate unit file it as an
+ordinary pending pair would spend a model call on exactly the case where the
+cheap rule is already correct — the inversion §9 exists to prevent. It also must
+not be superseded pairwise here: `Clusters` (`src/jobs/consolidate.rs:42`) exists
+because resolving one pair at a time leaves A pointing at a B that is itself
+hidden.
+
+So `classify_pair` routes such a pair to `NearIdentical`, and the sweep's cluster
+pass reads stored `NearIdentical` pairs **in addition to** the `near_pairs`
+result. That is an improvement in its own right: the cluster pass gains a durable
+input instead of depending entirely on what one sampled round trip happened to
+return.
+
+Step 3 is the real work of this section. That logic currently lives inline in
+the body of `consolidate::run` (`src/jobs/consolidate.rs:317–419`): the
+containment check, the fact-token filter, `record_pair` / `record_settled_pair`.
+It moves into one named function that **both** producers call. Two discovery
+paths with two copies of the rules is the kind of divergence you only notice
+when the outcome starts depending on which path saw a pair first.
+
+A separate unit rather than a tail on `embed_batch`: a failing Qdrant query
+would otherwise fail the embed job, whose retry pays for the embedding again.
+Two failure domains, two units — the same reasoning that already split judge
+calls out of the sweep.
+
+### 5.3 Why this is complete
+
+For a pair (X, Y), the member embedded **second** finds the other. When X's unit
+runs, Y is either already indexed — X finds it — or not, and Y finds X later.
+Embedded in the same batch, both units run after the shared `upsert` and both
+see each other. There is no window in which a pair falls through, provided both
+units run.
+
+Coverage becomes **1, independent of N**, at the cost of one Qdrant query per
+artifact. Under this project's economics that is free.
+
+Re-embeds re-arm the unit: when a vector moves (model change, `resurface`), its
+old neighbourhood is no longer the right one.
+
+### 5.4 What the sweep becomes
+
+It stays, loses its primary role, and keeps five:
+
+| Job | Why it stays in the sweep |
+|---|---|
+| Backlog | Artifacts embedded before this feature never had a `Relate` unit |
+| Backstop | Units that exhausted their retries leave holes nothing else sees |
+| ≥ `auto_supersede` clustering | Union-find spans many pairs at once; inherently a batch operation. Its input is now `near_pairs` **plus** stored `NearIdentical` pairs (§5.2) |
+| Lifecycle repair | See §5.5 |
+| Unfinished merges | See §8.1 |
+
+`sample` stops being a correctness parameter and becomes the rate at which the
+backlog is worked off.
+
+### 5.5 Lifecycle repair moves from scanning to marking
+
+`repair_lifecycle_drift` scans both stores with `DRIFT_SCAN = 5000`
+(`src/jobs/consolidate.rs:92`). Autonomous merging makes hidden artifacts grow
+monotonically — every merge hides at least two, forever — so the cap is reached
+permanently and the repair degrades into sampling an ever-growing set.
+
+`artifacts.lifecycle_dirty` is set in the same SQLite write that changes
+`status`/`superseded_by`, and cleared once the Qdrant write is acknowledged. The
+repair then reads `WHERE lifecycle_dirty = 1`: O(open writes) rather than
+O(hidden artifacts), and without the two mutually-offset scan windows that
+produced the bug pinned by `a_scan_cap_reached_from_both_sides_is_not_drift`.
+
+The existing full scan is retained as an infrequent reconciliation — it catches
+drift that arose with no SQLite write behind it — but no longer runs every
+sweep.
+
+## 6. The dedupe contract
+
+Renaming, to end a genuine collision: `/ui/judge` and `src/web/judge.rs` are the
+relevance-feedback evaluation surface, unrelated to this. This subsystem is
+renamed to match what it does.
+
+| Before | After |
+|---|---|
+| `src/jobs/judge.rs` | `src/jobs/dedupe.rs` |
+| `Stage::Judge` | `Stage::Dedupe` |
+| `consolidate.judge` | `consolidate.autonomous` |
+| `JUDGE_SYSTEM` | `DEDUPE_SYSTEM` |
+
+### 6.1 Four outcomes
+
+| Verdict | Meaning | Effect | Synthetic text? |
+|---|---|---|---|
+| `distinct` | different subjects | `NoConflict`, both stay | no |
+| `conflict` | same subject, differing value, no clear direction | `Contradiction`, both stay, **escalated to Ops** | no |
+| `replaced` | one plainly replaces the other | `supersede`; the survivor is a stored original | **no** |
+| `duplicate` | same subject, same claim, complementary detail | merge; both roots superseded | yes |
+
+`replaced` is preferred over `duplicate` wherever it applies, and the prompt says
+so. The survivor is then a verbatim stored artifact with a valid `corpus_span` —
+strictly better than a rewrite, and the path by which §3's fidelity argument
+keeps holding under autonomy. A merge is the answer only when *both* sides carry
+something the other lacks.
+
+The existing direction guard survives unchanged: a verdict naming the **newer**
+artifact obsolete is rejected and falls back to `conflict`
+(`src/jobs/judge.rs:96–102`).
+
+### 6.2 One call per component
+
+```json
+{
+  "relation": "duplicate" | "conflict" | "replaced" | "distinct",
+  "detail": "...",
+  "supersedes": "a",
+  "merged": { "title": "...", "text": "...", "category": "...",
+              "tags": [], "caveats": [] }
+}
+```
+
+One call, not two. Asking for classification and merged text separately doubles
+the only scarce resource in the system. The known risk — that a model asked for
+a merged text is likelier to answer `duplicate` — is addressed by the
+verification in §6.4, which costs nothing, rather than by a second call.
+
+`merged` must be null unless `relation` is `duplicate`; a `merged` block on any
+other verdict is a parse error and the reply is treated as unreadable.
+
+**Carried over from `JUDGE_SYSTEM` unchanged**, because it was expensive to
+learn: the subject check comes first and uses the titles. The comment at
+`src/infer/prompt.rs:149–154` records the case — an artifact titled "FAT32
+Specifications" whose body opens "32 Bit Clusternummern" and never names FAT32
+again. FAT12/FAT16/FAT32 sit at 0.91 similarity and every number in them
+differs. Without this rule the autonomous path merges a reference document into
+mush. It gets a test that pins it.
+
+### 6.3 Components, not pairs
+
+The unit's target stays an `artifact_pairs` id. At **run time** it expands to the
+connected component of `Pending` pairs containing that pair — `Pending` only, so
+that a settled, dismissed or `NearIdentical` pair never drags an already-answered
+artifact back into a group. The component is computed fresh, not snapshotted at
+arming time. The `Clusters` union-find already in
+`src/jobs/consolidate.rs:42` is reused.
+
+If a sibling pair's unit also runs, it finds its pairs settled and its artifacts
+superseded and becomes a no-op — the same race guard `src/jobs/judge.rs:38–47`
+already applies to status changes. No `merge_groups` table is required.
+
+**Fan-in cap.** Before the call, `COUNT(DISTINCT root_id)` over the component is
+checked against `merge_max_roots` (default 8). Above it, nothing is merged: the
+pairs move to `Oversized` and surface on Ops. A merge of 40 roots is no longer
+one atomic piece of knowledge, which is what `schema.sql:51` defines an artifact
+to be.
+
+### 6.4 Verification — what makes autonomy defensible
+
+Both checks are local and free. If either fails the merge is **discarded** and
+the component is escalated as `conflict`, with the reason in `detail` — "the
+merge would have lost `1.21.4`" is a usable line for an operator;
+"verification failed" is not.
+
+**1. No value may disappear.**
+
+```
+fact_tokens(merged.text ∪ merged.caveats)  ⊇  ⋃ fact_tokens(root.text)
+```
+
+If the model answers `duplicate` but quietly drops one side of a value conflict
+while writing, the value is missing from the output. That is the one way this
+feature can destroy knowledge without anyone noticing.
+
+**2. No literal may disappear.**
+`verify::missing_literals(root_text, &root_caveats, &merged.text)`. The
+signature is `(artifact_text, caveats, haystack)` (`src/infer/verify.rs:94`), so
+the existing function applies **unmodified** with the merged text as the
+haystack instead of the segment. It catches paraphrased commands and paths; the
+module header explains the stake: "a paraphrased command is a command that later
+gets pasted into a root shell."
+
+### 6.5 `may_disagree` changes role
+
+It stops being an admission gate — under §1 that would hide the best merge
+candidates from the model permanently. It becomes:
+
+- a **prior in the prompt**: the differing values are named, and the model is
+  asked whether they are a conflict about one subject or the same subject
+  described at different levels of detail.
+
+`fact_tokens`, the function underneath it, keeps carrying **verification 1**
+above. Only the `may_disagree` predicate loses its job; the tokeniser gains one.
+
+Consequence: substantially more pairs warrant a call. §9 absorbs this.
+
+### 6.6 Re-merge always rewrites from captured roots
+
+A merged artifact is freely eligible for further merging. When it is merged, the
+model is given the **captured roots** of the whole component — resolved through
+`artifact_sources` — and never a merged artifact's text.
+
+```
+gen 1:  a, b            -> M1  [roots: a, b]
+gen 2:  component {M1, c}
+        roots -> {a, b, c}
+        model reads a, b, c   (never M1)
+        -> M2  [roots: a, b, c];  M1 and c superseded by M2
+```
+
+Information loss stays exactly one generation deep, permanently. This is the
+whole reason lineage is stored as a closure.
+
+### 6.7 The configuration switch
+
+`consolidate.autonomous`, **default `true`**:
+
+- **false** — verdicts are recorded only, which is today's behaviour. `replaced`
+  is filed as a proposal for an operator. No merge is written.
+- **true** — `replaced` and `duplicate` are applied directly. `conflict` and
+  `Oversized` go to Ops. The operator keeps undo and the conflict queue, and
+  nothing else.
+
+The switch changes **who presses the button**, never what the model is asked.
+That makes the transition observable: an operator can run with `false`, read the
+recorded verdicts, and then let the system act.
+
+Defaulting to `true` means a fresh installation merges without being asked. The
+verification in §6.4 and the recovery paths in §8 are what carry that default;
+they are not optional refinements.
+
+## 7. Ops surface
+
+- **Merged artifacts** list, with roots, verdict detail, and **Undo merge**.
+- **Conflicts** — `Contradiction` pairs. The one queue that expects a human.
+- **Oversized** — components past the fan-in cap.
+- Detail pane: a `merged` artifact renders **its roots**, each linking to its own
+  corpus, where a captured artifact renders corpus lines from `corpus_span`.
+  `provenance` selects the branch.
+
+## 8. Write path and recovery
+
+A merge is five steps across two stores that cannot be written atomically — the
+same underlying problem that makes `repair_lifecycle_drift` necessary at all.
+
+```
+1. insert M (provenance='merged', corpus_id NULL, embed_state pending)
+2. insert artifact_sources rows for every root
+3. embed M
+4. supersede each root onto M   (SQLite, then Qdrant)
+5. settle the component's pairs
+```
+
+**1 and 2 in one SQLite transaction.** An M with no lineage rows is an artifact
+whose detail pane can render nothing and whose roots nobody can recover — and
+§6.6 depends on those rows. `insert_artifacts` already uses `tx`; this extends
+the pattern rather than introducing one.
+
+**3 before 4**, which is the deliberate departure from the obvious order.
+Superseding the roots before M is indexed opens a window in which the roots are
+out of search and M is not yet in it — the knowledge is **temporarily
+unreachable**. That is the failure class `deleting_the_survivor_puts_the_artifact_it_hid_back`
+(`src/jobs/consolidate.rs:883`) and `heal_dangling_supersessions` exist to
+prevent. In this order every interruption is benign:
+
+| Interrupted after | State | Visible? |
+|---|---|---|
+| 1+2 | M active but unindexed, roots active | roots in search — the pre-merge state |
+| 3 | M indexed, roots still active | M **and** roots in search — redundant, nothing lost |
+| 4 (SQLite) | roots hidden, payload lagging | `lifecycle_dirty` (§5.5) catches up |
+| 5 | applied, pairs still open | a sibling unit finds settled artifacts, no-ops |
+
+At no point does a statement leave search. The worst case is redundancy, which
+is the state the system is coming from anyway.
+
+### 8.1 Finishing an interrupted merge
+
+Step 3→4 hangs off the same hook as §5.2: when an artifact with
+`provenance = 'merged'` finishes embedding, its roots are superseded. A crash in
+between leaves row 3 of the table standing, so the sweep gains one repair, built
+on the model of `heal_dangling_supersessions`:
+
+> **Merged artifacts whose roots are still active** — a join of
+> `artifact_sources` against `artifacts.status`. Cheap, and the only thing that
+> would ever notice this state.
+
+### 8.2 Undo, and the trap in it
+
+**Undo merge**: reactivate the roots (`Core::reactivate` exists), set M to
+`deprecated` — not deleted, because `artifact_sources` cascades away with it and
+takes the record of what was attempted.
+
+That alone accomplishes nothing. The next sweep re-finds the reactivated roots,
+the model says `duplicate` again, and the operator's decision is silently
+undone. This is literally the bug pinned by
+`reactivating_a_superseded_artifact_survives_the_next_sweep`
+(`src/jobs/consolidate.rs:700`).
+
+So the undo **must also set the component's pairs to `Dismissed`**, in the same
+action. `record_pair` is `INSERT OR IGNORE` (`src/store/pairs.rs:109`) and
+respects that permanently — the mechanism exists and only needs to be used.
+
+Important distinction: this applies to an **explicit undo**. If M is simply
+*deleted*, `heal_dangling_supersessions` restores the roots on its own, and a
+fresh merge is then correct, because the duplication is genuinely back. A
+decision may overrule the sweep; a deletion may not.
+
+### 8.3 A deleted root
+
+`artifact_sources.root_id` cascades. Deleting a corpus removes its artifacts and
+with them lineage rows of M — while M's *text* still carries the content. M then
+claims less provenance than it has.
+
+Not data loss, but a silent untruth, and there is already a field for it:
+`artifacts.flags` / `flag_detail`, used today by verification. The sweep repair
+sets `orphaned_source` on M, and the detail pane says "one of this artifact's
+sources was deleted" rather than quietly omitting it. No new field, no new write
+path.
+
+### 8.4 Retries and dead endpoints
+
+Unchanged — the existing mechanism fits without adaptation.
+
+- Unreadable reply → `record_unreadable_judgement`; component stays open; the
+  unit retries under the queue's backoff.
+- The prompt carries the attempt number. Not optional against this endpoint:
+  identical prompts replay identical cached output, so an unchanged retry would
+  return the same unreadable bytes five times.
+- At `MAX_UNREADABLE_JUDGEMENTS` the asking stops, the component stays `pending`
+  and therefore on the Ops list. No merge is left half-applied.
+- Endpoint down → `gate.background()`, breaker, no merges. Because the write path
+  begins only **after** a successful and verified reply, an outage cannot produce
+  a partial merge.
+
+## 9. Budget and pacing
+
+`max_judgements = 20` bounds what **one sweep** arms. That was right while the
+sweep was the only producer. After §5 it is not, and after §6.5 the gate that
+kept most pairs away from the model is gone. A number per 24-hour tick is then
+not a budget but a queue that only grows.
+
+The fixed quantity in this system is neither the base nor the sweep — it is
+**hardware throughput**. So the budget becomes a rate:
+
+```toml
+[consolidate]
+autonomous            = true
+dedupe_interval_mins  = 15   # own ticker, independent of the 24h sweep
+max_dedupe_per_tick   = 5    # => ceiling of 20 calls/hour
+merge_max_roots       = 8
+```
+
+A dedicated ticker on the model of `spawn_retention_ticker`; the comment at
+`src/jobs/consolidate.rs:193` records why retention was lifted out of the sweep,
+and the same argument applies — the pacing of dedupe calls has nothing to do
+with the rhythm of duplicate discovery.
+
+Two existing rules are explicitly **not** touched:
+
+- **No cap on in-flight units.** `src/jobs/consolidate.rs:455–461` explains why:
+  a unit the queue cannot get through — open breaker, dead endpoint — would under
+  an in-flight cap block every other pair permanently. That is exactly the
+  head-of-line blocking the units were introduced to remove. The protection stays
+  `live_job` plus the ordering in `pairs_to_judge`.
+- **Queue ordering.** Dedupe units are armed with a high `seq` so they sort
+  behind synthesis and embed work of equal attempt count. `jobs.seq` and
+  `idx_jobs_claim2` already support this (`src/store/schema.sql:137`). Dedup then
+  consumes what capture leaves over, never the reverse: a large ingest may delay
+  hygiene; hygiene may not delay an ingest.
+
+## 10. Configuration
+
+```toml
+[consolidate]
+enabled               = true
+near_dupe_min         = 0.90
+review_min            = 0.88
+auto_supersede        = 0.95
+sample                = 2000
+per_point             = 5
+interval_hours        = 24
+autonomous            = true   # replaces `judge`
+dedupe_interval_mins  = 15
+max_dedupe_per_tick   = 5      # replaces `max_judgements`
+merge_max_roots       = 8
+```
+
+`README.md`'s configuration table and `config.example.toml` are updated,
+including a comment stating plainly what happens by default.
+
+## 11. Testing
+
+Test names in this project are sentences carrying the bug they pin in a comment.
+In that form:
+
+**Lineage and re-merge**
+- `a_merge_of_a_merge_is_written_from_the_captured_roots` — the core anti-drift
+  rule; M1(a,b) + c means the model sees a, b, c and never M1's text.
+- `the_lineage_of_a_merged_artifact_names_only_captured_artifacts`
+- `a_component_past_the_fan_in_cap_is_not_merged`
+
+**Detection**
+- `an_artifact_finds_its_duplicate_the_moment_it_is_embedded`
+- `a_pair_is_found_by_whichever_member_is_embedded_second`
+- `the_sweep_and_the_relate_unit_classify_a_pair_identically`
+- `a_re_embed_looks_for_neighbours_again`
+
+**Contract**
+- `two_artifacts_about_different_subjects_are_never_merged` — the
+  FAT12/FAT16/FAT32 lesson (`src/infer/prompt.rs:149–154`). The most important
+  test in the set.
+- `a_value_conflict_is_escalated_and_never_merged`
+- `a_plain_replacement_supersedes_rather_than_merging`
+- `a_direction_naming_the_newer_artifact_is_not_trusted` — existing, must survive.
+- `a_merge_that_drops_a_value_is_refused`
+- `a_merge_that_paraphrases_a_command_is_refused`
+- `a_pair_with_no_differing_values_still_reaches_the_model` — the polarity change.
+- `a_merged_block_on_a_non_duplicate_verdict_is_unreadable`
+- `a_near_identical_pair_never_costs_a_model_call` — §5.2's routing. The
+  regression it guards against is the expensive one: the free band quietly
+  becoming a paid one.
+
+**Write path and recovery**
+- `knowledge_is_never_unreachable_during_a_merge` — §8's invariant, checked by
+  interrupting at each of the five steps. The most valuable test in the design.
+- `a_merge_whose_roots_were_never_superseded_is_finished_by_the_next_sweep`
+- `undoing_a_merge_survives_the_next_sweep`
+- `deleting_a_merged_artifact_puts_its_roots_back`
+- `deleting_a_root_flags_the_merged_artifact_rather_than_hiding_the_loss`
+- `a_second_unit_for_the_same_component_is_a_no_op`
+
+**Pacing**
+- `dedupe_never_runs_ahead_of_capture`
+- `the_dedupe_ticker_holds_its_rate`
+
+Merge replies are scripted through `ScriptedCompleter` (`src/infer/fake.rs`), as
+the existing judge tests already do.
+
+**Two existing tests are deliberately rewritten**, named here so it does not
+disappear into a diff. Both encode the old polarity and are made wrong by §6.5:
+
+- `a_pair_with_nothing_to_disagree_about_never_reaches_the_queue`
+  (`src/jobs/consolidate.rs:1432`)
+- `a_pair_with_no_facts_to_disagree_about_never_reaches_the_model`
+  (`src/jobs/consolidate.rs:1285`)
+
+Both assert that a pair with no differing values is settled. It is now the best
+merge candidate. Their replacements carry a comment stating what used to hold
+and why it no longer does.
+
+### 11.1 The evaluation harness
+
+`tests/eval.rs` scores query/artifact pairs. Merging changes **what is
+retrievable at all**: a merged artifact stands where two originals stood.
+Whether that raises or lowers hit quality is a measurement, not a design
+question.
+
+The harness is extended to handle merged artifacts — a graded pair whose target
+artifact has since been superseded by a merge counts as a hit on the merged
+artifact, since that is where the knowledge now lives; without this the score
+collapses for a reason that says nothing about retrieval. Scores are then taken
+before and after a merge run over the same corpus, and the delta is recorded in
+the implementation plan. A drop is a finding about the feature.
+
+## 12. Rollout
+
+1. Schema and migration (§4). Requires recreating the database — the schema
+   header's stated path during testing.
+2. Detection and the lifecycle-repair rework (§5). Independently useful, changes
+   nothing about fidelity, and it is the foundation everything after it stands
+   on.
+3. Rename and the dedupe contract with `autonomous = false` (§6). Verdicts are
+   recorded; nothing is applied. The recorded verdicts are read before going on.
+4. The merge write path, verification, and recovery (§8).
+5. Ops surface (§7), pacing (§9), eval harness (§11.1).
+6. Flip the default to `true`.
+
+Steps 3 and 6 are separated on purpose: the observation window between them is
+the cheapest evidence available about whether the contract in §6 holds on real
+data.
+
+## 13. Risks
+
+- **The model merges two distinct subjects.** Mitigated by the subject-first
+  prompt rule and its test; residually caught by undo. The FAT32 case is the
+  known shape of this failure.
+- **Merged text is worse retrieval material than either original.** Not
+  detectable by any check in §6.4 — it is a quality question, and §11.1 is the
+  only instrument for it.
+- **Closure rows and edges disagree after a deletion.** Accepted with the
+  `orphaned_source` flag (§8.3) rather than resolved.
+- **A default of `true` means a shipped instance rewrites its own knowledge
+  base without being asked.** Every mechanism in §3 and §8 exists to bound this.
+  It remains the largest single risk in the design, and it is a deliberate
+  choice, recorded as such.

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,8 +149,22 @@ pub struct ConsolidateConfig {
     /// before the system is allowed to act on it. A value conflict is escalated
     /// to a person either way.
     pub autonomous: bool,
-    /// Ceiling on dedupe calls per sweep, so one sweep cannot occupy the GPU.
-    pub max_judgements: usize,
+    /// How often the dedupe ticker arms units, in minutes.
+    ///
+    /// Its own ticker rather than a passenger on the sweep. `max_judgements`
+    /// bounded what *one sweep* armed, which was right while the sweep was the
+    /// only producer of pairs; the relate units file them continuously now, so a
+    /// number per 24-hour tick is not a budget but a queue that only grows.
+    ///
+    /// The fixed quantity in this system is neither the base nor the sweep — it
+    /// is what the hardware can get through. So the budget is a rate.
+    pub dedupe_interval_mins: u64,
+    /// Units armed per tick. With the default interval that is a ceiling of
+    /// twenty calls an hour, whatever the base has grown to.
+    ///
+    /// Zero switches the model off entirely: pairs are still found, recorded and
+    /// clustered — all of which is free — and nothing is ever asked about.
+    pub max_dedupe_per_tick: usize,
     /// How many captured roots one merged artifact may be written from.
     ///
     /// Above this the component is left alone and surfaced instead. A merge of
@@ -181,7 +195,8 @@ impl Default for ConsolidateConfig {
             per_point: 5,
             interval_hours: 24,
             autonomous: false,
-            max_judgements: 20,
+            dedupe_interval_mins: 15,
+            max_dedupe_per_tick: 5,
             merge_max_roots: 8,
             stale_after_days: 365,
             stale_max_hits: 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,6 +182,19 @@ pub struct ConsolidateConfig {
     /// to the candidate list — it never feeds search scoring, or a frequently
     /// shown result would keep boosting its own visibility.
     pub stale_max_hits: i64,
+
+    /// Retired. Read only so that `judge = false` can be carried across rather
+    /// than ignored, and so an operator is told where the setting went.
+    ///
+    /// It gated whether the model was asked at all, which is now
+    /// `max_dedupe_per_tick = 0`. Left unread it would parse without complaint,
+    /// and the operator who had switched the only inference-costing stage off
+    /// would be given an autonomous one instead — a setting that hides
+    /// artifacts, arriving by upgrade, from a file that says the opposite.
+    pub judge: Option<bool>,
+    /// Retired. A number per 24-hour tick was a budget only while the sweep was
+    /// the only producer of pairs; see `max_dedupe_per_tick`, which is a rate.
+    pub max_judgements: Option<usize>,
 }
 
 impl Default for ConsolidateConfig {
@@ -200,6 +213,8 @@ impl Default for ConsolidateConfig {
             merge_max_roots: 8,
             stale_after_days: 365,
             stale_max_hits: 0,
+            judge: None,
+            max_judgements: None,
         }
     }
 }
@@ -461,11 +476,52 @@ impl Config {
             )
             .build()?;
         let mut cfg: Config = raw.try_deserialize()?;
+        cfg.carry_retired_keys();
         cfg.normalize();
         cfg.validate()?;
         cfg.warn_on_file_secrets(path);
         cfg.warn_on_moved_keys();
         Ok(cfg)
+    }
+
+    /// A retired key still says what its operator wanted, and is honoured where
+    /// something current can carry it.
+    ///
+    /// `judge` gated whether the dedupe pass was asked anything at all. Ignoring
+    /// it would have been the worst possible reading of `judge = false`: that
+    /// file is the record of an operator declining the one stage that spends
+    /// inference and hides artifacts, and an upgrade that dropped the key would
+    /// have handed them `autonomous = true` on the strength of it. So it is
+    /// carried to the setting that means the same thing now.
+    ///
+    /// `max_judgements` has no successor to carry to — a count per tick and a
+    /// rate are not the same quantity — so it is only named.
+    fn carry_retired_keys(&mut self) {
+        match self.consolidate.judge {
+            Some(false) => {
+                self.consolidate.max_dedupe_per_tick = 0;
+                tracing::warn!(
+                    "consolidate.judge has been retired; reading judge = false as \
+                     max_dedupe_per_tick = 0, which is what stops the dedupe pass \
+                     asking anything now. consolidate.autonomous, separately, decides \
+                     whether an answer is acted on."
+                );
+            }
+            Some(true) => tracing::warn!(
+                "consolidate.judge has been retired and is being ignored; \
+                 max_dedupe_per_tick decides how many groups are asked about per tick"
+            ),
+            None => {}
+        }
+        if let Some(n) = self.consolidate.max_judgements {
+            tracing::warn!(
+                was = n,
+                interval_mins = self.consolidate.dedupe_interval_mins,
+                per_tick = self.consolidate.max_dedupe_per_tick,
+                "consolidate.max_judgements has been retired and is being ignored; \
+                 the budget is a rate now — see dedupe_interval_mins and max_dedupe_per_tick"
+            );
+        }
     }
 
     /// Values that would make a feature quietly useless, put back rather than
@@ -744,6 +800,41 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             let cfg = Config::load(Some(&p)).unwrap();
             assert_eq!(cfg.infer.embed.dim, 768);
         });
+    }
+
+    #[test]
+    fn an_operator_who_switched_the_judge_off_does_not_get_autonomy_instead() {
+        // `judge = false` is the record of someone declining the one stage that
+        // spends inference and hides artifacts. The key was retired and the
+        // struct takes its defaults, so ignoring it would read that file as
+        // consent to `autonomous = true` — arriving by upgrade, from a config
+        // that says the opposite. It is carried to the key that stops the asking.
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, &format!("{MINIMAL}\n[consolidate]\njudge = false\n"));
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert_eq!(
+            cfg.consolidate.max_dedupe_per_tick, 0,
+            "a config declining the model call was asked anyway"
+        );
+    }
+
+    #[test]
+    fn a_retired_key_does_not_stop_a_config_that_otherwise_works() {
+        // Named in the log, not refused. `max_judgements` has no successor to
+        // carry it to, and a server that will not start is a worse answer than
+        // one that says where the setting went.
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            &format!("{MINIMAL}\n[consolidate]\nmax_judgements = 20\njudge = true\n"),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert_eq!(
+            cfg.consolidate.max_dedupe_per_tick,
+            ConsolidateConfig::default().max_dedupe_per_tick
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,7 +194,7 @@ impl Default for ConsolidateConfig {
             sample: 2000,
             per_point: 5,
             interval_hours: 24,
-            autonomous: false,
+            autonomous: true,
             dedupe_interval_mins: 15,
             max_dedupe_per_tick: 5,
             merge_max_roots: 8,

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,10 +141,14 @@ pub struct ConsolidateConfig {
     pub per_point: usize,
     /// How often the sweep is queued.
     pub interval_hours: u64,
-    /// Whether pairs in the review band that survive the fact-token prefilter
-    /// are sent to the completer. Off by default: it is the only part of
-    /// consolidation that costs inference.
-    pub judge: bool,
+    /// Whether the dedupe pass may act on what it decides: superseding where
+    /// one artifact plainly replaces another, and writing a merged artifact
+    /// where each side carries something the other lacks.
+    ///
+    /// With this off the verdicts are still recorded, so the queue can be read
+    /// before the system is allowed to act on it. A value conflict is escalated
+    /// to a person either way.
+    pub autonomous: bool,
     /// Ceiling on judge calls per sweep, so one sweep cannot occupy the GPU.
     pub max_judgements: usize,
     /// An active artifact not confirmed accurate (`last_verified_at`) in this
@@ -169,7 +173,7 @@ impl Default for ConsolidateConfig {
             sample: 2000,
             per_point: 5,
             interval_hours: 24,
-            judge: false,
+            autonomous: false,
             max_judgements: 20,
             stale_after_days: 365,
             stale_max_hits: 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -563,6 +563,20 @@ impl Config {
             );
             self.feedback.candidates = ceiling;
         }
+        // Same argument as above: every judgeable component flattens to at
+        // least two roots, so a cap of zero or one settles all of them
+        // Oversized before any call — merging silently off from a number
+        // nobody types meaning that.
+        if self.consolidate.merge_max_roots < 2 {
+            let d = ConsolidateConfig::default().merge_max_roots;
+            tracing::warn!(
+                configured = self.consolidate.merge_max_roots,
+                using = d,
+                "consolidate.merge_max_roots below 2 would settle every component \
+                 as oversized; using the default"
+            );
+            self.consolidate.merge_max_roots = d;
+        }
     }
 
     /// Rules that a config can satisfy syntactically and still be wrong.
@@ -689,6 +703,23 @@ mod tests {
         assert_eq!(cfg.infer.embed.timeout_secs, DEFAULT_TIMEOUT_SECS);
         assert_eq!(cfg.infer.ask.timeout_secs, DEFAULT_TIMEOUT_SECS);
         assert_eq!(cfg.infer.synthesize.reasoning_effort, None);
+    }
+
+    #[test]
+    fn a_merge_cap_below_two_goes_back_to_the_default() {
+        // The same put-back as feedback.candidates: every judgeable component
+        // flattens to at least two roots, so a cap of 0 or 1 settles all of
+        // them Oversized before any call — merging silently off.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            &format!("{MINIMAL}\n[consolidate]\nmerge_max_roots = 1\n"),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert_eq!(
+            cfg.consolidate.merge_max_roots,
+            ConsolidateConfig::default().merge_max_roots
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,8 +149,15 @@ pub struct ConsolidateConfig {
     /// before the system is allowed to act on it. A value conflict is escalated
     /// to a person either way.
     pub autonomous: bool,
-    /// Ceiling on judge calls per sweep, so one sweep cannot occupy the GPU.
+    /// Ceiling on dedupe calls per sweep, so one sweep cannot occupy the GPU.
     pub max_judgements: usize,
+    /// How many captured roots one merged artifact may be written from.
+    ///
+    /// Above this the component is left alone and surfaced instead. A merge of
+    /// forty sources is no longer one atomic piece of knowledge, which is what
+    /// `schema.sql` defines an artifact to be — so past the cap the honest
+    /// answer is to stop rather than to write something nobody asked for.
+    pub merge_max_roots: usize,
     /// An active artifact not confirmed accurate (`last_verified_at`) in this
     /// many days becomes a deprecation-review candidate — never anything more
     /// automatic than that. See `stale_max_hits`.
@@ -175,6 +182,7 @@ impl Default for ConsolidateConfig {
             interval_hours: 24,
             autonomous: false,
             max_judgements: 20,
+            merge_max_roots: 8,
             stale_after_days: 365,
             stale_max_hits: 0,
         }

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -166,6 +166,52 @@ pub fn spawn_retention_ticker(
     })
 }
 
+/// Arm dedupe units at a steady rate, independent of the consolidation sweep.
+///
+/// Its own ticker rather than a passenger on that sweep, for the same reason
+/// retention got one: the pacing of model calls has nothing to do with the
+/// rhythm of duplicate *discovery*. The sweep runs daily because re-examining
+/// the whole collection more often buys nothing; the calls want a rate the
+/// hardware can actually sustain.
+///
+/// What it does not do is cap units in flight. A unit the queue cannot get
+/// through — an open breaker, a dead endpoint — would then block every other
+/// pair permanently, which is the head-of-line blocking the per-pair units were
+/// introduced to remove. `live_job` skips a pair whose unit is already queued,
+/// and the ordering in `pairs_to_judge` keeps a pair that keeps failing from
+/// starving the rest.
+pub fn spawn_dedupe_ticker(
+    core: crate::core::Core,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !core.consolidate.enabled || core.consolidate.max_dedupe_per_tick == 0 {
+            tracing::info!("dedupe pass disabled");
+            return;
+        }
+        let period =
+            std::time::Duration::from_secs(core.consolidate.dedupe_interval_mins.max(1) * 60);
+        let mut tick = tokio::time::interval(period);
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = tick.tick() => {
+                    match crate::jobs::consolidate::arm_dedupe(&core).await {
+                        Ok(n) if n > 0 => tracing::info!(armed = n, "armed dedupe units"),
+                        // A failed tick is retried on the next one; there is
+                        // nothing here worth taking the process down for.
+                        Err(e) => tracing::warn!(error = %e, "could not arm dedupe units"),
+                        _ => {}
+                    }
+                }
+            }
+        }
+        tracing::info!("dedupe ticker stopped");
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -258,6 +258,8 @@ impl Core {
     /// job. Clearing the row first loses the only page that offers the undo
     /// while the artifact is still hidden from search.
     pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+        // Read before clearing: afterwards nothing says who was hiding it.
+        let winner = self.store.get_artifact(artifact_id).await?.superseded_by;
         // Marked before either store is touched. This direction writes the
         // payload first, so without it a crash between the two would leave
         // drift no row write ever announced.
@@ -271,6 +273,15 @@ impl Core {
         self.store
             .clear_lifecycle_dirty(std::slice::from_ref(&artifact_id.to_string()))
             .await?;
+        // A restore out of a merge is an operator overruling the merge for
+        // this one source. Recorded on the lineage, or the sweep's
+        // unfinished-merge repair re-hides it on the next tick, every tick.
+        if let Some(w) = winner
+            && let Ok(wc) = self.store.get_artifact(&w).await
+            && wc.provenance == crate::store::artifacts::Provenance::Merged
+        {
+            self.store.mark_source_restored(artifact_id).await?;
+        }
         tracing::info!(artifact_id, "restored a superseded artifact to search");
         Ok(())
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -788,7 +788,7 @@ impl Core {
             // call. An operator reprocesses a document, not one of its windows:
             // asking for `synthesize` re-windows the whole thing and arms them
             // all, and `embed` re-arms a `relate` unit per artifact behind it.
-            Stage::SegmentWindow | Stage::Title | Stage::Judge | Stage::Relate => {
+            Stage::SegmentWindow | Stage::Title | Stage::Dedupe | Stage::Relate => {
                 return Err(Error::Validation(
                     "that stage is a single inference call the queue arms itself; \
                      reprocess the document instead"

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -728,6 +728,17 @@ impl Core {
                 continue;
             }
             self.store.set_superseded_by(&id, None).await?;
+            // Cleared here as everywhere else, because `set_superseded_by`
+            // raises the marker in the same statement as the change it
+            // describes. This path writes the payload first and the row second,
+            // so by now the two already agree — and a marker left standing would
+            // have the next sweep's `repair_lifecycle_drift` rewrite a payload
+            // that is correct, on a base whose stores are in agreement, which is
+            // the one condition that function's own comment says would mean a
+            // bug somewhere.
+            self.store
+                .clear_lifecycle_dirty(std::slice::from_ref(&id))
+                .await?;
             tracing::info!(
                 artifact_id = %id,
                 "restored an artifact whose surviving copy was deleted"
@@ -842,6 +853,54 @@ mod tests {
     use crate::store::artifacts::EmbedState;
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::Stage;
+
+    #[tokio::test]
+    async fn healing_a_dangling_supersession_leaves_no_unfinished_write_behind() {
+        // `set_superseded_by` raises `lifecycle_dirty` in the same statement as
+        // the change it describes, and every other caller clears it once the
+        // payload write is acknowledged. This path writes the payload *first*,
+        // so the two stores already agree by the time the row is written — and a
+        // marker left standing has the next sweep's `repair_lifecycle_drift`
+        // rewrite a payload that is already correct, on a base in agreement.
+        // That function returns a count precisely so that a repair firing on
+        // such a base is visible rather than hiding behind a correct end state.
+        let core = test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])],
+        )
+        .await;
+        core.supersede(&ids[0], &ids[1]).await.unwrap();
+        assert!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "supersede itself left the write marked as unfinished"
+        );
+
+        // Through `Core`, not the store: the heal hangs off this deletion.
+        core.delete_artifact(&ids[1]).await.unwrap();
+
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "the artifact still points at a keeper that is gone"
+        );
+        assert!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the healed artifact is still marked as an unfinished write"
+        );
+    }
 
     #[tokio::test]
     async fn a_capture_remembers_where_it_came_from() {

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -754,8 +754,20 @@ impl Core {
     /// the ones that can be freed should be. The state a failure leaves behind
     /// is the recoverable one, so the next deletion or sweep finishes the job.
     pub(crate) async fn heal_dangling_supersessions(&self) -> Result<()> {
+        // Under the lifecycle lock like every other transition: this path
+        // reveals payload-first, and interleaving with the sweep's repair —
+        // which reads rows and writes payloads — is exactly the sequence that
+        // hides an artifact with no marker left to find it by.
+        let _guard = self.lifecycle_lock.lock().await;
         let mut first_err = None;
         for id in self.store.dangling_superseded().await? {
+            // Marked before the payload write, as `unsupersede` does and for
+            // the same reason: this direction writes the payload first, so
+            // without it a crash between the two stores would leave drift no
+            // row write ever announced. A payload write that fails below
+            // leaves the marker standing — correctly: the failed reveal is
+            // then findable drift, and the heal retries on the next sweep.
+            self.store.mark_lifecycle_dirty(&id).await?;
             if let Err(e) = self
                 .vectors
                 .set_lifecycle(&id, ArtifactStatus::Active, None)

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -258,10 +258,19 @@ impl Core {
     /// job. Clearing the row first loses the only page that offers the undo
     /// while the artifact is still hidden from search.
     pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+        // Marked before either store is touched. This direction writes the
+        // payload first, so without it a crash between the two would leave
+        // drift no row write ever announced.
+        self.store.mark_lifecycle_dirty(artifact_id).await?;
         self.vectors
             .set_lifecycle(artifact_id, ArtifactStatus::Active, None)
             .await?;
         self.store.set_superseded_by(artifact_id, None).await?;
+        // Both stores agree now, so the marker the row write set has nothing
+        // left to describe. Cleared only here, never before the payload write.
+        self.store
+            .clear_lifecycle_dirty(std::slice::from_ref(&artifact_id.to_string()))
+            .await?;
         tracing::info!(artifact_id, "restored a superseded artifact to search");
         Ok(())
     }
@@ -292,6 +301,9 @@ impl Core {
             .await?;
         self.vectors
             .set_lifecycle(loser_id, ArtifactStatus::Superseded, Some(winner_id))
+            .await?;
+        self.store
+            .clear_lifecycle_dirty(std::slice::from_ref(&loser_id.to_string()))
             .await?;
         tracing::info!(loser_id, winner_id, "superseded an artifact");
         Ok(())
@@ -330,6 +342,9 @@ impl Core {
         self.vectors
             .set_lifecycle(id, ArtifactStatus::Deprecated, None)
             .await?;
+        self.store
+            .clear_lifecycle_dirty(std::slice::from_ref(&id.to_string()))
+            .await?;
         tracing::info!(artifact_id = id, "deprecated an artifact");
         Ok(())
     }
@@ -355,11 +370,16 @@ impl Core {
         if self.store.get_artifact(id).await?.superseded_by.is_some() {
             return self.unsupersede(id).await;
         }
+        // As in `unsupersede`: payload first, so the marker has to go first.
+        self.store.mark_lifecycle_dirty(id).await?;
         self.vectors
             .set_lifecycle(id, ArtifactStatus::Active, None)
             .await?;
         self.store
             .set_artifact_status(id, ArtifactStatus::Active)
+            .await?;
+        self.store
+            .clear_lifecycle_dirty(std::slice::from_ref(&id.to_string()))
             .await?;
         tracing::info!(artifact_id = id, "reactivated an artifact");
         Ok(())
@@ -446,6 +466,17 @@ impl Core {
             tracing::info!(done = n, total, "lifecycle backfill progress");
         }
         self.heal_store_drift().await?;
+        // The two-sided scan runs here and nowhere else. It is O(hidden
+        // artifacts), which autonomous merging makes grow without bound, so it
+        // stopped being something the sweep can afford on every tick — but a
+        // backfill is exactly the moment to catch drift with no SQLite write
+        // behind it: a payload edited out of band, or a base that predates
+        // `lifecycle_dirty` and therefore has interrupted writes nothing marked.
+        match crate::jobs::consolidate::full_lifecycle_reconcile(self).await {
+            Ok(0) => {}
+            Ok(fixed) => tracing::info!(fixed, "reconciled lifecycle drift the marker never saw"),
+            Err(e) => tracing::warn!(error = %e, "could not run the full lifecycle reconcile"),
+        }
         tracing::info!(n, "backfilled lifecycle fields into the vector store");
         Ok(n)
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -275,6 +275,41 @@ impl Core {
         Ok(())
     }
 
+    /// Move an already-hidden artifact from one winner to another.
+    ///
+    /// Not `supersede`, which refuses a side that is not active — and both sides
+    /// here are exactly that: the artifact is already superseded, and it is
+    /// being re-pointed precisely because its current winner is about to be
+    /// hidden too.
+    ///
+    /// A supersession chain is what this exists to prevent. `A -> B -> C` leaves
+    /// the reader who opens A at an artifact that is not in results either, and
+    /// nothing in the UI can follow the second hop. The sweep avoids chains by
+    /// grouping with union-find before it decides anything; the merge path
+    /// cannot, because the group it is collapsing was already partly collapsed
+    /// by an earlier merge.
+    ///
+    /// Row before payload, like `supersede`.
+    pub async fn repoint_supersession(&self, artifact_id: &str, winner_id: &str) -> Result<()> {
+        let winner = self.store.get_artifact(winner_id).await?;
+        if winner.status != ArtifactStatus::Active || winner.superseded_by.is_some() {
+            return Err(Error::Validation(format!(
+                "cannot re-point {artifact_id}: {winner_id} is not active"
+            )));
+        }
+        self.store
+            .set_superseded_by(artifact_id, Some(winner_id))
+            .await?;
+        self.vectors
+            .set_lifecycle(artifact_id, ArtifactStatus::Superseded, Some(winner_id))
+            .await?;
+        self.store
+            .clear_lifecycle_dirty(std::slice::from_ref(&artifact_id.to_string()))
+            .await?;
+        tracing::info!(artifact_id, winner_id, "re-pointed a supersession");
+        Ok(())
+    }
+
     /// Hide `loser_id` in favour of `winner_id`. Row before payload, matching
     /// the sweep's existing auto-supersede order (`jobs::consolidate`): the
     /// intermediate state after a partial failure is one an operator can act

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -545,9 +545,26 @@ impl Core {
                     }
                 }
                 for p in group {
+                    // A payload with no `provenance` key predates merging, and
+                    // nothing that predates merging is merged — so `captured` is
+                    // the right reading rather than a guess.
+                    let provenance = p
+                        .provenance
+                        .as_deref()
+                        .map(crate::store::artifacts::Provenance::parse)
+                        .unwrap_or(crate::store::artifacts::Provenance::Captured);
                     let restored = crate::store::artifacts::RestoredArtifact {
                         id: p.artifact_id.clone(),
-                        corpus_id: p.corpus_id.clone(),
+                        // A merged artifact carries "" here, which is not a
+                        // corpus that exists; writing it would fail the foreign
+                        // key. The kind above is what says which case this is.
+                        corpus_id: match provenance {
+                            crate::store::artifacts::Provenance::Merged => None,
+                            crate::store::artifacts::Provenance::Captured => {
+                                Some(p.corpus_id.clone())
+                            }
+                        },
+                        provenance,
                         text: p.text.clone(),
                         title: p.title.clone(),
                         category: p.category.clone(),
@@ -1185,6 +1202,7 @@ mod tests {
                     status: None,
                     last_verified_at: None,
                     superseded_by: None,
+                    provenance: None,
                 },
             }])
             .await
@@ -1289,6 +1307,7 @@ mod tests {
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                provenance: None,
             },
         }
     }
@@ -1391,7 +1410,7 @@ mod tests {
         );
         let back = core.store.get_artifact("gone").await.unwrap();
         assert_eq!(back.text, "t");
-        assert_eq!(back.corpus_id, corpus);
+        assert_eq!(back.corpus_id.as_deref(), Some(corpus.as_str()));
         assert_eq!(
             back.embed_state,
             EmbedState::Pending,

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -258,6 +258,13 @@ impl Core {
     /// job. Clearing the row first loses the only page that offers the undo
     /// while the artifact is still hidden from search.
     pub async fn unsupersede(&self, artifact_id: &str) -> Result<()> {
+        let _guard = self.lifecycle_lock.lock().await;
+        self.unsupersede_locked(artifact_id).await
+    }
+
+    /// The body of `unsupersede`, entered with `lifecycle_lock` already held —
+    /// `reactivate` routes here so a superseded artifact is not locked twice.
+    async fn unsupersede_locked(&self, artifact_id: &str) -> Result<()> {
         // Read before clearing: afterwards nothing says who was hiding it.
         let winner = self.store.get_artifact(artifact_id).await?.superseded_by;
         // Marked before either store is touched. This direction writes the
@@ -302,6 +309,7 @@ impl Core {
     ///
     /// Row before payload, like `supersede`.
     pub async fn repoint_supersession(&self, artifact_id: &str, winner_id: &str) -> Result<()> {
+        let _guard = self.lifecycle_lock.lock().await;
         let winner = self.store.get_artifact(winner_id).await?;
         if winner.status != ArtifactStatus::Active || winner.superseded_by.is_some() {
             return Err(Error::Validation(format!(
@@ -327,6 +335,7 @@ impl Core {
     /// on, since the artifact is already listed on Ops with its `superseded_by`
     /// set, even if the search-side flag has not caught up yet.
     pub async fn supersede(&self, loser_id: &str, winner_id: &str) -> Result<()> {
+        let _guard = self.lifecycle_lock.lock().await;
         // Neither side may be retired. `set_superseded_by` writes
         // `status = 'superseded'` unconditionally, so superseding an artifact
         // an operator deprecated would silently overwrite that decision with
@@ -366,6 +375,7 @@ impl Core {
     /// payload first would instead hide the artifact behind a row that still
     /// says active, and the repair, reading the row, would undo it.
     pub async fn deprecate(&self, id: &str) -> Result<()> {
+        let _guard = self.lifecycle_lock.lock().await;
         // A superseded artifact is already out of search, and `deprecate` does
         // not clear `superseded_by`, so this would leave a row that is both:
         // listed on Ops under "deprecated" *and* under "hidden as near
@@ -413,8 +423,9 @@ impl Core {
     /// in results immediately, still listed on Ops as deprecated, and one more
     /// press finishes the job.
     pub async fn reactivate(&self, id: &str) -> Result<()> {
+        let _guard = self.lifecycle_lock.lock().await;
         if self.store.get_artifact(id).await?.superseded_by.is_some() {
-            return self.unsupersede(id).await;
+            return self.unsupersede_locked(id).await;
         }
         // As in `unsupersede`: payload first, so the marker has to go first.
         self.store.mark_lifecycle_dirty(id).await?;

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -657,6 +657,26 @@ impl Core {
                     };
                     if self.store.restore_artifact(&restored).await? {
                         out.rows_restored += 1;
+                        // A payload records neither `source_count` nor lineage
+                        // rows, so a restored merge definitionally cannot
+                        // support its provenance claim — and
+                        // `merged_missing_a_source` (0 > 0) will never say so.
+                        // Said here instead, with the flag that pass would
+                        // have set. `roots_of` already refuses to hand such a
+                        // merge back as its own root; this is the half an
+                        // operator sees.
+                        if provenance == crate::store::artifacts::Provenance::Merged {
+                            self.store
+                                .set_artifact_flags(
+                                    &p.artifact_id,
+                                    &["orphaned_source".to_string()],
+                                    Some(
+                                        "restored from the index; the record of its \
+                                         sources was lost",
+                                    ),
+                                )
+                                .await?;
+                        }
                         self.store
                             .enqueue(Stage::Embed, "artifact", &p.artifact_id)
                             .await?;
@@ -1553,6 +1573,27 @@ mod tests {
             EmbedState::Pending,
             "a restored row must be re-embedded: the stored vector may be from \
              another model, and nothing else would ever check"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_restored_from_the_index_is_flagged_as_orphaned() {
+        // `restore_artifact` cannot recreate lineage rows and leaves
+        // `source_count` at 0, so `merged_missing_a_source` (0 > 0) never
+        // fires and nothing ever flagged the restored merge — it stood as a
+        // merge with no record of its sources, silently.
+        let core = test_core().await;
+        let mut p = point("lost-merge", "");
+        p.payload.provenance = Some("merged".into());
+        core.vectors.upsert(vec![p]).await.unwrap();
+
+        let drift = core.heal_store_drift().await.unwrap();
+
+        assert_eq!(drift.rows_restored, 1, "{drift:?}");
+        let back = core.store.get_artifact("lost-merge").await.unwrap();
+        assert!(
+            back.flags.iter().any(|f| f == "orphaned_source"),
+            "a restored merge must say it cannot support its provenance claim"
         );
     }
 

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -311,7 +311,7 @@ impl Core {
     pub async fn repoint_supersession(&self, artifact_id: &str, winner_id: &str) -> Result<()> {
         let _guard = self.lifecycle_lock.lock().await;
         let winner = self.store.get_artifact(winner_id).await?;
-        if winner.status != ArtifactStatus::Active || winner.superseded_by.is_some() {
+        if !winner.in_results() {
             return Err(Error::Validation(format!(
                 "cannot re-point {artifact_id}: {winner_id} is not active"
             )));

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -753,10 +753,11 @@ impl Core {
                     "consolidate is a collection-wide sweep, not a per-corpus stage".into(),
                 ));
             }
-            // Units the queue arms for itself, one per inference call. An
-            // operator reprocesses a document, not one of its windows: asking
-            // for `synthesize` re-windows the whole thing and arms them all.
-            Stage::SegmentWindow | Stage::Title | Stage::Judge => {
+            // Units the queue arms for itself, one per artifact or inference
+            // call. An operator reprocesses a document, not one of its windows:
+            // asking for `synthesize` re-windows the whole thing and arms them
+            // all, and `embed` re-arms a `relate` unit per artifact behind it.
+            Stage::SegmentWindow | Stage::Title | Stage::Judge | Stage::Relate => {
                 return Err(Error::Validation(
                     "that stage is a single inference call the queue arms itself; \
                      reprocess the document instead"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -93,6 +93,14 @@ pub struct Core {
     /// One lock per document, so the local writes that rearrange a document
     /// cannot interleave with each other. Reach for it through `corpus_lock`.
     pub corpus_locks: CorpusLocks,
+    /// Serializes every lifecycle transition against the sweep's marker
+    /// repair. Each transition is two writes to two stores plus a dirty
+    /// marker, none of it atomic; without mutual exclusion the repair can
+    /// read a stale row mid-reveal, write the old state back over the new
+    /// payload, and the reveal then clears the marker — row active, payload
+    /// hidden, and nothing left that would ever notice. Shared by every
+    /// clone, like the background queue.
+    pub lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Core {
@@ -138,6 +146,7 @@ impl Core {
                 ),
             ),
             corpus_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -239,6 +248,7 @@ pub mod test_support {
                 std::time::Duration::ZERO,
             )),
             corpus_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -260,7 +260,7 @@ mod tests {
             "superseding at or below the review threshold would hide distinct artifacts"
         );
         assert!(
-            !cfg.consolidate.judge,
+            !cfg.consolidate.autonomous,
             "the only inference-costing stage must be opt-in"
         );
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -259,12 +259,23 @@ mod tests {
             cfg.consolidate.auto_supersede > cfg.consolidate.review_min,
             "superseding at or below the review threshold would hide distinct artifacts"
         );
-        // Asking is on by default; *acting* on the answer is not. The dedupe
-        // pass records its verdicts either way, so an operator can read what it
-        // would have done before granting it the authority to do it.
+        // Autonomy is on: a shipped instance consolidates its own knowledge base
+        // without being asked. That is a deliberate choice and the largest risk
+        // in the design, and what bounds it is not this flag — it is that a
+        // value conflict is escalated rather than settled, that a merge which
+        // would drop a value is refused, that the originals are superseded
+        // rather than deleted, and that every merge has an undo.
+        //
+        // What stays bounded here is the *spend*. A rate rather than a
+        // per-sweep count, so it does not grow with the base.
+        assert!(cfg.consolidate.autonomous);
         assert!(
-            !cfg.consolidate.autonomous,
-            "acting on a verdict without being asked to must be opt-in"
+            cfg.consolidate.max_dedupe_per_tick > 0 && cfg.consolidate.dedupe_interval_mins > 0,
+            "the pass must have a rate, or it either never runs or is unbounded"
+        );
+        assert!(
+            cfg.consolidate.merge_max_roots >= 2,
+            "a merge needs at least two sources to be a merge"
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -259,9 +259,12 @@ mod tests {
             cfg.consolidate.auto_supersede > cfg.consolidate.review_min,
             "superseding at or below the review threshold would hide distinct artifacts"
         );
+        // Asking is on by default; *acting* on the answer is not. The dedupe
+        // pass records its verdicts either way, so an operator can read what it
+        // would have done before granting it the authority to do it.
         assert!(
             !cfg.consolidate.autonomous,
-            "the only inference-costing stage must be opt-in"
+            "acting on a verdict without being asked to must be opt-in"
         );
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -988,6 +988,7 @@ mod tests {
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                provenance: None,
             },
             score,
             similarity: Some(score),

--- a/src/eval/export.rs
+++ b/src/eval/export.rs
@@ -21,7 +21,10 @@ pub async fn export(store: &Store, dir: &Path) -> Result<(usize, usize)> {
         .iter()
         .map(|c| FrozenArtifact {
             id: c.id.clone(),
-            source: c.corpus_id.clone(),
+            // Empty for a merged artifact, which has no single source document.
+            // The frozen set records what an artifact *is*, and a merge's
+            // sources are its lineage rather than a corpus id.
+            source: c.corpus_id.clone().unwrap_or_default(),
             text: c.text.clone(),
             title: c.title.clone(),
             category: c.category.clone(),
@@ -143,7 +146,12 @@ mod tests {
             frozen[0].id, artifact_id,
             "ids must stay the production ones, or a re-export invalidates every pair"
         );
-        let corpus = store.get_artifact(&artifact_id).await.unwrap().corpus_id;
+        let corpus = store
+            .get_artifact(&artifact_id)
+            .await
+            .unwrap()
+            .corpus_id
+            .expect("a captured artifact names its corpus");
         assert_eq!(
             frozen[0].source, corpus,
             "the cap groups by this, so it has to name a corpus uniquely"

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -105,6 +105,33 @@ pub fn may_disagree(a: &str, b: &str) -> bool {
     !fa.is_empty() && !fb.is_empty() && fa != fb
 }
 
+/// Values that not all of these texts state.
+///
+/// This is what `may_disagree` became once deduplication replaced contradiction
+/// hunting. As a gate the predicate was backwards: it admitted a pair only when
+/// values *differed*, which discards exactly the pairs that are cleanest to
+/// merge — two artifacts saying the same thing in different words have nothing
+/// to contradict and everything to combine.
+///
+/// As a list it is useful in both directions. Handed to the model it names what
+/// to look at without deciding anything, because it cannot tell a real
+/// disagreement from the same subject described at two levels of detail. Handed
+/// to the merge verification it becomes a hard rule: whatever appears here has
+/// to survive into the merged text, or the merge dropped a value and is refused.
+///
+/// Sorted, because it goes into a prompt: the endpoint caches by exact prompt
+/// text, and a set iterating in a different order would defeat that for no gain.
+pub fn differing_values(texts: &[&str]) -> Vec<String> {
+    let sets: Vec<BTreeSet<String>> = texts.iter().map(|t| fact_tokens(t)).collect();
+    let mut all: BTreeSet<String> = BTreeSet::new();
+    for s in &sets {
+        all.extend(s.iter().cloned());
+    }
+    all.into_iter()
+        .filter(|tok| !sets.iter().all(|s| s.contains(tok)))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -194,6 +221,41 @@ mod tests {
         let f = fact_tokens("Listens on 8080/tcp, tagged 2.0-rc1.");
         assert!(f.contains("8080/tcp"), "{f:?}");
         assert!(f.contains("2.0-rc1"), "{f:?}");
+    }
+
+    #[test]
+    fn differing_values_names_only_what_is_not_shared() {
+        // The prompt prior. A value every artifact states is not something to
+        // ask about; a value only some of them state is.
+        assert_eq!(
+            differing_values(&[
+                "The timeout is 30s on port 8080.",
+                "The timeout is 90s on port 8080."
+            ]),
+            vec!["30s".to_string(), "90s".to_string()],
+            "the shared port should not be named"
+        );
+    }
+
+    #[test]
+    fn texts_agreeing_on_every_value_differ_in_none() {
+        // And this is the case the old gate discarded: nothing to disagree
+        // about, everything to merge.
+        assert!(
+            differing_values(&["Needs v1.21.4 to build.", "To build it you need 1.21.4."])
+                .is_empty()
+        );
+        assert!(differing_values(&["Prose only.", "Different prose."]).is_empty());
+    }
+
+    #[test]
+    fn a_value_only_one_artifact_states_is_a_differing_value() {
+        // It is exactly what a merge must carry over, so verification has to
+        // see it even though nothing contradicts it.
+        assert_eq!(
+            differing_values(&["Mount it first.", "Mount it first. Wait 30s."]),
+            vec!["30s".to_string()]
+        );
     }
 
     #[test]

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -1,16 +1,17 @@
-//! Could these two artifacts actually disagree?
+//! Which values do these artifacts not state the same way?
 //!
-//! The similarity sweep says two artifacts cover the same ground. That is not
-//! the interesting question — the interesting one is whether they state some
-//! detail differently, because a wrong artifact ranks exactly as well as a
-//! right one and nothing else in the system notices. Answering it properly
-//! needs a model, and a model call is minutes on the hardware this is built
-//! for, so this narrows the candidate set first at the cost of a scan.
+//! A wrong artifact ranks exactly as well as a right one and nothing else in
+//! the system notices, so the values two artifacts give for the same thing are
+//! worth singling out. This finds them without a model.
 //!
-//! The rule is deliberately conservative in one direction only: it must never
-//! discard a pair that might disagree, and it is free to pass through pairs
-//! that turn out not to. A pair it passes costs one call; a pair it wrongly
-//! drops costs a stale artifact nobody ever finds.
+//! It used to answer a yes/no question — "could these two disagree?" — and gate
+//! the model on it. That gate was removed on 2026-08-14: it admitted a pair only
+//! when values *differed*, which is right for hunting contradictions and exactly
+//! backwards for deduplication, where two artifacts saying the same thing in
+//! different words are the cleanest thing there is to merge. What survives is
+//! the list, which decides nothing: it is a prior for the prompt, and the rule
+//! the merge verification enforces — whatever appears in it must survive into
+//! the merged text, or a value was dropped.
 
 use std::collections::BTreeSet;
 
@@ -80,31 +81,6 @@ pub fn fact_tokens(text: &str) -> BTreeSet<String> {
         .collect()
 }
 
-/// Whether a pair is worth a model call.
-///
-/// Both artifacts must state some value, and their values must not be
-/// identical. That is all this can safely require. An earlier version also
-/// demanded a shared value, on the theory that it showed the two were talking
-/// about the same measurable thing — but that is exactly backwards for the case
-/// this exists to catch: one artifact says `1.21.4` and the other says
-/// `1.30.0`, and they share nothing at all.
-///
-/// So a pair stating unrelated values does get through and costs one call. That
-/// is the cheap direction of the error, and it is the one to be wrong in.
-///
-/// What this deliberately does *not* decide is whether the two are about the
-/// same subject. That used to be assumed settled by the similarity that put
-/// them in a pair, and it is not: in a reference document the entries for
-/// FAT12, FAT16 and FAT32 are near-identical in form and deliberately different
-/// in content, so they score 0.91 and every number in them differs. Similarity
-/// measures shape. The judge is the only thing here that can read a subject,
-/// which is why it is given both titles and told that different named things
-/// are not in conflict.
-pub fn may_disagree(a: &str, b: &str) -> bool {
-    let (fa, fb) = (fact_tokens(a), fact_tokens(b));
-    !fa.is_empty() && !fb.is_empty() && fa != fb
-}
-
 /// Values that not all of these texts state.
 ///
 /// This is what `may_disagree` became once deduplication replaced contradiction
@@ -151,58 +127,24 @@ mod tests {
     }
 
     #[test]
-    fn two_artifacts_giving_a_different_version_may_disagree() {
-        assert!(may_disagree(
-            "engram requires Rust 1.21.4 to build.",
-            "engram requires Rust 1.30.0 to build.",
-        ));
-    }
-
-    #[test]
-    fn the_same_fact_stated_twice_does_not_disagree() {
-        assert!(!may_disagree(
-            "engram requires Rust 1.21.4 to build.",
-            "To build engram you need Rust 1.21.4.",
-        ));
-    }
-
-    #[test]
-    fn a_pair_where_only_one_side_states_a_value_is_not_judged() {
-        // Nothing to compare, so nothing a model could rule on.
-        assert!(!may_disagree(
-            "The mount command attaches a filesystem.",
-            "Version 9.9.9 of the pastry compiler ships on 2030-01-01.",
-        ));
-    }
-
-    #[test]
-    fn unrelated_values_do_get_through_and_that_is_deliberate() {
-        // The filter is allowed to pass a pair that turns out to be fine — that
-        // costs one call. It is not allowed to drop one that disagrees, which
-        // would cost a stale artifact nobody ever finds.
-        assert!(may_disagree(
-            "The timeout is 30 seconds.",
-            "It listens on 8080."
-        ));
-    }
-
-    #[test]
-    fn one_artifact_with_no_facts_never_disagrees() {
-        assert!(!may_disagree("Prose only.", "Requires 1.2.3."));
-    }
-
-    #[test]
     fn versions_carrying_a_v_are_facts_and_equal_the_bare_form() {
         let f = fact_tokens("Needs v1.21.4 of the toolchain.");
         assert!(f.contains("1.21.4"), "{f:?}");
-        assert!(!may_disagree(
-            "Needs v1.21.4 of the toolchain.",
-            "Needs 1.21.4 of the toolchain.",
-        ));
-        assert!(may_disagree(
-            "Needs v1.21.4 of the toolchain.",
-            "Needs v1.30.0 of the toolchain.",
-        ));
+        assert!(
+            differing_values(&[
+                "Needs v1.21.4 of the toolchain.",
+                "Needs 1.21.4 of the toolchain.",
+            ])
+            .is_empty(),
+            "the v prefix made one value look like two"
+        );
+        assert_eq!(
+            differing_values(&[
+                "Needs v1.21.4 of the toolchain.",
+                "Needs v1.30.0 of the toolchain.",
+            ]),
+            vec!["1.21.4".to_string(), "1.30.0".to_string()]
+        );
     }
 
     #[test]
@@ -213,7 +155,10 @@ mod tests {
         let f = fact_tokens("The timeout is 30s and the batch is 512MB.");
         assert!(f.contains("30s"), "{f:?}");
         assert!(f.contains("512mb"), "{f:?}");
-        assert!(may_disagree("Wait 30s.", "Wait 90s."));
+        assert_eq!(
+            differing_values(&["Wait 30s.", "Wait 90s."]),
+            vec!["30s".to_string(), "90s".to_string()]
+        );
     }
 
     #[test]

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -875,7 +875,11 @@ mod tests {
                 r#"{{"relation":"replaced","supersedes":"{letter}","detail":"stale"}}"#
             ))
             .unwrap();
-            assert_eq!(d.relation, Relation::Replaced, "{letter} was not a direction");
+            assert_eq!(
+                d.relation,
+                Relation::Replaced,
+                "{letter} was not a direction"
+            );
             assert_eq!(d.supersedes, Some(want));
         }
     }

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -121,7 +121,7 @@ pub fn title_prompt(text: &str, artifact_titles: &[String]) -> String {
     )
 }
 
-pub const JUDGE_SYSTEM: &str = r#"You compare two knowledge artifacts and answer one question: do they state some specific detail differently?
+pub const DEDUPE_SYSTEM: &str = r#"You compare two knowledge artifacts and answer one question: do they state some specific detail differently?
 
 First decide whether the two are about the same subject. Their titles say what each one is about, and the body may never repeat it — an artifact titled "FAT32 Specifications" can open with "32 Bit Clusternummern" and never name FAT32 again.
 
@@ -161,7 +161,7 @@ Reply with JSON only, no commentary, in exactly this shape:
 /// Zero adds nothing at all, so a first ask stays byte-identical to what it has
 /// always been — and keeps hitting the cache when it should, on a pair the sweep
 /// re-arms after a settled verdict was lost.
-pub fn judge_prompt(a: (&str, &str), b: (&str, &str), attempt: i64) -> String {
+pub fn dedupe_prompt(a: (&str, &str), b: (&str, &str), attempt: i64) -> String {
     let retry = if attempt > 0 {
         format!("(attempt {})\n", attempt + 1)
     } else {
@@ -512,7 +512,7 @@ mod tests {
         // Given the bodies alone, the model saw two anonymous spec lists with
         // different numbers and called them a contradiction — which was the
         // only honest answer to the question it was actually asked.
-        let p = judge_prompt(
+        let p = dedupe_prompt(
             ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
             ("FAT32 Specifications", "32 Bit Clusternummern."),
             0,
@@ -532,10 +532,10 @@ mod tests {
             ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
             ("FAT32 Specifications", "32 Bit Clusternummern."),
         );
-        let first = judge_prompt(pair.0, pair.1, 0);
-        let second = judge_prompt(pair.0, pair.1, 1);
+        let first = dedupe_prompt(pair.0, pair.1, 0);
+        let second = dedupe_prompt(pair.0, pair.1, 1);
         assert_ne!(first, second);
-        assert_ne!(second, judge_prompt(pair.0, pair.1, 2));
+        assert_ne!(second, dedupe_prompt(pair.0, pair.1, 2));
         // A first ask stays exactly what it was, so the cache still earns its
         // keep on a pair the sweep re-arms after a verdict was lost.
         assert!(first.starts_with("----- ARTIFACT A -----"), "{first}");
@@ -547,8 +547,8 @@ mod tests {
         // deliberately different in content, so similarity puts them in a pair
         // and every number in them differs. Without this rule the feature fires
         // hardest exactly where it is most wrong.
-        assert!(JUDGE_SYSTEM.contains("same subject"));
-        assert!(JUDGE_SYSTEM.contains("Answer false and stop."));
+        assert!(DEDUPE_SYSTEM.contains("same subject"));
+        assert!(DEDUPE_SYSTEM.contains("Answer false and stop."));
     }
 
     #[test]

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -310,15 +310,24 @@ pub fn parse_dedupe(body: &str) -> Result<Dedupe> {
         Error::MalformedLlmOutput(format!("dedupe reply was not the expected JSON: {e}"))
     })?;
 
-    // Anything else the model wrote there — a stray word, a whole sentence — is
+    // Any single letter, because `dedupe_prompt` letters as many artifacts as
+    // the component has and the fan-in cap — not this parser — is what bounds
+    // that. Stopping at "d" silently downgraded every direction named in a group
+    // of five or more to a conflict, which turned the cheapest and most faithful
+    // outcome, superseding one stored original by another, into a queue entry
+    // for a person.
+    //
+    // How far the letters actually run is the caller's to know: it resolves this
+    // against the list it showed, and a letter past the end downgrades there.
+    // Anything else the model wrote — a stray word, a whole sentence — is
     // treated the same as omitting it. An unreadable direction must not fail an
     // otherwise perfectly readable verdict.
-    let side = r.supersedes.as_deref().and_then(|s| match s.trim() {
-        "a" | "A" => Some('a'),
-        "b" | "B" => Some('b'),
-        "c" | "C" => Some('c'),
-        "d" | "D" => Some('d'),
-        _ => None,
+    let side = r.supersedes.as_deref().and_then(|s| {
+        let mut chars = s.trim().chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) if c.is_ascii_alphabetic() => Some(c.to_ascii_lowercase()),
+            _ => None,
+        }
     });
 
     let relation = match r.relation.trim().to_ascii_lowercase().as_str() {
@@ -852,6 +861,23 @@ mod tests {
         .unwrap();
         assert_eq!(d.relation, Relation::Replaced);
         assert_eq!(d.supersedes, Some('b'));
+    }
+
+    #[test]
+    fn a_direction_reaches_as_far_as_the_letters_the_prompt_hands_out() {
+        // `dedupe_prompt` letters one artifact per component member, and the
+        // fan-in cap defaults to eight — so H is a letter the model is routinely
+        // invited to answer with. A parser that stopped at D turned every one of
+        // those into a conflict, which spends a person on a group the model had
+        // already resolved the cheap way.
+        for (letter, want) in [("E", 'e'), ("f", 'f'), ("H", 'h')] {
+            let d = parse_dedupe(&format!(
+                r#"{{"relation":"replaced","supersedes":"{letter}","detail":"stale"}}"#
+            ))
+            .unwrap();
+            assert_eq!(d.relation, Relation::Replaced, "{letter} was not a direction");
+            assert_eq!(d.supersedes, Some(want));
+        }
     }
 
     #[test]

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -121,30 +121,81 @@ pub fn title_prompt(text: &str, artifact_titles: &[String]) -> String {
     )
 }
 
-pub const DEDUPE_SYSTEM: &str = r#"You compare two knowledge artifacts and answer one question: do they state some specific detail differently?
+/// What the dedupe pass decided about a group of near-duplicate artifacts.
+///
+/// Four outcomes, and the ordering between them is the design. `Replaced` is
+/// preferred over `Duplicate` wherever it applies: the survivor is then a stored
+/// original with a valid span and corpus lines to render beside it, which is
+/// strictly better than a rewrite. A merge is the answer only when *both* sides
+/// carry something the other lacks — the case where neither original is
+/// sufficient and the pre-merge state was already losing something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Relation {
+    /// Different subjects. Both stay exactly where they are.
+    Distinct,
+    /// The same subject with a different value for one detail, and no way to
+    /// tell which is current. Escalated to a person; never merged.
+    Conflict,
+    /// One artifact plainly replaces another. Superseded, with no synthetic
+    /// text written at all.
+    Replaced,
+    /// The same claim, each side carrying detail the other lacks. Merged.
+    Duplicate,
+}
 
-First decide whether the two are about the same subject. Their titles say what each one is about, and the body may never repeat it — an artifact titled "FAT32 Specifications" can open with "32 Bit Clusternummern" and never name FAT32 again.
+/// The artifact a `Duplicate` verdict asks to be written.
+#[derive(Debug, Clone)]
+pub struct MergedDraft {
+    pub title: Option<String>,
+    pub text: String,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub caveats: Vec<String>,
+}
 
-If the titles name different things — two versions, two variants, two products, two filesystems, two commands — then the artifacts are not in conflict no matter how far apart their numbers are. Different things have different numbers; that is what makes them different things. Answer false and stop.
+/// One dedupe verdict, parsed.
+#[derive(Debug, Clone)]
+pub struct Dedupe {
+    pub relation: Relation,
+    pub detail: Option<String>,
+    /// Which artifact was named obsolete, as the letter it was shown under.
+    /// Only meaningful for `Replaced`.
+    pub supersedes: Option<char>,
+    /// `Some` if and only if `relation` is `Duplicate`.
+    pub merged: Option<MergedDraft>,
+}
 
-Only when both describe the same subject: a contradiction is a concrete disagreement about it — a different version, number, date, path, flag, default, or step order for that one subject.
+pub const DEDUPE_SYSTEM: &str = r#"You compare knowledge artifacts that may be about the same thing, and decide what should happen to them.
 
-These are NOT contradictions:
+First decide whether they are about the same subject. Their titles say what each one is about, and the body may never repeat it — an artifact titled "FAT32 Specifications" can open with "32 Bit Clusternummern" and never name FAT32 again.
+
+If the titles name different things — two versions, two variants, two products, two filesystems, two commands — then they are neither duplicates nor in conflict, no matter how far apart their numbers are. Different things have different numbers; that is what makes them different things. Answer "distinct" and stop.
+
+Only when they describe the same subject, choose one of:
+
+- "replaced" — one artifact plainly supersedes another: a deprecated flag, step or default versus its current replacement. Prefer this whenever it applies. It keeps the surviving artifact's original wording, which is always better than rewriting.
+- "duplicate" — they make the same claim, and each carries some detail the others lack. Write one artifact that says everything all of them said.
+- "conflict" — they give a different value for the same detail of the same subject, and you cannot tell which is current. Do not choose a side and do not merge; a person decides this one.
+- "distinct" — different subjects, or one covers something the others simply do not.
+
+These are NOT conflicts:
 - The same fact in different words.
 - Different levels of detail about the same thing.
-- Two different subjects that happen to use similar language, or the same layout.
-- One artifact mentioning something the other simply does not cover.
-- Two values that both appear in the same artifact.
+- One artifact mentioning something the others do not cover.
+
+When you answer "duplicate", the merged text must contain every number, version, date, path, flag, command and error string that appeared in any input, and must read as one self-contained artifact rather than a list of sources. If you cannot write one that keeps all of them, the answer is "conflict", not "duplicate".
 
 Reply with JSON only, no commentary, in exactly this shape:
 
-{"contradicts": true, "detail": "...", "obsolete": "a"}
+{"relation": "duplicate", "detail": "...", "supersedes": "a", "merged": {"title": "...", "text": "...", "category": "...", "tags": [], "caveats": []}}
 
-- contradicts: true only for a concrete disagreement about one subject, as above.
-- detail: when true, one short sentence naming the two conflicting values and which artifact holds each. Omit it when false.
-- obsolete: "a" or "b" — only when you are confident one artifact plainly replaces the other (a deprecated flag, step, or default versus its current replacement), not merely that they differ. Omit this field whenever the direction is unclear, the two describe genuinely different but still-valid options, or you are not sure."#;
+- relation: one of "duplicate", "replaced", "conflict", "distinct".
+- detail: one short sentence saying why. Always.
+- supersedes: the letter of the artifact that is obsolete. Only with "replaced"; omit it otherwise.
+- merged: only with "duplicate"; omit it entirely otherwise. `text` must stand on its own without its sources. `caveats` are the conditions under which it does not apply."#;
 
-/// The two artifacts, each under its title.
+/// The artifacts, each under a letter and its title.
 ///
 /// The title is not decoration here, it is the subject. Synthesis writes a body
 /// that stands on its own within its segment, which is not the same as naming
@@ -152,25 +203,49 @@ Reply with JSON only, no commentary, in exactly this shape:
 /// opens "32 Bit Clusternummern" and never says FAT32 again. Handed the bodies
 /// alone, the model saw two anonymous spec lists with different numbers and
 /// called them a contradiction — correctly, on the evidence it was given.
-/// `attempt` is how many times this pair has already been asked about, and it is
-/// in the prompt for one reason: the endpoint caches by exact prompt text and
+///
+/// `differing_values` is what `facts::fact_tokens` found stated differently
+/// across the artifacts. It is a prior, not a verdict: it cannot tell a real
+/// disagreement from the same subject described at two levels of detail, which
+/// is the whole reason a model is asked. It used to be an admission gate, and
+/// as a gate it was backwards — a pair stating no differing value is the
+/// cleanest thing there is to merge, and gating on difference hid exactly those.
+///
+/// `attempt` is how many times this group has already been asked about, and it
+/// is in the prompt for one reason: the endpoint caches by exact prompt text and
 /// replays a cached reply in milliseconds. A retry of a reply the parser could
 /// not read would otherwise re-read the same unreadable bytes, five times, and
 /// call it five attempts.
 ///
-/// Zero adds nothing at all, so a first ask stays byte-identical to what it has
-/// always been — and keeps hitting the cache when it should, on a pair the sweep
-/// re-arms after a settled verdict was lost.
-pub fn dedupe_prompt(a: (&str, &str), b: (&str, &str), attempt: i64) -> String {
-    let retry = if attempt > 0 {
-        format!("(attempt {})\n", attempt + 1)
-    } else {
-        String::new()
-    };
-    format!(
-        "{retry}----- ARTIFACT A -----\nTitle: {}\n\n{}\n----- ARTIFACT B -----\nTitle: {}\n\n{}\n----- END -----",
-        a.0, a.1, b.0, b.1
-    )
+/// Zero adds nothing at all, so a first ask stays byte-identical between runs —
+/// and keeps hitting the cache when it should, on a group re-armed after a
+/// settled verdict was lost.
+pub fn dedupe_prompt(
+    members: &[(&str, &str)],
+    differing_values: &[String],
+    attempt: i64,
+) -> String {
+    let mut s = String::new();
+    if attempt > 0 {
+        s.push_str(&format!("(attempt {})\n", attempt + 1));
+    }
+    for (i, (title, text)) in members.iter().enumerate() {
+        let letter = (b'a' + i as u8) as char;
+        s.push_str(&format!(
+            "----- ARTIFACT {} -----\nTitle: {title}\n\n{text}\n",
+            letter.to_ascii_uppercase()
+        ));
+    }
+    s.push_str("----- END -----");
+    if !differing_values.is_empty() {
+        s.push_str(&format!(
+            "\n\nThese values are not stated the same way by all of them: {}. \
+             That may be a real disagreement, or the same subject described at \
+             different levels of detail. Decide which.",
+            differing_values.join(", ")
+        ));
+    }
+    s
 }
 
 pub const ASK_SYSTEM: &str = "You answer questions using only the provided knowledge-base excerpts. \
@@ -201,40 +276,108 @@ pub fn ask_prompt(question: &str, excerpts: &[String]) -> String {
     )
 }
 
-#[derive(serde::Deserialize)]
-struct Judgement {
-    contradicts: bool,
-    #[serde(default)]
-    detail: Option<String>,
-    #[serde(default)]
-    obsolete: Option<String>,
-}
-
 /// A reply that cannot be read is an error, not a verdict.
 ///
-/// Defaulting to "contradicts" would fill the review queue with noise an
-/// operator has to clear by hand; defaulting to "no" would quietly close real
-/// conflicts. Failing leaves the pair pending, and the next sweep asks again.
-///
-/// The third element is which side the judge named obsolete — `'a'` or
-/// `'b'` — when it named one with confidence. Anything else the model wrote
-/// there (a stray word, a full sentence) is treated the same as omitting it:
-/// an unreadable direction must not fail the whole reply, since the
-/// contradiction verdict itself may still be perfectly readable.
-pub fn parse_judgement(body: &str) -> Result<(bool, Option<String>, Option<char>)> {
-    let j: Judgement = serde_json::from_str(extract_json(body)).map_err(|e| {
-        Error::MalformedLlmOutput(format!("judge reply was not the expected JSON: {e}"))
+/// Defaulting to "conflict" would fill the escalation queue with noise a person
+/// has to clear by hand; defaulting to "distinct" would quietly close real
+/// duplicates. Failing leaves the group pending, and the unit retries under the
+/// queue's backoff with a prompt that differs by its attempt number.
+pub fn parse_dedupe(body: &str) -> Result<Dedupe> {
+    #[derive(serde::Deserialize)]
+    struct Raw {
+        relation: String,
+        #[serde(default)]
+        detail: Option<String>,
+        #[serde(default)]
+        supersedes: Option<String>,
+        #[serde(default)]
+        merged: Option<RawMerged>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawMerged {
+        text: String,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        category: Option<String>,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        caveats: Vec<String>,
+    }
+
+    let r: Raw = serde_json::from_str(extract_json(body)).map_err(|e| {
+        Error::MalformedLlmOutput(format!("dedupe reply was not the expected JSON: {e}"))
     })?;
-    let detail = j
-        .detail
-        .map(|d| d.trim().to_string())
-        .filter(|d| !d.is_empty() && j.contradicts);
-    let obsolete = j.obsolete.as_deref().and_then(|o| match o.trim() {
+
+    // Anything else the model wrote there — a stray word, a whole sentence — is
+    // treated the same as omitting it. An unreadable direction must not fail an
+    // otherwise perfectly readable verdict.
+    let side = r.supersedes.as_deref().and_then(|s| match s.trim() {
         "a" | "A" => Some('a'),
         "b" | "B" => Some('b'),
+        "c" | "C" => Some('c'),
+        "d" | "D" => Some('d'),
         _ => None,
     });
-    Ok((j.contradicts, detail, obsolete))
+
+    let relation = match r.relation.trim().to_ascii_lowercase().as_str() {
+        "duplicate" => Relation::Duplicate,
+        // A direction the model would not name is not a direction. Falling back
+        // to a conflict is what stops this picking a side by accident, which on
+        // a supersede means hiding an artifact for no stated reason.
+        "replaced" if side.is_some() => Relation::Replaced,
+        "replaced" | "conflict" => Relation::Conflict,
+        "distinct" => Relation::Distinct,
+        other => {
+            return Err(Error::MalformedLlmOutput(format!(
+                "dedupe reply named an unknown relation {other:?}"
+            )));
+        }
+    };
+
+    // `merged` belongs to `duplicate` and to nothing else. A conflict verdict
+    // that still handed us text to write would defeat the one outcome that
+    // verdict exists to produce — and a duplicate with no text is a merge the
+    // write path cannot carry out.
+    match (&relation, &r.merged) {
+        (Relation::Duplicate, None) => {
+            return Err(Error::MalformedLlmOutput(
+                "dedupe reply said duplicate but wrote no merged artifact".into(),
+            ));
+        }
+        (rel, Some(_)) if *rel != Relation::Duplicate => {
+            return Err(Error::MalformedLlmOutput(format!(
+                "dedupe reply carried a merged artifact on a {} verdict",
+                r.relation.trim()
+            )));
+        }
+        _ => {}
+    }
+
+    if let Some(m) = &r.merged
+        && m.text.trim().is_empty()
+    {
+        return Err(Error::MalformedLlmOutput(
+            "dedupe reply said duplicate and wrote an empty artifact".into(),
+        ));
+    }
+
+    Ok(Dedupe {
+        relation,
+        detail: r
+            .detail
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty()),
+        supersedes: side,
+        merged: r.merged.map(|m| MergedDraft {
+            title: m.title,
+            text: m.text,
+            category: m.category,
+            tags: m.tags,
+            caveats: m.caveats,
+        }),
+    })
 }
 
 #[derive(serde::Deserialize)]
@@ -506,15 +649,18 @@ mod tests {
     }
 
     #[test]
-    fn the_judge_is_told_what_each_artifact_is_about() {
+    fn the_dedupe_pass_is_told_what_each_artifact_is_about() {
         // The real case this fixes: an artifact headed "FAT32 Specifications"
         // whose body opens "32 Bit Clusternummern" and never says FAT32 again.
         // Given the bodies alone, the model saw two anonymous spec lists with
         // different numbers and called them a contradiction — which was the
         // only honest answer to the question it was actually asked.
         let p = dedupe_prompt(
-            ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
-            ("FAT32 Specifications", "32 Bit Clusternummern."),
+            &[
+                ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
+                ("FAT32 Specifications", "32 Bit Clusternummern."),
+            ],
+            &[],
             0,
         );
         assert!(p.contains("Title: FAT16 Specifications"), "{p}");
@@ -523,32 +669,60 @@ mod tests {
     }
 
     #[test]
+    fn a_component_is_lettered_so_a_direction_can_name_one() {
+        // `supersedes` answers with a letter, so the letters have to be in the
+        // prompt and in the same order the caller will read them back in.
+        let p = dedupe_prompt(&[("one", "a"), ("two", "b"), ("three", "c")], &[], 0);
+        assert!(p.contains("ARTIFACT A"), "{p}");
+        assert!(p.contains("ARTIFACT B"), "{p}");
+        assert!(p.contains("ARTIFACT C"), "{p}");
+    }
+
+    #[test]
+    fn differing_values_are_named_as_a_prior_not_a_verdict() {
+        let p = dedupe_prompt(
+            &[("t", "timeout is 30s"), ("t", "timeout is 90s")],
+            &["30s".into(), "90s".into()],
+            0,
+        );
+        assert!(p.contains("30s, 90s"), "{p}");
+        assert!(p.contains("Decide which."), "{p}");
+        // And nothing is added when there is nothing to say.
+        assert!(!dedupe_prompt(&[("t", "x"), ("t", "y")], &[], 0).contains("Decide which."));
+    }
+
+    #[test]
     fn a_retry_does_not_ask_the_endpoint_the_question_it_has_cached() {
         // The endpoint replays a cached reply for an identical prompt in
-        // milliseconds. A pair whose reply the parser could not read is retried
+        // milliseconds. A group whose reply the parser could not read is retried
         // up to `MAX_ATTEMPTS` times, and every one of those would have read the
         // same unreadable bytes back.
-        let pair = (
+        let members: &[(&str, &str)] = &[
             ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
             ("FAT32 Specifications", "32 Bit Clusternummern."),
-        );
-        let first = dedupe_prompt(pair.0, pair.1, 0);
-        let second = dedupe_prompt(pair.0, pair.1, 1);
+        ];
+        let first = dedupe_prompt(members, &[], 0);
+        let second = dedupe_prompt(members, &[], 1);
         assert_ne!(first, second);
-        assert_ne!(second, dedupe_prompt(pair.0, pair.1, 2));
+        assert_ne!(second, dedupe_prompt(members, &[], 2));
         // A first ask stays exactly what it was, so the cache still earns its
-        // keep on a pair the sweep re-arms after a verdict was lost.
+        // keep on a group re-armed after a verdict was lost.
         assert!(first.starts_with("----- ARTIFACT A -----"), "{first}");
     }
 
     #[test]
-    fn the_judge_is_told_that_different_subjects_are_not_a_conflict() {
+    fn the_dedupe_pass_is_told_that_different_subjects_are_not_a_conflict() {
         // Two sections of one reference document are near-identical in form and
         // deliberately different in content, so similarity puts them in a pair
         // and every number in them differs. Without this rule the feature fires
-        // hardest exactly where it is most wrong.
+        // hardest exactly where it is most wrong — and now it would not merely
+        // flag them, it would merge them into mush.
         assert!(DEDUPE_SYSTEM.contains("same subject"));
-        assert!(DEDUPE_SYSTEM.contains("Answer false and stop."));
+        assert!(DEDUPE_SYSTEM.contains("different things"));
+        assert!(DEDUPE_SYSTEM.contains(r#"Answer "distinct" and stop."#));
+        // And the fidelity preference, which is what keeps most groups from
+        // producing synthetic text at all.
+        assert!(DEDUPE_SYSTEM.contains("Prefer this whenever it applies"));
     }
 
     #[test]
@@ -622,55 +796,91 @@ mod tests {
     }
 
     #[test]
-    fn a_judgement_parses() {
-        let (yes, detail, obsolete) =
-            parse_judgement(r#"{"contradicts":true,"detail":"one says 1.2, the other 1.4"}"#)
-                .unwrap();
-        assert!(yes);
-        assert_eq!(detail.as_deref(), Some("one says 1.2, the other 1.4"));
-        assert!(obsolete.is_none());
-    }
-
-    #[test]
-    fn a_negative_judgement_carries_no_detail() {
-        let (yes, detail, _) = parse_judgement(r#"{"contradicts":false}"#).unwrap();
-        assert!(!yes);
-        assert!(detail.is_none());
-    }
-
-    #[test]
-    fn a_judgement_wrapped_in_prose_and_fences_still_parses() {
-        // The same models that fence the synthesis reply fence this one.
-        let (yes, ..) = parse_judgement("Sure:\n```json\n{\"contradicts\": true}\n```").unwrap();
-        assert!(yes);
-    }
-
-    #[test]
-    fn a_judgement_names_the_obsolete_side() {
-        let (yes, _, obsolete) = parse_judgement(
-            r#"{"contradicts":true,"detail":"a uses --old-flag, b uses --new-flag","obsolete":"a"}"#,
+    fn a_duplicate_verdict_carries_a_merged_draft() {
+        let d = parse_dedupe(
+            r#"{"relation":"duplicate","detail":"same command, more detail",
+                "merged":{"title":"Bind mounts","text":"Use mount --bind.",
+                          "tags":["mount"],"caveats":[],"category":"howto"}}"#,
         )
         .unwrap();
-        assert!(yes);
-        assert_eq!(obsolete, Some('a'));
+        assert_eq!(d.relation, Relation::Duplicate);
+        let m = d.merged.as_ref().unwrap();
+        assert_eq!(m.text, "Use mount --bind.");
+        assert_eq!(m.title.as_deref(), Some("Bind mounts"));
+        assert_eq!(m.tags, vec!["mount".to_string()]);
     }
 
     #[test]
-    fn an_unreadable_obsolete_value_is_treated_as_absent() {
-        // An unparsable direction must not fail the whole reply — the
-        // contradiction verdict itself is still readable.
-        let (yes, _, obsolete) =
-            parse_judgement(r#"{"contradicts":true,"obsolete":"not sure honestly"}"#).unwrap();
-        assert!(yes);
-        assert!(obsolete.is_none());
+    fn a_merged_block_on_a_non_duplicate_verdict_is_unreadable() {
+        // `merged` belongs to `duplicate` and to nothing else. Accepting it
+        // elsewhere would let a reply that classified a group as a conflict
+        // still hand us text to write — which is the one outcome the conflict
+        // verdict exists to prevent.
+        for relation in ["conflict", "replaced", "distinct"] {
+            let body = format!(
+                r#"{{"relation":"{relation}","supersedes":"a",
+                     "merged":{{"text":"x","tags":[],"caveats":[]}}}}"#
+            );
+            assert!(
+                matches!(parse_dedupe(&body), Err(Error::MalformedLlmOutput(_))),
+                "a {relation} verdict was allowed to carry a merge"
+            );
+        }
     }
 
     #[test]
-    fn an_unparsable_judgement_is_an_error_not_a_yes() {
-        // Defaulting to "contradicts" would fill the review queue with noise;
-        // defaulting to "no" would hide real conflicts. Neither: it fails, the
-        // pair stays pending, and the next sweep tries again.
-        assert!(parse_judgement("I could not decide.").is_err());
+    fn a_duplicate_verdict_with_nothing_to_write_is_unreadable() {
+        // A merge the write path cannot carry out. Failing re-asks; accepting
+        // would settle the group having done nothing.
+        assert!(matches!(
+            parse_dedupe(r#"{"relation":"duplicate","detail":"x"}"#),
+            Err(Error::MalformedLlmOutput(_))
+        ));
+        assert!(matches!(
+            parse_dedupe(
+                r#"{"relation":"duplicate","merged":{"text":"   ","tags":[],"caveats":[]}}"#
+            ),
+            Err(Error::MalformedLlmOutput(_))
+        ));
+    }
+
+    #[test]
+    fn a_replacement_names_the_obsolete_side() {
+        let d = parse_dedupe(
+            r#"{"relation":"replaced","supersedes":"B","detail":"a uses --old-flag"}"#,
+        )
+        .unwrap();
+        assert_eq!(d.relation, Relation::Replaced);
+        assert_eq!(d.supersedes, Some('b'));
+    }
+
+    #[test]
+    fn a_replacement_naming_no_side_falls_back_to_a_conflict() {
+        // A direction the model would not name is not a direction. Treating it
+        // as one would pick a side by accident, and on a supersede that means
+        // hiding an artifact for no stated reason.
+        let d = parse_dedupe(r#"{"relation":"replaced","detail":"one of them is old"}"#).unwrap();
+        assert_eq!(d.relation, Relation::Conflict);
+        let d =
+            parse_dedupe(r#"{"relation":"replaced","supersedes":"not sure honestly"}"#).unwrap();
+        assert_eq!(d.relation, Relation::Conflict);
+    }
+
+    #[test]
+    fn a_verdict_wrapped_in_prose_and_fences_still_parses() {
+        // The same models that fence the synthesis reply fence this one.
+        let d = parse_dedupe("Sure:\n```json\n{\"relation\": \"distinct\"}\n```").unwrap();
+        assert_eq!(d.relation, Relation::Distinct);
+    }
+
+    #[test]
+    fn an_unparsable_verdict_is_an_error_not_a_default() {
+        // Defaulting to "conflict" would fill the escalation queue with noise a
+        // person has to clear by hand; defaulting to "distinct" would quietly
+        // close real duplicates. Neither: it fails, the group stays pending, and
+        // the unit asks again with a prompt the endpoint has not cached.
+        assert!(parse_dedupe("I could not decide.").is_err());
+        assert!(parse_dedupe(r#"{"relation":"maybe"}"#).is_err());
     }
 
     #[test]

--- a/src/jobs/classify.rs
+++ b/src/jobs/classify.rs
@@ -1,0 +1,335 @@
+//! Turning one scored pair into one decision.
+//!
+//! Two things discover near pairs now — the per-artifact `Relate` unit, which
+//! is exact, and the sweep's sampled scan, which is the backlog and the
+//! backstop. Both must reach the same conclusion about the same pair. Leaving
+//! these rules in the sweep's body meant the second producer would have arrived
+//! with a copy, and a copy diverges silently: you find out when the outcome
+//! starts depending on which path saw a pair first.
+//!
+//! Nothing here calls a model. Every rule is local, and the two that settle a
+//! pair outright — containment, and the `auto_supersede` band — are why most
+//! near pairs still cost nothing at all.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::pairs::PairState;
+
+/// What was decided about a pair, for the caller's tally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Nothing was written: a side is not active, or the two are one artifact.
+    Skipped,
+    /// Filed at or above `auto_supersede`, for the sweep's clustering pass.
+    NearIdentical,
+    /// One text was wholly inside the other and both came from one corpus. The
+    /// shorter is superseded here, with no call and no queue slot.
+    Contained,
+    /// Filed as `Pending`. A dedupe unit will decide.
+    Queued,
+    /// Already recorded, or already answered. Nothing changed.
+    Unchanged,
+}
+
+/// Is the whole of one artifact inside the other, whitespace aside?
+///
+/// Not a similarity — containment. A score says two texts are alike; this says
+/// one of them adds nothing, which is the only ground on which a pair below
+/// `auto_supersede` is hidden without asking anyone.
+pub fn contains_normalized(long: &str, short: &str) -> bool {
+    let n = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+    !short.trim().is_empty() && n(long).contains(&n(short))
+}
+
+pub async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<Verdict> {
+    if a.id == b.id {
+        return Ok(Verdict::Skipped);
+    }
+    // Only two live artifacts have a question worth a queue slot, a model call,
+    // or a supersede. A retired artifact must not win against a live one, and a
+    // pair that is already resolved has nothing left to decide.
+    if [a, b]
+        .iter()
+        .any(|c| c.status != ArtifactStatus::Active || c.superseded_by.is_some())
+    {
+        return Ok(Verdict::Skipped);
+    }
+
+    // The free band. Filed, not acted on: resolving pairs one at a time leaves A
+    // pointing at a B that is itself hidden, and following that chain is
+    // something no page and no reader can do. The sweep's union-find groups
+    // these rows first and then picks one survivor per cluster.
+    if score >= core.consolidate.auto_supersede {
+        let changed = core
+            .store
+            .record_settled_pair(&a.id, &b.id, score, PairState::NearIdentical)
+            .await?;
+        return Ok(if changed {
+            Verdict::NearIdentical
+        } else {
+            Verdict::Unchanged
+        });
+    }
+
+    // One synthesis call emitting the same passage twice: the shorter text is
+    // wholly inside the longer, and both came out of the same document. That is
+    // a defect in one artifact rather than two sources saying different things,
+    // and nothing is lost by hiding it — the survivor says everything it said,
+    // Ops lists it, and one press undoes it.
+    //
+    // Same corpus is the whole of the condition. Two documents that share a
+    // sentence are two sources, and hiding one of those on a 0.9 similarity is
+    // exactly what `auto_supersede` refuses to do. A merged artifact has no
+    // corpus, so `is_some` also keeps two merges from matching on `None == None`.
+    if a.corpus_id.is_some() && a.corpus_id == b.corpus_id {
+        let (long, short) = if a.text.len() >= b.text.len() {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        if contains_normalized(&long.text, &short.text) {
+            // Warn and carry on. `supersede` refuses a side that is no longer
+            // active, and these statuses were read a moment ago, so an operator
+            // deprecating one in between is an ordinary race rather than a
+            // reason to fail the caller's whole sweep.
+            if let Err(e) = core.supersede(&short.id, &long.id).await {
+                tracing::warn!(
+                    superseded = %short.id,
+                    by = %long.id,
+                    error = %e,
+                    "could not hide a duplicated passage; it stays active"
+                );
+                return Ok(Verdict::Skipped);
+            }
+            tracing::info!(
+                superseded = %short.id,
+                by = %long.id,
+                "hid a passage one synthesis call emitted twice"
+            );
+            return Ok(Verdict::Contained);
+        }
+    }
+
+    // Everything else is a question for the dedupe pass.
+    //
+    // `may_disagree` used to gate this, filing a pair with no differing values
+    // as `NoConflict` and leaving both artifacts in every result set. That was
+    // right for the question it was written for — "do these two contradict?" —
+    // and is backwards for deduplication: a pair stating the same values in
+    // different words is the *cleanest* thing there is to merge, and the old
+    // rule made it the one case the model was never shown.
+    //
+    // It survives as a prior in the prompt and as the input to the merge
+    // verification. It is no longer an admission gate. See the design, §6.5.
+    let changed = core.store.record_pair(&a.id, &b.id, score).await?;
+    Ok(if changed {
+        Verdict::Queued
+    } else {
+        Verdict::Unchanged
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::jobs::consolidate::tests::{seed, seed_into_new_corpus};
+    use crate::store::pairs::PairState;
+
+    async fn pair_of(core: &Core, ids: &[String]) -> (Chunk, Chunk) {
+        (
+            core.store.get_artifact(&ids[0]).await.unwrap(),
+            core.store.get_artifact(&ids[1]).await.unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_pair_with_no_differing_values_is_queued_not_closed() {
+        // The polarity change. `may_disagree` admits a pair only when both
+        // sides state values AND those values differ, which is backwards for
+        // deduplication: the pairs it discarded are the cleanest merge
+        // candidates. Two artifacts at 0.93 saying the same thing in different
+        // words used to be filed "nothing to decide", and both stayed in every
+        // result set forever.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let (a, b) = pair_of(&core, &ids).await;
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.93).await.unwrap(),
+            Verdict::Queued
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_at_auto_supersede_is_filed_for_the_cluster_pass() {
+        // It must not reach the dedupe queue: that band is answered by a rule
+        // that costs nothing. It must also not be superseded here — pairwise
+        // resolution is what `Clusters` exists to avoid, because A loses to B
+        // and B then loses to C, leaving A pointing at something hidden.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        let (a, b) = pair_of(&core, &ids).await;
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.999).await.unwrap(),
+            Verdict::NearIdentical
+        );
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "the pair was resolved pairwise instead of being filed"
+            );
+        }
+        assert!(core.store.pairs_to_judge(10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_synthesis_call_emitting_a_passage_twice_resolves_itself() {
+        // Same corpus, one text wholly inside the other: a defect in one
+        // artifact rather than two sources saying different things. Nothing is
+        // lost by hiding it, and it costs no call.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                (
+                    "Bind mounts attach a directory elsewhere. Use mount --bind for it.",
+                    [1.0, 0.0],
+                ),
+                ("Bind mounts attach a directory elsewhere.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let (a, b) = pair_of(&core, &ids).await;
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.93).await.unwrap(),
+            Verdict::Contained
+        );
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[1])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(ids[0].as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn containment_across_two_corpora_is_left_alone() {
+        // Two documents that happen to share a sentence are two sources, and
+        // this is exactly the case auto_supersede refuses to act on below 0.95.
+        let core = test_core().await;
+        let a_ids = seed(
+            &core,
+            &[(
+                "Bind mounts attach a directory elsewhere. Use mount --bind for it.",
+                [1.0, 0.0],
+            )],
+        )
+        .await;
+        let b_id = seed_into_new_corpus(
+            &core,
+            "Bind mounts attach a directory elsewhere.",
+            [0.93, 0.37],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_ids[0]).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.93).await.unwrap(),
+            Verdict::Queued
+        );
+        for id in [&a_ids[0], &b_id] {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "two documents sharing a sentence are two sources"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_pair_naming_a_hidden_artifact_is_skipped() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        core.deprecate(&ids[0]).await.unwrap();
+        let (a, b) = pair_of(&core, &ids).await;
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.93).await.unwrap(),
+            Verdict::Skipped
+        );
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_the_same_pair_twice_changes_nothing() {
+        // Both producers find the same pair, and the sweep re-finds it on every
+        // run. If the second recording counted, the tallies would grow forever
+        // and a dismissed pair would come back.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let (a, b) = pair_of(&core, &ids).await;
+
+        assert_eq!(
+            classify_pair(&core, &a, &b, 0.93).await.unwrap(),
+            Verdict::Queued
+        );
+        assert_eq!(
+            classify_pair(&core, &b, &a, 0.93).await.unwrap(),
+            Verdict::Unchanged,
+            "the reversed pair was recorded a second time"
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+}

--- a/src/jobs/classify.rs
+++ b/src/jobs/classify.rs
@@ -13,7 +13,7 @@
 
 use crate::core::Core;
 use crate::error::Result;
-use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::artifacts::Chunk;
 use crate::store::pairs::PairState;
 
 /// What was decided about a pair, for the caller's tally.
@@ -49,10 +49,7 @@ pub async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Res
     // Only two live artifacts have a question worth a queue slot, a model call,
     // or a supersede. A retired artifact must not win against a live one, and a
     // pair that is already resolved has nothing left to decide.
-    if [a, b]
-        .iter()
-        .any(|c| c.status != ArtifactStatus::Active || c.superseded_by.is_some())
-    {
+    if [a, b].iter().any(|c| !c.in_results()) {
         return Ok(Verdict::Skipped);
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -369,6 +369,10 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     }
 
     let mut members: HashMap<String, Vec<Chunk>> = HashMap::new();
+    // Which of the clustered ids this sweep found active. Read once here because
+    // the filed rows are closed against it below, and re-reading every pair's two
+    // artifacts would be the same lookups a second time.
+    let mut live: HashSet<String> = HashSet::new();
     for id in &in_a_cluster {
         // An artifact the vector store still lists but SQLite has dropped is
         // ordinary: a delete can lag a sweep. It is not an error.
@@ -386,6 +390,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             tracing::debug!(artifact_id = %id, status = c.status.as_str(), "skipping a hidden artifact");
             continue;
         }
+        live.insert(id.clone());
         let root = clusters.find(id);
         members.entry(root).or_default().push(c);
     }
@@ -423,6 +428,44 @@ pub async fn run(core: &Core) -> Result<Outcome> {
                 by = %keep.id,
                 "hid a near-identical artifact"
             );
+        }
+    }
+
+    // Close the rows the clustering just answered.
+    //
+    // `NearIdentical` is where a pair is filed, not where it ends, and nothing
+    // used to move it out again. That is not merely untidy: the read above is
+    // `pairs_by_state(NearIdentical, 500)`, ordered by score, so once five
+    // hundred already-acted-on rows have accumulated a newly filed pair with a
+    // lower score never enters the window. Its cluster is never formed and its
+    // duplicate is never hidden — silently, and permanently on a growing base.
+    //
+    // `NoConflict` with a detail, as the merge path does: the question is
+    // settled and there is nothing here for a person. `Superseded` would put it
+    // on the Capture page behind an "apply" button for something already applied.
+    for p in &filed {
+        let a_live = live.contains(&p.a_id) && !hidden.contains(&p.a_id);
+        let b_live = live.contains(&p.b_id) && !hidden.contains(&p.b_id);
+        if a_live && b_live {
+            // Both still in results, so nothing here was answered — a supersede
+            // that failed above, and warned. It stays filed for the next sweep.
+            continue;
+        }
+        let detail = match (a_live, b_live) {
+            (true, false) => format!("near-identical; {} kept", p.a_id),
+            (false, true) => format!("near-identical; {} kept", p.b_id),
+            _ => "near-identical; neither side is in results any more".to_string(),
+        };
+        if let Err(e) = core
+            .store
+            .set_pair_state(
+                p.id,
+                crate::store::pairs::PairState::NoConflict,
+                Some(&detail),
+            )
+            .await
+        {
+            tracing::warn!(pair = p.id, error = %e, "could not close a settled near-identical pair");
         }
     }
 
@@ -1454,6 +1497,79 @@ pub(crate) mod tests {
                 .as_deref(),
             Some(ids[1].as_str()),
             "the newest member should have survived"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_the_cluster_pass_answered_stops_occupying_the_window() {
+        // `NearIdentical` is where a pair is filed, not where it ends. The read
+        // that feeds the cluster pass is `pairs_by_state(NearIdentical, 500)`
+        // ordered by score, so a row left in that state forever is not merely
+        // untidy — it holds a slot. Past five hundred already-acted-on rows a
+        // newly filed pair with a lower score never enters the window at all,
+        // and the duplicate it names is never hidden. On a growing base that is
+        // permanent and silent.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        core.store
+            .record_settled_pair(&ids[0], &ids[1], 0.999, PairState::NearIdentical)
+            .await
+            .unwrap();
+        core.vectors.delete_artifacts(&ids).await.unwrap();
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::NearIdentical, 500)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an answered pair is still holding a slot in the window"
+        );
+        let closed = core
+            .store
+            .pairs_by_state(PairState::NoConflict, 10)
+            .await
+            .unwrap();
+        assert_eq!(closed.len(), 1);
+        assert_eq!(
+            closed[0].detail.as_deref(),
+            Some(format!("near-identical; {} kept", ids[1]).as_str()),
+            "the row does not say which side survived"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_whose_supersede_failed_stays_filed_for_the_next_sweep() {
+        // The other half of the same rule. Closing a row means the question was
+        // answered; a cluster whose members are all still in results answered
+        // nothing, and closing it anyway would lose the duplicate for good.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        core.store
+            .record_settled_pair(&ids[0], &ids[1], 0.999, PairState::NearIdentical)
+            .await
+            .unwrap();
+        core.vectors.delete_artifacts(&ids).await.unwrap();
+        // Deprecated by an operator, so `supersede` refuses both directions and
+        // the cluster pass hides nothing.
+        core.deprecate(&ids[0]).await.unwrap();
+        core.deprecate(&ids[1]).await.unwrap();
+
+        run(&core).await.unwrap();
+
+        // Neither side is in results, so the question is moot rather than open —
+        // it closes, but it does not claim a survivor.
+        let closed = core
+            .store
+            .pairs_by_state(PairState::NoConflict, 10)
+            .await
+            .unwrap();
+        assert_eq!(closed.len(), 1);
+        assert_eq!(
+            closed[0].detail.as_deref(),
+            Some("near-identical; neither side is in results any more")
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -572,6 +572,60 @@ pub(crate) mod tests {
 
     /// Seed artifacts with hand-placed vectors, so the test controls the exact
     /// similarity rather than depending on what the fake embedder produces.
+    /// The same, with a title on each artifact.
+    ///
+    /// The title is the subject, and the dedupe prompt is built around that:
+    /// synthesis writes a body that stands alone within its segment, which is
+    /// not the same as naming what it is about. Anything testing the
+    /// same-subject rule needs titles or it is testing something else.
+    pub(crate) async fn seed_titled(
+        core: &crate::core::Core,
+        rows: &[(&str, &str, [f32; 2])],
+    ) -> Vec<String> {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, (title, text, _))| NewArtifact {
+                ordinal: i as i64,
+                text: (*text).to_string(),
+                corpus_span: None,
+                title: Some((*title).to_string()),
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        let made = core.store.insert_artifacts(&src.id, &new).await.unwrap();
+        let points: Vec<VectorPoint> = made
+            .iter()
+            .zip(rows)
+            .map(|(c, (title, text, v))| VectorPoint {
+                vector: v.to_vec(),
+                sparse: Default::default(),
+                payload: VectorPayload {
+                    artifact_id: c.id.clone(),
+                    corpus_id: c.corpus_id.clone().unwrap_or_default(),
+                    text: (*text).to_string(),
+                    title: Some((*title).to_string()),
+                    category: None,
+                    tags: vec![],
+                    created_at: c.created_at,
+                    last_seen_at: None,
+                    hit_count: None,
+                    superseded: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
+                    provenance: None,
+                },
+            })
+            .collect();
+        core.vectors.upsert(points).await.unwrap();
+        made.into_iter().map(|c| c.id).collect()
+    }
+
     pub(crate) async fn seed(
         core: &crate::core::Core,
         vectors: &[(&str, [f32; 2])],
@@ -1342,9 +1396,17 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn a_confident_direction_proposes_a_supersede_but_does_not_apply_it() {
-        // The judge names a direction; an operator still has to confirm it.
-        // Nothing about either artifact changes here — only the pair.
+    async fn a_confident_direction_is_applied_once_autonomy_is_on() {
+        // This asserted "proposed, not applied" until 2026-08-14, and the
+        // rename is what changed it: `consolidate.judge` gated whether the
+        // model was *asked*, and `consolidate.autonomous` gates whether the
+        // answer is *acted on*. The same `= true` therefore means something
+        // else, and a test that kept the old assertion would have been pinning
+        // a behaviour the flag no longer selects.
+        //
+        // The proposal path did not disappear — it is what `autonomous = false`
+        // does, and `dedupe::tests::a_replacement_is_only_proposed_while_autonomy_is_off`
+        // is where it is pinned now.
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
@@ -1359,18 +1421,22 @@ pub(crate) mod tests {
             .pairs_by_state(PairState::Superseded, 10)
             .await
             .unwrap();
-        assert_eq!(found.len(), 1, "the pair did not land as proposed");
+        assert_eq!(found.len(), 1, "the pair did not land as decided");
         assert_eq!(found[0].obsolete_id.as_deref(), Some(ids[0].as_str()));
 
-        // Proposed, not applied.
-        assert!(
+        // Applied, and the survivor is a stored original rather than a rewrite.
+        assert_eq!(
             core.store
                 .get_artifact(&ids[0])
                 .await
                 .unwrap()
                 .superseded_by
-                .is_none(),
-            "the judge's proposal must not hide anything by itself"
+                .as_deref(),
+            Some(ids[1].as_str())
+        );
+        assert_eq!(
+            core.store.get_artifact(&ids[1]).await.unwrap().provenance,
+            crate::store::artifacts::Provenance::Captured
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -407,7 +407,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         }
     }
 
-    if cfg.judge {
+    if cfg.autonomous {
         // Armed, not asked. `judged` counts the calls this sweep is responsible
         // for rather than the calls it made, since it now makes none. There is
         // deliberately no contradiction count beside it: the answers arrive one
@@ -415,7 +415,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         // here read as "the judge found nothing" rather than "the judge has not
         // been asked yet". `pairs_by_state(Contradiction, ..)` is where that
         // number actually lives, and the API and Ops both read it from there.
-        out.judged = arm_judgements(core).await?;
+        out.judged = arm_dedupe(core).await?;
     }
 
     if out.superseded > 0 || out.queued > 0 || out.judged > 0 {
@@ -448,7 +448,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 /// the sweep into units was for. Nothing runs away: `live_job` arms a pair at
 /// most once, so the depth is bounded by the pairs that exist, and the call rate
 /// is the gate's job rather than this number's.
-async fn arm_judgements(core: &Core) -> Result<usize> {
+async fn arm_dedupe(core: &Core) -> Result<usize> {
     let pending = core.store.pairs_to_judge(200).await?;
 
     let mut armed = 0usize;
@@ -522,7 +522,7 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
         // until it does — spending the budget on itself over and over while
         // pairs recorded since never get a turn.
         let target = p.id.to_string();
-        if core.store.live_job(Stage::Judge, &target).await? {
+        if core.store.live_job(Stage::Dedupe, &target).await? {
             continue;
         }
 
@@ -536,7 +536,7 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
         // guard above already skips those; this is what keeps it true if the
         // two ever drift.
         core.store
-            .rearm_idle_seq(Stage::Judge, "pair", &target, armed as i64)
+            .rearm_idle_seq(Stage::Dedupe, "pair", &target, armed as i64)
             .await?;
         armed += 1;
     }
@@ -556,7 +556,7 @@ pub(crate) mod tests {
     /// The sweep no longer calls the model: it decides which pairs are worth
     /// asking about and arms a unit each. Tests about what the judge *said*
     /// therefore have to drive the queue too, which is what a worker does.
-    async fn sweep_and_judge(core: &crate::core::Core) -> Outcome {
+    async fn sweep_and_dedupe(core: &crate::core::Core) -> Outcome {
         let out = run(core).await.unwrap();
         for _ in 0..100 {
             sqlx::query("UPDATE jobs SET run_after = 0")
@@ -940,7 +940,7 @@ pub(crate) mod tests {
         // count is the one the second sweep would make.
         let ids = disagreeing(&core).await;
         run(&core).await.unwrap();
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         assert_eq!(
             core.store
                 .pairs_by_state(PairState::Pending, 10)
@@ -972,7 +972,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn a_pair_whose_member_was_deprecated_never_reaches_the_judge() {
+    async fn a_pair_whose_member_was_deprecated_never_reaches_the_dedupe_pass() {
         // The other half of the same rule, and the one that leaves a button
         // nothing can press: a judgement can propose a supersede, Ops renders
         // "Apply supersede" for it, and `Core::supersede` refuses a deprecated
@@ -984,7 +984,7 @@ pub(crate) mod tests {
         core.completer = completer.clone();
         let ids = disagreeing(&core).await;
         run(&core).await.unwrap();
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
 
         core.deprecate(&ids[0]).await.unwrap();
 
@@ -1313,7 +1313,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn the_judge_is_off_by_default() {
+    async fn autonomy_is_off_by_default() {
         let core = test_core().await;
         disagreeing(&core).await;
         let out = run(&core).await.unwrap();
@@ -1322,15 +1322,15 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn an_enabled_judge_marks_a_real_contradiction() {
+    async fn an_enabled_dedupe_pass_marks_a_real_contradiction() {
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"contradicts":true,"detail":"1.21.4 versus 1.30.0"}"#.into(),
         ]));
         disagreeing(&core).await;
 
-        let out = sweep_and_judge(&core).await;
+        let out = sweep_and_dedupe(&core).await;
         assert_eq!(out.judged, 1, "one pair should have been armed: {out:?}");
         let found = core
             .store
@@ -1346,13 +1346,13 @@ pub(crate) mod tests {
         // The judge names a direction; an operator still has to confirm it.
         // Nothing about either artifact changes here — only the pair.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"contradicts":true,"detail":"old flag vs new flag","obsolete":"a"}"#.into(),
         ]));
         let ids = disagreeing(&core).await;
 
-        let out = sweep_and_judge(&core).await;
+        let out = sweep_and_dedupe(&core).await;
         assert_eq!(out.judged, 1, "one pair should have been armed: {out:?}");
         let found = core
             .store
@@ -1381,7 +1381,7 @@ pub(crate) mod tests {
         // with the sweep's own bias, so it must fall back to a plain
         // contradiction rather than being trusted.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         let ids = disagreeing(&core).await;
         // Force `b` (ids[1]) strictly newer than `a`: `now()` is second-grained,
         // so two rows inserted in the same test would otherwise tie, and a tie
@@ -1422,7 +1422,7 @@ pub(crate) mod tests {
         // so the single best merge candidate was the one case the model was
         // never shown.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         seed(
             &core,
             &[
@@ -1446,10 +1446,10 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn the_judge_stops_at_its_budget() {
+    async fn the_dedupe_pass_stops_at_its_budget() {
         // One sweep must not be able to occupy the GPU for an hour.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.consolidate.max_judgements = 1;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"contradicts":false}"#.into(),
@@ -1467,15 +1467,15 @@ pub(crate) mod tests {
         )
         .await;
 
-        sweep_and_judge(&core).await;
+        sweep_and_dedupe(&core).await;
         assert_eq!(completer.calls(), 1, "the budget was ignored");
     }
 
     #[tokio::test]
-    async fn a_failed_judgement_leaves_the_pair_pending() {
+    async fn a_failed_dedupe_call_leaves_the_pair_pending() {
         // A dead endpoint must not silently clear a queue of real conflicts.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             "not json".into(),
         ]));
@@ -1623,7 +1623,7 @@ pub(crate) mod tests {
         // it for as long as twenty calls took. The sweep now decides which
         // pairs are worth asking about — all of it local — and arms a unit each.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"contradicts":false}"#.into(),
         ]));
@@ -1635,7 +1635,7 @@ pub(crate) mod tests {
         assert_eq!(completer.calls(), 0, "the sweep called the model");
         assert_eq!(out.judged, 1, "no judge unit was armed: {out:?}");
         let armed: i64 = sqlx::query_scalar(
-            "SELECT count(*) FROM jobs WHERE stage = 'judge' AND state = 'pending'",
+            "SELECT count(*) FROM jobs WHERE stage = 'dedupe' AND state = 'pending'",
         )
         .fetch_one(&core.store.pool)
         .await
@@ -1659,7 +1659,7 @@ pub(crate) mod tests {
         // What has to remain true here is the part that was never about calls:
         // a dead endpoint must not silently clear a queue of real conflicts.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
         core.completer = completer.clone();
         seed(
@@ -1673,7 +1673,7 @@ pub(crate) mod tests {
         )
         .await;
 
-        let out = sweep_and_judge(&core).await;
+        let out = sweep_and_dedupe(&core).await;
         assert_eq!(out.queued, 2, "not enough pairs to prove anything: {out:?}");
         assert_eq!(
             core.store
@@ -1692,7 +1692,7 @@ pub(crate) mod tests {
         // score alone, the same top-scoring pair would then absorb every
         // sweep's budget forever and the rest would never be judged at all.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.consolidate.max_judgements = 1;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             "not json".into(),
@@ -1708,8 +1708,8 @@ pub(crate) mod tests {
         )
         .await;
 
-        sweep_and_judge(&core).await;
-        sweep_and_judge(&core).await;
+        sweep_and_dedupe(&core).await;
+        sweep_and_dedupe(&core).await;
 
         let pending = core.store.pairs_to_judge(10).await.unwrap();
         assert!(
@@ -1739,7 +1739,7 @@ pub(crate) mod tests {
         // completes it. One pair that lost a race therefore cost every pair
         // behind it a wait of up to `interval_hours`.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.consolidate.max_judgements = 5;
         let ids = seed(
             &core,
@@ -1776,16 +1776,17 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let armed = arm_judgements(&core).await.unwrap();
+        let armed = arm_dedupe(&core).await.unwrap();
 
         assert_eq!(
             armed, 1,
             "the pair that lost the race took the whole sweep down with it"
         );
-        let target: String = sqlx::query_scalar("SELECT target_id FROM jobs WHERE stage = 'judge'")
-            .fetch_one(&core.store.pool)
-            .await
-            .unwrap();
+        let target: String =
+            sqlx::query_scalar("SELECT target_id FROM jobs WHERE stage = 'dedupe'")
+                .fetch_one(&core.store.pool)
+                .await
+                .unwrap();
         let surviving = core
             .store
             .pairs_by_state(PairState::Pending, 10)
@@ -1798,7 +1799,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn a_sweep_leaves_a_judge_unit_that_is_already_queued_alone() {
+    async fn a_sweep_leaves_a_dedupe_unit_that_is_already_queued_alone() {
         // Two ways this went wrong at once. Re-arming a queued unit wound its
         // `attempts` back, so a pair the model will not judge never reached
         // `MAX_ATTEMPTS` and never reached the close-out that hands it to a
@@ -1807,7 +1808,7 @@ pub(crate) mod tests {
         // pair still waiting for its first call leads every sweep: the budget
         // went on re-arming it while pairs recorded since never got a turn.
         let mut core = test_core().await;
-        core.consolidate.judge = true;
+        core.consolidate.autonomous = true;
         core.consolidate.max_judgements = 1;
         // Two pairs in the review band and nothing near enough to cluster, so
         // the sweep has a second pair to reach once the first is spoken for.
@@ -1833,7 +1834,7 @@ pub(crate) mod tests {
         // A sweep arms one unit. Nothing runs it — the worker is busy.
         run(&core).await.unwrap();
         let first: (String, i64) =
-            sqlx::query_as("SELECT target_id, id FROM jobs WHERE stage = 'judge'")
+            sqlx::query_as("SELECT target_id, id FROM jobs WHERE stage = 'dedupe'")
                 .fetch_one(&core.store.pool)
                 .await
                 .unwrap();
@@ -1858,7 +1859,7 @@ pub(crate) mod tests {
             (2, later),
             "the sweep wound a queued judge unit back to zero attempts"
         );
-        let armed: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM jobs WHERE stage = 'judge'")
+        let armed: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM jobs WHERE stage = 'dedupe'")
             .fetch_one(&core.store.pool)
             .await
             .unwrap();

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -1326,7 +1326,7 @@ pub(crate) mod tests {
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            r#"{"contradicts":true,"detail":"1.21.4 versus 1.30.0"}"#.into(),
+            r#"{"relation":"conflict","detail":"1.21.4 versus 1.30.0"}"#.into(),
         ]));
         disagreeing(&core).await;
 
@@ -1348,7 +1348,7 @@ pub(crate) mod tests {
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            r#"{"contradicts":true,"detail":"old flag vs new flag","obsolete":"a"}"#.into(),
+            r#"{"relation":"replaced","detail":"old flag vs new flag","supersedes":"a"}"#.into(),
         ]));
         let ids = disagreeing(&core).await;
 
@@ -1393,7 +1393,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            r#"{"contradicts":true,"detail":"x","obsolete":"b"}"#.into(),
+            r#"{"relation":"replaced","detail":"x","supersedes":"b"}"#.into(),
         ]));
 
         run(&core).await.unwrap();
@@ -1452,9 +1452,9 @@ pub(crate) mod tests {
         core.consolidate.autonomous = true;
         core.consolidate.max_judgements = 1;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            r#"{"contradicts":false}"#.into(),
-            r#"{"contradicts":false}"#.into(),
-            r#"{"contradicts":false}"#.into(),
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
         core.completer = completer.clone();
         seed(
@@ -1625,7 +1625,7 @@ pub(crate) mod tests {
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            r#"{"contradicts":false}"#.into(),
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
         core.completer = completer.clone();
         disagreeing(&core).await;
@@ -1696,7 +1696,7 @@ pub(crate) mod tests {
         core.consolidate.max_judgements = 1;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             "not json".into(),
-            r#"{"contradicts":true,"detail":"30 versus 90"}"#.into(),
+            r#"{"relation":"conflict","detail":"30 versus 90"}"#.into(),
         ]));
         seed(
             &core,

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -649,20 +649,6 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
             );
             break;
         }
-        // A pair whose unit is still queued from an earlier sweep is already
-        // going to be judged. `pairs_to_judge` orders by `judge_attempts`, and a
-        // pair that has not run yet still has none, so it leads every sweep
-        // until it does — spending the budget on itself over and over while
-        // pairs recorded since never get a turn.
-        //
-        // Checked before the artifact reads, because those in-flight pairs
-        // lead the ordering: with the check after them, every tick re-fetched
-        // both full-text rows for the very pairs it was about to skip.
-        let target = p.id.to_string();
-        if core.store.live_job(Stage::Dedupe, &target).await? {
-            continue;
-        }
-
         // Reported, not skipped, with one exception. Skipping treated a store
         // that was briefly unwell as a pair not worth arming, and since nothing
         // recorded an attempt it led the next sweep's ordering all over again.
@@ -714,6 +700,16 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
         // The tokeniser under it survives: `dedupe_prompt` is given the values
         // that differ as a prior, and the merge verification refuses any merge
         // that drops one.
+
+        // A pair whose unit is still queued from an earlier sweep is already
+        // going to be judged. `pairs_to_judge` orders by `judge_attempts`, and a
+        // pair that has not run yet still has none, so it leads every sweep
+        // until it does — spending the budget on itself over and over while
+        // pairs recorded since never get a turn.
+        let target = p.id.to_string();
+        if core.store.live_job(Stage::Dedupe, &target).await? {
+            continue;
+        }
 
         // `seq` is the pair's position in this sweep. Left at zero, twenty
         // judge units would all sort ahead of every document's second window.

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -1,16 +1,38 @@
-//! Consolidation: what to do about two artifacts the index says are the same.
+//! Consolidation: what to do about artifacts the index says are the same.
 //!
-//! Three thresholds and three outcomes. At or above `auto_supersede` the pair
-//! is near enough to identical that the older one is hidden — it is still
-//! stored, still readable, and one write undoes it. Between `review_min` and
-//! that, the pair goes on a queue for a person, because two genuinely distinct
-//! artifacts about one subsystem sit at 0.88 routinely and acting on that score
-//! destroys knowledge rather than duplication. Below `review_min`, nothing.
+//! This sweep is no longer where duplicates are found. `jobs::relate` asks each
+//! artifact for its own neighbours when it is embedded, which is exact and
+//! costs no inference, where a sampled sweep needed both members of a pair in
+//! one draw — a probability that decays as (sample/N)² and leaves a given pair
+//! waiting years on a large base. What remains here is the backlog, the
+//! backstop, the clustering that spans many pairs at once, and the repairs.
 //!
-//! Nothing here rewrites an artifact. A merged artifact would be synthetic text
-//! standing where a stored passage used to, with no segment to verify it
-//! against and no corpus lines to show beside it, which is the one failure mode
-//! this design exists to avoid.
+//! Two thresholds still divide the work. At or above `auto_supersede` a group
+//! collapses onto its newest member for free: no call, no rewrite, and the
+//! survivor is a stored original. Between `review_min` and that, the group goes
+//! to `jobs::dedupe`, because two genuinely distinct artifacts about one
+//! subsystem sit at 0.88 routinely and acting on that score alone destroys
+//! knowledge rather than duplication.
+//!
+//! **On merging.** This header used to say that nothing here rewrites an
+//! artifact, and that a merged artifact would be synthetic text standing where
+//! a stored passage used to. Merging is now permitted, narrowly, and the four
+//! conditions that make it safe are part of that argument rather than
+//! exceptions to it:
+//!
+//! - Superseding is preferred wherever one stored original suffices, so most
+//!   groups still produce no synthetic text at all (`Relation::Replaced`).
+//! - A merged artifact is a distinct `provenance` kind naming what it was
+//!   written from, never mistakable for a captured passage.
+//! - The originals are superseded, never deleted — still stored, still
+//!   readable, one write from active, and one button from restored.
+//! - No merge may drop a value or a literal any source carried
+//!   (`jobs::merge::losses`), and one that would is escalated rather than
+//!   written.
+//!
+//! A disagreement about a value is still never settled here. It goes to a
+//! person, because deciding which of two facts is current is the judgement a
+//! model is worst at.
 
 use crate::core::Core;
 use crate::error::{Error, Result};
@@ -1494,7 +1516,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn the_pass_asks_by_default_and_acts_only_when_told_to() {
+    async fn the_pass_records_what_it_would_do_when_autonomy_is_off() {
         // This asserted `judged == 0` while the flag was called `judge`, because
         // that flag gated whether the model was *asked*. `autonomous` gates
         // whether the answer is *acted on*, and the two cannot be the same
@@ -1502,9 +1524,11 @@ pub(crate) mod tests {
         // having read no verdicts at all, which is exactly the leap the flag
         // exists to avoid.
         //
-        // So the default asks and records. `max_dedupe_per_tick = 0` is what
-        // switches the model off, and it has its own test.
+        // So the two are separate switches. `max_dedupe_per_tick = 0` stops the
+        // asking and has its own test; this one pins that turning acting off
+        // still leaves a verdict to read.
         let mut core = test_core().await;
+        core.consolidate.autonomous = false;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"relation":"replaced","supersedes":"a","detail":"old versus new"}"#.into(),
         ]));

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -73,6 +73,17 @@ fn keeper(members: &[Chunk]) -> &Chunk {
         .expect("a cluster has at least one member")
 }
 
+/// Where dedupe units sort in the queue.
+///
+/// `claim_job` orders by `(state, attempts, seq, id)`, and a segmentation
+/// window's seq is its index within a document — a few hundred at most. Starting
+/// dedupe far above that puts it behind every piece of capture work of equal
+/// attempt count, so hygiene consumes what capture leaves over.
+///
+/// The asymmetry is deliberate: a large ingest may delay tidying up, and tidying
+/// up may not delay an ingest. Nothing is lost by a dedupe unit waiting.
+const DEDUPE_SEQ_BASE: i64 = 1_000_000;
+
 /// How many hidden artifacts the drift repair compares per sweep, from either
 /// side. A base with more than this many hidden artifacts drifting at once is
 /// not a case worth unbounded scanning for; the next sweep continues.
@@ -426,16 +437,19 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         }
     }
 
-    if cfg.autonomous {
-        // Armed, not asked. `judged` counts the calls this sweep is responsible
-        // for rather than the calls it made, since it now makes none. There is
-        // deliberately no contradiction count beside it: the answers arrive one
-        // unit at a time long after the sweep has returned, and a zero logged
-        // here read as "the judge found nothing" rather than "the judge has not
-        // been asked yet". `pairs_by_state(Contradiction, ..)` is where that
-        // number actually lives, and the API and Ops both read it from there.
-        out.judged = arm_dedupe(core).await?;
-    }
+    // Armed, not asked. `judged` counts the calls this sweep is responsible for
+    // rather than the calls it made, since it makes none. There is deliberately
+    // no verdict count beside it: the answers arrive one unit at a time long
+    // after the sweep has returned, and a zero logged here would read as "the
+    // pass found nothing" rather than "the pass has not been asked yet".
+    // `pairs_by_state(Contradiction, ..)` is where that number actually lives.
+    //
+    // Not gated on `autonomous`. That flag decides whether a verdict is *acted
+    // on*, and gating the asking on it too would mean the observation window it
+    // exists to provide had nothing in it: an operator switching autonomy on
+    // would be doing so having read no verdicts at all. `max_dedupe_per_tick =
+    // 0` is what switches the model off.
+    out.judged = arm_dedupe(core).await?;
 
     if out.superseded > 0 || out.queued > 0 || out.judged > 0 {
         tracing::info!(
@@ -467,15 +481,15 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 /// the sweep into units was for. Nothing runs away: `live_job` arms a pair at
 /// most once, so the depth is bounded by the pairs that exist, and the call rate
 /// is the gate's job rather than this number's.
-async fn arm_dedupe(core: &Core) -> Result<usize> {
+pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
     let pending = core.store.pairs_to_judge(200).await?;
 
     let mut armed = 0usize;
     for p in pending {
-        if armed >= core.consolidate.max_judgements {
+        if armed >= core.consolidate.max_dedupe_per_tick {
             tracing::info!(
-                budget = core.consolidate.max_judgements,
-                "judge budget spent; the rest wait for the next sweep"
+                budget = core.consolidate.max_dedupe_per_tick,
+                "dedupe budget spent; the rest wait for the next tick"
             );
             break;
         }
@@ -555,7 +569,12 @@ async fn arm_dedupe(core: &Core) -> Result<usize> {
         // guard above already skips those; this is what keeps it true if the
         // two ever drift.
         core.store
-            .rearm_idle_seq(Stage::Dedupe, "pair", &target, armed as i64)
+            .rearm_idle_seq(
+                Stage::Dedupe,
+                "pair",
+                &target,
+                DEDUPE_SEQ_BASE + armed as i64,
+            )
             .await?;
         armed += 1;
     }
@@ -1295,6 +1314,95 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn dedupe_units_sort_behind_capture_work() {
+        // A large ingest may delay tidying up; tidying up may not delay an
+        // ingest. `claim_job` orders by (state, attempts, seq, id), and a
+        // window's seq is its index within a document, so dedupe starting at
+        // DEDUPE_SEQ_BASE puts it behind every piece of capture work of equal
+        // attempt count. Nothing is lost by a dedupe unit waiting; a document
+        // stuck behind twenty model calls is the thing this system was
+        // restructured to prevent.
+        let core = test_core().await;
+        core.store
+            .enqueue(Stage::SegmentWindow, "segment", "w0")
+            .await
+            .unwrap();
+        let ids = disagreeing(&core).await;
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+
+        assert_eq!(arm_dedupe(&core).await.unwrap(), 1);
+
+        let first = core.store.claim_job().await.unwrap().unwrap();
+        assert_eq!(
+            first.stage,
+            Stage::SegmentWindow,
+            "a dedupe unit was claimed ahead of capture work"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_dedupe_budget_is_per_tick_not_per_sweep() {
+        // `max_judgements` bounded what one sweep armed, which was right while
+        // the sweep was the only producer of pairs. The relate units file them
+        // continuously now, so a number per 24-hour tick is not a budget but a
+        // queue that only grows — the budget is a rate, and the ticker is what
+        // applies it.
+        let mut core = test_core().await;
+        core.consolidate.max_dedupe_per_tick = 1;
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.0, 1.0]),
+                ("timeout is 90 seconds", [0.5, 0.5]),
+                ("timeout is 120 seconds", [0.3, 0.7]),
+            ],
+        )
+        .await;
+        // Two independent pairs, so neither is swallowed by the other's
+        // component.
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        core.store
+            .record_pair(&ids[2], &ids[3], 0.90)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            arm_dedupe(&core).await.unwrap(),
+            1,
+            "the budget was ignored"
+        );
+        // And the next tick reaches the other one rather than re-arming the
+        // first: `live_job` skips a pair whose unit is already queued.
+        assert_eq!(arm_dedupe(&core).await.unwrap(), 1);
+        assert_eq!(
+            arm_dedupe(&core).await.unwrap(),
+            0,
+            "a pair with a live unit was armed again"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_zero_budget_asks_nothing_and_still_records_everything() {
+        // The one switch that turns the model off. Finding, recording and
+        // clustering pairs is free and keeps happening; only the asking stops.
+        let mut core = test_core().await;
+        core.consolidate.max_dedupe_per_tick = 0;
+        disagreeing(&core).await;
+
+        let out = run(&core).await.unwrap();
+
+        assert_eq!(out.queued, 1, "the pair was not recorded");
+        assert_eq!(out.judged, 0, "a call was armed on a zero budget");
+    }
+
+    #[tokio::test]
     async fn the_cluster_pass_settles_a_pair_the_relate_unit_filed() {
         // The relate unit files a pair above `auto_supersede` rather than
         // acting on it, because resolving where it is found leaves A pointing
@@ -1386,12 +1494,47 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn autonomy_is_off_by_default() {
-        let core = test_core().await;
-        disagreeing(&core).await;
-        let out = run(&core).await.unwrap();
+    async fn the_pass_asks_by_default_and_acts_only_when_told_to() {
+        // This asserted `judged == 0` while the flag was called `judge`, because
+        // that flag gated whether the model was *asked*. `autonomous` gates
+        // whether the answer is *acted on*, and the two cannot be the same
+        // switch: an operator turning autonomy on would otherwise be doing it
+        // having read no verdicts at all, which is exactly the leap the flag
+        // exists to avoid.
+        //
+        // So the default asks and records. `max_dedupe_per_tick = 0` is what
+        // switches the model off, and it has its own test.
+        let mut core = test_core().await;
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"old versus new"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+
+        let out = sweep_and_dedupe(&core).await;
+
         assert_eq!(out.queued, 1);
-        assert_eq!(out.judged, 0, "the judge ran without being asked for");
+        assert_eq!(out.judged, 1, "nothing was armed, so nothing can be read");
+        // Recorded...
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Superseded, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        // ...and not acted on.
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "the pass hid an artifact without being granted the authority"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1535,7 +1678,7 @@ pub(crate) mod tests {
         // One sweep must not be able to occupy the GPU for an hour.
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
-        core.consolidate.max_judgements = 1;
+        core.consolidate.max_dedupe_per_tick = 1;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
@@ -1778,7 +1921,7 @@ pub(crate) mod tests {
         // sweep's budget forever and the rest would never be judged at all.
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
-        core.consolidate.max_judgements = 1;
+        core.consolidate.max_dedupe_per_tick = 1;
         core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             "not json".into(),
             r#"{"relation":"conflict","detail":"30 versus 90"}"#.into(),
@@ -1825,7 +1968,7 @@ pub(crate) mod tests {
         // behind it a wait of up to `interval_hours`.
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
-        core.consolidate.max_judgements = 5;
+        core.consolidate.max_dedupe_per_tick = 5;
         let ids = seed(
             &core,
             &[
@@ -1894,7 +2037,7 @@ pub(crate) mod tests {
         // went on re-arming it while pairs recorded since never got a turn.
         let mut core = test_core().await;
         core.consolidate.autonomous = true;
-        core.consolidate.max_judgements = 1;
+        core.consolidate.max_dedupe_per_tick = 1;
         // Two pairs in the review band and nothing near enough to cluster, so
         // the sweep has a second pair to reach once the first is spoken for.
         let ids = seed(

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -232,12 +232,32 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     };
 
     // Group everything near-identical first, and only then decide who wins.
+    //
+    // Two inputs, and the second is the one that matters now. `near_pairs` is
+    // one sampled round trip, which was all this had while the sweep was the
+    // only detector. The stored `NearIdentical` rows are what the per-artifact
+    // relate units have filed since — exact rather than sampled, and filed
+    // rather than acted on because resolving a pair where it is found leaves A
+    // pointing at a B that is itself hidden.
+    //
+    // Reading only the sample would leave every such pair unsettled forever:
+    // nothing else acts on that band, and the odds of the sample redrawing both
+    // members together are the (s/N)² the relate unit exists to escape.
+    let filed = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::NearIdentical, 500)
+        .await?;
     let mut clusters = Clusters::default();
     let mut in_a_cluster: HashSet<String> = HashSet::new();
-    for p in pairs.iter().filter(|p| p.score >= cfg.auto_supersede) {
-        clusters.union(&p.a, &p.b);
-        in_a_cluster.insert(p.a.clone());
-        in_a_cluster.insert(p.b.clone());
+    let from_sweep = pairs
+        .iter()
+        .filter(|p| p.score >= cfg.auto_supersede)
+        .map(|p| (p.a.as_str(), p.b.as_str()));
+    let from_store = filed.iter().map(|p| (p.a_id.as_str(), p.b_id.as_str()));
+    for (a, b) in from_sweep.chain(from_store) {
+        clusters.union(a, b);
+        in_a_cluster.insert(a.to_string());
+        in_a_cluster.insert(b.to_string());
     }
 
     let mut members: HashMap<String, Vec<Chunk>> = HashMap::new();
@@ -1048,6 +1068,39 @@ pub(crate) mod tests {
         seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
         let out = run(&core).await.unwrap();
         assert_eq!((out.superseded, out.queued), (0, 0), "{out:?}");
+    }
+
+    #[tokio::test]
+    async fn the_cluster_pass_settles_a_pair_the_relate_unit_filed() {
+        // The relate unit files a pair above `auto_supersede` rather than
+        // acting on it, because resolving where it is found leaves A pointing
+        // at a B that is itself hidden. Nothing would ever settle those rows if
+        // the cluster pass read only what one sampled round trip returned —
+        // and the whole reason the relate unit exists is that the sample is
+        // unlikely to redraw both members together.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        core.store
+            .record_settled_pair(&ids[0], &ids[1], 0.999, PairState::NearIdentical)
+            .await
+            .unwrap();
+        // Empty the vector store's view, so `near_pairs` cannot supply the pair
+        // and only the stored row can.
+        core.vectors.delete_artifacts(&ids).await.unwrap();
+
+        let out = run(&core).await.unwrap();
+
+        assert_eq!(out.superseded, 1, "{out:?}");
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(ids[1].as_str()),
+            "the newest member should have survived"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -221,6 +221,14 @@ pub(crate) async fn full_lifecycle_reconcile(core: &Core) -> Result<usize> {
 /// The above with its cap as a parameter, so a test can reproduce what the two
 /// truncated scans do to each other without seeding `DRIFT_SCAN` artifacts.
 pub(crate) async fn full_lifecycle_reconcile_scanning(core: &Core, scan: usize) -> Result<usize> {
+    // Under the same lock as every lifecycle transition. The scan reads the
+    // row side and the payload side at different moments and then writes
+    // payloads from the row snapshot; interleaved with a payload-first reveal
+    // it would write the stale hidden state back over the fresh payload —
+    // and, writing with no marker, leave nothing behind for the complete
+    // marker pass to find it by. The scan is capped at `scan`, so the hold is
+    // bounded.
+    let _guard = core.lifecycle_lock.lock().await;
     // Both scans are capped, and neither cap lines up with the other:
     // `list_non_active_artifacts` returns the newest rows while `non_active_ids`
     // scrolls in point-id order. So set membership across the two proves
@@ -280,7 +288,15 @@ pub(crate) async fn full_lifecycle_reconcile_scanning(core: &Core, scan: usize) 
             repaired = rows.len(),
             "lifecycle state disagreed between sqlite and the vector store"
         );
+        // Marked before the payload write, cleared only after it returns: an
+        // interrupted repair is then ordinary marked drift the next marker
+        // pass finishes, instead of a best-effort scan's private problem.
+        let repaired: Vec<String> = rows.iter().map(|r| r.artifact_id.clone()).collect();
+        for id in &repaired {
+            core.store.mark_lifecycle_dirty(id).await?;
+        }
         core.vectors.apply_lifecycle(&rows).await?;
+        core.store.clear_lifecycle_dirty(&repaired).await?;
     }
     Ok(rows.len())
 }
@@ -1366,6 +1382,34 @@ pub(crate) mod tests {
             full_lifecycle_reconcile_scanning(&core, 1).await.unwrap(),
             0,
             "the edge of a page was reported as a disagreement"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_scan_repair_leaves_no_marker_behind_on_a_base_in_agreement() {
+        // The scan writes payloads from row state. An interrupted write must
+        // be findable by the complete marker pass, so the ids are marked
+        // dirty before the payload write and cleared only after it returns —
+        // the same contract every lifecycle mutator honours. A marker left
+        // standing afterwards would have the next marker pass rewrite a
+        // payload that is already correct.
+        let core = test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0])]).await;
+        // Drift no SQLite write produced: the payload hides what the row
+        // shows.
+        core.vectors
+            .set_lifecycle(&ids[0], ArtifactStatus::Deprecated, None)
+            .await
+            .unwrap();
+
+        assert_eq!(full_lifecycle_reconcile(&core).await.unwrap(), 1);
+        assert!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the scan left markers standing on a base in agreement"
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -661,13 +661,18 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
         // `NotFound` reaches `run_one`, which reads it as the sweep's own target
         // being gone: it completes the job, and every pair behind this one waits
         // for the next tick — up to `interval_hours` away.
-        let (a, b) = match (
-            core.store.get_artifact(&p.a_id).await,
-            core.store.get_artifact(&p.b_id).await,
+        //
+        // The status query, not `get_artifact`: this loop triages up to 200
+        // pairs per tick and arms at most a handful, and in-flight pairs lead
+        // the ordering — so most iterations used to pay two full-row fetches,
+        // text included, for a pair they went on to skip. The unit re-reads
+        // the full rows itself; nothing here needs more than liveness.
+        let (a_live, b_live) = match (
+            core.store.artifact_in_results(&p.a_id).await?,
+            core.store.artifact_in_results(&p.b_id).await?,
         ) {
-            (Ok(a), Ok(b)) => (a, b),
-            (Err(Error::NotFound), _) | (_, Err(Error::NotFound)) => continue,
-            (Err(e), _) | (_, Err(e)) => return Err(e),
+            (Some(a), Some(b)) => (a, b),
+            _ => continue,
         };
 
         // A pair queued in the review band can have a member retired after the
@@ -682,7 +687,7 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
         // returns a validation error and the pair stays pending forever. The
         // same guard runs in `run`'s cluster pass and review band, and again in
         // the unit itself, because a pair can be retired while it waits.
-        if !a.in_results() || !b.in_results() {
+        if !a_live || !b_live {
             core.store
                 .set_pair_state(p.id, crate::store::pairs::PairState::Dismissed, None)
                 .await?;

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -649,6 +649,20 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
             );
             break;
         }
+        // A pair whose unit is still queued from an earlier sweep is already
+        // going to be judged. `pairs_to_judge` orders by `judge_attempts`, and a
+        // pair that has not run yet still has none, so it leads every sweep
+        // until it does — spending the budget on itself over and over while
+        // pairs recorded since never get a turn.
+        //
+        // Checked before the artifact reads, because those in-flight pairs
+        // lead the ordering: with the check after them, every tick re-fetched
+        // both full-text rows for the very pairs it was about to skip.
+        let target = p.id.to_string();
+        if core.store.live_job(Stage::Dedupe, &target).await? {
+            continue;
+        }
+
         // Reported, not skipped, with one exception. Skipping treated a store
         // that was briefly unwell as a pair not worth arming, and since nothing
         // recorded an attempt it led the next sweep's ordering all over again.
@@ -700,16 +714,6 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
         // The tokeniser under it survives: `dedupe_prompt` is given the values
         // that differ as a prior, and the merge verification refuses any merge
         // that drops one.
-
-        // A pair whose unit is still queued from an earlier sweep is already
-        // going to be judged. `pairs_to_judge` orders by `judge_attempts`, and a
-        // pair that has not run yet still has none, so it leads every sweep
-        // until it does — spending the budget on itself over and over while
-        // pairs recorded since never get a turn.
-        let target = p.id.to_string();
-        if core.store.live_job(Stage::Dedupe, &target).await? {
-            continue;
-        }
 
         // `seq` is the pair's position in this sweep. Left at zero, twenty
         // judge units would all sort ahead of every document's second window.

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -603,6 +603,12 @@ pub async fn run(core: &Core) -> Result<Outcome> {
 /// most once, so the depth is bounded by the pairs that exist, and the call rate
 /// is the gate's job rather than this number's.
 pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
+    // `max_dedupe_per_tick = 0` is the off switch for the model (see `run`'s
+    // comment on the `autonomous` flag). Off means off: no 200-row read per
+    // tick, and no "budget spent" log line implying a budget was spent.
+    if core.consolidate.max_dedupe_per_tick == 0 {
+        return Ok(0);
+    }
     let pending = core.store.pairs_to_judge(200).await?;
 
     let mut armed = 0usize;
@@ -2310,6 +2316,28 @@ pub(crate) mod tests {
         seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
         let out = run(&core).await.unwrap();
         assert_eq!((out.examined, out.superseded, out.queued), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn a_zero_dedupe_budget_arms_nothing_and_reads_nothing() {
+        // With the budget at zero every tick still ran the 200-row query and
+        // logged "budget spent" — dead work on the sweep's hot path, and a
+        // misleading log line. The observable half: nothing is armed and no
+        // pair is touched.
+        let mut core = test_core().await;
+        core.consolidate.max_dedupe_per_tick = 0;
+        disagreeing(&core).await;
+        let out = run(&core).await.unwrap();
+        assert_eq!(out.judged, 0);
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the pending pair must be left exactly as it was"
+        );
     }
 
     #[test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -1718,13 +1718,23 @@ pub(crate) mod tests {
 
         let out = sweep_and_dedupe(&core).await;
         assert_eq!(out.judged, 1, "one pair should have been armed: {out:?}");
+        // Settled as the manual apply settles it: Dismissed, not left in
+        // Superseded — that state means "awaiting an operator", and an applied
+        // replacement has nothing left to confirm.
         let found = core
             .store
-            .pairs_by_state(PairState::Superseded, 10)
+            .pairs_by_state(PairState::Dismissed, 10)
             .await
             .unwrap();
         assert_eq!(found.len(), 1, "the pair did not land as decided");
-        assert_eq!(found[0].obsolete_id.as_deref(), Some(ids[0].as_str()));
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Superseded, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an applied replacement is still listed as a proposal"
+        );
 
         // Applied, and the survivor is a stored original rather than a rewrite.
         assert_eq!(

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -1124,6 +1124,34 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn the_heal_reveals_with_the_marker_protocol_and_leaves_none_standing() {
+        // Payload-first direction, so the contract is unsupersede's: mark
+        // before the payload write, clear only once both stores agree. Without
+        // the mark, a crash between the two writes is drift no marker ever
+        // announced; and without the lock, the sweep's repair can interleave
+        // and write the stale hidden state back with nothing left to notice.
+        let core = test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.0, 1.0])]).await;
+        core.supersede(&ids[0], &ids[1]).await.unwrap();
+
+        core.delete_artifact(&ids[1]).await.unwrap(); // runs the heal
+
+        let a = core.store.get_artifact(&ids[0]).await.unwrap();
+        assert!(
+            a.in_results(),
+            "the heal did not restore the dangling loser"
+        );
+        assert!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the heal left a marker on a base in agreement"
+        );
+    }
+
+    #[tokio::test]
     async fn deleting_the_survivor_puts_the_artifact_it_hid_back() {
         // `superseded_by` has no foreign key behind it. Deleting the keeper
         // left the loser pointing at nothing, hidden from search in favour of a

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -171,7 +171,8 @@ fn lifecycle_row_of(c: &Chunk) -> crate::vector::LifecycleRow {
 /// permanently, so both capped scans were on course to be truncated forever:
 /// repairing a shifting window of an ever-growing set, and reporting success
 /// either way. `full_lifecycle_reconcile` keeps that scan for the drift that
-/// arises with no SQLite write behind it, but it no longer runs every sweep.
+/// arises with no SQLite write behind it; it still runs every sweep, after
+/// this pass.
 ///
 /// Returns how many artifacts it rewrote, which is a number worth asserting on:
 /// a repair that fires on a base in agreement is a bug that hides behind a
@@ -202,8 +203,8 @@ async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
 /// The full two-sided scan, for drift that arose with no SQLite write behind it
 /// — a payload edited out of band, or a base predating `lifecycle_dirty`.
 ///
-/// Still on the sweep, behind the marker, and the division of labour is the
-/// point. The marker is *complete* for everything this system does to itself:
+/// Still on every sweep, after the marker pass, and the division of labour is
+/// the point. The marker is *complete* for everything this system does to itself:
 /// every lifecycle transition marks before it writes and clears only once both
 /// stores agree, so no in-system write can drift unseen however large the base
 /// grows. This scan is *best-effort* for everything else, and past `DRIFT_SCAN`

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -314,6 +314,19 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         }
         Err(e) => tracing::warn!(error = %e, "could not look for unfinished merges"),
     }
+    // The opposite failure: a merge that will never be embedded. Its pairs
+    // are already settled, its roots were never superseded, and its only
+    // signal was a forever-retrying embed job.
+    match core.store.stranded_merges(50).await {
+        Ok(stranded) => {
+            for id in stranded {
+                if let Err(e) = crate::jobs::merge::reap_stranded(core, &id).await {
+                    tracing::warn!(merged = %id, error = %e, "could not reap a stranded merge");
+                }
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "could not look for stranded merges"),
+    }
     // A merged artifact whose source was deleted still carries what that source
     // said, so this is not data loss — it is a claim of provenance the artifact
     // can no longer support, and saying so beats quietly showing one fewer.
@@ -2254,5 +2267,103 @@ pub(crate) mod tests {
         seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
         let out = run(&core).await.unwrap();
         assert_eq!((out.examined, out.superseded, out.queued), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_can_never_embed_is_reaped_and_its_pairs_reopened() {
+        // The pairs are settled the moment the merge is written. If the embed
+        // then fails permanently the merge is stranded active-but-unindexed,
+        // the roots are never superseded, and the settled pairs mean the
+        // duplicates can never be merged again — with a forever-retrying job
+        // as the only signal.
+        use crate::store::artifacts::NewMerged;
+        use crate::store::pairs::PairState;
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+        let m = core
+            .store
+            .insert_merged_artifact(
+                &NewMerged {
+                    text: "both".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[ids[0].clone(), ids[1].clone()],
+            )
+            .await
+            .unwrap();
+        core.store
+            .enqueue(crate::store::jobs::Stage::Embed, "artifact", &m.id)
+            .await
+            .unwrap();
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        let pid = core
+            .store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()[0]
+            .id;
+        core.store
+            .set_pair_merged(pid, &m.id, Some("same claim"))
+            .await
+            .unwrap();
+        // The embed job has exhausted its retries and cannot succeed.
+        sqlx::query("UPDATE jobs SET attempts = ? WHERE target_id = ?")
+            .bind(crate::store::jobs::MAX_ATTEMPTS)
+            .bind(&m.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        assert_eq!(
+            core.store.get_artifact(&m.id).await.unwrap().status,
+            ArtifactStatus::Deprecated,
+            "the stranded merge should be retired"
+        );
+        let p = core.store.get_pair(pid).await.unwrap();
+        assert_eq!(
+            p.state,
+            PairState::Contradiction,
+            "the pair goes back to a person"
+        );
+        for id in &ids {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().status,
+                ArtifactStatus::Active
+            );
+        }
+
+        // And a healthy in-flight merge is left alone.
+        let m2 = core
+            .store
+            .insert_merged_artifact(
+                &NewMerged {
+                    text: "x".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[ids[0].clone(), ids[1].clone()],
+            )
+            .await
+            .unwrap();
+        core.store
+            .enqueue(crate::store::jobs::Stage::Embed, "artifact", &m2.id)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        assert_eq!(
+            core.store.get_artifact(&m2.id).await.unwrap().status,
+            ArtifactStatus::Active,
+            "a merge whose embed is still in flight was reaped"
+        );
     }
 }

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -603,7 +603,7 @@ mod tests {
                 sparse: Default::default(),
                 payload: VectorPayload {
                     artifact_id: c.id.clone(),
-                    corpus_id: c.corpus_id.clone(),
+                    corpus_id: c.corpus_id.clone().unwrap_or_default(),
                     text: (*text).to_string(),
                     title: None,
                     category: None,
@@ -615,6 +615,7 @@ mod tests {
                     status: None,
                     last_verified_at: None,
                     superseded_by: None,
+                    provenance: None,
                 },
             })
             .collect();
@@ -653,7 +654,7 @@ mod tests {
                 sparse: Default::default(),
                 payload: VectorPayload {
                     artifact_id: made[0].id.clone(),
-                    corpus_id: made[0].corpus_id.clone(),
+                    corpus_id: made[0].corpus_id.clone().unwrap_or_default(),
                     text: text.to_string(),
                     title: None,
                     category: None,
@@ -665,6 +666,7 @@ mod tests {
                     status: None,
                     last_verified_at: None,
                     superseded_by: None,
+                    provenance: None,
                 },
             }])
             .await

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -281,6 +281,12 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         }
         Err(e) => tracing::warn!(error = %e, "could not look for unfinished merges"),
     }
+    // A merged artifact whose source was deleted still carries what that source
+    // said, so this is not data loss — it is a claim of provenance the artifact
+    // can no longer support, and saying so beats quietly showing one fewer.
+    if let Err(e) = crate::jobs::merge::flag_orphans(core).await {
+        tracing::warn!(error = %e, "could not flag merged artifacts that lost a source");
+    }
     // Startup heals too, but a process that stays up for weeks is exactly the
     // one whose stores drift: every interrupted write between the two happens
     // while it is running, not while it is starting.

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -23,9 +23,6 @@ pub struct Outcome {
     pub examined: usize,
     pub superseded: usize,
     pub queued: usize,
-    /// Pairs settled without asking anyone, because the two artifacts state no
-    /// value differently and so have nothing to disagree about.
-    pub closed: usize,
     /// Pairs this sweep armed a judge unit for. The calls happen later, one
     /// unit at a time, so this counts what was asked for rather than answered.
     pub judged: usize,
@@ -69,16 +66,6 @@ impl Clusters {
 /// not depend on clock resolution. Newer is the right default because the thing
 /// most often re-captured is a document that has since been updated — and Ops
 /// has an undo for when it is not.
-/// Is the whole of one artifact inside the other, whitespace aside?
-///
-/// Not a similarity — containment. A score says two texts are alike; this says
-/// one of them adds nothing, which is the only ground on which the sweep hides
-/// something below `auto_supersede`.
-fn contains_normalized(long: &str, short: &str) -> bool {
-    let n = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
-    !short.trim().is_empty() && n(long).contains(&n(short))
-}
-
 fn keeper(members: &[Chunk]) -> &Chunk {
     members
         .iter()
@@ -314,6 +301,9 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     // The review band. A pair whose members were just hidden has already been
     // answered, and queueing it would ask an operator to rule on an artifact
     // that is no longer in results.
+    //
+    // The rules themselves live in `classify_pair`, because the per-artifact
+    // relate unit applies the same ones and two copies would diverge silently.
     for p in pairs.iter().filter(|p| p.score < cfg.auto_supersede) {
         if hidden.contains(&p.a) || hidden.contains(&p.b) {
             continue;
@@ -324,96 +314,19 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         ) else {
             continue;
         };
-        // Same rule as the cluster pass: only two live artifacts have a
-        // question worth a queue slot, an inference call, or a containment
-        // supersede below.
-        if [&a, &b]
-            .iter()
-            .any(|c| c.status != ArtifactStatus::Active || c.superseded_by.is_some())
-        {
-            continue;
-        }
-
-        // One synthesis call emitting the same passage twice: the shorter text
-        // is wholly inside the longer, and both came out of the same document.
-        // That is a defect in one artifact rather than two sources saying
-        // different things, and nothing is lost by hiding it — the survivor
-        // says everything it said, Ops lists it, and one press undoes it.
-        //
-        // Same corpus is the whole of the condition. Two documents that share a
-        // sentence are two sources, and hiding one of those on a 0.9 similarity
-        // is what `auto_supersede` deliberately refuses to do.
-        if a.corpus_id == b.corpus_id {
-            let (long, short) = if a.text.len() >= b.text.len() {
-                (&a, &b)
-            } else {
-                (&b, &a)
-            };
-            if contains_normalized(&long.text, &short.text) {
-                // Same race, same treatment as the cluster pass above.
-                if let Err(e) = core.supersede(&short.id, &long.id).await {
-                    tracing::warn!(
-                        superseded = %short.id,
-                        by = %long.id,
-                        error = %e,
-                        "could not hide a duplicated passage; it stays active"
-                    );
-                    continue;
-                }
-                out.superseded += 1;
-                tracing::info!(
-                    superseded = %short.id,
-                    by = %long.id,
-                    "hid a passage one synthesis call emitted twice"
-                );
-                continue;
-            }
-        }
-
-        // Two artifacts that state no value differently have nothing for a
-        // person to rule on, and asking anyway is what turned this queue into a
-        // list of chores. The pair is filed as settled — the sweep re-finds it
-        // every run, so it has to be remembered — and both artifacts stay
-        // exactly where they are. Closing a question is not hiding an answer.
-        //
-        // The prefilter used to run only when the judge was enabled, which it
-        // is not by default, so the cheap answer was reached only by bases
-        // already paying for the expensive one.
-        // Both writes below warn and carry on, like the supersede calls above:
-        // a pair is one row about two artifacts, and a transient BUSY on it is
-        // no reason to abandon the rest of the band, the judge pass and the
-        // sweep's tally. The sweep re-finds the pair next run.
-        if !crate::infer::facts::may_disagree(&a.text, &b.text) {
-            match core
-                .store
-                .record_settled_pair(
-                    &p.a,
-                    &p.b,
-                    p.score,
-                    crate::store::pairs::PairState::NoConflict,
-                )
-                .await
-            {
-                Ok(true) => {
-                    out.closed += 1;
-                    tracing::debug!(a = %p.a, b = %p.b, score = p.score, "pair states nothing differently");
-                }
-                Ok(false) => {}
-                Err(e) => {
-                    tracing::warn!(a = %p.a, b = %p.b, error = %e, "could not file a settled pair; it will be re-examined next sweep");
-                }
-            }
-            continue;
-        }
-
-        match core.store.record_pair(&p.a, &p.b, p.score).await {
-            Ok(true) => {
+        // Warn and carry on. A pair is one row about two artifacts, and a
+        // transient BUSY on it is no reason to abandon the rest of the band,
+        // the dedupe pass, and the sweep's tally — the sweep re-finds the pair
+        // next run either way.
+        match crate::jobs::classify::classify_pair(core, &a, &b, p.score).await {
+            Ok(crate::jobs::classify::Verdict::Queued) => {
                 out.queued += 1;
                 tracing::info!(a = %p.a, b = %p.b, score = p.score, "queued a pair for review");
             }
-            Ok(false) => {}
+            Ok(crate::jobs::classify::Verdict::Contained) => out.superseded += 1,
+            Ok(_) => {}
             Err(e) => {
-                tracing::warn!(a = %p.a, b = %p.b, error = %e, "could not queue a pair for review; it will be re-examined next sweep");
+                tracing::warn!(a = %p.a, b = %p.b, error = %e, "could not classify a pair; it will be re-examined next sweep");
             }
         }
     }
@@ -515,12 +428,17 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
             continue;
         }
 
-        if !crate::infer::facts::may_disagree(&a.text, &b.text) {
-            core.store
-                .set_pair_state(p.id, crate::store::pairs::PairState::NoConflict, None)
-                .await?;
-            continue;
-        }
+        // `may_disagree` used to close the pair here, and it was the second
+        // copy of the gate `classify_pair` just lost. Both were right for the
+        // old question — "do these two contradict each other?" — and both are
+        // backwards for deduplication, where a pair stating no differing value
+        // is the cleanest thing there is to merge. Keeping this one would have
+        // meant the queue filed such a pair and the arming step closed it
+        // again, which reads as the sweep disagreeing with itself.
+        //
+        // The tokeniser under it survives: `dedupe_prompt` is given the values
+        // that differ as a prior, and the merge verification refuses any merge
+        // that drops one.
 
         // A pair whose unit is still queued from an earlier sweep is already
         // going to be judged. `pairs_to_judge` orders by `judge_attempts`, and a
@@ -550,7 +468,7 @@ async fn arm_judgements(core: &Core) -> Result<usize> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::core::test_support::test_core;
     use crate::store::artifacts::NewArtifact;
@@ -578,7 +496,10 @@ mod tests {
 
     /// Seed artifacts with hand-placed vectors, so the test controls the exact
     /// similarity rather than depending on what the fake embedder produces.
-    async fn seed(core: &crate::core::Core, vectors: &[(&str, [f32; 2])]) -> Vec<String> {
+    pub(crate) async fn seed(
+        core: &crate::core::Core,
+        vectors: &[(&str, [f32; 2])],
+    ) -> Vec<String> {
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let new: Vec<NewArtifact> = vectors
             .iter()
@@ -625,7 +546,7 @@ mod tests {
 
     /// One artifact under a corpus of its own, for the cases where "same
     /// document" is the thing under test.
-    async fn seed_into_new_corpus(
+    pub(crate) async fn seed_into_new_corpus(
         core: &crate::core::Core,
         text: &str,
         vector: [f32; 2],
@@ -1284,13 +1205,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_pair_with_no_facts_to_disagree_about_never_reaches_the_model() {
-        // The prefilter is the whole economic argument for this feature: a
-        // model call is minutes, and most near pairs have nothing to judge.
+    async fn a_pair_with_no_differing_values_is_armed_for_the_model() {
+        // This asserted the opposite until 2026-08-14, and the reversal is the
+        // point of the change rather than a side effect of it.
+        //
+        // `may_disagree` admits a pair only when both sides state values and
+        // those values differ. That was right for the question it was written
+        // for — "do these two contradict each other?" — and is backwards for
+        // deduplication: two artifacts at 0.93 saying the same thing in
+        // different words have nothing to contradict and everything to merge.
+        // The old rule filed them as settled and left both in every result set,
+        // so the single best merge candidate was the one case the model was
+        // never shown.
         let mut core = test_core().await;
         core.consolidate.judge = true;
-        let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
-        core.completer = completer.clone();
         seed(
             &core,
             &[
@@ -1301,20 +1229,15 @@ mod tests {
         .await;
 
         let out = run(&core).await.unwrap();
-        assert_eq!(
-            completer.calls(),
-            0,
-            "the prefilter let a factless pair through"
-        );
-        assert_eq!(out.judged, 0);
-        assert_eq!(
+        assert_eq!(out.queued, 1, "{out:?}");
+        assert_eq!(out.judged, 1, "the pair was never armed for a decision");
+        assert!(
             core.store
                 .pairs_by_state(PairState::NoConflict, 10)
                 .await
                 .unwrap()
-                .len(),
-            1,
-            "a cleared pair must leave the pending queue"
+                .is_empty(),
+            "the pair was closed by the old prefilter instead of being judged"
         );
     }
 
@@ -1431,11 +1354,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_pair_with_nothing_to_disagree_about_never_reaches_the_queue() {
-        // The prefilter already knows these two state no differing value, but
-        // it only ran when the judge was enabled — and the judge is off by
-        // default. So every near pair became a question for a person, which is
-        // a question with no answer to give.
+    async fn a_pair_with_no_differing_values_reaches_the_queue() {
+        // The sibling of the rewrite above, from the sweep's side. It used to
+        // assert `queued == 0` and `closed == 1`: a pair stating no differing
+        // value was filed as settled and both artifacts stayed active.
+        //
+        // Under deduplication that is the wrong way round. Two artifacts saying
+        // the same thing in different words are what merging is for, and the
+        // sweep now queues them for a decision rather than closing the question
+        // nobody asked. Queued is not hidden: nothing about either artifact
+        // changes until a dedupe unit has ruled.
         let core = test_core().await;
         let ids = seed(
             &core,
@@ -1447,16 +1375,15 @@ mod tests {
         .await;
 
         let out = run(&core).await.unwrap();
-        assert_eq!(out.queued, 0, "{out:?}");
-        assert_eq!(out.closed, 1, "{out:?}");
-        assert!(
+        assert_eq!(out.queued, 1, "{out:?}");
+        assert_eq!(
             core.store
                 .pairs_by_state(PairState::Pending, 10)
                 .await
                 .unwrap()
-                .is_empty()
+                .len(),
+            1
         );
-        // Closing a question is not hiding an answer.
         for id in &ids {
             assert!(
                 core.store
@@ -1464,7 +1391,8 @@ mod tests {
                     .await
                     .unwrap()
                     .superseded_by
-                    .is_none()
+                    .is_none(),
+                "queueing a pair must not hide anything"
             );
         }
     }

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -268,6 +268,19 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             "could not reconcile lifecycle state with the vector store; retrying on the next sweep"
         );
     }
+    // A merge whose process died between indexing and hiding what it replaced.
+    // Invisible to everything else: complete from the artifact side, absent
+    // from the pair side, and only a join across the lineage says otherwise.
+    match core.store.merged_with_active_roots(200).await {
+        Ok(unfinished) => {
+            for id in unfinished {
+                if let Err(e) = crate::jobs::merge::finish(core, &id).await {
+                    tracing::warn!(merged = %id, error = %e, "could not finish a merge");
+                }
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "could not look for unfinished merges"),
+    }
     // Startup heals too, but a process that stays up for weeks is exactly the
     // one whose stores drift: every interrupted write between the two happens
     // while it is running, not while it is starting.

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -36,7 +36,7 @@
 
 use crate::core::Core;
 use crate::error::{Error, Result};
-use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::artifacts::Chunk;
 use crate::store::jobs::Stage;
 use std::collections::{HashMap, HashSet};
 
@@ -437,7 +437,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
                 continue;
             }
         };
-        if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
+        if !c.in_results() {
             // The row says hidden but the vector store still offered this point
             // as a pair candidate, so its payload never caught up — the write
             // was interrupted, and `repair_lifecycle_drift` at the top of this
@@ -654,11 +654,7 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
         // returns a validation error and the pair stays pending forever. The
         // same guard runs in `run`'s cluster pass and review band, and again in
         // the unit itself, because a pair can be retired while it waits.
-        if a.status != ArtifactStatus::Active
-            || b.status != ArtifactStatus::Active
-            || a.superseded_by.is_some()
-            || b.superseded_by.is_some()
-        {
+        if !a.in_results() || !b.in_results() {
             core.store
                 .set_pair_state(p.id, crate::store::pairs::PairState::Dismissed, None)
                 .await?;
@@ -713,6 +709,7 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
 pub(crate) mod tests {
     use super::*;
     use crate::core::test_support::test_core;
+    use crate::store::artifacts::ArtifactStatus;
     use crate::store::artifacts::NewArtifact;
     use crate::store::pairs::PairState;
     use crate::vector::{VectorPayload, VectorPoint};

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -102,16 +102,60 @@ fn lifecycle_row_of(c: &Chunk) -> crate::vector::LifecycleRow {
 /// Broader than `heal_dangling_supersessions`, which repairs one specific case
 /// (a winner that has since been deleted) in the SQLite direction only.
 ///
+/// Reads `lifecycle_dirty` rather than scanning. The marker is written in the
+/// same UPDATE that changes `status`/`superseded_by` and cleared once the
+/// payload write is acknowledged, so the work list is exactly the writes that
+/// did not finish — which is almost always empty.
+///
+/// The scan it replaced could not survive this feature. Autonomous merging makes
+/// hidden artifacts grow monotonically, every merge hiding at least two
+/// permanently, so both capped scans were on course to be truncated forever:
+/// repairing a shifting window of an ever-growing set, and reporting success
+/// either way. `full_lifecycle_reconcile` keeps that scan for the drift that
+/// arises with no SQLite write behind it, but it no longer runs every sweep.
+///
 /// Returns how many artifacts it rewrote, which is a number worth asserting on:
 /// a repair that fires on a base in agreement is a bug that hides behind a
 /// correct end state.
 async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
-    repair_lifecycle_drift_scanning(core, DRIFT_SCAN).await
+    let dirty = core.store.dirty_lifecycle_artifacts(DRIFT_SCAN).await?;
+    if dirty.is_empty() {
+        return Ok(0);
+    }
+    let rows: Vec<crate::vector::LifecycleRow> = dirty.iter().map(lifecycle_row_of).collect();
+    core.vectors.apply_lifecycle(&rows).await?;
+    // Only after the payload write returns. Clearing first would turn a failed
+    // write into permanent drift that nothing is left to notice.
+    let ids: Vec<String> = dirty.iter().map(|c| c.id.clone()).collect();
+    core.store.clear_lifecycle_dirty(&ids).await?;
+    tracing::info!(
+        repaired = rows.len(),
+        "finished lifecycle writes that never reached the vector store"
+    );
+    Ok(rows.len())
+}
+
+/// The full two-sided scan, for drift that arose with no SQLite write behind it
+/// — a payload edited out of band, or a base predating `lifecycle_dirty`.
+///
+/// Still on the sweep, behind the marker, and the division of labour is the
+/// point. The marker is *complete* for everything this system does to itself:
+/// every lifecycle transition marks before it writes and clears only once both
+/// stores agree, so no in-system write can drift unseen however large the base
+/// grows. This scan is *best-effort* for everything else, and past `DRIFT_SCAN`
+/// hidden artifacts it samples rather than covers.
+///
+/// Deleting it was tempting and wrong. The skew it alone catches is the worse
+/// of the two: a payload that says deprecated behind a row that says active
+/// leaves the artifact out of search, off every Ops list, and out of reach of
+/// the one button that would restore it. Incomplete cover for that beats none.
+pub(crate) async fn full_lifecycle_reconcile(core: &Core) -> Result<usize> {
+    full_lifecycle_reconcile_scanning(core, DRIFT_SCAN).await
 }
 
 /// The above with its cap as a parameter, so a test can reproduce what the two
 /// truncated scans do to each other without seeding `DRIFT_SCAN` artifacts.
-async fn repair_lifecycle_drift_scanning(core: &Core, scan: usize) -> Result<usize> {
+pub(crate) async fn full_lifecycle_reconcile_scanning(core: &Core, scan: usize) -> Result<usize> {
     // Both scans are capped, and neither cap lines up with the other:
     // `list_non_active_artifacts` returns the newest rows while `non_active_ids`
     // scrolls in point-id order. So set membership across the two proves
@@ -206,7 +250,19 @@ pub async fn run(core: &Core) -> Result<Outcome> {
             "could not restore every artifact whose winner was deleted; retrying on the next sweep"
         );
     }
+    // Two passes, and the order is deliberate. The marker first: it is cheap,
+    // it is complete for every lifecycle write this system makes, and it does
+    // not grow with the base. Then the scan, which is the only thing that sees
+    // drift no SQLite write produced — a payload edited out of band leaves an
+    // artifact out of search, off every Ops list, and out of reach of the button
+    // that would restore it, and nothing else in the system would ever notice.
     if let Err(e) = repair_lifecycle_drift(core).await {
+        tracing::warn!(
+            error = %e,
+            "could not finish interrupted lifecycle writes; retrying on the next sweep"
+        );
+    }
+    if let Err(e) = full_lifecycle_reconcile(core).await {
         tracing::warn!(
             error = %e,
             "could not reconcile lifecycle state with the vector store; retrying on the next sweep"
@@ -950,7 +1006,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn the_drift_repair_rewrites_nothing_when_the_two_stores_agree() {
+    async fn the_full_reconcile_rewrites_nothing_when_the_two_stores_agree() {
         // Both scans are capped and neither cap lines up with the other, so
         // "missing from the other list" used to read as drift. On a base with
         // more hidden artifacts than one scan returns, that reported the whole
@@ -977,6 +1033,91 @@ pub(crate) mod tests {
             0,
             "the repair fired on a base that agrees with itself"
         );
+        assert_eq!(
+            full_lifecycle_reconcile(&core).await.unwrap(),
+            0,
+            "the full scan fired on a base that agrees with itself"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lifecycle_write_that_lost_its_payload_is_repaired_from_the_marker() {
+        // The scan this replaced was capped at DRIFT_SCAN from both sides, and
+        // autonomous merging makes hidden artifacts grow without bound — every
+        // merge hides at least two, permanently. Past the cap it repaired a
+        // shifting window of an ever-growing set and reported success either
+        // way. The marker's work list is the writes that did not finish, which
+        // is almost always empty and never grows with the base.
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+
+        // Row written, payload not — exactly what a crash between the two
+        // leaves behind.
+        core.store
+            .set_artifact_status(&ids[0], ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+        assert_eq!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the row write left no marker, so nothing would ever look for it"
+        );
+
+        assert_eq!(repair_lifecycle_drift(&core).await.unwrap(), 1);
+
+        assert!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the marker outlived the repair, so every sweep would redo it"
+        );
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            !hits.iter().any(|h| h.payload.artifact_id == ids[0]),
+            "a deprecated artifact is still in search"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_completed_lifecycle_change_leaves_no_marker() {
+        // If the four mutators did not clear it, the repair would rewrite every
+        // payload they ever touched, on every sweep, forever — write
+        // amplification behind a permanently correct end state.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("first", [1.0, 0.0]),
+                ("second", [0.0, 1.0]),
+                ("third", [0.5, 0.5]),
+            ],
+        )
+        .await;
+
+        core.deprecate(&ids[0]).await.unwrap();
+        core.supersede(&ids[1], &ids[2]).await.unwrap();
+        core.reactivate(&ids[0]).await.unwrap();
+        core.unsupersede(&ids[1]).await.unwrap();
+
+        assert!(
+            core.store
+                .dirty_lifecycle_artifacts(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a completed lifecycle change left its marker behind"
+        );
+        assert_eq!(repair_lifecycle_drift(&core).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -993,17 +1134,22 @@ pub(crate) mod tests {
         core.deprecate(&ids[1]).await.unwrap();
 
         assert_eq!(
-            repair_lifecycle_drift_scanning(&core, 1).await.unwrap(),
+            full_lifecycle_reconcile_scanning(&core, 1).await.unwrap(),
             0,
             "the edge of a page was reported as a disagreement"
         );
     }
 
     #[tokio::test]
-    async fn the_drift_repair_notices_a_payload_naming_the_wrong_status() {
+    async fn the_full_reconcile_notices_a_payload_naming_the_wrong_status() {
         // Not just hidden-or-not: a payload that says superseded behind a row
         // that says deprecated is drift too, and comparing set membership alone
         // never saw it.
+        //
+        // This is also precisely the drift the marker cannot see, and why the
+        // scan is kept rather than deleted: the payload was written out of band,
+        // so no SQLite write happened and nothing was marked. The marker covers
+        // what this system does to itself; the scan covers everything else.
         let core = test_core().await;
         let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
         core.deprecate(&ids[0]).await.unwrap();
@@ -1012,7 +1158,12 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        assert_eq!(repair_lifecycle_drift(&core).await.unwrap(), 1);
+        assert_eq!(
+            repair_lifecycle_drift(&core).await.unwrap(),
+            0,
+            "the marker claimed to see drift that no SQLite write produced"
+        );
+        assert_eq!(full_lifecycle_reconcile(&core).await.unwrap(), 1);
         let stored = core
             .vectors
             .lifecycle_of(std::slice::from_ref(&ids[0]))

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -610,6 +610,18 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
     if core.consolidate.max_dedupe_per_tick == 0 {
         return Ok(0);
     }
+    // Verdicts recorded while autonomy was off go back into the queue now
+    // that it is on. Idempotent and normally free: with autonomy on, no unit
+    // writes would_merge, so this touches rows exactly once per flip.
+    if core.consolidate.autonomous {
+        let reopened = core.store.reopen_would_merge_pairs().await?;
+        if reopened > 0 {
+            tracing::info!(
+                reopened,
+                "re-armed would-merge verdicts recorded before autonomy"
+            );
+        }
+    }
     let pending = core.store.pairs_to_judge(200).await?;
 
     let mut armed = 0usize;
@@ -1465,6 +1477,43 @@ pub(crate) mod tests {
             first.stage,
             Stage::SegmentWindow,
             "a dedupe unit was claimed ahead of capture work"
+        );
+    }
+
+    #[tokio::test]
+    async fn would_merge_verdicts_are_re_armed_once_autonomy_is_on() {
+        // Recorded while autonomy was off, the verdict's whole point is to be
+        // acted on once the switch flips — the variant's own doc says so. The
+        // ticker's arming pass is where the flip becomes visible.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.consolidate.max_dedupe_per_tick = 5;
+        let ids = disagreeing(&core).await;
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()[0]
+            .id;
+        core.store
+            .set_pair_state(
+                pair,
+                crate::store::pairs::PairState::WouldMerge,
+                Some("same claim"),
+            )
+            .await
+            .unwrap();
+
+        arm_dedupe(&core).await.unwrap();
+
+        assert_eq!(
+            core.store.get_pair(pair).await.unwrap().state,
+            crate::store::pairs::PairState::Pending,
+            "a would_merge verdict stayed stranded after autonomy came on"
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -95,6 +95,32 @@ fn keeper(members: &[Chunk]) -> &Chunk {
         .expect("a cluster has at least one member")
 }
 
+/// Whether the clustering pass answered a filed near-identical pair, and with
+/// what record. `known` is false when the member's row could not be read this
+/// sweep — an unreadable member is not a gone member, and closing on a
+/// transient store error would settle a live pair permanently, since
+/// `record_settled_pair` only updates pending rows.
+fn close_filed_pair(
+    a_known: bool,
+    b_known: bool,
+    a_live: bool,
+    b_live: bool,
+    a_id: &str,
+    b_id: &str,
+) -> Option<String> {
+    if !a_known || !b_known {
+        return None;
+    }
+    match (a_live, b_live) {
+        // Both still in results, so nothing here was answered — a supersede
+        // that failed and warned. The pair stays filed for the next sweep.
+        (true, true) => None,
+        (true, false) => Some(format!("near-identical; {a_id} kept")),
+        (false, true) => Some(format!("near-identical; {b_id} kept")),
+        (false, false) => Some("near-identical; neither side is in results any more".to_string()),
+    }
+}
+
 /// Where dedupe units sort in the queue.
 ///
 /// `claim_job` orders by `(state, attempts, seq, id)`, and a segmentation
@@ -386,12 +412,24 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     // the filed rows are closed against it below, and re-reading every pair's two
     // artifacts would be the same lookups a second time.
     let mut live: HashSet<String> = HashSet::new();
+    // Ids whose row could not be read this sweep. Unreadable is not gone: the
+    // closing pass must not settle a pair on the strength of a store that was
+    // briefly unwell.
+    let mut unknown: HashSet<String> = HashSet::new();
     for id in &in_a_cluster {
         // An artifact the vector store still lists but SQLite has dropped is
         // ordinary: a delete can lag a sweep. It is not an error.
-        let Ok(c) = core.store.get_artifact(id).await else {
-            tracing::debug!(artifact_id = %id, "pair names an artifact that is gone");
-            continue;
+        let c = match core.store.get_artifact(id).await {
+            Ok(c) => c,
+            Err(Error::NotFound) => {
+                tracing::debug!(artifact_id = %id, "pair names an artifact that is gone");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(artifact_id = %id, error = %e, "could not read a clustered artifact this sweep");
+                unknown.insert(id.clone());
+                continue;
+            }
         };
         if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
             // The row says hidden but the vector store still offered this point
@@ -456,18 +494,18 @@ pub async fn run(core: &Core) -> Result<Outcome> {
     // `NoConflict` with a detail, as the merge path does: the question is
     // settled and there is nothing here for a person. `Superseded` would put it
     // on the Capture page behind an "apply" button for something already applied.
+    // A pair with an unreadable member stays filed for the next sweep.
     for p in &filed {
-        let a_live = live.contains(&p.a_id) && !hidden.contains(&p.a_id);
-        let b_live = live.contains(&p.b_id) && !hidden.contains(&p.b_id);
-        if a_live && b_live {
-            // Both still in results, so nothing here was answered — a supersede
-            // that failed above, and warned. It stays filed for the next sweep.
+        let alive = |id: &String| live.contains(id) && !hidden.contains(id);
+        let Some(detail) = close_filed_pair(
+            !unknown.contains(&p.a_id),
+            !unknown.contains(&p.b_id),
+            alive(&p.a_id),
+            alive(&p.b_id),
+            &p.a_id,
+            &p.b_id,
+        ) else {
             continue;
-        }
-        let detail = match (a_live, b_live) {
-            (true, false) => format!("near-identical; {} kept", p.a_id),
-            (false, true) => format!("near-identical; {} kept", p.b_id),
-            _ => "near-identical; neither side is in results any more".to_string(),
         };
         if let Err(e) = core
             .store
@@ -2267,6 +2305,30 @@ pub(crate) mod tests {
         seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
         let out = run(&core).await.unwrap();
         assert_eq!((out.examined, out.superseded, out.queued), (0, 0, 0));
+    }
+
+    #[test]
+    fn an_unreadable_member_leaves_the_filed_pair_alone() {
+        // A transient BUSY on one member used to read as "gone", closing the
+        // pair as NoConflict while both artifacts were live — permanently,
+        // because record_settled_pair only updates pending rows.
+        assert_eq!(close_filed_pair(false, true, false, true, "a", "b"), None);
+        assert_eq!(close_filed_pair(true, false, true, false, "a", "b"), None);
+        // Both readable and live: genuinely unanswered, stays filed.
+        assert_eq!(close_filed_pair(true, true, true, true, "a", "b"), None);
+        // Known-gone or known-hidden sides do close.
+        assert_eq!(
+            close_filed_pair(true, true, true, false, "a", "b").as_deref(),
+            Some("near-identical; a kept")
+        );
+        assert_eq!(
+            close_filed_pair(true, true, false, true, "a", "b").as_deref(),
+            Some("near-identical; b kept")
+        );
+        assert_eq!(
+            close_filed_pair(true, true, false, false, "a", "b").as_deref(),
+            Some("near-identical; neither side is in results any more")
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -177,6 +177,11 @@ fn lifecycle_row_of(c: &Chunk) -> crate::vector::LifecycleRow {
 /// a repair that fires on a base in agreement is a bug that hides behind a
 /// correct end state.
 async fn repair_lifecycle_drift(core: &Core) -> Result<usize> {
+    // Under the same lock as every lifecycle transition: the repair reads
+    // rows, writes payloads and clears markers, and interleaving that with a
+    // payload-first reveal is exactly the sequence that hides an artifact
+    // with no marker left to find it by.
+    let _guard = core.lifecycle_lock.lock().await;
     let dirty = core.store.dirty_lifecycle_artifacts(DRIFT_SCAN).await?;
     if dirty.is_empty() {
         return Ok(0);

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -55,8 +55,8 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     let reply = match core
         .completer
         .complete(
-            crate::infer::prompt::JUDGE_SYSTEM,
-            &crate::infer::prompt::judge_prompt(
+            crate::infer::prompt::DEDUPE_SYSTEM,
+            &crate::infer::prompt::dedupe_prompt(
                 (a.title.as_deref().unwrap_or("untitled"), &a.text),
                 (b.title.as_deref().unwrap_or("untitled"), &b.text),
                 p.judge_attempts,
@@ -129,7 +129,7 @@ async fn apply(
         // A reply that cannot be read is an error, not a verdict: the pair stays
         // pending, and the unit retries under the queue's backoff.
         //
-        // Retrying is only worth anything because `judge_prompt` carries the
+        // Retrying is only worth anything because `dedupe_prompt` carries the
         // attempt number. `MalformedLlmOutput` is retryable, so this re-queues
         // the unit — and against an endpoint that caches by exact prompt, an
         // unchanged prompt would replay the same unreadable bytes for every one

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -283,47 +283,110 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                 .obsolete
                 .clone()
                 .expect("interpret sets this or downgrades to Conflict");
-            // Among the roots, for the same reason the letter was: the obsolete
-            // side is a root, and a winner drawn from `members` could be a
-            // merged artifact whose own sources include the one being hidden.
-            let winner = s
-                .roots
+            // Fresh statuses, not the snapshot `interpret` saw. The roots of a
+            // member that is itself a finished merge are already superseded,
+            // and a component can change while the unit waits out a backoff.
+            let mut fresh = Vec::new();
+            for r in &s.roots {
+                match core.store.get_artifact(&r.id).await {
+                    Ok(c) => fresh.push(c),
+                    Err(Error::NotFound) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+            let live = |c: &Chunk| c.status == ArtifactStatus::Active && c.superseded_by.is_none();
+            let obsolete_live = fresh.iter().any(|c| c.id == obsolete && live(c));
+            // A live root wins if one exists; otherwise the live member that
+            // carries the surviving roots — a finished merge's own sources are
+            // superseded, and the merge is the one thing still in results.
+            let winner = fresh
                 .iter()
-                .find(|m| m.id != obsolete)
-                .expect("run dismisses a component with fewer than two roots");
+                .find(|c| c.id != obsolete && live(c))
+                .map(|c| c.id.clone())
+                .or_else(|| {
+                    s.members
+                        .iter()
+                        .find(|m| m.id != obsolete)
+                        .map(|m| m.id.clone())
+                });
+            let (Some(winner), true) = (winner, obsolete_live) else {
+                // Nothing to apply: the named side is already out of results,
+                // so the replacement has in effect already happened.
+                return settle_all(
+                    core,
+                    &s.pairs,
+                    PairState::NoConflict,
+                    Some("the named replacement is already out of results"),
+                )
+                .await;
+            };
+
+            if core.consolidate.autonomous {
+                // The side effect FIRST. A failure here leaves every pair
+                // pending, so the unit retries under the queue's backoff — the
+                // reverse order left the verdict recorded on the pairs but
+                // never applied, permanently, because run() skips a component
+                // whose seed is no longer Pending.
+                core.supersede(&obsolete, &winner).await?;
+                tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
+                for pr in &s.pairs {
+                    if pr.a_id == obsolete || pr.b_id == obsolete {
+                        // As the manual apply settles it (`apply_pair_supersede_ui`):
+                        // done, with the model's reasoning kept as the record
+                        // of why. Leaving it Superseded listed the applied
+                        // replacement as awaiting confirmation forever, behind
+                        // Keep buttons that could only return a validation
+                        // error against the already-superseded side.
+                        core.store
+                            .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
+                            .await?;
+                    } else {
+                        // Both sides survived. Writing the direction here
+                        // anyway named an artifact the pair does not contain.
+                        // Not left pending either: the roots this verdict was
+                        // drawn from are unchanged, so re-arming would build
+                        // the identical prompt and receive the identical
+                        // answer forever. An unanswered question goes where
+                        // the others go: to a person.
+                        core.store
+                            .set_pair_state(
+                                pr.id,
+                                PairState::Contradiction,
+                                Some(&format!(
+                                    "{obsolete} was superseded; these two were not separated"
+                                )),
+                            )
+                            .await?;
+                    }
+                }
+                return Ok(());
+            }
+
+            // Proposal mode: nothing is hidden, the pair carries the direction
+            // and an operator confirms via "apply supersede".
             for pr in &s.pairs {
                 if pr.a_id == obsolete || pr.b_id == obsolete {
                     core.store
                         .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
                         .await?;
-                    continue;
+                } else {
+                    // Both sides survived. Writing the direction here anyway
+                    // named an artifact the pair does not contain, and Ops
+                    // rendered an "apply supersede" button for it — a button
+                    // that would hide a third artifact on the strength of a
+                    // question about two others.
+                    core.store
+                        .set_pair_state(
+                            pr.id,
+                            PairState::Contradiction,
+                            Some(&format!(
+                                "{obsolete} was superseded; these two were not separated"
+                            )),
+                        )
+                        .await?;
                 }
-                // Both sides survived. Writing the direction here anyway named
-                // an artifact the pair does not contain, and Ops rendered an
-                // "apply supersede" button for it — a button that would hide a
-                // third artifact on the strength of a question about two others.
-                //
-                // Not left pending either. The roots this verdict was drawn from
-                // are unchanged by the supersede, so re-arming the pair would
-                // build the identical prompt and, against an endpoint that
-                // caches by prompt, receive the identical answer forever. An
-                // unanswered question goes where the others go: to a person.
-                core.store
-                    .set_pair_state(
-                        pr.id,
-                        PairState::Contradiction,
-                        Some(&format!(
-                            "{obsolete} was superseded; these two were not separated"
-                        )),
-                    )
-                    .await?;
             }
-            if core.consolidate.autonomous {
-                core.supersede(&obsolete, &winner.id).await?;
-                tracing::info!(superseded = %obsolete, by = %winner.id, "applied a replacement");
-            } else {
-                tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
-            }
+            tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
             Ok(())
         }
         Relation::Duplicate => {
@@ -589,9 +652,19 @@ mod tests {
 
         run(&core, &first.to_string()).await.unwrap();
 
+        // Applied (autonomy is on), so its own pair is done — Dismissed, as
+        // the manual apply settles it, with the direction cleared.
         let held = core.store.get_pair(first).await.unwrap();
-        assert_eq!(held.state, PairState::Superseded);
-        assert_eq!(held.obsolete_id.as_deref(), Some(ids[0].as_str()));
+        assert_eq!(held.state, PairState::Dismissed);
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(ids[1].as_str())
+        );
 
         let survivors = core.store.get_pair(second).await.unwrap();
         assert_eq!(
@@ -894,6 +967,117 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn an_applied_replacement_does_not_wait_for_an_operator() {
+        // The pair used to stay in Superseded — the state every consumer reads
+        // as "awaiting confirmation" — with Keep buttons that could only
+        // return a validation error against the already-superseded side.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_some(),
+            "the replacement was not applied"
+        );
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Superseded, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an applied replacement is still listed as awaiting confirmation"
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Dismissed, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the applied pair should be settled the way the manual apply settles it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_replacement_naming_a_root_already_out_of_results_is_applied_to_the_carrier() {
+        // A component holding a finished merge flattens to roots that are
+        // already superseded. Applying blindly errored *after* the pairs were
+        // settled, and run()'s Pending guard made the error permanent: the
+        // verdict was recorded on the pairs yet never applied.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"c","detail":"superseded by the merge"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 30 s", [0.99, 0.02]),
+                ("timeout was 30 seconds once", [0.98, 0.04]),
+            ],
+        )
+        .await;
+        // uuid v7 sorts by creation, so the roots letter as a, b, c.
+        // Oldest, so the newest-wins guard accepts it as obsolete.
+        sqlx::query("UPDATE artifacts SET created_at = created_at - 100 WHERE id = ?")
+            .bind(&ids[2])
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        let merged = crate::jobs::merge::write(
+            &core,
+            &MergedDraft {
+                text: "timeout is 30 seconds".into(),
+                title: None,
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+            },
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await
+        .unwrap();
+        // The merge finished: its roots are superseded, only it and c remain.
+        crate::jobs::merge::finish(&core, &merged.id).await.unwrap();
+        let pair = queue_pair(&core, &merged.id, &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        // Every root besides c is superseded, so the live carrier — the merge
+        // itself, a member — wins, and the settle happens after the apply.
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[2])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(merged.id.as_str()),
+            "the replacement was not applied against the live carrier"
+        );
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the component was left pending"
         );
     }
 

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -497,7 +497,12 @@ mod tests {
 
     #[tokio::test]
     async fn a_replacement_is_only_proposed_while_autonomy_is_off() {
+        // The observation window. Switched off, the pass still asks and still
+        // records what it would have done -- which is the whole point: an
+        // operator can read the verdicts before granting the authority to act
+        // on them, rather than switching autonomy on blind.
         let mut core = test_core().await;
+        core.consolidate.autonomous = false;
         core.completer = Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
         ]));

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -335,18 +335,14 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                 // Recorded, not applied. Reading the verdicts before letting the
                 // system act on them is the cheapest evidence available about
                 // whether the contract holds on real data, and it is the only
-                // reason the switch is a switch rather than a leap.
-                let detail = s
-                    .detail
-                    .clone()
-                    .unwrap_or_else(|| "would merge".to_string());
-                return settle_all(
-                    core,
-                    &s.pairs,
-                    PairState::Contradiction,
-                    Some(&format!("would merge: {detail}")),
-                )
-                .await;
+                // reason the switch is a switch rather than a leap. Its own
+                // state rather than Contradiction: filing a mergeable pair
+                // among genuine conflicts made the UI claim the two disagree,
+                // and steered the operator toward hiding a side the model
+                // judged complementary. The draft is discarded — once autonomy
+                // is on, the unit re-judges and merges then.
+                return settle_all(core, &s.pairs, PairState::WouldMerge, s.detail.as_deref())
+                    .await;
             }
 
             // Every member, not just the roots. A merged member is not its own
@@ -899,5 +895,45 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn with_autonomy_off_a_duplicate_verdict_is_filed_as_would_merge() {
+        // It used to be filed as Contradiction, so the UI said "These two
+        // disagree" about a pair the model judged complementary, and offered
+        // only the lossy keep-one buttons for it.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = false;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"duplicate","detail":"same claim",
+                "merged":{"text":"engram needs Rust 1.21.4 and 1.30.0 to build.","tags":[],"caveats":[]}}"#
+                .into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let found = core
+            .store
+            .pairs_by_state(PairState::WouldMerge, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1, "the verdict must land as its own state");
+        assert_eq!(found[0].detail.as_deref(), Some("same claim"));
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Contradiction, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a mergeable pair was filed among genuine conflicts"
+        );
+        // Recorded, not applied: no merge written, nothing hidden.
+        for id in &ids {
+            let c = core.store.get_artifact(id).await.unwrap();
+            assert!(c.superseded_by.is_none());
+        }
+        assert!(core.store.merged_artifacts(10).await.unwrap().is_empty());
     }
 }

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -57,8 +57,11 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         .complete(
             crate::infer::prompt::DEDUPE_SYSTEM,
             &crate::infer::prompt::dedupe_prompt(
-                (a.title.as_deref().unwrap_or("untitled"), &a.text),
-                (b.title.as_deref().unwrap_or("untitled"), &b.text),
+                &[
+                    (a.title.as_deref().unwrap_or("untitled"), a.text.as_str()),
+                    (b.title.as_deref().unwrap_or("untitled"), b.text.as_str()),
+                ],
+                &crate::infer::facts::differing_values(&[&a.text, &b.text]),
                 p.judge_attempts,
             ),
         )
@@ -86,14 +89,39 @@ async fn apply(
     b: &crate::store::artifacts::Chunk,
     reply: &str,
 ) -> Result<()> {
-    match crate::infer::prompt::parse_judgement(reply) {
-        Ok((true, detail, obsolete)) => {
-            // Trust the judge's named direction only when it agrees with the
-            // sweep's own newest-wins bias (see `keeper`): a call that names the
-            // *newer* artifact obsolete is exactly the failure mode worth
-            // guarding against, since it would otherwise propose hiding the side
-            // more likely to be current.
-            let obsolete_id = obsolete.and_then(|side| {
+    use crate::infer::prompt::Relation;
+    let verdict = match crate::infer::prompt::parse_dedupe(reply) {
+        Ok(v) => v,
+        Err(e) => {
+            core.store.record_unreadable_judgement(p.id).await?;
+            tracing::warn!(
+                pair = p.id,
+                attempt = p.judge_attempts,
+                error = %e,
+                "dedupe reply unreadable; pair stays pending"
+            );
+            return Err(e);
+        }
+    };
+
+    match verdict.relation {
+        Relation::Distinct => {
+            core.store
+                .set_pair_state(p.id, PairState::NoConflict, verdict.detail.as_deref())
+                .await?;
+        }
+        Relation::Conflict => {
+            core.store
+                .set_pair_state(p.id, PairState::Contradiction, verdict.detail.as_deref())
+                .await?;
+            tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
+        }
+        Relation::Replaced => {
+            // Trust the named direction only when it agrees with the sweep's own
+            // newest-wins bias (see `keeper`): a call naming the *newer* artifact
+            // obsolete is exactly the failure mode worth guarding against, since
+            // it would otherwise hide the side more likely to be current.
+            let obsolete_id = verdict.supersedes.and_then(|side| {
                 let (named, other) = match side {
                     'a' => (a, b),
                     _ => (b, a),
@@ -102,54 +130,33 @@ async fn apply(
             });
             match obsolete_id {
                 Some(obsolete_id) => {
-                    // Proposed, not applied: an operator confirms via the pair's
-                    // "apply supersede" action before anything is hidden.
                     core.store
-                        .set_pair_superseded(p.id, &obsolete_id, detail.as_deref())
+                        .set_pair_superseded(p.id, &obsolete_id, verdict.detail.as_deref())
                         .await?;
                     tracing::info!(
                         pair = p.id,
                         obsolete = %obsolete_id,
-                        "judge proposed a supersede, pending operator confirmation"
+                        "dedupe proposed a supersede, pending operator confirmation"
                     );
                 }
                 None => {
                     core.store
-                        .set_pair_state(p.id, PairState::Contradiction, detail.as_deref())
+                        .set_pair_state(p.id, PairState::Contradiction, verdict.detail.as_deref())
                         .await?;
-                    tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
                 }
             }
         }
-        Ok((false, _, _)) => {
+        // The write path lands in the next commit. Until then a duplicate is
+        // recorded rather than applied, which is what `autonomous = false` will
+        // keep doing afterwards.
+        Relation::Duplicate => {
+            let detail = verdict
+                .detail
+                .clone()
+                .unwrap_or_else(|| "would merge".into());
             core.store
-                .set_pair_state(p.id, PairState::NoConflict, None)
+                .set_pair_state(p.id, PairState::Contradiction, Some(&detail))
                 .await?;
-        }
-        // A reply that cannot be read is an error, not a verdict: the pair stays
-        // pending, and the unit retries under the queue's backoff.
-        //
-        // Retrying is only worth anything because `dedupe_prompt` carries the
-        // attempt number. `MalformedLlmOutput` is retryable, so this re-queues
-        // the unit — and against an endpoint that caches by exact prompt, an
-        // unchanged prompt would replay the same unreadable bytes for every one
-        // of `MAX_ATTEMPTS`. One varying byte is what makes the second ask a
-        // second ask.
-        //
-        // Counted here and not beside `record_judge_attempt`, because this is
-        // the only failure that says anything about the pair. A call the
-        // endpoint never answered says something about the endpoint, and
-        // letting an outage count against every pending pair would take the
-        // whole review queue out of the judge's reach on its way past.
-        Err(e) => {
-            core.store.record_unreadable_judgement(p.id).await?;
-            tracing::warn!(
-                pair = p.id,
-                attempt = p.judge_attempts,
-                error = %e,
-                "judge reply unreadable; pair stays pending"
-            );
-            return Err(e);
         }
     }
     Ok(())

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -446,13 +446,15 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
             // captured roots, and `subsumed_merges` catches the merged members.
             let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
             let m = crate::jobs::merge::write(core, draft, &sources).await?;
-            settle_all(
-                core,
-                &s.pairs,
-                PairState::NoConflict,
-                Some(&format!("merged into {}", m.id)),
-            )
-            .await
+            // `merged_into` rather than a detail string: if the embed never
+            // lands, the sweep's reap has to find exactly these pairs and
+            // reopen them (`reap_stranded`).
+            for pr in &s.pairs {
+                core.store
+                    .set_pair_merged(pr.id, &m.id, s.detail.as_deref())
+                    .await?;
+            }
+            Ok(())
         }
     }
 }

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -120,6 +120,23 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     // Flatten before anything else, and never show the model a merged member's
     // own text.
     let root_map = core.store.roots_of(&member_ids).await?;
+    // A member with no roots at all is a merge whose sources were deleted out
+    // from under it. Its text is a paraphrase with nothing behind it — not
+    // something to show the model as an original, and not something a rule can
+    // settle. A person decides.
+    if members
+        .iter()
+        .any(|c| root_map.get(&c.id).is_none_or(|r| r.is_empty()))
+    {
+        settle_all(
+            core,
+            &pairs,
+            PairState::Contradiction,
+            Some("a merged member has lost its sources; resolve by hand"),
+        )
+        .await?;
+        return Ok(());
+    }
     let mut root_ids: Vec<String> = root_map.values().flatten().cloned().collect();
     root_ids.sort();
     root_ids.dedup();
@@ -1000,6 +1017,53 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_lost_its_sources_is_never_shown_as_an_original() {
+        // The self-root fallback put a model-synthesized paraphrase in the
+        // prompt as a captured original, and a Duplicate verdict would then
+        // record a merged artifact as root_id — paraphrase drift, one
+        // generation per merge, which the lineage design exists to prevent.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        let completer = Arc::new(ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        let ids = disagreeing(&core).await;
+        let m = core
+            .store
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    text: "a paraphrase".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[ids[0].clone()],
+            )
+            .await
+            .unwrap();
+        // Its every source cascades away, as a corpus deletion does.
+        sqlx::query("DELETE FROM artifact_sources WHERE child_id = ?")
+            .bind(&m.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let pair = queue_pair(&core, &m.id, &ids[1]).await;
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            completer.calls(),
+            0,
+            "a rootless merge reached the model as an original"
+        );
+        assert_eq!(
+            core.store.get_pair(pair).await.unwrap().state,
+            PairState::Contradiction,
+            "the component goes to a person rather than being judged on a paraphrase"
         );
     }
 

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -119,6 +119,12 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
 
     // Flatten before anything else, and never show the model a merged member's
     // own text.
+    //
+    // From `members`, not the list the component arrived with: the partition
+    // above drops retired members and their pairs, and roots resolved from the
+    // stale list would put a retired artifact back into the prompt, the fan-in
+    // cap, and the loss check — the question this unit is no longer asking.
+    let member_ids: Vec<String> = members.iter().map(|c| c.id.clone()).collect();
     let root_map = core.store.roots_of(&member_ids).await?;
     // A member with no roots at all is a merge whose sources were deleted out
     // from under it. Its text is a paraphrase with nothing behind it — not
@@ -510,6 +516,53 @@ mod tests {
             .find(|p| (p.a_id == a || p.b_id == a) && (p.a_id == b || p.b_id == b))
             .expect("the pair was just recorded")
             .id
+    }
+
+    #[tokio::test]
+    async fn a_retired_members_roots_do_not_count_against_the_cap() {
+        // C is deprecated while the unit waits. Its pair is dismissed and it
+        // is dropped from the component — but its root must also leave the
+        // question, or a two-root component at the cap is settled Oversized
+        // for fan-in it does not have, and C's text is shown to the model as
+        // an original.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.consolidate.merge_max_roots = 2;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("a text", [1.0, 0.0]),
+                ("b text", [0.93, 0.37]),
+                ("c text", [0.90, 0.44]),
+            ],
+        )
+        .await;
+        let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        queue_pair(&core, &ids[1], &ids[2]).await;
+        core.deprecate(&ids[2]).await.unwrap();
+
+        run(&core, &seed_pair.to_string()).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Oversized, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a retired member's root was counted against merge_max_roots"
+        );
+        // The live pair reached the model and took its verdict.
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::NoConflict, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     async fn disagreeing(core: &Core) -> Vec<String> {

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -27,7 +27,7 @@
 use crate::core::Core;
 use crate::error::{Error, Result};
 use crate::infer::prompt::{MergedDraft, Relation};
-use crate::store::artifacts::{ArtifactStatus, Chunk};
+use crate::store::artifacts::Chunk;
 use crate::store::pairs::{ArtifactPair, PairState};
 
 /// What the model decided, with everything the write path needs already read.
@@ -76,7 +76,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         // superseded by a later sweep or deprecated by an operator while this
         // waits out a backoff, and spending the scarcest thing in the system to
         // rule on an artifact no longer in results buys nothing.
-        if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
+        if !c.in_results() {
             retired.insert(c.id);
             continue;
         }
@@ -342,14 +342,13 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                     Err(e) => return Err(e),
                 }
             }
-            let live = |c: &Chunk| c.status == ArtifactStatus::Active && c.superseded_by.is_none();
-            let obsolete_live = fresh.iter().any(|c| c.id == obsolete && live(c));
+            let obsolete_live = fresh.iter().any(|c| c.id == obsolete && c.in_results());
             // A live root wins if one exists; otherwise the live member that
             // carries the surviving roots — a finished merge's own sources are
             // superseded, and the merge is the one thing still in results.
             let winner = fresh
                 .iter()
-                .find(|c| c.id != obsolete && live(c))
+                .find(|c| c.id != obsolete && c.in_results())
                 .map(|c| c.id.clone())
                 .or_else(|| {
                     s.members
@@ -497,6 +496,7 @@ mod tests {
     use crate::core::test_support::test_core;
     use crate::infer::fake::ScriptedCompleter;
     use crate::jobs::consolidate::tests::{seed, seed_titled};
+    use crate::store::artifacts::ArtifactStatus;
     use std::sync::Arc;
 
     /// Record a pair for two artifacts and hand back its row id.

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -374,6 +374,11 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                 .await;
             };
 
+            let (touching, survivors): (Vec<&ArtifactPair>, Vec<&ArtifactPair>) = s
+                .pairs
+                .iter()
+                .partition(|pr| pr.a_id == obsolete || pr.b_id == obsolete);
+
             if core.consolidate.autonomous {
                 // The side effect FIRST. A failure here leaves every pair
                 // pending, so the unit retries under the queue's backoff — the
@@ -382,64 +387,50 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                 // whose seed is no longer Pending.
                 core.supersede(&obsolete, &winner).await?;
                 tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
-                for pr in &s.pairs {
-                    if pr.a_id == obsolete || pr.b_id == obsolete {
-                        // As the manual apply settles it (`apply_pair_supersede_ui`):
-                        // done, with the model's reasoning kept as the record
-                        // of why. Leaving it Superseded listed the applied
-                        // replacement as awaiting confirmation forever, behind
-                        // Keep buttons that could only return a validation
-                        // error against the already-superseded side.
-                        core.store
-                            .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
-                            .await?;
-                    } else {
-                        // Both sides survived. Writing the direction here
-                        // anyway named an artifact the pair does not contain.
-                        // Not left pending either: the roots this verdict was
-                        // drawn from are unchanged, so re-arming would build
-                        // the identical prompt and receive the identical
-                        // answer forever. An unanswered question goes where
-                        // the others go: to a person.
-                        core.store
-                            .set_pair_state(
-                                pr.id,
-                                PairState::Contradiction,
-                                Some(&format!(
-                                    "{obsolete} was superseded; these two were not separated"
-                                )),
-                            )
-                            .await?;
-                    }
+                for pr in &touching {
+                    // As the manual apply settles it (`apply_pair_supersede_ui`):
+                    // done, with the model's reasoning kept as the record of
+                    // why. Leaving it Superseded listed the applied replacement
+                    // as awaiting confirmation forever, behind Keep buttons
+                    // that could only return a validation error against the
+                    // already-superseded side.
+                    core.store
+                        .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
+                        .await?;
                 }
-                return Ok(());
-            }
-
-            // Proposal mode: nothing is hidden, the pair carries the direction
-            // and an operator confirms via "apply supersede".
-            for pr in &s.pairs {
-                if pr.a_id == obsolete || pr.b_id == obsolete {
+            } else {
+                // Proposal mode: nothing is hidden, the pair carries the
+                // direction and an operator confirms via "apply supersede".
+                for pr in &touching {
                     core.store
                         .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
                         .await?;
-                } else {
-                    // Both sides survived. Writing the direction here anyway
-                    // named an artifact the pair does not contain, and Ops
-                    // rendered an "apply supersede" button for it — a button
-                    // that would hide a third artifact on the strength of a
-                    // question about two others.
-                    core.store
-                        .set_pair_state(
-                            pr.id,
-                            PairState::Contradiction,
-                            Some(&format!(
-                                "{obsolete} was superseded; these two were not separated"
-                            )),
-                        )
-                        .await?;
                 }
+                tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
             }
-            tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
+
+            // Both sides of these pairs survived. Writing the direction on
+            // them named an artifact the pair does not contain — and Ops
+            // rendered an "apply supersede" button for it, one that would hide
+            // a third artifact on the strength of a question about two others.
+            // Not left pending either: the roots this verdict was drawn from
+            // are unchanged, so re-arming would build the identical prompt and
+            // receive the identical answer forever. An unanswered question
+            // goes where the others go: to a person.
+            //
+            // Past tense only where the supersede actually ran. In proposal
+            // mode it may yet be rejected, and a record asserting it happened
+            // would outlive the rejection.
+            let survivor_detail = if core.consolidate.autonomous {
+                format!("{obsolete} was superseded; these two were not separated")
+            } else {
+                format!("superseding {obsolete} was proposed; these two were not separated")
+            };
+            for pr in &survivors {
+                core.store
+                    .set_pair_state(pr.id, PairState::Contradiction, Some(&survivor_detail))
+                    .await?;
+            }
             Ok(())
         }
         Relation::Duplicate => {
@@ -563,6 +554,47 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn a_proposed_supersede_is_not_recorded_as_a_done_one() {
+        // Proposal mode: the supersede is a proposal an operator may reject.
+        // The sibling pair's record must not assert an event that has not
+        // happened.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = false;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"a is stale"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
+                ("engram needs Rust 1.30.0 to build.", [0.93, 0.37]),
+                ("engram builds with stable Rust.", [0.90, 0.44]),
+            ],
+        )
+        .await;
+        let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        queue_pair(&core, &ids[1], &ids[2]).await;
+
+        run(&core, &seed_pair.to_string()).await.unwrap();
+
+        let contradictions = core
+            .store
+            .pairs_by_state(PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(contradictions.len(), 1, "the survivor pair escalates");
+        let detail = contradictions[0].detail.clone().unwrap_or_default();
+        assert!(
+            !detail.contains("was superseded"),
+            "the record asserts a supersession that is only proposed: {detail}"
+        );
+        // Nothing was hidden in proposal mode.
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().in_results());
+        }
     }
 
     async fn disagreeing(core: &Core) -> Vec<String> {

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -1,69 +1,138 @@
-//! One pair, one call.
+//! One component, one call.
 //!
 //! The sweep used to make up to `max_judgements` of these in a single job, so a
 //! consolidation run blocked every capture behind it for as long as twenty model
 //! calls took — the second-worst blocker in the system after synthesis. The
 //! sweep now decides *which* pairs are worth asking about, which costs nothing,
-//! and arms one unit per pair. The queue paces them and interleaves them with
+//! and arms one unit each. The queue paces them and interleaves them with
 //! everything else.
+//!
+//! The unit expands its pair into the connected component of still-open pairs
+//! around it. Four related artifacts settled pairwise cost three calls and write
+//! two merged artifacts that are superseded almost immediately — and since a
+//! re-merge is always written from captured roots, those intermediates are paid
+//! for and thrown away for nothing.
+//!
+//! Before the call, the component is flattened to its captured roots. A merged
+//! member's own text is never shown to the model: rewriting from a rewrite is
+//! how a paraphrase of a paraphrase ends up three generations from the wording
+//! someone actually captured. The lineage closure exists precisely so that
+//! flattening costs one query, and it keeps information loss one generation deep
+//! however many times a group is merged.
+//!
+//! Four verdicts come back and only two touch an artifact. A value conflict is
+//! escalated to a person and never merged; a group past the fan-in cap is
+//! surfaced rather than rewritten.
 
 use crate::core::Core;
 use crate::error::{Error, Result};
-use crate::store::artifacts::ArtifactStatus;
+use crate::infer::prompt::{MergedDraft, Relation};
+use crate::store::artifacts::{ArtifactStatus, Chunk};
 use crate::store::pairs::{ArtifactPair, PairState};
+
+/// What the model decided, with everything the write path needs already read.
+pub struct Settlement {
+    pub relation: Relation,
+    pub detail: Option<String>,
+    /// The artifact named obsolete, already checked against newest-wins. Only
+    /// set for `Replaced`.
+    pub obsolete: Option<String>,
+    /// Only set for `Duplicate`, and only once the loss check has passed.
+    pub merged: Option<MergedDraft>,
+    /// The component's members, active as of the call.
+    pub members: Vec<Chunk>,
+    /// Their captured roots, flattened. What the model was actually shown.
+    pub roots: Vec<Chunk>,
+    pub pairs: Vec<ArtifactPair>,
+}
 
 pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     let id: i64 = pair_id.parse().map_err(|_| Error::NotFound)?;
     let p = core.store.get_pair(id).await?;
     if p.state != PairState::Pending {
-        // Settled by an operator, or by a later sweep, while this waited.
+        // Settled by an operator, by a later sweep, or by a sibling unit that
+        // already answered this whole component while this one waited.
         return Ok(());
     }
 
-    // Reported, not swallowed. This read used to treat any failure as "one side
-    // was deleted while the unit waited" — it recorded an attempt and returned
-    // `Ok`, so a store that was briefly unwell closed the unit and counted the
-    // pair as having had its turn. There is no deletion to handle: `a_id` and
-    // `b_id` are `ON DELETE CASCADE` and every pool sets `foreign_keys`, so a
-    // pair naming an artifact that is gone is a state the schema does not allow.
-    let (a, b) = (
-        core.store.get_artifact(&p.a_id).await?,
-        core.store.get_artifact(&p.b_id).await?,
-    );
+    let pairs = core.store.open_component(id).await?;
+    let mut member_ids: Vec<String> = pairs
+        .iter()
+        .flat_map(|p| [p.a_id.clone(), p.b_id.clone()])
+        .collect();
+    member_ids.sort();
+    member_ids.dedup();
 
-    // Re-checked here and not only when the unit was armed. A pair can wait out
-    // a backoff, and in that time a member can be superseded by a later sweep or
-    // deprecated by an operator — spending the scarcest thing here to post a
-    // contradiction about an artifact no longer in results.
-    if a.status != ArtifactStatus::Active
-        || b.status != ArtifactStatus::Active
-        || a.superseded_by.is_some()
-        || b.superseded_by.is_some()
-    {
-        core.store
-            .set_pair_state(id, PairState::Dismissed, None)
-            .await?;
+    let mut members = Vec::new();
+    for mid in &member_ids {
+        // Reported, not swallowed. `a_id` and `b_id` are `ON DELETE CASCADE` and
+        // every pool sets `foreign_keys`, so a pair naming an artifact that is
+        // gone is a state the schema does not allow — a failure here is the
+        // store being unwell, not a deletion to absorb.
+        let c = core.store.get_artifact(mid).await?;
+        // Re-checked here and not only when the unit was armed: a member can be
+        // superseded by a later sweep or deprecated by an operator while this
+        // waits out a backoff, and spending the scarcest thing in the system to
+        // rule on an artifact no longer in results buys nothing.
+        if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
+            settle_all(core, &pairs, PairState::Dismissed, None).await?;
+            return Ok(());
+        }
+        members.push(c);
+    }
+    if members.len() < 2 {
+        settle_all(core, &pairs, PairState::Dismissed, None).await?;
         return Ok(());
     }
 
-    // Counted before the call and regardless of how it goes, so a pair the model
-    // keeps failing on drops behind the rest of the queue rather than absorbing
-    // the budget again on the next sweep.
-    core.store.record_judge_attempt(id).await?;
+    // Flatten before anything else, and never show the model a merged member's
+    // own text.
+    let root_map = core.store.roots_of(&member_ids).await?;
+    let mut root_ids: Vec<String> = root_map.values().flatten().cloned().collect();
+    root_ids.sort();
+    root_ids.dedup();
+
+    if root_ids.len() > core.consolidate.merge_max_roots {
+        tracing::info!(
+            pair = id,
+            roots = root_ids.len(),
+            cap = core.consolidate.merge_max_roots,
+            "component draws on more roots than the cap; surfacing instead of merging"
+        );
+        let detail = format!(
+            "{} sources, cap is {}",
+            root_ids.len(),
+            core.consolidate.merge_max_roots
+        );
+        settle_all(core, &pairs, PairState::Oversized, Some(&detail)).await?;
+        return Ok(());
+    }
+
+    let mut roots = Vec::new();
+    for rid in &root_ids {
+        roots.push(core.store.get_artifact(rid).await?);
+    }
+
+    // Counted before the call and regardless of how it goes, so a group the
+    // model keeps failing on drops behind the rest of the queue rather than
+    // absorbing the budget again on the next sweep.
+    for pr in &pairs {
+        core.store.record_judge_attempt(pr.id).await?;
+    }
+
+    let shown: Vec<(&str, &str)> = roots
+        .iter()
+        .map(|c| (c.title.as_deref().unwrap_or("untitled"), c.text.as_str()))
+        .collect();
+    let texts: Vec<&str> = roots.iter().map(|c| c.text.as_str()).collect();
+    let differing = crate::infer::facts::differing_values(&texts);
 
     let permit = core.gate.background().await;
     let reply = match core
         .completer
         .complete(
             crate::infer::prompt::DEDUPE_SYSTEM,
-            &crate::infer::prompt::dedupe_prompt(
-                &[
-                    (a.title.as_deref().unwrap_or("untitled"), a.text.as_str()),
-                    (b.title.as_deref().unwrap_or("untitled"), b.text.as_str()),
-                ],
-                &crate::infer::facts::differing_values(&[&a.text, &b.text]),
-                p.judge_attempts,
-            ),
+            &crate::infer::prompt::dedupe_prompt(&shown, &differing, p.judge_attempts),
         )
         .await
     {
@@ -77,87 +146,589 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         }
     };
 
-    apply(core, &p, &a, &b, &reply).await
-}
-
-/// Record what the judge said. Split out because it is the half that has
-/// nothing to do with the endpoint, and the half worth reading on its own.
-async fn apply(
-    core: &Core,
-    p: &ArtifactPair,
-    a: &crate::store::artifacts::Chunk,
-    b: &crate::store::artifacts::Chunk,
-    reply: &str,
-) -> Result<()> {
-    use crate::infer::prompt::Relation;
-    let verdict = match crate::infer::prompt::parse_dedupe(reply) {
+    let verdict = match crate::infer::prompt::parse_dedupe(&reply) {
         Ok(v) => v,
+        // A reply that cannot be read is an error, not a verdict: the component
+        // stays pending and the unit retries under the queue's backoff.
+        //
+        // Retrying is only worth anything because `dedupe_prompt` carries the
+        // attempt number. Against an endpoint that caches by exact prompt, an
+        // unchanged prompt would replay the same unreadable bytes for every one
+        // of `MAX_ATTEMPTS`.
+        //
+        // Counted here and not beside `record_judge_attempt`, because this is
+        // the only failure that says anything about the group. A call the
+        // endpoint never answered says something about the endpoint, and letting
+        // an outage count against every pending pair would take the whole review
+        // queue out of reach on its way past.
         Err(e) => {
-            core.store.record_unreadable_judgement(p.id).await?;
+            for pr in &pairs {
+                core.store.record_unreadable_judgement(pr.id).await?;
+            }
             tracing::warn!(
-                pair = p.id,
+                pair = id,
                 attempt = p.judge_attempts,
                 error = %e,
-                "dedupe reply unreadable; pair stays pending"
+                "dedupe reply unreadable; component stays pending"
             );
             return Err(e);
         }
     };
 
-    match verdict.relation {
-        Relation::Distinct => {
-            core.store
-                .set_pair_state(p.id, PairState::NoConflict, verdict.detail.as_deref())
-                .await?;
-        }
-        Relation::Conflict => {
-            core.store
-                .set_pair_state(p.id, PairState::Contradiction, verdict.detail.as_deref())
-                .await?;
-            tracing::info!(pair = p.id, a = %a.id, b = %b.id, "artifacts disagree");
-        }
-        Relation::Replaced => {
-            // Trust the named direction only when it agrees with the sweep's own
-            // newest-wins bias (see `keeper`): a call naming the *newer* artifact
-            // obsolete is exactly the failure mode worth guarding against, since
-            // it would otherwise hide the side more likely to be current.
-            let obsolete_id = verdict.supersedes.and_then(|side| {
-                let (named, other) = match side {
-                    'a' => (a, b),
-                    _ => (b, a),
-                };
-                (named.created_at <= other.created_at).then(|| named.id.clone())
-            });
-            match obsolete_id {
-                Some(obsolete_id) => {
-                    core.store
-                        .set_pair_superseded(p.id, &obsolete_id, verdict.detail.as_deref())
-                        .await?;
-                    tracing::info!(
-                        pair = p.id,
-                        obsolete = %obsolete_id,
-                        "dedupe proposed a supersede, pending operator confirmation"
-                    );
-                }
-                None => {
-                    core.store
-                        .set_pair_state(p.id, PairState::Contradiction, verdict.detail.as_deref())
-                        .await?;
-                }
+    apply(core, interpret(verdict, members, roots, pairs)).await
+}
+
+/// Turn a parsed reply into what the write path will do.
+///
+/// Both guards live here because neither needs the store, which makes them
+/// testable without one — and both turn a verdict *down* rather than up. This
+/// pass is allowed to decline to act; it is not allowed to act on a shaky
+/// answer.
+fn interpret(
+    v: crate::infer::prompt::Dedupe,
+    members: Vec<Chunk>,
+    roots: Vec<Chunk>,
+    pairs: Vec<ArtifactPair>,
+) -> Settlement {
+    let mut relation = v.relation;
+    let mut detail = v.detail;
+    let mut merged = v.merged;
+    let mut obsolete = None;
+
+    if relation == Relation::Replaced {
+        // Trust a named direction only when it agrees with the sweep's own
+        // newest-wins bias (see `keeper`): a call naming the *newer* artifact
+        // obsolete is exactly the failure mode worth guarding against, since it
+        // would hide the side more likely to be current.
+        //
+        // The letter indexes `members`, which is what `dedupe_prompt` lettered.
+        let named = v
+            .supersedes
+            .map(|c| (c as u8 - b'a') as usize)
+            .and_then(|i| members.get(i));
+        obsolete = match named {
+            Some(named)
+                if members
+                    .iter()
+                    .all(|o| o.id == named.id || named.created_at <= o.created_at) =>
+            {
+                Some(named.id.clone())
             }
-        }
-        // The write path lands in the next commit. Until then a duplicate is
-        // recorded rather than applied, which is what `autonomous = false` will
-        // keep doing afterwards.
-        Relation::Duplicate => {
-            let detail = verdict
-                .detail
-                .clone()
-                .unwrap_or_else(|| "would merge".into());
-            core.store
-                .set_pair_state(p.id, PairState::Contradiction, Some(&detail))
-                .await?;
+            _ => None,
+        };
+        if obsolete.is_none() {
+            relation = Relation::Conflict;
         }
     }
+
+    if relation == Relation::Duplicate
+        && let Some(d) = &merged
+    {
+        let lost = crate::jobs::merge::losses(&roots, d);
+        if !lost.is_empty() {
+            // Escalated rather than retried: the merge is the thing that was
+            // wrong, and naming what it would have cost is a line an operator
+            // can act on where "verification failed" is not.
+            detail = Some(format!("the merge would have lost {}", lost.join(", ")));
+            relation = Relation::Conflict;
+            merged = None;
+        }
+    }
+
+    Settlement {
+        relation,
+        detail,
+        obsolete,
+        merged,
+        members,
+        roots,
+        pairs,
+    }
+}
+
+async fn apply(core: &Core, s: Settlement) -> Result<()> {
+    match s.relation {
+        Relation::Distinct => {
+            settle_all(core, &s.pairs, PairState::NoConflict, s.detail.as_deref()).await
+        }
+        Relation::Conflict => {
+            tracing::info!(
+                members = s.members.len(),
+                "artifacts disagree; escalating rather than merging"
+            );
+            settle_all(
+                core,
+                &s.pairs,
+                PairState::Contradiction,
+                s.detail.as_deref(),
+            )
+            .await
+        }
+        Relation::Replaced => {
+            let obsolete = s
+                .obsolete
+                .clone()
+                .expect("interpret sets this or downgrades to Conflict");
+            let winner = s
+                .members
+                .iter()
+                .find(|m| m.id != obsolete)
+                .expect("a component has at least two members");
+            for pr in &s.pairs {
+                core.store
+                    .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
+                    .await?;
+            }
+            if core.consolidate.autonomous {
+                core.supersede(&obsolete, &winner.id).await?;
+                tracing::info!(superseded = %obsolete, by = %winner.id, "applied a replacement");
+            } else {
+                tracing::info!(obsolete = %obsolete, "proposed a replacement, pending confirmation");
+            }
+            Ok(())
+        }
+        // The write path lands in the next commit. Recorded rather than applied
+        // until then — which is also what `autonomous = false` keeps doing
+        // afterwards, so the verdicts can be read before the system acts on them.
+        Relation::Duplicate => {
+            let detail = s
+                .detail
+                .clone()
+                .unwrap_or_else(|| "would merge".to_string());
+            settle_all(
+                core,
+                &s.pairs,
+                PairState::Contradiction,
+                Some(&format!("would merge: {detail}")),
+            )
+            .await
+        }
+    }
+}
+
+/// One verdict answers every pair in the component. The ones it did not answer
+/// would be armed and asked about all over again, at full price, for a decision
+/// that has already been made.
+async fn settle_all(
+    core: &Core,
+    pairs: &[ArtifactPair],
+    state: PairState,
+    detail: Option<&str>,
+) -> Result<()> {
+    for p in pairs {
+        core.store.set_pair_state(p.id, state, detail).await?;
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::infer::fake::ScriptedCompleter;
+    use crate::jobs::consolidate::tests::{seed, seed_titled};
+    use std::sync::Arc;
+
+    /// Record a pair for two artifacts and hand back its row id.
+    async fn queue_pair(core: &Core, a: &str, b: &str) -> i64 {
+        core.store.record_pair(a, b, 0.91).await.unwrap();
+        core.store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| (p.a_id == a || p.b_id == a) && (p.a_id == b || p.b_id == b))
+            .expect("the pair was just recorded")
+            .id
+    }
+
+    async fn disagreeing(core: &Core) -> Vec<String> {
+        seed(
+            core,
+            &[
+                ("engram needs Rust 1.21.4 to build.", [1.0, 0.0]),
+                ("engram needs Rust 1.30.0 to build.", [0.93, 0.37]),
+            ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn two_artifacts_about_different_subjects_are_never_merged() {
+        // FAT12, FAT16 and FAT32 are near-identical in form and deliberately
+        // different in content: they sit at 0.91 and every number in them
+        // differs. This is where the feature fires hardest and is most wrong,
+        // and it no longer merely flags them — a merge would grind a reference
+        // document into one paragraph that describes none of its subjects.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"two different filesystems"}"#.into(),
+        ]));
+        let ids = seed_titled(
+            &core,
+            &[
+                (
+                    "FAT16 Specifications",
+                    "Maximale Partitionsgröße 2 GB, 65524 Cluster.",
+                    [1.0, 0.0],
+                ),
+                (
+                    "FAT32 Specifications",
+                    "32 Bit Clusternummern, 268435445 Cluster.",
+                    [0.93, 0.37],
+                ),
+            ],
+        )
+        .await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::NoConflict, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "a reference document's sections were consolidated into each other"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_value_conflict_is_escalated_and_never_merged() {
+        // Deciding which of two contradictory facts is current stays a person's
+        // job. This is the one queue that expects a human, and autonomy does not
+        // empty it.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"conflict","detail":"1.21.4 versus 1.30.0"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let found = core
+            .store
+            .pairs_by_state(PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].detail.as_deref(), Some("1.21.4 versus 1.30.0"));
+        for id in &ids {
+            let c = core.store.get_artifact(id).await.unwrap();
+            assert_eq!(
+                c.status,
+                ArtifactStatus::Active,
+                "a conflict hid an artifact"
+            );
+            assert!(c.superseded_by.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn a_plain_replacement_supersedes_rather_than_merging() {
+        // The survivor is a stored original with a valid span and corpus lines
+        // to render beside it. That is strictly better than a rewrite, and it is
+        // the path by which the fidelity thesis keeps holding under autonomy —
+        // so the prompt prefers it and this pins that the code does too.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(ids[1].as_str())
+        );
+        let winner = core.store.get_artifact(&ids[1]).await.unwrap();
+        assert_eq!(
+            winner.provenance,
+            crate::store::artifacts::Provenance::Captured,
+            "a replacement wrote synthetic text where an original would do"
+        );
+        assert_eq!(winner.text, "engram needs Rust 1.30.0 to build.");
+    }
+
+    #[tokio::test]
+    async fn a_replacement_is_only_proposed_while_autonomy_is_off() {
+        let mut core = test_core().await;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let found = core
+            .store
+            .pairs_by_state(PairState::Superseded, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1, "the direction was not recorded");
+        assert_eq!(found[0].obsolete_id.as_deref(), Some(ids[0].as_str()));
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "a proposal hid an artifact without being asked to"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_replacement_naming_the_newer_artifact_is_not_trusted() {
+        // A miscalibrated call proposing to hide the *newer* side disagrees with
+        // the sweep's own newest-wins bias, so it falls back to a conflict
+        // rather than being applied. Guessing here means hiding an artifact for
+        // no stated reason.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        let ids = disagreeing(&core).await;
+        // `now()` is second-grained, so two rows inserted in one test would tie,
+        // and a tie is meant to pass the guard. Force b strictly newer.
+        sqlx::query("UPDATE artifacts SET created_at = created_at + 100 WHERE id = ?")
+            .bind(&ids[1])
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"b","detail":"x"}"#.into(),
+        ]));
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none()
+            );
+        }
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Contradiction, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "an untrusted direction must land as a conflict, not vanish"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_would_lose_a_value_is_escalated_with_the_reason() {
+        // The loss check, from the unit's side. "the merge would have lost
+        // 1.21.4" is a line an operator can act on; "verification failed" is not.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"duplicate","detail":"same claim",
+                "merged":{"text":"engram needs Rust 1.30.0 to build.","tags":[],"caveats":[]}}"#
+                .into(),
+        ]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let found = core
+            .store
+            .pairs_by_state(PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(
+            found[0]
+                .detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains("1.21.4"),
+            "the escalation did not say what would have been lost: {:?}",
+            found[0].detail
+        );
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn one_call_settles_every_pair_in_the_component() {
+        // A verdict that answered only its own pair would leave the siblings
+        // pending, and the next sweep would arm them and ask the same question
+        // again at full price.
+        let mut core = test_core().await;
+        let completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"three different things"}"#.into(),
+        ]));
+        core.completer = completer.clone();
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        queue_pair(&core, &ids[1], &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            completer.calls(),
+            1,
+            "the component cost more than one call"
+        );
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a sibling pair was left to be asked about again"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_component_past_the_fan_in_cap_is_surfaced_and_never_called_about() {
+        // A merge of forty sources is no longer one atomic piece of knowledge,
+        // which is what an artifact is defined to be. Past the cap the honest
+        // answer is to stop, not to write something nobody asked for.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.consolidate.merge_max_roots = 2;
+        let completer = Arc::new(ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        queue_pair(&core, &ids[1], &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(completer.calls(), 0, "an oversized component cost a call");
+        let over = core
+            .store
+            .pairs_by_state(PairState::Oversized, 10)
+            .await
+            .unwrap();
+        assert_eq!(over.len(), 2, "every pair in the component must be settled");
+        assert_eq!(over[0].detail.as_deref(), Some("3 sources, cap is 2"));
+    }
+
+    #[tokio::test]
+    async fn a_sibling_unit_for_a_settled_component_is_a_no_op() {
+        // Two units are armed for one component and both run. The second must
+        // find its work done rather than asking again.
+        let mut core = test_core().await;
+        let completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"unrelated"}"#.into(),
+        ]));
+        core.completer = completer.clone();
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        let first = queue_pair(&core, &ids[0], &ids[1]).await;
+        let second = queue_pair(&core, &ids[1], &ids[2]).await;
+
+        run(&core, &first.to_string()).await.unwrap();
+        run(&core, &second.to_string()).await.unwrap();
+
+        assert_eq!(completer.calls(), 1, "the sibling unit asked again");
+    }
+
+    #[tokio::test]
+    async fn a_failed_dedupe_leaves_the_component_pending() {
+        // A dead endpoint must not silently clear a queue of real duplicates.
+        let mut core = test_core().await;
+        core.completer = Arc::new(ScriptedCompleter::new(vec!["not json".into()]));
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        assert!(run(&core, &pair.to_string()).await.is_err());
+
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(core.store.get_pair(pair).await.unwrap().judge_unreadable, 1);
+    }
+
+    #[tokio::test]
+    async fn a_component_whose_member_was_retired_is_dismissed_without_a_call() {
+        let mut core = test_core().await;
+        let completer = Arc::new(ScriptedCompleter::new(vec![]));
+        core.completer = completer.clone();
+        let ids = disagreeing(&core).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        core.deprecate(&ids[0]).await.unwrap();
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(completer.calls(), 0, "a retired artifact cost a call");
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Dismissed, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
 }

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -287,19 +287,41 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
             }
             Ok(())
         }
-        // The write path lands in the next commit. Recorded rather than applied
-        // until then — which is also what `autonomous = false` keeps doing
-        // afterwards, so the verdicts can be read before the system acts on them.
         Relation::Duplicate => {
-            let detail = s
-                .detail
-                .clone()
-                .unwrap_or_else(|| "would merge".to_string());
+            let draft = s
+                .merged
+                .as_ref()
+                .expect("interpret keeps this or downgrades to Conflict");
+            if !core.consolidate.autonomous {
+                // Recorded, not applied. Reading the verdicts before letting the
+                // system act on them is the cheapest evidence available about
+                // whether the contract holds on real data, and it is the only
+                // reason the switch is a switch rather than a leap.
+                let detail = s
+                    .detail
+                    .clone()
+                    .unwrap_or_else(|| "would merge".to_string());
+                return settle_all(
+                    core,
+                    &s.pairs,
+                    PairState::Contradiction,
+                    Some(&format!("would merge: {detail}")),
+                )
+                .await;
+            }
+
+            // Every member, not just the roots. A merged member is not its own
+            // root, and `finish` hides what the lineage names — so passing only
+            // the roots would leave that earlier merge active and near-identical
+            // to the new one. `insert_merged_artifact` flattens all of them to
+            // captured roots, and `subsumed_merges` catches the merged members.
+            let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
+            let m = crate::jobs::merge::write(core, draft, &sources).await?;
             settle_all(
                 core,
                 &s.pairs,
-                PairState::Contradiction,
-                Some(&format!("would merge: {detail}")),
+                PairState::NoConflict,
+                Some(&format!("merged into {}", m.id)),
             )
             .await
         }

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -292,8 +292,30 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                 .find(|m| m.id != obsolete)
                 .expect("run dismisses a component with fewer than two roots");
             for pr in &s.pairs {
+                if pr.a_id == obsolete || pr.b_id == obsolete {
+                    core.store
+                        .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
+                        .await?;
+                    continue;
+                }
+                // Both sides survived. Writing the direction here anyway named
+                // an artifact the pair does not contain, and Ops rendered an
+                // "apply supersede" button for it — a button that would hide a
+                // third artifact on the strength of a question about two others.
+                //
+                // Not left pending either. The roots this verdict was drawn from
+                // are unchanged by the supersede, so re-arming the pair would
+                // build the identical prompt and, against an endpoint that
+                // caches by prompt, receive the identical answer forever. An
+                // unanswered question goes where the others go: to a person.
                 core.store
-                    .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
+                    .set_pair_state(
+                        pr.id,
+                        PairState::Contradiction,
+                        Some(&format!(
+                            "{obsolete} was superseded; these two were not separated"
+                        )),
+                    )
                     .await?;
             }
             if core.consolidate.autonomous {
@@ -543,6 +565,47 @@ mod tests {
                 .superseded_by
                 .is_none(),
             "a proposal hid an artifact without being asked to"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_of_two_survivors_is_not_closed_with_someone_elses_direction() {
+        // Three artifacts, two pairs, and one of the three named obsolete. The
+        // pair that holds it has a direction; the pair of the other two does
+        // not, and stamping the same `obsolete_id` on it put an artifact it does
+        // not contain behind an "apply supersede" button in Ops.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"a","detail":"the first is stale"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        let first = queue_pair(&core, &ids[0], &ids[1]).await;
+        let second = queue_pair(&core, &ids[1], &ids[2]).await;
+
+        run(&core, &first.to_string()).await.unwrap();
+
+        let held = core.store.get_pair(first).await.unwrap();
+        assert_eq!(held.state, PairState::Superseded);
+        assert_eq!(held.obsolete_id.as_deref(), Some(ids[0].as_str()));
+
+        let survivors = core.store.get_pair(second).await.unwrap();
+        assert_eq!(
+            survivors.obsolete_id, None,
+            "a pair was closed naming an artifact it does not contain"
+        );
+        assert_eq!(
+            survivors.state,
+            PairState::Contradiction,
+            "two artifacts the verdict never separated were quietly settled"
         );
     }
 

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -34,8 +34,9 @@ use crate::store::pairs::{ArtifactPair, PairState};
 pub struct Settlement {
     pub relation: Relation,
     pub detail: Option<String>,
-    /// The artifact named obsolete, already checked against newest-wins. Only
-    /// set for `Replaced`.
+    /// The root named obsolete, already checked against newest-wins. A root and
+    /// not a member, because roots are what the model was shown and therefore
+    /// the only things its letter can be naming. Only set for `Replaced`.
     pub obsolete: Option<String>,
     /// Only set for `Duplicate`, and only once the loss check has passed.
     pub merged: Option<MergedDraft>,
@@ -105,6 +106,14 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
             core.consolidate.merge_max_roots
         );
         settle_all(core, &pairs, PairState::Oversized, Some(&detail)).await?;
+        return Ok(());
+    }
+
+    // Two members can flatten to one root — a merge and one of its own sources
+    // meet this way — and one root is nothing to compare. Asking would spend a
+    // call to be told an artifact matches itself.
+    if root_ids.len() < 2 {
+        settle_all(core, &pairs, PairState::Dismissed, None).await?;
         return Ok(());
     }
 
@@ -201,14 +210,19 @@ fn interpret(
         // obsolete is exactly the failure mode worth guarding against, since it
         // would hide the side more likely to be current.
         //
-        // The letter indexes `members`, which is what `dedupe_prompt` lettered.
+        // The letter indexes `roots`. `run` builds the lettered list from the
+        // flattened roots and never shows a merged member's own text, so a
+        // letter resolved against `members` would name a different artifact
+        // whenever the two lists diverge — which is exactly when the component
+        // contains an earlier merge. That mismatch superseded an artifact the
+        // model had never been shown.
         let named = v
             .supersedes
             .map(|c| (c as u8 - b'a') as usize)
-            .and_then(|i| members.get(i));
+            .and_then(|i| roots.get(i));
         obsolete = match named {
             Some(named)
-                if members
+                if roots
                     .iter()
                     .all(|o| o.id == named.id || named.created_at <= o.created_at) =>
             {
@@ -269,11 +283,14 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
                 .obsolete
                 .clone()
                 .expect("interpret sets this or downgrades to Conflict");
+            // Among the roots, for the same reason the letter was: the obsolete
+            // side is a root, and a winner drawn from `members` could be a
+            // merged artifact whose own sources include the one being hidden.
             let winner = s
-                .members
+                .roots
                 .iter()
                 .find(|m| m.id != obsolete)
-                .expect("a component has at least two members");
+                .expect("run dismisses a component with fewer than two roots");
             for pr in &s.pairs {
                 core.store
                     .set_pair_superseded(pr.id, &obsolete, s.detail.as_deref())
@@ -526,6 +543,68 @@ mod tests {
                 .superseded_by
                 .is_none(),
             "a proposal hid an artifact without being asked to"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_letter_names_the_root_it_was_shown_beside_not_the_nth_member() {
+        // The component holds an earlier merge and one captured artifact, so the
+        // members are {M, c} and the lettered roots are {a, b, c}. The two lists
+        // diverge, and the model only ever saw the second — answering "b" means
+        // the root b, whose text was on the screen. Resolved against the members
+        // the same letter lands on the merge, which was never shown and never
+        // named. Under autonomy that hides the wrong artifact outright.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"replaced","supersedes":"b","detail":"b is the stale one"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 30 s", [0.99, 0.02]),
+                ("timeout is thirty seconds", [0.98, 0.04]),
+            ],
+        )
+        .await;
+        // uuid v7 sorts by creation, so the roots letter as a, b, c and the
+        // merge sorts after all three.
+        let merged = crate::jobs::merge::write(
+            &core,
+            &MergedDraft {
+                text: "timeout is 30 seconds".into(),
+                title: None,
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+            },
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await
+        .unwrap();
+        let pair = queue_pair(&core, &merged.id, &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .get_artifact(&ids[1])
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(ids[0].as_str()),
+            "the letter did not resolve to the root it was shown beside"
+        );
+        assert!(
+            core.store
+                .get_artifact(&merged.id)
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "an artifact the model was never shown was superseded"
         );
     }
 

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -56,7 +56,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         return Ok(());
     }
 
-    let pairs = core.store.open_component(id).await?;
+    let mut pairs = core.store.open_component(id).await?;
     let mut member_ids: Vec<String> = pairs
         .iter()
         .flat_map(|p| [p.a_id.clone(), p.b_id.clone()])
@@ -65,6 +65,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     member_ids.dedup();
 
     let mut members = Vec::new();
+    let mut retired: std::collections::HashSet<String> = Default::default();
     for mid in &member_ids {
         // Reported, not swallowed. `a_id` and `b_id` are `ON DELETE CASCADE` and
         // every pool sets `foreign_keys`, so a pair naming an artifact that is
@@ -76,10 +77,40 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         // waits out a backoff, and spending the scarcest thing in the system to
         // rule on an artifact no longer in results buys nothing.
         if c.status != ArtifactStatus::Active || c.superseded_by.is_some() {
-            settle_all(core, &pairs, PairState::Dismissed, None).await?;
-            return Ok(());
+            retired.insert(c.id);
+            continue;
         }
         members.push(c);
+    }
+    if !retired.is_empty() {
+        // Only the pairs naming a retired member are answered by its
+        // retirement. Dismissing the whole component killed sibling pairs
+        // between still-active duplicates — record_pair is INSERT OR IGNORE
+        // and Dismissed appears on no list, so nothing could ever re-file
+        // them and the surviving duplication was invisible forever.
+        let (dead, live): (Vec<_>, Vec<_>) = pairs
+            .into_iter()
+            .partition(|pr| retired.contains(&pr.a_id) || retired.contains(&pr.b_id));
+        settle_all(
+            core,
+            &dead,
+            PairState::Dismissed,
+            Some("a member is no longer in results"),
+        )
+        .await?;
+        pairs = live;
+        // Dropping a member can strand others with no surviving pair; they
+        // are simply not part of this unit's question any more.
+        let named: std::collections::HashSet<&str> = pairs
+            .iter()
+            .flat_map(|pr| [pr.a_id.as_str(), pr.b_id.as_str()])
+            .collect();
+        members.retain(|c| named.contains(c.id.as_str()));
+        // The seed pair itself may be among the dead; the survivors keep
+        // their own units and nothing further is owed here.
+        if !pairs.iter().any(|pr| pr.id == id) {
+            return Ok(());
+        }
     }
     if members.len() < 2 {
         settle_all(core, &pairs, PairState::Dismissed, None).await?;
@@ -967,6 +998,44 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_retired_member_dismisses_only_its_own_pairs() {
+        // Dismissing the whole component killed sibling pairs between
+        // still-active duplicates permanently: record_pair is INSERT OR
+        // IGNORE and Dismissed appears on no list, so the surviving
+        // duplication became invisible forever.
+        let mut core = test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("timeout is 30 seconds", [1.0, 0.0]),
+                ("timeout is 60 seconds", [0.93, 0.37]),
+                ("timeout is 90 seconds", [0.94, 0.34]),
+            ],
+        )
+        .await;
+        let p_ab = queue_pair(&core, &ids[0], &ids[1]).await;
+        let p_bc = queue_pair(&core, &ids[1], &ids[2]).await;
+        core.deprecate(&ids[2]).await.unwrap();
+
+        run(&core, &p_ab.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store.get_pair(p_bc).await.unwrap().state,
+            PairState::Dismissed,
+            "the pair naming the retired artifact should be dismissed"
+        );
+        assert_eq!(
+            core.store.get_pair(p_ab).await.unwrap().state,
+            PairState::NoConflict,
+            "the pair between two live artifacts must still be judged, not dismissed"
         );
     }
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -98,7 +98,12 @@ pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Res
             return Err(e);
         }
     }
-    settle_corpus(core, &chunk.corpus_id).await
+    match &chunk.corpus_id {
+        Some(corpus_id) => settle_corpus(core, corpus_id).await,
+        // A merged artifact belongs to no corpus, so there is no document whose
+        // coverage this embedding advances and nothing to settle.
+        None => Ok(()),
+    }
 }
 
 /// Embed every chunk of a source that is still waiting, in as few inference
@@ -394,7 +399,12 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         }])
         .await?;
     mark_indexed(core, chunk).await?;
-    settle_corpus(core, &chunk.corpus_id).await
+    match &chunk.corpus_id {
+        Some(corpus_id) => settle_corpus(core, corpus_id).await,
+        // A merged artifact belongs to no corpus, so there is no document whose
+        // coverage this embedding advances and nothing to settle.
+        None => Ok(()),
+    }
 }
 
 /// Cut text on blank lines, packing as many paragraphs into each part as the
@@ -484,6 +494,19 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
         )));
     }
 
+    // Splitting means writing siblings into the parent's document, at ordinals
+    // around its own. A merged artifact has neither: no corpus to insert into
+    // and no reading order to preserve, and its siblings would lose the lineage
+    // that says what it was made of. A merge that will not embed is a bug in
+    // the merge — the draft is too long, or the model ran away — and it belongs
+    // on Ops rather than being quietly chopped into fragments nothing can trace.
+    let Some(corpus_id) = chunk.corpus_id.as_deref() else {
+        return Err(Error::Validation(format!(
+            "refusing to split merged artifact {}: it belongs to no corpus",
+            chunk.id
+        )));
+    };
+
     tracing::info!(artifact_id = %chunk.id, parts = parts.len(), "split oversize chunk into siblings");
 
     let base = chunk.ordinal;
@@ -492,7 +515,7 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
     // after chunks 3 onward rather than before them, and the next segmentation
     // pass renumbers that wrong order into place permanently.
     core.store
-        .make_room_after(&chunk.corpus_id, base, parts.len() as i64 - 1)
+        .make_room_after(corpus_id, base, parts.len() as i64 - 1)
         .await?;
     let new: Vec<NewArtifact> = parts
         .iter()
@@ -515,7 +538,7 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
         })
         .collect();
 
-    let inserted = core.store.insert_artifacts(&chunk.corpus_id, &new).await?;
+    let inserted = core.store.insert_artifacts(corpus_id, &new).await?;
     core.store.delete_artifact(&chunk.id).await?;
     core.vectors
         .delete_artifacts(std::slice::from_ref(&chunk.id))
@@ -534,7 +557,13 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
 fn payload_of(chunk: &Chunk) -> VectorPayload {
     VectorPayload {
         artifact_id: chunk.id.clone(),
-        corpus_id: chunk.corpus_id.clone(),
+        // A merged artifact belongs to no corpus and carries the empty string
+        // here. `provenance` below is what tells the two apart — a corpus
+        // filter genuinely should not match an artifact that belongs to none,
+        // and `restore_artifact` reads the kind rather than guessing what an
+        // empty id meant.
+        corpus_id: chunk.corpus_id.clone().unwrap_or_default(),
+        provenance: Some(chunk.provenance.as_str().to_string()),
         text: chunk.text.clone(),
         title: chunk.title.clone(),
         category: chunk.category.clone(),

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -298,6 +298,11 @@ async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
     // This is what makes duplicate detection complete rather than sampled; see
     // the module header of `jobs::relate`.
     crate::jobs::relate::arm(core, &chunk.id, 0).await?;
+    // A merged artifact hides what it replaced only once it is itself in the
+    // index, so the knowledge is never out of search on both sides at once.
+    if chunk.provenance == crate::store::artifacts::Provenance::Merged {
+        crate::jobs::merge::finish(core, &chunk.id).await?;
+    }
     Ok(())
 }
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -289,7 +289,15 @@ async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
             artifact_id = %chunk.id,
             "chunk was edited while it was being embedded; leaving it pending"
         );
+        return Ok(());
     }
+    // Only now: the vector is in the index, so a neighbour query has something
+    // to find. Armed rather than run inline — a Qdrant query that fails must not
+    // fail the embed job, whose retry would pay for the embedding again.
+    //
+    // This is what makes duplicate detection complete rather than sampled; see
+    // the module header of `jobs::relate`.
+    crate::jobs::relate::arm(core, &chunk.id, 0).await?;
     Ok(())
 }
 
@@ -1259,16 +1267,30 @@ mod tests {
     #[tokio::test]
     async fn a_long_document_re_arms_itself_until_it_is_drained() {
         let core = test_core().await;
-        let id = corpus_with_chunks(&core, BATCH * 2 + 5).await;
+        let chunks = BATCH * 2 + 5;
+        let id = corpus_with_chunks(&core, chunks).await;
         core.store
             .enqueue(Stage::Embed, "corpus", &id)
             .await
             .unwrap();
 
+        // The termination guard is what this test exists for: the batch job
+        // re-arms itself, and a re-arm that does not stop is an infinite queue
+        // rather than a slow one.
+        //
+        // The exact total is what pins it, and it is now two things rather than
+        // one: three batch claims, plus one `relate` unit per artifact that
+        // reached the index. Either number drifting shows up here — an extra
+        // batch claim means the re-arm ran long, and a missing relate unit means
+        // an artifact was indexed without ever being checked for duplicates,
+        // which is the silent half.
         let mut claims = 0;
         while crate::jobs::run_one(&core).await.unwrap() {
             claims += 1;
-            assert!(claims < 20, "the re-arm never terminated");
+            assert!(
+                claims <= 3 + chunks,
+                "the re-arm never terminated: {claims} claims"
+            );
         }
 
         assert!(
@@ -1279,7 +1301,11 @@ mod tests {
                 .is_empty(),
             "the re-arm did not drain the corpus"
         );
-        assert_eq!(claims, 3, "expected one claim per batch");
+        assert_eq!(
+            claims,
+            3 + chunks,
+            "expected one claim per batch, plus one relate unit per artifact"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -295,13 +295,33 @@ async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
     // to find. Armed rather than run inline — a Qdrant query that fails must not
     // fail the embed job, whose retry would pay for the embedding again.
     //
+    // Which is why neither of these propagates. Both are follow-up work over an
+    // artifact that is already indexed, and returning their errors from here
+    // would have failed the embed job for exactly the reason the arming exists
+    // to avoid — buying the same embedding twice to retry a step that costs
+    // nothing. Both have a backstop: the sweep re-finds an unarmed artifact's
+    // pairs through `near_pairs`, and an unfinished merge through
+    // `merged_with_active_roots`.
+    //
     // This is what makes duplicate detection complete rather than sampled; see
     // the module header of `jobs::relate`.
-    crate::jobs::relate::arm(core, &chunk.id, 0).await?;
+    if let Err(e) = crate::jobs::relate::arm(core, &chunk.id, 0).await {
+        tracing::warn!(
+            artifact_id = %chunk.id,
+            error = %e,
+            "could not arm the neighbour query; the sweep will find its pairs"
+        );
+    }
     // A merged artifact hides what it replaced only once it is itself in the
     // index, so the knowledge is never out of search on both sides at once.
-    if chunk.provenance == crate::store::artifacts::Provenance::Merged {
-        crate::jobs::merge::finish(core, &chunk.id).await?;
+    if chunk.provenance == crate::store::artifacts::Provenance::Merged
+        && let Err(e) = crate::jobs::merge::finish(core, &chunk.id).await
+    {
+        tracing::warn!(
+            merged = %chunk.id,
+            error = %e,
+            "could not finish the merge; the next sweep will"
+        );
     }
     Ok(())
 }

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -220,11 +220,8 @@ pub async fn reap_stranded(core: &Core, merged_id: &str) -> Result<()> {
 /// hiding behind a correct end state.
 pub async fn flag_orphans(core: &Core) -> Result<usize> {
     let mut n = 0;
+    // The scan already excludes flagged rows, so every id here is new work.
     for id in core.store.merged_missing_a_source(500).await? {
-        let c = core.store.get_artifact(&id).await?;
-        if c.flags.iter().any(|f| f == "orphaned_source") {
-            continue;
-        }
         core.store
             .set_artifact_flags(
                 &id,
@@ -774,6 +771,65 @@ mod tests {
                 "the sweep merged the pair again after an explicit undo"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn an_already_flagged_merge_does_not_occupy_the_orphan_scan() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        write(&core, &draft("a text and b text"), &ids)
+            .await
+            .unwrap();
+        core.store.delete_artifact(&ids[0]).await.unwrap();
+        assert_eq!(flag_orphans(&core).await.unwrap(), 1);
+        // Flagged rows leave the scan entirely — not fetched and skipped in
+        // Rust, which is what let 500 of them starve every newer orphan out
+        // of the LIMIT.
+        assert!(
+            core.store
+                .merged_missing_a_source(500)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a flagged merge still occupies a scan slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn reviewing_an_orphaned_merge_is_not_undone_by_the_next_sweep() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        let m = write(&core, &draft("a text and b text"), &ids)
+            .await
+            .unwrap();
+        core.store.delete_artifact(&ids[0]).await.unwrap();
+        assert_eq!(flag_orphans(&core).await.unwrap(), 1);
+
+        // What mark_artifact_reviewed does for an orphaned merge.
+        core.store.accept_source_loss(&m.id).await.unwrap();
+        core.store.clear_artifact_flags(&m.id).await.unwrap();
+
+        assert_eq!(
+            flag_orphans(&core).await.unwrap(),
+            0,
+            "the sweep re-flagged a merge the operator had reviewed"
+        );
+        assert!(
+            core.store
+                .get_artifact(&m.id)
+                .await
+                .unwrap()
+                .flags
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -11,8 +11,103 @@
 //! unattended is not that it rarely goes wrong; it is that when it does, a rule
 //! that costs nothing catches it before anything is written.
 
+use crate::core::Core;
+use crate::error::Result;
 use crate::infer::prompt::MergedDraft;
-use crate::store::artifacts::Chunk;
+use crate::store::artifacts::{ArtifactStatus, Chunk, NewMerged, Provenance};
+use crate::store::jobs::Stage;
+
+/// Create a merged artifact and queue its embedding. Its roots are **not**
+/// superseded here.
+///
+/// The order is the whole design of this function. Superseding before the merge
+/// is indexed opens a window in which the roots are out of search and the merge
+/// is not yet in it — the knowledge temporarily unreachable, which is the
+/// failure class `heal_dangling_supersessions` and
+/// `deleting_the_survivor_puts_the_artifact_it_hid_back` exist to prevent, and
+/// the window is as long as the embed queue is deep.
+///
+/// In this order the worst a crash can leave is the merge and its roots all in
+/// search at once. That is redundancy, which is the state the system was already
+/// in before the merge — strictly better than a gap. `finish` closes it once the
+/// embedding lands, and the sweep finishes any that were interrupted.
+pub async fn write(core: &Core, draft: &MergedDraft, roots: &[String]) -> Result<Chunk> {
+    let m = core
+        .store
+        .insert_merged_artifact(
+            &NewMerged {
+                text: draft.text.clone(),
+                title: draft.title.clone(),
+                category: draft.category.clone(),
+                tags: draft.tags.clone(),
+                caveats: draft.caveats.clone(),
+            },
+            roots,
+        )
+        .await?;
+    core.store.enqueue(Stage::Embed, "artifact", &m.id).await?;
+    tracing::info!(merged = %m.id, sources = roots.len(), "wrote a merged artifact");
+    Ok(m)
+}
+
+/// Hide what an already-indexed merged artifact replaced.
+///
+/// Called from `mark_indexed` when a merged artifact finishes embedding, and
+/// again from the sweep for merges whose process died in between — a state that
+/// is complete from the artifact side and absent from the pair side, so only a
+/// join across the lineage would ever notice it.
+pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
+    let m = core.store.get_artifact(merged_id).await?;
+    if m.provenance != Provenance::Merged
+        || m.status != ArtifactStatus::Active
+        || m.superseded_by.is_some()
+    {
+        return Ok(());
+    }
+
+    let roots = core.store.roots_of(std::slice::from_ref(&m.id)).await?;
+    for root in roots.get(&m.id).into_iter().flatten() {
+        let Ok(r) = core.store.get_artifact(root).await else {
+            continue;
+        };
+        if r.status != ArtifactStatus::Active || r.superseded_by.is_some() {
+            continue;
+        }
+        // Warn and carry on. `supersede` refuses a side that is no longer
+        // active, and an operator deprecating a root between the read and here
+        // is an ordinary race rather than a reason to abandon the other roots —
+        // the sweep's repair reaches whatever is left.
+        if let Err(e) = core.supersede(root, &m.id).await {
+            tracing::warn!(root = %root, merged = %m.id, error = %e,
+                "could not hide a merged artifact's root; it stays active");
+        }
+    }
+
+    // And any earlier merge this one subsumes. Superseding only the roots would
+    // leave that merge active and near-identical to this one, so the relate unit
+    // would file the pair again on the next sweep and the two would churn
+    // against each other for as long as they both existed.
+    for older in core.store.subsumed_merges(&m.id).await? {
+        // Everything the older merge was hiding has to be re-pointed first.
+        // Those roots are already superseded — by `older` — so `finish`'s loop
+        // above skipped them, and hiding `older` behind this merge without
+        // moving them would leave `root -> older -> m`: a chain whose middle is
+        // itself out of results. That is the exact failure `Clusters` exists to
+        // prevent on the sweep's side, and the reader who opens a root would be
+        // sent to a dead end.
+        for hidden in core.store.artifacts_superseded_by(&older).await? {
+            if let Err(e) = core.repoint_supersession(&hidden, &m.id).await {
+                tracing::warn!(artifact = %hidden, to = %m.id, error = %e,
+                    "could not re-point a supersession; it still names a hidden winner");
+            }
+        }
+        if let Err(e) = core.supersede(&older, &m.id).await {
+            tracing::warn!(subsumed = %older, by = %m.id, error = %e,
+                "could not hide a merge this one subsumes; it stays active");
+        }
+    }
+    Ok(())
+}
 
 /// Every value and literal in `roots` that `draft` does not carry.
 ///
@@ -187,6 +282,227 @@ mod tests {
             lost.iter().any(|l| l.contains("systemctl stop app")),
             "a caveat's command was dropped without complaint: {lost:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn knowledge_is_never_unreachable_during_a_merge() {
+        // The write path is several steps over two stores that cannot be
+        // written atomically. Indexing before superseding means the worst a
+        // crash can leave is the merge and its roots all in search at once --
+        // redundancy, which is the state the system was already in. The other
+        // order leaves a window in which none of them is findable, and that
+        // window is as long as the embed queue is deep.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let d = draft("Mount the filesystem, or attach the volume, before writing.");
+
+        // Step one: the merge exists and nothing is hidden.
+        let m = write(&core, &d, &ids).await.unwrap();
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "a root left search before the merge was indexed"
+            );
+        }
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.payload.artifact_id == ids[0]),
+            "the roots are gone and the merge is not indexed yet"
+        );
+
+        // Step two: indexing the merge, which is what triggers the supersede.
+        crate::jobs::embed::run(&core, &m.id).await.unwrap();
+
+        for id in &ids {
+            assert_eq!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .as_deref(),
+                Some(m.id.as_str()),
+                "the roots were never superseded"
+            );
+        }
+        let hits = core
+            .vectors
+            .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.payload.artifact_id == m.id),
+            "the merge never reached search"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_whose_roots_were_never_superseded_is_finished_by_the_next_sweep() {
+        // A crash between indexing the merge and hiding its roots. The merge
+        // looks complete from the artifact side and absent from the pair side,
+        // so only a join across the lineage would ever notice.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let d = draft("Mount the filesystem, or attach the volume, before writing.");
+        let m = write(&core, &d, &ids).await.unwrap();
+        // Marked indexed without the arming hook, as an interrupted run leaves it.
+        core.store
+            .mark_embedded(&m.id, "fake-embed", 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            core.store.merged_with_active_roots(10).await.unwrap(),
+            vec![m.id.clone()]
+        );
+
+        crate::jobs::consolidate::run(&core).await.unwrap();
+
+        for id in &ids {
+            assert_eq!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .as_deref(),
+                Some(m.id.as_str())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_merge_of_a_merge_is_written_from_the_captured_roots() {
+        // The anti-drift rule end to end. M1(a,b) merged with c is written from
+        // a, b and c -- never from M1's text, which is itself a rewrite.
+        // Otherwise each generation paraphrases a paraphrase and the originals
+        // drift further away with every pass.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        let m1 = write(&core, &draft("a text and b text"), &ids)
+            .await
+            .unwrap();
+        crate::jobs::embed::run(&core, &m1.id).await.unwrap();
+
+        let c =
+            crate::jobs::consolidate::tests::seed_into_new_corpus(&core, "c text", [0.94, 0.34])
+                .await;
+        let m2 = write(
+            &core,
+            &draft("a text and b text and c text"),
+            &[m1.id.clone(), c.clone()],
+        )
+        .await
+        .unwrap();
+        crate::jobs::embed::run(&core, &m2.id).await.unwrap();
+
+        let roots = core
+            .store
+            .roots_of(std::slice::from_ref(&m2.id))
+            .await
+            .unwrap();
+        let mut got = roots[&m2.id].clone();
+        got.sort();
+        let mut want = vec![ids[0].clone(), ids[1].clone(), c];
+        want.sort();
+        assert_eq!(
+            got, want,
+            "the second merge did not flatten to captured roots"
+        );
+        assert!(
+            !got.contains(&m1.id),
+            "a merged artifact was recorded as a root of another merge"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_subsumes_an_earlier_one_hides_it() {
+        // Superseding only the roots leaves the earlier merge active and
+        // near-identical to the new one, so the relate unit re-pairs them on
+        // every sweep and the two churn against each other forever. This is the
+        // gap the design did not cover; `subsumed_merges` closes it.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        let m1 = write(&core, &draft("a text and b text"), &ids)
+            .await
+            .unwrap();
+        crate::jobs::embed::run(&core, &m1.id).await.unwrap();
+
+        let c =
+            crate::jobs::consolidate::tests::seed_into_new_corpus(&core, "c text", [0.94, 0.34])
+                .await;
+        let m2 = write(
+            &core,
+            &draft("a text and b text and c text"),
+            &[m1.id.clone(), c.clone()],
+        )
+        .await
+        .unwrap();
+        crate::jobs::embed::run(&core, &m2.id).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .get_artifact(&m1.id)
+                .await
+                .unwrap()
+                .superseded_by
+                .as_deref(),
+            Some(m2.id.as_str()),
+            "the subsumed merge is still active and will be re-paired forever"
+        );
+        // And no chain: every hidden artifact points at something that is
+        // itself in results. `root -> m1 -> m2` would leave the reader who
+        // opens a root at an artifact that is not in results either, and
+        // nothing in the UI can follow the second hop.
+        for id in ids.iter().chain(std::iter::once(&c)) {
+            let winner = core
+                .store
+                .get_artifact(id)
+                .await
+                .unwrap()
+                .superseded_by
+                .expect("every member should be hidden by now");
+            assert_eq!(winner, m2.id, "{id} was left pointing at the older merge");
+            assert!(
+                core.store
+                    .get_artifact(&winner)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "{id} points at a winner that is itself superseded"
+            );
+        }
     }
 
     #[test]

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -109,6 +109,93 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Take a merge back: what it replaced returns, the merge is retired, and the
+/// pairs that produced it are dismissed.
+///
+/// The third of those is easy to leave out and useless to leave out. Restoring
+/// the sources alone accomplishes nothing: the sweep re-finds them, the model
+/// reaches the same verdict, and the operator's decision is silently undone on
+/// the next tick. `record_pair` is `INSERT OR IGNORE`, so a dismissed row is
+/// respected forever — the mechanism exists and only needs to be used. This is
+/// the same bug `reactivating_a_superseded_artifact_survives_the_next_sweep`
+/// pins for the sweep's own supersessions.
+///
+/// The merge is deprecated rather than deleted, because `artifact_sources`
+/// cascades away with a delete and takes the record of what was attempted.
+///
+/// For an *explicit* undo only. A merged artifact that is simply deleted is
+/// handled by `heal_dangling_supersessions`, which restores what it hid — and a
+/// fresh merge is then correct, because the duplication is genuinely back. A
+/// decision may overrule the sweep; a deletion may not.
+pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
+    let m = core.store.get_artifact(merged_id).await?;
+    if m.provenance != Provenance::Merged {
+        return Err(crate::error::Error::Validation(format!(
+            "{merged_id} is not a merged artifact"
+        )));
+    }
+
+    // Everything it hid, not just its roots: an earlier merge it subsumed was
+    // superseded onto it too, and leaving that hidden behind a deprecated
+    // artifact is the dead end `repoint_supersession` exists to avoid.
+    let restored = core.store.artifacts_superseded_by(&m.id).await?;
+    for id in &restored {
+        if let Err(e) = core.reactivate(id).await {
+            tracing::warn!(artifact = %id, error = %e, "could not restore a merged artifact's source");
+        }
+    }
+
+    // Only after they are back. The other order leaves a moment with nothing in
+    // search at all, which is the window the whole write path is ordered to
+    // avoid.
+    core.deprecate(&m.id).await?;
+
+    // Without this the undo lasts exactly one sweep.
+    for pair in core.store.pairs_among(&restored).await? {
+        core.store
+            .set_pair_state(
+                pair.id,
+                crate::store::pairs::PairState::Dismissed,
+                Some("merge undone"),
+            )
+            .await?;
+    }
+    tracing::info!(merged = %m.id, restored = restored.len(), "undid a merge");
+    Ok(())
+}
+
+/// Flag merged artifacts that have lost a source to a delete.
+///
+/// The text still carries what the deleted source said, so this is not data
+/// loss — it is a claim of provenance the artifact can no longer support. The
+/// detail pane says so rather than quietly showing one fewer source, which
+/// would make a merge of three look like a merge of two.
+///
+/// Returns how many it flagged, which is worth asserting on for the same reason
+/// the repairs are: a pass that fires on a base with nothing wrong is a bug
+/// hiding behind a correct end state.
+pub async fn flag_orphans(core: &Core) -> Result<usize> {
+    let mut n = 0;
+    for id in core.store.merged_missing_a_source(500).await? {
+        let c = core.store.get_artifact(&id).await?;
+        if c.flags.iter().any(|f| f == "orphaned_source") {
+            continue;
+        }
+        core.store
+            .set_artifact_flags(
+                &id,
+                &["orphaned_source".to_string()],
+                Some("one of the artifacts this was written from has been deleted"),
+            )
+            .await?;
+        n += 1;
+    }
+    if n > 0 {
+        tracing::info!(flagged = n, "merged artifacts have lost a source");
+    }
+    Ok(n)
+}
+
 /// Every value and literal in `roots` that `draft` does not carry.
 ///
 /// Empty means the merge may be written. Anything else is a merge that would
@@ -503,6 +590,124 @@ mod tests {
                 "{id} points at a winner that is itself superseded"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn undoing_a_merge_survives_the_next_sweep() {
+        // Restoring the sources alone accomplishes nothing: the sweep re-finds
+        // them, the model reaches the same verdict, and the operator's decision
+        // is silently undone on the next tick. Dismissing the pairs is what
+        // makes it stick, and it is the half that is easy to leave out --
+        // literally the same bug as
+        // reactivating_a_superseded_artifact_survives_the_next_sweep.
+        let mut core = crate::core::test_support::test_core().await;
+        core.consolidate.autonomous = true;
+        core.completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"relation":"duplicate","detail":"same claim",
+                "merged":{"text":"Mount the filesystem, or attach the volume, before writing.",
+                          "tags":[],"caveats":[]}}"#
+                .into(),
+        ]));
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()[0]
+            .id;
+        crate::jobs::dedupe::run(&core, &pair.to_string())
+            .await
+            .unwrap();
+        let merged_id = core
+            .store
+            .merged_artifacts(10)
+            .await
+            .unwrap()
+            .first()
+            .map(|c| c.id.clone())
+            .unwrap_or_else(|| panic!("no merge was written"));
+        crate::jobs::embed::run(&core, &merged_id).await.unwrap();
+
+        undo(&core, &merged_id).await.unwrap();
+
+        for id in &ids {
+            let c = core.store.get_artifact(id).await.unwrap();
+            assert_eq!(c.status, ArtifactStatus::Active);
+            assert!(c.superseded_by.is_none());
+        }
+        assert_eq!(
+            core.store.get_artifact(&merged_id).await.unwrap().status,
+            ArtifactStatus::Deprecated,
+            "the merge was deleted, taking its lineage with it"
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::Dismissed, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the pair was left answerable, so the sweep will merge it again"
+        );
+
+        // The point of the whole test: it survives.
+        crate::jobs::consolidate::run(&core).await.unwrap();
+        for id in &ids {
+            assert!(
+                core.store
+                    .get_artifact(id)
+                    .await
+                    .unwrap()
+                    .superseded_by
+                    .is_none(),
+                "the sweep merged the pair again after an explicit undo"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn deleting_a_source_flags_the_merge_rather_than_hiding_the_loss() {
+        // The cascade removes the lineage row while the merged text still
+        // carries that source's content, so the artifact claims less provenance
+        // than it has. Not data loss, but a silent untruth: a merge of three
+        // would quietly render as a merge of two.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        let m = write(&core, &draft("a text and b text"), &ids)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            flag_orphans(&core).await.unwrap(),
+            0,
+            "the flag fired on a merge with all its sources"
+        );
+
+        core.store.delete_artifact(&ids[0]).await.unwrap();
+        assert_eq!(flag_orphans(&core).await.unwrap(), 1);
+
+        let flagged = core.store.get_artifact(&m.id).await.unwrap();
+        assert!(
+            flagged.flags.iter().any(|f| f == "orphaned_source"),
+            "{flagged:?}"
+        );
+        // And it does not keep re-flagging the same artifact every sweep.
+        assert_eq!(flag_orphans(&core).await.unwrap(), 0);
     }
 
     #[test]

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -1,0 +1,204 @@
+//! Writing, verifying and undoing a merge.
+//!
+//! Merging is the one thing in this system that puts model-written text where
+//! stored text used to be, so it is also the one thing that can lose knowledge
+//! without anyone noticing: a plausible paragraph reads exactly as well without
+//! the number it dropped, ranks exactly as well, and nothing downstream can
+//! tell. `losses` is what stands between a verdict and a write.
+//!
+//! Both checks are local and free — two token sets and one substring pass — and
+//! that is the point. The argument for letting a model rewrite stored knowledge
+//! unattended is not that it rarely goes wrong; it is that when it does, a rule
+//! that costs nothing catches it before anything is written.
+
+use crate::infer::prompt::MergedDraft;
+use crate::store::artifacts::Chunk;
+
+/// Every value and literal in `roots` that `draft` does not carry.
+///
+/// Empty means the merge may be written. Anything else is a merge that would
+/// have lost something, and the caller escalates rather than retrying: the text
+/// is what was wrong, and a person can read what it would have cost.
+///
+/// Both halves search the draft's text *and* its caveats. A caveat is stored,
+/// rendered and recoverable, so a value demoted there has not been lost — this
+/// checks for loss, not for prominence. Deciding that a value belongs in the
+/// caveats rather than the body is exactly the judgement a merge is for.
+pub fn losses(roots: &[Chunk], draft: &MergedDraft) -> Vec<String> {
+    let mut haystack = draft.text.clone();
+    for c in &draft.caveats {
+        haystack.push(' ');
+        haystack.push_str(c);
+    }
+
+    let have = crate::infer::facts::fact_tokens(&haystack);
+    let mut out: Vec<String> = Vec::new();
+
+    for r in roots {
+        // Values: a version, a timeout, a port. The failure this catches is a
+        // model answering "duplicate" and then quietly picking a side while
+        // writing, which is a conflict resolved by deletion.
+        for tok in crate::infer::facts::fact_tokens(&r.text) {
+            if !have.contains(&tok) {
+                out.push(tok);
+            }
+        }
+        // Literals: commands, paths, flags, error strings. The existing check,
+        // with the merged text as the haystack instead of the segment —
+        // `missing_literals(artifact_text, caveats, haystack)` asks which
+        // literals of the first argument are absent from the third, which is
+        // exactly this question with the arguments in this order.
+        //
+        // `verify`'s module header states the stake: a paraphrased command is a
+        // command that later gets pasted into a root shell.
+        out.extend(crate::infer::verify::missing_literals(
+            &r.text, &r.caveats, &haystack,
+        ));
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::artifacts::{ArtifactStatus, EmbedState, Provenance};
+
+    fn draft(text: &str) -> MergedDraft {
+        MergedDraft {
+            title: None,
+            text: text.into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        }
+    }
+
+    /// A captured artifact carrying only the text the checks read.
+    fn root(text: &str) -> Chunk {
+        Chunk {
+            id: "root".into(),
+            corpus_id: Some("corpus".into()),
+            provenance: Provenance::Captured,
+            source_count: 0,
+            ordinal: 0,
+            text: text.into(),
+            corpus_span: None,
+            title: None,
+            category: None,
+            tags: vec![],
+            embed_state: EmbedState::Embedded,
+            embed_model: None,
+            created_at: 0,
+            embed_rev: 0,
+            segment_idx: None,
+            flags: vec![],
+            flag_detail: None,
+            superseded_by: None,
+            caveats: vec![],
+            status: ArtifactStatus::Active,
+            last_verified_at: None,
+        }
+    }
+
+    #[test]
+    fn a_merge_that_keeps_both_values_is_allowed() {
+        let roots = [
+            root("The request timeout is 30 seconds."),
+            root("The request timeout is 90 seconds."),
+        ];
+        let d = draft(
+            "Sources differ on the request timeout: an earlier capture gives 30 seconds, \
+             a later one 90 seconds.",
+        );
+        assert!(losses(&roots, &d).is_empty(), "{:?}", losses(&roots, &d));
+    }
+
+    #[test]
+    fn a_merge_that_drops_a_value_is_refused() {
+        // The one way this feature can destroy knowledge without anyone
+        // noticing: the model answers "duplicate" and quietly picks a side while
+        // writing. The result reads well, ranks well, and the missing number is
+        // gone from the base — a conflict resolved by deletion.
+        let roots = [
+            root("The request timeout is 30 seconds."),
+            root("The request timeout is 90 seconds."),
+        ];
+        let d = draft("The request timeout is 90 seconds.");
+        assert_eq!(losses(&roots, &d), vec!["30".to_string()]);
+    }
+
+    #[test]
+    fn a_value_moved_into_the_caveats_is_not_lost() {
+        // Caveats are stored and rendered beside the artifact, so a value
+        // demoted there is still recoverable. This checks for loss, not for
+        // prominence — deciding what belongs in the body is what a merge is for.
+        let roots = [
+            root("The request timeout is 30 seconds."),
+            root("The request timeout is 90 seconds."),
+        ];
+        let mut d = draft("The request timeout is 90 seconds.");
+        d.caveats = vec!["An earlier capture gave 30 seconds.".into()];
+        assert!(losses(&roots, &d).is_empty(), "{:?}", losses(&roots, &d));
+    }
+
+    #[test]
+    fn a_merge_that_paraphrases_a_command_is_refused() {
+        // A paraphrased command is a command that later gets pasted into a root
+        // shell. The literal check is the same one synthesis already runs, with
+        // the merged text as the haystack instead of the source window.
+        let roots = [
+            root("Attach it with `mount --bind /src /dst`."),
+            root("Bind mounts attach a directory elsewhere."),
+        ];
+        let d = draft("Bind mounts attach a directory elsewhere; use the bind mount option.");
+        let lost = losses(&roots, &d);
+        assert!(
+            lost.iter().any(|l| l.contains("mount --bind")),
+            "the literal check let a paraphrased command through: {lost:?}"
+        );
+    }
+
+    #[test]
+    fn a_merge_that_reproduces_the_command_verbatim_is_allowed() {
+        let roots = [
+            root("Attach it with `mount --bind /src /dst`."),
+            root("Bind mounts attach a directory elsewhere."),
+        ];
+        let d = draft(
+            "Bind mounts attach a directory elsewhere. Attach one with \
+             `mount --bind /src /dst`.",
+        );
+        assert!(losses(&roots, &d).is_empty(), "{:?}", losses(&roots, &d));
+    }
+
+    #[test]
+    fn a_literal_a_root_carried_only_in_its_caveats_still_has_to_survive() {
+        // Caveats are the newest place model prose appears, and one that says to
+        // run something first is a command like any other. `missing_literals`
+        // already reads them on the source side; this pins that a merge cannot
+        // drop them.
+        let mut r = root("Mount the filesystem before writing.");
+        r.caveats = vec!["Only after running `systemctl stop app`.".into()];
+        let d = draft("Mount the filesystem before writing.");
+        let lost = losses(&[r], &d);
+        assert!(
+            lost.iter().any(|l| l.contains("systemctl stop app")),
+            "a caveat's command was dropped without complaint: {lost:?}"
+        );
+    }
+
+    #[test]
+    fn a_merge_of_three_roots_is_checked_against_all_of_them() {
+        // The fan-in cap allows up to eight. A check that only read the first
+        // two would pass a merge that dropped everything the third said.
+        let roots = [
+            root("Port 8080 is the default."),
+            root("The timeout is 30s."),
+            root("Retries are capped at 5."),
+        ];
+        let d = draft("Port 8080 is the default and the timeout is 30s.");
+        assert_eq!(losses(&roots, &d), vec!["5".to_string()]);
+    }
+}

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -14,7 +14,7 @@
 use crate::core::Core;
 use crate::error::Result;
 use crate::infer::prompt::MergedDraft;
-use crate::store::artifacts::{ArtifactStatus, Chunk, NewMerged, Provenance};
+use crate::store::artifacts::{Chunk, NewMerged, Provenance};
 use crate::store::jobs::Stage;
 
 /// Create a merged artifact and queue its embedding. Its roots are **not**
@@ -58,10 +58,7 @@ pub async fn write(core: &Core, draft: &MergedDraft, roots: &[String]) -> Result
 /// join across the lineage would ever notice it.
 pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
     let m = core.store.get_artifact(merged_id).await?;
-    if m.provenance != Provenance::Merged
-        || m.status != ArtifactStatus::Active
-        || m.superseded_by.is_some()
-    {
+    if m.provenance != Provenance::Merged || !m.in_results() {
         return Ok(());
     }
 
@@ -73,7 +70,7 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
         let Ok(r) = core.store.get_artifact(&root).await else {
             continue;
         };
-        if r.status != ArtifactStatus::Active || r.superseded_by.is_some() {
+        if !r.in_results() {
             continue;
         }
         // Warn and carry on. `supersede` refuses a side that is no longer
@@ -182,8 +179,7 @@ pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
 pub async fn reap_stranded(core: &Core, merged_id: &str) -> Result<()> {
     let m = core.store.get_artifact(merged_id).await?;
     if m.provenance != Provenance::Merged
-        || m.status != ArtifactStatus::Active
-        || m.superseded_by.is_some()
+        || !m.in_results()
         || m.embed_state == crate::store::artifacts::EmbedState::Embedded
     {
         // The embed landed (or someone else acted) between the scan and

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -160,6 +160,13 @@ pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
             )
             .await?;
     }
+    // And by lineage, for an undo that outran the embed: before `finish` runs,
+    // nothing is superseded by this merge, so `restored` above is empty — but
+    // the pairs were settled the moment the merge was written, and leaving
+    // them would keep the duplicates invisible to every later sweep.
+    core.store
+        .dismiss_pairs_merged_into(&m.id, "merge undone")
+        .await?;
     tracing::info!(merged = %m.id, restored = restored.len(), "undid a merge");
     Ok(())
 }
@@ -767,6 +774,49 @@ mod tests {
                 "the sweep merged the pair again after an explicit undo"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn undoing_a_merge_before_its_embed_lands_still_releases_its_pairs() {
+        // Pairs are settled at write time; roots are superseded at embed time.
+        // An undo in between used to find nothing superseded, dismiss nothing,
+        // and leave the pairs no_conflict behind a deprecated merge — both
+        // duplicates active, and record_pair unable to ever re-file them.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        let pair = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()[0]
+            .id;
+
+        let m = write(&core, &draft("a text and b text"), &ids)
+            .await
+            .unwrap();
+        core.store
+            .set_pair_merged(pair, &m.id, Some("duplicate"))
+            .await
+            .unwrap();
+        // No embed ran: nothing is superseded by m yet.
+
+        undo(&core, &m.id).await.unwrap();
+
+        let p = core.store.get_pair(pair).await.unwrap();
+        assert_eq!(
+            p.state,
+            crate::store::pairs::PairState::Dismissed,
+            "the pair stayed settled behind a deprecated merge: {p:?}"
+        );
+        assert_eq!(p.merged_into, None);
     }
 
     #[tokio::test]

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -164,6 +164,44 @@ pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Retire a merge whose embedding can never arrive, and hand its pairs back
+/// to a person.
+///
+/// Safe by the write path's own ordering: the roots are superseded only after
+/// the embed lands, so a stranded merge has hidden nothing — the base is
+/// exactly what it was before the verdict, plus one unindexed artifact.
+/// Deprecated rather than deleted for the same reason `undo` deprecates: the
+/// lineage is the record of what was attempted.
+///
+/// The reopened pairs go to `Contradiction`, not back to `Pending`: re-arming
+/// the model would regenerate the same unembeddable draft, at full price,
+/// forever.
+pub async fn reap_stranded(core: &Core, merged_id: &str) -> Result<()> {
+    let m = core.store.get_artifact(merged_id).await?;
+    if m.provenance != Provenance::Merged
+        || m.status != ArtifactStatus::Active
+        || m.superseded_by.is_some()
+        || m.embed_state == crate::store::artifacts::EmbedState::Embedded
+    {
+        // The embed landed (or someone else acted) between the scan and
+        // here. Nothing is stranded any more.
+        return Ok(());
+    }
+    core.deprecate(&m.id).await?;
+    let reopened = core
+        .store
+        .reopen_pairs_merged_into(
+            &m.id,
+            "the merged text could not be indexed; resolve by hand",
+        )
+        .await?;
+    // The forever-retrying job was this state's only signal; with the merge
+    // retired it is pure noise.
+    core.store.delete_job(Stage::Embed, &m.id).await?;
+    tracing::warn!(merged = %m.id, reopened, "reaped a merge that could not be embedded");
+    Ok(())
+}
+
 /// Flag merged artifacts that have lost a source to a delete.
 ///
 /// The text still carries what the deleted source said, so this is not data

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -65,9 +65,12 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
         return Ok(());
     }
 
-    let roots = core.store.roots_of(std::slice::from_ref(&m.id)).await?;
-    for root in roots.get(&m.id).into_iter().flatten() {
-        let Ok(r) = core.store.get_artifact(root).await else {
+    // `roots_to_hide`, not `roots_of`: a root an operator explicitly restored
+    // out of this merge stays in results, and this repair path — re-run by the
+    // sweep for as long as the merge stands — must not undo that decision on
+    // every tick.
+    for root in core.store.roots_to_hide(&m.id).await? {
+        let Ok(r) = core.store.get_artifact(&root).await else {
             continue;
         };
         if r.status != ArtifactStatus::Active || r.superseded_by.is_some() {
@@ -77,7 +80,7 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
         // active, and an operator deprecating a root between the read and here
         // is an ordinary race rather than a reason to abandon the other roots —
         // the sweep's repair reaches whatever is left.
-        if let Err(e) = core.supersede(root, &m.id).await {
+        if let Err(e) = core.supersede(&root, &m.id).await {
             tracing::warn!(root = %root, merged = %m.id, error = %e,
                 "could not hide a merged artifact's root; it stays active");
         }
@@ -516,6 +519,62 @@ mod tests {
                 Some(m.id.as_str())
             );
         }
+    }
+
+    #[tokio::test]
+    async fn restoring_one_merge_source_survives_the_next_sweep() {
+        // "Put it back" on a merge-hidden artifact used to last exactly one
+        // sweep: merged_with_active_roots cannot tell a crash-interrupted
+        // merge from an operator's explicit restore, and finish re-hid it.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let d = draft("Mount the filesystem, or attach the volume, before writing.");
+        let m = write(&core, &d, &ids).await.unwrap();
+        crate::jobs::embed::run(&core, &m.id).await.unwrap();
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_some(),
+            "the merge never finished; the test setup is wrong"
+        );
+
+        core.unsupersede(&ids[0]).await.unwrap();
+
+        crate::jobs::consolidate::run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_artifact(&ids[0])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "the sweep re-hid an artifact an operator had explicitly restored"
+        );
+        // The rest of the merge is untouched: the other source stays hidden,
+        // the merge stays active.
+        assert!(
+            core.store
+                .get_artifact(&ids[1])
+                .await
+                .unwrap()
+                .superseded_by
+                .is_some()
+        );
+        assert_eq!(
+            core.store.get_artifact(&m.id).await.unwrap().status,
+            ArtifactStatus::Active
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,7 +1,7 @@
 pub mod classify;
 pub mod consolidate;
+pub mod dedupe;
 pub mod embed;
-pub mod judge;
 pub mod reconcile;
 pub mod relate;
 pub mod synthesize;
@@ -49,7 +49,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
         (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
-        (Stage::Judge, _) => judge::run(core, &job.target_id).await,
+        (Stage::Dedupe, _) => dedupe::run(core, &job.target_id).await,
         (Stage::Relate, _) => relate::run(core, &job.target_id).await,
     };
 
@@ -84,7 +84,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                 // unit here is not a hand-off but a loop: the next sweep finds
                 // the pair pending with no live job and arms it for another
                 // `MAX_ATTEMPTS`, forever.
-                (Stage::Judge, _) if exhausted => {
+                (Stage::Dedupe, _) if exhausted => {
                     tracing::warn!(error = %e, "could not judge this pair; leaving it for a later sweep");
                     core.store.complete_job(job.id).await?;
                 }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,3 +1,4 @@
+pub mod classify;
 pub mod consolidate;
 pub mod embed;
 pub mod judge;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -116,8 +116,12 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                         .await?;
                     if job.stage == Stage::Embed && exhausted {
                         core.store.mark_embed_failed(&job.target_id).await?;
-                        if let Ok(c) = core.store.get_artifact(&job.target_id).await {
-                            embed::settle_corpus(core, &c.corpus_id).await?;
+                        // A merged artifact belongs to no corpus, so there is
+                        // no document whose coverage its failure completes.
+                        if let Ok(c) = core.store.get_artifact(&job.target_id).await
+                            && let Some(corpus_id) = c.corpus_id.as_deref()
+                        {
+                            embed::settle_corpus(core, corpus_id).await?;
                         }
                     }
                 }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -2,6 +2,7 @@ pub mod classify;
 pub mod consolidate;
 pub mod dedupe;
 pub mod embed;
+pub mod merge;
 pub mod reconcile;
 pub mod relate;
 pub mod synthesize;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -3,6 +3,7 @@ pub mod consolidate;
 pub mod embed;
 pub mod judge;
 pub mod reconcile;
+pub mod relate;
 pub mod synthesize;
 pub mod window;
 
@@ -49,6 +50,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
         (Stage::Judge, _) => judge::run(core, &job.target_id).await,
+        (Stage::Relate, _) => relate::run(core, &job.target_id).await,
     };
 
     match result {

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -28,7 +28,6 @@
 
 use crate::core::Core;
 use crate::error::Result;
-use crate::store::artifacts::ArtifactStatus;
 use crate::store::jobs::Stage;
 
 /// Queue a neighbour query for this artifact.
@@ -47,7 +46,7 @@ pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
     // A retired artifact has no duplicates worth recording. Every pair naming
     // it would be skipped by `classify_pair` anyway, so this saves the query
     // rather than changing the outcome.
-    if me.status != ArtifactStatus::Active || me.superseded_by.is_some() {
+    if !me.in_results() {
         tracing::debug!(
             artifact_id,
             status = me.status.as_str(),

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -1,0 +1,265 @@
+//! What else is this artifact already saying?
+//!
+//! Duplicate detection used to be a sampled sweep: `consolidate.sample` points
+//! drawn per run, pairs computed only *within* that draw, so both members of a
+//! pair had to land in the same sample. The probability of that is (sample/N)²
+//! and it decays quadratically — at five thousand artifacts a given pair waits
+//! about a week, at a hundred thousand it waits years. No amount of judging
+//! fixes a pair the detector never hands over.
+//!
+//! This asks the opposite question. One artifact, its own neighbours, one
+//! query. `VectorStore::neighbours` addresses the point by id, so the vector is
+//! looked up in the index and no embedding call is paid, and it already
+//! excludes superseded and deprecated points. Coverage becomes 1, independent
+//! of N, at the cost of one round trip per artifact — which under this
+//! project's economics is free.
+//!
+//! Completeness argument: for a pair (X, Y), the member embedded **second**
+//! finds the other. When X's unit runs, Y is either already indexed — X finds
+//! it — or it is not, and Y finds X when its own unit runs. Embedded in the
+//! same batch, both units run after the shared upsert and both see each other.
+//! No pair falls through, provided both units run; the sweep remains as the
+//! backstop for the ones that did not.
+//!
+//! A separate unit rather than a tail on `embed_batch`: a failing Qdrant query
+//! would otherwise fail the embed job, whose retry pays for the embedding all
+//! over again. Two failure domains, two units — the same reasoning that split
+//! the judge calls out of the sweep.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::ArtifactStatus;
+use crate::store::jobs::Stage;
+
+/// Queue a neighbour query for this artifact.
+///
+/// Idle-only, like every other automatic arming: a re-embed can reach this
+/// while an earlier unit is still queued, and `enqueue` would wind that unit's
+/// attempts back to zero underneath it.
+pub async fn arm(core: &Core, artifact_id: &str, seq: i64) -> Result<()> {
+    core.store
+        .rearm_idle_seq(Stage::Relate, "artifact", artifact_id, seq)
+        .await
+}
+
+pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
+    let me = core.store.get_artifact(artifact_id).await?;
+    // A retired artifact has no duplicates worth recording. Every pair naming
+    // it would be skipped by `classify_pair` anyway, so this saves the query
+    // rather than changing the outcome.
+    if me.status != ArtifactStatus::Active || me.superseded_by.is_some() {
+        tracing::debug!(
+            artifact_id,
+            status = me.status.as_str(),
+            "skipping a hidden artifact"
+        );
+        return Ok(());
+    }
+
+    let hits = core
+        .vectors
+        .neighbours(artifact_id, core.consolidate.per_point)
+        .await?;
+
+    for h in hits {
+        // `similarity` and not `score`. `review_min` is a cosine, and `score`
+        // is a fused rank everywhere else in this trait — `neighbours` fills
+        // the cosine in precisely so this comparison means what it reads as.
+        let Some(similarity) = h.similarity else {
+            tracing::warn!(
+                artifact_id,
+                neighbour = %h.payload.artifact_id,
+                "neighbour came back with no cosine; skipping rather than guessing"
+            );
+            continue;
+        };
+        if similarity < core.consolidate.review_min {
+            continue;
+        }
+        // Ordinary rather than an error: the vector store can list a point
+        // SQLite has already dropped, because a delete lags its reindex.
+        let Ok(other) = core.store.get_artifact(&h.payload.artifact_id).await else {
+            tracing::debug!(artifact_id = %h.payload.artifact_id, "neighbour is gone");
+            continue;
+        };
+        // Warn and carry on, as the sweep does. One unwritable pair row is no
+        // reason to drop the other neighbours, and the next run finds it again.
+        if let Err(e) = crate::jobs::classify::classify_pair(core, &me, &other, similarity).await {
+            tracing::warn!(a = %me.id, b = %other.id, error = %e, "could not classify a neighbour");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::jobs::consolidate::tests::seed;
+    use crate::store::pairs::PairState;
+
+    #[tokio::test]
+    async fn an_artifact_finds_its_duplicate_the_moment_it_is_embedded() {
+        // The sweep samples `sample` points and needs both members of a pair in
+        // the same draw, so coverage decays as (sample/N)² — at 100k artifacts
+        // a given pair waits years. Asking one artifact for its own neighbours
+        // costs one Qdrant query, no embedding call, and is exact.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        run(&core, &ids[1]).await.unwrap();
+
+        let pending = core
+            .store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 1, "the unit found no duplicate");
+        assert!(
+            [&pending[0].a_id, &pending[0].b_id].contains(&&ids[0])
+                && [&pending[0].a_id, &pending[0].b_id].contains(&&ids[1])
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_is_found_by_whichever_member_is_embedded_second() {
+        // The completeness argument, and the reason the sweep can stop being
+        // the primary detector. Running both units must not double-file: the
+        // pair row is unique on (a_id, b_id) whichever way round it is seen.
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+
+        run(&core, &ids[0]).await.unwrap();
+        let from_a = core
+            .store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .len();
+        run(&core, &ids[1]).await.unwrap();
+        let after_b = core
+            .store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap()
+            .len();
+
+        assert_eq!(from_a, 1, "the first member found nothing");
+        assert_eq!(after_b, 1, "the second member filed the same pair twice");
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_neighbour_never_costs_a_model_call() {
+        // At or above `auto_supersede` the pair is settled for free by
+        // clustering. Filing it as an ordinary pending pair would arm a dedupe
+        // unit and spend a call on the one case where the cheap rule is already
+        // right — the free path quietly becoming a paid one.
+        let core = test_core().await;
+        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        let ids = core
+            .store
+            .all_active_artifacts()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect::<Vec<_>>();
+
+        run(&core, &ids[1]).await.unwrap();
+
+        assert!(core.store.pairs_to_judge(10).await.unwrap().is_empty());
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::NearIdentical, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_neighbour_is_left_entirely_alone() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
+
+        run(&core, &ids[1]).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_retired_artifact_asks_for_nothing() {
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        core.deprecate(&ids[1]).await.unwrap();
+
+        run(&core, &ids[1]).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a retired artifact filed a pair about itself"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_artifact_that_is_not_indexed_yet_is_not_an_error() {
+        // `neighbours` answers an unknown point with an empty list rather than
+        // failing, and this unit is armed from the embed path — but a
+        // re-arming, a restore, or a hand-queued job can reach it before the
+        // vector exists. Failing here would burn the unit's attempts on a state
+        // that resolves itself.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "never embedded".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        run(&core, &made[0].id).await.unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,11 +289,13 @@ async fn main() -> anyhow::Result<()> {
         engram::core::background::spawn_consolidation_ticker(core.clone(), shutdown_rx.clone());
     let retention =
         engram::core::background::spawn_retention_ticker(core.clone(), shutdown_rx.clone());
+    let dedupe = engram::core::background::spawn_dedupe_ticker(core.clone(), shutdown_rx.clone());
     let mut handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
     // Joined with the workers so shutdown waits for them too, rather than
     // leaving tasks the runtime drops mid-enqueue.
     handles.push(ticker);
     handles.push(retention);
+    handles.push(dedupe);
 
     let listener = tokio::net::TcpListener::bind(&cfg.server.bind).await?;
     tracing::info!(bind = %cfg.server.bind, mode = ?cfg.auth.mode, "engram listening");

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -947,6 +947,25 @@ impl Store {
         self.set_artifact_flags(id, &[], None).await
     }
 
+    /// `Chunk::in_results`, answered from two columns instead of the full row.
+    ///
+    /// For callers that triage many artifacts and read the text of few —
+    /// `arm_dedupe` walks up to 200 pairs per tick and skips most of them, and
+    /// paying two full-row fetches (text included) per skipped pair was the
+    /// bulk of the tick's work. `None` means the row is gone, which is its own
+    /// answer rather than an error: a pair cascades away mid-loop and the
+    /// caller moves on.
+    pub async fn artifact_in_results(&self, id: &str) -> Result<Option<bool>> {
+        let row = sqlx::query(
+            "SELECT status = 'active' AND superseded_by IS NULL AS live
+               FROM artifacts WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| r.get::<bool, _>("live")))
+    }
+
     /// Record that an operator reviewed a merge's lost sources and accepted it
     /// as a merge of what remains. `source_count` comes down to the surviving
     /// lineage count, so the orphan scan's comparison goes quiet — without
@@ -1277,6 +1296,40 @@ mod tests {
             .await
             .unwrap();
         assert!(!s.get_artifact(&made[1].id).await.unwrap().in_results());
+    }
+
+    #[tokio::test]
+    async fn liveness_is_answerable_without_fetching_the_row() {
+        // What `arm_dedupe` reads 200 times per tick, most of them for pairs
+        // it goes on to skip — two columns, never the text.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "one"), nc(1, "two")])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.artifact_in_results(&made[0].id).await.unwrap(),
+            Some(true)
+        );
+        s.set_superseded_by(&made[0].id, Some(&made[1].id))
+            .await
+            .unwrap();
+        assert_eq!(
+            s.artifact_in_results(&made[0].id).await.unwrap(),
+            Some(false)
+        );
+        s.set_artifact_status(&made[1].id, ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+        assert_eq!(
+            s.artifact_in_results(&made[1].id).await.unwrap(),
+            Some(false)
+        );
+        // A missing row is its own answer, not an error: the caller treats a
+        // cascaded-away pair differently from a store that is unwell.
+        assert_eq!(s.artifact_in_results("no-such-id").await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -251,6 +251,17 @@ impl Store {
         // Resolved before the transaction opens: this is a read, and holding a
         // write transaction across it buys nothing.
         let resolved = self.roots_of(sources).await?;
+        // The roots actually about to be written, deduped the way the table
+        // dedupes them: `artifact_sources` is keyed on (child_id, root_id), so
+        // two sources sharing a root produce one row.
+        //
+        // Counting `sources` instead counted the inputs, which for a merge of a
+        // merge is fewer than the roots — M2 = merge(M1(a,b), c) recorded two
+        // against three rows. `merged_missing_a_source` asks whether the count
+        // exceeds the surviving rows, so deleting a root left 2 > 2, false, and
+        // the orphan flag never fired for a merge of a merge at all. That is
+        // precisely the case the counter was added for.
+        let root_ids: std::collections::BTreeSet<&String> = resolved.values().flatten().collect();
 
         let mut tx = self.pool.begin().await?;
         let created_at = now();
@@ -258,7 +269,7 @@ impl Store {
             id: new_id(),
             corpus_id: None,
             provenance: Provenance::Merged,
-            source_count: sources.len() as i64,
+            source_count: root_ids.len() as i64,
             ordinal: 0,
             text: new.text.clone(),
             corpus_span: None,

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -196,7 +196,7 @@ pub struct RestoredArtifact {
     pub superseded_by: Option<String>,
 }
 
-fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
+pub(crate) fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
     let tags_json: String = r.get("tags");
     let span_json: Option<String> = r.get("corpus_span");
     let flags_json: Option<String> = r.get("flags");

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -855,6 +855,20 @@ impl Store {
         Ok(rows.iter().map(|r| r.get::<String, _>("id")).collect())
     }
 
+    /// Artifacts hidden in favour of this one.
+    ///
+    /// What a supersession chain is made of. When the winner is itself
+    /// superseded, everything pointing at it has to be re-pointed or the reader
+    /// who opens one of these is sent to an artifact that is not in results
+    /// either — a dead end no page can follow.
+    pub async fn artifacts_superseded_by(&self, winner_id: &str) -> Result<Vec<String>> {
+        let rows = sqlx::query("SELECT id FROM artifacts WHERE superseded_by = ?")
+            .bind(winner_id)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(|r| r.get::<String, _>("id")).collect())
+    }
+
     /// Artifacts currently hidden by consolidation, newest first.
     pub async fn superseded_artifacts(&self, limit: i64) -> Result<Vec<Chunk>> {
         let rows = sqlx::query(

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -54,6 +54,41 @@ impl ArtifactStatus {
     }
 }
 
+/// Where an artifact's text came from.
+///
+/// `Captured` text was written by synthesis over one window of one corpus, so
+/// it has a corpus, a span, and lines to render beside it. `Merged` text was
+/// written by the dedupe pass out of two or more captured artifacts; it has no
+/// corpus and no span, and names its sources through `artifact_sources`
+/// instead.
+///
+/// Nothing may treat the two alike. `verify` cannot check a merged artifact
+/// against a segment that does not exist, and the detail pane cannot render
+/// corpus lines for a span it does not have — so both branch on this rather
+/// than on `corpus_id.is_none()`. A null says a field is absent; this says what
+/// the row *is*, which is what a reader needs in order to know why.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+    Captured,
+    Merged,
+}
+
+impl Provenance {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Provenance::Captured => "captured",
+            Provenance::Merged => "merged",
+        }
+    }
+    pub fn parse(s: &str) -> Provenance {
+        match s {
+            "merged" => Provenance::Merged,
+            _ => Provenance::Captured,
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct CorpusSpan {
     pub start_line: i64,
@@ -63,7 +98,13 @@ pub struct CorpusSpan {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct Chunk {
     pub id: String,
-    pub corpus_id: String,
+    /// `None` for a merged artifact, which belongs to no single corpus. Branch
+    /// on `provenance`, not on this: see `Provenance`.
+    pub corpus_id: Option<String>,
+    pub provenance: Provenance,
+    /// How many artifacts a merge was written from, so a source deleted since
+    /// can be noticed. Zero for a captured artifact.
+    pub source_count: i64,
     pub ordinal: i64,
     pub text: String,
     pub corpus_span: Option<CorpusSpan>,
@@ -124,7 +165,12 @@ pub struct NewArtifact {
 #[derive(Debug, Clone)]
 pub struct RestoredArtifact {
     pub id: String,
-    pub corpus_id: String,
+    /// `None` for a merged artifact. A payload carries `corpus_id` as the empty
+    /// string for one of those, which is not a corpus that exists — writing it
+    /// would break the foreign key, and writing it as a corpus id would be a
+    /// lie. `provenance` is what tells the two cases apart.
+    pub corpus_id: Option<String>,
+    pub provenance: Provenance,
     pub text: String,
     pub title: Option<String>,
     pub category: Option<String>,
@@ -142,6 +188,8 @@ fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
     Chunk {
         id: r.get("id"),
         corpus_id: r.get("corpus_id"),
+        provenance: Provenance::parse(r.get::<String, _>("provenance").as_str()),
+        source_count: r.get("source_count"),
         ordinal: r.get("ordinal"),
         text: r.get("text"),
         corpus_span: span_json.and_then(|s| serde_json::from_str(&s).ok()),
@@ -179,7 +227,9 @@ impl Store {
             let created_at = now();
             let c = Chunk {
                 id: new_id(),
-                corpus_id: corpus_id.to_string(),
+                corpus_id: Some(corpus_id.to_string()),
+                provenance: Provenance::Captured,
+                source_count: 0,
                 ordinal: nc.ordinal,
                 text: nc.text.clone(),
                 corpus_span: nc.corpus_span.clone(),
@@ -199,8 +249,8 @@ impl Store {
                 last_verified_at: Some(created_at),
             };
             sqlx::query(
-                "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)",
+                "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
+                 VALUES (?, ?, 'captured', ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)",
             )
             .bind(&c.id)
             .bind(&c.corpus_id)
@@ -245,12 +295,13 @@ impl Store {
     /// makes `embed_model` true.
     pub async fn restore_artifact(&self, c: &RestoredArtifact) -> Result<bool> {
         let res = sqlx::query(
-            "INSERT INTO artifacts (id, corpus_id, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, superseded_by)
-             VALUES (?, ?, 0, ?, NULL, ?, ?, ?, 'pending', NULL, ?, NULL, '[]', ?, ?, ?)
+            "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, superseded_by)
+             VALUES (?, ?, ?, 0, ?, NULL, ?, ?, ?, 'pending', NULL, ?, NULL, '[]', ?, ?, ?)
              ON CONFLICT(id) DO NOTHING",
         )
         .bind(&c.id)
         .bind(&c.corpus_id)
+        .bind(c.provenance.as_str())
         .bind(&c.text)
         .bind(&c.title)
         .bind(&c.category)
@@ -739,6 +790,59 @@ mod tests {
             tags: vec!["forensics".into(), "windows".into()],
             segment_idx: None,
         }
+    }
+
+    #[tokio::test]
+    async fn a_captured_artifact_is_captured_and_names_its_corpus() {
+        // `provenance` is the discriminator every consumer branches on, never
+        // `corpus_id IS NULL`. A null is an absence; a kind is an assertion,
+        // and the failure modes merging can produce want to hang off an
+        // assertion — `verify` cannot check a merged artifact against a segment
+        // that does not exist, and the detail pane cannot render lines for a
+        // span it does not have.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s.insert_artifacts(&src.id, &[nc(0, "one")]).await.unwrap();
+
+        assert_eq!(made[0].provenance, Provenance::Captured);
+        assert_eq!(made[0].corpus_id.as_deref(), Some(src.id.as_str()));
+
+        let read = s.get_artifact(&made[0].id).await.unwrap();
+        assert_eq!(read.provenance, Provenance::Captured);
+        assert_eq!(read.corpus_id.as_deref(), Some(src.id.as_str()));
+        assert_eq!(
+            read.source_count, 0,
+            "a captured artifact was merged from something"
+        );
+    }
+
+    #[tokio::test]
+    async fn restoring_a_merged_artifact_gives_it_no_corpus() {
+        // A payload carries `corpus_id` as the empty string for a merged
+        // artifact, and "" is not a corpus that exists — restoring it as one
+        // fails the foreign key, and restoring it as a corpus id would put the
+        // wrong document's lines beside the artifact forever. The kind is what
+        // tells the two cases apart, which is why it rides in the payload.
+        let s = Store::memory().await.unwrap();
+        let restored = RestoredArtifact {
+            id: "merged-1".into(),
+            corpus_id: None,
+            provenance: Provenance::Merged,
+            text: "one artifact out of two".into(),
+            title: None,
+            category: None,
+            tags: vec![],
+            created_at: 1,
+            status: ArtifactStatus::Active,
+            last_verified_at: None,
+            superseded_by: None,
+        };
+
+        assert!(s.restore_artifact(&restored).await.unwrap());
+
+        let back = s.get_artifact("merged-1").await.unwrap();
+        assert_eq!(back.provenance, Provenance::Merged);
+        assert_eq!(back.corpus_id, None);
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -695,12 +695,18 @@ impl Store {
         } else {
             ArtifactStatus::Active
         };
-        let res = sqlx::query("UPDATE artifacts SET superseded_by = ?, status = ? WHERE id = ?")
-            .bind(by)
-            .bind(status.as_str())
-            .bind(artifact_id)
-            .execute(&self.pool)
-            .await?;
+        // The marker rides the same statement as the change it describes. Two
+        // statements could be interrupted between, which is the exact failure
+        // this is here to catch — a lifecycle change that never reached the
+        // payload and that nothing afterwards knows to look for.
+        let res = sqlx::query(
+            "UPDATE artifacts SET superseded_by = ?, status = ?, lifecycle_dirty = 1 WHERE id = ?",
+        )
+        .bind(by)
+        .bind(status.as_str())
+        .bind(artifact_id)
+        .execute(&self.pool)
+        .await?;
         if res.rows_affected() == 0 {
             return Err(Error::NotFound);
         }
@@ -712,13 +718,67 @@ impl Store {
     /// other end. Does not touch `superseded_by`; callers that mean to clear
     /// a supersession should use `set_superseded_by(id, None)` instead.
     pub async fn set_artifact_status(&self, id: &str, status: ArtifactStatus) -> Result<()> {
+        // Marked dirty in the same statement, like `set_superseded_by`. See
+        // `dirty_lifecycle_artifacts`.
         self.expect_updated(
-            sqlx::query("UPDATE artifacts SET status = ? WHERE id = ?")
+            sqlx::query("UPDATE artifacts SET status = ?, lifecycle_dirty = 1 WHERE id = ?")
                 .bind(status.as_str())
                 .bind(id)
                 .execute(&self.pool)
                 .await?,
         )
+    }
+
+    /// Artifacts whose lifecycle row has changed since the payload was last
+    /// written. The drift repair's whole work list.
+    ///
+    /// This replaced a pair of capped scans over every non-active artifact.
+    /// Merging makes hidden artifacts grow monotonically — every merge hides at
+    /// least two, permanently — so those scans were on course to be truncated
+    /// forever, repairing a shifting window of an ever-growing set while
+    /// reporting success either way. What needs repairing is the writes that
+    /// did not finish, and that set is almost always empty.
+    pub async fn dirty_lifecycle_artifacts(&self, limit: usize) -> Result<Vec<Chunk>> {
+        let rows =
+            sqlx::query("SELECT * FROM artifacts WHERE lifecycle_dirty = 1 ORDER BY id LIMIT ?")
+                .bind(limit as i64)
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
+    /// Mark an artifact's lifecycle as in flight before either store is
+    /// written.
+    ///
+    /// For `supersede` and `deprecate` this is redundant — the row write sets
+    /// the marker itself, and it comes first. The reveal direction is why this
+    /// exists: `reactivate` and `unsupersede` write the *payload* first, on
+    /// purpose, so that a half-finished reveal leaves the artifact visible
+    /// rather than hidden behind a payload no page explains. Without marking
+    /// up front, a crash between the two stores leaves drift that no row write
+    /// ever announced, and the marker would miss the one direction whose
+    /// intermediate state it was most needed for.
+    pub async fn mark_lifecycle_dirty(&self, id: &str) -> Result<()> {
+        sqlx::query("UPDATE artifacts SET lifecycle_dirty = 1 WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Clear the marker once the payload write has been acknowledged.
+    ///
+    /// Never before it. Clearing first turns a failed payload write into
+    /// permanent drift with nothing left that knows to look for it, which is
+    /// precisely the state this mechanism exists to make impossible.
+    pub async fn clear_lifecycle_dirty(&self, ids: &[String]) -> Result<()> {
+        for id in ids {
+            sqlx::query("UPDATE artifacts SET lifecycle_dirty = 0 WHERE id = ?")
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Stamp an artifact as confirmed accurate now — what search ranking's

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -947,6 +947,24 @@ impl Store {
         self.set_artifact_flags(id, &[], None).await
     }
 
+    /// Record that an operator reviewed a merge's lost sources and accepted it
+    /// as a merge of what remains. `source_count` comes down to the surviving
+    /// lineage count, so the orphan scan's comparison goes quiet — without
+    /// this, clearing the flag lasts exactly one sweep, because the row still
+    /// answers "lost a source" and is flagged all over again.
+    pub async fn accept_source_loss(&self, id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE artifacts
+                SET source_count = (SELECT COUNT(*) FROM artifact_sources WHERE child_id = ?)
+              WHERE id = ? AND provenance = 'merged'",
+        )
+        .bind(id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn count_by_embed_state(&self, corpus_id: &str, state: &str) -> Result<i64> {
         let row = sqlx::query(
             "SELECT COUNT(*) AS n FROM artifacts WHERE corpus_id = ? AND embed_state = ?",

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -143,6 +143,21 @@ pub struct Chunk {
     pub last_verified_at: Option<i64>,
 }
 
+/// A merged artifact being created.
+///
+/// Deliberately not `NewArtifact`. There is no corpus, no span, no segment and
+/// no position within a document, and a struct carrying those as `None` invites
+/// a caller to fill one in — which is exactly the claim a merged artifact must
+/// not make.
+#[derive(Debug, Clone)]
+pub struct NewMerged {
+    pub text: String,
+    pub title: Option<String>,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub caveats: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct NewArtifact {
     pub ordinal: i64,
@@ -216,6 +231,91 @@ fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
 }
 
 impl Store {
+    /// Write a merged artifact and its lineage in one transaction.
+    ///
+    /// One transaction, not two writes. A merged artifact with no lineage rows
+    /// is one whose detail pane can render nothing and whose sources nobody can
+    /// recover — and the re-merge rule reads exactly those rows to avoid ever
+    /// rewriting from text a model produced. Splitting the writes makes that
+    /// state reachable by a crash, and nothing afterwards could tell it from an
+    /// artifact whose sources were all deleted.
+    ///
+    /// `sources` may name merged artifacts. They are flattened to their own
+    /// captured roots here, so `artifact_sources.root_id` only ever names a
+    /// `captured` artifact — the invariant the whole anti-drift rule rests on.
+    pub async fn insert_merged_artifact(
+        &self,
+        new: &NewMerged,
+        sources: &[String],
+    ) -> Result<Chunk> {
+        // Resolved before the transaction opens: this is a read, and holding a
+        // write transaction across it buys nothing.
+        let resolved = self.roots_of(sources).await?;
+
+        let mut tx = self.pool.begin().await?;
+        let created_at = now();
+        let c = Chunk {
+            id: new_id(),
+            corpus_id: None,
+            provenance: Provenance::Merged,
+            source_count: sources.len() as i64,
+            ordinal: 0,
+            text: new.text.clone(),
+            corpus_span: None,
+            title: new.title.clone(),
+            category: new.category.clone(),
+            tags: new.tags.clone(),
+            embed_state: EmbedState::Pending,
+            embed_model: None,
+            created_at,
+            embed_rev: 0,
+            segment_idx: None,
+            flags: vec![],
+            flag_detail: None,
+            superseded_by: None,
+            caveats: new.caveats.clone(),
+            status: ArtifactStatus::Active,
+            last_verified_at: Some(created_at),
+        };
+        sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, provenance, source_count, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
+             VALUES (?, NULL, 'merged', ?, 0, ?, NULL, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)",
+        )
+        .bind(&c.id)
+        .bind(c.source_count)
+        .bind(&c.text)
+        .bind(&c.title)
+        .bind(&c.category)
+        .bind(serde_json::to_string(&c.tags).unwrap())
+        .bind(c.embed_state.as_str())
+        .bind(c.created_at)
+        .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
+        .bind(c.status.as_str())
+        .bind(c.last_verified_at)
+        .execute(&mut *tx)
+        .await?;
+
+        for (via, roots) in &resolved {
+            for root in roots {
+                // OR IGNORE because two sources can share a root: merging M(a,b)
+                // with a itself is a component the sweep can legitimately build,
+                // and it names `a` twice.
+                sqlx::query(
+                    "INSERT OR IGNORE INTO artifact_sources (child_id, root_id, via_id, created_at)
+                     VALUES (?, ?, ?, ?)",
+                )
+                .bind(&c.id)
+                .bind(root)
+                .bind(via)
+                .bind(created_at)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(c)
+    }
+
     pub async fn insert_artifacts(
         &self,
         corpus_id: &str,

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -143,6 +143,17 @@ pub struct Chunk {
     pub last_verified_at: Option<i64>,
 }
 
+impl Chunk {
+    /// Whether search may return this artifact: active and not hidden behind
+    /// a winner. This is the predicate every consolidation decision gates on —
+    /// what may win a cluster, be shown to the model, or be superseded — so it
+    /// has exactly one spelling. A third lifecycle state changes this method,
+    /// not a dozen call sites.
+    pub fn in_results(&self) -> bool {
+        self.status == ArtifactStatus::Active && self.superseded_by.is_none()
+    }
+}
+
 /// A merged artifact being created.
 ///
 /// Deliberately not `NewArtifact`. There is no corpus, no span, no segment and
@@ -1228,6 +1239,26 @@ mod tests {
                 .superseded_by
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn in_results_means_active_and_not_superseded() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "one"), nc(1, "two")])
+            .await
+            .unwrap();
+
+        assert!(s.get_artifact(&made[0].id).await.unwrap().in_results());
+        s.set_superseded_by(&made[0].id, Some(&made[1].id))
+            .await
+            .unwrap();
+        assert!(!s.get_artifact(&made[0].id).await.unwrap().in_results());
+        s.set_artifact_status(&made[1].id, ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+        assert!(!s.get_artifact(&made[1].id).await.unwrap().in_results());
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -846,4 +846,26 @@ mod tests {
         let again = s.claim_job().await.unwrap().unwrap();
         assert_eq!(again.attempts, 1, "requeue must reset the attempt counter");
     }
+
+    #[tokio::test]
+    async fn a_legacy_judge_row_is_not_claimed_as_something_else() {
+        // `Stage::parse` has no 'judge' arm and `claim_job` falls back to
+        // Synthesize, so a leftover row from the branch this replaced was
+        // claimed as a synthesize job aimed at a pair id.
+        let s = Store::memory().await.unwrap();
+        sqlx::query(
+            "INSERT INTO jobs (stage, target_kind, target_id, state, run_after, attempts, seq)
+             VALUES ('judge', 'pair', '17', 'pending', 0, 0, 0)",
+        )
+        .execute(&s.pool)
+        .await
+        .unwrap();
+
+        s.migrate().await.unwrap();
+
+        assert!(
+            s.claim_job().await.unwrap().is_none(),
+            "a legacy judge row survived migration and was claimed"
+        );
+    }
 }

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -26,6 +26,15 @@ pub enum Stage {
     Consolidate,
     /// One pair, one call.
     Judge,
+    /// One artifact, one neighbour query. No inference: `neighbours` looks the
+    /// vector up by point id, so this costs a round trip and nothing else.
+    ///
+    /// What makes duplicate detection complete rather than sampled. The sweep
+    /// draws `sample` points and computes pairs only within that draw, so both
+    /// members of a pair have to land in the same one — probability (s/N)^2,
+    /// which decays quadratically and leaves a given pair waiting years on a
+    /// large base.
+    Relate,
 }
 
 impl Stage {
@@ -38,6 +47,7 @@ impl Stage {
             Stage::Embed => "embed",
             Stage::Consolidate => "consolidate",
             Stage::Judge => "judge",
+            Stage::Relate => "relate",
         }
     }
     pub fn parse(s: &str) -> Option<Stage> {
@@ -49,6 +59,7 @@ impl Stage {
             "embed" => Some(Stage::Embed),
             "consolidate" => Some(Stage::Consolidate),
             "judge" => Some(Stage::Judge),
+            "relate" => Some(Stage::Relate),
             _ => None,
         }
     }

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -24,8 +24,8 @@ pub enum Stage {
     /// than any one corpus, so there is exactly one of these in the queue at a
     /// time. Local work: it arms `Judge` units rather than calling the model.
     Consolidate,
-    /// One pair, one call.
-    Judge,
+    /// One component of near-duplicate artifacts, one call.
+    Dedupe,
     /// One artifact, one neighbour query. No inference: `neighbours` looks the
     /// vector up by point id, so this costs a round trip and nothing else.
     ///
@@ -46,7 +46,7 @@ impl Stage {
             Stage::Title => "title",
             Stage::Embed => "embed",
             Stage::Consolidate => "consolidate",
-            Stage::Judge => "judge",
+            Stage::Dedupe => "dedupe",
             Stage::Relate => "relate",
         }
     }
@@ -58,7 +58,7 @@ impl Stage {
             "title" => Some(Stage::Title),
             "embed" => Some(Stage::Embed),
             "consolidate" => Some(Stage::Consolidate),
-            "judge" => Some(Stage::Judge),
+            "dedupe" => Some(Stage::Dedupe),
             "relate" => Some(Stage::Relate),
             _ => None,
         }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -1,0 +1,373 @@
+//! Which captured artifacts a merged artifact is made of.
+//!
+//! Stored as the resolved closure rather than as parent edges. The re-merge
+//! rule needs the *captured* roots of every candidate on every decision — a
+//! merge is always written from originals, never from text an earlier merge
+//! produced, which is what keeps information loss one generation deep however
+//! many times a group is merged. Walking edges with a recursive CTE would put a
+//! graph traversal on the sweep's hot path for an answer that never changes
+//! once written.
+//!
+//! The cost of the denormalisation is that a deleted root removes closure rows
+//! an edge table could have recomputed. `source_count` on the artifact is what
+//! notices: it records how many sources the merge was written from, so a merge
+//! that has lost one can be flagged rather than quietly claiming less
+//! provenance than its text carries.
+
+use super::Store;
+use crate::error::Result;
+use crate::store::pairs::ArtifactPair;
+use sqlx::Row;
+use std::collections::BTreeMap;
+
+impl Store {
+    /// The captured roots of each of `artifact_ids`, keyed by the input id.
+    ///
+    /// A captured artifact is its own root — the dedupe pass asks for the roots
+    /// of every component member without caring which kind it is, and answering
+    /// "none" for a captured one would silently drop it from the very prompt it
+    /// is supposed to be in.
+    ///
+    /// A merged artifact resolves through `artifact_sources`, which already
+    /// holds the closure, so this is one query per id and not a traversal.
+    pub async fn roots_of(&self, artifact_ids: &[String]) -> Result<BTreeMap<String, Vec<String>>> {
+        let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for id in artifact_ids {
+            let rows = sqlx::query(
+                "SELECT root_id FROM artifact_sources WHERE child_id = ? ORDER BY root_id",
+            )
+            .bind(id)
+            .fetch_all(&self.pool)
+            .await?;
+            let roots: Vec<String> = rows.iter().map(|r| r.get("root_id")).collect();
+            // No lineage rows means a captured artifact — or a merged one every
+            // root of which has since been deleted. The two are told apart by
+            // `source_count`, and the second is `merged_missing_a_source`'s
+            // business; treating it as its own root here is the safe reading,
+            // since it keeps the artifact in the prompt rather than dropping it.
+            out.insert(
+                id.clone(),
+                if roots.is_empty() {
+                    vec![id.clone()]
+                } else {
+                    roots
+                },
+            );
+        }
+        Ok(out)
+    }
+
+    /// Merged artifacts at least one of whose roots is still active.
+    ///
+    /// The write path indexes a merged artifact before superseding its roots,
+    /// so this is precisely the state a crash between those two steps leaves
+    /// behind. Nothing else would see it: the merge looks finished from the
+    /// artifact side and absent from the pair side, and only a join across the
+    /// lineage says otherwise.
+    pub async fn merged_with_active_roots(&self, limit: i64) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT DISTINCT s.child_id FROM artifact_sources s
+               JOIN artifacts child ON child.id = s.child_id
+               JOIN artifacts root  ON root.id  = s.root_id
+              WHERE child.provenance = 'merged'
+                AND child.status = 'active'
+                AND child.superseded_by IS NULL
+                AND child.embed_state = 'embedded'
+                AND root.status = 'active'
+                AND root.superseded_by IS NULL
+              LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("child_id")).collect())
+    }
+
+    /// Active merged artifacts, other than `child_id`, every root of which is
+    /// also a root of `child_id`.
+    ///
+    /// A merge written from everything an earlier merge was made of subsumes
+    /// it. Superseding only the roots would leave that earlier merge active and
+    /// near-identical to the new one, so the relate unit would file the pair
+    /// again on the next sweep and the two would churn against each other for
+    /// as long as they both existed.
+    pub async fn subsumed_merges(&self, child_id: &str) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            // The EXISTS guard is load-bearing. A merged artifact whose roots
+            // have all been deleted has no lineage rows left, and without it the
+            // NOT EXISTS below would call the empty set a subset of everything
+            // and hide it behind an unrelated merge. That artifact is
+            // `merged_missing_a_source`'s business, not this function's.
+            "SELECT other.id FROM artifacts other
+              WHERE other.provenance = 'merged'
+                AND other.status = 'active'
+                AND other.superseded_by IS NULL
+                AND other.id != ?1
+                AND EXISTS (SELECT 1 FROM artifact_sources WHERE child_id = other.id)
+                AND NOT EXISTS (
+                      SELECT 1 FROM artifact_sources mine
+                       WHERE mine.child_id = other.id
+                         AND mine.root_id NOT IN (
+                               SELECT root_id FROM artifact_sources WHERE child_id = ?1))",
+        )
+        .bind(child_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("id")).collect())
+    }
+
+    /// Merged artifacts holding fewer lineage rows than the number of sources
+    /// they were written from.
+    ///
+    /// A comparison rather than a guess, which is what `source_count` is for:
+    /// without it, "lost a source" cannot be told from "only ever had two".
+    pub async fn merged_missing_a_source(&self, limit: i64) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT a.id FROM artifacts a
+              WHERE a.provenance = 'merged'
+                AND a.source_count >
+                    (SELECT COUNT(*) FROM artifact_sources WHERE child_id = a.id)
+              LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("id")).collect())
+    }
+
+    /// Every pair, in any state, both of whose artifacts are in this set.
+    ///
+    /// What undoing a merge has to dismiss. Reactivating the roots alone
+    /// accomplishes nothing: the sweep re-finds them and reaches the same
+    /// verdict, so the operator's decision lasts until the next tick.
+    pub async fn pairs_among(&self, ids: &[String]) -> Result<Vec<ArtifactPair>> {
+        if ids.len() < 2 {
+            return Ok(vec![]);
+        }
+        let mut out = Vec::new();
+        // A handful of ids at most — the fan-in cap bounds it — so the pairwise
+        // loop is cheaper than building a variadic IN clause for sqlx.
+        for (i, a) in ids.iter().enumerate() {
+            for b in &ids[i + 1..] {
+                let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                if let Some(row) =
+                    sqlx::query("SELECT * FROM artifact_pairs WHERE a_id = ? AND b_id = ?")
+                        .bind(lo)
+                        .bind(hi)
+                        .fetch_optional(&self.pool)
+                        .await?
+                {
+                    out.push(crate::store::pairs::row_to_pair(&row));
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use crate::store::artifacts::{NewArtifact, NewMerged, Provenance};
+
+    async fn three(s: &Store) -> (String, String, String) {
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..3)
+            .map(|i| NewArtifact {
+                ordinal: i,
+                text: format!("artifact {i}"),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        let made = s.insert_artifacts(&src.id, &new).await.unwrap();
+        (made[0].id.clone(), made[1].id.clone(), made[2].id.clone())
+    }
+
+    fn merged(text: &str) -> NewMerged {
+        NewMerged {
+            text: text.into(),
+            title: None,
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn a_captured_artifact_is_its_own_root() {
+        // The dedupe pass asks for the roots of every component member without
+        // caring which kind it is. Answering "none" for a captured artifact
+        // would silently drop it from the prompt it is supposed to be in.
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let roots = s.roots_of(&[a.clone(), b.clone()]).await.unwrap();
+        assert_eq!(roots[&a], vec![a.clone()]);
+        assert_eq!(roots[&b], vec![b.clone()]);
+    }
+
+    #[tokio::test]
+    async fn a_merged_artifact_resolves_to_its_captured_roots() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m = s
+            .insert_merged_artifact(&merged("both"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+
+        let roots = s.roots_of(std::slice::from_ref(&m.id)).await.unwrap();
+        let mut got = roots[&m.id].clone();
+        got.sort();
+        let mut want = vec![a, b];
+        want.sort();
+        assert_eq!(got, want);
+        assert_eq!(m.provenance, Provenance::Merged);
+        assert_eq!(m.corpus_id, None);
+        assert_eq!(m.source_count, 2);
+    }
+
+    #[tokio::test]
+    async fn a_merge_of_a_merge_records_only_captured_roots() {
+        // The anti-drift invariant, at the storage layer: `root_id` never names
+        // a merged artifact, so a re-merge is always written from originals and
+        // never from text an earlier merge produced.
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("a and b and c"), &[m1.id.clone(), c.clone()])
+            .await
+            .unwrap();
+
+        let roots = s.roots_of(std::slice::from_ref(&m2.id)).await.unwrap();
+        let mut got = roots[&m2.id].clone();
+        got.sort();
+        let mut want = vec![a, b, c];
+        want.sort();
+        assert_eq!(
+            got, want,
+            "the second merge did not flatten to captured roots"
+        );
+        assert!(
+            !got.contains(&m1.id),
+            "a merged artifact was recorded as a root of another merge"
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_a_root_takes_its_lineage_rows_with_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m = s
+            .insert_merged_artifact(&merged("both"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+
+        s.delete_artifact(&a).await.unwrap();
+
+        let roots = s.roots_of(std::slice::from_ref(&m.id)).await.unwrap();
+        assert_eq!(roots[&m.id], vec![b], "the cascade left a dangling root");
+        // And the loss is visible rather than silent: the merge still claims
+        // two sources while only one row survives.
+        assert_eq!(s.merged_missing_a_source(10).await.unwrap(), vec![m.id]);
+    }
+
+    #[tokio::test]
+    async fn a_merge_whose_roots_are_still_active_is_findable() {
+        // The write path indexes a merged artifact before superseding its
+        // roots, so a crash in between leaves exactly this state. Nothing else
+        // in the system would ever notice it.
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m = s
+            .insert_merged_artifact(&merged("both"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+
+        // Not yet: an unindexed merge has not reached the step that hides its
+        // roots, so it is not unfinished — it is unstarted.
+        assert!(
+            s.merged_with_active_roots(10).await.unwrap().is_empty(),
+            "a merge that is not indexed yet was reported as unfinished"
+        );
+
+        s.mark_embedded(&m.id, "fake-embed", 0).await.unwrap();
+        assert_eq!(
+            s.merged_with_active_roots(10).await.unwrap(),
+            vec![m.id.clone()]
+        );
+
+        s.set_superseded_by(&a, Some(&m.id)).await.unwrap();
+        s.set_superseded_by(&b, Some(&m.id)).await.unwrap();
+        assert!(
+            s.merged_with_active_roots(10).await.unwrap().is_empty(),
+            "a finished merge is still reported as unfinished"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_subsumes_an_earlier_one_built_from_the_same_roots() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("a and b and c"), &[m1.id.clone(), c])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.subsumed_merges(&m2.id).await.unwrap(),
+            vec![m1.id.clone()]
+        );
+        // Not the other way round: m2 draws on a root m1 never had.
+        assert!(s.subsumed_merges(&m1.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_lost_every_root_is_not_subsumed_by_an_unrelated_one() {
+        // Without the EXISTS guard the empty root set reads as a subset of
+        // everything, and an artifact whose sources were deleted would be
+        // hidden behind a merge it has nothing to do with.
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        let orphan = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+        let unrelated = s
+            .insert_merged_artifact(&merged("c alone"), &[c])
+            .await
+            .unwrap();
+
+        s.delete_artifact(&a).await.unwrap();
+        s.delete_artifact(&b).await.unwrap();
+
+        assert!(
+            s.subsumed_merges(&unrelated.id).await.unwrap().is_empty(),
+            "a merge with no surviving roots was swallowed by an unrelated one"
+        );
+    }
+
+    #[tokio::test]
+    async fn pairs_among_finds_only_pairs_inside_the_set() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        s.record_pair(&b, &c, 0.90).await.unwrap();
+
+        let found = s.pairs_among(&[a.clone(), b.clone()]).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].a_id == a || found[0].b_id == a);
+    }
+}

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -93,6 +93,10 @@ impl Store {
     /// behind. Nothing else would see it: the merge looks finished from the
     /// artifact side and absent from the pair side, and only a join across the
     /// lineage says otherwise.
+    ///
+    /// A root an operator explicitly restored (`restored = 1`) is not an
+    /// unfinished merge, and the repair must not see it — re-hiding it undid
+    /// the operator's decision on every sweep.
     pub async fn merged_with_active_roots(&self, limit: i64) -> Result<Vec<String>> {
         let rows = sqlx::query(
             "SELECT DISTINCT s.child_id FROM artifact_sources s
@@ -104,12 +108,42 @@ impl Store {
                 AND child.embed_state = 'embedded'
                 AND root.status = 'active'
                 AND root.superseded_by IS NULL
+                AND s.restored = 0
               LIMIT ?",
         )
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.iter().map(|r| r.get("child_id")).collect())
+    }
+
+    /// Record that an operator explicitly restored this captured root: no
+    /// repair may hide it behind a merge again. Every merge naming it, not
+    /// one — the operator's decision is about the root, not about a lineage
+    /// edge. A *new* merge decision may still hide it: `insert_merged_artifact`
+    /// writes fresh rows with `restored = 0`, and that is new evidence rather
+    /// than a repair of old state.
+    pub async fn mark_source_restored(&self, root_id: &str) -> Result<()> {
+        sqlx::query("UPDATE artifact_sources SET restored = 1 WHERE root_id = ?")
+            .bind(root_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// The roots `merge::finish` is allowed to hide: the lineage minus every
+    /// root an operator explicitly restored. Distinct from `roots_of`, which
+    /// answers "what was this written from" and must keep seeing the true
+    /// closure.
+    pub async fn roots_to_hide(&self, child_id: &str) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT root_id FROM artifact_sources
+              WHERE child_id = ? AND restored = 0 ORDER BY root_id",
+        )
+        .bind(child_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("root_id")).collect())
     }
 
     /// Active merged artifacts whose embedding can no longer arrive: no live

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -57,6 +57,24 @@ impl Store {
         Ok(out)
     }
 
+    /// Merged artifacts, newest first. What Ops lists.
+    pub async fn merged_artifacts(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<crate::store::artifacts::Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE provenance = 'merged'
+              ORDER BY created_at DESC, id LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(crate::store::artifacts::row_to_artifact)
+            .collect())
+    }
+
     /// Merged artifacts at least one of whose roots is still active.
     ///
     /// The write path indexes a merged artifact before superseding its roots,

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -57,13 +57,24 @@ impl Store {
         Ok(out)
     }
 
-    /// Merged artifacts, newest first. What Ops lists.
+    /// Merged artifacts still standing, newest first. What Ops lists.
+    ///
+    /// Standing is the whole of the filter, and it is not cosmetic: every row
+    /// here is rendered with an "Undo merge" button, and undoing is defined as
+    /// restoring what the merge hid and then deprecating it. A merge that was
+    /// already undone is deprecated and hid nothing that is still hidden; one
+    /// subsumed by a later merge is superseded, and its sources belong to that
+    /// later merge now. Pressing undo on either finds nothing to restore and
+    /// deprecates an artifact that is already gone from results.
     pub async fn merged_artifacts(
         &self,
         limit: i64,
     ) -> Result<Vec<crate::store::artifacts::Chunk>> {
         let rows = sqlx::query(
-            "SELECT * FROM artifacts WHERE provenance = 'merged'
+            "SELECT * FROM artifacts
+              WHERE provenance = 'merged'
+                AND status = 'active'
+                AND superseded_by IS NULL
               ORDER BY created_at DESC, id LIMIT ?",
         )
         .bind(limit)
@@ -295,6 +306,48 @@ mod tests {
         // And the loss is visible rather than silent: the merge still claims
         // two sources while only one row survives.
         assert_eq!(s.merged_missing_a_source(10).await.unwrap(), vec![m.id]);
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_is_no_longer_standing_leaves_the_ops_list() {
+        // Every row Ops renders carries an "Undo merge" button, and undo means
+        // restore what this hid, then deprecate it. A merge already deprecated
+        // hid nothing that is still hidden, and one superseded by a later merge
+        // has handed its sources over — so the button would restore nothing and
+        // deprecate an artifact that is already gone from results.
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        let live = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b])
+            .await
+            .unwrap();
+        let undone = s
+            .insert_merged_artifact(&merged("undone"), &[a.clone(), c.clone()])
+            .await
+            .unwrap();
+        let subsumed = s
+            .insert_merged_artifact(&merged("subsumed"), &[a, c])
+            .await
+            .unwrap();
+        s.set_artifact_status(
+            &undone.id,
+            crate::store::artifacts::ArtifactStatus::Deprecated,
+        )
+        .await
+        .unwrap();
+        s.set_superseded_by(&subsumed.id, Some(&live.id))
+            .await
+            .unwrap();
+
+        let listed: Vec<String> = s
+            .merged_artifacts(50)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+
+        assert_eq!(listed, vec![live.id], "{listed:?}");
     }
 
     #[tokio::test]

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -216,7 +216,11 @@ impl Store {
     }
 
     /// Merged artifacts holding fewer lineage rows than the number of sources
-    /// they were written from.
+    /// they were written from — and not yet flagged for it. The exclusion is
+    /// in the SQL, not the caller: membership in this set is permanent
+    /// (deletes are hard), so without it the oldest flagged rows fill the
+    /// LIMIT forever and a newly orphaned merge past the five-hundredth is
+    /// never seen. Newest first for the same reason.
     ///
     /// A comparison rather than a guess, which is what `source_count` is for:
     /// without it, "lost a source" cannot be told from "only ever had two".
@@ -226,6 +230,8 @@ impl Store {
               WHERE a.provenance = 'merged'
                 AND a.source_count >
                     (SELECT COUNT(*) FROM artifact_sources WHERE child_id = a.id)
+                AND (a.flags IS NULL OR a.flags NOT LIKE '%orphaned_source%')
+              ORDER BY a.created_at DESC, a.id
               LIMIT ?",
         )
         .bind(limit)

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -112,6 +112,33 @@ impl Store {
         Ok(rows.iter().map(|r| r.get("child_id")).collect())
     }
 
+    /// Active merged artifacts whose embedding can no longer arrive: no live
+    /// embed job below the retry ceiling. The write path settles the pairs the
+    /// moment the merge is written, so a merge stuck here is invisible to
+    /// search, its roots were never superseded, and nothing else would notice
+    /// — the only signal was a forever-retrying job.
+    pub async fn stranded_merges(&self, limit: i64) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT a.id FROM artifacts a
+              WHERE a.provenance = 'merged'
+                AND a.status = 'active'
+                AND a.superseded_by IS NULL
+                AND a.embed_state != 'embedded'
+                AND NOT EXISTS (
+                      SELECT 1 FROM jobs j
+                       WHERE j.stage = 'embed'
+                         AND j.target_id = a.id
+                         AND j.state IN ('pending', 'running')
+                         AND j.attempts < ?)
+              LIMIT ?",
+        )
+        .bind(crate::store::jobs::MAX_ATTEMPTS)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("id")).collect())
+    }
+
     /// Active merged artifacts, other than `child_id`, every root of which is
     /// also a root of `child_id`.
     ///

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -167,7 +167,6 @@ impl Store {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::store::Store;
     use crate::store::artifacts::{NewArtifact, NewMerged, Provenance};
 
@@ -341,7 +340,7 @@ mod tests {
         // hidden behind a merge it has nothing to do with.
         let s = Store::memory().await.unwrap();
         let (a, b, c) = three(&s).await;
-        let orphan = s
+        let _orphan = s
             .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
             .await
             .unwrap();

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -30,6 +30,13 @@ impl Store {
     ///
     /// A merged artifact resolves through `artifact_sources`, which already
     /// holds the closure, so this is one query per id and not a traversal.
+    ///
+    /// A merged artifact with no lineage rows — every root deleted out from
+    /// under it — resolves to the *empty* list, never to itself. Its text is a
+    /// synthesis, and handing it back as a root is how a paraphrase of a
+    /// paraphrase ends up in a prompt as an original, or recorded as another
+    /// merge's `root_id`. The empty answer makes that state visible to the
+    /// caller instead; the dedupe unit escalates such a component to a person.
     pub async fn roots_of(&self, artifact_ids: &[String]) -> Result<BTreeMap<String, Vec<String>>> {
         let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
         for id in artifact_ids {
@@ -40,19 +47,21 @@ impl Store {
             .fetch_all(&self.pool)
             .await?;
             let roots: Vec<String> = rows.iter().map(|r| r.get("root_id")).collect();
-            // No lineage rows means a captured artifact — or a merged one every
-            // root of which has since been deleted. The two are told apart by
-            // `source_count`, and the second is `merged_missing_a_source`'s
-            // business; treating it as its own root here is the safe reading,
-            // since it keeps the artifact in the prompt rather than dropping it.
-            out.insert(
-                id.clone(),
-                if roots.is_empty() {
-                    vec![id.clone()]
+            let entry = if roots.is_empty() {
+                let provenance: Option<String> =
+                    sqlx::query_scalar("SELECT provenance FROM artifacts WHERE id = ?")
+                        .bind(id)
+                        .fetch_optional(&self.pool)
+                        .await?;
+                if provenance.as_deref() == Some("merged") {
+                    vec![]
                 } else {
-                    roots
-                },
-            );
+                    vec![id.clone()]
+                }
+            } else {
+                roots
+            };
+            out.insert(id.clone(), entry);
         }
         Ok(out)
     }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -373,7 +373,10 @@ mod tests {
         s.delete_artifact(&a).await.unwrap();
 
         assert!(
-            s.merged_missing_a_source(10).await.unwrap().contains(&m2.id),
+            s.merged_missing_a_source(10)
+                .await
+                .unwrap()
+                .contains(&m2.id),
             "a merge of a merge lost a root without saying so"
         );
     }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -298,6 +298,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_merge_of_a_merge_notices_a_lost_root_too() {
+        // `source_count` counted the arguments the call was given, which for a
+        // merge of a merge is fewer than the roots it wrote: M2 = merge(M1(a,b),
+        // c) recorded two against three lineage rows. `merged_missing_a_source`
+        // asks whether the count exceeds the surviving rows, so losing a root
+        // left 2 > 2 — false — and the orphan flag never fired for a merge of a
+        // merge at all. That is the case the counter was added for.
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("a and b and c"), &[m1.id.clone(), c.clone()])
+            .await
+            .unwrap();
+        assert_eq!(m2.source_count, 3, "the count is the roots, not the inputs");
+
+        s.delete_artifact(&a).await.unwrap();
+
+        assert!(
+            s.merged_missing_a_source(10).await.unwrap().contains(&m2.id),
+            "a merge of a merge lost a root without saying so"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_sources_sharing_a_root_are_counted_once() {
+        // Merging M(a,b) with `a` itself is a component the sweep can build, and
+        // it names `a` twice. `artifact_sources` is keyed on (child_id, root_id)
+        // so it writes one row — and a count of three against two rows would
+        // report a lost source that was never there.
+        let s = Store::memory().await.unwrap();
+        let (a, b, _) = three(&s).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("still a and b"), &[m1.id.clone(), a.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(m2.source_count, 2);
+        assert!(
+            s.merged_missing_a_source(10).await.unwrap().is_empty(),
+            "a shared root was reported as a loss"
+        );
+    }
+
+    #[tokio::test]
     async fn a_merge_whose_roots_are_still_active_is_findable() {
         // The write path indexes a merged artifact before superseding its
         // roots, so a crash in between leaves exactly this state. Nothing else

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod corpora;
 pub mod feedback;
 pub mod jobs;
+pub mod lineage;
 pub mod pairs;
 pub mod segments;
 pub mod shingle;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -99,6 +99,10 @@ impl Store {
             ),
             ("artifacts", "source_count", "INTEGER NOT NULL DEFAULT 0"),
             ("artifacts", "lifecycle_dirty", "INTEGER NOT NULL DEFAULT 0"),
+            // Arrived with the stranded-merge reap. NULL on every pair
+            // predating it, which is correct: those settlements predate the
+            // column and are not reopenable by merge id.
+            ("artifact_pairs", "merged_into", "TEXT"),
         ];
 
         // Before the schema, not after. `schema.sql` builds an index over `seq`,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -103,6 +103,10 @@ impl Store {
             // predating it, which is correct: those settlements predate the
             // column and are not reopenable by merge id.
             ("artifact_pairs", "merged_into", "TEXT"),
+            // The operator's partial restore of a merge source. 0 on every
+            // existing row, which is correct: nothing predating the column
+            // was explicitly restored.
+            ("artifact_sources", "restored", "INTEGER NOT NULL DEFAULT 0"),
         ];
 
         // Before the schema, not after. `schema.sql` builds an index over `seq`,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -168,6 +168,16 @@ impl Store {
             .await
             .map_err(|e| crate::error::Error::Store(e.to_string()))?;
 
+        // The judge became the dedupe unit and its stage name went with it. A
+        // leftover row would otherwise be claimed under `Stage::parse`'s
+        // Synthesize fallback and aimed at a pair id. Deleted rather than
+        // renamed: the pair is still pending, so the next sweep re-arms it
+        // under its real stage, and a rename could collide with a dedupe row
+        // the sweep has already written for the same pair.
+        sqlx::query("DELETE FROM jobs WHERE stage = 'judge'")
+            .execute(&self.pool)
+            .await?;
+
         let mut missing = Vec::new();
         for (table, columns) in schema_columns(SCHEMA) {
             // The table-valued form of `PRAGMA table_info`, which takes a bind

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -92,7 +92,11 @@ impl Store {
             // The three that arrived with merging. Every artifact predating it
             // was captured, from a corpus, with nothing outstanding — which is
             // what each default says, so the append needs no backfill.
-            ("artifacts", "provenance", "TEXT NOT NULL DEFAULT 'captured'"),
+            (
+                "artifacts",
+                "provenance",
+                "TEXT NOT NULL DEFAULT 'captured'",
+            ),
             ("artifacts", "source_count", "INTEGER NOT NULL DEFAULT 0"),
             ("artifacts", "lifecycle_dirty", "INTEGER NOT NULL DEFAULT 0"),
         ];

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -89,6 +89,12 @@ impl Store {
             // Nullable, and rightly so: a corpus captured before the extension
             // and link doors existed was read from nowhere this can name.
             ("corpora", "source_url", "TEXT"),
+            // The three that arrived with merging. Every artifact predating it
+            // was captured, from a corpus, with nothing outstanding — which is
+            // what each default says, so the append needs no backfill.
+            ("artifacts", "provenance", "TEXT NOT NULL DEFAULT 'captured'"),
+            ("artifacts", "source_count", "INTEGER NOT NULL DEFAULT 0"),
+            ("artifacts", "lifecycle_dirty", "INTEGER NOT NULL DEFAULT 0"),
         ];
 
         // Before the schema, not after. `schema.sql` builds an index over `seq`,
@@ -121,6 +127,28 @@ impl Store {
             .await
             .map_err(|e| crate::error::Error::Store(e.to_string()))?;
             tracing::info!(table, column, "added a column to an existing database");
+        }
+
+        // The one change merging needed that an append cannot make. `corpus_id`
+        // went from NOT NULL to nullable because a merged artifact belongs to no
+        // single corpus, and SQLite can add a column but not relax a constraint
+        // on one that is already there. Left unsaid, such a database passes every
+        // check here and then fails at the first merge, on a NOT NULL constraint,
+        // a long way from the cause. So it is said here, and it names the cost:
+        // this is the case `ADDED_COLUMNS` deliberately does not cover.
+        let strict_corpus: Option<i64> = sqlx::query_scalar(
+            r#"SELECT "notnull" FROM pragma_table_info('artifacts') WHERE name = 'corpus_id'"#,
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        if strict_corpus == Some(1) {
+            return Err(crate::error::Error::Store(
+                "this database predates merging: artifacts.corpus_id is still NOT NULL, \
+                 and a merged artifact belongs to no corpus. SQLite cannot relax that \
+                 constraint in place, so the artifacts table has to be rebuilt — copy it \
+                 into one declared by the current schema, or recreate the database."
+                    .into(),
+            ));
         }
 
         sqlx::raw_sql(SCHEMA)
@@ -310,6 +338,107 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(seq, 0);
+    }
+
+    #[tokio::test]
+    async fn a_base_captured_before_merging_gains_the_provenance_columns() {
+        // The three columns merging added to `artifacts`. All of them have
+        // defaults that say exactly what was true of every artifact predating
+        // merging — captured, from a corpus, nothing outstanding — so this is an
+        // append, and 608 artifacts bought with GPU time must not be recreated
+        // to gain it.
+        let store = Store::memory().await.unwrap();
+        // Both indexes name a column being dropped, so they go first — the same
+        // ordering constraint migrate() respects by running the appends before
+        // it applies schema.sql.
+        for stmt in [
+            "DROP INDEX IF EXISTS idx_artifacts_dirty",
+            "DROP INDEX IF EXISTS idx_artifacts_provenance",
+            "ALTER TABLE artifacts DROP COLUMN provenance",
+            "ALTER TABLE artifacts DROP COLUMN source_count",
+            "ALTER TABLE artifacts DROP COLUMN lifecycle_dirty",
+        ] {
+            sqlx::query(stmt)
+                .execute(&store.pool)
+                .await
+                .expect("the fixture needs an artifacts table from before merging");
+        }
+
+        store
+            .migrate()
+            .await
+            .expect("migrate refused a base captured before merging");
+
+        for column in ["provenance", "source_count", "lifecycle_dirty"] {
+            let has: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pragma_table_info('artifacts') WHERE name = ?",
+            )
+            .bind(column)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+            assert_eq!(has, 1, "{column} was never added to the existing table");
+        }
+
+        // And the defaults have to be the truth about an artifact that predates
+        // merging, or every one of them reads back as a merge with no sources.
+        let c = store
+            .insert_corpus_with_signature("alpha\n\nbeta", "web", None, vec![], None)
+            .await
+            .unwrap()
+            .into_corpus();
+        let made = store
+            .insert_artifacts(
+                &c.id,
+                &[artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "alpha".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        let got = store.get_artifact(&made[0].id).await.unwrap();
+        assert_eq!(got.provenance, artifacts::Provenance::Captured);
+        assert_eq!(got.source_count, 0);
+    }
+
+    #[tokio::test]
+    async fn a_base_whose_corpus_id_is_still_not_null_is_named_as_such() {
+        // The change an append cannot make. A merged artifact belongs to no
+        // corpus, so `corpus_id` had to become nullable, and SQLite cannot relax
+        // that in place. The failure has to arrive at startup naming the table
+        // to rebuild — not at the first merge, as a bare constraint violation.
+        let store = Store::memory().await.unwrap();
+        // Put the constraint back the way a pre-merging base declared it. Both
+        // indexes name the column, so they come out first and the schema puts
+        // them back.
+        for stmt in [
+            "DROP INDEX IF EXISTS idx_artifacts_corpus",
+            "DROP INDEX IF EXISTS idx_artifacts_window",
+            "ALTER TABLE artifacts DROP COLUMN corpus_id",
+            "ALTER TABLE artifacts ADD COLUMN corpus_id TEXT NOT NULL DEFAULT ''",
+        ] {
+            sqlx::query(stmt)
+                .execute(&store.pool)
+                .await
+                .expect("the fixture needs an artifacts table from before merging");
+        }
+
+        let err = store
+            .migrate()
+            .await
+            .expect_err("migrate accepted a base that cannot hold a merged artifact");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("corpus_id") && msg.contains("rebuilt"),
+            "the error has to name the column and the remedy, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -24,6 +24,17 @@ use sqlx::Row;
 /// queue, and an operator settles it by hand.
 pub const MAX_UNREADABLE_JUDGEMENTS: i64 = super::jobs::MAX_ATTEMPTS;
 
+/// How many pending pairs `open_component` may follow outward from its seed.
+///
+/// A bound on the walk, not on which pairs may be judged: the seed is read
+/// directly and is always in the component, however far down the score ordering
+/// it sits. Small under `cfg(test)` so that the difference between the two is
+/// something a test can actually reach.
+#[cfg(not(test))]
+const COMPONENT_WINDOW: i64 = 5_000;
+#[cfg(test)]
+const COMPONENT_WINDOW: i64 = 3;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PairState {
@@ -301,8 +312,29 @@ impl Store {
     /// `Pending` only. A dismissed, near-identical or oversized row carries a
     /// decision, and following it would pull an already-settled artifact into a
     /// group that is about to be superseded.
+    ///
+    /// The window bounds how far a component may grow, and nothing else. It is
+    /// ordered by score and capped, so on a base with more than `WINDOW` pending
+    /// pairs the lowest-scoring ones fall outside it — and reading the seed from
+    /// the window alone returned an empty component for exactly those. The unit
+    /// then found fewer than two members, settled an empty slice, and returned
+    /// without recording an attempt; `pairs_to_judge` orders by `judge_attempts`
+    /// ascending, so that pair sorted to the front and was armed again on every
+    /// tick, consuming a slot of the per-tick budget forever without ever being
+    /// judged. The seed is read directly and joins the window if it is missing.
     pub async fn open_component(&self, pair_id: i64) -> Result<Vec<ArtifactPair>> {
-        let open = self.pairs_by_state(PairState::Pending, 5_000).await?;
+        let mut open = self
+            .pairs_by_state(PairState::Pending, COMPONENT_WINDOW)
+            .await?;
+        if !open.iter().any(|p| p.id == pair_id) {
+            let seed = self.get_pair(pair_id).await?;
+            // Settled while the unit waited. That is the one case where an empty
+            // component is the right answer, and `run` treats it as such.
+            if seed.state != PairState::Pending {
+                return Ok(vec![]);
+            }
+            open.push(seed);
+        }
         let Some(seed) = open.iter().find(|p| p.id == pair_id) else {
             return Ok(vec![]);
         };
@@ -626,6 +658,43 @@ mod tests {
             .unwrap();
 
         assert_eq!(s.open_component(seed).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_pair_below_the_window_is_still_the_seed_of_its_own_component() {
+        // The window bounds how far the walk may go, not which pairs may be
+        // judged. It is ordered by score, so on a base with more pending pairs
+        // than it holds the lowest-scoring ones fall outside — and reading the
+        // seed from the window alone gave those an empty component. The unit
+        // then found fewer than two members, settled an empty slice and returned
+        // without recording an attempt, and `pairs_to_judge` orders by attempts
+        // ascending: the pair sorted to the front and was armed again every
+        // tick, spending a slot of the per-tick budget forever without ever
+        // being judged.
+        let s = Store::memory().await.unwrap();
+        let m = four_artifacts(&s).await;
+        s.record_pair(&m[0], &m[1], 0.99).await.unwrap();
+        s.record_pair(&m[1], &m[2], 0.98).await.unwrap();
+        s.record_pair(&m[2], &m[3], 0.97).await.unwrap();
+        s.record_pair(&m[3], &m[0], 0.90).await.unwrap();
+
+        let window = s
+            .pairs_by_state(PairState::Pending, COMPONENT_WINDOW)
+            .await
+            .unwrap();
+        let all = s.pairs_by_state(PairState::Pending, 100).await.unwrap();
+        let seed = all
+            .iter()
+            .find(|p| !window.iter().any(|w| w.id == p.id))
+            .expect("the fixture must put one pair outside the window")
+            .id;
+
+        let comp = s.open_component(seed).await.unwrap();
+
+        assert!(
+            comp.iter().any(|p| p.id == seed),
+            "a pair outside the window has no component of its own: {comp:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -287,6 +287,57 @@ impl Store {
         Ok(rows.iter().map(row_to_pair).collect())
     }
 
+    /// Every `Pending` pair reachable from this one through a shared artifact.
+    ///
+    /// One component, one call. Three related artifacts settled pairwise cost
+    /// two calls and produce a merged artifact that is superseded almost
+    /// immediately — and with the re-merge rule flattening to captured roots
+    /// each time, the intermediate merge is written and thrown away for nothing.
+    ///
+    /// Computed at the moment of use rather than snapshotted when the unit was
+    /// armed. Membership changes while a unit waits out a backoff, and acting on
+    /// a stale group would rewrite artifacts that have since been answered.
+    ///
+    /// `Pending` only. A dismissed, near-identical or oversized row carries a
+    /// decision, and following it would pull an already-settled artifact into a
+    /// group that is about to be superseded.
+    pub async fn open_component(&self, pair_id: i64) -> Result<Vec<ArtifactPair>> {
+        let open = self.pairs_by_state(PairState::Pending, 5_000).await?;
+        let Some(seed) = open.iter().find(|p| p.id == pair_id) else {
+            return Ok(vec![]);
+        };
+
+        let mut members: std::collections::HashSet<&str> = [seed.a_id.as_str(), seed.b_id.as_str()]
+            .into_iter()
+            .collect();
+        let mut picked: std::collections::HashSet<i64> = [seed.id].into_iter().collect();
+        // A fixed point rather than one pass. A pair joins the component only
+        // once one of its artifacts is already in it, and the pair that brings
+        // that artifact in can come later in the list — a single pass would
+        // return a component whose contents depended on row order.
+        loop {
+            let mut grew = false;
+            for p in &open {
+                if picked.contains(&p.id) {
+                    continue;
+                }
+                if members.contains(p.a_id.as_str()) || members.contains(p.b_id.as_str()) {
+                    members.insert(p.a_id.as_str());
+                    members.insert(p.b_id.as_str());
+                    picked.insert(p.id);
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+        Ok(open
+            .into_iter()
+            .filter(|p| picked.contains(&p.id))
+            .collect())
+    }
+
     /// Count one model call against a pair, whether or not it produced an
     /// answer. Written before the call, so a run that dies mid-judgement still
     /// leaves the pair at the back of the next sweep's queue.
@@ -487,6 +538,110 @@ mod tests {
                 state.as_str()
             );
         }
+    }
+
+    /// Four artifacts under one corpus, for the component tests.
+    async fn four_artifacts(s: &Store) -> Vec<String> {
+        let src = s.insert_corpus("four", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..4)
+            .map(|i| NewArtifact {
+                ordinal: i,
+                text: format!("artifact {i}"),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        s.insert_artifacts(&src.id, &new)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_component_gathers_every_pending_pair_that_shares_an_artifact() {
+        // One component, one call. Merging a four-artifact group pairwise costs
+        // three calls and writes two merged artifacts that are superseded
+        // almost immediately.
+        let s = Store::memory().await.unwrap();
+        let m = four_artifacts(&s).await;
+        s.record_pair(&m[0], &m[1], 0.91).await.unwrap();
+        s.record_pair(&m[1], &m[2], 0.90).await.unwrap();
+        s.record_pair(&m[3], &m[0], 0.89).await.unwrap();
+        let seed = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+        let comp = s.open_component(seed).await.unwrap();
+        assert_eq!(comp.len(), 3, "the component stopped short: {comp:?}");
+    }
+
+    #[tokio::test]
+    async fn a_component_is_the_same_set_whichever_pair_seeds_it() {
+        // The fixed point is what makes this true. A single pass would return a
+        // component whose contents depended on which row happened to come
+        // first, so two units for one group could act on different sets.
+        let s = Store::memory().await.unwrap();
+        let m = four_artifacts(&s).await;
+        s.record_pair(&m[0], &m[1], 0.91).await.unwrap();
+        s.record_pair(&m[1], &m[2], 0.90).await.unwrap();
+        s.record_pair(&m[2], &m[3], 0.89).await.unwrap();
+
+        let all = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        let mut sets: Vec<Vec<i64>> = Vec::new();
+        for p in &all {
+            let mut ids: Vec<i64> = s
+                .open_component(p.id)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|c| c.id)
+                .collect();
+            ids.sort_unstable();
+            sets.push(ids);
+        }
+        assert_eq!(sets[0].len(), 3);
+        assert!(
+            sets.iter().all(|s| *s == sets[0]),
+            "the component depended on which pair seeded it: {sets:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_settled_pair_never_drags_an_answered_artifact_into_a_component() {
+        // Pending only. A dismissed or near-identical row carries a decision,
+        // and following it would pull an already-settled artifact into a group
+        // that is about to be superseded and rewritten.
+        let s = Store::memory().await.unwrap();
+        let m = four_artifacts(&s).await;
+        s.record_pair(&m[0], &m[1], 0.91).await.unwrap();
+        s.record_pair(&m[1], &m[2], 0.90).await.unwrap();
+        let all = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        let (seed, other) = (all[0].id, all[1].id);
+        s.set_pair_state(other, PairState::Dismissed, None)
+            .await
+            .unwrap();
+
+        assert_eq!(s.open_component(seed).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_component_of_a_pair_that_is_no_longer_open_is_empty() {
+        // The unit re-reads its own pair before acting. A sibling unit that
+        // already settled the group must find nothing to do rather than an
+        // empty-but-plausible component.
+        let s = Store::memory().await.unwrap();
+        let m = four_artifacts(&s).await;
+        s.record_pair(&m[0], &m[1], 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(p, PairState::NoConflict, None)
+            .await
+            .unwrap();
+
+        assert!(s.open_component(p).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -400,29 +400,29 @@ impl Store {
             return Ok(vec![]);
         };
 
-        let mut members: std::collections::HashSet<&str> = [seed.a_id.as_str(), seed.b_id.as_str()]
-            .into_iter()
-            .collect();
+        // Adjacency once, then a flood fill from the seed's two artifacts. A
+        // pair joins the component only once one of its artifacts is already
+        // in it, and the pair that brings that artifact in can come anywhere
+        // in the list — the fixed-point loop this replaces got that right by
+        // rescanning the whole window per growth pass, which is quadratic at
+        // the window size for one long chain.
+        let mut by_artifact: std::collections::HashMap<&str, Vec<usize>> = Default::default();
+        for (i, p) in open.iter().enumerate() {
+            by_artifact.entry(p.a_id.as_str()).or_default().push(i);
+            by_artifact.entry(p.b_id.as_str()).or_default().push(i);
+        }
         let mut picked: std::collections::HashSet<i64> = [seed.id].into_iter().collect();
-        // A fixed point rather than one pass. A pair joins the component only
-        // once one of its artifacts is already in it, and the pair that brings
-        // that artifact in can come later in the list — a single pass would
-        // return a component whose contents depended on row order.
-        loop {
-            let mut grew = false;
-            for p in &open {
-                if picked.contains(&p.id) {
-                    continue;
+        let mut queue: Vec<&str> = vec![seed.a_id.as_str(), seed.b_id.as_str()];
+        let mut seen: std::collections::HashSet<&str> = queue.iter().copied().collect();
+        while let Some(id) = queue.pop() {
+            for &i in by_artifact.get(id).into_iter().flatten() {
+                let p = &open[i];
+                picked.insert(p.id);
+                for other in [p.a_id.as_str(), p.b_id.as_str()] {
+                    if seen.insert(other) {
+                        queue.push(other);
+                    }
                 }
-                if members.contains(p.a_id.as_str()) || members.contains(p.b_id.as_str()) {
-                    members.insert(p.a_id.as_str());
-                    members.insert(p.b_id.as_str());
-                    picked.insert(p.id);
-                    grew = true;
-                }
-            }
-            if !grew {
-                break;
             }
         }
         Ok(open

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -85,7 +85,7 @@ pub struct ArtifactPair {
     pub obsolete_id: Option<String>,
 }
 
-fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
+pub(crate) fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
     ArtifactPair {
         id: r.get("id"),
         a_id: r.get("a_id"),

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -334,6 +334,25 @@ impl Store {
         Ok(res.rows_affected())
     }
 
+    /// Dismiss every pair a merge being undone had settled, by the lineage the
+    /// settlement recorded. `pairs_among` covers only what the merge had
+    /// already hidden — before the embed lands that is nothing, while the
+    /// pairs were settled the moment the merge was written. Dismissed, not
+    /// Contradiction: an undo is an operator overruling the verdict, and
+    /// `record_pair` respecting dismissed rows is what makes that last.
+    pub async fn dismiss_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs
+                SET state = 'dismissed', detail = ?, merged_into = NULL
+              WHERE merged_into = ?",
+        )
+        .bind(detail)
+        .bind(merged_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+
     /// Pending pairs in the order the judge should spend its budget on them.
     ///
     /// Least-attempted first, then by score. A pair whose reply could not be

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -65,6 +65,13 @@ pub enum PairState {
     /// sources is no longer one atomic piece of knowledge, which is what an
     /// artifact is defined to be.
     Oversized,
+    /// The model answered "duplicate" while autonomy is off. Recorded so an
+    /// operator can read the verdicts before letting the system act on them;
+    /// the merged draft is not kept, and flipping autonomy on lets a later
+    /// unit re-judge and merge. Its own state rather than `Contradiction`,
+    /// because filing a mergeable pair among genuine conflicts made the UI
+    /// claim a disagreement the model did not find.
+    WouldMerge,
 }
 
 impl PairState {
@@ -77,6 +84,7 @@ impl PairState {
             PairState::Dismissed => "dismissed",
             PairState::NearIdentical => "near_identical",
             PairState::Oversized => "oversized",
+            PairState::WouldMerge => "would_merge",
         }
     }
     pub fn parse(s: &str) -> PairState {
@@ -87,6 +95,7 @@ impl PairState {
             "dismissed" => PairState::Dismissed,
             "near_identical" => PairState::NearIdentical,
             "oversized" => PairState::Oversized,
+            "would_merge" => PairState::WouldMerge,
             _ => PairState::Pending,
         }
     }
@@ -112,6 +121,10 @@ pub struct ArtifactPair {
     /// Lets the review UI offer "apply supersede" without asking the model
     /// again.
     pub obsolete_id: Option<String>,
+    /// Which merged artifact answered this pair, when the settlement was an
+    /// applied merge. What the stranded-merge reap uses to reopen exactly the
+    /// pairs a merge that never embedded had closed.
+    pub merged_into: Option<String>,
 }
 
 pub(crate) fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
@@ -126,6 +139,7 @@ pub(crate) fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
         judge_attempts: r.get("judge_attempts"),
         judge_unreadable: r.get("judge_unreadable"),
         obsolete_id: r.get("obsolete_id"),
+        merged_into: r.get("merged_into"),
     }
 }
 
@@ -223,7 +237,8 @@ impl Store {
     /// only path that writes it. A pair the judge proposed a winner for and an
     /// operator then dismissed would otherwise keep naming a supersede that was
     /// explicitly rejected, and any later listing of dismissed pairs would offer
-    /// to apply it.
+    /// to apply it. `merged_into` is cleared for the same reason: it belongs to
+    /// the merged settlement `set_pair_merged` writes, and to nothing else.
     pub async fn set_pair_state(
         &self,
         id: i64,
@@ -231,7 +246,9 @@ impl Store {
         detail: Option<&str>,
     ) -> Result<()> {
         let res = sqlx::query(
-            "UPDATE artifact_pairs SET state = ?, detail = ?, obsolete_id = NULL WHERE id = ?",
+            "UPDATE artifact_pairs
+                SET state = ?, detail = ?, obsolete_id = NULL, merged_into = NULL
+              WHERE id = ?",
         )
         .bind(state.as_str())
         .bind(detail)
@@ -260,7 +277,9 @@ impl Store {
         detail: Option<&str>,
     ) -> Result<()> {
         let res = sqlx::query(
-            "UPDATE artifact_pairs SET state = 'superseded', detail = ?, obsolete_id = ? WHERE id = ?",
+            "UPDATE artifact_pairs
+                SET state = 'superseded', detail = ?, obsolete_id = ?, merged_into = NULL
+              WHERE id = ?",
         )
         .bind(detail)
         .bind(obsolete_id)
@@ -271,6 +290,48 @@ impl Store {
             return Err(crate::error::Error::NotFound);
         }
         Ok(())
+    }
+
+    /// Settle a pair as answered by an applied merge. `merged_into` names the
+    /// merged artifact, which is what lets the stranded-merge reap reopen
+    /// exactly the pairs a merge that never embedded had closed.
+    pub async fn set_pair_merged(
+        &self,
+        id: i64,
+        merged_into: &str,
+        detail: Option<&str>,
+    ) -> Result<()> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs
+                SET state = 'no_conflict', detail = ?, merged_into = ?, obsolete_id = NULL
+              WHERE id = ?",
+        )
+        .bind(detail)
+        .bind(merged_into)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Err(crate::error::Error::NotFound);
+        }
+        Ok(())
+    }
+
+    /// Reopen every pair a now-dead merge had settled, handing them to a
+    /// person. Contradiction rather than Pending on purpose: re-arming the
+    /// model would regenerate the same unembeddable draft, at full price,
+    /// forever.
+    pub async fn reopen_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs
+                SET state = 'contradiction', detail = ?, merged_into = NULL
+              WHERE merged_into = ?",
+        )
+        .bind(detail)
+        .bind(merged_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
     }
 
     /// Pending pairs in the order the judge should spend its budget on them.
@@ -933,5 +994,72 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn a_merged_settlement_records_which_merge_answered_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+        s.set_pair_merged(id, "merge-1", Some("same claim"))
+            .await
+            .unwrap();
+
+        let p = s.get_pair(id).await.unwrap();
+        assert_eq!(p.state, PairState::NoConflict);
+        assert_eq!(p.merged_into.as_deref(), Some("merge-1"));
+
+        // Leaving the settlement drops the record, exactly as obsolete_id does.
+        s.set_pair_state(id, PairState::Dismissed, None)
+            .await
+            .unwrap();
+        assert_eq!(s.get_pair(id).await.unwrap().merged_into, None);
+    }
+
+    #[tokio::test]
+    async fn reopening_a_stranded_merge_s_pairs_touches_only_its_own() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_merged(id, "merge-1", None).await.unwrap();
+
+        assert_eq!(
+            s.reopen_pairs_merged_into("merge-other", "unrelated")
+                .await
+                .unwrap(),
+            0,
+            "another merge's undo reopened this pair"
+        );
+        assert_eq!(
+            s.reopen_pairs_merged_into("merge-1", "the merged text could not be indexed")
+                .await
+                .unwrap(),
+            1
+        );
+        let p = s.get_pair(id).await.unwrap();
+        assert_eq!(p.state, PairState::Contradiction);
+        assert_eq!(p.merged_into, None);
+    }
+
+    #[tokio::test]
+    async fn would_merge_is_a_state_of_its_own() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(id, PairState::WouldMerge, Some("same claim"))
+            .await
+            .unwrap();
+        assert_eq!(
+            s.pairs_by_state(PairState::WouldMerge, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(PairState::parse("would_merge"), PairState::WouldMerge);
     }
 }

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -429,9 +429,10 @@ impl Store {
             }
             open.push(seed);
         }
-        let Some(seed) = open.iter().find(|p| p.id == pair_id) else {
-            return Ok(vec![]);
-        };
+        let seed = open
+            .iter()
+            .find(|p| p.id == pair_id)
+            .expect("the block above put the seed in the window or returned");
 
         // Adjacency once, then a flood fill from the seed's two artifacts. A
         // pair joins the component only once one of its artifacts is already

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -40,6 +40,20 @@ pub enum PairState {
     Superseded,
     /// An operator looked and decided there is nothing here.
     Dismissed,
+    /// Scored at or above `auto_supersede`. Settled by the sweep's free
+    /// clustering pass, and never armed for a model call: that band is answered
+    /// correctly by a rule that costs nothing, and spending a call there is the
+    /// free path quietly becoming a paid one.
+    ///
+    /// Filed rather than acted on where it is found, because resolving pairs one
+    /// at a time leaves A pointing at a B that is itself hidden — which is what
+    /// the sweep's union-find exists to prevent.
+    NearIdentical,
+    /// The component this pair belongs to draws on more captured roots than
+    /// `merge_max_roots`. Not merged, and surfaced instead: a merge of forty
+    /// sources is no longer one atomic piece of knowledge, which is what an
+    /// artifact is defined to be.
+    Oversized,
 }
 
 impl PairState {
@@ -50,6 +64,8 @@ impl PairState {
             PairState::Contradiction => "contradiction",
             PairState::Superseded => "superseded",
             PairState::Dismissed => "dismissed",
+            PairState::NearIdentical => "near_identical",
+            PairState::Oversized => "oversized",
         }
     }
     pub fn parse(s: &str) -> PairState {
@@ -58,6 +74,8 @@ impl PairState {
             "contradiction" => PairState::Contradiction,
             "superseded" => PairState::Superseded,
             "dismissed" => PairState::Dismissed,
+            "near_identical" => PairState::NearIdentical,
+            "oversized" => PairState::Oversized,
             _ => PairState::Pending,
         }
     }
@@ -395,6 +413,80 @@ mod tests {
             1,
             "an endpoint outage put the pair permanently out of the judge's reach"
         );
+    }
+
+    #[tokio::test]
+    async fn a_near_identical_pair_is_never_offered_to_the_model() {
+        // The >= auto_supersede band is settled for free by clustering. A pair
+        // filed there that reached the dedupe queue would spend a model call on
+        // exactly the case where the cheap rule is already correct — the free
+        // path quietly becoming a paid one, which is the expensive regression
+        // and the silent one.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_settled_pair(&a, &b, 0.99, PairState::NearIdentical)
+            .await
+            .unwrap();
+
+        assert!(s.pairs_to_judge(10).await.unwrap().is_empty());
+        assert_eq!(
+            s.pairs_by_state(PairState::NearIdentical, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the pair has to stay findable: the cluster pass reads these rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_oversized_pair_leaves_the_pending_queue_but_stays_visible() {
+        // Past the fan-in cap nothing is merged, and the pair must not sit on
+        // the pending queue costing a call per sweep for a decision that will
+        // always come out the same way. It still has to be listed, or the
+        // component becomes invisible rather than deferred.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(p, PairState::Oversized, Some("9 roots, cap is 8"))
+            .await
+            .unwrap();
+
+        assert!(s.pairs_to_judge(10).await.unwrap().is_empty());
+        let found = s.pairs_by_state(PairState::Oversized, 10).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].detail.as_deref(), Some("9 roots, cap is 8"));
+    }
+
+    #[tokio::test]
+    async fn every_state_survives_a_round_trip_through_the_database() {
+        // `parse` falls back to Pending for anything it does not know, so a
+        // state whose string is missing from either half reads back as an
+        // unanswered pair — and the sweep would ask about it again forever.
+        for state in [
+            PairState::Pending,
+            PairState::NoConflict,
+            PairState::Contradiction,
+            PairState::Superseded,
+            PairState::Dismissed,
+            PairState::NearIdentical,
+            PairState::Oversized,
+        ] {
+            let s = Store::memory().await.unwrap();
+            let (a, b) = two_artifacts(&s).await;
+            s.record_pair(&a, &b, 0.91).await.unwrap();
+            let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+            if state != PairState::Pending {
+                s.set_pair_state(p, state, None).await.unwrap();
+            }
+            assert_eq!(
+                s.get_pair(p).await.unwrap().state,
+                state,
+                "{} did not survive the round trip",
+                state.as_str()
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -334,6 +334,20 @@ impl Store {
         Ok(res.rows_affected())
     }
 
+    /// Hand every recorded would-merge verdict back to the judge queue.
+    ///
+    /// `would_merge` exists only as a note taken while autonomy is off — the
+    /// draft was discarded, so there is nothing to apply directly; the unit
+    /// re-judges and merges at the queue's own pace. The detail is kept: it is
+    /// the model's recorded reasoning, and `pending` reads it never.
+    pub async fn reopen_would_merge_pairs(&self) -> Result<u64> {
+        let res =
+            sqlx::query("UPDATE artifact_pairs SET state = 'pending' WHERE state = 'would_merge'")
+                .execute(&self.pool)
+                .await?;
+        Ok(res.rows_affected())
+    }
+
     /// Dismiss every pair a merge being undone had settled, by the lineage the
     /// settlement recorded. `pairs_among` covers only what the merge had
     /// already hidden — before the embed lands that is nothing, while the

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -126,6 +126,11 @@ CREATE TABLE IF NOT EXISTS artifact_sources (
   -- CASCADE because a deleted intermediate does not invalidate the root.
   via_id     TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
   created_at INTEGER NOT NULL,
+  -- Set when an operator explicitly restored this root out of the merge. The
+  -- unfinished-merge repair must never hide such a root again; a *new* merge
+  -- decision writes fresh rows with 0, which is new evidence rather than a
+  -- repair of old state.
+  restored   INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (child_id, root_id)
 );
 CREATE INDEX IF NOT EXISTS idx_sources_root ON artifact_sources(root_id);

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -63,9 +63,11 @@ CREATE TABLE IF NOT EXISTS artifacts (
   -- than `corpus_id IS NULL`: a null is an absence, and the failure modes
   -- merging can produce want to hang off an assertion.
   provenance       TEXT NOT NULL DEFAULT 'captured',
-  -- How many artifacts a merge was written from. Compared against the surviving
-  -- `artifact_sources` rows to notice a source that has since been deleted;
-  -- without it "lost a source" cannot be told from "only ever had two".
+  -- How many captured roots a merge was written from — the number of
+  -- `artifact_sources` rows it started with, not the number of arguments it was
+  -- called with, which for a merge of a merge is fewer. Compared against the
+  -- surviving rows to notice a source that has since been deleted; without it
+  -- "lost a source" cannot be told from "only ever had two".
   source_count     INTEGER NOT NULL DEFAULT 0,
   -- Set in the same UPDATE that changes status/superseded_by, cleared once the
   -- payload write is acknowledged. The lifecycle repair reads this instead of

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -221,6 +221,9 @@ CREATE TABLE IF NOT EXISTS artifact_pairs (
   -- time the model is down.
   judge_unreadable INTEGER NOT NULL DEFAULT 0,
   obsolete_id    TEXT REFERENCES artifacts(id),
+  -- Which merged artifact answered this pair, when the settlement was an
+  -- applied merge. The stranded-merge reap reopens pairs by it.
+  merged_into    TEXT,
   UNIQUE(a_id, b_id)
 );
 CREATE INDEX IF NOT EXISTS idx_pairs_state ON artifact_pairs(state, created_at DESC);

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -49,11 +49,29 @@ CREATE INDEX IF NOT EXISTS idx_corpora_created ON corpora(created_at DESC);
 
 -- ── Artifacts ────────────────────────────────────────────────────────────────
 -- One atomic piece of knowledge, rewritten to stand alone. Superseding hides
--- an artifact and names its replacement; nothing is ever merged or rewritten
--- in place.
+-- an artifact and names its replacement; a captured artifact's text is never
+-- rewritten in place. The dedupe pass may write a *new* artifact out of several
+-- others — see `provenance` and `artifact_sources` — but it never edits one,
+-- and the artifacts it was written from stay stored and one write from active.
 CREATE TABLE IF NOT EXISTS artifacts (
   id               TEXT PRIMARY KEY,
-  corpus_id        TEXT NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+  -- NULL for a merged artifact, which belongs to no single corpus. Claiming a
+  -- corpus it did not come from would put the wrong lines beside it in the
+  -- detail pane, which is the one dishonesty merging must not commit.
+  corpus_id        TEXT REFERENCES corpora(id) ON DELETE CASCADE,
+  -- 'captured' | 'merged'. The discriminator every consumer branches on, rather
+  -- than `corpus_id IS NULL`: a null is an absence, and the failure modes
+  -- merging can produce want to hang off an assertion.
+  provenance       TEXT NOT NULL DEFAULT 'captured',
+  -- How many artifacts a merge was written from. Compared against the surviving
+  -- `artifact_sources` rows to notice a source that has since been deleted;
+  -- without it "lost a source" cannot be told from "only ever had two".
+  source_count     INTEGER NOT NULL DEFAULT 0,
+  -- Set in the same UPDATE that changes status/superseded_by, cleared once the
+  -- payload write is acknowledged. The lifecycle repair reads this instead of
+  -- scanning, so its cost is the open writes rather than the set of hidden
+  -- artifacts — which merging makes grow without bound.
+  lifecycle_dirty  INTEGER NOT NULL DEFAULT 0,
   ordinal          INTEGER NOT NULL,
   text             TEXT NOT NULL,
   -- Line range in the corpus this came from, as JSON.
@@ -83,6 +101,32 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_embed      ON artifacts(embed_state);
 CREATE INDEX IF NOT EXISTS idx_artifacts_window     ON artifacts(corpus_id, segment_idx);
 CREATE INDEX IF NOT EXISTS idx_artifacts_superseded ON artifacts(superseded_by);
 CREATE INDEX IF NOT EXISTS idx_artifacts_status     ON artifacts(status);
+-- Partial: the repair's work list is the open writes, which is almost always
+-- empty. A full index on a column that is 0 for every row but a handful would
+-- be paid for on every lifecycle write and read nothing back.
+CREATE INDEX IF NOT EXISTS idx_artifacts_dirty      ON artifacts(lifecycle_dirty) WHERE lifecycle_dirty = 1;
+CREATE INDEX IF NOT EXISTS idx_artifacts_provenance ON artifacts(provenance);
+
+-- ── Lineage ──────────────────────────────────────────────────────────────────
+-- What a merged artifact is made of, as resolved captured roots rather than as
+-- parent edges. `root_id` always names a `provenance = 'captured'` artifact, so
+-- a re-merge reads the leaves in one query and is never written from text a
+-- model produced — which is what keeps information loss one generation deep
+-- however many times a group is merged.
+--
+-- The closure duplicates what edges would imply. That is the trade: the fan-in
+-- cap bounds how much, and it buys a hot-path read with no recursive CTE.
+CREATE TABLE IF NOT EXISTS artifact_sources (
+  child_id   TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  root_id    TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- The direct parent through which root_id entered this child; equal to
+  -- root_id for a first-generation merge. Rendering only. SET NULL rather than
+  -- CASCADE because a deleted intermediate does not invalidate the root.
+  via_id     TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (child_id, root_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sources_root ON artifact_sources(root_id);
 
 -- ── Segments ─────────────────────────────────────────────────────────────────
 -- The windows a corpus was split into for synthesis. One window is one

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -507,6 +507,7 @@ mod tests {
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                provenance: None,
             },
         }
     }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -403,12 +403,19 @@ impl VectorStore for MemoryVectors {
                 p.payload.artifact_id != artifact_id
                     && status_of(&p.payload) == ArtifactStatus::Active
             })
-            .map(|p| SearchHit {
-                payload: p.payload.clone(),
-                score: cosine(&seed.vector, &p.vector),
-                // The seed is an artifact, not a query. "Loosely related" is
-                // the honest description of every neighbour list.
-                similarity: None,
+            .map(|p| {
+                let cos = cosine(&seed.vector, &p.vector);
+                SearchHit {
+                    payload: p.payload.clone(),
+                    score: cos,
+                    // Stated rather than left `None`. This is one dense lookup
+                    // with no fusion, so the score *is* a cosine — and the
+                    // relate unit compares it against `review_min`, which is a
+                    // cosine threshold. Leaving it unset would make a caller
+                    // read `score`, which everywhere else in this trait means a
+                    // fused rank that is not comparable to anything.
+                    similarity: Some(cos),
+                }
             })
             .collect();
         hits.sort_by(|a, b| {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -51,6 +51,17 @@ pub struct VectorPayload {
     /// without a second lookup.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub superseded_by: Option<String>,
+    /// `captured` or `merged`, mirroring `Chunk::provenance`.
+    ///
+    /// Carried here for one reason that is not cosmetic: `restore_artifact`
+    /// rebuilds a SQLite row from this payload, and `corpus_id` is the empty
+    /// string for a merged artifact. Without the kind, a restore cannot tell a
+    /// merged artifact from a captured one whose corpus id was lost, and would
+    /// write the wrong sort of row back. Omitted when unset, like the fields
+    /// above, so a point written before this existed reads as `captured` — the
+    /// right default, since no merge can predate the column.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1867,6 +1867,14 @@ impl VectorStore for QdrantVectors {
         let mut hits = hits_of(res);
         hits.retain(|h| h.payload.artifact_id != artifact_id);
         hits.truncate(limit);
+        // One dense query, no prefetch and no fusion, so Qdrant's score here
+        // *is* the cosine. Stated rather than left at `hits_of`'s `None`: the
+        // relate unit compares this against `review_min`, a cosine threshold,
+        // and `score` everywhere else in this trait is a fused rank that means
+        // nothing across queries.
+        for h in &mut hits {
+            h.similarity = Some(h.score);
+        }
         Ok(hits)
     }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -441,6 +441,14 @@ async fn consolidation(
             .store
             .pairs_by_state(PairState::Superseded, 100)
             .await?,
+        // Merge verdicts recorded while autonomy is off. Their own key for
+        // the same reason they are their own state: a consumer counting
+        // `contradictions` must not see pairs the model judged complementary.
+        "merge_proposals": st
+            .core
+            .store
+            .pairs_by_state(PairState::WouldMerge, 100)
+            .await?,
         "pairs": st
             .core
             .store

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -632,7 +632,8 @@ async fn patch_artifact(
             .vectors
             .set_payload(&crate::vector::VectorPayload {
                 artifact_id: chunk.id.clone(),
-                corpus_id: chunk.corpus_id.clone(),
+                corpus_id: chunk.corpus_id.clone().unwrap_or_default(),
+                provenance: Some(chunk.provenance.as_str().to_string()),
                 text: chunk.text.clone(),
                 title: chunk.title.clone(),
                 category: chunk.category.clone(),

--- a/src/web/corpus_view.rs
+++ b/src/web/corpus_view.rs
@@ -19,6 +19,10 @@ pub struct CorpusLine {
     pub in_span: bool,
 }
 
+/// `Default` is the empty slice, which is what a merged artifact has: it
+/// belongs to no corpus, so there are no lines to show beside it and no range
+/// to name. The detail pane renders its sources there instead.
+#[derive(Default)]
 pub struct CorpusSlice {
     pub lines: Vec<CorpusLine>,
     /// What to call this range in the UI: `lines 118–141`, later `page 42`.

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -11,7 +11,6 @@
 
 use crate::auth::Identity;
 use crate::error::Result;
-use crate::store::artifacts::ArtifactStatus;
 use crate::store::feedback::{PendingEvent, Stats, Verdict};
 use crate::web::auth_routes::HtmlTemplate;
 use crate::web::state::AppState;
@@ -171,7 +170,7 @@ async fn card_for(st: &AppState, event: PendingEvent) -> Result<Card> {
                 // `hit` refuses these anyway — `eval::export` would drop the
                 // pair — so showing them unchoosable says the same thing on the
                 // card, before the keystroke, instead of after it.
-                usable: a.status == ArtifactStatus::Active && a.superseded_by.is_none(),
+                usable: a.in_results(),
                 artifact_id: a.id,
                 title: a.title.unwrap_or_else(|| "Untitled".into()),
                 snippet: snippet_of(&a.text),
@@ -360,7 +359,7 @@ async fn hit(
     // asked to trust, disagreeing about the same judgement. Refused rather than
     // recorded: the card comes back so the answer can be given again against
     // something the benchmark will still be able to hold.
-    if artifact.status != ArtifactStatus::Active || artifact.superseded_by.is_some() {
+    if !artifact.in_results() {
         return card_again(
             &st,
             &event_id,

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -176,7 +176,12 @@
          and they are the only honest answer to "where did this come from".
          Rendering a corpus it did not come from would be the one dishonesty
          merging must not commit. #}
-      {% if d.sources.is_empty() %}
+      {# On provenance, not on the list being empty. A merge that has lost every
+         source to a delete has an empty list and is still a merge: it has no
+         corpus to link and no span to highlight, so the captured branch would
+         render a dead link over an empty table — on the very artifact whose
+         orphan notice matters most. #}
+      {% if !d.merged %}
       <div class="pane-label">
         <a href="{{ d.source_at_lines }}">Source</a> · {{ d.slice_label }} highlighted
       </div>
@@ -190,9 +195,21 @@
         </table>
       </div>
       {% else %}
-      <div class="pane-label">Written from {{ d.sources.len() }} artifacts</div>
+      <div class="pane-label">
+        {% if d.sources.is_empty() %}
+        Written from artifacts that are gone
+        {% else %}
+        Written from {{ d.sources.len() }} artifacts
+        {% endif %}
+      </div>
       <div class="raw">
-        {% if d.orphaned_source %}
+        {% if d.sources.is_empty() %}
+        <p class="muted">
+          Every artifact this was written from has since been deleted. Its
+          content is still in the text above; what is gone is the record of
+          where that content came from.
+        </p>
+        {% else if d.orphaned_source %}
         <p class="muted">
           One of the artifacts this was written from has since been deleted. Its
           content is still in the text above; only the link to it is gone.

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -170,6 +170,13 @@
          against the line numbers actually on screen. The link opens the
          document scrolled to those lines; an artifact with no recorded span
          has none to jump to and gets the plain link. #}
+      {# A merged artifact belongs to no corpus and has no span, so there are no
+         lines to put beside it. What it was written from goes here instead:
+         those artifacts are still stored, each still names its own document,
+         and they are the only honest answer to "where did this come from".
+         Rendering a corpus it did not come from would be the one dishonesty
+         merging must not commit. #}
+      {% if d.sources.is_empty() %}
       <div class="pane-label">
         <a href="{{ d.source_at_lines }}">Source</a> · {{ d.slice_label }} highlighted
       </div>
@@ -182,6 +189,25 @@
           {% endfor %}
         </table>
       </div>
+      {% else %}
+      <div class="pane-label">Written from {{ d.sources.len() }} artifacts</div>
+      <div class="raw">
+        {% if d.orphaned_source %}
+        <p class="muted">
+          One of the artifacts this was written from has since been deleted. Its
+          content is still in the text above; only the link to it is gone.
+        </p>
+        {% endif %}
+        {% for src in d.sources %}
+        <p>
+          <a href="/ui/artifacts/{{ src.id }}">{{ src.title }}</a>
+          {% if !src.corpus_id.is_empty() %}
+          · <a class="muted" href="/ui/corpora/{{ src.corpus_id }}">source document</a>
+          {% endif %}
+        </p>
+        {% endfor %}
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/src/web/templates/_decide.html
+++ b/src/web/templates/_decide.html
@@ -12,7 +12,7 @@
 {% for p in pairs %}
 <div class="decide">
   <div class="decide-head">
-    {% if p.contradiction %}<b>These two disagree</b>{% else %}<b>These two cover the same ground</b>{% endif %}
+    {% if p.contradiction %}<b>These two disagree</b>{% else %}{% if p.would_merge %}<b>The model would merge these</b>{% else %}<b>These two cover the same ground</b>{% endif %}{% endif %}
     — {{ p.percent }}% alike.
     <a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a> and
     <a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a>.

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -13,6 +13,44 @@
   {% if let Some(age) = oldest_pending_secs %}Oldest pending job {{ age }}s old.{% endif %}
 </p>
 
+{% if !merged.is_empty() %}
+<h3>Merged</h3>
+<p class="muted">
+  Artifacts the dedupe pass wrote out of several others. What each was written
+  from is listed beside it and is still stored — undoing brings those back and
+  retires the merge, and the pairs behind it stay dismissed so the next sweep
+  does not simply do it again.
+</p>
+<table class="grid">
+  <thead><tr><th>Artifact</th><th>Written from</th><th></th></tr></thead>
+  <tbody>
+  {% for m in merged %}
+    <tr>
+      <td>
+        <a href="/ui/artifacts/{{ m.id }}">{{ m.title }}</a>
+        {% if m.orphaned %}
+        {# Not data loss: the text still says what the deleted source said. It
+           is a claim of provenance the artifact can no longer support, and
+           saying so beats silently listing one source fewer. #}
+        <div class="muted">a source has since been deleted</div>
+        {% endif %}
+      </td>
+      <td>
+        {% for src in m.sources %}
+        <div><a href="/ui/artifacts/{{ src.id }}">{{ src.title }}</a></div>
+        {% endfor %}
+      </td>
+      <td>
+        <form method="post" action="/ui/ops/merges/{{ m.id }}/undo">
+          <button class="btn btn-sm" type="submit">Undo merge</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 {% if !deprecated.is_empty() %}
 <h3>Deprecated</h3>
 <p class="muted">Flagged stale with no specific replacement. Still stored and still readable; kept out of results only.</p>
@@ -145,7 +183,7 @@
 
 {# One sentence for everything that is empty. Five headings each answered
    "None." made a base with nothing wrong with it look like a backlog. #}
-{% if deprecated.is_empty() && stale.is_empty() && superseded.is_empty() && parked.is_empty() && retrying.is_empty() %}
+{% if deprecated.is_empty() && stale.is_empty() && superseded.is_empty() && merged.is_empty() && parked.is_empty() && retrying.is_empty() %}
 <p class="muted">Nothing deprecated, nothing hidden, nothing waiting on a decision, nothing retrying.</p>
 {% endif %}
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -95,7 +95,9 @@ pub struct ArtifactDetail {
     pub last_verified_at: Option<i64>,
     /// Conditions the source stated under which this artifact does not apply.
     pub caveats: Vec<String>,
-    pub corpus_id: String,
+    /// `None` for a merged artifact, which belongs to no corpus. The pane shows
+    /// what it was made of instead of corpus lines — see `build_artifact_detail`.
+    pub corpus_id: Option<String>,
     /// True when this artifact's source was never captured here — the artifact
     /// was restored from the vector store and its corpus row is a placeholder.
     /// The pane shows the source beside the artifact, so it has to say when what
@@ -804,7 +806,12 @@ async fn delete_artifact_ui(
     if headers.contains_key("hx-request") {
         return Ok(axum::response::Html(String::new()).into_response());
     }
-    Ok(Redirect::to(&format!("/ui/corpora/{corpus_id}")).into_response())
+    // A merged artifact has no document to return to, so the artifact list is
+    // where deleting one leaves you.
+    Ok(match corpus_id {
+        Some(cid) => Redirect::to(&format!("/ui/corpora/{cid}")).into_response(),
+        None => Redirect::to("/ui/ops").into_response(),
+    })
 }
 
 async fn reprocess_ui(
@@ -1291,8 +1298,18 @@ pub(crate) async fn build_artifact_detail(
     terms: &str,
 ) -> Result<ArtifactDetail> {
     let c = core.store.get_artifact(artifact_id).await?;
-    let src = core.store.get_corpus(&c.corpus_id).await?;
-    let slice = crate::web::corpus_view::for_corpus(&src).slice(&src, c.corpus_span.as_ref(), 3);
+    // A merged artifact belongs to no corpus, so there are no lines to show
+    // beside it and no span to highlight. Task 15 fills that half of the pane
+    // with the artifacts it was written from; until then it renders without a
+    // source block rather than claiming a document it did not come from.
+    let src = match &c.corpus_id {
+        Some(id) => Some(core.store.get_corpus(id).await?),
+        None => None,
+    };
+    let slice = match &src {
+        Some(s) => crate::web::corpus_view::for_corpus(s).slice(s, c.corpus_span.as_ref(), 3),
+        None => crate::web::corpus_view::CorpusSlice::default(),
+    };
     // A missing neighbour list is not a missing pane. The vector store may be
     // down, or this artifact may simply not be embedded yet, and neither is a
     // reason to refuse to show the artifact beside its source.
@@ -1317,12 +1334,15 @@ pub(crate) async fn build_artifact_detail(
     // Built before the struct consumes `c`. The fragment is what makes the
     // browser scroll to the span; the query parameters are what make the page
     // highlight it.
-    let source_at_lines = match c.corpus_span.as_ref() {
-        Some(sp) => format!(
-            "/ui/corpora/{}?from={}&to={}#L{}",
-            c.corpus_id, sp.start_line, sp.end_line, sp.start_line
+    // Empty for a merged artifact: there is no document to link to, and the
+    // template hides the whole source block rather than offering a dead link.
+    let source_at_lines = match (&c.corpus_id, c.corpus_span.as_ref()) {
+        (Some(cid), Some(sp)) => format!(
+            "/ui/corpora/{cid}?from={}&to={}#L{}",
+            sp.start_line, sp.end_line, sp.start_line
         ),
-        None => format!("/ui/corpora/{}", c.corpus_id),
+        (Some(cid), None) => format!("/ui/corpora/{cid}"),
+        (None, _) => String::new(),
     };
     Ok(ArtifactDetail {
         related,
@@ -1339,7 +1359,8 @@ pub(crate) async fn build_artifact_detail(
         last_verified_at: c.last_verified_at,
         caveats: c.caveats,
         corpus_id: c.corpus_id,
-        corpus_restored: src.restored_at.is_some(),
+        // A merged artifact has no corpus and so cannot have a restored one.
+        corpus_restored: src.as_ref().is_some_and(|s| s.restored_at.is_some()),
         segment_idx: c.segment_idx,
         slice_label: slice.label,
         slice_lines: slice.lines,
@@ -1508,7 +1529,7 @@ mod tests {
             Err(e) => panic!("detail view failed: {e}"),
         };
 
-        assert_eq!(d.corpus_id, out.id);
+        assert_eq!(d.corpus_id.as_deref(), Some(out.id.as_str()));
         assert!(d.html.contains("alpha"), "the chunk body must be rendered");
         assert!(
             !d.slice_lines.is_empty(),

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -444,6 +444,36 @@ pub struct SourceRow {
     pub corpus_id: String,
 }
 
+/// The source list a merge renders: its lineage roots, fetched and titled.
+/// One shape for Ops and the detail pane — the two must stay behaviorally
+/// identical (same self-guard, same tolerance for deleted sources, same
+/// corpus fallback), and a copy in each is how they come to disagree about
+/// what a merge was made of.
+async fn source_rows(
+    store: &crate::store::Store,
+    merged_id: &str,
+    roots: &[String],
+) -> Vec<SourceRow> {
+    let mut sources = Vec::new();
+    for rid in roots {
+        // A source deleted since leaves no row; skipping it is what the
+        // `orphaned` flag exists to say out loud. `roots_of` answers an empty
+        // list for a merge that lost every source; the self guard stays as
+        // defense against a base written before that change.
+        if rid == merged_id {
+            continue;
+        }
+        if let Ok(r) = store.get_artifact(rid).await {
+            sources.push(SourceRow {
+                corpus_id: r.corpus_id.clone().unwrap_or_default(),
+                title: title_of(&r),
+                id: r.id,
+            });
+        }
+    }
+    sources
+}
+
 #[derive(Template)]
 #[template(path = "_token_created.html")]
 struct TokenCreatedTemplate {
@@ -1041,31 +1071,22 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     }
 
     let mut merged = Vec::new();
-    for c in st.core.store.merged_artifacts(50).await? {
-        let roots = st
-            .core
-            .store
-            .roots_of(std::slice::from_ref(&c.id))
-            .await
-            .unwrap_or_default();
-        let mut sources = Vec::new();
-        for rid in roots.get(&c.id).into_iter().flatten() {
-            // A source deleted since leaves no row. `orphaned` is what says
-            // so, rather than the list quietly being one shorter. `roots_of`
-            // now answers an empty list for a merge that lost every source;
-            // the self guard stays as defense against a base written before
-            // that change.
-            if rid == &c.id {
-                continue;
-            }
-            if let Ok(r) = st.core.store.get_artifact(rid).await {
-                sources.push(SourceRow {
-                    corpus_id: r.corpus_id.clone().unwrap_or_default(),
-                    title: title_of(&r),
-                    id: r.id,
-                });
-            }
-        }
+    let merged_chunks = st.core.store.merged_artifacts(50).await?;
+    // One lineage call per page, not one per row: `roots_of` takes the batch.
+    let merged_ids: Vec<String> = merged_chunks.iter().map(|c| c.id.clone()).collect();
+    let roots = st
+        .core
+        .store
+        .roots_of(&merged_ids)
+        .await
+        .unwrap_or_default();
+    for c in merged_chunks {
+        let sources = source_rows(
+            &st.core.store,
+            &c.id,
+            roots.get(&c.id).map(Vec::as_slice).unwrap_or_default(),
+        )
+        .await;
         merged.push(MergedRow {
             orphaned: c.flags.iter().any(|f| f == "orphaned_source"),
             title: title_of(&c),
@@ -1416,22 +1437,12 @@ pub(crate) async fn build_artifact_detail(
             .roots_of(std::slice::from_ref(&c.id))
             .await
             .unwrap_or_default();
-        for rid in roots.get(&c.id).into_iter().flatten() {
-            // `roots_of` now answers an empty list for a merge with no lineage
-            // rows, so nothing here would list a merge as written from itself;
-            // the guard stays as defense against a base written before that
-            // change.
-            if rid == &c.id {
-                continue;
-            }
-            if let Ok(r) = core.store.get_artifact(rid).await {
-                sources.push(SourceRow {
-                    corpus_id: r.corpus_id.clone().unwrap_or_default(),
-                    title: title_of(&r),
-                    id: r.id,
-                });
-            }
-        }
+        sources = source_rows(
+            &core.store,
+            &c.id,
+            roots.get(&c.id).map(Vec::as_slice).unwrap_or_default(),
+        )
+        .await;
     }
     // A missing neighbour list is not a missing pane. The vector store may be
     // down, or this artifact may simply not be embedded yet, and neither is a

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -98,6 +98,14 @@ pub struct ArtifactDetail {
     /// `None` for a merged artifact, which belongs to no corpus. The pane shows
     /// what it was made of instead of corpus lines — see `build_artifact_detail`.
     pub corpus_id: Option<String>,
+    /// What a merged artifact was written from. Empty for a captured one, which
+    /// is what the template branches on: a captured artifact renders the corpus
+    /// lines its span claims, a merged one renders these.
+    pub sources: Vec<SourceRow>,
+    /// True when one of those sources has since been deleted. The text still
+    /// carries what it said, so this is a missing link rather than missing
+    /// knowledge — and saying so beats listing one source fewer in silence.
+    pub orphaned_source: bool,
     /// True when this artifact's source was never captured here — the artifact
     /// was restored from the vector store and its corpus row is a placeholder.
     /// The pane shows the source beside the artifact, so it has to say when what
@@ -394,12 +402,33 @@ struct OpsTemplate {
     retrying: Vec<RetryingRow>,
     parked: Vec<ParkedRow>,
     superseded: Vec<SupersededRow>,
+    /// Artifacts the dedupe pass wrote out of several others, with what they
+    /// were written from and an undo.
+    merged: Vec<MergedRow>,
     deprecated: Vec<DeprecatedRow>,
     stale: Vec<StaleRow>,
     tokens: Vec<TokenRow>,
     /// `None` when capture is switched off, which renders nothing at all: a
     /// section about a log nobody is keeping is noise.
     feedback: Option<crate::store::feedback::Stats>,
+}
+
+struct MergedRow {
+    id: String,
+    title: String,
+    /// What it was written from, in the order the lineage stores them.
+    sources: Vec<SourceRow>,
+    /// True when a source has been deleted since, so the artifact claims less
+    /// provenance than its text carries.
+    orphaned: bool,
+}
+
+pub struct SourceRow {
+    pub id: String,
+    pub title: String,
+    /// Empty when the source belongs to no corpus — a merge of merges resolves
+    /// to captured roots, so in practice this is always set.
+    pub corpus_id: String,
 }
 
 #[derive(Template)]
@@ -845,9 +874,13 @@ fn title_of(c: &crate::store::artifacts::Chunk) -> String {
 /// the cap strands nothing — there is no second page to go and find the rest
 /// on, which is the point: Housekeeping is reference, not work.
 const PAIR_LIMIT: usize = 5;
-const PAIR_STATES: [crate::store::pairs::PairState; 3] = [
+const PAIR_STATES: [crate::store::pairs::PairState; 4] = [
     crate::store::pairs::PairState::Contradiction,
     crate::store::pairs::PairState::Superseded,
+    // A group past `merge_max_roots` was not merged and will not be: it needs a
+    // person, so it belongs on the page a person opens rather than on
+    // Housekeeping beside the things that resolve themselves.
+    crate::store::pairs::PairState::Oversized,
     crate::store::pairs::PairState::Pending,
 ];
 
@@ -990,6 +1023,34 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         });
     }
 
+    let mut merged = Vec::new();
+    for c in st.core.store.merged_artifacts(50).await? {
+        let roots = st
+            .core
+            .store
+            .roots_of(std::slice::from_ref(&c.id))
+            .await
+            .unwrap_or_default();
+        let mut sources = Vec::new();
+        for rid in roots.get(&c.id).into_iter().flatten() {
+            // A source deleted since leaves no row. `orphaned` is what says so,
+            // rather than the list quietly being one shorter.
+            if let Ok(r) = st.core.store.get_artifact(rid).await {
+                sources.push(SourceRow {
+                    corpus_id: r.corpus_id.clone().unwrap_or_default(),
+                    title: title_of(&r),
+                    id: r.id,
+                });
+            }
+        }
+        merged.push(MergedRow {
+            orphaned: c.flags.iter().any(|f| f == "orphaned_source"),
+            title: title_of(&c),
+            id: c.id,
+            sources,
+        });
+    }
+
     let deprecated = st
         .core
         .store
@@ -1028,6 +1089,7 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         retrying,
         parked,
         superseded,
+        merged,
         deprecated,
         stale,
         job_counts: st.core.store.job_counts().await?,
@@ -1043,6 +1105,17 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         },
     })
     .into_response())
+}
+
+/// Take a merge back: what it replaced returns, the merge is retired, and the
+/// pairs behind it are dismissed so the sweep does not simply redo it.
+async fn undo_merge_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(aid): Path<String>,
+) -> Result<Response> {
+    crate::jobs::merge::undo(&st.core, &aid).await?;
+    Ok(Redirect::to("/ui/ops").into_response())
 }
 
 /// Forget every captured search.
@@ -1310,6 +1383,25 @@ pub(crate) async fn build_artifact_detail(
         Some(s) => crate::web::corpus_view::for_corpus(s).slice(s, c.corpus_span.as_ref(), 3),
         None => crate::web::corpus_view::CorpusSlice::default(),
     };
+    // Only a merged artifact has these, and the template branches on the list
+    // being non-empty rather than on the kind — one fewer field to keep in step.
+    let mut sources = Vec::new();
+    if c.provenance == crate::store::artifacts::Provenance::Merged {
+        let roots = core
+            .store
+            .roots_of(std::slice::from_ref(&c.id))
+            .await
+            .unwrap_or_default();
+        for rid in roots.get(&c.id).into_iter().flatten() {
+            if let Ok(r) = core.store.get_artifact(rid).await {
+                sources.push(SourceRow {
+                    corpus_id: r.corpus_id.clone().unwrap_or_default(),
+                    title: title_of(&r),
+                    id: r.id,
+                });
+            }
+        }
+    }
     // A missing neighbour list is not a missing pane. The vector store may be
     // down, or this artifact may simply not be embedded yet, and neither is a
     // reason to refuse to show the artifact beside its source.
@@ -1344,8 +1436,10 @@ pub(crate) async fn build_artifact_detail(
         (Some(cid), None) => format!("/ui/corpora/{cid}"),
         (None, _) => String::new(),
     };
+    let orphaned_source = c.flags.iter().any(|f| f == "orphaned_source");
     Ok(ArtifactDetail {
         related,
+        orphaned_source,
         source_at_lines,
         id: c.id,
         title: c.title.unwrap_or_else(|| format!("Chunk {}", c.ordinal)),
@@ -1358,6 +1452,7 @@ pub(crate) async fn build_artifact_detail(
         status: c.status,
         last_verified_at: c.last_verified_at,
         caveats: c.caveats,
+        sources,
         corpus_id: c.corpus_id,
         // A merged artifact has no corpus and so cannot have a restored one.
         corpus_restored: src.as_ref().is_some_and(|s| s.restored_at.is_some()),
@@ -1438,6 +1533,7 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/ops/artifacts/{id}/unsupersede", post(unsupersede_ui))
         .route("/ui/ops/artifacts/{id}/deprecate", post(deprecate_ui))
         .route("/ui/ops/artifacts/{id}/reactivate", post(reactivate_ui))
+        .route("/ui/ops/merges/{id}/undo", post(undo_merge_ui))
         .route("/ui/ops/artifacts/{id}/verify", post(verify_ui))
         .route("/ui/ops/pairs/{id}/dismiss", post(dismiss_pair_ui))
         .route(
@@ -1507,6 +1603,65 @@ mod tests {
             !r.snippet.contains('<'),
             "the snippet must not carry markup"
         );
+    }
+
+    #[tokio::test]
+    async fn a_merged_artifact_shows_its_sources_instead_of_corpus_lines() {
+        // A captured artifact renders the corpus lines its span claims. A merged
+        // one has neither corpus nor span, so the pane shows what it was written
+        // from — each source still stored, each still naming its own document.
+        // Rendering a corpus it did not come from would put the wrong lines
+        // beside it forever, which is the one dishonesty merging must not
+        // commit.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        let m = crate::jobs::merge::write(
+            &core,
+            &crate::infer::prompt::MergedDraft {
+                title: Some("a and b".into()),
+                text: "a text and b text".into(),
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+            },
+            &ids,
+        )
+        .await
+        .unwrap();
+
+        let d = build_artifact_detail(&core, &m.id, "").await.unwrap();
+
+        assert_eq!(d.corpus_id, None, "a merged artifact claimed a corpus");
+        assert!(
+            d.slice_lines.is_empty(),
+            "a merged artifact rendered lines from a document it did not come from"
+        );
+        assert_eq!(d.sources.len(), 2);
+        let listed: Vec<&str> = d.sources.iter().map(|s| s.id.as_str()).collect();
+        for id in &ids {
+            assert!(listed.contains(&id.as_str()), "source {id} is not listed");
+        }
+        // And each source still points at the document it was captured from.
+        assert!(d.sources.iter().all(|s| !s.corpus_id.is_empty()));
+        assert!(!d.orphaned_source);
+    }
+
+    #[tokio::test]
+    async fn a_captured_artifact_lists_no_sources() {
+        // The template branches on the list being empty, so a captured artifact
+        // filling it would swap its corpus lines for a provenance list it does
+        // not have.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(&core, &[("a text", [1.0, 0.0])]).await;
+
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+
+        assert!(d.sources.is_empty());
+        assert!(d.corpus_id.is_some());
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1531,6 +1531,13 @@ async fn mark_artifact_reviewed(
     _id: Identity,
     Path(cid): Path<String>,
 ) -> Result<Response> {
+    // For an orphaned merge, "reviewed" means accepted as a merge of what
+    // remains — recorded on source_count, or the next sweep re-flags it and
+    // the operator's judgement lasts one tick.
+    let c = st.core.store.get_artifact(&cid).await?;
+    if c.flags.iter().any(|f| f == "orphaned_source") {
+        st.core.store.accept_source_loss(&cid).await?;
+    }
     st.core.store.clear_artifact_flags(&cid).await?;
     Ok(axum::response::Html(String::new()).into_response())
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -98,10 +98,20 @@ pub struct ArtifactDetail {
     /// `None` for a merged artifact, which belongs to no corpus. The pane shows
     /// what it was made of instead of corpus lines — see `build_artifact_detail`.
     pub corpus_id: Option<String>,
-    /// What a merged artifact was written from. Empty for a captured one, which
-    /// is what the template branches on: a captured artifact renders the corpus
-    /// lines its span claims, a merged one renders these.
+    /// What a merged artifact was written from. Empty for a captured one — and
+    /// also for a merged one that has lost every source to a delete, which is
+    /// why `merged` and not this is what the template branches on.
     pub sources: Vec<SourceRow>,
+    /// Which of the two panes to render. A merged artifact belongs to no corpus
+    /// and has no span, so the source pane has no document to link and no lines
+    /// to list; it shows what the artifact was written from instead.
+    ///
+    /// The template used to branch on `sources` being empty, which is the same
+    /// question only while a merge still has its sources. One that had lost them
+    /// all fell through to the captured branch and rendered a "Source · …
+    /// highlighted" label over an empty link and an empty line table — on
+    /// exactly the artifact whose orphan notice matters most.
+    pub merged: bool,
     /// True when one of those sources has since been deleted. The text still
     /// carries what it said, so this is a missing link rather than missing
     /// knowledge — and saying so beats listing one source fewer in silence.
@@ -1034,7 +1044,12 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         let mut sources = Vec::new();
         for rid in roots.get(&c.id).into_iter().flatten() {
             // A source deleted since leaves no row. `orphaned` is what says so,
-            // rather than the list quietly being one shorter.
+            // rather than the list quietly being one shorter — and `roots_of`
+            // answers "itself" once the last row is gone, which must not be
+            // rendered as a merge written from itself.
+            if rid == &c.id {
+                continue;
+            }
             if let Ok(r) = st.core.store.get_artifact(rid).await {
                 sources.push(SourceRow {
                     corpus_id: r.corpus_id.clone().unwrap_or_default(),
@@ -1383,8 +1398,9 @@ pub(crate) async fn build_artifact_detail(
         Some(s) => crate::web::corpus_view::for_corpus(s).slice(s, c.corpus_span.as_ref(), 3),
         None => crate::web::corpus_view::CorpusSlice::default(),
     };
-    // Only a merged artifact has these, and the template branches on the list
-    // being non-empty rather than on the kind — one fewer field to keep in step.
+    // Only a merged artifact has these. The template branches on `merged`, not
+    // on this list, because a merge can lose every source to a delete and still
+    // be a merge.
     let mut sources = Vec::new();
     if c.provenance == crate::store::artifacts::Provenance::Merged {
         let roots = core
@@ -1393,6 +1409,13 @@ pub(crate) async fn build_artifact_detail(
             .await
             .unwrap_or_default();
         for rid in roots.get(&c.id).into_iter().flatten() {
+            // `roots_of` answers "itself" for an artifact with no lineage rows,
+            // which is the safe reading where it is used to build a prompt and
+            // the wrong one here: it would list a merge that has lost every
+            // source as having been written from itself.
+            if rid == &c.id {
+                continue;
+            }
             if let Ok(r) = core.store.get_artifact(rid).await {
                 sources.push(SourceRow {
                     corpus_id: r.corpus_id.clone().unwrap_or_default(),
@@ -1453,6 +1476,7 @@ pub(crate) async fn build_artifact_detail(
         last_verified_at: c.last_verified_at,
         caveats: c.caveats,
         sources,
+        merged: c.provenance == crate::store::artifacts::Provenance::Merged,
         corpus_id: c.corpus_id,
         // A merged artifact has no corpus and so cannot have a restored one.
         corpus_restored: src.as_ref().is_some_and(|s| s.restored_at.is_some()),
@@ -1652,16 +1676,57 @@ mod tests {
 
     #[tokio::test]
     async fn a_captured_artifact_lists_no_sources() {
-        // The template branches on the list being empty, so a captured artifact
-        // filling it would swap its corpus lines for a provenance list it does
-        // not have.
+        // The template branches on provenance, and a captured artifact filling
+        // this list would put a provenance list it does not have where its
+        // corpus lines belong.
         let core = crate::core::test_support::test_core().await;
         let ids = crate::jobs::consolidate::tests::seed(&core, &[("a text", [1.0, 0.0])]).await;
 
         let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
 
         assert!(d.sources.is_empty());
+        assert!(!d.merged);
         assert!(d.corpus_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_merge_that_lost_every_source_still_renders_as_a_merge() {
+        // An empty source list is not the same question as "was this captured".
+        // The template branched on the list, so a merge whose sources had all
+        // been deleted fell through to the captured branch and rendered a
+        // "Source · … highlighted" label over an empty link and an empty line
+        // table — on exactly the artifact whose orphan notice matters most.
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])],
+        )
+        .await;
+        let m = crate::jobs::merge::write(
+            &core,
+            &crate::infer::prompt::MergedDraft {
+                title: Some("a and b".into()),
+                text: "a text and b text".into(),
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+            },
+            &ids,
+        )
+        .await
+        .unwrap();
+        for id in &ids {
+            core.store.delete_artifact(id).await.unwrap();
+        }
+
+        let d = build_artifact_detail(&core, &m.id, "").await.unwrap();
+
+        assert!(d.sources.is_empty(), "the fixture did not lose the sources");
+        assert!(d.merged, "a merge was rendered as a captured artifact");
+        assert!(
+            d.source_at_lines.is_empty() && d.slice_lines.is_empty(),
+            "there is no document to link and no lines to show"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1050,10 +1050,11 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             .unwrap_or_default();
         let mut sources = Vec::new();
         for rid in roots.get(&c.id).into_iter().flatten() {
-            // A source deleted since leaves no row. `orphaned` is what says so,
-            // rather than the list quietly being one shorter — and `roots_of`
-            // answers "itself" once the last row is gone, which must not be
-            // rendered as a merge written from itself.
+            // A source deleted since leaves no row. `orphaned` is what says
+            // so, rather than the list quietly being one shorter. `roots_of`
+            // now answers an empty list for a merge that lost every source;
+            // the self guard stays as defense against a base written before
+            // that change.
             if rid == &c.id {
                 continue;
             }
@@ -1416,10 +1417,10 @@ pub(crate) async fn build_artifact_detail(
             .await
             .unwrap_or_default();
         for rid in roots.get(&c.id).into_iter().flatten() {
-            // `roots_of` answers "itself" for an artifact with no lineage rows,
-            // which is the safe reading where it is used to build a prompt and
-            // the wrong one here: it would list a merge that has lost every
-            // source as having been written from itself.
+            // `roots_of` now answers an empty list for a merge with no lineage
+            // rows, so nothing here would list a merge as written from itself;
+            // the guard stays as defense against a base written before that
+            // change.
             if rid == &c.id {
                 continue;
             }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -183,6 +183,9 @@ pub struct PairRow {
     pub b_title: String,
     pub detail: Option<String>,
     pub contradiction: bool,
+    /// The model would merge these. Rendered with its own header so the page
+    /// never claims a disagreement the model did not find.
+    pub would_merge: bool,
     /// Set when the judge named a direction with enough confidence to propose
     /// a supersede. A recommendation only: nothing here has hidden anything,
     /// and either side can still be kept.
@@ -884,13 +887,16 @@ fn title_of(c: &crate::store::artifacts::Chunk) -> String {
 /// the cap strands nothing — there is no second page to go and find the rest
 /// on, which is the point: Housekeeping is reference, not work.
 const PAIR_LIMIT: usize = 5;
-const PAIR_STATES: [crate::store::pairs::PairState; 4] = [
+const PAIR_STATES: [crate::store::pairs::PairState; 5] = [
     crate::store::pairs::PairState::Contradiction,
     crate::store::pairs::PairState::Superseded,
     // A group past `merge_max_roots` was not merged and will not be: it needs a
     // person, so it belongs on the page a person opens rather than on
     // Housekeeping beside the things that resolve themselves.
     crate::store::pairs::PairState::Oversized,
+    // A merge verdict recorded in observation mode: worth a person's read,
+    // less urgent than something the base states differently.
+    crate::store::pairs::PairState::WouldMerge,
     crate::store::pairs::PairState::Pending,
 ];
 
@@ -940,6 +946,7 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
                 b_id: p.b_id,
                 detail: p.detail,
                 contradiction: state == crate::store::pairs::PairState::Contradiction,
+                would_merge: state == crate::store::pairs::PairState::WouldMerge,
                 obsolete_title,
                 keeps_a,
                 keeps_b,

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -332,6 +332,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
             std::time::Duration::ZERO,
         )),
         corpus_locks: Default::default(),
+        lifecycle_lock: Default::default(),
     };
     let translated = index(&core, &artifacts).await;
 

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -123,7 +123,15 @@ async fn evaluate_retrieval() {
         let expect = translated
             .get(&pair.expect)
             .expect("every pair was checked against artifacts.json above");
-        let rank = results.iter().position(|r| &r.artifact_id == expect);
+        // Anything that superseded it counts too. A merge moves the knowledge
+        // into a new artifact and search correctly returns that one instead, so
+        // scoring only the original would report a retrieval regression that is
+        // really a bookkeeping change — and the one number that says whether
+        // merging helps would be unreadable exactly when it matters.
+        let satisfies = resolve_expected(&core, expect).await;
+        let rank = results
+            .iter()
+            .position(|r| satisfies.iter().any(|id| id == &r.artifact_id));
         if rank.is_none_or(|i| i >= LIMIT) {
             misses.push((pair, rank));
         }
@@ -132,6 +140,36 @@ async fn evaluate_retrieval() {
 
     report(&cfg, &artifacts, &pairs, &ranks, &misses, cap);
     vectors.drop_collection().await.unwrap();
+}
+
+/// The artifact ids that satisfy a grade naming `expected`: itself, plus
+/// whatever superseded it.
+///
+/// A graded pair names the artifact that answered the query. When consolidation
+/// merges it into another, or supersedes it in favour of one that plainly
+/// replaced it, the knowledge is in the survivor and search returns that. The
+/// grade is still satisfied; only the id changed.
+///
+/// Bounded rather than trusted to terminate. Chains should not exist — a merge
+/// re-points what it hides, precisely so no reader lands on a hidden winner —
+/// but a harness that hangs on a cycle in the data is worse than one that stops
+/// looking after a few hops.
+async fn resolve_expected(core: &Core, expected: &str) -> Vec<String> {
+    let mut out = vec![expected.to_string()];
+    let mut cursor = expected.to_string();
+    for _ in 0..8 {
+        match core.store.get_artifact(&cursor).await {
+            Ok(c) => match c.superseded_by {
+                Some(next) => {
+                    out.push(next.clone());
+                    cursor = next;
+                }
+                None => break,
+            },
+            Err(_) => break,
+        }
+    }
+    out
 }
 
 /// Load the frozen artifacts and embed them, reporting the id each one was
@@ -318,5 +356,36 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         results.iter().position(|r| &r.artifact_id == expect),
         Some(0),
         "the frozen id was never translated to the one the store minted"
+    );
+
+    // And a grade against an artifact that has since been merged away is still
+    // satisfied by the artifact the knowledge moved into. Without this the
+    // score collapses for a bookkeeping reason and the one number that says
+    // whether merging helps becomes unreadable exactly when it matters.
+    let other = translated.get("frozen-1").unwrap();
+    let merged = core
+        .store
+        .insert_merged_artifact(
+            &engram::store::artifacts::NewMerged {
+                text: "a journal records intent before the write, in clusters".into(),
+                title: Some("journal and cluster".into()),
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+            },
+            &[expect.clone(), other.clone()],
+        )
+        .await
+        .unwrap();
+    core.supersede(expect, &merged.id).await.unwrap();
+
+    let satisfies = resolve_expected(&core, expect).await;
+    assert!(
+        satisfies.contains(&merged.id),
+        "a grade against a merged-away artifact no longer resolves: {satisfies:?}"
+    );
+    assert!(
+        satisfies.contains(expect),
+        "the original must still satisfy its own grade"
     );
 }

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -58,6 +58,7 @@ fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPo
             status: None,
             last_verified_at: None,
             superseded_by: None,
+            provenance: None,
         },
     }
 }
@@ -781,6 +782,7 @@ fn hybrid_point(id: &str, text: &str, dense: Vec<f32>) -> VectorPoint {
             status: None,
             last_verified_at: None,
             superseded_by: None,
+            provenance: None,
         },
     }
 }
@@ -982,6 +984,7 @@ fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint 
             // scores, so it has to set the field the formula actually uses.
             last_verified_at: Some(ts),
             superseded_by: None,
+            provenance: None,
         },
     }
 }


### PR DESCRIPTION
Consolidation stops needing an operator. It finds duplicates completely
rather than by sampling, settles a whole group in one model call, and
either supersedes a redundant artifact or writes one merged artifact in
place of several — while a value conflict still goes to a person.

Design: `docs/superpowers/specs/2026-08-14-autonomous-consolidation-design.md`
Plan: `docs/superpowers/plans/2026-08-14-autonomous-consolidation.md`

## Why

Two things did not scale.

**Detection was a lottery.** `near_pairs` sampled 2000 points per sweep and
computed pairs only *within* that draw, so both members of a pair had to land
in the same sample — probability (s/N)², decaying quadratically:

| Artifacts | P(pair found per sweep) | Expected wait |
|---|---|---|
| 5,000 | ~16% | ~6 days |
| 100,000 | ~0.04% | ~7 years |

No judge fixes a pair the detector never hands over.

**The prefilter had the wrong polarity.** `may_disagree` admitted a pair only
when both sides stated values *and those values differed*. Right for "do these
contradict?", backwards for "are these duplicates?" — two artifacts at 0.93
saying the same thing in different words were filed "nothing to decide" and both
stayed in every result set. The single best merge candidate was the one case the
model never saw.

## What changed

**Detection.** A `Stage::Relate` unit asks each artifact for its own neighbours
when it finishes embedding. `neighbours()` queries by point id, so no embedding
call is paid, and lifecycle filtering is already there. Coverage becomes 1
regardless of N: for a pair (X, Y), whichever is embedded second finds the other.
The sweep keeps the backlog, the backstop, the clustering, and the repairs.

**The contract.** Four verdicts — `distinct`, `conflict`, `replaced`,
`duplicate` — settling a whole connected component in one call rather than a
pair at a time. `replaced` is preferred wherever it applies: the survivor is
then a stored original with a valid span, which beats a rewrite. A merge happens
only when *both* sides carry something the other lacks.

**Merged artifacts.** A distinct `provenance` kind with `corpus_id` nullable,
naming its sources through `artifact_sources` — stored as the resolved closure,
so a re-merge is always written from *captured roots* and information loss stays
one generation deep however often a group is merged.

## What bounds it

`consolidate.autonomous` defaults to **true**, so a fresh instance consolidates
its own knowledge base unasked. Four things make that defensible, and they are
part of the fidelity thesis rather than exceptions to it:

- Superseding is preferred wherever one stored original suffices, so most groups
  produce no synthetic text at all.
- Merged artifacts are never mistakable for captured passages, in the store or
  in the UI.
- Originals are superseded, never deleted — one write from active, one button
  from restored.
- **No merge may drop a value or a literal any source carried.** Two local,
  free checks (`jobs::merge::losses`); one that would is escalated with the
  reason, not written.

A disagreement about a value is escalated to a person and never merged.

Turning autonomy off does not stop the pass asking — verdicts are recorded
either way, so the queue can be read before the system is granted the authority
to act on it. `max_dedupe_per_tick = 0` is what switches the model off.

## Three bugs the tests caught

1. **Supersession chains.** Merging M1(a,b) with c left `a → M1 → M2`: a chain
   whose middle is out of results, so the reader who opens `a` lands nowhere and
   no page can follow the second hop. `Core::repoint_supersession` moves what an
   about-to-be-hidden merge was hiding.
2. **Subsumed merges.** Superseding only the roots left an earlier merge active
   and near-identical to the new one — the relate unit would re-pair them every
   sweep, forever. `subsumed_merges` closes it from stored data, so it survives
   a crash.
3. **Asking vs acting.** The rename left the sweep gating *arming* on
   `autonomous`, so with it off nothing was ever asked — and an operator would
   have been switching autonomy on having read no verdicts at all, which is the
   leap the flag exists to prevent.

## Also here

- **Lifecycle repair from a marker.** `lifecycle_dirty` rides the same UPDATE as
  the change it describes. The scan it fronts is O(hidden artifacts), which
  merging makes grow monotonically. The scan stays — it alone catches a payload
  mutated out of band, which leaves an artifact unreachable — but it is no
  longer the only cover.
- **Budget becomes a rate.** Its own ticker, ~20 calls/hour, because the fixed
  quantity is hardware throughput rather than the base size. Units sort behind
  capture work: a large ingest may delay tidying up, not the reverse.
- **Rename.** `judge` → `dedupe` throughout the consolidation path. `/ui/judge`
  (relevance feedback) is untouched.

## Verification

`cargo test`: **784 passed, 0 failed**, exit 0. `cargo clippy --all-targets`
clean, `cargo fmt --check` clean, schema applies to a fresh database.

## Note for the reviewer

**This requires recreating the database.** `migrate` cannot alter a table, and
`corpus_id` losing `NOT NULL` is a column change.

The eval harness now resolves a grade through supersession (`tests/eval.rs`), so
a merged-away artifact still satisfies its pair. Worth running before and after
a merge pass over a real corpus — whether merging helps retrieval is a
measurement this PR makes readable, not one it answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWVC4uHAK372Gr9yZYjYj3