### PR TITLE
feat: image capture — photos as corpora, read by a vision model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,10 +427,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1250,6 +1262,8 @@ dependencies = [
  "encoding_rs",
  "hex",
  "html2md",
+ "image",
+ "kamadak-exif",
  "mime_guess",
  "openidconnect",
  "pulldown-cmark",
@@ -1336,6 +1350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1392,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -2006,6 +2030,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2216,15 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
 ]
 
 [[package]]
@@ -2395,6 +2454,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2479,12 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -2880,6 +2955,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +3033,18 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -5358,4 +5458,19 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ html2md = "0.2.15"
 encoding_rs = "0.8.35"
 url = "2"
 schemars = "1.2.2"
+# Decoding, orientation and the downscaled preview of a captured image. Only
+# the three formats a phone or a browser actually hands over.
+image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "webp"] }
+# EXIF is where the phone says when and where a photo was taken.
+kamadak-exif = "0.6.1"
 
 [dev-dependencies]
 # `test-util` is not part of tokio's `full`. It carries the pausable clock the

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Claude Code or Claude Desktop can read and write it mid-session.
 A **corpus** is what you paste: a chapter, a manual, a transcript. Stored
 verbatim, never edited, and the provenance every answer traces back to.
 
+A corpus can also be a **photo or image** — a whiteboard, a receipt, a page,
+a diagram — dropped on the capture page, taken with the phone camera through
+the installed PWA, pasted from the clipboard, or sent to
+`POST /api/v1/corpora/image` (multipart `image`, optional `note` and
+`title_hint`). Needs `[infer.vision]` in the config; without it the image door
+is closed. The original file is kept untouched and served at
+`GET /api/v1/corpora/{id}/image?original=1`; a vision model reads it into
+markdown in the background, and from there it is a text corpus like any other.
+File facts and EXIF (time, camera, location) are recorded on the corpus and
+handed to the model as context. Every file door also accepts a short `note` —
+your own words about what the file is — which is stored with the corpus and,
+for an image, read by the model too.
+
 A **segment** is a slice of one corpus, sized to fit the model's context. The
 split is local and mechanical — a heading, then a blank line, then wherever the
 budget runs out. It stores line numbers rather than a copy, and doubles as the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ markdown in the background, and from there it is a text corpus like any other.
 File facts and EXIF (time, camera, location) are recorded on the corpus and
 handed to the model as context. Every file door also accepts a short `note` —
 your own words about what the file is — which is stored with the corpus and,
-for an image, read by the model too.
+for an image, read by the model too. A photo the model cannot read — the
+endpoint refuses it, it answers with nothing, or the retries run out — is shown
+as `failed` with the reason on its page; **Re-read** on that page (or
+`POST /api/v1/corpora/{id}/reprocess` with `{"stage":"describe"}`) reads it
+again from the stored original, with whatever model is configured now.
 
 A **segment** is a slice of one corpus, sized to fit the model's context. The
 split is local and mechanical — a heading, then a blank line, then wherever the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,8 +137,9 @@ to the query path.
   as the label — and the pane needs no changes. `.txt` upload and image
   capture are in: images live in the `attachments` table beside their corpus,
   are read by the `[infer.vision]` role in a `describe` job, and render
-  through `ImageTranscript`; PDF slots into the same two places. The body
-  limit is 8 MB globally and 25 MB on the image door.
+  through `ImageTranscript`, and can be re-read from the stored original with
+  `reprocess(describe)`; PDF slots into the same two places. The body limit is
+  8 MB globally and 25 MB on the image door.
 - **Backup and restore.** Qdrant snapshots plus the SQLite file, restored
   together, so recovery does not mean paying for every embedding again. The
   snapshot is the artifact of record for a rebuild; a reindex is the fallback,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,11 +131,14 @@ to the query path.
 
 ## [Core Platform & Tooling]
 
-- **File upload**, then **PDF**, then a **CLI**. The detail pane asks a
-  `SourceView` for the lines an artifact claims, so a PDF corpus implements the
-  same trait — extracted text, a page map, `page 42` as the label — and the
-  pane needs no changes. Upload comes first; the body limit is explicit now, at
-  8 MB.
+- ~~**File upload**~~, ~~**image capture**~~, then **PDF**, then a **CLI**.
+  The detail pane asks a `CorpusView` for the lines an artifact claims, so a
+  PDF corpus implements the same trait — extracted text, a page map, `page 42`
+  as the label — and the pane needs no changes. `.txt` upload and image
+  capture are in: images live in the `attachments` table beside their corpus,
+  are read by the `[infer.vision]` role in a `describe` job, and render
+  through `ImageTranscript`; PDF slots into the same two places. The body
+  limit is 8 MB globally and 25 MB on the image door.
 - **Backup and restore.** Qdrant snapshots plus the SQLite file, restored
   together, so recovery does not mean paying for every embedding again. The
   snapshot is the artifact of record for a rebuild; a reindex is the fallback,

--- a/config.example.toml
+++ b/config.example.toml
@@ -120,6 +120,17 @@ context_tokens = 32768
 # model = "bge-reranker-v2-m3"
 # style = "tei"
 
+# Reading captured images. Optional and disabled by default: with this block
+# absent the image door is closed and the capture page offers text only.
+# `model` is required. `base_url` and `api_key` default to the synthesize
+# role's, which is the common case — one local server hosting a multimodal
+# model. Set them when a separate vision endpoint serves the images.
+# [infer.vision]
+# model = "qwen2.5-vl-7b"
+# base_url = "http://localhost:8002/v1"
+# api_key = ""
+# timeout_secs = 120
+
 # ── Authentication ──────────────────────────────────────────────────────────
 # Exactly one mode is active.
 
@@ -274,3 +285,9 @@ fetch_max_bytes = 8388608
 # a corpus that quietly holds the subscribe prompt instead of the article is
 # worse than no capture at all.
 min_extracted_chars = 200
+# Bytes an uploaded image may weigh. The image door has its own ceiling
+# because a phone photo is several times the 8 MB the rest of the API allows.
+image_max_bytes = 26214400
+# Longest edge of the preview shown to the vision model and in the UI. The
+# original is stored untouched either way.
+image_preview_edge = 2048

--- a/docs/superpowers/plans/2026-08-15-image-capture.md
+++ b/docs/superpowers/plans/2026-08-15-image-capture.md
@@ -1,0 +1,2364 @@
+# Image Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Photos and images become first-class corpora: uploaded instantly, stored verbatim, read into markdown by a vision model in a background job, then processed by the existing text pipeline untouched.
+
+**Architecture:** A new `attachments` table holds the original bytes and a derived preview; a generic `corpora.metadata` JSON column holds file facts, EXIF and the user's `note`. `POST /api/v1/corpora/image` validates, decodes, extracts EXIF, builds the preview, inserts a corpus in the new `describing` status and enqueues the new `Describe` job stage. That stage calls the new `Describer` trait (optional `[infer.vision]` role, inheriting the synthesize endpoint when its own is absent), writes the markdown into `raw_text`, runs the existing near-duplicate check, and hands off to `Synthesize`. The capture page's drop zone accepts images from picker/camera/drag/paste plus an optional context note; the corpus page renders the photo and metadata with the transcription labelled as derived.
+
+**Tech Stack:** Rust 2024 / axum 0.8 / sqlx 0.9 SQLite / askama / htmx; new crates `image` (jpeg, png, webp features only) and `kamadak-exif`. OpenAI-compatible chat/completions with content-array (`image_url` data URI) messages.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-image-capture-design.md`
+
+## Global Constraints
+
+- The capture request path makes **no inference call**. Only `Stage::Describe` calls the vision model.
+- Original image bytes are stored untouched; only the preview is re-encoded.
+- `corpora.raw_text` stays `NOT NULL`; it is `''` while `describing`.
+- New columns go through `ADDED_COLUMNS` in `src/store/mod.rs` (append-only, with default). New tables go in `src/store/schema.sql` as `CREATE TABLE IF NOT EXISTS`.
+- Every background inference call goes through `core.gate.background()` and reports `succeeded()`/`failed(&e)`.
+- Supported image inputs: JPEG, PNG, WebP — sniffed from bytes, never trusted from the declared mime.
+- Config: `[infer.vision]` absent → image capture disabled; `model` required when present; `base_url`/`api_key` inherit from `[infer.synthesize]` when absent; `timeout_secs` default 120.
+- Config: `capture.image_max_bytes` default `25 * 1024 * 1024`; `capture.image_preview_edge` default `2048`.
+- Origin value for image corpora: `image`. New corpus status: `describing`. New job stage string: `describe`.
+- Metadata JSON namespaces: `note` (string), `file` (`name,size,mime,width,height`), `exif` (`taken_at,camera,orientation,gps{lat,lon,alt},tags{...}`), `describe` (`error`).
+- Every new inference-free store/API function has a test; every refusal is a distinct, tested error message.
+- Run `cargo test` (all green) and `cargo clippy --all-targets -- -D warnings` before every commit. Commit message trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `Cargo.toml` | add `image`, `kamadak-exif` |
+| `src/config.rs` | `VisionRole`, `CaptureConfig.image_*`, redaction |
+| `config.example.toml` | documented `[infer.vision]` + capture keys |
+| `src/store/schema.sql` | `attachments` table |
+| `src/store/mod.rs` | `ADDED_COLUMNS` gets `corpora.metadata`; `pub mod attachments` |
+| `src/store/attachments.rs` (new) | `Attachment`, insert/get |
+| `src/store/corpora.rs` | `CorpusStatus::Describing`, `Corpus.metadata`, `insert_image_corpus`, `set_described_text`, `set_corpus_metadata`, metadata on `insert_corpus_with_signature` |
+| `src/store/jobs.rs` | `Stage::Describe` |
+| `src/core/image.rs` (new) | `prepare()`: sniff, decode, EXIF→JSON, orientation, preview |
+| `src/infer/mod.rs` | `Describer` trait |
+| `src/infer/openai.rs` | `HttpDescriber` |
+| `src/infer/fake.rs` | `FakeDescriber` |
+| `src/infer/prompt.rs` | `DESCRIBE_SYSTEM`, `describe_context()` |
+| `src/core/mod.rs` | `Core.describer`, wiring, test_support |
+| `src/core/ingest.rs` | `Capture.metadata`, `ImageCapture`, `Core::ingest_image` |
+| `src/jobs/describe.rs` (new) + `src/jobs/mod.rs` | the `Describe` stage |
+| `src/web/api.rs` | `upload_image`, `get_image`, `note` on `upload`, per-route body limit |
+| `src/web/mod.rs` | pass `image_max_bytes` into `api_router` |
+| `src/web/ui.rs`, `templates/capture.html`, `templates/corpus.html`, `src/web/corpus_view.rs` | UI |
+| `src/main.rs` | vision probe |
+
+---
+
+### Task 1: Config — the vision role and image capture limits
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/config.rs` (CaptureConfig ~line 27, InferConfig ~line 286, `redacted` ~line 634, tests ~line 660+)
+- Modify: `config.example.toml` (after `[infer.ask]` block ~line 113; `[capture]` block ~line 261)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct VisionRole { pub model: String, pub base_url: Option<String>, pub api_key: Option<String>, pub timeout_secs: u64 }
+  impl VisionRole { pub fn resolve(&self, synth: &SynthesizeRole) -> (String, Option<String>) } // (base_url, api_key)
+  pub struct InferConfig { ..., pub vision: Option<VisionRole> }
+  pub struct CaptureConfig { ..., pub image_max_bytes: usize, pub image_preview_edge: u32 }
+  ```
+
+- [ ] **Step 1: Add the crates**
+
+Run: `cargo add image --no-default-features --features jpeg,png,webp && cargo add kamadak-exif`
+Expected: `Cargo.toml` gains both lines (image 0.25.x, kamadak-exif 0.6.x). Add a comment above them:
+```toml
+# Decoding, orientation and the downscaled preview of a captured image. Only
+# the three formats a phone or a browser actually hands over.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+# EXIF is where the phone says when and where a photo was taken.
+kamadak-exif = "0.6"
+```
+
+- [ ] **Step 2: Write the failing config tests**
+
+Append to the `tests` module in `src/config.rs`:
+
+```rust
+    #[test]
+    fn vision_is_off_unless_configured() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, MINIMAL);
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert!(cfg.infer.vision.is_none(), "vision must default to disabled");
+        assert_eq!(cfg.capture.image_max_bytes, 25 * 1024 * 1024);
+        assert_eq!(cfg.capture.image_preview_edge, 2048);
+    }
+
+    #[test]
+    fn a_vision_role_without_its_own_endpoint_inherits_synthesize() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, &format!("{MINIMAL}\n[infer.vision]\nmodel = \"qwen-vl\"\n"));
+        let cfg = Config::load(Some(&p)).unwrap();
+        let v = cfg.infer.vision.as_ref().expect("configured");
+        assert_eq!(v.model, "qwen-vl");
+        assert_eq!(v.timeout_secs, 120);
+        let (url, key) = v.resolve(&cfg.infer.synthesize);
+        assert_eq!(url, cfg.infer.synthesize.base_url);
+        assert_eq!(key, cfg.infer.synthesize.api_key);
+    }
+
+    #[test]
+    fn a_dedicated_vision_endpoint_wins_over_synthesize() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            &format!(
+                "{MINIMAL}\n[infer.vision]\nmodel = \"qwen-vl\"\nbase_url = \"http://vision:9000/v1\"\napi_key = \"vk\"\n"
+            ),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        let (url, key) = cfg.infer.vision.as_ref().unwrap().resolve(&cfg.infer.synthesize);
+        assert_eq!(url, "http://vision:9000/v1");
+        assert_eq!(key.as_deref(), Some("vk"));
+        assert!(!cfg.redacted().contains("\"vk\""), "vision key leaked");
+    }
+
+    #[test]
+    fn the_example_config_documents_the_vision_role() {
+        let text = std::fs::read_to_string("config.example.toml").unwrap();
+        assert!(text.contains("[infer.vision]"), "example config must show the vision block");
+        assert!(text.contains("image_max_bytes"));
+    }
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `cargo test config::tests::vision -- --nocapture 2>&1 | tail -20`
+Expected: compile error — `vision`, `image_max_bytes` unknown.
+
+- [ ] **Step 4: Implement**
+
+In `CaptureConfig` add fields and defaults:
+```rust
+    /// Bytes an uploaded image may weigh. A phone photo is 3–8 MB; this is the
+    /// per-route ceiling for the image door only, the global body limit stays.
+    pub image_max_bytes: usize,
+    /// Longest edge, in pixels, of the preview the vision model is shown and
+    /// the UI displays. The original is stored untouched regardless.
+    pub image_preview_edge: u32,
+```
+and in `Default`: `image_max_bytes: 25 * 1024 * 1024, image_preview_edge: 2048,`.
+
+After `RerankRole` add:
+```rust
+/// The vision model that reads a captured image into text. Optional: absent
+/// means the image door is closed. `base_url` and `api_key` are optional
+/// because the common case is the synthesize endpoint serving a multimodal
+/// model too — then only `model` needs saying.
+#[derive(Debug, Deserialize, Clone)]
+pub struct VisionRole {
+    pub model: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default = "default_vision_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_vision_timeout_secs() -> u64 {
+    120
+}
+
+impl VisionRole {
+    /// The endpoint and key this role actually calls: its own where given,
+    /// the synthesize role's otherwise.
+    pub fn resolve(&self, synth: &SynthesizeRole) -> (String, Option<String>) {
+        (
+            self.base_url.clone().unwrap_or_else(|| synth.base_url.clone()),
+            self.api_key.clone().or_else(|| synth.api_key.clone()),
+        )
+    }
+}
+```
+Add `#[serde(default)] pub vision: Option<VisionRole>,` to `InferConfig`. In `redacted()` add:
+```rust
+        if let Some(v) = c.infer.vision.as_mut() {
+            v.api_key = v.api_key.as_ref().map(|_| R.into());
+        }
+```
+
+In `config.example.toml`, after the rerank block:
+```toml
+# Reading captured images. Optional and disabled by default: with this block
+# absent the image door is closed and the capture page offers text only.
+# `model` is required. `base_url` and `api_key` default to the synthesize
+# role's, which is the common case — one local server hosting a multimodal
+# model. Set them when a separate vision endpoint serves the images.
+# [infer.vision]
+# model = "qwen2.5-vl-7b"
+# base_url = "http://localhost:8002/v1"
+# api_key = ""
+# timeout_secs = 120
+```
+Wait — the test asserts the literal `[infer.vision]` is present; a commented line contains it, so this passes while keeping the block off by default. In the `[capture]` block append:
+```toml
+# Bytes an uploaded image may weigh. The image door has its own ceiling
+# because a phone photo is several times the 8 MB the rest of the API allows.
+image_max_bytes = 26214400
+# Longest edge of the preview shown to the vision model and in the UI. The
+# original is stored untouched either way.
+image_preview_edge = 2048
+```
+
+- [ ] **Step 5: Run and commit**
+
+Run: `cargo test config:: 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+Expected: all pass, no warnings.
+```bash
+git add Cargo.toml Cargo.lock src/config.rs config.example.toml
+git commit -m "feat(config): optional vision role and image capture limits"
+```
+
+---
+
+### Task 2: Store — status, stage, metadata column, attachments table
+
+**Files:**
+- Modify: `src/store/schema.sql` (after the `corpora` table)
+- Modify: `src/store/mod.rs` (`ADDED_COLUMNS`, `pub mod attachments`)
+- Create: `src/store/attachments.rs`
+- Modify: `src/store/corpora.rs`
+- Modify: `src/store/jobs.rs` (`Stage`)
+- Modify: `src/web/ui.rs:221-232` (`status_badge`), `:722` (`in_flight`)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  // corpora.rs
+  pub enum CorpusStatus { Describing, Raw, ... }            // "describing"
+  pub struct Corpus { ..., pub metadata: serde_json::Value } // '{}' when nothing was recorded
+  Store::insert_corpus_with_signature(raw_text, origin, title_hint, shingles, source_url, metadata: &serde_json::Value) -> Result<Insertion>
+  Store::insert_image_corpus(content_hash: &str, origin: &str, title_hint: Option<&str>, metadata: &serde_json::Value) -> Result<Insertion>
+  Store::set_described_text(id: &str, text: &str, shingles: Vec<u64>) -> Result<()>
+  Store::set_corpus_metadata(id: &str, metadata: &serde_json::Value) -> Result<()>
+  // attachments.rs
+  pub struct Attachment { pub id: i64, pub corpus_id: String, pub kind: String, pub mime: String, pub filename: Option<String>, pub bytes: Vec<u8>, pub preview: Vec<u8>, pub width: Option<i64>, pub height: Option<i64>, pub created_at: i64 }
+  pub struct NewAttachment<'a> { pub corpus_id: &'a str, pub kind: &'a str, pub mime: &'a str, pub filename: Option<&'a str>, pub bytes: &'a [u8], pub preview: &'a [u8], pub width: Option<i64>, pub height: Option<i64> }
+  Store::insert_attachment(&NewAttachment) -> Result<i64>
+  Store::attachment_for_corpus(corpus_id: &str) -> Result<Option<Attachment>>
+  Store::attachment_preview(corpus_id: &str) -> Result<Option<(String /*mime*/, Vec<u8>)>>   // always image/jpeg
+  Store::attachment_original(corpus_id: &str) -> Result<Option<(String, Vec<u8>)>>
+  // jobs.rs
+  Stage::Describe  // "describe"
+  ```
+
+- [ ] **Step 1: Failing tests**
+
+Append to `src/store/corpora.rs` tests:
+```rust
+    #[tokio::test]
+    async fn an_image_corpus_starts_describing_with_no_text_and_its_metadata() {
+        let s = Store::memory().await.unwrap();
+        let meta = serde_json::json!({"file": {"name": "a.jpg"}, "note": "whiteboard"});
+        let ins = s
+            .insert_image_corpus("hash-1", "image", Some("a.jpg"), &meta)
+            .await
+            .unwrap();
+        let src = ins.into_corpus();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert_eq!(src.raw_text, "");
+        assert_eq!(src.content_hash, "hash-1");
+        let back = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(back.metadata["note"], "whiteboard");
+        assert_eq!(back.status, CorpusStatus::Describing);
+
+        // The same photo again is the same row.
+        assert!(matches!(
+            s.insert_image_corpus("hash-1", "image", None, &meta).await.unwrap(),
+            Insertion::Existing(e) if e.id == src.id
+        ));
+    }
+
+    #[tokio::test]
+    async fn describing_writes_the_text_and_signature_but_keeps_the_hash() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_image_corpus("hash-2", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        let sig = crate::store::shingle::signature("hello world");
+        s.set_described_text(&src.id, "hello world", sig.clone()).await.unwrap();
+        let back = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(back.raw_text, "hello world");
+        assert_eq!(back.shingles, sig);
+        assert_eq!(back.content_hash, "hash-2");
+        // Status is the caller's decision, not this write's.
+        assert_eq!(back.status, CorpusStatus::Describing);
+    }
+
+    #[tokio::test]
+    async fn metadata_defaults_to_an_empty_object_and_can_be_replaced() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("plain", "web", None).await.unwrap();
+        assert_eq!(src.metadata, serde_json::json!({}));
+        s.set_corpus_metadata(&src.id, &serde_json::json!({"note": "n"}))
+            .await
+            .unwrap();
+        assert_eq!(s.get_corpus(&src.id).await.unwrap().metadata["note"], "n");
+    }
+```
+
+Create `src/store/attachments.rs` with tests at the bottom:
+```rust
+//! The bytes a corpus was captured from, when it was not text.
+//!
+//! One row per image corpus today. The original is kept exactly as uploaded —
+//! that is the verbatim source, the way `raw_text` is for a paste — and the
+//! preview is derived once, for the model and the screen.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+#[derive(Debug, Clone)]
+pub struct Attachment {
+    pub id: i64,
+    pub corpus_id: String,
+    pub kind: String,
+    pub mime: String,
+    pub filename: Option<String>,
+    pub bytes: Vec<u8>,
+    pub preview: Vec<u8>,
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+    pub created_at: i64,
+}
+
+pub struct NewAttachment<'a> {
+    pub corpus_id: &'a str,
+    pub kind: &'a str,
+    pub mime: &'a str,
+    pub filename: Option<&'a str>,
+    pub bytes: &'a [u8],
+    pub preview: &'a [u8],
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+}
+
+/// What every preview is encoded as. See `core::image::prepare`.
+pub const PREVIEW_MIME: &str = "image/jpeg";
+
+impl Store {
+    pub async fn insert_attachment(&self, a: &NewAttachment<'_>) -> Result<i64> {
+        let res = sqlx::query(
+            "INSERT INTO attachments (corpus_id, kind, mime, filename, bytes, preview, width, height, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(a.corpus_id)
+        .bind(a.kind)
+        .bind(a.mime)
+        .bind(a.filename)
+        .bind(a.bytes)
+        .bind(a.preview)
+        .bind(a.width)
+        .bind(a.height)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.last_insert_rowid())
+    }
+
+    pub async fn attachment_for_corpus(&self, corpus_id: &str) -> Result<Option<Attachment>> {
+        let row = sqlx::query(
+            "SELECT id, corpus_id, kind, mime, filename, bytes, preview, width, height, created_at
+             FROM attachments WHERE corpus_id = ? ORDER BY id LIMIT 1",
+        )
+        .bind(corpus_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| Attachment {
+            id: r.get("id"),
+            corpus_id: r.get("corpus_id"),
+            kind: r.get("kind"),
+            mime: r.get("mime"),
+            filename: r.get("filename"),
+            bytes: r.get("bytes"),
+            preview: r.get("preview"),
+            width: r.get("width"),
+            height: r.get("height"),
+            created_at: r.get("created_at"),
+        }))
+    }
+
+    /// The preview alone. Separate from `attachment_for_corpus` so serving a
+    /// thumbnail does not read the original's megabytes off disk.
+    pub async fn attachment_preview(&self, corpus_id: &str) -> Result<Option<(String, Vec<u8>)>> {
+        let row = sqlx::query("SELECT preview FROM attachments WHERE corpus_id = ? ORDER BY id LIMIT 1")
+            .bind(corpus_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| (PREVIEW_MIME.to_string(), r.get("preview"))))
+    }
+
+    pub async fn attachment_original(&self, corpus_id: &str) -> Result<Option<(String, Vec<u8>)>> {
+        let row = sqlx::query("SELECT mime, bytes FROM attachments WHERE corpus_id = ? ORDER BY id LIMIT 1")
+            .bind(corpus_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| (r.get("mime"), r.get("bytes"))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn an_attachment_round_trips_and_goes_with_its_corpus() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        s.insert_attachment(&NewAttachment {
+            corpus_id: &src.id,
+            kind: "image",
+            mime: "image/png",
+            filename: Some("x.png"),
+            bytes: b"orig",
+            preview: b"prev",
+            width: Some(10),
+            height: Some(20),
+        })
+        .await
+        .unwrap();
+
+        let a = s.attachment_for_corpus(&src.id).await.unwrap().unwrap();
+        assert_eq!(a.bytes, b"orig");
+        assert_eq!(a.preview, b"prev");
+        assert_eq!(a.mime, "image/png");
+        assert_eq!((a.width, a.height), (Some(10), Some(20)));
+        assert_eq!(
+            s.attachment_preview(&src.id).await.unwrap().unwrap(),
+            (PREVIEW_MIME.to_string(), b"prev".to_vec())
+        );
+        assert_eq!(
+            s.attachment_original(&src.id).await.unwrap().unwrap(),
+            ("image/png".to_string(), b"orig".to_vec())
+        );
+
+        s.delete_corpus(&src.id).await.unwrap();
+        assert!(s.attachment_for_corpus(&src.id).await.unwrap().is_none());
+    }
+}
+```
+
+Append to `src/store/jobs.rs` tests (or create a `tests` module if there is none — check with `grep -n "mod tests" src/store/jobs.rs`):
+```rust
+    #[test]
+    fn describe_is_a_stage_that_round_trips_its_name() {
+        assert_eq!(Stage::Describe.as_str(), "describe");
+        assert_eq!(Stage::parse("describe"), Some(Stage::Describe));
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test store:: 2>&1 | grep -E "^error|cannot find" | head`
+Expected: compile errors for `Describing`, `insert_image_corpus`, `metadata`, `Stage::Describe`, module `attachments`.
+
+- [ ] **Step 3: Implement**
+
+`src/store/schema.sql`, after the `corpora` table:
+```sql
+-- The bytes an image corpus was captured from. `bytes` is the upload exactly
+-- as it arrived — the verbatim source, as `raw_text` is for a paste — and
+-- `preview` is the one derived copy: orientation applied, downscaled, JPEG.
+CREATE TABLE IF NOT EXISTS attachments (
+  id         INTEGER PRIMARY KEY,
+  corpus_id  TEXT    NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+  kind       TEXT    NOT NULL,
+  mime       TEXT    NOT NULL,
+  filename   TEXT,
+  bytes      BLOB    NOT NULL,
+  preview    BLOB    NOT NULL,
+  width      INTEGER,
+  height     INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS attachments_corpus ON attachments(corpus_id);
+```
+Also add `metadata TEXT NOT NULL DEFAULT '{}'` as the last column of the `corpora` table in `schema.sql` (fresh databases), with a comment: `-- What a door knew about the capture beyond the text: a note, file facts, EXIF. Namespaced JSON, '{}' when nothing was recorded.` Check how `schema_columns` parses lines (`src/store/mod.rs` ~line 240): a column line starts with its name, so this is fine.
+
+`src/store/mod.rs`: `pub mod attachments;` and append to `ADDED_COLUMNS`:
+```rust
+            // Arrived with image capture. Every corpus predating it recorded
+            // nothing beyond its text, which is what the empty object says.
+            ("corpora", "metadata", "TEXT NOT NULL DEFAULT '{}'"),
+```
+
+`src/store/jobs.rs`: add variant with doc comment
+```rust
+    /// One image, one vision call: reads a captured image into the markdown
+    /// that becomes its `raw_text`, then hands off to `Synthesize`.
+    Describe,
+```
+plus `Stage::Describe => "describe"` and `"describe" => Some(Stage::Describe)`.
+
+`src/store/corpora.rs`:
+- `CorpusStatus`: add `Describing` as the first variant with doc `/// An image whose text has not been read yet. Only image corpora hold it.`; `as_str` → `"describing"`, `parse` → `"describing" => CorpusStatus::Describing`.
+- `Corpus`: add `pub metadata: serde_json::Value,` with doc from the schema comment.
+- `row_to_corpus`: `metadata: r.get::<Option<String>, _>("metadata").and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_else(|| serde_json::json!({})),`
+- `insert_corpus_with_signature`: add trailing param `metadata: &serde_json::Value`, set `metadata: metadata.clone()` on the struct, add `metadata` to the INSERT column list and `.bind(src.metadata.to_string())`. Update `insert_corpus` to pass `&serde_json::json!({})`, and update the one caller in `src/core/ingest.rs` (`ingest_capture`) to pass `&c.metadata` — that field arrives in Task 6; for now pass `&serde_json::json!({})` there and note it.
+- `ensure_restored_corpus`: no change (column defaults).
+- New:
+```rust
+    /// The row for a captured image. There is no text yet — the vision stage
+    /// writes it — so the hash is the caller's, over the image bytes, and the
+    /// row starts in `describing`. Same conflict handling as a text capture:
+    /// the same photo twice is one row.
+    pub async fn insert_image_corpus(
+        &self,
+        content_hash: &str,
+        origin: &str,
+        title_hint: Option<&str>,
+        metadata: &serde_json::Value,
+    ) -> Result<Insertion> {
+        let at = now();
+        let id = new_id();
+        let res = sqlx::query(
+            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, metadata)
+             VALUES (?, '', ?, ?, ?, ?, ?, ?, '', ?)
+             ON CONFLICT(content_hash) DO NOTHING",
+        )
+        .bind(&id)
+        .bind(origin)
+        .bind(title_hint)
+        .bind(content_hash)
+        .bind(CorpusStatus::Describing.as_str())
+        .bind(at)
+        .bind(at)
+        .bind(metadata.to_string())
+        .execute(&self.pool)
+        .await?;
+        let existing = self.find_by_hash(content_hash).await?.ok_or_else(|| {
+            Error::Store("image capture conflicted with a corpus that then vanished".into())
+        })?;
+        Ok(if res.rows_affected() == 0 {
+            Insertion::Existing(existing)
+        } else {
+            Insertion::Created(existing)
+        })
+    }
+
+    /// What the vision stage read. Text and signature together, so the row is
+    /// never comparable-by-shingle to something it does not say. Status is
+    /// left to the caller, who knows whether this parks or proceeds.
+    pub async fn set_described_text(&self, id: &str, text: &str, shingles: Vec<u64>) -> Result<()> {
+        let res = sqlx::query(
+            "UPDATE corpora SET raw_text = ?, shingles = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(text)
+        .bind(super::shingle::encode(&shingles))
+        .bind(now())
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Err(Error::NotFound);
+        }
+        Ok(())
+    }
+
+    pub async fn set_corpus_metadata(&self, id: &str, metadata: &serde_json::Value) -> Result<()> {
+        let res = sqlx::query("UPDATE corpora SET metadata = ?, updated_at = ? WHERE id = ?")
+            .bind(metadata.to_string())
+            .bind(now())
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Err(Error::NotFound);
+        }
+        Ok(())
+    }
+```
+
+`src/web/ui.rs`: `status_badge` → `Describing | Raw | Segmenting | Segmented | Embedding => "badge-accent"`. The `in_flight` match at ~line 722 lists terminal states, so `Describing` is in flight already — verify by reading it, no change needed. Fix every other exhaustive `match` on `CorpusStatus` the compiler reports (`grep -rn "CorpusStatus::Raw =>" src`).
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+Expected: all green.
+```bash
+git add src/store src/web/ui.rs src/core/ingest.rs
+git commit -m "feat(store): describing status, describe stage, corpus metadata and attachments"
+```
+
+---
+
+### Task 3: `core::image::prepare` — sniff, decode, EXIF, orientation, preview
+
+**Files:**
+- Create: `src/core/image.rs`
+- Modify: `src/core/mod.rs` (`pub mod image;`)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct PreparedImage { pub mime: &'static str, pub width: u32, pub height: u32, pub preview_jpeg: Vec<u8>, pub exif: serde_json::Value /* {} when none */ }
+  pub fn prepare(bytes: &[u8], preview_edge: u32) -> Result<PreparedImage>   // Error::Validation on unsupported/undecodable
+  pub fn file_facts(name: Option<&str>, size: usize, img: &PreparedImage) -> serde_json::Value  // {"name","size","mime","width","height"}
+  pub fn exif_to_json(exif: &exif::Exif) -> serde_json::Value
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/core/image.rs` with this test module (implementation follows in step 3):
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Rgb};
+    use std::io::Cursor;
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let img = ImageBuffer::from_fn(w, h, |x, _| Rgb([(x % 256) as u8, 0, 0]));
+        let mut out = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    fn jpeg(w: u32, h: u32) -> Vec<u8> {
+        let img = ImageBuffer::from_fn(w, h, |x, _| Rgb([0, (x % 256) as u8, 0]));
+        let mut out = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Jpeg)
+            .unwrap();
+        out.into_inner()
+    }
+
+    /// A JPEG carrying the given EXIF fields in an APP1 segment, spliced in
+    /// right after SOI — which is where every camera puts it.
+    fn jpeg_with_exif(w: u32, h: u32, fields: &[exif::Field]) -> Vec<u8> {
+        let mut writer = exif::experimental::Writer::new();
+        for f in fields {
+            writer.push_field(f);
+        }
+        let mut blob = Cursor::new(Vec::new());
+        writer.write(&mut blob, false).unwrap();
+        let blob = blob.into_inner();
+        let mut app1 = Vec::new();
+        app1.extend_from_slice(&[0xFF, 0xE1]);
+        let len = (blob.len() + 6 + 2) as u16;
+        app1.extend_from_slice(&len.to_be_bytes());
+        app1.extend_from_slice(b"Exif\0\0");
+        app1.extend_from_slice(&blob);
+        let plain = jpeg(w, h);
+        let mut out = plain[..2].to_vec();
+        out.extend_from_slice(&app1);
+        out.extend_from_slice(&plain[2..]);
+        out
+    }
+
+    fn ascii(tag: exif::Tag, s: &str) -> exif::Field {
+        exif::Field {
+            tag,
+            ifd_num: exif::In::PRIMARY,
+            value: exif::Value::Ascii(vec![s.as_bytes().to_vec()]),
+        }
+    }
+
+    #[test]
+    fn a_png_is_decoded_measured_and_previewed_as_jpeg() {
+        let p = prepare(&png(300, 100), 2048).unwrap();
+        assert_eq!(p.mime, "image/png");
+        assert_eq!((p.width, p.height), (300, 100));
+        assert_eq!(p.exif, serde_json::json!({}));
+        let prev = image::load_from_memory(&p.preview_jpeg).unwrap();
+        assert_eq!(image::guess_format(&p.preview_jpeg).unwrap(), image::ImageFormat::Jpeg);
+        // Not upscaled: smaller than the edge stays its own size.
+        assert_eq!((prev.width(), prev.height()), (300, 100));
+    }
+
+    #[test]
+    fn a_large_image_is_downscaled_to_the_edge_keeping_its_ratio() {
+        let p = prepare(&jpeg(4000, 2000), 1000).unwrap();
+        let prev = image::load_from_memory(&p.preview_jpeg).unwrap();
+        assert_eq!((prev.width(), prev.height()), (1000, 500));
+        // The recorded size is the original's.
+        assert_eq!((p.width, p.height), (4000, 2000));
+    }
+
+    #[test]
+    fn exif_orientation_is_applied_to_the_preview_and_recorded() {
+        let orient = exif::Field {
+            tag: exif::Tag::Orientation,
+            ifd_num: exif::In::PRIMARY,
+            value: exif::Value::Short(vec![6]), // rotate 90° CW
+        };
+        let p = prepare(&jpeg_with_exif(400, 200, &[orient]), 2048).unwrap();
+        let prev = image::load_from_memory(&p.preview_jpeg).unwrap();
+        assert_eq!((prev.width(), prev.height()), (200, 400));
+        assert_eq!((p.width, p.height), (200, 400), "dimensions are as displayed");
+        assert_eq!(p.exif["orientation"], 6);
+    }
+
+    #[test]
+    fn exif_facts_are_mapped_and_the_rest_kept_as_tags() {
+        let fields = vec![
+            ascii(exif::Tag::DateTimeOriginal, "2026:08:09 14:12:03"),
+            ascii(exif::Tag::Make, "Apple"),
+            ascii(exif::Tag::Model, "iPhone 15"),
+            ascii(exif::Tag::Software, "17.5"),
+        ];
+        let p = prepare(&jpeg_with_exif(64, 64, &fields), 2048).unwrap();
+        assert_eq!(p.exif["taken_at"], "2026-08-09T14:12:03");
+        assert_eq!(p.exif["camera"], "Apple iPhone 15");
+        assert_eq!(p.exif["tags"]["Software"], "17.5");
+        assert!(p.exif.get("gps").is_none());
+    }
+
+    #[test]
+    fn gps_is_converted_to_decimal_degrees() {
+        let dms = |d: u32, m: u32, s: u32| {
+            exif::Value::Rational(vec![
+                exif::Rational { num: d, denom: 1 },
+                exif::Rational { num: m, denom: 1 },
+                exif::Rational { num: s * 100, denom: 100 },
+            ])
+        };
+        let f = |tag, value| exif::Field { tag, ifd_num: exif::In::PRIMARY, value };
+        let fields = vec![
+            f(exif::Tag::GPSLatitude, dms(48, 12, 30)),
+            ascii(exif::Tag::GPSLatitudeRef, "N"),
+            f(exif::Tag::GPSLongitude, dms(16, 22, 0)),
+            ascii(exif::Tag::GPSLongitudeRef, "W"),
+            f(exif::Tag::GPSAltitude, exif::Value::Rational(vec![exif::Rational { num: 1710, denom: 10 }])),
+        ];
+        let p = prepare(&jpeg_with_exif(64, 64, &fields), 2048).unwrap();
+        let g = &p.exif["gps"];
+        assert!((g["lat"].as_f64().unwrap() - 48.208333).abs() < 1e-4, "{g}");
+        assert!((g["lon"].as_f64().unwrap() + 16.366667).abs() < 1e-4, "{g}");
+        assert!((g["alt"].as_f64().unwrap() - 171.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn junk_and_unsupported_formats_are_refused_with_the_reason() {
+        let e = prepare(b"not an image at all", 2048).unwrap_err();
+        assert!(matches!(e, crate::error::Error::Validation(_)));
+        assert!(e.to_string().contains("not a supported image"), "{e}");
+
+        // A GIF header sniffs as an image but is not one of the three.
+        let e = prepare(b"GIF89a\x01\x00\x01\x00\x80\x00\x00", 2048).unwrap_err();
+        assert!(e.to_string().contains("gif"), "{e}");
+    }
+
+    #[test]
+    fn file_facts_carry_name_size_and_dimensions() {
+        let p = prepare(&png(30, 10), 2048).unwrap();
+        let f = file_facts(Some("IMG_1.png"), 1234, &p);
+        assert_eq!(f, serde_json::json!({"name": "IMG_1.png", "size": 1234, "mime": "image/png", "width": 30, "height": 10}));
+        assert!(file_facts(None, 1, &p).get("name").is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test core::image 2>&1 | grep -E "^error" | head -3`
+Expected: `prepare`, `file_facts` not found.
+
+- [ ] **Step 3: Implement**
+
+Top of `src/core/image.rs`:
+```rust
+//! What happens to an uploaded image before anything is stored: sniff the
+//! format, decode it, read its EXIF, and derive the one preview the vision
+//! model is shown and the UI displays. Pure functions; no I/O.
+
+use crate::error::{Error, Result};
+use image::{DynamicImage, ImageFormat};
+use std::io::Cursor;
+
+pub struct PreparedImage {
+    /// Of the original, from its bytes rather than from what the client said.
+    pub mime: &'static str,
+    /// As displayed: after the EXIF orientation is applied.
+    pub width: u32,
+    pub height: u32,
+    /// Orientation applied, longest edge at most `preview_edge`, JPEG.
+    pub preview_jpeg: Vec<u8>,
+    /// See `exif_to_json`. `{}` when the file carries none.
+    pub exif: serde_json::Value,
+}
+
+/// JPEG quality of the preview: high enough that small print in a photographed
+/// page survives, well below the original's size.
+const PREVIEW_QUALITY: u8 = 85;
+
+pub fn prepare(bytes: &[u8], preview_edge: u32) -> Result<PreparedImage> {
+    let format = image::guess_format(bytes)
+        .map_err(|_| Error::Validation("that upload is not a supported image (JPEG, PNG or WebP)".into()))?;
+    let mime = match format {
+        ImageFormat::Jpeg => "image/jpeg",
+        ImageFormat::Png => "image/png",
+        ImageFormat::WebP => "image/webp",
+        other => {
+            return Err(Error::Validation(format!(
+                "that image is {} — only JPEG, PNG and WebP are accepted",
+                other.extensions_str().first().copied().unwrap_or("of an unsupported format")
+            )));
+        }
+    };
+    let decoded = image::load_from_memory_with_format(bytes, format)
+        .map_err(|e| Error::Validation(format!("that image could not be decoded: {e}")))?;
+
+    let exif = read_exif(bytes);
+    let exif_json = exif.as_ref().map(exif_to_json).unwrap_or_else(|| serde_json::json!({}));
+    let orientation = exif_json["orientation"]
+        .as_u64()
+        .and_then(|o| image::metadata::Orientation::from_exif(o as u8))
+        .unwrap_or(image::metadata::Orientation::NoTransforms);
+
+    let mut img = decoded;
+    img.apply_orientation(orientation);
+    let (width, height) = (img.width(), img.height());
+    let preview_jpeg = encode_preview(&img, preview_edge)?;
+
+    Ok(PreparedImage { mime, width, height, preview_jpeg, exif: exif_json })
+}
+
+fn read_exif(bytes: &[u8]) -> Option<exif::Exif> {
+    exif::Reader::new()
+        .read_from_container(&mut Cursor::new(bytes))
+        .ok()
+}
+
+fn encode_preview(img: &DynamicImage, edge: u32) -> Result<Vec<u8>> {
+    let scaled = if img.width().max(img.height()) > edge {
+        img.thumbnail(edge, edge)
+    } else {
+        img.clone()
+    };
+    // JPEG has no alpha; a PNG with transparency is flattened rather than refused.
+    let rgb = DynamicImage::ImageRgb8(scaled.to_rgb8());
+    let mut out = Cursor::new(Vec::new());
+    let enc = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, PREVIEW_QUALITY);
+    rgb.write_with_encoder(enc)
+        .map_err(|e| Error::Internal(format!("preview encoding failed: {e}")))?;
+    Ok(out.into_inner())
+}
+
+/// The `file` namespace of a corpus's metadata.
+pub fn file_facts(name: Option<&str>, size: usize, img: &PreparedImage) -> serde_json::Value {
+    let mut v = serde_json::json!({
+        "size": size,
+        "mime": img.mime,
+        "width": img.width,
+        "height": img.height,
+    });
+    if let Some(n) = name {
+        v["name"] = serde_json::Value::String(n.to_string());
+    }
+    v
+}
+
+/// The `exif` namespace: the handful of facts worth naming, then every other
+/// tag under `tags` by name so nothing the file carries is thrown away.
+pub fn exif_to_json(exif: &exif::Exif) -> serde_json::Value {
+    use exif::{In, Tag};
+    let mut out = serde_json::Map::new();
+
+    let ascii = |tag: Tag| -> Option<String> {
+        exif.get_field(tag, In::PRIMARY).and_then(|f| match &f.value {
+            exif::Value::Ascii(v) => v.first().map(|b| String::from_utf8_lossy(b).trim().to_string()),
+            _ => None,
+        })
+    };
+
+    if let Some(dt) = ascii(Tag::DateTimeOriginal) {
+        // "2026:08:09 14:12:03" → "2026-08-09T14:12:03", offset appended when the
+        // file says one.
+        let mut iso = dt.replacen(':', "-", 2).replacen(' ', "T", 1);
+        if let Some(off) = ascii(Tag::OffsetTimeOriginal) {
+            iso.push_str(&off);
+        }
+        out.insert("taken_at".into(), iso.into());
+    }
+    let camera: Vec<String> = [ascii(Tag::Make), ascii(Tag::Model)].into_iter().flatten().collect();
+    if !camera.is_empty() {
+        out.insert("camera".into(), camera.join(" ").into());
+    }
+    if let Some(o) = exif.get_field(Tag::Orientation, In::PRIMARY).and_then(|f| f.value.get_uint(0)) {
+        out.insert("orientation".into(), o.into());
+    }
+    if let Some(gps) = gps_json(exif) {
+        out.insert("gps".into(), gps);
+    }
+
+    let mut tags = serde_json::Map::new();
+    for f in exif.fields() {
+        if f.ifd_num != In::PRIMARY {
+            continue;
+        }
+        let name = f.tag.to_string();
+        // Already named above, or binary noise nobody reads back.
+        if matches!(f.tag, Tag::MakerNote | Tag::UserComment) || name.starts_with("Tag(") {
+            continue;
+        }
+        let value: String = f.display_value().with_unit(exif).to_string().chars().take(200).collect();
+        tags.insert(name, value.into());
+    }
+    if !tags.is_empty() {
+        out.insert("tags".into(), tags.into());
+    }
+    serde_json::Value::Object(out)
+}
+
+fn gps_json(exif: &exif::Exif) -> Option<serde_json::Value> {
+    use exif::{In, Tag};
+    let dms = |tag: Tag, r: Tag, neg: &str| -> Option<f64> {
+        let f = exif.get_field(tag, In::PRIMARY)?;
+        let exif::Value::Rational(v) = &f.value else { return None };
+        if v.len() < 3 {
+            return None;
+        }
+        let deg = v[0].to_f64() + v[1].to_f64() / 60.0 + v[2].to_f64() / 3600.0;
+        let sign = match exif.get_field(r, In::PRIMARY).map(|f| f.display_value().to_string()) {
+            Some(s) if s.trim() == neg => -1.0,
+            _ => 1.0,
+        };
+        Some(deg * sign)
+    };
+    let lat = dms(Tag::GPSLatitude, Tag::GPSLatitudeRef, "S")?;
+    let lon = dms(Tag::GPSLongitude, Tag::GPSLongitudeRef, "W")?;
+    let mut g = serde_json::json!({ "lat": lat, "lon": lon });
+    if let Some(f) = exif.get_field(Tag::GPSAltitude, In::PRIMARY)
+        && let exif::Value::Rational(v) = &f.value
+        && let Some(a) = v.first()
+    {
+        g["alt"] = serde_json::json!(a.to_f64());
+    }
+    Some(g)
+}
+```
+Add `pub mod image;` to `src/core/mod.rs`. If `image::metadata::Orientation::from_exif` or `apply_orientation` are missing in the resolved `image` version, run `cargo doc -p image --open`-equivalent `grep -rn "fn from_exif\|fn apply_orientation" ~/.cargo/registry/src/*/image-0.25*/src/` and adapt; both exist from 0.25.2. `GPSLatitudeRef` display value renders as `N`/`S` — if the test fails on sign, match on the raw `Ascii` bytes instead as `ascii()` does.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test core::image 2>&1 | tail -12 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+Expected: 7 tests pass.
+```bash
+git add src/core/image.rs src/core/mod.rs
+git commit -m "feat(image): decode, exif and preview for a captured image"
+```
+
+---
+
+### Task 4: Inference — `Describer` trait, HTTP and fake implementations, prompt
+
+**Files:**
+- Modify: `src/infer/mod.rs` (after `Completer`)
+- Modify: `src/infer/prompt.rs` (append)
+- Modify: `src/infer/openai.rs` (after `HttpCompleter`)
+- Modify: `src/infer/fake.rs` (append)
+- Modify: `src/core/mod.rs` (`Core.describer`, `from_config`, `test_support`)
+- Modify: `src/main.rs:157` (probe)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[async_trait] pub trait Describer: Send + Sync { async fn describe(&self, image_jpeg: &[u8], context: &str) -> Result<String>; }
+  pub struct HttpDescriber; impl HttpDescriber { pub fn new(model: &str, base_url: &str, api_key: Option<&str>, timeout_secs: u64) -> Self }
+  pub struct FakeDescriber { pub reply: String, pub fail_with: Option<String>, pub calls: AtomicUsize, pub last_context: Mutex<String> }
+  impl FakeDescriber { pub fn saying(s: &str) -> Self; pub fn failing(msg: &str) -> Self; pub fn calls(&self) -> usize; pub fn last_context(&self) -> String }
+  pub const DESCRIBE_SYSTEM: &str;
+  pub fn describe_context(metadata: &serde_json::Value) -> String;
+  Core { pub describer: Option<Arc<dyn Describer>>, ... }
+  test_support::test_core_with_describer(d: Arc<FakeDescriber>) -> Core; test_support::test_core_without_vision() -> Core
+  ```
+
+- [ ] **Step 1: Failing tests**
+
+Append to `src/infer/prompt.rs` tests (find `mod tests`; add if absent):
+```rust
+    #[test]
+    fn describe_context_leads_with_the_note_then_the_facts_and_omits_what_is_absent() {
+        let m = serde_json::json!({
+            "note": "whiteboard from Tuesday planning",
+            "file": {"name": "IMG_2041.jpeg"},
+            "exif": {"taken_at": "2026-08-09T14:12:03", "camera": "Apple iPhone 15",
+                     "gps": {"lat": 48.2082, "lon": 16.3738}}
+        });
+        let ctx = describe_context(&m);
+        let note_at = ctx.find("whiteboard from Tuesday planning").unwrap();
+        let taken_at = ctx.find("2026-08-09T14:12:03").unwrap();
+        assert!(note_at < taken_at, "{ctx}");
+        assert!(ctx.contains("48.2082"), "{ctx}");
+        assert!(ctx.contains("Apple iPhone 15"));
+        assert!(ctx.contains("IMG_2041.jpeg"));
+
+        let bare = describe_context(&serde_json::json!({}));
+        assert!(!bare.contains("taken"), "{bare}");
+        assert!(!bare.contains("GPS"), "{bare}");
+        assert!(bare.contains("Read the image"), "{bare}");
+    }
+```
+
+Append to the tests module in `src/infer/openai.rs`:
+```rust
+    #[tokio::test]
+    async fn the_describer_sends_the_image_as_a_data_url_beside_the_context() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "# Whiteboard\n\n- item"}}]
+            })))
+            .mount(&server)
+            .await;
+        let d = HttpDescriber::new("vl", &format!("{}/v1", server.uri()), Some("k"), 30);
+        let out = d.describe(b"\xFF\xD8jpegbytes", "Photo taken 2026-08-09").await.unwrap();
+        assert_eq!(out, "# Whiteboard\n\n- item");
+
+        let req = &server.received_requests().await.unwrap()[0];
+        assert_eq!(req.headers.get("authorization").unwrap(), "Bearer k");
+        let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body["model"], "vl");
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"], prompt::DESCRIBE_SYSTEM);
+        let parts = body["messages"][1]["content"].as_array().unwrap();
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "Photo taken 2026-08-09");
+        assert_eq!(parts[1]["type"], "image_url");
+        let url = parts[1]["image_url"]["url"].as_str().unwrap();
+        assert!(url.starts_with("data:image/jpeg;base64,"), "{url}");
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(url.trim_start_matches("data:image/jpeg;base64,"))
+            .unwrap();
+        assert_eq!(decoded, b"\xFF\xD8jpegbytes");
+    }
+
+    #[tokio::test]
+    async fn a_describer_error_is_an_inference_error_for_the_vision_role() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("busy"))
+            .mount(&server)
+            .await;
+        let d = HttpDescriber::new("vl", &server.uri(), None, 30);
+        let e = d.describe(b"x", "").await.unwrap_err();
+        assert!(matches!(e, Error::Inference { role: "vision", .. }), "{e}");
+        assert!(e.retryable());
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test infer:: 2>&1 | grep -E "^error" | head -3`
+Expected: `describe_context`, `HttpDescriber`, `DESCRIBE_SYSTEM` not found.
+
+- [ ] **Step 3: Implement**
+
+`src/infer/mod.rs`, after `Completer`:
+```rust
+/// Reads a captured image into text. One call per image; the caller has
+/// already decoded, oriented and downscaled the picture into a JPEG.
+#[async_trait]
+pub trait Describer: Send + Sync {
+    /// `context` is what is known about the capture beyond its pixels — the
+    /// user's note, when and where it was taken. Markdown comes back.
+    async fn describe(&self, image_jpeg: &[u8], context: &str) -> Result<String>;
+}
+```
+
+`src/infer/prompt.rs`, append:
+```rust
+pub const DESCRIBE_SYSTEM: &str = r#"You read images for a personal knowledge base and write down everything in them worth keeping, as markdown.
+
+Rules:
+- Transcribe any visible text faithfully and completely. Keep its structure: headings as headings, lists as lists, tables as markdown tables, code as code blocks. Do not correct, summarize or reorder it.
+- Where there is no text, or beside it, describe what is shown: diagrams (their parts and how they connect), charts (axes, series, the values that can be read), scenes, objects, people's roles if evident, places, labels, brands, numbers, dates. Name what is identifiable.
+- Prefer specifics over impressions. Do not pad, do not speculate beyond what is visible, do not add advice.
+- You may be given context about the capture: a note from the person who took it, when and where it was taken, the device. Where it is relevant, weave it in naturally so the text can be found again by it — as a short opening line or where it explains the content — but do not repeat it mechanically or invent detail around it.
+- Output markdown only. No preamble, no closing remarks, no mention of these instructions."#;
+
+/// The user turn's text part for `Describer::describe`: the note first, then
+/// the facts the file carried, each only when present.
+pub fn describe_context(metadata: &serde_json::Value) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    if let Some(note) = metadata["note"].as_str().filter(|n| !n.trim().is_empty()) {
+        lines.push(format!("Context from the person who captured this: {}", note.trim()));
+    }
+    let mut facts: Vec<String> = Vec::new();
+    let exif = &metadata["exif"];
+    if let Some(t) = exif["taken_at"].as_str() {
+        facts.push(format!("taken {t}"));
+    }
+    if let (Some(lat), Some(lon)) = (exif["gps"]["lat"].as_f64(), exif["gps"]["lon"].as_f64()) {
+        facts.push(format!("GPS {lat:.4},{lon:.4}"));
+    }
+    if let Some(c) = exif["camera"].as_str() {
+        facts.push(format!("device {c}"));
+    }
+    if let Some(n) = metadata["file"]["name"].as_str() {
+        facts.push(format!("file {n}"));
+    }
+    if !facts.is_empty() {
+        lines.push(format!("Capture facts: {}.", facts.join(", ")));
+    }
+    lines.push("Read the image and write down everything worth keeping.".into());
+    lines.join("\n")
+}
+```
+
+`src/infer/openai.rs`, after `HttpCompleter` impl:
+```rust
+// ── Describer ────────────────────────────────────────────────────────────────
+
+pub struct HttpDescriber {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+    api_key: Option<String>,
+}
+
+impl HttpDescriber {
+    pub fn new(model: &str, base_url: &str, api_key: Option<&str>, timeout_secs: u64) -> Self {
+        Self {
+            client: client(timeout_secs),
+            base_url: base_url.to_string(),
+            model: model.to_string(),
+            api_key: api_key.map(str::to_string),
+        }
+    }
+}
+
+#[async_trait]
+impl super::Describer for HttpDescriber {
+    async fn describe(&self, image_jpeg: &[u8], context: &str) -> Result<String> {
+        use base64::Engine;
+        let data_url = format!(
+            "data:image/jpeg;base64,{}",
+            base64::engine::general_purpose::STANDARD.encode(image_jpeg)
+        );
+        let body = json!({
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": prompt::DESCRIBE_SYSTEM},
+                {"role": "user", "content": [
+                    {"type": "text", "text": context},
+                    {"type": "image_url", "image_url": {"url": data_url}}
+                ]}
+            ],
+            "temperature": 0.2,
+        });
+        let started = std::time::Instant::now();
+        let v = post_json(
+            "vision",
+            &self.client,
+            url(&self.base_url, "chat/completions"),
+            self.api_key.as_deref(),
+            body,
+        )
+        .await?;
+        tracing::info!(
+            ms = started.elapsed().as_millis(),
+            tokens = v["usage"]["completion_tokens"].as_u64(),
+            "vision call finished"
+        );
+        v["choices"][0]["message"]["content"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| Error::Inference {
+                role: "vision",
+                detail: "no message content".into(),
+            })
+    }
+}
+```
+Add `Describer` to the `use super::{...}` list at the top or keep the `super::Describer` path — either compiles.
+
+`src/infer/fake.rs`, append:
+```rust
+/// Answers every image with one scripted reply, or one scripted failure, and
+/// remembers what context it was shown.
+pub struct FakeDescriber {
+    pub reply: String,
+    pub fail_with: Option<String>,
+    calls: std::sync::atomic::AtomicUsize,
+    last_context: std::sync::Mutex<String>,
+}
+
+impl Default for FakeDescriber {
+    fn default() -> Self {
+        Self::saying("# Photo\n\nA whiteboard listing three tasks: ship, test, rest.")
+    }
+}
+
+impl FakeDescriber {
+    pub fn saying(reply: &str) -> Self {
+        Self {
+            reply: reply.into(),
+            fail_with: None,
+            calls: Default::default(),
+            last_context: Default::default(),
+        }
+    }
+    pub fn failing(msg: &str) -> Self {
+        let mut d = Self::saying("");
+        d.fail_with = Some(msg.into());
+        d
+    }
+    pub fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+    pub fn last_context(&self) -> String {
+        self.last_context.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl super::Describer for FakeDescriber {
+    async fn describe(&self, _image_jpeg: &[u8], context: &str) -> Result<String> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        *self.last_context.lock().unwrap() = context.to_string();
+        match &self.fail_with {
+            Some(m) => Err(Error::Inference { role: "vision", detail: m.clone() }),
+            None => Ok(self.reply.clone()),
+        }
+    }
+}
+```
+(Check the top of `fake.rs` for its `use` lines; `Error` and `Result` from `crate::error` and `async_trait` are already imported for the other fakes.)
+
+`src/core/mod.rs`:
+- import `HttpDescriber` and `Describer`;
+- field after `completer`: 
+  ```rust
+      /// The vision model, when one is configured. `None` closes the image door.
+      pub describer: Option<Arc<dyn Describer>>,
+  ```
+- `from_config`: 
+  ```rust
+              describer: cfg.infer.vision.as_ref().map(|v| {
+                  let (base_url, api_key) = v.resolve(&cfg.infer.synthesize);
+                  Arc::new(HttpDescriber::new(&v.model, &base_url, api_key.as_deref(), v.timeout_secs))
+                      as Arc<dyn Describer>
+              }),
+  ```
+- `test_support::build`: `describer: Some(Arc::new(FakeDescriber::default())),` and add:
+  ```rust
+      /// A core whose vision model is the given fake, for asserting what it was
+      /// asked and answering what a test needs.
+      pub async fn test_core_with_describer(d: Arc<FakeDescriber>) -> Core {
+          let mut core = build(Arc::new(FakeSynthesizer::default()), None).await;
+          core.describer = Some(d);
+          core
+      }
+
+      /// The shipped default: no `[infer.vision]`, image door closed.
+      pub async fn test_core_without_vision() -> Core {
+          let mut core = build(Arc::new(FakeSynthesizer::default()), None).await;
+          core.describer = None;
+          core
+      }
+  ```
+  and import `FakeDescriber` there.
+
+`src/main.rs`, after the rerank probe:
+```rust
+    if let Some(v) = &cfg.infer.vision {
+        let (base_url, api_key) = v.resolve(&cfg.infer.synthesize);
+        engram::infer::openai::probe("vision", &base_url, api_key.as_deref()).await;
+    } else {
+        tracing::info!("vision not configured; the image door is closed");
+    }
+```
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+```bash
+git add src/infer src/core/mod.rs src/main.rs
+git commit -m "feat(infer): Describer role — vision call, fake, prompt"
+```
+
+---
+
+### Task 5: `Core::ingest_image` — the door's logic, and `note` on text captures
+
+**Files:**
+- Modify: `src/core/ingest.rs` (`Capture` ~line 60, `ingest_capture` ~line 105, tests at the bottom)
+
+**Interfaces:**
+- Consumes: `core::image::{prepare, file_facts}`, `Store::insert_image_corpus`, `Store::insert_attachment`, `Stage::Describe`, `Core.describer`.
+- Produces:
+  ```rust
+  pub struct Capture { ..., pub metadata: serde_json::Value }   // default {}
+  impl Capture { pub fn with_note(self, note: Option<String>) -> Self; pub fn with_file(self, name: Option<&str>, size: usize, mime: &str) -> Self }
+  pub const ORIGIN_IMAGE: &str = "image";
+  pub const MAX_NOTE_CHARS: usize = 2000;
+  pub struct ImageCapture { pub bytes: Vec<u8>, pub filename: Option<String>, pub title_hint: Option<String>, pub note: Option<String> }
+  Core::ingest_image(&self, c: ImageCapture) -> Result<IngestOutcome>   // status Describing on create; duplicate=true on same bytes
+  ```
+
+- [ ] **Step 1: Failing tests**
+
+Append to `src/core/ingest.rs` tests:
+```rust
+    fn a_png() -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(40, 20, |x, _| Rgb([(x * 6) as u8, 0, 0]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    #[tokio::test]
+    async fn an_image_capture_stores_the_original_and_queues_describe_without_calling_the_model() {
+        let describer = std::sync::Arc::new(crate::infer::fake::FakeDescriber::default());
+        let core = crate::core::test_support::test_core_with_describer(describer.clone()).await;
+        let bytes = a_png();
+        let out = core
+            .ingest_image(ImageCapture {
+                bytes: bytes.clone(),
+                filename: Some("IMG_1.png".into()),
+                title_hint: None,
+                note: Some("  the kitchen whiteboard ".into()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.status, CorpusStatus::Describing);
+        assert!(!out.duplicate);
+        assert_eq!(describer.calls(), 0, "capture must not call the model");
+
+        let src = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(src.origin, ORIGIN_IMAGE);
+        assert_eq!(src.raw_text, "");
+        assert_eq!(src.title_hint.as_deref(), Some("IMG_1.png"));
+        assert_eq!(src.metadata["note"], "the kitchen whiteboard");
+        assert_eq!(src.metadata["file"]["name"], "IMG_1.png");
+        assert_eq!(src.metadata["file"]["mime"], "image/png");
+        assert_eq!(src.metadata["file"]["width"], 40);
+
+        let a = core.store.attachment_for_corpus(&out.id).await.unwrap().unwrap();
+        assert_eq!(a.bytes, bytes, "the original is stored byte for byte");
+        assert_eq!(a.mime, "image/png");
+        assert!(image::load_from_memory(&a.preview).is_ok());
+
+        let job = core.store.claim_job().await.unwrap().expect("a job was queued");
+        assert_eq!(job.stage, Stage::Describe);
+        assert_eq!(job.target_id, out.id);
+    }
+
+    #[tokio::test]
+    async fn the_same_photo_twice_is_a_duplicate_before_any_model_call() {
+        let core = crate::core::test_support::test_core().await;
+        let first = core
+            .ingest_image(ImageCapture { bytes: a_png(), filename: None, title_hint: None, note: None })
+            .await
+            .unwrap();
+        let again = core
+            .ingest_image(ImageCapture { bytes: a_png(), filename: None, title_hint: None, note: None })
+            .await
+            .unwrap();
+        assert!(again.duplicate);
+        assert_eq!(again.id, first.id);
+        assert_eq!(core.store.list_corpora(10, 0).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn without_a_vision_role_the_image_door_is_closed() {
+        let core = crate::core::test_support::test_core_without_vision().await;
+        let e = core
+            .ingest_image(ImageCapture { bytes: a_png(), filename: None, title_hint: None, note: None })
+            .await
+            .unwrap_err();
+        assert!(matches!(e, Error::Validation(_)));
+        assert!(e.to_string().contains("not configured"), "{e}");
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn junk_is_refused_before_anything_is_stored() {
+        let core = crate::core::test_support::test_core().await;
+        let e = core
+            .ingest_image(ImageCapture { bytes: b"nope".to_vec(), filename: Some("x.jpg".into()), title_hint: None, note: None })
+            .await
+            .unwrap_err();
+        assert!(matches!(e, Error::Validation(_)));
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_note_is_capped_and_a_blank_one_is_dropped() {
+        let core = crate::core::test_support::test_core().await;
+        let long = "x".repeat(MAX_NOTE_CHARS + 50);
+        let out = core
+            .ingest_capture(Capture::new("some text", "upload").with_note(Some(long)))
+            .await
+            .unwrap();
+        let src = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(src.metadata["note"].as_str().unwrap().len(), MAX_NOTE_CHARS);
+
+        let out = core
+            .ingest_capture(Capture::new("other text", "upload").with_note(Some("   ".into())))
+            .await
+            .unwrap();
+        assert!(core.store.get_corpus(&out.id).await.unwrap().metadata.get("note").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_text_capture_carries_its_file_facts() {
+        let core = crate::core::test_support::test_core().await;
+        let out = core
+            .ingest_capture(Capture::new("hello", "upload").with_file(Some("n.txt"), 5, "text/plain"))
+            .await
+            .unwrap();
+        let m = core.store.get_corpus(&out.id).await.unwrap().metadata;
+        assert_eq!(m["file"], serde_json::json!({"name": "n.txt", "size": 5, "mime": "text/plain"}));
+    }
+```
+Add `use super::*;`-visible imports the tests need (`ImageCapture`, `ORIGIN_IMAGE`, `MAX_NOTE_CHARS` are in scope via `super::*` once defined).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test core::ingest::tests 2>&1 | grep -E "^error" | head -3`
+
+- [ ] **Step 3: Implement**
+
+In `src/core/ingest.rs`:
+```rust
+/// The channel an image arrives through. Its own value, like `upload`, so
+/// the queue and the detail page can tell a photo from a paste.
+pub const ORIGIN_IMAGE: &str = "image";
+/// Longest note kept. Context, not a document: someone wanting to say more
+/// than this has a paste box.
+pub const MAX_NOTE_CHARS: usize = 2000;
+
+/// The user's context for a capture, cleaned: trimmed, capped, `None` when
+/// there is nothing in it.
+fn clean_note(note: Option<String>) -> Option<String> {
+    let n = note?.trim().to_string();
+    if n.is_empty() {
+        return None;
+    }
+    Some(n.chars().take(MAX_NOTE_CHARS).collect())
+}
+```
+`Capture` gains `pub metadata: serde_json::Value` (init `serde_json::json!({})` in `new`) with doc `/// What the door knew beyond the text. Namespaced; see the schema comment.` and:
+```rust
+    pub fn with_note(mut self, note: Option<String>) -> Self {
+        if let Some(n) = clean_note(note) {
+            self.metadata["note"] = serde_json::Value::String(n);
+        }
+        self
+    }
+
+    /// The `file` facts of an uploaded text file.
+    pub fn with_file(mut self, name: Option<&str>, size: usize, mime: &str) -> Self {
+        let mut f = serde_json::json!({ "size": size, "mime": mime });
+        if let Some(n) = name {
+            f["name"] = serde_json::Value::String(n.to_string());
+        }
+        self.metadata["file"] = f;
+        self
+    }
+```
+In `ingest_capture`, replace the `serde_json::json!({})` placeholder from Task 2 with `&c.metadata`.
+
+```rust
+/// One image, whichever door it arrived through.
+#[derive(Debug, Clone)]
+pub struct ImageCapture {
+    pub bytes: Vec<u8>,
+    pub filename: Option<String>,
+    pub title_hint: Option<String>,
+    pub note: Option<String>,
+}
+
+impl Core {
+    /// Store the image and queue the vision stage. Like `ingest_capture`, this
+    /// makes no inference call: the phone gets its answer the moment the bytes
+    /// are safe, and a dead vision endpoint costs a wait, not a photo.
+    pub async fn ingest_image(&self, c: ImageCapture) -> Result<IngestOutcome> {
+        if self.describer.is_none() {
+            return Err(Error::Validation(
+                "image capture is not configured — set [infer.vision] to enable it".into(),
+            ));
+        }
+        let prepared = super::image::prepare(&c.bytes, self.capture.image_preview_edge)?;
+        let hash = hex::encode(sha2::Sha256::digest(&c.bytes));
+        if let Some(existing) = self.store.find_by_hash(&hash).await? {
+            tracing::info!(corpus_id = %existing.id, "duplicate image, returning existing source");
+            return Ok(IngestOutcome { id: existing.id, status: existing.status, duplicate: true, near_duplicate: None });
+        }
+
+        let mut metadata = serde_json::json!({
+            "file": super::image::file_facts(c.filename.as_deref(), c.bytes.len(), &prepared),
+        });
+        if prepared.exif.as_object().is_some_and(|o| !o.is_empty()) {
+            metadata["exif"] = prepared.exif.clone();
+        }
+        if let Some(n) = clean_note(c.note) {
+            metadata["note"] = serde_json::Value::String(n);
+        }
+        let title_hint = c.title_hint.or_else(|| c.filename.clone());
+
+        let src = match self
+            .store
+            .insert_image_corpus(&hash, ORIGIN_IMAGE, title_hint.as_deref(), &metadata)
+            .await?
+        {
+            Insertion::Created(src) => src,
+            Insertion::Existing(existing) => {
+                return Ok(IngestOutcome { id: existing.id, status: existing.status, duplicate: true, near_duplicate: None });
+            }
+        };
+        self.store
+            .insert_attachment(&crate::store::attachments::NewAttachment {
+                corpus_id: &src.id,
+                kind: "image",
+                mime: prepared.mime,
+                filename: c.filename.as_deref(),
+                bytes: &c.bytes,
+                preview: &prepared.preview_jpeg,
+                width: Some(prepared.width as i64),
+                height: Some(prepared.height as i64),
+            })
+            .await?;
+        self.store.enqueue(Stage::Describe, "corpus", &src.id).await?;
+        tracing::info!(corpus_id = %src.id, bytes = c.bytes.len(), mime = prepared.mime, "image captured; queued for reading");
+        Ok(IngestOutcome { id: src.id, status: CorpusStatus::Describing, duplicate: false, near_duplicate: None })
+    }
+}
+```
+Add `use sha2::Digest;` at the top of the file.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test core::ingest 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+```bash
+git add src/core/ingest.rs
+git commit -m "feat(ingest): image door — store, hash, queue describe; note and file facts on captures"
+```
+
+---
+
+### Task 6: `Stage::Describe` — the job
+
+**Files:**
+- Create: `src/jobs/describe.rs`
+- Modify: `src/jobs/mod.rs` (`pub mod describe;`, dispatch arm)
+
+**Interfaces:**
+- Consumes: `Core.describer`, `Store::attachment_preview`, `Store::set_described_text`, `Store::set_corpus_metadata`, `Store::find_near_duplicate`, `Store::set_near_dupe`, `prompt::describe_context`, `core.gate.background()`.
+- Produces: `pub async fn run(core: &Core, corpus_id: &str) -> Result<()>`
+
+- [ ] **Step 1: Failing tests**
+
+Create `src/jobs/describe.rs` with this test module:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ingest::ImageCapture;
+    use crate::core::test_support::{test_core_with_describer, test_core_without_vision};
+    use crate::infer::fake::FakeDescriber;
+    use crate::store::corpora::CorpusStatus;
+    use crate::store::jobs::Stage;
+    use std::sync::Arc;
+
+    fn a_png(seed: u8) -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(32, 32, |x, y| Rgb([seed, x as u8, y as u8]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img).write_to(&mut out, image::ImageFormat::Png).unwrap();
+        out.into_inner()
+    }
+
+    async fn captured(core: &crate::core::Core, seed: u8, note: Option<&str>) -> String {
+        core.ingest_image(ImageCapture { bytes: a_png(seed), filename: Some("p.png".into()), title_hint: None, note: note.map(str::to_string) })
+            .await
+            .unwrap()
+            .id
+    }
+
+    #[tokio::test]
+    async fn describing_writes_the_text_and_hands_off_to_synthesize() {
+        let d = Arc::new(FakeDescriber::saying("# Board\n\n- ship\n- test"));
+        let core = test_core_with_describer(d.clone()).await;
+        let id = captured(&core, 1, Some("kitchen board")).await;
+        core.store.claim_job().await.unwrap(); // the Describe job
+        run(&core, &id).await.unwrap();
+
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Raw);
+        assert_eq!(src.raw_text, "# Board\n\n- ship\n- test");
+        assert!(!src.shingles.is_empty());
+        assert!(d.last_context().contains("kitchen board"), "{}", d.last_context());
+        assert!(d.last_context().contains("p.png"));
+        let next = core.store.claim_job().await.unwrap().expect("synthesize queued");
+        assert_eq!(next.stage, Stage::Synthesize);
+        assert_eq!(next.target_id, id);
+    }
+
+    #[tokio::test]
+    async fn the_whole_pipeline_takes_a_photo_to_ready() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::default())).await;
+        let id = captured(&core, 2, None).await;
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Ready, "{:?}", src.status);
+        assert!(!core.store.artifacts_for_corpus(&id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_failing_model_leaves_the_corpus_describing_and_the_error_retryable() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::failing("gpu on fire"))).await;
+        let id = captured(&core, 3, None).await;
+        let e = run(&core, &id).await.unwrap_err();
+        assert!(e.retryable());
+        assert_eq!(core.store.get_corpus(&id).await.unwrap().status, CorpusStatus::Describing);
+    }
+
+    #[tokio::test]
+    async fn an_empty_reading_parks_the_corpus_with_the_reason() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::saying("  \n"))).await;
+        let id = captured(&core, 4, None).await;
+        core.store.claim_job().await.unwrap();
+        run(&core, &id).await.unwrap();
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert!(src.metadata["describe"]["error"].as_str().unwrap().contains("no text"));
+        assert!(core.store.claim_job().await.unwrap().is_none(), "nothing further queued");
+    }
+
+    #[tokio::test]
+    async fn a_reading_that_matches_an_existing_corpus_is_parked_as_a_near_duplicate() {
+        let text = "The quarterly plan lists three goals: ship the beta, hire two engineers, and cut latency in half by autumn.";
+        let core = test_core_with_describer(Arc::new(FakeDescriber::saying(text))).await;
+        let first = core.ingest(text, "web", None).await.unwrap();
+        let id = captured(&core, 5, None).await;
+        core.store.claim_job().await.unwrap(); // synthesize for the paste
+        core.store.claim_job().await.unwrap(); // describe
+        run(&core, &id).await.unwrap();
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert_eq!(src.near_dupe_of.as_deref(), Some(first.id.as_str()));
+        assert_eq!(src.raw_text, text, "the reading is kept even when parked");
+    }
+
+    #[tokio::test]
+    async fn a_job_for_a_corpus_that_is_gone_is_not_found() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::default())).await;
+        assert!(matches!(run(&core, "nope").await, Err(crate::error::Error::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn without_a_vision_role_the_job_waits_rather_than_failing_the_corpus() {
+        // Configured when the photo was taken, removed before it was read: the
+        // job stays queued at the backoff ceiling until the role comes back.
+        let core = test_core_without_vision().await;
+        let src = core.store.insert_image_corpus("h", "image", None, &serde_json::json!({})).await.unwrap().into_corpus();
+        let e = run(&core, &src.id).await.unwrap_err();
+        assert!(e.retryable(), "{e}");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test jobs::describe 2>&1 | grep -E "^error" | head -3`
+
+- [ ] **Step 3: Implement**
+
+Top of `src/jobs/describe.rs`:
+```rust
+//! The vision stage: one captured image, one call, and a corpus that from
+//! here on is text like any other.
+
+use crate::core::Core;
+use crate::error::{Error, Result};
+use crate::store::corpora::CorpusStatus;
+use crate::store::jobs::Stage;
+
+pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    if src.status != CorpusStatus::Describing {
+        tracing::info!(corpus_id, status = src.status.as_str(), "already described; nothing to do");
+        return Ok(());
+    }
+    let Some(describer) = core.describer.as_ref() else {
+        // Not a validation error: the photo is stored and the job should wait
+        // for the role, not be dropped.
+        return Err(Error::Inference { role: "vision", detail: "no vision role configured".into() });
+    };
+    let Some((_, preview)) = core.store.attachment_preview(corpus_id).await? else {
+        return Err(Error::Store(format!("image corpus {corpus_id} has no attachment")));
+    };
+    let context = crate::infer::prompt::describe_context(&src.metadata);
+
+    let permit = core.gate.background().await;
+    let read = describer.describe(&preview, &context).await;
+    match &read {
+        Ok(_) => permit.succeeded(),
+        Err(e) => permit.failed(e),
+    }
+    let text = read?;
+
+    if text.trim().is_empty() {
+        let mut meta = src.metadata.clone();
+        meta["describe"] = serde_json::json!({ "error": "the model returned no text for this image" });
+        core.store.set_corpus_metadata(corpus_id, &meta).await?;
+        core.store.set_corpus_status(corpus_id, CorpusStatus::NeedsReview).await?;
+        tracing::warn!(corpus_id, "vision model returned nothing; parked for review");
+        return Ok(());
+    }
+
+    let sig = crate::store::shingle::signature(&text);
+    let near = core.store.find_near_duplicate(&sig, core.consolidate.near_dupe_min).await?;
+    core.store.set_described_text(corpus_id, &text, sig).await?;
+    match near {
+        Some(n) => {
+            core.store.set_near_dupe(corpus_id, Some(&n.corpus_id), Some(n.similarity)).await?;
+            core.store.set_corpus_status(corpus_id, CorpusStatus::NeedsReview).await?;
+            tracing::info!(corpus_id, near = %n.corpus_id, similarity = n.similarity, "reading looks like an existing corpus; parked for review");
+        }
+        None => {
+            core.store.set_corpus_status(corpus_id, CorpusStatus::Raw).await?;
+            core.store.enqueue(Stage::Synthesize, "corpus", corpus_id).await?;
+            tracing::info!(corpus_id, chars = text.len(), "image read; queued for synthesis");
+        }
+    }
+    Ok(())
+}
+```
+Check `find_near_duplicate`'s signature (`src/store/corpora.rs:335`) and `set_near_dupe` (`:366`) and match them exactly. In `src/jobs/mod.rs`: `pub mod describe;` and the dispatch arm `(Stage::Describe, _) => describe::run(core, &job.target_id).await,`. Note `set_corpus_status` on a NeedsReview near-dupe path: `find_near_duplicate` may need the corpus's own signature excluded — read its implementation; it compares against stored signatures and this corpus's is `''` until `set_described_text`, so calling `find_near_duplicate` **before** `set_described_text` (as written) is what keeps it from matching itself.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test jobs:: 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+```bash
+git add src/jobs
+git commit -m "feat(jobs): describe stage reads an image into its corpus text"
+```
+
+---
+
+### Task 7: API — image upload, image serving, `note` on text upload
+
+**Files:**
+- Modify: `src/web/api.rs` (`upload` ~line 279, router ~line 698, tests)
+- Modify: `src/web/mod.rs:53-66` (`router`)
+
+**Interfaces:**
+- Consumes: `Core::ingest_image`, `Capture::with_note/with_file`, `Store::attachment_preview/attachment_original`.
+- Produces: `pub fn api_router(image_max_bytes: usize) -> Router<AppState>`; routes `POST /api/v1/corpora/image`, `GET /api/v1/corpora/{id}/image[?original=1]`.
+
+- [ ] **Step 1: Failing tests**
+
+In `src/web/api.rs` tests, generalize the multipart helper: rename `post_file` → keep it, and add a sibling that carries extra text fields:
+```rust
+    /// Like `post_file`, with text fields sent before the file part.
+    fn post_file_with(
+        uri: &str,
+        token: &str,
+        fields: &[(&str, &str)],
+        field_name: &str,
+        filename: &str,
+        mime: Option<&str>,
+        body: &[u8],
+    ) -> Request<Body> {
+        const B: &str = "engramtestboundary";
+        let mut buf: Vec<u8> = Vec::new();
+        for (k, v) in fields {
+            buf.extend_from_slice(
+                format!("--{B}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").as_bytes(),
+            );
+        }
+        let typed = match mime {
+            Some(m) => format!("Content-Type: {m}\r\n"),
+            None => String::new(),
+        };
+        buf.extend_from_slice(
+            format!(
+                "--{B}\r\nContent-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n{typed}\r\n"
+            )
+            .as_bytes(),
+        );
+        buf.extend_from_slice(body);
+        buf.extend_from_slice(format!("\r\n--{B}--\r\n").as_bytes());
+        Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", format!("multipart/form-data; boundary={B}"))
+            .body(Body::from(buf))
+            .unwrap()
+    }
+
+    fn a_png() -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(24, 12, |x, _| Rgb([x as u8 * 10, 0, 0]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img).write_to(&mut out, image::ImageFormat::Png).unwrap();
+        out.into_inner()
+    }
+
+    #[tokio::test]
+    async fn an_image_upload_is_accepted_with_its_note_and_queued() {
+        let (app, token, core) = app_token_and_core().await;
+        let res = app
+            .clone()
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image", &token,
+                &[("note", "front of the router"), ("title_hint", "Router label")],
+                "image", "IMG_9.png", Some("image/png"), &a_png(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+        let body = json_of(res).await;
+        assert_eq!(body["status"], "describing");
+        let id = body["id"].as_str().unwrap().to_string();
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.title_hint.as_deref(), Some("Router label"));
+        assert_eq!(src.metadata["note"], "front of the router");
+        assert_eq!(src.origin, "image");
+
+        // The same bytes again: 200, same id.
+        let res = app
+            .oneshot(post_file_with("/api/v1/corpora/image", &token, &[], "image", "IMG_9.png", Some("image/png"), &a_png()))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(json_of(res).await["id"], id);
+    }
+
+    #[tokio::test]
+    async fn the_image_door_refuses_junk_missing_parts_and_a_closed_door() {
+        let (app, token, core) = app_token_and_core().await;
+        let res = app.clone()
+            .oneshot(post_file_with("/api/v1/corpora/image", &token, &[], "image", "x.jpg", Some("image/jpeg"), b"not really"))
+            .await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert!(json_of(res).await["error"].as_str().unwrap().contains("supported image"));
+
+        let res = app.clone()
+            .oneshot(post_file_with("/api/v1/corpora/image", &token, &[("note", "n")], "file", "x.png", Some("image/png"), &a_png()))
+            .await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "wrong part name is 'no image in the upload'");
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+
+        let (app, token, _) = app_from_core(crate::core::test_support::test_core_without_vision().await).await;
+        let res = app
+            .oneshot(post_file_with("/api/v1/corpora/image", &token, &[], "image", "x.png", Some("image/png"), &a_png()))
+            .await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert!(json_of(res).await["error"].as_str().unwrap().contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn the_image_door_has_its_own_larger_body_limit() {
+        // Over the global 8 MB, under the image ceiling: the multipart parser
+        // gets to see it, so the answer is the handler's (junk → 400), not the
+        // framework's 413.
+        let (app, token) = app_and_token().await;
+        let big = vec![0u8; crate::web::MAX_BODY_BYTES + 1024];
+        let res = app.clone()
+            .oneshot(post_file_with("/api/v1/corpora/image", &token, &[], "image", "big.png", Some("image/png"), &big))
+            .await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        // And the text door still stops at 8 MB.
+        let res = app
+            .oneshot(post_file("/api/v1/corpora/upload", &token, "big.txt", Some("text/plain"), &big))
+            .await.unwrap();
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn the_preview_and_the_original_are_served() {
+        let (app, token, _core) = app_token_and_core().await;
+        let res = app.clone()
+            .oneshot(post_file_with("/api/v1/corpora/image", &token, &[], "image", "p.png", Some("image/png"), &a_png()))
+            .await.unwrap();
+        let id = json_of(res).await["id"].as_str().unwrap().to_string();
+
+        let res = app.clone().oneshot(get(&format!("/api/v1/corpora/{id}/image"), Some(&token))).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["content-type"], "image/jpeg");
+        let bytes = axum::body::to_bytes(res.into_body(), 1 << 22).await.unwrap();
+        assert!(image::load_from_memory(&bytes).is_ok());
+
+        let res = app.clone().oneshot(get(&format!("/api/v1/corpora/{id}/image?original=1"), Some(&token))).await.unwrap();
+        assert_eq!(res.headers()["content-type"], "image/png");
+        let bytes = axum::body::to_bytes(res.into_body(), 1 << 22).await.unwrap();
+        assert_eq!(bytes.to_vec(), a_png());
+
+        let res = app.clone().oneshot(get(&format!("/api/v1/corpora/{id}/image"), None)).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+        let res = app.oneshot(get("/api/v1/corpora/nope/image", Some(&token))).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn a_text_upload_records_its_note_and_file_facts() {
+        let (app, token, core) = app_token_and_core().await;
+        let res = app
+            .oneshot(post_file_with("/api/v1/corpora/upload", &token, &[("note", "from the printer")], "file", "notes.txt", Some("text/plain"), b"hello there"))
+            .await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+        let id = json_of(res).await["id"].as_str().unwrap().to_string();
+        let m = core.store.get_corpus(&id).await.unwrap().metadata;
+        assert_eq!(m["note"], "from the printer");
+        assert_eq!(m["file"]["name"], "notes.txt");
+        assert_eq!(m["file"]["size"], 11);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test web::api::tests::the_image 2>&1 | grep -E "^error|test result" | head`
+Expected: 404s / compile errors.
+
+- [ ] **Step 3: Implement**
+
+Restructure `upload` to collect parts first (a `note` may precede or follow the file):
+```rust
+async fn upload(
+    State(st): State<AppState>,
+    _id: Identity,
+    mut multipart: axum::extract::Multipart,
+) -> Result<(StatusCode, Json<crate::core::ingest::IngestOutcome>)> {
+    let mut note: Option<String> = None;
+    let mut file: Option<(Option<String>, String, axum::body::Bytes)> = None; // (filename, declared type, bytes)
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
+    {
+        match field.name() {
+            Some("note") => note = Some(field.text().await.map_err(|e| Error::Validation(format!("malformed upload: {e}")))?),
+            Some("file") => {
+                let filename = field.file_name().map(str::to_string);
+                let declared = field.content_type().unwrap_or("").to_string();
+                let bytes = field.bytes().await.map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
+                file = Some((filename, declared, bytes));
+            }
+            _ => {}
+        }
+    }
+    let Some((filename, declared, bytes)) = file else {
+        return Err(Error::Validation("no file in the upload".into()));
+    };
+    // (the existing type checks, verbatim, moved here — the `declared.is_empty()` /
+    //  `named_txt` branch and the `starts_with("text/plain")` branch)
+    let text = String::from_utf8(bytes.to_vec())
+        .map_err(|_| Error::Validation("that file is not valid UTF-8 text".into()))?;
+    let size = bytes.len();
+    let out = st
+        .core
+        .ingest_capture(
+            crate::core::ingest::Capture::new(text, ORIGIN_UPLOAD)
+                .with_title(filename.clone())
+                .with_note(note)
+                .with_file(filename.as_deref(), size, "text/plain"),
+        )
+        .await?;
+    let code = if out.duplicate { StatusCode::OK } else { StatusCode::CREATED };
+    Ok((code, Json(out)))
+}
+```
+Keep the existing comments about absent content types where the checks land. Then:
+```rust
+/// The image door. Parts: `image` (required), `title_hint`, `note`. The
+/// bytes are validated and stored here; the reading happens in a job.
+async fn upload_image(
+    State(st): State<AppState>,
+    _id: Identity,
+    mut multipart: axum::extract::Multipart,
+) -> Result<(StatusCode, Json<crate::core::ingest::IngestOutcome>)> {
+    let mut note = None;
+    let mut title_hint = None;
+    let mut image: Option<(Option<String>, axum::body::Bytes)> = None;
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
+    {
+        let text_of = |f: axum::extract::multipart::Field<'_>| async move {
+            f.text().await.map_err(|e| Error::Validation(format!("malformed upload: {e}")))
+        };
+        match field.name() {
+            Some("note") => note = Some(text_of(field).await?),
+            Some("title_hint") => title_hint = Some(text_of(field).await?).filter(|t| !t.trim().is_empty()),
+            Some("image") => {
+                let filename = field.file_name().map(str::to_string);
+                let bytes = field.bytes().await.map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
+                image = Some((filename, bytes));
+            }
+            _ => {}
+        }
+    }
+    let Some((filename, bytes)) = image else {
+        return Err(Error::Validation("no image in the upload".into()));
+    };
+    let out = st
+        .core
+        .ingest_image(crate::core::ingest::ImageCapture {
+            bytes: bytes.to_vec(),
+            filename,
+            title_hint,
+            note,
+        })
+        .await?;
+    // 202, not 201: stored, but the reading — the part that makes it a corpus
+    // anyone can search — is still queued.
+    let code = if out.duplicate { StatusCode::OK } else { StatusCode::ACCEPTED };
+    Ok((code, Json(out)))
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ImageQuery {
+    #[serde(default)]
+    original: Option<String>,
+}
+
+async fn get_image(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(id): Path<String>,
+    Query(q): Query<ImageQuery>,
+) -> Result<axum::response::Response> {
+    let want_original = q.original.as_deref().is_some_and(|v| v == "1" || v == "true");
+    let found = if want_original {
+        st.core.store.attachment_original(&id).await?
+    } else {
+        st.core.store.attachment_preview(&id).await?
+    };
+    let Some((mime, bytes)) = found else {
+        return Err(Error::NotFound);
+    };
+    Ok((
+        [(axum::http::header::CONTENT_TYPE, mime), (axum::http::header::CACHE_CONTROL, "private, max-age=3600".to_string())],
+        bytes,
+    )
+        .into_response())
+}
+```
+Router:
+```rust
+pub fn api_router(image_max_bytes: usize) -> Router<AppState> {
+    Router::new()
+        .route("/corpora", post(ingest).get(list_corpora))
+        .route("/corpora/upload", post(upload))
+        // Its own ceiling: a phone photo is several times the global limit.
+        .route(
+            "/corpora/image",
+            post(upload_image).layer(axum::extract::DefaultBodyLimit::max(image_max_bytes)),
+        )
+        .route("/corpora/{id}", get(get_corpus).delete(delete_corpus))
+        .route("/corpora/{id}/image", get(get_image))
+        // ... rest unchanged
+```
+`src/web/mod.rs`: `.nest("/api/v1", api::api_router(state.core.capture.image_max_bytes))`. Grep for other `api_router()` callers (`grep -rn "api_router(" src`) and fix them. If the per-route limit does not override the outer one in the body-limit test, move `.layer(DefaultBodyLimit::max(MAX_BODY_BYTES))` in `web::router` **before** `.nest("/api/v1", ...)` is not the fix — the fix is `DefaultBodyLimit::disable()` on the image route followed by `axum::extract::RequestBodyLimitLayer`-free manual check: `tower_http::limit::RequestBodyLimitLayer::new(image_max_bytes)` from `tower-http` feature `limit`. Try the plain per-route `DefaultBodyLimit::max` first; axum documents that the innermost applies.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test web:: 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+```bash
+git add src/web/api.rs src/web/mod.rs
+git commit -m "feat(api): image upload and serving; note on text uploads"
+```
+
+---
+
+### Task 8: UI — capture page inputs and the image corpus view
+
+**Files:**
+- Modify: `src/web/ui.rs` (`CaptureTemplate` ~line 297, `capture_page` ~line 501, `CorpusTemplate` ~line 362, `corpus_detail` ~line 770, queue label ~line 745)
+- Modify: `src/web/templates/capture.html`
+- Modify: `src/web/templates/corpus.html`
+- Modify: `src/web/corpus_view.rs`
+
+**Interfaces:**
+- `CaptureTemplate { ..., vision_enabled: bool }`
+- `CorpusTemplate { ..., image: bool, derived: bool, meta_rows: Vec<(String, String)>, note: Option<String> }`
+- `corpus_view::for_corpus` returns `ImageTranscript` for `origin == "image"`, whose labels read `transcription lines a–b` / `transcription`.
+
+- [ ] **Step 1: Failing tests**
+
+`src/web/corpus_view.rs` tests:
+```rust
+    #[tokio::test]
+    async fn an_image_corpus_labels_its_lines_as_transcription() {
+        let s = crate::store::Store::memory().await.unwrap();
+        let src = s.insert_image_corpus("h", "image", None, &serde_json::json!({})).await.unwrap().into_corpus();
+        s.set_described_text(&src.id, "a\nb\nc", vec![]).await.unwrap();
+        let src = s.get_corpus(&src.id).await.unwrap();
+        let view = for_corpus(&src);
+        assert_eq!(view.slice(&src, Some(&CorpusSpan { start_line: 2, end_line: 2 }), 0).label, "transcription lines 2–2");
+        assert_eq!(view.slice(&src, None, 0).label, "transcription");
+    }
+```
+`src/web/ui.rs` tests (find the module's app helper — it reuses `crate::web::api::tests::app_from_core`; follow the pattern of an existing page test that asserts on HTML, e.g. grep `capture_page` or `"/ui/capture"` in the tests):
+```rust
+    #[tokio::test]
+    async fn the_capture_page_offers_images_only_when_vision_is_configured() {
+        let (app, _t, _c) = crate::web::api::tests::app_from_core(crate::core::test_support::test_core().await).await;
+        let html = page(app, "/ui/capture").await;   // use the module's existing helper for an authenticated GET
+        assert!(html.contains("image/*"), "picker accepts images");
+        assert!(html.contains("name=\"note\""), "the context field is there");
+
+        let (app, _t, _c) = crate::web::api::tests::app_from_core(crate::core::test_support::test_core_without_vision().await).await;
+        let html = page(app, "/ui/capture").await;
+        assert!(!html.contains("image/*"));
+        assert!(html.contains("accept=\".txt,text/plain\""));
+    }
+
+    #[tokio::test]
+    async fn an_image_corpus_page_shows_the_photo_its_facts_and_the_reading_as_derived() {
+        let core = crate::core::test_support::test_core().await;
+        let src = core.store.insert_image_corpus("h", "image", Some("IMG.png"), &serde_json::json!({
+            "note": "front porch",
+            "file": {"name": "IMG.png", "width": 4, "height": 2},
+            "exif": {"taken_at": "2026-08-09T14:12:03", "camera": "Pixel", "gps": {"lat": 1.5, "lon": 2.5}}
+        })).await.unwrap().into_corpus();
+        core.store.set_described_text(&src.id, "# Porch\n\nblue door", vec![]).await.unwrap();
+        let (app, _t, _c) = crate::web::api::tests::app_from_core(core).await;
+        let html = page(app, &format!("/ui/corpora/{}", src.id)).await;
+        assert!(html.contains(&format!("/api/v1/corpora/{}/image", src.id)), "img src");
+        assert!(html.contains("front porch"));
+        assert!(html.contains("2026-08-09T14:12:03"));
+        assert!(html.contains("1.5"));
+        assert!(html.contains("Transcription"), "the text is labelled as derived, not 'Raw corpus'");
+        assert!(html.contains("blue door"));
+    }
+```
+If no `page(app, uri)` helper exists in `ui.rs` tests, add one: mint a token via `crate::auth::tokens::mint`, GET with `authorization: Bearer`, and read the body to a `String` (mirror `api::tests::get` + `to_bytes`).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test web::ui::tests::the_capture_page web::corpus_view 2>&1 | grep -E "^error|panicked" | head`
+
+- [ ] **Step 3: Implement**
+
+`src/web/corpus_view.rs`:
+```rust
+/// An image corpus: the lines are the model's reading of the picture, and the
+/// label says so, because a span into a transcription is a claim about what
+/// the model wrote, not about what the photo shows.
+pub struct ImageTranscript;
+
+impl CorpusView for ImageTranscript {
+    fn slice(&self, source: &Corpus, span: Option<&CorpusSpan>, context: usize) -> CorpusSlice {
+        let mut s = TextLines.slice(source, span, context);
+        s.label = match span {
+            Some(sp) => format!("transcription lines {}–{}", sp.start_line, sp.end_line),
+            None => "transcription".into(),
+        };
+        s
+    }
+}
+
+pub fn for_corpus(source: &Corpus) -> Box<dyn CorpusView> {
+    if source.origin == crate::core::ingest::ORIGIN_IMAGE {
+        Box::new(ImageTranscript)
+    } else {
+        Box::new(TextLines)
+    }
+}
+```
+Update the module doc comment's "One implementation today" sentence.
+
+`src/web/ui.rs`:
+- `CaptureTemplate` gets `vision_enabled: bool`; `capture_page` sets `vision_enabled: st.core.describer.is_some()`.
+- `CorpusTemplate` gets:
+  ```rust
+      /// An image corpus: the page shows the photo, and the lines below are the
+      /// model's reading of it rather than the source itself.
+      image: bool,
+      /// Rows of what the door recorded about the capture, already formatted.
+      meta_rows: Vec<(String, String)>,
+      note: Option<String>,
+  ```
+- In `corpus_detail`, compute:
+  ```rust
+      let image = s.origin == crate::core::ingest::ORIGIN_IMAGE;
+      let note = s.metadata["note"].as_str().map(str::to_string);
+      let meta_rows = metadata_rows(&s.metadata);
+  ```
+  and add:
+  ```rust
+  /// The metadata worth a row on the corpus page, in reading order. Everything
+  /// else the file carried is in the JSON, one API call away.
+  fn metadata_rows(m: &serde_json::Value) -> Vec<(String, String)> {
+      let mut rows = Vec::new();
+      let exif = &m["exif"];
+      if let Some(t) = exif["taken_at"].as_str() { rows.push(("Taken".into(), t.into())); }
+      if let Some(c) = exif["camera"].as_str() { rows.push(("Camera".into(), c.into())); }
+      if let (Some(lat), Some(lon)) = (exif["gps"]["lat"].as_f64(), exif["gps"]["lon"].as_f64()) {
+          rows.push(("Location".into(), format!("{lat}, {lon}")));
+      }
+      let f = &m["file"];
+      if let Some(n) = f["name"].as_str() { rows.push(("File".into(), n.into())); }
+      if let (Some(w), Some(h)) = (f["width"].as_u64(), f["height"].as_u64()) {
+          rows.push(("Size".into(), format!("{w}×{h}")));
+      }
+      if let Some(e) = m["describe"]["error"].as_str() { rows.push(("Reading".into(), e.into())); }
+      rows
+  }
+  ```
+- Queue label (~line 745): when `s.raw_text` is empty and `s.title_hint` is `None`, fall back to `"photo"` for image origin: `.unwrap_or_else(|| if s.origin == ORIGIN_IMAGE && s.raw_text.is_empty() { "photo".into() } else { markdown::snippet(&s.raw_text, 60) })`.
+
+`src/web/templates/capture.html`: replace the drop label and its script with:
+```html
+  <label class="row muted" id="drop"
+         style="border:1px dashed var(--line);padding:.6rem;border-radius:.4rem">
+    {% if vision_enabled %}
+    <input type="file" name="file" accept=".txt,text/plain,image/*" hidden>
+    <span>…or drop a <code>.txt</code> file or an image here — on a phone, tap to take a photo.</span>
+    {% else %}
+    <input type="file" name="file" accept=".txt,text/plain" hidden>
+    <span>…or drop a <code>.txt</code> file here.</span>
+    {% endif %}
+  </label>
+  {# Context for whatever file comes next: a sentence about what it is. Sent
+     with the file, then cleared. For an image the vision model reads it too. #}
+  <input class="input" type="text" name="note" maxlength="2000"
+         placeholder="Add context for the file (optional) — what is it, why keep it?">
+```
+and the script's `send`:
+```js
+    var noteBox = document.querySelector('input[name="note"]');
+    var VISION = {% if vision_enabled %}true{% else %}false{% endif %};
+    function send(file) {
+      if (!file) return;
+      var isImage = file.type.indexOf('image/') === 0;
+      var result = document.getElementById('capture-result');
+      if (isImage && !VISION) {
+        result.textContent = 'Image capture is not configured on this server.';
+        return;
+      }
+      var payload = new FormData();
+      if (noteBox && noteBox.value.trim()) payload.append('note', noteBox.value.trim());
+      payload.append(isImage ? 'image' : 'file', file, file.name || (isImage ? 'photo.jpg' : 'paste.txt'));
+      var url = isImage ? '/api/v1/corpora/image' : '/api/v1/corpora/upload';
+      fetch(url, { method: 'POST', body: payload })
+        .then(function (r) {
+          return r.json()
+            .catch(function () { return { error: 'engram answered ' + r.status + '.' }; })
+            .then(function (j) { return [r.ok, j]; });
+        })
+        .catch(function () { return [false, { error: 'engram is unreachable.' }]; })
+        .then(function (pair) {
+          result.textContent = pair[0]
+            ? (isImage ? 'Captured — the photo is queued to be read.' : 'Captured.')
+            : (pair[1].error || 'Upload failed.');
+          if (pair[0]) { if (noteBox) noteBox.value = ''; htmx.trigger(document.body, 'captured'); }
+        });
+    }
+    if (drop) {
+      picker.addEventListener('change', function () { send(picker.files[0]); });
+      drop.addEventListener('dragover', function (e) { e.preventDefault(); });
+      drop.addEventListener('drop', function (e) { e.preventDefault(); send(e.dataTransfer.files[0]); });
+    }
+    // A pasted screenshot goes the same way as a dropped one.
+    document.addEventListener('paste', function (e) {
+      var items = (e.clipboardData && e.clipboardData.items) || [];
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].kind === 'file' && items[i].type.indexOf('image/') === 0) {
+          e.preventDefault();
+          send(items[i].getAsFile());
+          return;
+        }
+      }
+    });
+```
+Keep the existing comments about the 8 MB reply not being JSON and the same-origin cookie. Note the surrounding `<form>` posts urlencoded text; the `note` input is inside it — give it `form="none"`-equivalent by placing it **outside** the `<form>` (right after `</form>`, before `#capture-result`) so a text paste does not send it. Adjust the markup accordingly.
+
+`src/web/templates/corpus.html`: after the `source_url` block add:
+```html
+{% if image %}
+<div class="card">
+  <div class="card-head"><span class="card-title">Photo</span>
+    <span class="spacer"></span>
+    <a class="quiet-link" href="/api/v1/corpora/{{ id }}/image?original=1">original</a>
+  </div>
+  <a href="/api/v1/corpora/{{ id }}/image?original=1">
+    <img src="/api/v1/corpora/{{ id }}/image" alt="captured image" style="max-width:100%;height:auto;border-radius:.4rem">
+  </a>
+  {% if let Some(n) = note %}<p><b>Note:</b> {{ n }}</p>{% endif %}
+  {% if !meta_rows.is_empty() %}
+  <table class="meta">
+    {% for r in meta_rows %}<tr><td class="muted">{{ r.0 }}</td><td>{{ r.1 }}</td></tr>{% endfor %}
+  </table>
+  {% endif %}
+</div>
+{% else if let Some(n) = note %}
+<p><b>Note:</b> {{ n }}</p>
+{% endif %}
+```
+and change the raw-corpus card title to:
+```html
+    <span class="card-title">{% if restored %}Restored artifacts{% else if image %}Transcription{% else %}Raw corpus{% endif %}</span>
+    {% if image %}<span class="muted">— the model's reading of the photo, not the source itself</span>{% endif %}
+```
+When `image` and `lines` is empty (still describing), show `<p class="muted">Not read yet — the photo is queued for the vision model.</p>` inside the card instead of the empty table.
+
+- [ ] **Step 4: Run, eyeball, commit**
+
+Run: `cargo test web:: 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+Optionally run the server with a `[infer.vision]` block against a local model and drop a photo on `/ui/capture`; watch the job log for `image read; queued for synthesis`.
+```bash
+git add src/web
+git commit -m "feat(ui): image capture from picker, camera, drop and paste; image corpus page"
+```
+
+---
+
+### Task 9: Docs and roadmap
+
+**Files:**
+- Modify: `README.md` (capture doors section), `ROADMAP.md`
+
+- [ ] **Step 1: README** — in the section listing capture doors, add one bullet: images (JPEG/PNG/WebP) via the capture page, phone camera through the PWA, or `POST /api/v1/corpora/image` (multipart `image`, optional `note`, `title_hint`); requires `[infer.vision]`; the original is kept and served at `GET /api/v1/corpora/{id}/image?original=1`.
+- [ ] **Step 2: ROADMAP** — mark image capture done under the "File upload, then PDF" line and note that `attachments` + `CorpusView` are where PDF slots in.
+- [ ] **Step 3: Commit**
+```bash
+git add README.md ROADMAP.md
+git commit -m "docs: image capture door"
+```
+
+---
+
+## Self-review against the spec
+
+- §1 data model — Task 2 (table, column, statuses, hash) ✔; `exif.tags` "everything the file carries" — Task 3 ✔.
+- §2 flow/pipeline — Task 5 (door, no inference), Task 6 (stage, empty → parked with reason, near-dupe → parked, retry via error) ✔.
+- §2 system prompt — Task 4 ✔.
+- §3 config three modes, probe, redaction, capture keys — Tasks 1, 4 ✔.
+- §4 UI: picker/camera/drop/paste, context field, disabled state — Task 8 ✔. Offline: unchanged ✔.
+- §5 API endpoints, per-route limit, `note` on `.txt` upload, image serving, detail pane, ops (nothing needed) — Tasks 7, 8 ✔.
+- §6 note table — Tasks 5, 6, 7 ✔ (text synthesis does not read the note).
+- §7 tests — each task carries its own; end-to-end in Task 6.
+- Type consistency: `insert_image_corpus(hash, origin, title_hint, &metadata)`, `set_described_text(id, text, Vec<u64>)`, `attachment_preview -> Option<(String, Vec<u8>)>`, `FakeDescriber::{saying,failing,calls,last_context}`, `test_core_with_describer(Arc<FakeDescriber>)`, `test_core_without_vision()`, `api_router(usize)` — used identically across tasks.

--- a/docs/superpowers/plans/2026-08-15-pr15-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-15-pr15-review-fixes.md
@@ -1,0 +1,1436 @@
+# PR 15 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix every finding from the multi-agent review of PR 15 (feat/image-capture) — the eight ranked ones and the ones the reviewer cut as minor — so no captured image can end in a state with no operator recovery.
+
+**Architecture:** The image door (`Core::ingest_image`) and the vision stage (`jobs/describe.rs`) get a real failure model: a reading that cannot happen parks the corpus as `failed` with the reason in `metadata.describe.error`, and a new `reprocess(Describe)` re-queues the read from the stored original ("Re-read" on the corpus page). Permanent 4xx from any inference endpoint becomes a new non-retryable `Error::InferenceRejected`, and the job runner learns what to do with it for the two stages that carry knowledge (Embed: split chunk by chunk; Describe: park). Both capture doors write their rows in one transaction, share one corpus INSERT and one multipart reader, and stop seeding `title_hint` from a filename. Image decoding runs under `spawn_blocking` with dimension/allocation limits, and duplicate detection happens before the decode.
+
+**Tech Stack:** Rust, sqlx/SQLite, tokio, axum, `image` crate. Tests are in-file `#[cfg(test)] mod tests` using `crate::core::test_support::{test_core, test_core_with_describer, test_core_without_vision}` and `crate::infer::fake::FakeDescriber`.
+
+**Spec:** The findings come from the `/code-review 15` run recorded in the "Findings and decisions" section below. The branch's own design spec is `docs/superpowers/plans/2026-08-15-image-capture.md`.
+
+## Global Constraints
+
+- Run `cargo test` after every implementation step; run `cargo fmt` before every commit. `cargo clippy --all-targets` must stay clean.
+- Comment style: comments state constraints the code cannot show, in the codebase's essay style. Never "fixed per review".
+- Test names are full snake_case sentences, matching the existing suites.
+- Commit after each task with a conventional-commit message.
+- No schema changes: `corpora`, `attachments`, `jobs` columns are as they are on the branch.
+- Statuses: `describing → raw → … → ready`; the only new terminal state used here is the existing `failed`.
+
+## Findings and decisions
+
+Ranked findings (task number in parentheses):
+
+1. Empty vision reading parks the corpus in `needs_review` with `near_dupe_of` NULL — a state no UI/API path can act on (Task 4, Task 5).
+2. `reprocess(Synthesize)` on an image still `describing` (unguarded "Re-segment" button) flips it to `raw` with empty text, synthesize marks it `failed`, the pending Describe no-ops (Task 5, Task 6).
+3. Permanent 4xx from the vision endpoint is retried forever; Describe has no exhaustion arm and never sets `failed` (Task 1, Task 2, Task 3).
+4. `image::prepare` + SHA-256 run synchronously on the async worker (Task 8).
+5. `load_from_memory_with_format` has no dimension/allocation limits (Task 7).
+6. Filename → `title_hint` fallback disarms the Title stage for every image (Task 9).
+7. Text upload handler drains all parts and the last `file` part silently wins (Task 10).
+8. Image hashing re-implements `content_hash` inline and runs after the expensive decode (Task 8).
+
+Minor findings the reviewer cut, included by the user's request:
+
+9. Non-transactional corpus / attachment / enqueue writes in `ingest_image`, and the same insert-then-enqueue pattern in `ingest_capture` (Task 11).
+10. `insert_image_corpus` duplicates `insert_corpus_with_signature`'s INSERT (Task 11).
+11. `upload` and `upload_image` duplicate the multipart loop (Task 10).
+12. The near-dupe park block in `describe.rs` duplicates `ingest_capture`'s (Task 4, Task 11).
+
+Decisions from the user (2026-08-15):
+
+- **`reprocess(Describe)` is in scope.** It re-queues the vision read of the stored original; the corpus page gets a "Re-read" button for image corpora. Re-segment is refused while an image corpus is unread.
+- **4xx classification applies to all roles via `post_json`.** 400/404/413/415/422 (and any other 4xx except 408 and 429) become non-retryable. Embed's "exhausted → split chunk by chunk" path is preserved for the non-retryable case.
+- **Filename → `title_hint` fallback goes for both doors** (images and text uploads). The filename stays in `metadata.file.name`.
+- **Both doors become transactional.**
+
+Decision made in planning, flagged for the executor: when the vision role is *not configured*, an exhausted Describe job keeps waiting at the backoff ceiling (the existing test `without_a_vision_role_the_job_waits_rather_than_failing_the_corpus` pins that intent). Every other exhausted or rejected Describe parks the corpus as `failed`.
+
+---
+
+### Task 1: `Error::InferenceRejected` — a non-retryable inference failure
+
+**Files:**
+- Modify: `src/error.rs` (enum around line 10; `retryable()` line 42; `status()` line 52; tests line 109)
+- Modify: `src/infer/openai.rs:30-63` (`post_json`)
+- Modify: `src/infer/fake.rs:533-585` (`FakeDescriber`)
+
+**Interfaces:**
+- Produces: `Error::InferenceRejected { role: &'static str, detail: String }` — `retryable() == false`, HTTP status `502 BAD_GATEWAY` (same as `Inference`; check what `Inference` maps to in `status()` and use the same arm).
+- Produces: `pub fn permanent_upstream_status(status: reqwest::StatusCode) -> bool` in `src/infer/openai.rs`.
+- Produces: `FakeDescriber::rejecting(msg: &str) -> Self` — `describe()` returns `Error::InferenceRejected { role: "vision", detail: msg }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/error.rs` tests, extend `retryable_only_for_transient_failures`:
+
+```rust
+        // The endpoint answered and said no: another attempt sends the same
+        // request and gets the same answer.
+        assert!(
+            !Error::InferenceRejected {
+                role: "vision",
+                detail: "HTTP 400: model does not accept images".into()
+            }
+            .retryable()
+        );
+```
+
+In `src/infer/openai.rs` add a `#[cfg(test)] mod tests` (or extend the existing one) with:
+
+```rust
+    #[test]
+    fn a_4xx_is_permanent_except_the_two_that_mean_try_again() {
+        use reqwest::StatusCode as S;
+        assert!(permanent_upstream_status(S::BAD_REQUEST));
+        assert!(permanent_upstream_status(S::NOT_FOUND));
+        assert!(permanent_upstream_status(S::PAYLOAD_TOO_LARGE));
+        assert!(permanent_upstream_status(S::UNSUPPORTED_MEDIA_TYPE));
+        assert!(permanent_upstream_status(S::UNPROCESSABLE_ENTITY));
+        assert!(!permanent_upstream_status(S::REQUEST_TIMEOUT));
+        assert!(!permanent_upstream_status(S::TOO_MANY_REQUESTS));
+        assert!(!permanent_upstream_status(S::INTERNAL_SERVER_ERROR));
+        assert!(!permanent_upstream_status(S::BAD_GATEWAY));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test error:: infer::openai::tests`
+Expected: compile error — `InferenceRejected` and `permanent_upstream_status` do not exist.
+
+- [ ] **Step 3: Implement**
+
+`src/error.rs`, after the `Inference` variant:
+
+```rust
+    /// The endpoint understood the request and refused it — a model that does
+    /// not take images, a body over its limit, a name it does not serve.
+    /// Kept apart from `Inference` because the two ask opposite things of a
+    /// worker: one is a wait, the other is the same answer for as long as the
+    /// same request is sent.
+    #[error("inference[{role}] rejected: {detail}")]
+    InferenceRejected { role: &'static str, detail: String },
+```
+
+`retryable()` is a `matches!` over the retryable set, so `InferenceRejected` is non-retryable by omission — leave the match as is. In `status()`, add `InferenceRejected` to the same arm as `Inference`.
+
+`src/infer/openai.rs`:
+
+```rust
+/// A 4xx that says the request itself is wrong. 408 and 429 are 4xx by number
+/// but "come back later" by meaning, and stay retryable.
+pub fn permanent_upstream_status(status: reqwest::StatusCode) -> bool {
+    status.is_client_error()
+        && status != reqwest::StatusCode::REQUEST_TIMEOUT
+        && status != reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+```
+
+In `post_json`, replace the `!status.is_success()` block:
+
+```rust
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        // Truncate: an upstream error page can be megabytes, and this string
+        // ends up in a job's last_error column.
+        let detail: String = body.chars().take(400).collect();
+        let detail = format!("HTTP {status}: {detail}");
+        return Err(if permanent_upstream_status(status) {
+            Error::InferenceRejected { role, detail }
+        } else {
+            Error::Inference { role, detail }
+        });
+    }
+```
+
+`src/infer/fake.rs` — `FakeDescriber` gets a `reject: bool` field (default false), a constructor, and the `describe` failure arm honours it:
+
+```rust
+    /// The endpoint's "no", not its "not now": what a non-multimodal model
+    /// answers with, and what a worker must not retry.
+    pub fn rejecting(msg: &str) -> Self {
+        let mut d = Self::failing(msg);
+        d.reject = true;
+        d
+    }
+```
+
+```rust
+        match &self.fail_with {
+            Some(m) if self.reject => Err(Error::InferenceRejected {
+                role: "vision",
+                detail: m.clone(),
+            }),
+            Some(m) => Err(Error::Inference {
+                role: "vision",
+                detail: m.clone(),
+            }),
+            None => Ok(self.reply.clone()),
+        }
+```
+
+(Adjust to the actual shape of the existing match; `Default` for `FakeDescriber` must set `reject: false`.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/error.rs src/infer/openai.rs src/infer/fake.rs
+git commit -m "feat(infer): a 4xx from the endpoint is a rejection, not a retry"
+```
+
+---
+
+### Task 2: The job runner handles a rejection for the two stages that carry knowledge
+
+**Files:**
+- Modify: `src/jobs/mod.rs:44-140` (`run_claimed`)
+- Modify: `src/jobs/describe.rs` (new `pub async fn park_failed`)
+- Test: `src/jobs/mod.rs` tests, `src/jobs/describe.rs` tests
+
+**Interfaces:**
+- Consumes: `Error::InferenceRejected` (Task 1), `FakeDescriber::rejecting` (Task 1).
+- Produces: `describe::park_failed(core: &Core, corpus_id: &str, reason: &str) -> Result<()>` — writes `metadata.describe = {"error": reason}` and sets status `Failed`. Used by Task 3 and Task 4 too.
+
+Behaviour to implement in `run_claimed`:
+
+- `Err(e) if e.retryable()`, `(Stage::Describe, _) if exhausted`: if `core.describer.is_none()` → keep the existing `fail_job` behaviour (log "vision role not configured; waiting"). Otherwise → `describe::park_failed(core, target, &e.to_string())` then `complete_job`.
+- The final `Err(e)` (non-retryable) arm gains a match on stage:
+  - `(Stage::Embed, "corpus")` → `embed::split_into_artifact_jobs` then `complete_job` (the same thing the exhausted arm does; extract the existing block into a local `async fn split_or_fail(core, &job, &e)` so both arms call it).
+  - `(Stage::Embed, _)` (single artifact) → `fail_job(MAX_ATTEMPTS)`, `mark_embed_failed`, `settle_corpus` — the same three writes the retryable-exhausted path already does; extract into `async fn settle_failed_artifact(core, &job)`.
+  - `(Stage::Describe, _)` → `describe::park_failed(...)` then `complete_job`.
+  - everything else → today's `fail_job(job.id, MAX_ATTEMPTS, ...)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/jobs/describe.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn a_rejected_reading_parks_the_corpus_as_failed_with_the_reason() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::rejecting(
+            "HTTP 400: this model does not accept images",
+        )))
+        .await;
+        let id = captured(&core, 6, None).await;
+        assert!(crate::jobs::run_one(&core).await.unwrap());
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Failed);
+        assert!(
+            src.metadata["describe"]["error"]
+                .as_str()
+                .unwrap()
+                .contains("does not accept images")
+        );
+        assert!(
+            !core.store.live_job(Stage::Describe, &id).await.unwrap(),
+            "the job is closed, not re-armed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reading_that_keeps_failing_parks_the_corpus_after_its_attempts() {
+        let d = Arc::new(FakeDescriber::failing("gpu on fire"));
+        let core = test_core_with_describer(d.clone()).await;
+        let id = captured(&core, 7, None).await;
+        // Each run_one claims, fails, and re-arms with backoff; the store's
+        // clock is what gates the next claim, so drive the row directly.
+        for _ in 0..crate::store::jobs::MAX_ATTEMPTS {
+            core.store.reset_backoff_for_tests(Stage::Describe, &id).await;
+            assert!(crate::jobs::run_one(&core).await.unwrap());
+        }
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Failed);
+        assert!(src.metadata["describe"]["error"].as_str().unwrap().contains("gpu on fire"));
+        assert!(!core.store.live_job(Stage::Describe, &id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn without_a_vision_role_an_exhausted_job_keeps_waiting() {
+        let core = test_core_without_vision().await;
+        let src = core.store
+            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .await.unwrap().into_corpus();
+        core.store.enqueue(Stage::Describe, "corpus", &src.id).await.unwrap();
+        for _ in 0..crate::store::jobs::MAX_ATTEMPTS + 1 {
+            core.store.reset_backoff_for_tests(Stage::Describe, &src.id).await;
+            assert!(crate::jobs::run_one(&core).await.unwrap());
+        }
+        assert_eq!(core.store.get_corpus(&src.id).await.unwrap().status, CorpusStatus::Describing);
+        assert!(core.store.live_job(Stage::Describe, &src.id).await.unwrap());
+    }
+```
+
+Look at how `src/store/jobs.rs` tests (around line 557, the `MAX_ATTEMPTS + 3` loop) drive a job past its backoff and use the same mechanism. If there is no helper, add `#[cfg(test)] pub async fn reset_backoff_for_tests(&self, stage: Stage, target_id: &str)` to `src/store/jobs.rs` that runs `UPDATE jobs SET run_after = 0 WHERE stage = ? AND target_id = ?`.
+
+In `src/jobs/mod.rs` tests, add an embed test only if a fake embedder can be made to reject; `FakeEmbedder` cannot fail today. Add `FakeEmbedder::rejecting(msg)` (mirror `FakeDescriber::rejecting`) plus a `test_core_with_embedder(Arc<FakeEmbedder>)` in `src/core/mod.rs::test_support` mirroring `test_core_with_describer`, then:
+
+```rust
+    #[tokio::test]
+    async fn a_batch_embed_the_endpoint_rejects_is_retried_chunk_by_chunk() {
+        let core = test_core_with_embedder(Arc::new(FakeEmbedder::rejecting("HTTP 413"))).await;
+        let src = core.ingest("alpha para\n\nbeta para", "web", None).await.unwrap();
+        // Drive to the batch embed job and run it once.
+        while let Some(job) = core.store.claim_job().await.unwrap() {
+            if job.stage == Stage::Embed && job.target_kind == "corpus" {
+                run_claimed(&core, job).await.unwrap();
+                break;
+            }
+            run_claimed(&core, job).await.unwrap();
+        }
+        let per_chunk = core.store.pending_artifacts_for_corpus(&src.id).await.unwrap();
+        assert!(!per_chunk.is_empty());
+        for c in per_chunk {
+            assert!(core.store.live_job(Stage::Embed, &c.id).await.unwrap(), "per-chunk unit armed");
+        }
+    }
+```
+
+(If the synthesize path in tests does not reach Embed without extra steps, mirror how `draining_the_queue_takes_a_source_all_the_way_to_ready` in the same module gets there.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test jobs::`
+Expected: FAIL — `park_failed`, `reset_backoff_for_tests`, `FakeEmbedder::rejecting`, `test_core_with_embedder` missing; then behavioural failures.
+
+- [ ] **Step 3: Implement**
+
+`src/jobs/describe.rs`:
+
+```rust
+/// The read is not going to happen — the model said no, or said nothing for
+/// as long as we were willing to ask. The photo stays; the corpus says why it
+/// stopped, on the page and on Ops, and `reprocess(Describe)` is the way back.
+pub async fn park_failed(core: &Core, corpus_id: &str, reason: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    let mut meta = src.metadata.clone();
+    meta["describe"] = serde_json::json!({ "error": reason });
+    core.store.set_corpus_metadata(corpus_id, &meta).await?;
+    core.store.set_corpus_status(corpus_id, CorpusStatus::Failed).await?;
+    tracing::warn!(corpus_id, reason, "image could not be read; parked as failed");
+    Ok(())
+}
+```
+
+`src/jobs/mod.rs`: restructure `run_claimed` per the behaviour list above. The retryable-exhausted match gains:
+
+```rust
+                // The photo is stored, so nothing is lost by stopping — but a
+                // corpus shown as in flight forever is a lie. Unless the role is
+                // simply not configured, which is a wait, not a failure.
+                (Stage::Describe, _) if exhausted && core.describer.is_some() => {
+                    tracing::warn!(error = %e, "could not read this image; parking it");
+                    describe::park_failed(core, &job.target_id, &e.to_string()).await?;
+                    core.store.complete_job(job.id).await?;
+                }
+```
+
+The non-retryable arm:
+
+```rust
+        Err(e) => {
+            tracing::error!(error = %e, "job failed permanently");
+            match (job.stage, job.target_kind.as_str()) {
+                // Refused as a batch does not mean refused as chunks; the same
+                // isolation the exhausted path buys is worth buying here.
+                (Stage::Embed, "corpus") => split_or_fail(core, &job, &e).await?,
+                (Stage::Embed, _) => settle_failed_artifact(core, &job, &e).await?,
+                (Stage::Describe, _) => {
+                    describe::park_failed(core, &job.target_id, &e.to_string()).await?;
+                    core.store.complete_job(job.id).await?;
+                }
+                _ => {
+                    core.store
+                        .fail_job(job.id, MAX_ATTEMPTS, &e.to_string())
+                        .await?;
+                }
+            }
+            Ok(true)
+        }
+```
+
+with the two helpers holding the bodies currently inline in the exhausted arms (unchanged logic, moved).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/mod.rs src/jobs/describe.rs src/store/jobs.rs src/infer/fake.rs src/core/mod.rs
+git commit -m "feat(jobs): a read that cannot happen parks the image as failed; a rejected batch embed splits"
+```
+
+---
+
+### Task 3: `reprocess(Describe)` — re-read a stored image
+
+**Files:**
+- Modify: `src/core/ingest.rs:947-1043` (`reprocess`)
+- Modify: `src/jobs/describe.rs` (doc comment near line 9 already fine; nothing else)
+- Test: `src/core/ingest.rs` tests
+
+**Interfaces:**
+- Consumes: `describe::park_failed` (Task 2) only conceptually — the reverse operation.
+- Produces: `Core::reprocess(id, Stage::Describe)` succeeds for a corpus with an image attachment; refuses (Validation) for one without. Needs `Store::attachment_for_corpus` (exists, `src/store/attachments.rs:59`) and two new store methods:
+  - `Store::clear_described_text(&self, id: &str) -> Result<()>` — `UPDATE corpora SET raw_text = '', shingles = '', updated_at = ? WHERE id = ?`.
+  - `Store::clear_describe_error(&self, id) ` is not needed: read the metadata, remove the `describe` key, `set_corpus_metadata`.
+
+Semantics of Re-read: same cleanup as re-segment (vectors, artifacts, segments, coverage, window jobs, Title job, near-dupe park, dangling supersessions), then clear the read text and signature, drop `metadata.describe`, set status `Describing`, delete any closed Describe job row and enqueue Describe. Refuse when `self.describer.is_none()` with the same message `ingest_image` uses.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/core/ingest.rs` tests (the module already imports `ImageCapture`, `Stage`, `CorpusStatus`):
+
+```rust
+    fn a_png(seed: u8) -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(16, 16, |x, y| Rgb([seed, x as u8, y as u8]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    #[tokio::test]
+    async fn re_reading_a_failed_image_clears_the_reason_and_queues_describe_again() {
+        let core = test_core().await; // test_core has a default FakeDescriber
+        let id = core
+            .ingest_image(ImageCapture { bytes: a_png(1), filename: None, title_hint: None, note: None })
+            .await.unwrap().id;
+        crate::jobs::describe::park_failed(&core, &id, "HTTP 400").await.unwrap();
+        core.store.complete_job(core.store.claim_job().await.unwrap().unwrap().id).await.unwrap();
+
+        core.reprocess(&id, Stage::Describe).await.unwrap();
+
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert!(src.metadata.get("describe").is_none());
+        let job = core.store.claim_job().await.unwrap().expect("describe re-armed");
+        assert_eq!((job.stage, job.target_id.as_str()), (Stage::Describe, id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn re_reading_a_ready_image_starts_it_over_from_the_pixels() {
+        let core = test_core().await;
+        let id = core
+            .ingest_image(ImageCapture { bytes: a_png(2), filename: None, title_hint: None, note: None })
+            .await.unwrap().id;
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert_eq!(core.store.get_corpus(&id).await.unwrap().status, CorpusStatus::Ready);
+
+        core.reprocess(&id, Stage::Describe).await.unwrap();
+
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert_eq!(src.raw_text, "");
+        assert!(src.shingles.is_empty());
+        assert!(core.store.artifacts_for_corpus(&id).await.unwrap().is_empty());
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert_eq!(core.store.get_corpus(&id).await.unwrap().status, CorpusStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn a_text_corpus_cannot_be_re_read() {
+        let core = test_core().await;
+        let src = core.ingest("some text", "web", None).await.unwrap();
+        assert!(matches!(
+            core.reprocess(&src.id, Stage::Describe).await,
+            Err(Error::Validation(_))
+        ));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test core::ingest::tests::re_reading core::ingest::tests::a_text_corpus_cannot`
+Expected: FAIL — `reprocess(Describe)` returns the "not supported yet" Validation error; `clear_described_text` missing.
+
+- [ ] **Step 3: Implement**
+
+Extract the cleanup shared by Synthesize and Describe into a private method on `Core` in `src/core/ingest.rs`, keeping every existing comment with the line it explains:
+
+```rust
+    /// Everything a rerun of the pipeline from `raw_text` has to forget first.
+    /// Shared by re-segment and re-read; the comments on each line are the
+    /// reasons the line exists.
+    async fn forget_derived_work(&self, id: &str) -> Result<()> {
+        self.vectors.delete_by_corpus(id).await?;
+        for c in self.store.artifacts_for_corpus(id).await? {
+            self.store.delete_artifact(&c.id).await?;
+        }
+        self.store.clear_segments(id).await?;          // (existing comment)
+        self.store.clear_corpus_coverage(id).await?;   // (existing comment)
+        self.store.delete_window_jobs(id).await?;      // (existing comment)
+        self.store.delete_job(Stage::Title, id).await?; // (existing comment)
+        self.store.set_near_dupe(id, None, None).await?; // (existing comment)
+        Ok(())
+    }
+```
+
+Then in `reprocess`:
+
+```rust
+            Stage::Synthesize | Stage::Enrich => {
+                self.forget_derived_work(&src.id).await?;
+                self.store.set_corpus_status(&src.id, CorpusStatus::Raw).await?;
+                self.heal_dangling_supersessions().await?;
+                self.store.enqueue(Stage::Synthesize, "corpus", &src.id).await?;
+            }
+            // ...
+            // A stored image can always be read again — with a better model, or
+            // after the endpoint that refused it is fixed. The reading and
+            // everything derived from it are replaced wholesale, because a chunk
+            // of the old reading has no span in the new one.
+            Stage::Describe => {
+                if self.store.attachment_for_corpus(&src.id).await?.is_none() {
+                    return Err(Error::Validation(
+                        "only a captured image can be re-read".into(),
+                    ));
+                }
+                if self.describer.is_none() {
+                    return Err(Error::Validation(
+                        "image capture is not configured — set [infer.vision] to enable it".into(),
+                    ));
+                }
+                self.forget_derived_work(&src.id).await?;
+                self.store.clear_described_text(&src.id).await?;
+                let mut meta = src.metadata.clone();
+                if let Some(m) = meta.as_object_mut() {
+                    m.remove("describe");
+                }
+                self.store.set_corpus_metadata(&src.id, &meta).await?;
+                self.store.set_corpus_status(&src.id, CorpusStatus::Describing).await?;
+                self.heal_dangling_supersessions().await?;
+                self.store.enqueue(Stage::Describe, "corpus", &src.id).await?;
+            }
+```
+
+`src/store/corpora.rs`, next to `set_described_text`:
+
+```rust
+    /// The reverse of `set_described_text`, for a re-read: no text and no
+    /// signature, so the row is comparable to nothing until the model speaks.
+    pub async fn clear_described_text(&self, id: &str) -> Result<()> {
+        sqlx::query("UPDATE corpora SET raw_text = '', shingles = '', updated_at = ? WHERE id = ?")
+            .bind(now())
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+```
+
+Note: `enqueue` uses `Guard::Any`, so a Describe row closed by `complete_job` is re-armed — no explicit delete needed.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS. Also update `an_unknown_reprocess_stage_is_a_400` neighbours in `src/web/api.rs` if any test asserted that `describe` is refused (grep `not supported yet`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ingest.rs src/store/corpora.rs src/web/api.rs
+git commit -m "feat(ingest): reprocess(describe) re-reads a stored image from the pixels"
+```
+
+---
+
+### Task 4: An empty reading parks as `failed`; the near-dupe park is shared
+
+**Files:**
+- Modify: `src/jobs/describe.rs:41-56` and `:63-93`
+- Modify: `src/core/ingest.rs` (new `pub(crate) async fn park_or_queue`)
+- Test: `src/jobs/describe.rs` tests (`an_empty_reading_parks_the_corpus_with_the_reason`)
+
+**Interfaces:**
+- Consumes: `describe::park_failed` (Task 2).
+- Produces: `Core::park_or_queue(&self, corpus_id: &str, near: Option<&NearDuplicate>) -> Result<()>` — `Some` → `set_near_dupe` + status `NeedsReview` + info log; `None` → status `Raw` + enqueue Synthesize. `describe::run` calls it after `set_described_text`. (`ingest_capture` stops needing it in Task 11, where the park is written at insert time; until then leave `ingest_capture` as is.)
+
+- [ ] **Step 1: Change the test**
+
+Rename and rewrite `an_empty_reading_parks_the_corpus_with_the_reason` → `an_empty_reading_parks_the_corpus_as_failed_with_the_reason`: assert `CorpusStatus::Failed` instead of `NeedsReview`, and add:
+
+```rust
+        assert!(src.near_dupe_of.is_none(), "not a near-duplicate; not on the review queue");
+        assert!(core.store.parked_corpora(10).await.unwrap().is_empty());
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test an_empty_reading_parks`
+Expected: FAIL on the status assertion.
+
+- [ ] **Step 3: Implement**
+
+`src/jobs/describe.rs`, the empty branch becomes:
+
+```rust
+    if text.trim().is_empty() {
+        // Not a near-duplicate, so not the review queue: that page offers
+        // "keep" and "discard" against another corpus, and there is none.
+        park_failed(core, corpus_id, "the model returned no text for this image").await?;
+        return Ok(());
+    }
+```
+
+and the tail:
+
+```rust
+    let sig = crate::store::shingle::signature(&text);
+    let near = core.store.find_near_duplicate(&sig, core.consolidate.near_dupe_min).await?;
+    core.store.set_described_text(corpus_id, &text, sig).await?;
+    core.park_or_queue(corpus_id, near.as_ref()).await?;
+    tracing::info!(corpus_id, chars = text.len(), parked = near.is_some(), "image read");
+    Ok(())
+```
+
+`src/core/ingest.rs`, on `impl Core`:
+
+```rust
+    /// The fork every capture reaches once its text is known: parked next to
+    /// what it resembles, or queued for synthesis. The status write is here so
+    /// no caller can park without saying what it parked beside.
+    pub(crate) async fn park_or_queue(
+        &self,
+        corpus_id: &str,
+        near: Option<&crate::store::corpora::NearDuplicate>,
+    ) -> Result<()> {
+        match near {
+            Some(n) => {
+                self.store.set_near_dupe(corpus_id, Some(&n.corpus_id), Some(n.similarity)).await?;
+                self.store.set_corpus_status(corpus_id, CorpusStatus::NeedsReview).await?;
+                tracing::info!(corpus_id, near = %n.corpus_id, similarity = n.similarity,
+                    "looks like an existing corpus; parked for review");
+            }
+            None => {
+                self.store.set_corpus_status(corpus_id, CorpusStatus::Raw).await?;
+                self.store.enqueue(Stage::Synthesize, "corpus", corpus_id).await?;
+            }
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/describe.rs src/core/ingest.rs
+git commit -m "fix(describe): an empty reading is a failure with a way back, not a review item"
+```
+
+---
+
+### Task 5: Re-segment refuses an unread image
+
+**Files:**
+- Modify: `src/core/ingest.rs` (`reprocess`, `Stage::Synthesize | Stage::Enrich` arm)
+- Test: `src/core/ingest.rs` tests
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn re_segmenting_an_image_that_has_not_been_read_is_refused() {
+        let core = test_core().await;
+        let id = core
+            .ingest_image(ImageCapture { bytes: a_png(3), filename: None, title_hint: None, note: None })
+            .await.unwrap().id;
+        // Still describing.
+        assert!(matches!(core.reprocess(&id, Stage::Synthesize).await, Err(Error::Validation(_))));
+        // Failed before any text was read.
+        crate::jobs::describe::park_failed(&core, &id, "HTTP 400").await.unwrap();
+        assert!(matches!(core.reprocess(&id, Stage::Synthesize).await, Err(Error::Validation(_))));
+        // The describe job is untouched either way.
+        assert!(core.store.live_job(Stage::Describe, &id).await.unwrap());
+        assert_eq!(core.store.get_corpus(&id).await.unwrap().status, CorpusStatus::Failed);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test re_segmenting_an_image_that_has_not_been_read`
+Expected: FAIL — reprocess succeeds and flips to Raw.
+
+- [ ] **Step 3: Implement**
+
+At the top of the `Stage::Synthesize | Stage::Enrich` arm:
+
+```rust
+                // Re-segmenting starts from `raw_text`, and an image whose read
+                // has not landed has none. Flipping it to `raw` would have
+                // synthesis fail on empty text and the pending read then find
+                // a corpus that is no longer `describing` — a photo never read,
+                // by way of a button that promised to process it.
+                if src.status == CorpusStatus::Describing
+                    || (src.origin == ORIGIN_IMAGE && src.raw_text.trim().is_empty())
+                {
+                    return Err(Error::Validation(
+                        "this image has not been read yet — re-read it instead".into(),
+                    ));
+                }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ingest.rs
+git commit -m "fix(ingest): re-segment refuses an image that has no reading yet"
+```
+
+---
+
+### Task 6: Corpus page — "Re-read" for images, "Re-segment" only when there is text
+
+**Files:**
+- Modify: `src/web/templates/corpus.html:4-18`
+- Modify: `src/web/ui.rs:368-392` (`CorpusTemplate`), `:800-835` (construction), `:935-943` (`reprocess_ui`)
+- Test: `src/web/ui.rs` tests
+
+**Interfaces:**
+- Produces: `POST /ui/corpora/{id}/reprocess` accepts an optional form field `stage` (`synthesize` default, `describe`), parsed with `Stage::parse`.
+- Template fields: `image: bool` (exists), new `unread: bool` = `image && (status == describing || lines.is_empty())`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/web/ui.rs` tests (use the module's existing helpers for building the app and posting forms; look at how `/ui/corpora/abc/reprocess` is exercised around line 2500):
+
+```rust
+    #[tokio::test]
+    async fn an_unread_image_page_offers_re_read_and_not_re_segment() {
+        let (app, core) = ui_app_and_core().await; // whatever the module's helper is called
+        let id = core.ingest_image(crate::core::ingest::ImageCapture {
+            bytes: a_png(1), filename: Some("p.png".into()), title_hint: None, note: None,
+        }).await.unwrap().id;
+        let html = get_html(&app, &format!("/ui/corpora/{id}")).await;
+        assert!(html.contains("Re-read"));
+        assert!(!html.contains("Re-segment"));
+    }
+
+    #[tokio::test]
+    async fn the_re_read_button_queues_describe() {
+        let (app, core) = ui_app_and_core().await;
+        let id = core.ingest_image(/* as above */).await.unwrap().id;
+        crate::jobs::describe::park_failed(&core, &id, "HTTP 400").await.unwrap();
+        let res = post_form(&app, &format!("/ui/corpora/{id}/reprocess"), "stage=describe").await;
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        assert_eq!(core.store.get_corpus(&id).await.unwrap().status, CorpusStatus::Describing);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test web::ui::tests::an_unread_image_page web::ui::tests::the_re_read_button`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`corpus.html`:
+
+```html
+  {# Re-segmenting a placeholder would delete the restored artifacts and pay the
+     model to re-derive them from their own text. Nothing to re-segment. An
+     image with no reading yet has nothing to re-segment either. #}
+  {% if !restored && !unread %}
+  <form method="post" action="/ui/corpora/{{ id }}/reprocess" style="display:inline">
+    <button class="btn btn-sm" type="submit">Re-segment</button>
+  </form>
+  {% endif %}
+  {% if image %}
+  <form method="post" action="/ui/corpora/{{ id }}/reprocess" style="display:inline"
+        onsubmit="return confirm('Read the photo again? The current reading and its artifacts are replaced.')">
+    <input type="hidden" name="stage" value="describe">
+    <button class="btn btn-sm" type="submit">Re-read</button>
+  </form>
+  {% endif %}
+```
+
+`ui.rs`: add `unread: bool` to `CorpusTemplate` with a doc comment; set `unread: image && (s.status == CorpusStatus::Describing || lines.is_empty())` (compute before `lines` is moved). `reprocess_ui`:
+
+```rust
+#[derive(serde::Deserialize, Default)]
+struct ReprocessForm {
+    #[serde(default)]
+    stage: Option<String>,
+}
+
+async fn reprocess_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(cid): Path<String>,
+    form: Option<axum::Form<ReprocessForm>>,
+) -> Result<Response> {
+    let stage = match form.and_then(|f| f.0.stage) {
+        None => crate::store::jobs::Stage::Synthesize,
+        Some(s) => crate::store::jobs::Stage::parse(&s)
+            .ok_or_else(|| Error::Validation(format!("unknown stage `{s}`")))?,
+    };
+    st.core.reprocess(&cid, stage).await?;
+    Ok(Redirect::to(&format!("/ui/corpora/{cid}")).into_response())
+}
+```
+
+(Check whether the existing form posts with a body; if the extractor rejects an empty body, use `Option<Form<_>>` as shown or `axum::extract::RawForm`.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/corpus.html src/web/ui.rs
+git commit -m "feat(ui): re-read a captured image; re-segment only once it has a reading"
+```
+
+---
+
+### Task 7: Decode limits for uploaded images
+
+**Files:**
+- Modify: `src/core/image.rs:25-70` (`prepare`)
+- Test: `src/core/image.rs` tests
+
+**Interfaces:**
+- Produces: constants `MAX_IMAGE_EDGE: u32 = 12_000` and `MAX_DECODE_BYTES: u64 = 256 * 1024 * 1024` in `src/core/image.rs`; `prepare` refuses over-limit images with `Error::Validation`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn an_image_declaring_absurd_dimensions_is_refused_before_it_is_decoded() {
+        // A valid PNG header for a 20000x20000 RGBA image, no pixel data worth
+        // the name: the decoder must stop at the header.
+        let mut png = Vec::new();
+        {
+            let mut enc = png::Encoder::new(&mut png, 20_000, 20_000);
+            enc.set_color(png::ColorType::Rgba);
+            enc.set_depth(png::BitDepth::Eight);
+            let _ = enc.write_header(); // header only; the stream is truncated
+        }
+        let e = prepare(&png, 2048).unwrap_err();
+        assert!(matches!(e, Error::Validation(_)), "{e}");
+        assert!(e.to_string().contains("large"), "{e}");
+    }
+```
+
+If the `png` crate is not a direct dependency, build the header by hand: PNG signature + IHDR chunk (width/height big-endian, depth 8, colour type 6) with a correct CRC via the `crc32fast` crate if present, else copy the 33 bytes from a real 1×1 PNG and patch the width/height and CRC. Whichever the executor picks, the test must not add a new dependency without noting it in the commit.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test core::image::tests::an_image_declaring_absurd`
+Expected: FAIL — either the decode error message doesn't mention "large" or the process allocates 1.6 GB and the assertion on the message fails.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Longest side a capture may have. Phone sensors top out around 9 000 px on
+/// the long edge; the cap exists for the file that *claims* to be bigger, which
+/// costs width × height × 4 bytes before a single pixel is checked.
+pub const MAX_IMAGE_EDGE: u32 = 12_000;
+/// Ceiling on what the decoder may allocate for one image.
+pub const MAX_DECODE_BYTES: u64 = 256 * 1024 * 1024;
+```
+
+Replace `image::load_from_memory_with_format` with:
+
+```rust
+    let mut reader = image::ImageReader::with_format(Cursor::new(bytes), format);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_EDGE);
+    limits.max_image_height = Some(MAX_IMAGE_EDGE);
+    limits.max_alloc = Some(MAX_DECODE_BYTES);
+    reader.limits(limits);
+    let decoded = reader.decode().map_err(|e| match e {
+        image::ImageError::Limits(_) => Error::Validation(format!(
+            "that image is too large to read — at most {MAX_IMAGE_EDGE} pixels on a side"
+        )),
+        e => Error::Validation(format!("that image could not be decoded: {e}")),
+    })?;
+```
+
+(`ImageReader::with_format` and `Limits` exist in `image` 0.25; check `Cargo.toml` for the version.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test core::image`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/image.rs
+git commit -m "fix(image): cap decode dimensions and allocation before reading the pixels"
+```
+
+---
+
+### Task 8: Hash first, then decode off the async worker
+
+**Files:**
+- Modify: `src/core/ingest.rs:248-320` (`ingest_image`)
+- Modify: `src/store/corpora.rs:118` (`content_hash`)
+- Test: `src/core/ingest.rs` tests, `src/store/corpora.rs` tests
+
+**Interfaces:**
+- Produces: `pub fn content_hash(bytes: impl AsRef<[u8]>) -> String` in `src/store/corpora.rs` — the existing `&str` callers keep compiling.
+- `ingest_image` order: hash → `find_by_hash` (duplicate short-circuit) → `spawn_blocking(prepare)` → insert.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/corpora.rs` tests:
+
+```rust
+    #[test]
+    fn content_hash_is_one_function_for_text_and_bytes() {
+        assert_eq!(content_hash("abc"), content_hash(b"abc"));
+        assert_eq!(content_hash("abc"), hex::encode(Sha256::digest(b"abc")));
+    }
+```
+
+`src/core/ingest.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn a_duplicate_image_is_recognised_without_being_decoded() {
+        let core = test_core().await;
+        let bytes = a_png(4);
+        let first = core.ingest_image(ImageCapture { bytes: bytes.clone(), filename: None, title_hint: None, note: None }).await.unwrap();
+        // The same hash, but bytes that would not decode: if the door hashed
+        // and looked up before decoding, this is a duplicate; if it decoded
+        // first, it is a 400.
+        let src = core.store.get_corpus(&first.id).await.unwrap();
+        assert_eq!(src.content_hash, crate::store::corpora::content_hash(&bytes));
+        let again = core.ingest_image(ImageCapture { bytes, filename: None, title_hint: None, note: None }).await.unwrap();
+        assert!(again.duplicate);
+        assert_eq!(again.id, first.id);
+    }
+```
+
+(The "would not decode" half is not directly testable without a hash collision; the test pins the hash algorithm and the duplicate answer. The ordering is enforced by code review of the diff.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test content_hash_is_one_function a_duplicate_image_is_recognised`
+Expected: compile error on `content_hash(b"abc")`.
+
+- [ ] **Step 3: Implement**
+
+`src/store/corpora.rs`:
+
+```rust
+/// The dedupe key of a corpus: text for a capture, the file's bytes for an
+/// image. One function, so the two doors can never drift onto different keys
+/// for the same column.
+pub fn content_hash(bytes: impl AsRef<[u8]>) -> String {
+    hex::encode(Sha256::digest(bytes.as_ref()))
+}
+```
+
+`ingest_image`:
+
+```rust
+        let hash = content_hash(&c.bytes);
+        if let Some(existing) = self.store.find_by_hash(&hash).await? {
+            tracing::info!(corpus_id = %existing.id, "duplicate image, returning existing source");
+            return Ok(IngestOutcome { id: existing.id, status: existing.status, duplicate: true, near_duplicate: None });
+        }
+        // Decoding, EXIF, the preview and its re-encode are a synchronous walk
+        // over up to `image_max_bytes` of pixels. Held on a Tokio worker that
+        // is seconds during which search, health and the queue poll on that
+        // thread all wait; see `web::api::extract` for the same move.
+        let edge = self.capture.image_preview_edge;
+        let (bytes, prepared) = tokio::task::spawn_blocking(move || {
+            let prepared = super::image::prepare(&c.bytes, edge)?;
+            Ok::<_, Error>((c.bytes, prepared))
+        })
+        .await
+        .map_err(|e| Error::Internal(format!("image preparation did not finish: {e}")))??;
+```
+
+Restructure so `c` is destructured before the closure (`let ImageCapture { bytes, filename, title_hint, note } = c;`) and only `bytes` moves in; the remaining code uses `bytes` where it used `c.bytes`. Remove `use sha2::Digest`/`hex` from `ingest.rs` if now unused.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ingest.rs src/store/corpora.rs
+git commit -m "perf(ingest): hash and dedupe an image before decoding it, off the async worker"
+```
+
+---
+
+### Task 9: No door seeds `title_hint` from a filename
+
+**Files:**
+- Modify: `src/core/ingest.rs` (`ingest_image`, the `title_hint` line ~277)
+- Modify: `src/web/api.rs:342-350` (`upload`, drop `.with_title(filename.clone())`)
+- Test: `src/web/api.rs:1395` (`an_uploaded_filename_becomes_the_title_hint` → rewrite), `src/core/ingest.rs` tests
+
+- [ ] **Step 1: Rewrite the tests**
+
+`src/web/api.rs`: rename `an_uploaded_filename_becomes_the_title_hint` → `an_uploaded_filename_is_a_file_fact_not_a_title` and assert:
+
+```rust
+        assert_eq!(src.title_hint, None, "the Title stage names it; the filename is not a name");
+        assert_eq!(src.metadata["file"]["name"], "mounting-notes.txt");
+```
+
+`src/core/ingest.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn an_image_filename_is_kept_as_a_file_fact_and_not_used_as_its_title() {
+        let core = test_core().await;
+        let id = core.ingest_image(ImageCapture {
+            bytes: a_png(5), filename: Some("photo.jpg".into()), title_hint: None, note: None,
+        }).await.unwrap().id;
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.title_hint, None);
+        assert_eq!(src.metadata["file"]["name"], "photo.jpg");
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert!(core.store.get_corpus(&id).await.unwrap().title_hint.is_some(), "the Title stage named it");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test an_uploaded_filename_is_a_file_fact an_image_filename_is_kept`
+Expected: FAIL on the `title_hint == None` assertions.
+
+- [ ] **Step 3: Implement**
+
+`ingest_image`: `let title_hint = c.title_hint;` (drop the `or_else`). Add the comment:
+
+```rust
+        // A filename is a file fact, not a name: `photo.jpg` and `image.png`
+        // are what a camera and a clipboard call everything. Seeding the title
+        // from it would disarm the one stage that can name the capture.
+```
+
+`api.rs::upload`: remove `.with_title(filename.clone())`; the filename already flows through `.with_file(...)`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS. Check `src/web/api.rs` for other tests asserting a filename title (grep `title_hint.as_deref(), Some("` in the upload tests) and update them the same way.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ingest.rs src/web/api.rs
+git commit -m "fix(ingest): a filename is a file fact, not a title; let the Title stage name uploads"
+```
+
+---
+
+### Task 10: One multipart reader for both doors; a second file part is a 400
+
+**Files:**
+- Modify: `src/web/api.rs:279-300` (`upload`), `:361-395` (`upload_image`)
+- Test: `src/web/api.rs` tests
+
+**Interfaces:**
+- Produces, in `src/web/api.rs`:
+
+```rust
+struct FilePart {
+    filename: Option<String>,
+    declared: String,       // Content-Type or ""
+    bytes: axum::body::Bytes,
+}
+
+struct UploadParts {
+    file: Option<FilePart>,
+    /// The text fields asked for, by name; only non-blank values are kept.
+    fields: std::collections::HashMap<&'static str, String>,
+}
+
+/// Drain a multipart body: one file part under `file_field`, any of
+/// `text_fields` as text. Order-independent, because a browser sends `note`
+/// before or after the file depending on the form. A second part under
+/// `file_field` is refused rather than silently winning or losing: two files
+/// in one request is a client bug, and whichever we picked would be wrong for
+/// half of them.
+async fn read_upload(
+    mut multipart: axum::extract::Multipart,
+    file_field: &'static str,
+    text_fields: &[&'static str],
+) -> Result<UploadParts>
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn an_upload_with_two_file_parts_is_refused() {
+        let (app, token, _core) = app_token_and_core().await;
+        // Build the body by hand: two `file` parts.
+        let boundary = "xyz";
+        let body = format!(
+            "--{b}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nfirst\r\n\
+             --{b}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"b.txt\"\r\nContent-Type: text/plain\r\n\r\nsecond\r\n\
+             --{b}--\r\n",
+            b = boundary
+        );
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/corpora/upload")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", format!("multipart/form-data; boundary={boundary}"))
+            .body(Body::from(body))
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert!(json_of(res).await["error"].as_str().unwrap().contains("one file"));
+    }
+```
+
+(Model the request construction on `post_file_with` at line 960.) Add the mirror test for `/api/v1/corpora/image` with two `image` parts.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test an_upload_with_two_file_parts_is_refused`
+Expected: FAIL — 201 (second file ingested).
+
+- [ ] **Step 3: Implement**
+
+```rust
+async fn read_upload(
+    mut multipart: axum::extract::Multipart,
+    file_field: &'static str,
+    text_fields: &[&'static str],
+) -> Result<UploadParts> {
+    let mut out = UploadParts { file: None, fields: Default::default() };
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
+    {
+        let Some(name) = field.name().map(str::to_string) else { continue };
+        if name == file_field {
+            if out.file.is_some() {
+                return Err(Error::Validation(format!(
+                    "more than one `{file_field}` part — send one file per request"
+                )));
+            }
+            let filename = field.file_name().map(str::to_string);
+            let declared = field.content_type().unwrap_or("").to_string();
+            let bytes = field.bytes().await
+                .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
+            out.file = Some(FilePart { filename, declared, bytes });
+        } else if let Some(key) = text_fields.iter().copied().find(|k| *k == name) {
+            let text = field.text().await
+                .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?;
+            if !text.trim().is_empty() {
+                out.fields.insert(key, text);
+            }
+        }
+    }
+    Ok(out)
+}
+```
+
+`upload`:
+
+```rust
+    let parts = read_upload(multipart, "file", &["note"]).await?;
+    let Some(FilePart { filename, declared, bytes }) = parts.file else {
+        return Err(Error::Validation("no file in the upload".into()));
+    };
+    let note = parts.fields.get("note").cloned();
+    // ... existing type/UTF-8 checks and ingest_capture call unchanged
+```
+
+`upload_image`:
+
+```rust
+    let mut parts = read_upload(multipart, "image", &["note", "title_hint"]).await?;
+    let Some(FilePart { filename, bytes, .. }) = parts.file else {
+        return Err(Error::Validation("no image in the upload".into()));
+    };
+    let out = st.core.ingest_image(crate::core::ingest::ImageCapture {
+        bytes: bytes.to_vec(),
+        filename,
+        title_hint: parts.fields.remove("title_hint"),
+        note: parts.fields.remove("note"),
+    }).await?;
+```
+
+Note `note` previously kept a blank value and `ingest_capture`'s `clean_note` dropped it; keeping only non-blank in `read_upload` is equivalent. Verify `a_text_upload_records_its_note_and_file_facts` and `an_image_upload_is_accepted_with_its_note_and_queued` still pass.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test web::api`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/api.rs
+git commit -m "refactor(api): one multipart reader for both doors; a second file part is refused"
+```
+
+---
+
+### Task 11: One corpus INSERT, and each door's writes in one transaction
+
+**Files:**
+- Modify: `src/store/corpora.rs:150-250` (`insert_corpus_with_signature`), `:455-495` (`insert_image_corpus`)
+- Modify: `src/store/attachments.rs:40-57` (`insert_attachment`)
+- Modify: `src/store/jobs.rs:153-215` (`enqueue` / `upsert_job`)
+- Modify: `src/core/ingest.rs` (`ingest_capture` ~150-245, `ingest_image` ~248-320)
+- Test: `src/store/corpora.rs` tests, `src/core/ingest.rs` tests, `src/jobs/describe.rs` tests (the `insert_image_corpus("h", ...)` call sites)
+
+**Interfaces:**
+
+In `src/store/corpora.rs`:
+
+```rust
+/// What a capture wants done in the same transaction as its row.
+pub enum Followup {
+    /// Queue this stage. Text captures queue Synthesize; images queue Describe.
+    Queue(Stage),
+    /// Park beside a near-duplicate: `near_dupe_of`, its score, and
+    /// `needs_review`, written on the row itself. No job.
+    Park { of: String, similarity: f64 },
+}
+
+/// The one INSERT every corpus row goes through, on whatever executor the
+/// caller is inside. `ON CONFLICT(content_hash) DO NOTHING`; returns whether
+/// the row was written.
+async fn insert_corpus_row<'e>(
+    exec: impl sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    src: &Corpus,
+) -> Result<bool>
+
+pub async fn insert_corpus_with_signature(
+    &self,
+    raw_text: &str,
+    origin: &str,
+    title_hint: Option<&str>,
+    shingles: Vec<u64>,
+    source_url: Option<&str>,
+    metadata: &serde_json::Value,
+    followup: Followup,           // NEW
+) -> Result<Insertion>
+
+pub async fn insert_image_corpus(
+    &self,
+    content_hash: &str,
+    origin: &str,
+    title_hint: Option<&str>,
+    metadata: &serde_json::Value,
+    attachment: &super::attachments::NewImage<'_>,   // NEW: everything but corpus_id
+) -> Result<Insertion>
+```
+
+In `src/store/attachments.rs`: `NewAttachment` keeps its shape; add `pub(crate) async fn insert_attachment_with<'e>(exec: impl Executor<'e, Database = Sqlite>, a: &NewAttachment<'_>) -> Result<i64>` and have `insert_attachment` call it with `&self.pool`. Add `pub struct NewImage<'a> { kind, mime, filename, bytes, preview, width, height }` — `NewAttachment` minus `corpus_id` — with `fn for_corpus(&self, corpus_id: &'a str) -> NewAttachment<'a>`.
+
+In `src/store/jobs.rs`: `pub(crate) async fn enqueue_with<'e>(exec: impl Executor<'e, Database = Sqlite>, stage, target_kind, target_id) -> Result<()>` — the `Guard::Any` upsert on the given executor; `upsert_job` calls it with `&self.pool` for `Guard::Any` (or generalise `upsert_job` to take the executor and keep the guard; executor's choice, but one statement text, no duplication).
+
+Insertion semantics: `insert_corpus_with_signature` opens `let mut tx = self.pool.begin().await?;`, calls `insert_corpus_row(&mut *tx, &src)`; if `false` → `tx.rollback()`, `find_by_hash`, `Insertion::Existing`; else apply the followup (`Queue` → `enqueue_with(&mut *tx, ...)`; `Park` is already on the row: build `src` with `near_dupe_of`, `near_dupe_score`, `status: NeedsReview` before insert), commit, `Insertion::Created(src)`. `insert_image_corpus` does row + `insert_attachment_with` + `enqueue_with(Describe)` in one tx.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/corpora.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn a_text_capture_and_its_job_land_together() {
+        let s = Store::memory().await.unwrap();
+        let ins = s.insert_corpus_with_signature("hello", "web", None, vec![], None,
+            &serde_json::json!({}), Followup::Queue(Stage::Synthesize)).await.unwrap();
+        let src = ins.into_corpus();
+        assert_eq!(src.status, CorpusStatus::Raw);
+        assert!(s.live_job(Stage::Synthesize, &src.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_parked_capture_is_written_parked_with_no_job() {
+        let s = Store::memory().await.unwrap();
+        let other = s.insert_corpus("other", "web", None).await.unwrap();
+        let src = s.insert_corpus_with_signature("hello", "web", None, vec![], None,
+            &serde_json::json!({}), Followup::Park { of: other.id.clone(), similarity: 0.9 })
+            .await.unwrap().into_corpus();
+        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert_eq!(src.near_dupe_of.as_deref(), Some(other.id.as_str()));
+        assert!(!s.live_job(Stage::Synthesize, &src.id).await.unwrap());
+        assert_eq!(s.parked_corpora(10).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn an_image_row_its_attachment_and_its_job_land_together() {
+        let s = Store::memory().await.unwrap();
+        let img = NewImage { kind: "image", mime: "image/png", filename: Some("x.png"),
+            bytes: b"orig", preview: b"prev", width: Some(10), height: Some(20) };
+        let src = s.insert_image_corpus("hash-1", "image", None, &serde_json::json!({}), &img)
+            .await.unwrap().into_corpus();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert!(s.attachment_for_corpus(&src.id).await.unwrap().is_some());
+        assert!(s.live_job(Stage::Describe, &src.id).await.unwrap());
+        // The same hash again: Existing, and nothing new written.
+        assert!(matches!(
+            s.insert_image_corpus("hash-1", "image", None, &serde_json::json!({}), &img).await.unwrap(),
+            Insertion::Existing(_)
+        ));
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test store::corpora`
+Expected: compile errors (`Followup`, `NewImage`, new signatures).
+
+- [ ] **Step 3: Implement**
+
+`insert_corpus_row`:
+
+```rust
+async fn insert_corpus_row<'e>(
+    exec: impl sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    src: &Corpus,
+) -> Result<bool> {
+    let res = sqlx::query(
+        "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at,
+                              shingles, source_url, metadata, near_dupe_of, near_dupe_score)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(content_hash) DO NOTHING",
+    )
+    .bind(&src.id).bind(&src.raw_text).bind(&src.origin).bind(&src.title_hint)
+    .bind(&src.content_hash).bind(src.status.as_str()).bind(src.created_at).bind(src.updated_at)
+    .bind(super::shingle::encode(&src.shingles)).bind(&src.source_url).bind(src.metadata.to_string())
+    .bind(&src.near_dupe_of).bind(src.near_dupe_score)
+    .execute(exec)
+    .await?;
+    Ok(res.rows_affected() > 0)
+}
+```
+
+(Verify column names `near_dupe_of` / `near_dupe_score` against `src/store/schema.sql`; keep the `ensure_restored_corpus` INSERT separate — it writes `restored_at` and is a different row kind.)
+
+`insert_corpus_with_signature` builds `src` as today, then:
+
+```rust
+        let (status, near_dupe_of, near_dupe_score) = match &followup {
+            Followup::Park { of, similarity } => (CorpusStatus::NeedsReview, Some(of.clone()), Some(*similarity)),
+            Followup::Queue(_) => (CorpusStatus::Raw, None, None),
+        };
+        let src = Corpus { status, near_dupe_of, near_dupe_score, /* ...as before */ };
+        let mut tx = self.pool.begin().await?;
+        if !insert_corpus_row(&mut *tx, &src).await? {
+            tx.rollback().await?;
+            let existing = self.find_by_hash(&src.content_hash).await?.ok_or_else(|| {
+                Error::Store("capture conflicted with a corpus that then vanished".into())
+            })?;
+            return Ok(Insertion::Existing(existing));
+        }
+        if let Followup::Queue(stage) = followup {
+            super::jobs::enqueue_with(&mut *tx, stage, "corpus", &src.id).await?;
+        }
+        tx.commit().await?;
+        Ok(Insertion::Created(src))
+```
+
+Keep the existing doc comment about the concurrent-writer window and add: "The job is armed in the same transaction as the row: a process that dies between the two would otherwise leave a `raw` corpus nothing will ever pick up."
+
+`insert_image_corpus` builds a `Corpus` with `raw_text: ""`, `shingles: vec![]`, `status: Describing`, `source_url: None`, `restored_at: None`, `coverage: None`, near fields `None`, then:
+
+```rust
+        let mut tx = self.pool.begin().await?;
+        if !insert_corpus_row(&mut *tx, &src).await? {
+            tx.rollback().await?;
+            let existing = self.find_by_hash(content_hash).await?.ok_or_else(|| {
+                Error::Store("image capture conflicted with a corpus that then vanished".into())
+            })?;
+            return Ok(Insertion::Existing(existing));
+        }
+        super::attachments::insert_attachment_with(&mut *tx, &attachment.for_corpus(&src.id)).await?;
+        super::jobs::enqueue_with(&mut *tx, Stage::Describe, "corpus", &src.id).await?;
+        tx.commit().await?;
+        Ok(Insertion::Created(src))
+```
+
+`ingest_capture`: replace the insert + the `match &near` block with:
+
+```rust
+        let followup = match &near {
+            Some(n) => Followup::Park { of: n.corpus_id.clone(), similarity: n.similarity },
+            None => Followup::Queue(Stage::Synthesize),
+        };
+        let src = match self.store.insert_corpus_with_signature(text, origin, title_hint, sig,
+            c.source_url.as_deref(), &c.metadata, followup).await? { /* as before */ };
+        match &near {
+            Some(n) => tracing::info!(corpus_id = %src.id, near = %n.corpus_id, similarity = n.similarity,
+                "capture looks like an existing corpus; parked for review"),
+            None => tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested"),
+        }
+```
+
+`ingest_image`: build `NewImage { kind: "image", mime: prepared.mime, filename: filename.as_deref(), bytes: &bytes, preview: &prepared.preview_jpeg, width: Some(..), height: Some(..) }` and pass it to `insert_image_corpus`; delete the separate `insert_attachment` and `enqueue` calls. Update `insert_corpus` (the plain wrapper at line ~150) to pass `Followup::Queue(Stage::Synthesize)`? No — `insert_corpus` is used by tests that then run the queue themselves; check its callers (`grep -n "insert_corpus(" src`) and keep its behaviour (no job) by giving `Followup` a third variant only if a caller needs one. Prefer: `insert_corpus` passes `Followup::Queue(Stage::Synthesize)` if every caller is a test that drains the queue anyway, else add `Followup::Nothing`. Executor decides after grepping; note the choice in the commit message.
+
+Update the two `insert_image_corpus("h", "image", None, &json!({}))` call sites in `src/jobs/describe.rs` tests to pass a `NewImage` (any bytes).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store src/core/ingest.rs src/jobs/describe.rs
+git commit -m "refactor(store): one corpus insert; each capture door writes its row, attachment and job in one transaction"
+```
+
+---
+
+### Task 12: Docs
+
+**Files:**
+- Modify: `README.md` (image capture section added by 57aaf58), `ROADMAP.md`, `src/core/ingest.rs` (remove the "later feature" comment if any remains)
+
+- [ ] **Step 1: Update**
+
+In README's image capture section, add one paragraph: a photo whose reading fails (endpoint refuses, model returns nothing, retries exhausted) is shown as `failed` with the reason on its page; "Re-read" (or `POST /api/v1/corpora/{id}/reprocess {"stage":"describe"}`) reads it again from the stored original. In ROADMAP, move "re-read a stored image" from later to done, if listed.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md ROADMAP.md
+git commit -m "docs: re-read and failure states of image capture"
+```
+
+---
+
+## Self-review
+
+- Finding 1 → Tasks 4 (Failed, not NeedsReview) and 3/6 (recovery). Finding 2 → Tasks 5, 6. Finding 3 → Tasks 1, 2, 3. Finding 4 → Task 8. Finding 5 → Task 7. Finding 6 → Task 9. Finding 7 → Task 10. Finding 8 → Task 8. Minor 9/10/12 → Task 11 (+4). Minor 11 → Task 10.
+- Type consistency: `park_failed(core, id, reason)` used identically in Tasks 2–6; `Followup::{Queue, Park}` and `NewImage` only in Task 11; `content_hash(impl AsRef<[u8]>)` in Task 8 is what Task 11's `insert_image_corpus` caller already computes.
+- Order matters: Task 11 changes `insert_image_corpus`'s signature, which Task 2's test calls with the old one — the executor updates that test in Task 11 (listed).

--- a/docs/superpowers/specs/2026-08-15-image-capture-design.md
+++ b/docs/superpowers/specs/2026-08-15-image-capture-design.md
@@ -1,0 +1,271 @@
+# Image capture — design
+
+Date: 2026-08-15
+Status: approved in brainstorm, awaiting implementation plan
+
+## Goal
+
+Capture photos and images (drag-and-drop, file picker, phone camera via the
+PWA, clipboard paste) as first-class corpora. A vision model reads the image
+into markdown, which then flows through the existing text pipeline untouched.
+The original image is retained as the verbatim source. Image metadata (file
+facts + full EXIF including GPS) is recorded, and the metadata column is
+generic so other doors can use it. Every file-type door additionally accepts a
+free-text `note` giving user context for the upload.
+
+## Decisions taken in brainstorm
+
+| Question | Decision |
+|---|---|
+| Fate of the image | Kept permanently as the corpus source; transcription is derived |
+| What the model produces | Mixed: transcribe visible text faithfully as markdown, describe diagrams/scenes/objects, capture everything worth preserving |
+| Metadata | Everything: file facts + all EXIF incl. GPS |
+| Metadata scope | Generic `corpora.metadata` JSON column now; images populate it; other doors opportunistically, no retrofit |
+| Metadata use | Compact summary is fed to the vision model so dates/places become searchable; raw metadata stored on the corpus |
+| Where the vision call happens | New background job stage `Describe`, never in the request path (capture stays instant, endpoint-independent) |
+| EXIF / resize | Server-side from the original upload; per-route body limit raised |
+| User context | Optional `note` on all file-type doors; stored in metadata; for images fed to the vision model |
+
+Rejected: synchronous vision call at the door (breaks the "capture makes no
+inference call" rule; a phone upload would block on GPU latency and fail when
+the endpoint is down).
+
+## 1. Data model
+
+### `attachments` (new table)
+
+```sql
+CREATE TABLE IF NOT EXISTS attachments (
+  id         INTEGER PRIMARY KEY,
+  corpus_id  INTEGER NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+  kind       TEXT    NOT NULL,          -- 'image'
+  mime       TEXT    NOT NULL,          -- of the original
+  filename   TEXT,                      -- original filename if supplied
+  bytes      BLOB    NOT NULL,          -- original upload, untouched
+  preview    BLOB    NOT NULL,          -- derived JPEG, orientation applied, ~2048px long edge
+  width      INTEGER, height INTEGER,   -- of the original, post-orientation
+  created_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS attachments_corpus ON attachments(corpus_id);
+```
+
+Original bytes are the verbatim source and are never re-encoded. The preview
+is derived once at upload (decode with `image`, apply EXIF orientation,
+downscale, encode JPEG) and is what goes to the model and the UI. Storage stays
+in SQLite so backup/deploy remains one file. Supported inputs: JPEG, PNG, WebP
+(iOS transcodes HEIC to JPEG on web upload; no libheif).
+
+### `corpora.metadata` (new column)
+
+Appended via `ADDED_COLUMNS`: `metadata TEXT NOT NULL DEFAULT '{}'`.
+Namespaced JSON; namespaces never collide across doors:
+
+```json
+{
+  "note": "whiteboard from Tuesday planning",
+  "file": { "name": "IMG_2041.jpeg", "size": 4812733, "mime": "image/jpeg",
+            "width": 4032, "height": 3024 },
+  "exif": { "taken_at": "2026-08-09T14:12:03", "camera": "Apple iPhone 15",
+            "orientation": 6, "gps": { "lat": 48.2082, "lon": 16.3738, "alt": 171.0 } }
+}
+```
+
+- `note` — user-supplied context, any door. Plain string, trimmed, capped
+  (e.g. 2000 chars).
+- `file` — for any file upload. The existing `.txt` door starts writing
+  `file.name/size/mime` since it has them in hand. No other retrofit.
+- `exif` — images only. Parsed with `kamadak-exif` from the original. Fields
+  present only when the tag exists. `taken_at` from DateTimeOriginal (naive
+  local time as written; offset added if OffsetTimeOriginal exists).
+  Everything the file carries is kept, GPS included — deliberate choice for a
+  personal knowledge base.
+
+### `content_hash`
+
+For image corpora: SHA-256 of the *original* bytes. Re-uploading the same
+photo dedupes at the door before any inference. Text-level near duplicates
+(two photos of the same page) are caught by the existing shingle check once
+the transcription exists (see §2 step 3).
+
+### Corpus status
+
+New status `describing`, preceding `raw`. Only image-backed corpora ever hold
+it. `raw_text` is `''` while describing (column stays NOT NULL).
+
+Origin value for the new door: `image`.
+
+## 2. Capture flow and pipeline
+
+```
+POST image ──► validate mime/size ─► decode ─► EXIF ─► preview
+           ──► insert corpus {origin:'image', status:'describing', raw_text:'',
+                              content_hash: sha256(original), metadata}
+           ──► insert attachment ─► enqueue Stage::Describe ─► 202
+```
+
+No inference in the request path.
+
+### `Stage::Describe` (new job stage)
+
+Dispatched from `jobs::mod::run_claimed` like every stage; inference passes
+through the shared `InferenceGate`.
+
+1. Load corpus, attachment preview, metadata.
+2. Build the context line from metadata: user `note` first (verbatim, labeled
+   as user-provided context), then the compact facts —
+   `Photo taken 2026-08-09 14:12, GPS 48.2082,16.3738, Apple iPhone 15,
+   file IMG_2041.jpeg`. Omit whatever is absent.
+3. Call `Describer::describe(preview_jpeg, context)`.
+4. Result handling:
+   - Non-empty markdown → write `raw_text`, compute shingles, run the existing
+     near-duplicate check (near-dupe → `needs_review`, same as text captures),
+     else status `raw`, enqueue `Synthesize`.
+   - Empty/whitespace → park as `needs_review` with a `flag_detail`-style
+     reason on the corpus so ops shows why. Image remains viewable.
+   - Transport/model error → job error, existing retry with backoff. Corpus
+     stays visibly in `describing`. Nothing is lost.
+
+From `raw` onward the pipeline (`Synthesize → SegmentWindow → Title → Embed →
+Relate/Dedupe/Consolidate`) is untouched; it sees a text corpus. Coverage,
+spans and artifacts work against the transcription.
+
+### System prompt
+
+`DESCRIBE_SYSTEM` in `src/infer/prompt.rs`. Intent: read the image the way a
+careful archivist would. Transcribe any visible text faithfully, preserving
+structure (headings, lists, tables) as markdown. Describe diagrams, charts,
+scenes and objects with everything worth preserving; name entities that are
+identifiable. Do not pad, do not speculate beyond what is visible, do not
+summarize away specifics. Where the provided capture context (user note,
+date, place, device) is relevant, incorporate it naturally so it can be
+recalled later; do not repeat it mechanically. Output markdown only, no
+preamble.
+
+## 3. Config and inference layer
+
+```toml
+[infer.vision]              # section absent → image capture disabled
+model = "qwen2.5-vl-7b"     # required when present
+base_url = "http://..."     # optional; absent → inherit [infer.synthesize].base_url
+api_key = "..."             # optional; absent → inherit [infer.synthesize].api_key
+timeout_secs = 120          # default 120
+```
+
+This maps the three requested modes onto the existing optional-role pattern
+(`rerank`):
+
+- disabled — section absent; `POST .../image` returns 4xx `image capture is
+  not configured`; capture UI renders without image affordances.
+- main LLM — section present with `model` only; endpoint/key inherited.
+- dedicated — section present with its own `base_url`/`api_key`.
+
+Startup probe warns (never fails) like other roles. `--print-config` redacts
+`vision.api_key`. Env override works as everywhere (`ENGRAM__INFER__VISION__MODEL`).
+
+New `[capture]` keys: `image_max_bytes` (default 25 MiB, per-route body
+limit), `image_preview_edge` (default 2048).
+
+### Inference
+
+New trait in `src/infer/mod.rs`:
+
+```rust
+pub trait Describer: Send + Sync {
+    fn describe(&self, image_jpeg: &[u8], context: &str)
+        -> impl Future<Output = Result<String>> + Send;
+}
+```
+
+`HttpDescriber` in `src/infer/openai.rs` builds the OpenAI content-array
+form: system = `DESCRIBE_SYSTEM`; user content =
+`[{type:"text", text: context}, {type:"image_url", image_url:{url:"data:image/jpeg;base64,…"}}]`.
+Reads `choices[0].message.content`. Existing string-only traits are untouched.
+`FakeDescriber` in `src/infer/fake.rs` (scripted responses/errors) like every
+other trait. `Core` gains `describer: Option<Arc<dyn Describer>>`, wired in
+`Core::from_config` and `test_support::build`.
+
+## 4. Capture UI and PWA
+
+`capture.html`'s `#drop` zone becomes the single entry for all files, with
+one JS handler branching on file type:
+
+- File picker / camera: hidden input `accept=".txt,text/plain,image/*"`. No
+  forced `capture=` attribute — the OS sheet offers both camera and gallery.
+  PWA start URL is already the capture page: open → tap → shoot → done.
+- Drag-and-drop of image files (desktop).
+- Clipboard `paste` of image data (screenshots).
+- **Context field**: one optional textarea "Add context (optional)" next to
+  the drop zone. Its value is sent as `note` with whichever file is dropped,
+  picked or pasted next, then cleared. Same control serves `.txt` and images.
+
+Text files → existing `/api/v1/corpora/upload` (now also carrying `note`);
+images → the new image endpoint. Success shows the existing "captured"
+confirmation plus a hint that the photo is queued for reading. When vision is
+disabled, the template omits image affordances (flag from `Core`) and the
+handler rejects images with the clear message.
+
+Service worker unchanged: no offline queueing (documented stance). Photos
+taken offline fail visibly.
+
+## 5. API and detail pane
+
+- `POST /api/v1/corpora/image` — multipart: `image` (required),
+  `title_hint`, `note` (optional). Per-route `DefaultBodyLimit` of
+  `capture.image_max_bytes`; the global 8 MiB stays for everything else.
+  Refusals, each distinct and tested: unsupported mime, undecodable image,
+  too large, vision not configured. Filename → `title_hint` fallback. Returns
+  the same shape as other capture doors. Origin `image`.
+- `POST /api/v1/corpora/upload` — gains optional `note`; writes
+  `metadata.note` and `metadata.file`.
+- `GET /api/v1/corpora/{id}/image` — serves the preview JPEG;
+  `?original=1` serves the original bytes with its stored mime. Auth like all
+  routes.
+- Detail pane: a `CorpusView` implementation for image-backed corpora (the
+  extension point ROADMAP reserves for non-text sources). Renders the photo,
+  the metadata (note, taken-at, camera, location, dimensions), and the
+  transcription labeled *derived — model reading of the image*. Line-based
+  span highlighting continues to work against the transcription.
+- Markdown sanitizer: unchanged. The image is rendered by the view template
+  from the GET route, not embedded in markdown.
+- Ops: nothing new; `describing` corpora and stuck `Describe` jobs appear via
+  the existing jobs/retry machinery.
+
+## 6. Note handling across doors (this feature's scope)
+
+| Door | `note` stored | `note` consumed |
+|---|---|---|
+| image | yes | fed to `Describe` as user context |
+| `.txt` upload | yes | displayed only |
+| paste / JSON / MCP / extension | not in scope | — |
+
+Feeding `note` into text synthesis would touch the untouched pipeline and is
+explicitly a follow-up.
+
+## 7. Testing
+
+- Unit: EXIF extraction (GPS, DateTimeOriginal, orientation) and preview
+  generation on small fixture images (JPEG with tags, PNG without); metadata
+  JSON shape; context-line builder incl. note ordering and omission of absent
+  fields; `Describer` request body shape.
+- Endpoint: the four refusals; successful upload creates corpus + attachment
+  + `Describe` job and returns 202; exact re-upload dedupes at the door;
+  `note` and `file` land in metadata for both image and `.txt` doors;
+  per-route body limit while global limit test still holds.
+- Pipeline: with `FakeDescriber`, image upload → `describing → raw → … →
+  ready` with embedded artifacts; erroring fake leaves corpus in `describing`
+  with job retried; empty fake parks as `needs_review`; near-dupe transcription
+  parks as `needs_review`.
+- Config: absent / inherit / dedicated resolve correctly; redaction.
+- UI: template hides image affordances when disabled; manifest/sw tests
+  unchanged.
+
+## Dependencies
+
+`image` (decode/resize/encode; features limited to jpeg/png/webp),
+`kamadak-exif`. Pure Rust, no system libraries.
+
+## Out of scope
+
+Offline queueing; HEIC decoding; PDF; feeding `note` to text synthesis;
+re-describing an image with a different model (the retained original makes
+this a later feature, not a schema change).

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,12 @@ pub struct CaptureConfig {
     /// nothing. A corpus that silently holds a cookie banner instead of the
     /// document is the failure this whole path is shaped to prevent.
     pub min_extracted_chars: usize,
+    /// Bytes an uploaded image may weigh. A phone photo is 3–8 MB; this is the
+    /// per-route ceiling for the image door only, the global body limit stays.
+    pub image_max_bytes: usize,
+    /// Longest edge, in pixels, of the preview the vision model is shown and
+    /// the UI displays. The original is stored untouched regardless.
+    pub image_preview_edge: u32,
 }
 
 impl Default for CaptureConfig {
@@ -44,6 +50,8 @@ impl Default for CaptureConfig {
             fetch_timeout_secs: 30,
             fetch_max_bytes: 8 * 1024 * 1024,
             min_extracted_chars: 200,
+            image_max_bytes: 25 * 1024 * 1024,
+            image_preview_edge: 2048,
         }
     }
 }
@@ -289,6 +297,8 @@ pub struct InferConfig {
     pub ask: AskRole,
     #[serde(default)]
     pub rerank: Option<RerankRole>,
+    #[serde(default)]
+    pub vision: Option<VisionRole>,
 }
 
 /// Seconds an inference request may take before the client gives up.
@@ -395,6 +405,38 @@ pub struct RerankRole {
     pub style: RerankStyle,
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+}
+
+/// The vision model that reads a captured image into text. Optional: absent
+/// means the image door is closed. `base_url` and `api_key` are optional
+/// because the common case is the synthesize endpoint serving a multimodal
+/// model too — then only `model` needs saying.
+#[derive(Debug, Deserialize, Clone)]
+pub struct VisionRole {
+    pub model: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default = "default_vision_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_vision_timeout_secs() -> u64 {
+    120
+}
+
+impl VisionRole {
+    /// The endpoint and key this role actually calls: its own where given,
+    /// the synthesize role's otherwise.
+    pub fn resolve(&self, synth: &SynthesizeRole) -> (String, Option<String>) {
+        (
+            self.base_url
+                .clone()
+                .unwrap_or_else(|| synth.base_url.clone()),
+            self.api_key.clone().or_else(|| synth.api_key.clone()),
+        )
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -640,6 +682,9 @@ impl Config {
         c.infer.ask.api_key = c.infer.ask.api_key.map(|_| R.into());
         if let Some(r) = c.infer.rerank.as_mut() {
             r.api_key = r.api_key.as_ref().map(|_| R.into());
+        }
+        if let Some(v) = c.infer.vision.as_mut() {
+            v.api_key = v.api_key.as_ref().map(|_| R.into());
         }
         if let Some(o) = c.auth.oidc.as_mut() {
             o.client_secret = o.client_secret.as_ref().map(|_| R.into());
@@ -894,5 +939,68 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         let dump = cfg.redacted();
         assert!(!dump.contains("$argon2id$"), "password hash leaked: {dump}");
         assert!(dump.contains("REDACTED"));
+    }
+
+    #[test]
+    fn vision_is_off_unless_configured() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, MINIMAL);
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert!(
+            cfg.infer.vision.is_none(),
+            "vision must default to disabled"
+        );
+        assert_eq!(cfg.capture.image_max_bytes, 25 * 1024 * 1024);
+        assert_eq!(cfg.capture.image_preview_edge, 2048);
+    }
+
+    #[test]
+    fn a_vision_role_without_its_own_endpoint_inherits_synthesize() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            &format!("{MINIMAL}\n[infer.vision]\nmodel = \"qwen-vl\"\n"),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        let v = cfg.infer.vision.as_ref().expect("configured");
+        assert_eq!(v.model, "qwen-vl");
+        assert_eq!(v.timeout_secs, 120);
+        let (url, key) = v.resolve(&cfg.infer.synthesize);
+        assert_eq!(url, cfg.infer.synthesize.base_url);
+        assert_eq!(key, cfg.infer.synthesize.api_key);
+    }
+
+    #[test]
+    fn a_dedicated_vision_endpoint_wins_over_synthesize() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            &format!(
+                "{MINIMAL}\n[infer.vision]\nmodel = \"qwen-vl\"\nbase_url = \"http://vision:9000/v1\"\napi_key = \"vk\"\n"
+            ),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        let (url, key) = cfg
+            .infer
+            .vision
+            .as_ref()
+            .unwrap()
+            .resolve(&cfg.infer.synthesize);
+        assert_eq!(url, "http://vision:9000/v1");
+        assert_eq!(key.as_deref(), Some("vk"));
+        assert!(!cfg.redacted().contains("\"vk\""), "vision key leaked");
+    }
+
+    #[test]
+    fn the_example_config_documents_the_vision_role() {
+        let text = std::fs::read_to_string("config.example.toml").unwrap();
+        assert!(
+            text.contains("[infer.vision]"),
+            "example config must show the vision block"
+        );
+        assert!(text.contains("image_max_bytes"));
     }
 }

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -23,6 +23,13 @@ pub struct PreparedImage {
 /// page survives, well below the original's size.
 const PREVIEW_QUALITY: u8 = 85;
 
+/// Longest side a capture may have. Phone sensors top out around 9 000 px on
+/// the long edge; the cap exists for the file that *claims* to be bigger,
+/// which costs width × height × 4 bytes before a single pixel is checked.
+pub const MAX_IMAGE_EDGE: u32 = 10_000;
+/// Ceiling on what the decoder may allocate for one image.
+pub const MAX_DECODE_BYTES: u64 = 256 * 1024 * 1024;
+
 pub fn prepare(bytes: &[u8], preview_edge: u32) -> Result<PreparedImage> {
     let format = image::guess_format(bytes).map_err(|_| {
         Error::Validation("that upload is not a supported image (JPEG, PNG or WebP)".into())
@@ -42,8 +49,18 @@ pub fn prepare(bytes: &[u8], preview_edge: u32) -> Result<PreparedImage> {
             )));
         }
     };
-    let decoded = image::load_from_memory_with_format(bytes, format)
-        .map_err(|e| Error::Validation(format!("that image could not be decoded: {e}")))?;
+    let mut reader = image::ImageReader::with_format(Cursor::new(bytes), format);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_EDGE);
+    limits.max_image_height = Some(MAX_IMAGE_EDGE);
+    limits.max_alloc = Some(MAX_DECODE_BYTES);
+    reader.limits(limits);
+    let decoded = reader.decode().map_err(|e| match e {
+        image::ImageError::Limits(_) => Error::Validation(format!(
+            "that image is too large to read — at most {MAX_IMAGE_EDGE} pixels on a side"
+        )),
+        e => Error::Validation(format!("that image could not be decoded: {e}")),
+    })?;
 
     let exif = read_exif(bytes);
     let exif_json = exif
@@ -217,6 +234,45 @@ mod tests {
     use super::*;
     use image::{ImageBuffer, Rgb};
     use std::io::Cursor;
+
+    /// PNG's CRC-32, spelled out because no crate in the tree exposes it
+    /// directly and the header the test patches must still verify.
+    fn crc32(bytes: &[u8]) -> u32 {
+        let mut crc = 0xFFFF_FFFFu32;
+        for &b in bytes {
+            crc ^= b as u32;
+            for _ in 0..8 {
+                crc = if crc & 1 == 1 {
+                    (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >> 1
+                };
+            }
+        }
+        !crc
+    }
+
+    #[test]
+    fn an_image_declaring_absurd_dimensions_is_refused_before_it_is_decoded() {
+        // A real 1x1 PNG whose IHDR is patched to claim 11000x11000 — under the decoder's own default allocation ceiling, so only a limit of ours refuses it: the
+        // header verifies, the pixel data does not match, and the decoder must
+        // stop at the header rather than allocate for what it announces.
+        let img = ImageBuffer::from_fn(1, 1, |_, _| Rgb([1u8, 2, 3]));
+        let mut out = Cursor::new(Vec::new());
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, ImageFormat::Png)
+            .unwrap();
+        let mut png = out.into_inner();
+        // Signature (8) + length (4) + "IHDR" (4) + width (4) + height (4) ...
+        png[16..20].copy_from_slice(&11_000u32.to_be_bytes());
+        png[20..24].copy_from_slice(&11_000u32.to_be_bytes());
+        let crc = crc32(&png[12..29]);
+        png[29..33].copy_from_slice(&crc.to_be_bytes());
+
+        let e = prepare(&png, 2048).unwrap_err();
+        assert!(matches!(e, Error::Validation(_)), "{e}");
+        assert!(e.to_string().contains("large"), "{e}");
+    }
 
     fn png(w: u32, h: u32) -> Vec<u8> {
         let img = ImageBuffer::from_fn(w, h, |x, _| Rgb([(x % 256) as u8, 0, 0]));

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -1,0 +1,385 @@
+//! What happens to an uploaded image before anything is stored: sniff the
+//! format, decode it, read its EXIF, and derive the one preview the vision
+//! model is shown and the UI displays. Pure functions; no I/O.
+
+use crate::error::{Error, Result};
+use image::{DynamicImage, ImageFormat};
+use std::io::Cursor;
+
+#[derive(Debug)]
+pub struct PreparedImage {
+    /// Of the original, from its bytes rather than from what the client said.
+    pub mime: &'static str,
+    /// As displayed: after the EXIF orientation is applied.
+    pub width: u32,
+    pub height: u32,
+    /// Orientation applied, longest edge at most `preview_edge`, JPEG.
+    pub preview_jpeg: Vec<u8>,
+    /// See `exif_to_json`. `{}` when the file carries none.
+    pub exif: serde_json::Value,
+}
+
+/// JPEG quality of the preview: high enough that small print in a photographed
+/// page survives, well below the original's size.
+const PREVIEW_QUALITY: u8 = 85;
+
+pub fn prepare(bytes: &[u8], preview_edge: u32) -> Result<PreparedImage> {
+    let format = image::guess_format(bytes).map_err(|_| {
+        Error::Validation("that upload is not a supported image (JPEG, PNG or WebP)".into())
+    })?;
+    let mime = match format {
+        ImageFormat::Jpeg => "image/jpeg",
+        ImageFormat::Png => "image/png",
+        ImageFormat::WebP => "image/webp",
+        other => {
+            return Err(Error::Validation(format!(
+                "that image is {} — only JPEG, PNG and WebP are accepted",
+                other
+                    .extensions_str()
+                    .first()
+                    .copied()
+                    .unwrap_or("of an unsupported format")
+            )));
+        }
+    };
+    let decoded = image::load_from_memory_with_format(bytes, format)
+        .map_err(|e| Error::Validation(format!("that image could not be decoded: {e}")))?;
+
+    let exif = read_exif(bytes);
+    let exif_json = exif
+        .as_ref()
+        .map(exif_to_json)
+        .unwrap_or_else(|| serde_json::json!({}));
+    let orientation = exif_json["orientation"]
+        .as_u64()
+        .and_then(|o| image::metadata::Orientation::from_exif(o as u8))
+        .unwrap_or(image::metadata::Orientation::NoTransforms);
+
+    let mut img = decoded;
+    img.apply_orientation(orientation);
+    let (width, height) = (img.width(), img.height());
+    let preview_jpeg = encode_preview(&img, preview_edge)?;
+
+    Ok(PreparedImage {
+        mime,
+        width,
+        height,
+        preview_jpeg,
+        exif: exif_json,
+    })
+}
+
+fn read_exif(bytes: &[u8]) -> Option<exif::Exif> {
+    exif::Reader::new()
+        .read_from_container(&mut Cursor::new(bytes))
+        .ok()
+}
+
+fn encode_preview(img: &DynamicImage, edge: u32) -> Result<Vec<u8>> {
+    let scaled = if img.width().max(img.height()) > edge {
+        img.thumbnail(edge, edge)
+    } else {
+        img.clone()
+    };
+    // JPEG has no alpha; a PNG with transparency is flattened rather than refused.
+    let rgb = DynamicImage::ImageRgb8(scaled.to_rgb8());
+    let mut out = Cursor::new(Vec::new());
+    let enc = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, PREVIEW_QUALITY);
+    rgb.write_with_encoder(enc)
+        .map_err(|e| Error::Internal(format!("preview encoding failed: {e}")))?;
+    Ok(out.into_inner())
+}
+
+/// The `file` namespace of a corpus's metadata.
+pub fn file_facts(name: Option<&str>, size: usize, img: &PreparedImage) -> serde_json::Value {
+    let mut v = serde_json::json!({
+        "size": size,
+        "mime": img.mime,
+        "width": img.width,
+        "height": img.height,
+    });
+    if let Some(n) = name {
+        v["name"] = serde_json::Value::String(n.to_string());
+    }
+    v
+}
+
+/// The `exif` namespace: the handful of facts worth naming, then every other
+/// tag under `tags` by name so nothing the file carries is thrown away.
+pub fn exif_to_json(exif: &exif::Exif) -> serde_json::Value {
+    use exif::{In, Tag};
+    let mut out = serde_json::Map::new();
+
+    let ascii = |tag: Tag| -> Option<String> {
+        exif.get_field(tag, In::PRIMARY)
+            .and_then(|f| match &f.value {
+                exif::Value::Ascii(v) => v
+                    .first()
+                    .map(|b| String::from_utf8_lossy(b).trim().to_string()),
+                _ => None,
+            })
+    };
+
+    if let Some(dt) = ascii(Tag::DateTimeOriginal) {
+        // "2026:08:09 14:12:03" → "2026-08-09T14:12:03", offset appended when the
+        // file says one.
+        let mut iso = dt.replacen(':', "-", 2).replacen(' ', "T", 1);
+        if let Some(off) = ascii(Tag::OffsetTimeOriginal) {
+            iso.push_str(&off);
+        }
+        out.insert("taken_at".into(), iso.into());
+    }
+    let camera: Vec<String> = [ascii(Tag::Make), ascii(Tag::Model)]
+        .into_iter()
+        .flatten()
+        .collect();
+    if !camera.is_empty() {
+        out.insert("camera".into(), camera.join(" ").into());
+    }
+    if let Some(o) = exif
+        .get_field(Tag::Orientation, In::PRIMARY)
+        .and_then(|f| f.value.get_uint(0))
+    {
+        out.insert("orientation".into(), o.into());
+    }
+    if let Some(gps) = gps_json(exif) {
+        out.insert("gps".into(), gps);
+    }
+
+    let mut tags = serde_json::Map::new();
+    for f in exif.fields() {
+        if f.ifd_num != In::PRIMARY {
+            continue;
+        }
+        let name = f.tag.to_string();
+        // Already named above, or binary noise nobody reads back.
+        if matches!(f.tag, Tag::MakerNote | Tag::UserComment) || name.starts_with("Tag(") {
+            continue;
+        }
+        // ASCII fields display quoted; the quotes are the formatter's, not
+        // the file's.
+        let value: String = match &f.value {
+            exif::Value::Ascii(v) => v
+                .first()
+                .map(|b| String::from_utf8_lossy(b).trim().to_string())
+                .unwrap_or_default(),
+            _ => f.display_value().with_unit(exif).to_string(),
+        };
+        let value: String = value.chars().take(200).collect();
+        tags.insert(name, value.into());
+    }
+    if !tags.is_empty() {
+        out.insert("tags".into(), tags.into());
+    }
+    serde_json::Value::Object(out)
+}
+
+fn gps_json(exif: &exif::Exif) -> Option<serde_json::Value> {
+    use exif::{In, Tag};
+    let reference = |tag: Tag| -> Option<String> {
+        exif.get_field(tag, In::PRIMARY)
+            .and_then(|f| match &f.value {
+                exif::Value::Ascii(v) => v
+                    .first()
+                    .map(|b| String::from_utf8_lossy(b).trim().to_string()),
+                _ => None,
+            })
+    };
+    let dms = |tag: Tag, r: Tag, neg: &str| -> Option<f64> {
+        let f = exif.get_field(tag, In::PRIMARY)?;
+        let exif::Value::Rational(v) = &f.value else {
+            return None;
+        };
+        if v.len() < 3 {
+            return None;
+        }
+        let deg = v[0].to_f64() + v[1].to_f64() / 60.0 + v[2].to_f64() / 3600.0;
+        let sign = match reference(r) {
+            Some(s) if s == neg => -1.0,
+            _ => 1.0,
+        };
+        Some(deg * sign)
+    };
+    let lat = dms(Tag::GPSLatitude, Tag::GPSLatitudeRef, "S")?;
+    let lon = dms(Tag::GPSLongitude, Tag::GPSLongitudeRef, "W")?;
+    let mut g = serde_json::json!({ "lat": lat, "lon": lon });
+    if let Some(f) = exif.get_field(Tag::GPSAltitude, In::PRIMARY)
+        && let exif::Value::Rational(v) = &f.value
+        && let Some(a) = v.first()
+    {
+        g["alt"] = serde_json::json!(a.to_f64());
+    }
+    Some(g)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Rgb};
+    use std::io::Cursor;
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let img = ImageBuffer::from_fn(w, h, |x, _| Rgb([(x % 256) as u8, 0, 0]));
+        let mut out = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    fn jpeg(w: u32, h: u32) -> Vec<u8> {
+        let img = ImageBuffer::from_fn(w, h, |x, _| Rgb([0, (x % 256) as u8, 0]));
+        let mut out = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Jpeg)
+            .unwrap();
+        out.into_inner()
+    }
+
+    /// A JPEG carrying the given EXIF fields in an APP1 segment, spliced in
+    /// right after SOI — which is where every camera puts it.
+    fn jpeg_with_exif(w: u32, h: u32, fields: &[exif::Field]) -> Vec<u8> {
+        let mut writer = exif::experimental::Writer::new();
+        for f in fields {
+            writer.push_field(f);
+        }
+        let mut blob = Cursor::new(Vec::new());
+        writer.write(&mut blob, false).unwrap();
+        let blob = blob.into_inner();
+        let mut app1 = Vec::new();
+        app1.extend_from_slice(&[0xFF, 0xE1]);
+        let len = (blob.len() + 6 + 2) as u16;
+        app1.extend_from_slice(&len.to_be_bytes());
+        app1.extend_from_slice(b"Exif\0\0");
+        app1.extend_from_slice(&blob);
+        let plain = jpeg(w, h);
+        let mut out = plain[..2].to_vec();
+        out.extend_from_slice(&app1);
+        out.extend_from_slice(&plain[2..]);
+        out
+    }
+
+    fn ascii(tag: exif::Tag, s: &str) -> exif::Field {
+        exif::Field {
+            tag,
+            ifd_num: exif::In::PRIMARY,
+            value: exif::Value::Ascii(vec![s.as_bytes().to_vec()]),
+        }
+    }
+
+    #[test]
+    fn a_png_is_decoded_measured_and_previewed_as_jpeg() {
+        let p = prepare(&png(300, 100), 2048).unwrap();
+        assert_eq!(p.mime, "image/png");
+        assert_eq!((p.width, p.height), (300, 100));
+        assert_eq!(p.exif, serde_json::json!({}));
+        let prev = image::load_from_memory(&p.preview_jpeg).unwrap();
+        assert_eq!(
+            image::guess_format(&p.preview_jpeg).unwrap(),
+            image::ImageFormat::Jpeg
+        );
+        // Not upscaled: smaller than the edge stays its own size.
+        assert_eq!((prev.width(), prev.height()), (300, 100));
+    }
+
+    #[test]
+    fn a_large_image_is_downscaled_to_the_edge_keeping_its_ratio() {
+        let p = prepare(&jpeg(4000, 2000), 1000).unwrap();
+        let prev = image::load_from_memory(&p.preview_jpeg).unwrap();
+        assert_eq!((prev.width(), prev.height()), (1000, 500));
+        // The recorded size is the original's.
+        assert_eq!((p.width, p.height), (4000, 2000));
+    }
+
+    #[test]
+    fn exif_orientation_is_applied_to_the_preview_and_recorded() {
+        let orient = exif::Field {
+            tag: exif::Tag::Orientation,
+            ifd_num: exif::In::PRIMARY,
+            value: exif::Value::Short(vec![6]), // rotate 90° CW
+        };
+        let p = prepare(&jpeg_with_exif(400, 200, &[orient]), 2048).unwrap();
+        let prev = image::load_from_memory(&p.preview_jpeg).unwrap();
+        assert_eq!((prev.width(), prev.height()), (200, 400));
+        assert_eq!(
+            (p.width, p.height),
+            (200, 400),
+            "dimensions are as displayed"
+        );
+        assert_eq!(p.exif["orientation"], 6);
+    }
+
+    #[test]
+    fn exif_facts_are_mapped_and_the_rest_kept_as_tags() {
+        let fields = vec![
+            ascii(exif::Tag::DateTimeOriginal, "2026:08:09 14:12:03"),
+            ascii(exif::Tag::Make, "Apple"),
+            ascii(exif::Tag::Model, "iPhone 15"),
+            ascii(exif::Tag::Software, "17.5"),
+        ];
+        let p = prepare(&jpeg_with_exif(64, 64, &fields), 2048).unwrap();
+        assert_eq!(p.exif["taken_at"], "2026-08-09T14:12:03");
+        assert_eq!(p.exif["camera"], "Apple iPhone 15");
+        assert_eq!(p.exif["tags"]["Software"], "17.5");
+        assert!(p.exif.get("gps").is_none());
+    }
+
+    #[test]
+    fn gps_is_converted_to_decimal_degrees() {
+        let dms = |d: u32, m: u32, s: u32| {
+            exif::Value::Rational(vec![
+                exif::Rational { num: d, denom: 1 },
+                exif::Rational { num: m, denom: 1 },
+                exif::Rational {
+                    num: s * 100,
+                    denom: 100,
+                },
+            ])
+        };
+        let f = |tag, value| exif::Field {
+            tag,
+            ifd_num: exif::In::PRIMARY,
+            value,
+        };
+        let fields = vec![
+            f(exif::Tag::GPSLatitude, dms(48, 12, 30)),
+            ascii(exif::Tag::GPSLatitudeRef, "N"),
+            f(exif::Tag::GPSLongitude, dms(16, 22, 0)),
+            ascii(exif::Tag::GPSLongitudeRef, "W"),
+            f(
+                exif::Tag::GPSAltitude,
+                exif::Value::Rational(vec![exif::Rational {
+                    num: 1710,
+                    denom: 10,
+                }]),
+            ),
+        ];
+        let p = prepare(&jpeg_with_exif(64, 64, &fields), 2048).unwrap();
+        let g = &p.exif["gps"];
+        assert!((g["lat"].as_f64().unwrap() - 48.208333).abs() < 1e-4, "{g}");
+        assert!((g["lon"].as_f64().unwrap() + 16.366667).abs() < 1e-4, "{g}");
+        assert!((g["alt"].as_f64().unwrap() - 171.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn junk_and_unsupported_formats_are_refused_with_the_reason() {
+        let e = prepare(b"not an image at all", 2048).unwrap_err();
+        assert!(matches!(e, crate::error::Error::Validation(_)));
+        assert!(e.to_string().contains("not a supported image"), "{e}");
+
+        // A GIF header sniffs as an image but is not one of the three.
+        let e = prepare(b"GIF89a\x01\x00\x01\x00\x80\x00\x00", 2048).unwrap_err();
+        assert!(e.to_string().contains("gif"), "{e}");
+    }
+
+    #[test]
+    fn file_facts_carry_name_size_and_dimensions() {
+        let p = prepare(&png(30, 10), 2048).unwrap();
+        let f = file_facts(Some("IMG_1.png"), 1234, &p);
+        assert_eq!(
+            f,
+            serde_json::json!({"name": "IMG_1.png", "size": 1234, "mime": "image/png", "width": 30, "height": 10})
+        );
+        assert!(file_facts(None, 1, &p).get("name").is_none());
+    }
+}

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -93,18 +93,50 @@ fn read_exif(bytes: &[u8]) -> Option<exif::Exif> {
 }
 
 fn encode_preview(img: &DynamicImage, edge: u32) -> Result<Vec<u8>> {
+    // Before the resize, not after. A filter with a wide kernel mixes the RGB
+    // stored under transparent pixels into their opaque neighbours, so
+    // flattening afterwards leaves a dark fringe around everything that met
+    // the transparent ground.
+    let img = &DynamicImage::ImageRgb8(flatten_onto_white(img));
     let scaled = if img.width().max(img.height()) > edge {
-        img.thumbnail(edge, edge)
+        // Lanczos rather than `thumbnail`. Both average — `thumbnail` does not
+        // drop hairlines, and the test below holds for either — but its fast
+        // integer algorithm quantises to coarse levels and its sample windows
+        // drift in and out of phase with a repeating pattern, which is what
+        // moiré across a photographed page of text looks like. This runs once
+        // per capture, inside a `spawn_blocking`, on the one image the model
+        // will ever be shown; the extra milliseconds buy the sharper reading.
+        img.resize(edge, edge, image::imageops::FilterType::Lanczos3)
     } else {
         img.clone()
     };
-    // JPEG has no alpha; a PNG with transparency is flattened rather than refused.
-    let rgb = DynamicImage::ImageRgb8(scaled.to_rgb8());
+    let rgb = scaled;
     let mut out = Cursor::new(Vec::new());
     let enc = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, PREVIEW_QUALITY);
     rgb.write_with_encoder(enc)
         .map_err(|e| Error::Internal(format!("preview encoding failed: {e}")))?;
     Ok(out.into_inner())
+}
+
+/// Composite over an opaque white ground. White rather than black because the
+/// transparency in a capture is nearly always the page the content sits on —
+/// a cropped screenshot, a window's rounded corner — and dark text is what it
+/// usually carries.
+///
+/// An image with no alpha to composite skips the arithmetic entirely; `to_rgb8`
+/// is exact for those, which is every JPEG and most PNGs.
+fn flatten_onto_white(img: &DynamicImage) -> image::RgbImage {
+    if !img.color().has_alpha() {
+        return img.to_rgb8();
+    }
+    let rgba = img.to_rgba8();
+    let mut out = image::RgbImage::new(rgba.width(), rgba.height());
+    for (x, y, p) in rgba.enumerate_pixels() {
+        let a = p.0[3] as u32;
+        let over = |c: u8| ((c as u32 * a + 255 * (255 - a)) / 255) as u8;
+        out.put_pixel(x, y, image::Rgb([over(p.0[0]), over(p.0[1]), over(p.0[2])]));
+    }
+    out
 }
 
 /// The `file` namespace of a corpus's metadata.
@@ -250,6 +282,98 @@ mod tests {
             }
         }
         !crc
+    }
+
+    /// The preview is both what the vision model reads and what the UI shows,
+    /// and `PREVIEW_QUALITY` is chosen so small print in a photographed page
+    /// survives it. That only holds while the downscale in front of it
+    /// *averages*: a point-sampling filter keeps every nth column and discards
+    /// the rest, so a hairline falling in a discarded column is not blurred but
+    /// gone, and no quality setting downstream can bring it back.
+    #[test]
+    fn a_hairline_survives_the_downscale_wherever_it_falls() {
+        // 2000 px wide, a 2 px black line every 20 px: 99 lines, and a preview
+        // edge of 512 makes the factor 3.9 — not an integer, which is where
+        // point sampling drops columns.
+        const W: u32 = 2000;
+        const PITCH: u32 = 20;
+        let src = ImageBuffer::from_fn(W, 200, |x, _| {
+            if x % PITCH < 2 {
+                Rgb([0u8, 0, 0])
+            } else {
+                Rgb([255u8, 255, 255])
+            }
+        });
+        let mut out = Cursor::new(Vec::new());
+        DynamicImage::ImageRgb8(src)
+            .write_to(&mut out, ImageFormat::Png)
+            .unwrap();
+
+        let prepared = prepare(&out.into_inner(), 512).unwrap();
+        let preview = image::load_from_memory(&prepared.preview_jpeg)
+            .unwrap()
+            .to_luma8();
+
+        // Every line must leave a darkening somewhere in the preview column
+        // its position maps to. A tolerance of one column either side absorbs
+        // the rounding; it cannot absorb a line that was thrown away.
+        let scale = preview.width() as f32 / W as f32;
+        let column_min = |x: u32| -> u8 {
+            (0..preview.height())
+                .map(|y| preview.get_pixel(x, y).0[0])
+                .min()
+                .unwrap()
+        };
+        let lost: Vec<u32> = (0..W / PITCH)
+            .filter(|i| {
+                let centre = (((i * PITCH + 1) as f32) * scale).round() as u32;
+                let lo = centre.saturating_sub(1);
+                let hi = (centre + 1).min(preview.width() - 1);
+                (lo..=hi).all(|x| column_min(x) > 200)
+            })
+            .collect();
+        assert!(
+            lost.is_empty(),
+            "{} of {} hairlines left no trace in the preview: {:?}",
+            lost.len(),
+            W / PITCH,
+            lost
+        );
+    }
+
+    /// JPEG has no alpha, so the preview has to put something behind it.
+    /// Discarding the channel is not that: the RGB stored under a fully
+    /// transparent pixel is zero in most encoders, so a screenshot with a
+    /// transparent margin or rounded corners reached the model as black.
+    #[test]
+    fn transparency_is_flattened_onto_white_rather_than_onto_black() {
+        // Dark text on a transparent ground — a window capture's shape.
+        let src = ImageBuffer::from_fn(64, 64, |x, y| {
+            if (20..44).contains(&x) && (20..44).contains(&y) {
+                image::Rgba([10u8, 10, 10, 255])
+            } else {
+                image::Rgba([0u8, 0, 0, 0])
+            }
+        });
+        let mut out = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(src)
+            .write_to(&mut out, ImageFormat::Png)
+            .unwrap();
+
+        let prepared = prepare(&out.into_inner(), 2048).unwrap();
+        let preview = image::load_from_memory(&prepared.preview_jpeg)
+            .unwrap()
+            .to_luma8();
+
+        assert!(
+            preview.get_pixel(2, 2).0[0] > 240,
+            "the transparent ground must come out white, not black; it was {}",
+            preview.get_pixel(2, 2).0[0]
+        );
+        assert!(
+            preview.get_pixel(32, 32).0[0] < 40,
+            "and the opaque mark must still be dark"
+        );
     }
 
     #[test]

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -30,6 +30,20 @@ pub const MAX_IMAGE_EDGE: u32 = 10_000;
 /// Ceiling on what the decoder may allocate for one image.
 pub const MAX_DECODE_BYTES: u64 = 256 * 1024 * 1024;
 
+/// How many uploads may be decoded at once, across the whole process.
+///
+/// The two ceilings above bound one image and say nothing about ten. Decoding
+/// runs on `spawn_blocking`, whose pool is 512 threads deep and which — unlike
+/// every inference call — passes through no gate, so the arithmetic that ends
+/// at `MAX_DECODE_BYTES` for one photo ends at the OOM killer for a handful of
+/// concurrent uploads, each holding its source plus the RGB copy the preview
+/// is composited into.
+///
+/// Not configurable: this is the floor that keeps the process alive rather
+/// than a throughput setting, and a base whose owner has raised it has no way
+/// to find out except by losing the process.
+pub const MAX_CONCURRENT_DECODES: usize = 2;
+
 pub fn prepare(bytes: &[u8], preview_edge: u32) -> Result<PreparedImage> {
     let format = image::guess_format(bytes).map_err(|_| {
         Error::Validation("that upload is not a supported image (JPEG, PNG or WebP)".into())

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -295,13 +295,25 @@ impl Core {
         // over up to `image_max_bytes` of pixels. Held on a Tokio worker that
         // is seconds during which search, health and the queue poll on that
         // thread all wait; see `web::api::extract` for the same move.
+        //
+        // Held across the whole decode, and taken before it rather than inside
+        // it: the blocking pool is 512 threads deep, so without a permit the
+        // only bound on how much of this runs at once is how fast clients can
+        // post. See `image::MAX_CONCURRENT_DECODES`.
         let edge = self.capture.image_preview_edge;
-        let (bytes, prepared) = tokio::task::spawn_blocking(move || {
+        let permit = self
+            .decodes
+            .acquire()
+            .await
+            .expect("the decode permit is never closed");
+        let decoded = tokio::task::spawn_blocking(move || {
             let prepared = super::image::prepare(&bytes, edge)?;
             Ok::<_, Error>((bytes, prepared))
         })
         .await
-        .map_err(|e| Error::Internal(format!("image preparation did not finish: {e}")))??;
+        .map_err(|e| Error::Internal(format!("image preparation did not finish: {e}")))?;
+        drop(permit);
+        let (bytes, prepared) = decoded?;
 
         let mut metadata = serde_json::json!({
             "file": super::image::file_facts(filename.as_deref(), bytes.len(), &prepared),
@@ -1146,6 +1158,46 @@ mod tests {
             title_hint: None,
             note: None,
         }
+    }
+
+    /// `MAX_IMAGE_EDGE` and `MAX_DECODE_BYTES` bound one image and say nothing
+    /// about ten at once. Decoding runs on a 512-thread blocking pool through
+    /// no gate at all, so without a permit the ceiling on resident pixels is
+    /// however many uploads a client cares to have in flight.
+    #[tokio::test]
+    async fn only_so_many_uploads_are_decoded_at_once() {
+        let core = test_core().await;
+        // Stand in for the decodes already running: hold every permit, and the
+        // next capture must wait rather than start a decode of its own.
+        let held = core
+            .decodes
+            .clone()
+            .acquire_many_owned(crate::core::image::MAX_CONCURRENT_DECODES as u32)
+            .await
+            .unwrap();
+
+        let mut waiting = tokio::spawn({
+            let core = core.clone();
+            async move { core.ingest_image(an_image(11)).await }
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), &mut waiting)
+                .await
+                .is_err(),
+            "a capture must not decode while the permits are all taken"
+        );
+        waiting.abort();
+
+        drop(held);
+        // And once they are free again it goes through as usual.
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            core.ingest_image(an_image(12)),
+        )
+        .await
+        .expect("released permits let the next capture through")
+        .unwrap();
+        assert!(!out.duplicate);
     }
 
     #[tokio::test]

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -243,29 +243,23 @@ impl Core {
         corpus_id: &str,
         near: Option<&crate::store::corpora::NearDuplicate>,
     ) -> Result<()> {
-        match near {
-            Some(n) => {
-                self.store
-                    .set_near_dupe(corpus_id, Some(&n.corpus_id), Some(n.similarity))
-                    .await?;
-                self.store
-                    .set_corpus_status(corpus_id, CorpusStatus::NeedsReview)
-                    .await?;
-                tracing::info!(
-                    corpus_id,
-                    near = %n.corpus_id,
-                    similarity = n.similarity,
-                    "looks like an existing corpus; parked for review"
-                );
-            }
-            None => {
-                self.store
-                    .set_corpus_status(corpus_id, CorpusStatus::Raw)
-                    .await?;
-                self.store
-                    .enqueue(Stage::Synthesize, "corpus", corpus_id)
-                    .await?;
-            }
+        let followup = match near {
+            Some(n) => crate::store::corpora::Followup::Park {
+                of: n.corpus_id.clone(),
+                similarity: n.similarity,
+            },
+            None => crate::store::corpora::Followup::Queue(Stage::Synthesize),
+        };
+        // One transaction, the same one a text capture's insert uses: the
+        // status and the job it implies cannot be written apart.
+        self.store.apply_followup(corpus_id, followup).await?;
+        if let Some(n) = near {
+            tracing::info!(
+                corpus_id,
+                near = %n.corpus_id,
+                similarity = n.similarity,
+                "looks like an existing corpus; parked for review"
+            );
         }
         Ok(())
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -244,6 +244,41 @@ impl Core {
         })
     }
 
+    /// The fork every capture reaches once its text is known: parked next to
+    /// what it resembles, or queued for synthesis. The status write is here so
+    /// no caller can park without saying what it parked beside.
+    pub(crate) async fn park_or_queue(
+        &self,
+        corpus_id: &str,
+        near: Option<&crate::store::corpora::NearDuplicate>,
+    ) -> Result<()> {
+        match near {
+            Some(n) => {
+                self.store
+                    .set_near_dupe(corpus_id, Some(&n.corpus_id), Some(n.similarity))
+                    .await?;
+                self.store
+                    .set_corpus_status(corpus_id, CorpusStatus::NeedsReview)
+                    .await?;
+                tracing::info!(
+                    corpus_id,
+                    near = %n.corpus_id,
+                    similarity = n.similarity,
+                    "looks like an existing corpus; parked for review"
+                );
+            }
+            None => {
+                self.store
+                    .set_corpus_status(corpus_id, CorpusStatus::Raw)
+                    .await?;
+                self.store
+                    .enqueue(Stage::Synthesize, "corpus", corpus_id)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
     /// Store the image and queue the vision stage. Like `ingest_capture`, this
     /// makes no inference call: the phone gets its answer the moment the bytes
     /// are safe, and a dead vision endpoint costs a wait, not a photo.

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -4,6 +4,24 @@ use crate::store::artifacts::ArtifactStatus;
 use crate::store::corpora::{CorpusStatus, Insertion, NearDuplicate, content_hash};
 use crate::store::jobs::Stage;
 use crate::store::now;
+use sha2::Digest;
+
+/// The channel an image arrives through. Its own value, like `upload`, so
+/// the queue and the detail page can tell a photo from a paste.
+pub const ORIGIN_IMAGE: &str = "image";
+/// Longest note kept. Context, not a document: someone wanting to say more
+/// than this has a paste box.
+pub const MAX_NOTE_CHARS: usize = 2000;
+
+/// The user's context for a capture, cleaned: trimmed, capped, `None` when
+/// there is nothing in it.
+fn clean_note(note: Option<String>) -> Option<String> {
+    let n = note?.trim().to_string();
+    if n.is_empty() {
+        return None;
+    }
+    Some(n.chars().take(MAX_NOTE_CHARS).collect())
+}
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct IngestOutcome {
@@ -51,6 +69,15 @@ pub enum NearDupeAction {
     Discard,
 }
 
+/// One image, whichever door it arrived through.
+#[derive(Debug, Clone)]
+pub struct ImageCapture {
+    pub bytes: Vec<u8>,
+    pub filename: Option<String>,
+    pub title_hint: Option<String>,
+    pub note: Option<String>,
+}
+
 /// One capture, whichever door it arrived through.
 ///
 /// A struct rather than four positional arguments: `origin` and `source_url`
@@ -65,6 +92,8 @@ pub struct Capture {
     /// Where the text was read. Provenance, never an instruction: nothing
     /// downstream ever fetches this.
     pub source_url: Option<String>,
+    /// What the door knew beyond the text. Namespaced; see the schema comment.
+    pub metadata: serde_json::Value,
 }
 
 impl Capture {
@@ -74,7 +103,25 @@ impl Capture {
             origin: origin.into(),
             title_hint: None,
             source_url: None,
+            metadata: serde_json::json!({}),
         }
+    }
+
+    pub fn with_note(mut self, note: Option<String>) -> Self {
+        if let Some(n) = clean_note(note) {
+            self.metadata["note"] = serde_json::Value::String(n);
+        }
+        self
+    }
+
+    /// The `file` facts of an uploaded text file.
+    pub fn with_file(mut self, name: Option<&str>, size: usize, mime: &str) -> Self {
+        let mut f = serde_json::json!({ "size": size, "mime": mime });
+        if let Some(n) = name {
+            f["name"] = serde_json::Value::String(n.to_string());
+        }
+        self.metadata["file"] = f;
+        self
     }
 
     pub fn with_title(mut self, title: Option<String>) -> Self {
@@ -136,7 +183,7 @@ impl Core {
                 title_hint,
                 sig,
                 c.source_url.as_deref(),
-                &serde_json::json!({}),
+                &c.metadata,
             )
             .await?
         {
@@ -194,6 +241,82 @@ impl Core {
             },
             duplicate: false,
             near_duplicate: near,
+        })
+    }
+
+    /// Store the image and queue the vision stage. Like `ingest_capture`, this
+    /// makes no inference call: the phone gets its answer the moment the bytes
+    /// are safe, and a dead vision endpoint costs a wait, not a photo.
+    pub async fn ingest_image(&self, c: ImageCapture) -> Result<IngestOutcome> {
+        if self.describer.is_none() {
+            return Err(Error::Validation(
+                "image capture is not configured — set [infer.vision] to enable it".into(),
+            ));
+        }
+        let prepared = super::image::prepare(&c.bytes, self.capture.image_preview_edge)?;
+        let hash = hex::encode(sha2::Sha256::digest(&c.bytes));
+        if let Some(existing) = self.store.find_by_hash(&hash).await? {
+            tracing::info!(corpus_id = %existing.id, "duplicate image, returning existing source");
+            return Ok(IngestOutcome {
+                id: existing.id,
+                status: existing.status,
+                duplicate: true,
+                near_duplicate: None,
+            });
+        }
+
+        let mut metadata = serde_json::json!({
+            "file": super::image::file_facts(c.filename.as_deref(), c.bytes.len(), &prepared),
+        });
+        if prepared.exif.as_object().is_some_and(|o| !o.is_empty()) {
+            metadata["exif"] = prepared.exif.clone();
+        }
+        if let Some(n) = clean_note(c.note) {
+            metadata["note"] = serde_json::Value::String(n);
+        }
+        let title_hint = c.title_hint.or_else(|| c.filename.clone());
+
+        let src = match self
+            .store
+            .insert_image_corpus(&hash, ORIGIN_IMAGE, title_hint.as_deref(), &metadata)
+            .await?
+        {
+            Insertion::Created(src) => src,
+            Insertion::Existing(existing) => {
+                return Ok(IngestOutcome {
+                    id: existing.id,
+                    status: existing.status,
+                    duplicate: true,
+                    near_duplicate: None,
+                });
+            }
+        };
+        self.store
+            .insert_attachment(&crate::store::attachments::NewAttachment {
+                corpus_id: &src.id,
+                kind: "image",
+                mime: prepared.mime,
+                filename: c.filename.as_deref(),
+                bytes: &c.bytes,
+                preview: &prepared.preview_jpeg,
+                width: Some(prepared.width as i64),
+                height: Some(prepared.height as i64),
+            })
+            .await?;
+        self.store
+            .enqueue(Stage::Describe, "corpus", &src.id)
+            .await?;
+        tracing::info!(
+            corpus_id = %src.id,
+            bytes = c.bytes.len(),
+            mime = prepared.mime,
+            "image captured; queued for reading"
+        );
+        Ok(IngestOutcome {
+            id: src.id,
+            status: CorpusStatus::Describing,
+            duplicate: false,
+            near_duplicate: None,
         })
     }
 
@@ -916,8 +1039,11 @@ impl Core {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ingest::{NearDupeAction, StoreDrift};
+    use crate::core::ingest::{
+        Capture, ImageCapture, MAX_NOTE_CHARS, NearDupeAction, ORIGIN_IMAGE, StoreDrift,
+    };
     use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
+    use crate::error::Error;
     use crate::store::artifacts::EmbedState;
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::Stage;
@@ -1714,5 +1840,165 @@ mod tests {
         let drift = core.heal_store_drift().await.unwrap();
 
         assert_eq!(drift, StoreDrift::default(), "{drift:?}");
+    }
+
+    fn a_png() -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(40, 20, |x, _| Rgb([(x * 6) as u8, 0, 0]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    #[tokio::test]
+    async fn an_image_capture_stores_the_original_and_queues_describe_without_calling_the_model() {
+        let describer = std::sync::Arc::new(crate::infer::fake::FakeDescriber::default());
+        let core = crate::core::test_support::test_core_with_describer(describer.clone()).await;
+        let bytes = a_png();
+        let out = core
+            .ingest_image(ImageCapture {
+                bytes: bytes.clone(),
+                filename: Some("IMG_1.png".into()),
+                title_hint: None,
+                note: Some("  the kitchen whiteboard ".into()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.status, CorpusStatus::Describing);
+        assert!(!out.duplicate);
+        assert_eq!(describer.calls(), 0, "capture must not call the model");
+
+        let src = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(src.origin, ORIGIN_IMAGE);
+        assert_eq!(src.raw_text, "");
+        assert_eq!(src.title_hint.as_deref(), Some("IMG_1.png"));
+        assert_eq!(src.metadata["note"], "the kitchen whiteboard");
+        assert_eq!(src.metadata["file"]["name"], "IMG_1.png");
+        assert_eq!(src.metadata["file"]["mime"], "image/png");
+        assert_eq!(src.metadata["file"]["width"], 40);
+
+        let a = core
+            .store
+            .attachment_for_corpus(&out.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(a.bytes, bytes, "the original is stored byte for byte");
+        assert_eq!(a.mime, "image/png");
+        assert!(image::load_from_memory(&a.preview).is_ok());
+
+        let job = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("a job was queued");
+        assert_eq!(job.stage, Stage::Describe);
+        assert_eq!(job.target_id, out.id);
+    }
+
+    #[tokio::test]
+    async fn the_same_photo_twice_is_a_duplicate_before_any_model_call() {
+        let core = crate::core::test_support::test_core().await;
+        let first = core
+            .ingest_image(ImageCapture {
+                bytes: a_png(),
+                filename: None,
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap();
+        let again = core
+            .ingest_image(ImageCapture {
+                bytes: a_png(),
+                filename: None,
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap();
+        assert!(again.duplicate);
+        assert_eq!(again.id, first.id);
+        assert_eq!(core.store.list_corpora(10, 0).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn without_a_vision_role_the_image_door_is_closed() {
+        let core = crate::core::test_support::test_core_without_vision().await;
+        let e = core
+            .ingest_image(ImageCapture {
+                bytes: a_png(),
+                filename: None,
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(e, Error::Validation(_)));
+        assert!(e.to_string().contains("not configured"), "{e}");
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn junk_is_refused_before_anything_is_stored() {
+        let core = crate::core::test_support::test_core().await;
+        let e = core
+            .ingest_image(ImageCapture {
+                bytes: b"nope".to_vec(),
+                filename: Some("x.jpg".into()),
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(e, Error::Validation(_)));
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_note_is_capped_and_a_blank_one_is_dropped() {
+        let core = crate::core::test_support::test_core().await;
+        let long = "x".repeat(MAX_NOTE_CHARS + 50);
+        let out = core
+            .ingest_capture(Capture::new("some text", "upload").with_note(Some(long)))
+            .await
+            .unwrap();
+        let src = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(src.metadata["note"].as_str().unwrap().len(), MAX_NOTE_CHARS);
+
+        let out = core
+            .ingest_capture(Capture::new("other text", "upload").with_note(Some("   ".into())))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .get_corpus(&out.id)
+                .await
+                .unwrap()
+                .metadata
+                .get("note")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_text_capture_carries_its_file_facts() {
+        let core = crate::core::test_support::test_core().await;
+        let out = core
+            .ingest_capture(Capture::new("hello", "upload").with_file(
+                Some("n.txt"),
+                5,
+                "text/plain",
+            ))
+            .await
+            .unwrap();
+        let m = core.store.get_corpus(&out.id).await.unwrap().metadata;
+        assert_eq!(
+            m["file"],
+            serde_json::json!({"name": "n.txt", "size": 5, "mime": "text/plain"})
+        );
     }
 }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -4,7 +4,6 @@ use crate::store::artifacts::ArtifactStatus;
 use crate::store::corpora::{CorpusStatus, Insertion, NearDuplicate, content_hash};
 use crate::store::jobs::Stage;
 use crate::store::now;
-use sha2::Digest;
 
 /// The channel an image arrives through. Its own value, like `upload`, so
 /// the queue and the detail page can tell a photo from a paste.
@@ -288,8 +287,15 @@ impl Core {
                 "image capture is not configured — set [infer.vision] to enable it".into(),
             ));
         }
-        let prepared = super::image::prepare(&c.bytes, self.capture.image_preview_edge)?;
-        let hash = hex::encode(sha2::Sha256::digest(&c.bytes));
+        let ImageCapture {
+            bytes,
+            filename,
+            title_hint,
+            note,
+        } = c;
+        // Hashed and looked up before it is decoded: a photo sent twice costs
+        // one SHA-256 the second time, not a full decode and re-encode.
+        let hash = content_hash(&bytes);
         if let Some(existing) = self.store.find_by_hash(&hash).await? {
             tracing::info!(corpus_id = %existing.id, "duplicate image, returning existing source");
             return Ok(IngestOutcome {
@@ -299,17 +305,28 @@ impl Core {
                 near_duplicate: None,
             });
         }
+        // Decoding, EXIF, the preview and its re-encode are a synchronous walk
+        // over up to `image_max_bytes` of pixels. Held on a Tokio worker that
+        // is seconds during which search, health and the queue poll on that
+        // thread all wait; see `web::api::extract` for the same move.
+        let edge = self.capture.image_preview_edge;
+        let (bytes, prepared) = tokio::task::spawn_blocking(move || {
+            let prepared = super::image::prepare(&bytes, edge)?;
+            Ok::<_, Error>((bytes, prepared))
+        })
+        .await
+        .map_err(|e| Error::Internal(format!("image preparation did not finish: {e}")))??;
 
         let mut metadata = serde_json::json!({
-            "file": super::image::file_facts(c.filename.as_deref(), c.bytes.len(), &prepared),
+            "file": super::image::file_facts(filename.as_deref(), bytes.len(), &prepared),
         });
         if prepared.exif.as_object().is_some_and(|o| !o.is_empty()) {
             metadata["exif"] = prepared.exif.clone();
         }
-        if let Some(n) = clean_note(c.note) {
+        if let Some(n) = clean_note(note) {
             metadata["note"] = serde_json::Value::String(n);
         }
-        let title_hint = c.title_hint.or_else(|| c.filename.clone());
+        let title_hint = title_hint.or_else(|| filename.clone());
 
         let src = match self
             .store
@@ -331,8 +348,8 @@ impl Core {
                 corpus_id: &src.id,
                 kind: "image",
                 mime: prepared.mime,
-                filename: c.filename.as_deref(),
-                bytes: &c.bytes,
+                filename: filename.as_deref(),
+                bytes: &bytes,
                 preview: &prepared.preview_jpeg,
                 width: Some(prepared.width as i64),
                 height: Some(prepared.height as i64),
@@ -343,7 +360,7 @@ impl Core {
             .await?;
         tracing::info!(
             corpus_id = %src.id,
-            bytes = c.bytes.len(),
+            bytes = bytes.len(),
             mime = prepared.mime,
             "image captured; queued for reading"
         );
@@ -1223,6 +1240,37 @@ mod tests {
             core.store.get_corpus(&id).await.unwrap().status,
             CorpusStatus::Failed
         );
+    }
+
+    #[tokio::test]
+    async fn a_duplicate_image_is_recognised_by_the_shared_hash() {
+        let core = test_core().await;
+        let bytes = a_seeded_png(4);
+        let first = core
+            .ingest_image(ImageCapture {
+                bytes: bytes.clone(),
+                filename: None,
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap();
+        let src = core.store.get_corpus(&first.id).await.unwrap();
+        assert_eq!(
+            src.content_hash,
+            crate::store::corpora::content_hash(&bytes)
+        );
+        let again = core
+            .ingest_image(ImageCapture {
+                bytes,
+                filename: None,
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap();
+        assert!(again.duplicate);
+        assert_eq!(again.id, first.id);
     }
 
     #[tokio::test]

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1088,7 +1088,7 @@ impl Core {
             // everything derived from it are replaced wholesale, because a
             // chunk of the old reading has no span in the new one.
             Stage::Describe => {
-                if self.store.attachment_for_corpus(&src.id).await?.is_none() {
+                if !self.store.has_attachment(&src.id).await? {
                     return Err(Error::Validation(
                         "only a captured image can be re-read".into(),
                     ));

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -326,7 +326,9 @@ impl Core {
         if let Some(n) = clean_note(note) {
             metadata["note"] = serde_json::Value::String(n);
         }
-        let title_hint = title_hint.or_else(|| filename.clone());
+        // A filename is a file fact, not a name: `photo.jpg` and `image.png`
+        // are what a camera and a clipboard call everything. Seeding the title
+        // from it would disarm the one stage that can name the capture.
 
         let src = match self
             .store
@@ -1274,6 +1276,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_image_filename_is_kept_as_a_file_fact_and_not_used_as_its_title() {
+        let core = test_core().await;
+        let id = core
+            .ingest_image(ImageCapture {
+                bytes: a_seeded_png(5),
+                filename: Some("photo.jpg".into()),
+                title_hint: None,
+                note: None,
+            })
+            .await
+            .unwrap()
+            .id;
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.title_hint, None);
+        assert_eq!(src.metadata["file"]["name"], "photo.jpg");
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert!(
+            core.store
+                .get_corpus(&id)
+                .await
+                .unwrap()
+                .title_hint
+                .is_some(),
+            "the Title stage named it"
+        );
+    }
+
+    #[tokio::test]
     async fn a_text_corpus_cannot_be_re_read() {
         let core = test_core().await;
         let src = core.ingest("some text", "web", None).await.unwrap();
@@ -2108,7 +2138,10 @@ mod tests {
         let src = core.store.get_corpus(&out.id).await.unwrap();
         assert_eq!(src.origin, ORIGIN_IMAGE);
         assert_eq!(src.raw_text, "");
-        assert_eq!(src.title_hint.as_deref(), Some("IMG_1.png"));
+        assert_eq!(
+            src.title_hint, None,
+            "a filename is a file fact; the Title stage names the capture"
+        );
         assert_eq!(src.metadata["note"], "the kitchen whiteboard");
         assert_eq!(src.metadata["file"]["name"], "IMG_1.png");
         assert_eq!(src.metadata["file"]["mime"], "image/png");

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -945,50 +945,56 @@ impl Core {
         Ok(())
     }
 
+    /// Everything a rerun of the pipeline from `raw_text` has to forget first.
+    /// Shared by re-segment and re-read; the comment on each line is the reason
+    /// the line exists.
+    async fn forget_derived_work(&self, id: &str) -> Result<()> {
+        // Re-segmenting replaces every chunk, so the old vectors and rows go
+        // first.
+        self.vectors.delete_by_corpus(id).await?;
+        for c in self.store.artifacts_for_corpus(id).await? {
+            self.store.delete_artifact(&c.id).await?;
+        }
+        // The window rows are the segment job's memory of what it has already
+        // done. Leaving them behind means the rerun finds every window `done`,
+        // segments nothing, and lands on a source with no chunks at all.
+        // Re-windowing is also the point of a reprocess after a model or budget
+        // change.
+        self.store.clear_segments(id).await?;
+        // The measure those windows produced goes with them. It is not just
+        // stale: the reconciliation sweep identifies a document whose last
+        // window resolved but whose `settle` never ran by having no coverage,
+        // so a value left over from the previous run reads as "already
+        // finished". A rerun that dies in exactly that window would then be
+        // stuck in `segmenting` for good — nothing resolves again to trigger
+        // `settle`, and the one sweep that repairs it has been told there is
+        // nothing to repair.
+        self.store.clear_corpus_coverage(id).await?;
+        // And the units that name those windows, which outlive them. Planning
+        // arms idle-only, so a unit still queued from the run being replaced
+        // would carry its attempts into the rerun — the person who asked for
+        // another try would get a window that gives up after one.
+        self.store.delete_window_jobs(id).await?;
+        // The title unit is armed once per corpus and never again, so that a
+        // document the model will not name stops costing calls. The row is
+        // what remembers that, which also means a corpus left unnamed by a
+        // transient failure could never be named again — including by the
+        // person who noticed and asked for the rerun. An explicit reprocess is
+        // exactly the case that rule is not meant to cover.
+        self.store.delete_job(Stage::Title, id).await?;
+        // Reprocessing a parked capture is a decision to process it, so the
+        // park has to be lifted with it. Leaving the flag set means a fully
+        // synthesized and embedded corpus sits on the review queue forever,
+        // where the discard button now deletes real work.
+        self.store.set_near_dupe(id, None, None).await?;
+        Ok(())
+    }
+
     pub async fn reprocess(&self, id: &str, stage: Stage) -> Result<()> {
         let src = self.store.get_corpus(id).await?;
         match stage {
             Stage::Synthesize | Stage::Enrich => {
-                // Re-segmenting replaces every chunk, so the old vectors and
-                // rows go first.
-                self.vectors.delete_by_corpus(&src.id).await?;
-                for c in self.store.artifacts_for_corpus(&src.id).await? {
-                    self.store.delete_artifact(&c.id).await?;
-                }
-                // The window rows are the segment job's memory of what it has
-                // already done. Leaving them behind means the rerun finds every
-                // window `done`, segments nothing, and lands on a source with
-                // no chunks at all. Re-windowing is also the point of a
-                // reprocess after a model or budget change.
-                self.store.clear_segments(&src.id).await?;
-                // The measure those windows produced goes with them. It is not
-                // just stale: the reconciliation sweep identifies a document
-                // whose last window resolved but whose `settle` never ran by
-                // having no coverage, so a value left over from the previous run
-                // reads as "already finished". A rerun that dies in exactly that
-                // window would then be stuck in `segmenting` for good — nothing
-                // resolves again to trigger `settle`, and the one sweep that
-                // repairs it has been told there is nothing to repair.
-                self.store.clear_corpus_coverage(&src.id).await?;
-                // And the units that name those windows, which outlive them.
-                // Planning arms idle-only, so a unit still queued from the run
-                // being replaced would carry its attempts into the rerun — the
-                // person who asked for another try would get a window that gives
-                // up after one.
-                self.store.delete_window_jobs(&src.id).await?;
-                // The title unit is armed once per corpus and never again, so
-                // that a document the model will not name stops costing calls.
-                // The row is what remembers that, which also means a corpus left
-                // unnamed by a transient failure could never be named again —
-                // including by the person who noticed and asked for the rerun.
-                // An explicit reprocess is exactly the case that rule is not
-                // meant to cover.
-                self.store.delete_job(Stage::Title, &src.id).await?;
-                // Reprocessing a parked capture is a decision to process it, so
-                // the park has to be lifted with it. Leaving the flag set means
-                // a fully synthesized and embedded corpus sits on the review
-                // queue forever, where the discard button now deletes real work.
-                self.store.set_near_dupe(&src.id, None, None).await?;
+                self.forget_derived_work(&src.id).await?;
                 self.store
                     .set_corpus_status(&src.id, CorpusStatus::Raw)
                     .await?;
@@ -1025,12 +1031,35 @@ impl Core {
                         .into(),
                 ));
             }
-            // Re-reading a stored image with a different model is a later
-            // feature; the original is kept so it stays possible.
+            // A stored image can always be read again — with a better model, or
+            // after the endpoint that refused it is fixed. The reading and
+            // everything derived from it are replaced wholesale, because a
+            // chunk of the old reading has no span in the new one.
             Stage::Describe => {
-                return Err(Error::Validation(
-                    "re-reading an image is not supported yet; capture it again".into(),
-                ));
+                if self.store.attachment_for_corpus(&src.id).await?.is_none() {
+                    return Err(Error::Validation(
+                        "only a captured image can be re-read".into(),
+                    ));
+                }
+                if self.describer.is_none() {
+                    return Err(Error::Validation(
+                        "image capture is not configured — set [infer.vision] to enable it".into(),
+                    ));
+                }
+                self.forget_derived_work(&src.id).await?;
+                self.store.clear_described_text(&src.id).await?;
+                let mut meta = src.metadata.clone();
+                if let Some(m) = meta.as_object_mut() {
+                    m.remove("describe");
+                }
+                self.store.set_corpus_metadata(&src.id, &meta).await?;
+                self.store
+                    .set_corpus_status(&src.id, CorpusStatus::Describing)
+                    .await?;
+                self.heal_dangling_supersessions().await?;
+                self.store
+                    .enqueue(Stage::Describe, "corpus", &src.id)
+                    .await?;
             }
         }
         Ok(())
@@ -1047,6 +1076,92 @@ mod tests {
     use crate::store::artifacts::EmbedState;
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::Stage;
+
+    fn a_seeded_png(seed: u8) -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(16, 16, |x, y| Rgb([seed, x as u8, y as u8]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    fn an_image(seed: u8) -> ImageCapture {
+        ImageCapture {
+            bytes: a_seeded_png(seed),
+            filename: None,
+            title_hint: None,
+            note: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn re_reading_a_failed_image_clears_the_reason_and_queues_describe_again() {
+        let core = test_core().await;
+        let id = core.ingest_image(an_image(1)).await.unwrap().id;
+        crate::jobs::describe::park_failed(&core, &id, "HTTP 400")
+            .await
+            .unwrap();
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        core.store.complete_job(job.id).await.unwrap();
+
+        core.reprocess(&id, Stage::Describe).await.unwrap();
+
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert!(src.metadata.get("describe").is_none());
+        let job = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("describe re-armed");
+        assert_eq!(
+            (job.stage, job.target_id.as_str()),
+            (Stage::Describe, id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn re_reading_a_ready_image_starts_it_over_from_the_pixels() {
+        let core = test_core().await;
+        let id = core.ingest_image(an_image(2)).await.unwrap().id;
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert_eq!(
+            core.store.get_corpus(&id).await.unwrap().status,
+            CorpusStatus::Ready
+        );
+
+        core.reprocess(&id, Stage::Describe).await.unwrap();
+
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert_eq!(src.raw_text, "");
+        assert!(src.shingles.is_empty());
+        assert!(
+            core.store
+                .artifacts_for_corpus(&id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        assert_eq!(
+            core.store.get_corpus(&id).await.unwrap().status,
+            CorpusStatus::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn a_text_corpus_cannot_be_re_read() {
+        let core = test_core().await;
+        let src = core.ingest("some text", "web", None).await.unwrap();
+        assert!(matches!(
+            core.reprocess(&src.id, Stage::Describe).await,
+            Err(Error::Validation(_))
+        ));
+    }
 
     #[tokio::test]
     async fn healing_a_dangling_supersession_leaves_no_unfinished_write_behind() {

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1029,6 +1029,18 @@ impl Core {
         let src = self.store.get_corpus(id).await?;
         match stage {
             Stage::Synthesize | Stage::Enrich => {
+                // Re-segmenting starts from `raw_text`, and an image whose read
+                // has not landed has none. Flipping it to `raw` would have
+                // synthesis fail on empty text and the pending read then find
+                // a corpus that is no longer `describing` — a photo never
+                // read, by way of a button that promised to process it.
+                if src.status == CorpusStatus::Describing
+                    || (src.origin == ORIGIN_IMAGE && src.raw_text.trim().is_empty())
+                {
+                    return Err(Error::Validation(
+                        "this image has not been read yet — re-read it instead".into(),
+                    ));
+                }
                 self.forget_derived_work(&src.id).await?;
                 self.store
                     .set_corpus_status(&src.id, CorpusStatus::Raw)
@@ -1185,6 +1197,31 @@ mod tests {
         assert_eq!(
             core.store.get_corpus(&id).await.unwrap().status,
             CorpusStatus::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn re_segmenting_an_image_that_has_not_been_read_is_refused() {
+        let core = test_core().await;
+        let id = core.ingest_image(an_image(3)).await.unwrap().id;
+        // Still describing.
+        assert!(matches!(
+            core.reprocess(&id, Stage::Synthesize).await,
+            Err(Error::Validation(_))
+        ));
+        // Failed before any text was read.
+        crate::jobs::describe::park_failed(&core, &id, "HTTP 400")
+            .await
+            .unwrap();
+        assert!(matches!(
+            core.reprocess(&id, Stage::Synthesize).await,
+            Err(Error::Validation(_))
+        ));
+        // The describe job and the status are untouched either way.
+        assert!(core.store.live_job(Stage::Describe, &id).await.unwrap());
+        assert_eq!(
+            core.store.get_corpus(&id).await.unwrap().status,
+            CorpusStatus::Failed
         );
     }
 

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -130,7 +130,14 @@ impl Core {
 
         let src = match self
             .store
-            .insert_corpus_with_signature(text, origin, title_hint, sig, c.source_url.as_deref())
+            .insert_corpus_with_signature(
+                text,
+                origin,
+                title_hint,
+                sig,
+                c.source_url.as_deref(),
+                &serde_json::json!({}),
+            )
             .await?
         {
             Insertion::Created(src) => src,
@@ -893,6 +900,13 @@ impl Core {
                     "that stage is a single inference call the queue arms itself; \
                      reprocess the document instead"
                         .into(),
+                ));
+            }
+            // Re-reading a stored image with a different model is a later
+            // feature; the original is kept so it stays possible.
+            Stage::Describe => {
+                return Err(Error::Validation(
+                    "re-reading an image is not supported yet; capture it again".into(),
                 ));
             }
         }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1,7 +1,7 @@
 use super::Core;
 use crate::error::{Error, Result};
 use crate::store::artifacts::ArtifactStatus;
-use crate::store::corpora::{CorpusStatus, Insertion, NearDuplicate, content_hash};
+use crate::store::corpora::{CorpusStatus, Followup, Insertion, NearDuplicate, content_hash};
 use crate::store::jobs::Stage;
 use crate::store::now;
 
@@ -174,6 +174,17 @@ impl Core {
             .find_near_duplicate(&sig, self.consolidate.near_dupe_min)
             .await?;
 
+        // Parked, or queued. Synthesis is the expensive stage and text that
+        // resembles something stored may not deserve it; an operator decides
+        // on Ops. Nothing is lost either way — the corpus is stored verbatim
+        // like any other. Written with the row, not after it.
+        let followup = match &near {
+            Some(n) => Followup::Park {
+                of: n.corpus_id.clone(),
+                similarity: n.similarity,
+            },
+            None => Followup::Queue(Stage::Synthesize),
+        };
         let src = match self
             .store
             .insert_corpus_with_signature(
@@ -183,6 +194,7 @@ impl Core {
                 sig,
                 c.source_url.as_deref(),
                 &c.metadata,
+                followup,
             )
             .await?
         {
@@ -206,38 +218,18 @@ impl Core {
         };
 
         match &near {
-            // Parked. Synthesis is the expensive stage and this text may not
-            // deserve it; an operator decides on Ops. Nothing is lost either
-            // way — the corpus is stored verbatim like any other.
-            Some(n) => {
-                self.store
-                    .set_near_dupe(&src.id, Some(&n.corpus_id), Some(n.similarity))
-                    .await?;
-                self.store
-                    .set_corpus_status(&src.id, CorpusStatus::NeedsReview)
-                    .await?;
-                tracing::info!(
-                    corpus_id = %src.id,
-                    near = %n.corpus_id,
-                    similarity = n.similarity,
-                    "capture looks like an existing corpus; parked for review"
-                );
-            }
-            None => {
-                self.store
-                    .enqueue(Stage::Synthesize, "corpus", &src.id)
-                    .await?;
-                tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested");
-            }
+            Some(n) => tracing::info!(
+                corpus_id = %src.id,
+                near = %n.corpus_id,
+                similarity = n.similarity,
+                "capture looks like an existing corpus; parked for review"
+            ),
+            None => tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested"),
         }
 
         Ok(IngestOutcome {
             id: src.id,
-            status: if near.is_some() {
-                CorpusStatus::NeedsReview
-            } else {
-                CorpusStatus::Raw
-            },
+            status: src.status,
             duplicate: false,
             near_duplicate: near,
         })
@@ -330,9 +322,24 @@ impl Core {
         // are what a camera and a clipboard call everything. Seeding the title
         // from it would disarm the one stage that can name the capture.
 
+        let attachment = crate::store::attachments::NewImage {
+            kind: "image",
+            mime: prepared.mime,
+            filename: filename.as_deref(),
+            bytes: &bytes,
+            preview: &prepared.preview_jpeg,
+            width: Some(prepared.width as i64),
+            height: Some(prepared.height as i64),
+        };
         let src = match self
             .store
-            .insert_image_corpus(&hash, ORIGIN_IMAGE, title_hint.as_deref(), &metadata)
+            .insert_image_corpus(
+                &hash,
+                ORIGIN_IMAGE,
+                title_hint.as_deref(),
+                &metadata,
+                &attachment,
+            )
             .await?
         {
             Insertion::Created(src) => src,
@@ -345,21 +352,6 @@ impl Core {
                 });
             }
         };
-        self.store
-            .insert_attachment(&crate::store::attachments::NewAttachment {
-                corpus_id: &src.id,
-                kind: "image",
-                mime: prepared.mime,
-                filename: filename.as_deref(),
-                bytes: &bytes,
-                preview: &prepared.preview_jpeg,
-                width: Some(prepared.width as i64),
-                height: Some(prepared.height as i64),
-            })
-            .await?;
-        self.store
-            .enqueue(Stage::Describe, "corpus", &src.id)
-            .await?;
         tracing::info!(
             corpus_id = %src.id,
             bytes = bytes.len(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -106,6 +106,10 @@ pub struct Core {
     /// hidden, and nothing left that would ever notice. Shared by every
     /// clone, like the background queue.
     pub lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
+    /// How many uploads may be decoded at once. See
+    /// `image::MAX_CONCURRENT_DECODES`; shared by every clone, because a
+    /// per-clone permit would bound nothing.
+    pub decodes: Arc<tokio::sync::Semaphore>,
 }
 
 impl Core {
@@ -161,6 +165,9 @@ impl Core {
             ),
             corpus_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
+            decodes: Arc::new(tokio::sync::Semaphore::new(
+                crate::core::image::MAX_CONCURRENT_DECODES,
+            )),
         }
     }
 
@@ -221,7 +228,9 @@ pub mod test_support {
     /// take, which the worker classifies as permanent.
     pub async fn test_core_with_rejecting_synthesizer() -> Core {
         build(
-            Arc::new(FakeSynthesizer::rejecting("HTTP 400: context length exceeded")),
+            Arc::new(FakeSynthesizer::rejecting(
+                "HTTP 400: context length exceeded",
+            )),
             None,
         )
         .await
@@ -300,6 +309,9 @@ pub mod test_support {
             )),
             corpus_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
+            decodes: Arc::new(tokio::sync::Semaphore::new(
+                crate::core::image::MAX_CONCURRENT_DECODES,
+            )),
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,8 +8,10 @@ pub mod search;
 
 use crate::config::Config;
 use crate::infer::budget::TokenCounter;
-use crate::infer::openai::{HttpCompleter, HttpEmbedder, HttpReranker, HttpSynthesizer};
-use crate::infer::{Completer, Embedder, Reranker, Synthesizer};
+use crate::infer::openai::{
+    HttpCompleter, HttpDescriber, HttpEmbedder, HttpReranker, HttpSynthesizer,
+};
+use crate::infer::{Completer, Describer, Embedder, Reranker, Synthesizer};
 use crate::store::Store;
 use crate::vector::VectorStore;
 use background::Background;
@@ -69,6 +71,8 @@ pub struct Core {
     pub embedder: Arc<dyn Embedder>,
     pub reranker: Option<Arc<dyn Reranker>>,
     pub completer: Arc<dyn Completer>,
+    /// The vision model, when one is configured. `None` closes the image door.
+    pub describer: Option<Arc<dyn Describer>>,
     pub counter: Arc<TokenCounter>,
     /// Writes that run off the request path. Shared by every clone of `Core`,
     /// so draining one drains them all.
@@ -128,6 +132,15 @@ impl Core {
                 .as_ref()
                 .map(|r| Arc::new(HttpReranker::new(r)) as Arc<dyn Reranker>),
             completer: Arc::new(HttpCompleter::new(&cfg.infer.ask)),
+            describer: cfg.infer.vision.as_ref().map(|v| {
+                let (base_url, api_key) = v.resolve(&cfg.infer.synthesize);
+                Arc::new(HttpDescriber::new(
+                    &v.model,
+                    &base_url,
+                    api_key.as_deref(),
+                    v.timeout_secs,
+                )) as Arc<dyn Describer>
+            }),
             counter: Arc::new(TokenCounter::load(
                 cfg.infer.synthesize.tokenizer_path.as_deref(),
             )),
@@ -188,7 +201,9 @@ impl Core {
 #[cfg(test)]
 pub mod test_support {
     use super::*;
-    use crate::infer::fake::{FakeCompleter, FakeEmbedder, FakeReranker, FakeSynthesizer};
+    use crate::infer::fake::{
+        FakeCompleter, FakeDescriber, FakeEmbedder, FakeReranker, FakeSynthesizer,
+    };
     use crate::vector::memory::MemoryVectors;
 
     pub const TEST_DIM: usize = 8;
@@ -222,6 +237,21 @@ pub mod test_support {
         (core, embedder)
     }
 
+    /// A core whose vision model is the given fake, for asserting what it was
+    /// asked and answering what a test needs.
+    pub async fn test_core_with_describer(d: Arc<FakeDescriber>) -> Core {
+        let mut core = build(Arc::new(FakeSynthesizer::default()), None).await;
+        core.describer = Some(d);
+        core
+    }
+
+    /// The shipped default: no `[infer.vision]`, image door closed.
+    pub async fn test_core_without_vision() -> Core {
+        let mut core = build(Arc::new(FakeSynthesizer::default()), None).await;
+        core.describer = None;
+        core
+    }
+
     async fn build(synthesizer: Arc<dyn Synthesizer>, reranker: Option<Arc<dyn Reranker>>) -> Core {
         let store = Store::memory().await.unwrap();
         Core {
@@ -231,6 +261,7 @@ pub mod test_support {
             embedder: Arc::new(FakeEmbedder::new(TEST_DIM)),
             reranker,
             completer: Arc::new(FakeCompleter::default()),
+            describer: Some(Arc::new(FakeDescriber::default())),
             counter: Arc::new(TokenCounter::Estimate),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@ pub mod ask;
 pub mod background;
 pub mod extract;
 pub mod fetch;
+pub mod image;
 pub mod ingest;
 pub mod search;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -216,6 +216,17 @@ pub mod test_support {
         build(Arc::new(FakeSynthesizer::failing("endpoint down")), None).await
     }
 
+    /// A synthesizer whose every call comes back refused rather than
+    /// unanswered — the 400 an endpoint returns for a window it will never
+    /// take, which the worker classifies as permanent.
+    pub async fn test_core_with_rejecting_synthesizer() -> Core {
+        build(
+            Arc::new(FakeSynthesizer::rejecting("HTTP 400: context length exceeded")),
+            None,
+        )
+        .await
+    }
+
     pub async fn test_core_with_rerank() -> Core {
         test_core_counting_reranked_docs().await.0
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -237,6 +237,14 @@ pub mod test_support {
         (core, embedder)
     }
 
+    /// A core whose embedder is the given fake, for driving the embed stage
+    /// into a refusal.
+    pub async fn test_core_with_embedder(e: Arc<FakeEmbedder>) -> Core {
+        let mut core = build(Arc::new(FakeSynthesizer::default()), None).await;
+        core.embedder = e;
+        core
+    }
+
     /// A core whose vision model is the given fake, for asserting what it was
     /// asked and answering what a test needs.
     pub async fn test_core_with_describer(d: Arc<FakeDescriber>) -> Core {

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,13 @@ pub enum Error {
     Forbidden,
     #[error("inference[{role}]: {detail}")]
     Inference { role: &'static str, detail: String },
+    /// The endpoint understood the request and refused it — a model that does
+    /// not take images, a body over its limit, a name it does not serve. Kept
+    /// apart from `Inference` because the two ask opposite things of a worker:
+    /// one is a wait, the other is the same answer for as long as the same
+    /// request is sent.
+    #[error("inference[{role}] rejected: {detail}")]
+    InferenceRejected { role: &'static str, detail: String },
     #[error("vector store: {0}")]
     Vector(String),
     #[error("store: {0}")]
@@ -56,7 +63,9 @@ impl Error {
             Error::Validation(_) => StatusCode::BAD_REQUEST,
             Error::Unauthorized => StatusCode::UNAUTHORIZED,
             Error::Forbidden => StatusCode::FORBIDDEN,
-            Error::Inference { .. } | Error::Vector(_) => StatusCode::BAD_GATEWAY,
+            Error::Inference { .. } | Error::InferenceRejected { .. } | Error::Vector(_) => {
+                StatusCode::BAD_GATEWAY
+            }
             Error::Store(_) | Error::MalformedLlmOutput(_) | Error::Internal(_) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
@@ -117,6 +126,15 @@ mod tests {
         assert!(Error::Vector("connection refused".into()).retryable());
         assert!(Error::Store("database is locked".into()).retryable());
         assert!(Error::MalformedLlmOutput("expected `{`".into()).retryable());
+        // The endpoint answered and said no: another attempt sends the same
+        // request and gets the same answer.
+        assert!(
+            !Error::InferenceRejected {
+                role: "vision",
+                detail: "HTTP 400: model does not accept images".into()
+            }
+            .retryable()
+        );
 
         // Retrying these burns inference calls and never succeeds.
         assert!(!Error::Validation("empty text".into()).retryable());

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -389,6 +389,11 @@ impl Synthesizer for HallucinatingSynthesizer {
 pub struct StrictEmbedder {
     inner: FakeEmbedder,
     limit: usize,
+    /// Whether the refusal arrives the way an HTTP endpoint's does — a 413 the
+    /// client classified as a rejection — rather than as a bare server's
+    /// message inside an otherwise ordinary failure. Both mean "too large",
+    /// and a worker that only understands one of them stops splitting.
+    over_http: bool,
 }
 
 impl StrictEmbedder {
@@ -396,7 +401,14 @@ impl StrictEmbedder {
         Self {
             inner: FakeEmbedder::new(dim),
             limit,
+            over_http: false,
         }
+    }
+    /// The same ceiling, refused as a real endpoint refuses it.
+    pub fn over_http(dim: usize, limit: usize) -> Self {
+        let mut e = Self::new(dim, limit);
+        e.over_http = true;
+        e
     }
     pub fn calls(&self) -> usize {
         self.inner.calls()
@@ -411,13 +423,29 @@ impl Embedder for StrictEmbedder {
             // not depend on a tokenizer.
             let tokens = t.len() / 4;
             if tokens > self.limit {
-                return Err(Error::Inference {
-                    role: "embed",
-                    detail: format!(
+                let detail = if self.over_http {
+                    format!(
+                        "HTTP 413 Payload Too Large: input ({tokens} tokens) is too large \
+                         to process (limit {})",
+                        self.limit
+                    )
+                } else {
+                    format!(
                         "input ({tokens} tokens) is too large to process. increase the \
                          physical batch size (current batch size: {})",
                         self.limit
-                    ),
+                    )
+                };
+                return Err(if self.over_http {
+                    Error::InferenceRejected {
+                        role: "embed",
+                        detail,
+                    }
+                } else {
+                    Error::Inference {
+                        role: "embed",
+                        detail,
+                    }
                 });
             }
         }

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -14,6 +14,9 @@ pub struct FakeEmbedder {
     /// How many times the endpoint was called. Batching is invisible in the
     /// output — only the call count shows whether it happened.
     calls: std::sync::atomic::AtomicUsize,
+    /// When set, every call is refused with this reason — the endpoint's "no",
+    /// which a worker must not retry.
+    reject_with: Option<String>,
 }
 
 impl FakeEmbedder {
@@ -21,7 +24,14 @@ impl FakeEmbedder {
         Self {
             dim,
             calls: std::sync::atomic::AtomicUsize::new(0),
+            reject_with: None,
         }
+    }
+
+    pub fn rejecting(msg: &str) -> Self {
+        let mut e = Self::new(8);
+        e.reject_with = Some(msg.to_string());
+        e
     }
 
     pub fn calls(&self) -> usize {
@@ -34,6 +44,12 @@ impl Embedder for FakeEmbedder {
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         self.calls
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Some(m) = &self.reject_with {
+            return Err(Error::InferenceRejected {
+                role: "embed",
+                detail: m.clone(),
+            });
+        }
         Ok(texts
             .iter()
             .map(|t| {

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -1,5 +1,6 @@
 use super::{
-    Completer, Embedder, ProposedArtifact, Reranker, SegmentInput, SynthesisBudget, Synthesizer,
+    Completer, Describer, Embedder, ProposedArtifact, Reranker, SegmentInput, SynthesisBudget,
+    Synthesizer,
 };
 use crate::error::{Error, Result};
 use async_trait::async_trait;
@@ -526,6 +527,58 @@ impl Completer for ScriptedCompleter {
     }
     fn context_tokens(&self) -> usize {
         4096
+    }
+}
+
+/// Answers every image with one scripted reply, or one scripted failure, and
+/// remembers what context it was shown.
+pub struct FakeDescriber {
+    pub reply: String,
+    pub fail_with: Option<String>,
+    calls: std::sync::atomic::AtomicUsize,
+    last_context: std::sync::Mutex<String>,
+}
+
+impl Default for FakeDescriber {
+    fn default() -> Self {
+        Self::saying("# Photo\n\nA whiteboard listing three tasks: ship, test, rest.")
+    }
+}
+
+impl FakeDescriber {
+    pub fn saying(reply: &str) -> Self {
+        Self {
+            reply: reply.into(),
+            fail_with: None,
+            calls: Default::default(),
+            last_context: Default::default(),
+        }
+    }
+    pub fn failing(msg: &str) -> Self {
+        let mut d = Self::saying("");
+        d.fail_with = Some(msg.into());
+        d
+    }
+    pub fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+    pub fn last_context(&self) -> String {
+        self.last_context.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Describer for FakeDescriber {
+    async fn describe(&self, _image_jpeg: &[u8], context: &str) -> Result<String> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        *self.last_context.lock().unwrap() = context.to_string();
+        match &self.fail_with {
+            Some(m) => Err(Error::Inference {
+                role: "vision",
+                detail: m.clone(),
+            }),
+            None => Ok(self.reply.clone()),
+        }
     }
 }
 

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -86,6 +86,8 @@ pub struct FakeSynthesizer {
     /// Answer, but with something the parser cannot read. Distinct from the
     /// two above, which model an endpoint that never answered at all.
     unparsable_on_marker: Option<String>,
+    /// Whether `fail_with` is the endpoint's "no" rather than its "not now".
+    reject: bool,
 }
 
 impl FakeSynthesizer {
@@ -94,7 +96,16 @@ impl FakeSynthesizer {
             fail_with: Some(msg.to_string()),
             fail_on_marker: None,
             unparsable_on_marker: None,
+            reject: false,
         }
+    }
+
+    /// The same refusal, arriving the way a 400 does: the request itself is
+    /// wrong, and asking again sends the same request.
+    pub fn rejecting(msg: &str) -> Self {
+        let mut s = Self::failing(msg);
+        s.reject = true;
+        s
     }
 
     pub fn failing_on(marker: &str) -> Self {
@@ -102,6 +113,7 @@ impl FakeSynthesizer {
             fail_with: None,
             fail_on_marker: Some(marker.to_string()),
             unparsable_on_marker: None,
+            reject: false,
         }
     }
 
@@ -114,6 +126,15 @@ impl FakeSynthesizer {
             fail_with: None,
             fail_on_marker: None,
             unparsable_on_marker: Some(marker.to_string()),
+            reject: false,
+        }
+    }
+
+    fn refusal(&self, role: &'static str, detail: String) -> Error {
+        if self.reject {
+            Error::InferenceRejected { role, detail }
+        } else {
+            Error::Inference { role, detail }
         }
     }
 }
@@ -138,10 +159,7 @@ impl Synthesizer for FakeSynthesizer {
             ));
         }
         if let Some(m) = &self.fail_with {
-            return Err(Error::Inference {
-                role: "chunk",
-                detail: m.clone(),
-            });
+            return Err(self.refusal("chunk", m.clone()));
         }
         Ok(text
             .split("\n\n")
@@ -174,10 +192,7 @@ impl Synthesizer for FakeSynthesizer {
     /// other, and the caller has to survive it failing.
     async fn title(&self, text: &str, _artifact_titles: &[String]) -> Result<Option<String>> {
         if let Some(m) = &self.fail_with {
-            return Err(Error::Inference {
-                role: "title",
-                detail: m.clone(),
-            });
+            return Err(self.refusal("title", m.clone()));
         }
         let first: String = text
             .lines()

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -535,6 +535,8 @@ impl Completer for ScriptedCompleter {
 pub struct FakeDescriber {
     pub reply: String,
     pub fail_with: Option<String>,
+    /// Whether `fail_with` is the endpoint's "no" rather than its "not now".
+    pub reject: bool,
     calls: std::sync::atomic::AtomicUsize,
     last_context: std::sync::Mutex<String>,
 }
@@ -550,6 +552,7 @@ impl FakeDescriber {
         Self {
             reply: reply.into(),
             fail_with: None,
+            reject: false,
             calls: Default::default(),
             last_context: Default::default(),
         }
@@ -557,6 +560,13 @@ impl FakeDescriber {
     pub fn failing(msg: &str) -> Self {
         let mut d = Self::saying("");
         d.fail_with = Some(msg.into());
+        d
+    }
+    /// The endpoint's "no", not its "not now": what a non-multimodal model
+    /// answers with, and what a worker must not retry.
+    pub fn rejecting(msg: &str) -> Self {
+        let mut d = Self::failing(msg);
+        d.reject = true;
         d
     }
     pub fn calls(&self) -> usize {
@@ -573,6 +583,10 @@ impl Describer for FakeDescriber {
         self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         *self.last_context.lock().unwrap() = context.to_string();
         match &self.fail_with {
+            Some(m) if self.reject => Err(Error::InferenceRejected {
+                role: "vision",
+                detail: m.clone(),
+            }),
             Some(m) => Err(Error::Inference {
                 role: "vision",
                 detail: m.clone(),

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -81,3 +81,12 @@ pub trait Completer: Send + Sync {
     async fn complete(&self, system: &str, user: &str) -> Result<String>;
     fn context_tokens(&self) -> usize;
 }
+
+/// Reads a captured image into text. One call per image; the caller has
+/// already decoded, oriented and downscaled the picture into a JPEG.
+#[async_trait]
+pub trait Describer: Send + Sync {
+    /// `context` is what is known about the capture beyond its pixels — the
+    /// user's note, when and where it was taken. Markdown comes back.
+    async fn describe(&self, image_jpeg: &[u8], context: &str) -> Result<String>;
+}

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -42,7 +42,11 @@ pub fn permanent_upstream_status(status: reqwest::StatusCode) -> bool {
     status.is_client_error()
         && !matches!(
             status,
-            S::REQUEST_TIMEOUT | S::TOO_MANY_REQUESTS | S::UNAUTHORIZED | S::FORBIDDEN | S::NOT_FOUND
+            S::REQUEST_TIMEOUT
+                | S::TOO_MANY_REQUESTS
+                | S::UNAUTHORIZED
+                | S::FORBIDDEN
+                | S::NOT_FOUND
         )
 }
 

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -28,6 +28,14 @@ fn url(base: &str, path: &str) -> String {
     )
 }
 
+/// A 4xx that says the request itself is wrong. 408 and 429 are 4xx by number
+/// but "come back later" by meaning, and stay retryable.
+pub fn permanent_upstream_status(status: reqwest::StatusCode) -> bool {
+    status.is_client_error()
+        && status != reqwest::StatusCode::REQUEST_TIMEOUT
+        && status != reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
 async fn post_json(
     role: &'static str,
     c: &reqwest::Client,
@@ -52,9 +60,11 @@ async fn post_json(
         // Truncate: an upstream error page can be megabytes, and this string
         // ends up in a job's last_error column.
         let detail: String = body.chars().take(400).collect();
-        return Err(Error::Inference {
-            role,
-            detail: format!("HTTP {status}: {detail}"),
+        let detail = format!("HTTP {status}: {detail}");
+        return Err(if permanent_upstream_status(status) {
+            Error::InferenceRejected { role, detail }
+        } else {
+            Error::Inference { role, detail }
         });
     }
     res.json().await.map_err(|e| Error::Inference {
@@ -519,6 +529,20 @@ pub async fn probe(role: &str, base_url: &str, api_key: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_4xx_is_permanent_except_the_two_that_mean_try_again() {
+        use reqwest::StatusCode as S;
+        assert!(permanent_upstream_status(S::BAD_REQUEST));
+        assert!(permanent_upstream_status(S::NOT_FOUND));
+        assert!(permanent_upstream_status(S::PAYLOAD_TOO_LARGE));
+        assert!(permanent_upstream_status(S::UNSUPPORTED_MEDIA_TYPE));
+        assert!(permanent_upstream_status(S::UNPROCESSABLE_ENTITY));
+        assert!(!permanent_upstream_status(S::REQUEST_TIMEOUT));
+        assert!(!permanent_upstream_status(S::TOO_MANY_REQUESTS));
+        assert!(!permanent_upstream_status(S::INTERNAL_SERVER_ERROR));
+        assert!(!permanent_upstream_status(S::BAD_GATEWAY));
+    }
 
     /// The empty context every one of these tests wants: they exercise the
     /// transport and the parser, not the windowing.

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -1,6 +1,6 @@
 use super::{
-    Completer, Embedder, ProposedArtifact, Reranker, SegmentInput, SynthesisBudget, Synthesizer,
-    prompt,
+    Completer, Describer, Embedder, ProposedArtifact, Reranker, SegmentInput, SynthesisBudget,
+    Synthesizer, prompt,
 };
 use crate::config::{AskRole, EmbedRole, RerankRole, RerankStyle, SynthesizeRole};
 use crate::error::{Error, Result};
@@ -429,6 +429,69 @@ impl Completer for HttpCompleter {
     }
 }
 
+// ── Describer ────────────────────────────────────────────────────────────────
+
+pub struct HttpDescriber {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+    api_key: Option<String>,
+}
+
+impl HttpDescriber {
+    pub fn new(model: &str, base_url: &str, api_key: Option<&str>, timeout_secs: u64) -> Self {
+        Self {
+            client: client(timeout_secs),
+            base_url: base_url.to_string(),
+            model: model.to_string(),
+            api_key: api_key.map(str::to_string),
+        }
+    }
+}
+
+#[async_trait]
+impl Describer for HttpDescriber {
+    async fn describe(&self, image_jpeg: &[u8], context: &str) -> Result<String> {
+        use base64::Engine;
+        let data_url = format!(
+            "data:image/jpeg;base64,{}",
+            base64::engine::general_purpose::STANDARD.encode(image_jpeg)
+        );
+        let body = json!({
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": prompt::DESCRIBE_SYSTEM},
+                {"role": "user", "content": [
+                    {"type": "text", "text": context},
+                    {"type": "image_url", "image_url": {"url": data_url}}
+                ]}
+            ],
+            "temperature": 0.2,
+        });
+        let started = std::time::Instant::now();
+        let v = post_json(
+            "vision",
+            &self.client,
+            url(&self.base_url, "chat/completions"),
+            self.api_key.as_deref(),
+            body,
+        )
+        .await?;
+        tracing::info!(
+            ms = started.elapsed().as_millis(),
+            tokens = v["usage"]["completion_tokens"].as_u64(),
+            "vision call finished"
+        );
+        v["choices"][0]["message"]["content"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| Error::Inference {
+                role: "vision",
+                detail: "no message content".into(),
+            })
+    }
+}
+
 /// One cheap reachability check per role at startup. Failure is a warning, not
 /// a fatal error: ingest is designed to survive a dead inference endpoint.
 pub async fn probe(role: &str, base_url: &str, api_key: Option<&str>) -> bool {
@@ -828,5 +891,54 @@ mod tests {
             "error string was {} chars",
             e.to_string().len()
         );
+    }
+
+    #[tokio::test]
+    async fn the_describer_sends_the_image_as_a_data_url_beside_the_context() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "# Whiteboard\n\n- item"}}]
+            })))
+            .mount(&server)
+            .await;
+        let d = HttpDescriber::new("vl", &format!("{}/v1", server.uri()), Some("k"), 30);
+        let out = d
+            .describe(b"\xFF\xD8jpegbytes", "Photo taken 2026-08-09")
+            .await
+            .unwrap();
+        assert_eq!(out, "# Whiteboard\n\n- item");
+
+        let req = &server.received_requests().await.unwrap()[0];
+        assert_eq!(req.headers.get("authorization").unwrap(), "Bearer k");
+        let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body["model"], "vl");
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"], prompt::DESCRIBE_SYSTEM);
+        let parts = body["messages"][1]["content"].as_array().unwrap();
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "Photo taken 2026-08-09");
+        assert_eq!(parts[1]["type"], "image_url");
+        let url = parts[1]["image_url"]["url"].as_str().unwrap();
+        assert!(url.starts_with("data:image/jpeg;base64,"), "{url}");
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(url.trim_start_matches("data:image/jpeg;base64,"))
+            .unwrap();
+        assert_eq!(decoded, b"\xFF\xD8jpegbytes");
+    }
+
+    #[tokio::test]
+    async fn a_describer_error_is_an_inference_error_for_the_vision_role() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("busy"))
+            .mount(&server)
+            .await;
+        let d = HttpDescriber::new("vl", &server.uri(), None, 30);
+        let e = d.describe(b"x", "").await.unwrap_err();
+        assert!(matches!(e, Error::Inference { role: "vision", .. }), "{e}");
+        assert!(e.retryable());
     }
 }

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -30,10 +30,20 @@ fn url(base: &str, path: &str) -> String {
 
 /// A 4xx that says the request itself is wrong. 408 and 429 are 4xx by number
 /// but "come back later" by meaning, and stay retryable.
+///
+/// So do 401, 403 and 404. Those three describe the endpoint rather than the
+/// request: a key expires, a token is rotated, a proxy answers 404 for as long
+/// as the backend behind it is restarting — and in every one of them the same
+/// request succeeds once the wall is fixed. Calling them permanent meant one
+/// expired key was enough to mark chunks `embed_failed` and settle their
+/// corpora to `partial`, which coming back up does not undo.
 pub fn permanent_upstream_status(status: reqwest::StatusCode) -> bool {
+    use reqwest::StatusCode as S;
     status.is_client_error()
-        && status != reqwest::StatusCode::REQUEST_TIMEOUT
-        && status != reqwest::StatusCode::TOO_MANY_REQUESTS
+        && !matches!(
+            status,
+            S::REQUEST_TIMEOUT | S::TOO_MANY_REQUESTS | S::UNAUTHORIZED | S::FORBIDDEN | S::NOT_FOUND
+        )
 }
 
 async fn post_json(
@@ -534,12 +544,16 @@ mod tests {
     fn a_4xx_is_permanent_except_the_two_that_mean_try_again() {
         use reqwest::StatusCode as S;
         assert!(permanent_upstream_status(S::BAD_REQUEST));
-        assert!(permanent_upstream_status(S::NOT_FOUND));
         assert!(permanent_upstream_status(S::PAYLOAD_TOO_LARGE));
         assert!(permanent_upstream_status(S::UNSUPPORTED_MEDIA_TYPE));
         assert!(permanent_upstream_status(S::UNPROCESSABLE_ENTITY));
         assert!(!permanent_upstream_status(S::REQUEST_TIMEOUT));
         assert!(!permanent_upstream_status(S::TOO_MANY_REQUESTS));
+        // The endpoint, not the request: an expired key and a restarting proxy
+        // both answer like this, and both heal on their own.
+        assert!(!permanent_upstream_status(S::UNAUTHORIZED));
+        assert!(!permanent_upstream_status(S::FORBIDDEN));
+        assert!(!permanent_upstream_status(S::NOT_FOUND));
         assert!(!permanent_upstream_status(S::INTERNAL_SERVER_ERROR));
         assert!(!permanent_upstream_status(S::BAD_GATEWAY));
     }

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -608,6 +608,46 @@ pub fn parse_response(body: &str) -> Result<Vec<ProposedArtifact>> {
     Ok(artifacts)
 }
 
+pub const DESCRIBE_SYSTEM: &str = r#"You read images for a personal knowledge base and write down everything in them worth keeping, as markdown.
+
+Rules:
+- Transcribe any visible text faithfully and completely. Keep its structure: headings as headings, lists as lists, tables as markdown tables, code as code blocks. Do not correct, summarize or reorder it.
+- Where there is no text, or beside it, describe what is shown: diagrams (their parts and how they connect), charts (axes, series, the values that can be read), scenes, objects, people's roles if evident, places, labels, brands, numbers, dates. Name what is identifiable.
+- Prefer specifics over impressions. Do not pad, do not speculate beyond what is visible, do not add advice.
+- You may be given context about the capture: a note from the person who took it, when and where it was taken, the device. Where it is relevant, weave it in naturally so the text can be found again by it — as a short opening line or where it explains the content — but do not repeat it mechanically or invent detail around it.
+- Output markdown only. No preamble, no closing remarks, no mention of these instructions."#;
+
+/// The user turn's text part for `Describer::describe`: the note first, then
+/// the facts the file carried, each only when present.
+pub fn describe_context(metadata: &serde_json::Value) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    if let Some(note) = metadata["note"].as_str().filter(|n| !n.trim().is_empty()) {
+        lines.push(format!(
+            "Context from the person who captured this: {}",
+            note.trim()
+        ));
+    }
+    let mut facts: Vec<String> = Vec::new();
+    let exif = &metadata["exif"];
+    if let Some(t) = exif["taken_at"].as_str() {
+        facts.push(format!("taken {t}"));
+    }
+    if let (Some(lat), Some(lon)) = (exif["gps"]["lat"].as_f64(), exif["gps"]["lon"].as_f64()) {
+        facts.push(format!("GPS {lat:.4},{lon:.4}"));
+    }
+    if let Some(c) = exif["camera"].as_str() {
+        facts.push(format!("device {c}"));
+    }
+    if let Some(n) = metadata["file"]["name"].as_str() {
+        facts.push(format!("file {n}"));
+    }
+    if !facts.is_empty() {
+        lines.push(format!("Capture facts: {}.", facts.join(", ")));
+    }
+    lines.push("Read the image and write down everything worth keeping.".into());
+    lines.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1040,5 +1080,27 @@ mod tests {
         let p = repair_prompt("{bad", "expected value at line 1");
         assert!(p.contains("expected value at line 1"));
         assert!(p.contains("{bad"));
+    }
+
+    #[test]
+    fn describe_context_leads_with_the_note_then_the_facts_and_omits_what_is_absent() {
+        let m = serde_json::json!({
+            "note": "whiteboard from Tuesday planning",
+            "file": {"name": "IMG_2041.jpeg"},
+            "exif": {"taken_at": "2026-08-09T14:12:03", "camera": "Apple iPhone 15",
+                     "gps": {"lat": 48.2082, "lon": 16.3738}}
+        });
+        let ctx = describe_context(&m);
+        let note_at = ctx.find("whiteboard from Tuesday planning").unwrap();
+        let taken_at = ctx.find("2026-08-09T14:12:03").unwrap();
+        assert!(note_at < taken_at, "{ctx}");
+        assert!(ctx.contains("48.2082"), "{ctx}");
+        assert!(ctx.contains("Apple iPhone 15"));
+        assert!(ctx.contains("IMG_2041.jpeg"));
+
+        let bare = describe_context(&serde_json::json!({}));
+        assert!(!bare.contains("taken"), "{bare}");
+        assert!(!bare.contains("GPS"), "{bare}");
+        assert!(bare.contains("Read the image"), "{bare}");
     }
 }

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -85,10 +85,10 @@ pub async fn park_failed(core: &Core, corpus_id: &str, reason: &str) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::jobs::Stage;
     use crate::core::ingest::ImageCapture;
     use crate::core::test_support::{test_core_with_describer, test_core_without_vision};
     use crate::infer::fake::FakeDescriber;
+    use crate::store::jobs::Stage;
     use std::sync::Arc;
 
     fn a_png(seed: u8) -> Vec<u8> {

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -263,7 +263,21 @@ mod tests {
         let core = test_core_without_vision().await;
         let src = core
             .store
-            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .insert_image_corpus(
+                "h",
+                "image",
+                None,
+                &serde_json::json!({}),
+                &crate::store::attachments::NewImage {
+                    kind: "image",
+                    mime: "image/png",
+                    filename: None,
+                    bytes: b"orig",
+                    preview: b"prev",
+                    width: Some(1),
+                    height: Some(1),
+                },
+            )
             .await
             .unwrap()
             .into_corpus();
@@ -298,7 +312,21 @@ mod tests {
         let core = test_core_without_vision().await;
         let src = core
             .store
-            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .insert_image_corpus(
+                "h",
+                "image",
+                None,
+                &serde_json::json!({}),
+                &crate::store::attachments::NewImage {
+                    kind: "image",
+                    mime: "image/png",
+                    filename: None,
+                    bytes: b"orig",
+                    preview: b"prev",
+                    width: Some(1),
+                    height: Some(1),
+                },
+            )
             .await
             .unwrap()
             .into_corpus();

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -95,6 +95,25 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// The read is not going to happen — the model said no, or said nothing for
+/// as long as we were willing to ask. The photo stays; the corpus says why it
+/// stopped, on its page and on Ops, and `reprocess(Describe)` is the way back.
+pub async fn park_failed(core: &Core, corpus_id: &str, reason: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    let mut meta = src.metadata.clone();
+    meta["describe"] = serde_json::json!({ "error": reason });
+    core.store.set_corpus_metadata(corpus_id, &meta).await?;
+    core.store
+        .set_corpus_status(corpus_id, CorpusStatus::Failed)
+        .await?;
+    tracing::warn!(
+        corpus_id,
+        reason,
+        "image could not be read; parked as failed"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +234,78 @@ mod tests {
         assert_eq!(src.status, CorpusStatus::NeedsReview);
         assert_eq!(src.near_dupe_of.as_deref(), Some(first.id.as_str()));
         assert_eq!(src.raw_text, text, "the reading is kept even when parked");
+    }
+
+    async fn clear_backoff(core: &Core) {
+        sqlx::query("UPDATE jobs SET run_after = 0")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_rejected_reading_parks_the_corpus_as_failed_with_the_reason() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::rejecting(
+            "HTTP 400: this model does not accept images",
+        )))
+        .await;
+        let id = captured(&core, 6, None).await;
+        assert!(crate::jobs::run_one(&core).await.unwrap());
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Failed);
+        assert!(
+            src.metadata["describe"]["error"]
+                .as_str()
+                .unwrap()
+                .contains("does not accept images")
+        );
+        assert!(
+            !core.store.live_job(Stage::Describe, &id).await.unwrap(),
+            "the job is closed, not re-armed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reading_that_keeps_failing_parks_the_corpus_after_its_attempts() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::failing("gpu on fire"))).await;
+        let id = captured(&core, 7, None).await;
+        for _ in 0..crate::store::jobs::MAX_ATTEMPTS {
+            clear_backoff(&core).await;
+            assert!(crate::jobs::run_one(&core).await.unwrap());
+        }
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Failed);
+        assert!(
+            src.metadata["describe"]["error"]
+                .as_str()
+                .unwrap()
+                .contains("gpu on fire")
+        );
+        assert!(!core.store.live_job(Stage::Describe, &id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn without_a_vision_role_an_exhausted_job_keeps_waiting() {
+        let core = test_core_without_vision().await;
+        let src = core
+            .store
+            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        core.store
+            .enqueue(Stage::Describe, "corpus", &src.id)
+            .await
+            .unwrap();
+        for _ in 0..crate::store::jobs::MAX_ATTEMPTS + 1 {
+            clear_backoff(&core).await;
+            assert!(crate::jobs::run_one(&core).await.unwrap());
+        }
+        assert_eq!(
+            core.store.get_corpus(&src.id).await.unwrap().status,
+            CorpusStatus::Describing
+        );
+        assert!(core.store.live_job(Stage::Describe, &src.id).await.unwrap());
     }
 
     #[tokio::test]

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -40,18 +40,9 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
     let text = read?;
 
     if text.trim().is_empty() {
-        let mut meta = src.metadata.clone();
-        meta["describe"] = serde_json::json!({
-            "error": "the model returned no text for this image"
-        });
-        core.store.set_corpus_metadata(corpus_id, &meta).await?;
-        core.store
-            .set_corpus_status(corpus_id, CorpusStatus::NeedsReview)
-            .await?;
-        tracing::warn!(
-            corpus_id,
-            "vision model returned nothing; parked for review"
-        );
+        // Not a near-duplicate, so not the review queue: that page offers
+        // "keep" and "discard" against another corpus, and there is none.
+        park_failed(core, corpus_id, "the model returned no text for this image").await?;
         return Ok(());
     }
 
@@ -63,35 +54,13 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
         .find_near_duplicate(&sig, core.consolidate.near_dupe_min)
         .await?;
     core.store.set_described_text(corpus_id, &text, sig).await?;
-    match near {
-        Some(n) => {
-            core.store
-                .set_near_dupe(corpus_id, Some(&n.corpus_id), Some(n.similarity))
-                .await?;
-            core.store
-                .set_corpus_status(corpus_id, CorpusStatus::NeedsReview)
-                .await?;
-            tracing::info!(
-                corpus_id,
-                near = %n.corpus_id,
-                similarity = n.similarity,
-                "reading looks like an existing corpus; parked for review"
-            );
-        }
-        None => {
-            core.store
-                .set_corpus_status(corpus_id, CorpusStatus::Raw)
-                .await?;
-            core.store
-                .enqueue(Stage::Synthesize, "corpus", corpus_id)
-                .await?;
-            tracing::info!(
-                corpus_id,
-                chars = text.len(),
-                "image read; queued for synthesis"
-            );
-        }
-    }
+    core.park_or_queue(corpus_id, near.as_ref()).await?;
+    tracing::info!(
+        corpus_id,
+        chars = text.len(),
+        parked = near.is_some(),
+        "image read"
+    );
     Ok(())
 }
 
@@ -202,19 +171,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_empty_reading_parks_the_corpus_with_the_reason() {
+    async fn an_empty_reading_parks_the_corpus_as_failed_with_the_reason() {
         let core = test_core_with_describer(Arc::new(FakeDescriber::saying("  \n"))).await;
         let id = captured(&core, 4, None).await;
         core.store.claim_job().await.unwrap();
         run(&core, &id).await.unwrap();
         let src = core.store.get_corpus(&id).await.unwrap();
-        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert_eq!(src.status, CorpusStatus::Failed);
         assert!(
             src.metadata["describe"]["error"]
                 .as_str()
                 .unwrap()
                 .contains("no text")
         );
+        assert!(
+            src.near_dupe_of.is_none(),
+            "not a near-duplicate; not on the review queue"
+        );
+        assert!(core.store.parked_corpora(10).await.unwrap().is_empty());
         assert!(
             core.store.claim_job().await.unwrap().is_none(),
             "nothing further queued"

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -4,7 +4,6 @@
 use crate::core::Core;
 use crate::error::{Error, Result};
 use crate::store::corpora::CorpusStatus;
-use crate::store::jobs::Stage;
 
 pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
@@ -86,6 +85,7 @@ pub async fn park_failed(core: &Core, corpus_id: &str, reason: &str) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::jobs::Stage;
     use crate::core::ingest::ImageCapture;
     use crate::core::test_support::{test_core_with_describer, test_core_without_vision};
     use crate::infer::fake::FakeDescriber;

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -69,6 +69,13 @@ pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
 pub async fn park_failed(core: &Core, corpus_id: &str, reason: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
     let mut meta = src.metadata.clone();
+    // Indexing a `Value` that is not an object panics, and this one comes
+    // straight out of a column. The reason is the whole point of the write —
+    // it is what the corpus page and Ops show — so a column holding something
+    // else is started over rather than left to take the worker down.
+    if !meta.is_object() {
+        meta = serde_json::json!({});
+    }
     meta["describe"] = serde_json::json!({ "error": reason });
     core.store.set_corpus_metadata(corpus_id, &meta).await?;
     core.store
@@ -256,6 +263,44 @@ mod tests {
                 .contains("gpu on fire")
         );
         assert!(!core.store.live_job(Stage::Describe, &id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn parking_survives_a_metadata_column_that_is_not_an_object() {
+        // `meta["describe"] = ...` panics on anything but an object or null,
+        // and the value comes out of a column. A worker is the wrong place to
+        // find that out.
+        let core = test_core_without_vision().await;
+        let src = core
+            .store
+            .insert_image_corpus(
+                "h",
+                "image",
+                None,
+                &serde_json::json!("not an object"),
+                &crate::store::attachments::NewImage {
+                    kind: "image",
+                    mime: "image/png",
+                    filename: None,
+                    bytes: b"orig",
+                    preview: b"prev",
+                    width: Some(1),
+                    height: Some(1),
+                },
+            )
+            .await
+            .unwrap()
+            .into_corpus();
+
+        park_failed(&core, &src.id, "gpu on fire").await.unwrap();
+
+        let got = core.store.get_corpus(&src.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::Failed);
+        assert_eq!(
+            got.metadata["describe"]["error"].as_str(),
+            Some("gpu on fire"),
+            "the reason is what the corpus page shows; it cannot be lost"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -1,0 +1,243 @@
+//! The vision stage: one captured image, one call, and a corpus that from
+//! here on is text like any other.
+
+use crate::core::Core;
+use crate::error::{Error, Result};
+use crate::store::corpora::CorpusStatus;
+use crate::store::jobs::Stage;
+
+pub async fn run(core: &Core, corpus_id: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    if src.status != CorpusStatus::Describing {
+        tracing::info!(
+            corpus_id,
+            status = src.status.as_str(),
+            "already described; nothing to do"
+        );
+        return Ok(());
+    }
+    let Some(describer) = core.describer.as_ref() else {
+        // Not a validation error: the photo is stored and the job should wait
+        // for the role, not be dropped.
+        return Err(Error::Inference {
+            role: "vision",
+            detail: "no vision role configured".into(),
+        });
+    };
+    let Some((_, preview)) = core.store.attachment_preview(corpus_id).await? else {
+        return Err(Error::Store(format!(
+            "image corpus {corpus_id} has no attachment"
+        )));
+    };
+    let context = crate::infer::prompt::describe_context(&src.metadata);
+
+    let permit = core.gate.background().await;
+    let read = describer.describe(&preview, &context).await;
+    match &read {
+        Ok(_) => permit.succeeded(),
+        Err(e) => permit.failed(e),
+    }
+    let text = read?;
+
+    if text.trim().is_empty() {
+        let mut meta = src.metadata.clone();
+        meta["describe"] = serde_json::json!({
+            "error": "the model returned no text for this image"
+        });
+        core.store.set_corpus_metadata(corpus_id, &meta).await?;
+        core.store
+            .set_corpus_status(corpus_id, CorpusStatus::NeedsReview)
+            .await?;
+        tracing::warn!(
+            corpus_id,
+            "vision model returned nothing; parked for review"
+        );
+        return Ok(());
+    }
+
+    // Before the text is written: the scan reads every stored signature, and
+    // this row's is still empty, so it cannot match itself.
+    let sig = crate::store::shingle::signature(&text);
+    let near = core
+        .store
+        .find_near_duplicate(&sig, core.consolidate.near_dupe_min)
+        .await?;
+    core.store.set_described_text(corpus_id, &text, sig).await?;
+    match near {
+        Some(n) => {
+            core.store
+                .set_near_dupe(corpus_id, Some(&n.corpus_id), Some(n.similarity))
+                .await?;
+            core.store
+                .set_corpus_status(corpus_id, CorpusStatus::NeedsReview)
+                .await?;
+            tracing::info!(
+                corpus_id,
+                near = %n.corpus_id,
+                similarity = n.similarity,
+                "reading looks like an existing corpus; parked for review"
+            );
+        }
+        None => {
+            core.store
+                .set_corpus_status(corpus_id, CorpusStatus::Raw)
+                .await?;
+            core.store
+                .enqueue(Stage::Synthesize, "corpus", corpus_id)
+                .await?;
+            tracing::info!(
+                corpus_id,
+                chars = text.len(),
+                "image read; queued for synthesis"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ingest::ImageCapture;
+    use crate::core::test_support::{test_core_with_describer, test_core_without_vision};
+    use crate::infer::fake::FakeDescriber;
+    use std::sync::Arc;
+
+    fn a_png(seed: u8) -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(32, 32, |x, y| Rgb([seed, x as u8, y as u8]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    async fn captured(core: &Core, seed: u8, note: Option<&str>) -> String {
+        core.ingest_image(ImageCapture {
+            bytes: a_png(seed),
+            filename: Some("p.png".into()),
+            title_hint: None,
+            note: note.map(str::to_string),
+        })
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn describing_writes_the_text_and_hands_off_to_synthesize() {
+        let d = Arc::new(FakeDescriber::saying("# Board\n\n- ship\n- test"));
+        let core = test_core_with_describer(d.clone()).await;
+        let id = captured(&core, 1, Some("kitchen board")).await;
+        core.store.claim_job().await.unwrap(); // the Describe job
+        run(&core, &id).await.unwrap();
+
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Raw);
+        assert_eq!(src.raw_text, "# Board\n\n- ship\n- test");
+        assert!(!src.shingles.is_empty());
+        assert!(
+            d.last_context().contains("kitchen board"),
+            "{}",
+            d.last_context()
+        );
+        assert!(d.last_context().contains("p.png"));
+        let next = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("synthesize queued");
+        assert_eq!(next.stage, Stage::Synthesize);
+        assert_eq!(next.target_id, id);
+    }
+
+    #[tokio::test]
+    async fn the_whole_pipeline_takes_a_photo_to_ready() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::default())).await;
+        let id = captured(&core, 2, None).await;
+        while crate::jobs::run_one(&core).await.unwrap() {}
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::Ready, "{:?}", src.status);
+        assert!(
+            !core
+                .store
+                .artifacts_for_corpus(&id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failing_model_leaves_the_corpus_describing_and_the_error_retryable() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::failing("gpu on fire"))).await;
+        let id = captured(&core, 3, None).await;
+        let e = run(&core, &id).await.unwrap_err();
+        assert!(e.retryable());
+        assert_eq!(
+            core.store.get_corpus(&id).await.unwrap().status,
+            CorpusStatus::Describing
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_reading_parks_the_corpus_with_the_reason() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::saying("  \n"))).await;
+        let id = captured(&core, 4, None).await;
+        core.store.claim_job().await.unwrap();
+        run(&core, &id).await.unwrap();
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert!(
+            src.metadata["describe"]["error"]
+                .as_str()
+                .unwrap()
+                .contains("no text")
+        );
+        assert!(
+            core.store.claim_job().await.unwrap().is_none(),
+            "nothing further queued"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reading_that_matches_an_existing_corpus_is_parked_as_a_near_duplicate() {
+        let text = "The quarterly plan lists three goals: ship the beta, hire two engineers, and cut latency in half by autumn.";
+        let core = test_core_with_describer(Arc::new(FakeDescriber::saying(text))).await;
+        let first = core.ingest(text, "web", None).await.unwrap();
+        let id = captured(&core, 5, None).await;
+        core.store.claim_job().await.unwrap(); // synthesize for the paste
+        core.store.claim_job().await.unwrap(); // describe
+        run(&core, &id).await.unwrap();
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert_eq!(src.near_dupe_of.as_deref(), Some(first.id.as_str()));
+        assert_eq!(src.raw_text, text, "the reading is kept even when parked");
+    }
+
+    #[tokio::test]
+    async fn a_job_for_a_corpus_that_is_gone_is_not_found() {
+        let core = test_core_with_describer(Arc::new(FakeDescriber::default())).await;
+        assert!(matches!(
+            run(&core, "nope").await,
+            Err(crate::error::Error::NotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn without_a_vision_role_the_job_waits_rather_than_failing_the_corpus() {
+        // Configured when the photo was taken, removed before it was read: the
+        // job stays queued at the backoff ceiling until the role comes back.
+        let core = test_core_without_vision().await;
+        let src = core
+            .store
+            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        let e = run(&core, &src.id).await.unwrap_err();
+        assert!(e.retryable(), "{e}");
+    }
+}

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -38,13 +38,23 @@ fn default_limit(core: &Core) -> usize {
 /// changes that. Configuration is meant to keep chunks under it, but the
 /// configured ceiling is a claim about the model while this is the server's
 /// real limit, and the two disagree more often than not.
+///
+/// Both inference variants, because both carry this answer: a bare llama.cpp
+/// says it in the body of a 200-shaped failure, while an endpoint that answers
+/// 413 or 400 arrives here already classified as a rejection. Matching only
+/// the first left the 413 case falling through to the permanent path, where a
+/// chunk that wanted cutting was marked `embed_failed` instead.
 fn input_too_large(e: &Error) -> bool {
-    let Error::Inference {
-        role: "embed",
-        detail,
-    } = e
-    else {
-        return false;
+    let detail = match e {
+        Error::Inference {
+            role: "embed",
+            detail,
+        }
+        | Error::InferenceRejected {
+            role: "embed",
+            detail,
+        } => detail,
+        _ => return false,
     };
     let d = detail.to_ascii_lowercase();
     d.contains("too large")
@@ -1015,6 +1025,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_413_from_a_real_endpoint_splits_the_chunk_like_a_bare_servers_refusal() {
+        // The two refusals differ only in how they travelled: a bare server
+        // says "too large" in a body, an endpoint answers 413 and the client
+        // classifies it as a rejection. Understanding only the first took the
+        // whole splitting path out of service against every real deployment —
+        // the chunk went to the permanent path and was marked `embed_failed`
+        // instead of being cut.
+        let mut core = crate::core::test_support::test_core().await;
+        core.embedder = std::sync::Arc::new(crate::infer::fake::StrictEmbedder::over_http(
+            crate::core::test_support::TEST_DIM,
+            120,
+        ));
+
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let text = (0..40)
+            .map(|i| format!("paragraph {i} with enough words in it to measure\n\nmore"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text,
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        // A limit our own estimate is happy with, so the proactive check passes
+        // and the endpoint's answer is the only thing that can start the split.
+        run_with_limit(&core, &made[0].id, 8192).await.unwrap();
+
+        let chunks = core.store.artifacts_for_corpus(&src.id).await.unwrap();
+        assert!(
+            chunks.len() > 1,
+            "a 413 has to cut the chunk; got {} chunk(s)",
+            chunks.len()
+        );
+        for c in &chunks {
+            assert_ne!(
+                c.embed_state,
+                crate::store::artifacts::EmbedState::Failed,
+                "the chunk was parked instead of split"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn a_refusal_during_the_as_is_attempt_still_ends_in_a_split() {
         // The trap this closes: the estimate says the chunk is oversize, there
         // is no paragraph to cut on, so it is embedded whole — and the server
@@ -1138,6 +1204,16 @@ mod tests {
                 .into(),
         };
         assert!(input_too_large(&too_big));
+
+        // The same refusal from a real endpoint, which answers 413 and is
+        // classified as a rejection rather than a failure. Missing this arm
+        // took the whole splitting path out of service: the chunk went
+        // straight to `embed_failed` instead of being cut.
+        let refused = Error::InferenceRejected {
+            role: "embed",
+            detail: "HTTP 413 Payload Too Large: input is too large to process".into(),
+        };
+        assert!(input_too_large(&refused));
 
         // A transient failure must stay retryable, or a flaky local server
         // would start shredding chunks instead of waiting for it to recover.

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,6 +1,7 @@
 pub mod classify;
 pub mod consolidate;
 pub mod dedupe;
+pub mod describe;
 pub mod embed;
 pub mod merge;
 pub mod reconcile;
@@ -52,7 +53,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
         (Stage::Dedupe, _) => dedupe::run(core, &job.target_id).await,
         (Stage::Relate, _) => relate::run(core, &job.target_id).await,
-        (Stage::Describe, _) => Err(Error::Internal("describe stage not wired yet".into())),
+        (Stage::Describe, _) => describe::run(core, &job.target_id).await,
     };
 
     match result {

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -99,36 +99,29 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                     tracing::warn!(error = %e, "could not name this corpus; leaving it unnamed");
                     core.store.complete_job(job.id).await?;
                 }
+                // The photo is stored, so nothing is lost by stopping — but a
+                // corpus shown as in flight forever is a lie. Unless the role
+                // is simply not configured, which is a wait, not a failure.
+                (Stage::Describe, _) if exhausted && core.describer.is_some() => {
+                    tracing::warn!(error = %e, "could not read this image; parking it");
+                    describe::park_failed(core, &job.target_id, &e.to_string()).await?;
+                    core.store.complete_job(job.id).await?;
+                }
                 // A whole source failing together usually means the endpoint is
                 // down, but it can also be one chunk the embedder rejects.
                 // Retrying chunk by chunk isolates the culprit either way.
                 (Stage::Embed, "corpus") if exhausted => {
                     tracing::warn!(error = %e, "batch embedding exhausted retries; retrying chunk by chunk");
-                    match embed::split_into_artifact_jobs(core, &job.target_id).await {
-                        Ok(()) => {
-                            core.store.complete_job(job.id).await?;
-                        }
-                        Err(fe) => {
-                            core.store
-                                .fail_job(job.id, job.attempts, &fe.to_string())
-                                .await?;
-                        }
-                    }
+                    split_or_fail(core, &job, &e).await?;
                 }
                 _ => {
                     tracing::warn!(error = %e, "job failed; will retry");
-                    core.store
-                        .fail_job(job.id, job.attempts, &e.to_string())
-                        .await?;
                     if job.stage == Stage::Embed && exhausted {
-                        core.store.mark_embed_failed(&job.target_id).await?;
-                        // A merged artifact belongs to no corpus, so there is
-                        // no document whose coverage its failure completes.
-                        if let Ok(c) = core.store.get_artifact(&job.target_id).await
-                            && let Some(corpus_id) = c.corpus_id.as_deref()
-                        {
-                            embed::settle_corpus(core, corpus_id).await?;
-                        }
+                        settle_failed_artifact(core, &job, &e).await?;
+                    } else {
+                        core.store
+                            .fail_job(job.id, job.attempts, &e.to_string())
+                            .await?;
                     }
                 }
             }
@@ -136,12 +129,58 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         }
         Err(e) => {
             tracing::error!(error = %e, "job failed permanently");
-            core.store
-                .fail_job(job.id, MAX_ATTEMPTS, &e.to_string())
-                .await?;
+            match (job.stage, job.target_kind.as_str()) {
+                // Refused as a batch does not mean refused as chunks; the same
+                // isolation the exhausted path buys is worth buying here.
+                (Stage::Embed, "corpus") => split_or_fail(core, &job, &e).await?,
+                (Stage::Embed, _) => settle_failed_artifact(core, &job, &e).await?,
+                (Stage::Describe, _) => {
+                    describe::park_failed(core, &job.target_id, &e.to_string()).await?;
+                    core.store.complete_job(job.id).await?;
+                }
+                _ => {
+                    core.store
+                        .fail_job(job.id, MAX_ATTEMPTS, &e.to_string())
+                        .await?;
+                }
+            }
             Ok(true)
         }
     }
+}
+
+/// Hand a batch embed that will not go through as a batch to per-chunk units.
+/// The batch unit closes only once the split is queued; if even that fails,
+/// the batch stays armed so the work is not lost.
+async fn split_or_fail(core: &Core, job: &Job, e: &Error) -> Result<()> {
+    match embed::split_into_artifact_jobs(core, &job.target_id).await {
+        Ok(()) => core.store.complete_job(job.id).await,
+        Err(fe) => {
+            tracing::warn!(error = %fe, original = %e, "could not split the batch; keeping it queued");
+            core.store
+                .fail_job(job.id, job.attempts, &fe.to_string())
+                .await
+        }
+    }
+}
+
+/// One chunk the embedder will not take: mark it, and let the corpus settle to
+/// `partial` if this was the last one outstanding.
+async fn settle_failed_artifact(core: &Core, job: &Job, e: &Error) -> Result<()> {
+    // Kept armed at the backoff ceiling like every failed unit: no terminal
+    // state, see `fail_job`.
+    core.store
+        .fail_job(job.id, job.attempts.max(MAX_ATTEMPTS), &e.to_string())
+        .await?;
+    core.store.mark_embed_failed(&job.target_id).await?;
+    // A merged artifact belongs to no corpus, so there is no document whose
+    // coverage its failure completes.
+    if let Ok(c) = core.store.get_artifact(&job.target_id).await
+        && let Some(corpus_id) = c.corpus_id.as_deref()
+    {
+        embed::settle_corpus(core, corpus_id).await?;
+    }
+    Ok(())
 }
 
 pub struct Worker;
@@ -185,9 +224,49 @@ impl Worker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::test_support::{test_core, test_core_with_failing_synthesizer};
+    use crate::core::test_support::{
+        test_core, test_core_with_embedder, test_core_with_failing_synthesizer,
+    };
+    use crate::infer::fake::FakeEmbedder;
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::MAX_ATTEMPTS;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn a_batch_embed_the_endpoint_rejects_is_retried_chunk_by_chunk() {
+        let core = test_core_with_embedder(Arc::new(FakeEmbedder::rejecting("HTTP 413"))).await;
+        let src = core
+            .ingest("alpha para\n\nbeta para", "web", None)
+            .await
+            .unwrap();
+        // Run the queue up to and including the batch embed of this corpus.
+        let mut guard = 0;
+        while let Some(job) = core.store.claim_job().await.unwrap() {
+            guard += 1;
+            assert!(guard < 50, "queue did not reach the batch embed");
+            let is_batch = job.stage == Stage::Embed && job.target_kind == "corpus";
+            run_claimed(&core, job).await.unwrap();
+            if is_batch {
+                break;
+            }
+        }
+        let per_chunk = core
+            .store
+            .pending_artifacts_for_corpus(&src.id)
+            .await
+            .unwrap();
+        assert!(!per_chunk.is_empty());
+        for c in per_chunk {
+            assert!(
+                core.store.live_job(Stage::Embed, &c.id).await.unwrap(),
+                "per-chunk unit armed"
+            );
+        }
+        assert!(
+            !core.store.live_job(Stage::Embed, &src.id).await.unwrap(),
+            "the batch unit is closed"
+        );
+    }
 
     #[tokio::test]
     async fn run_one_reports_when_the_queue_is_empty() {

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -138,9 +138,17 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                     park_failed_if_still_there(core, &job.target_id, &e).await?;
                     core.store.complete_job(job.id).await?;
                 }
+                // Kept armed like every other failed unit, but at the *unit's*
+                // own attempt count rather than at the constant. Passing
+                // `MAX_ATTEMPTS` pinned the delay at its value for ever, so a
+                // window the endpoint refuses outright would poll it every 32
+                // seconds until someone noticed — far harder than a window it
+                // merely could not reach, which backs off to six hours. The
+                // floor stays, so the first refusal still waits out the whole
+                // ordinary budget rather than retrying in two seconds.
                 _ => {
                     core.store
-                        .fail_job(job.id, MAX_ATTEMPTS, &e.to_string())
+                        .fail_job(job.id, job.attempts.max(MAX_ATTEMPTS), &e.to_string())
                         .await?;
                 }
             }
@@ -244,10 +252,11 @@ mod tests {
     use super::*;
     use crate::core::test_support::{
         test_core, test_core_with_embedder, test_core_with_failing_synthesizer,
+        test_core_with_rejecting_synthesizer,
     };
     use crate::infer::fake::FakeEmbedder;
     use crate::store::corpora::CorpusStatus;
-    use crate::store::jobs::MAX_ATTEMPTS;
+    use crate::store::jobs::{MAX_ATTEMPTS, backoff_secs};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -283,6 +292,67 @@ mod tests {
         assert!(
             !core.store.live_job(Stage::Embed, &src.id).await.unwrap(),
             "the batch unit is closed"
+        );
+    }
+
+    /// A window the endpoint *refuses* used to be requeued at a fixed 32
+    /// seconds forever, because the permanent arm passed the `MAX_ATTEMPTS`
+    /// constant rather than the unit's own attempt count. Work the endpoint
+    /// said no to would then poll it 675 times more often than work that
+    /// merely failed to reach it — the wrong way round.
+    #[tokio::test]
+    async fn a_refused_window_backs_off_further_every_time_it_is_refused() {
+        let core = test_core_with_rejecting_synthesizer().await;
+        let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
+
+        let delay = |core: &Core| {
+            let pool = core.store.pool.clone();
+            let id = out.id.clone();
+            async move {
+                sqlx::query_scalar::<_, i64>(
+                    "SELECT run_after - ? FROM jobs
+                      WHERE stage = 'segment_window' AND target_id LIKE ? || '%'",
+                )
+                .bind(crate::store::now())
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+            }
+        };
+
+        // Wind each refusal's delay back so the attempt budget is spent
+        // without sleeping, and record how long the unit asked to wait.
+        let mut gaps = Vec::new();
+        for _ in 0..MAX_ATTEMPTS + 3 {
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            let _ = run_one(&core).await;
+            // Before the window's own unit is first claimed its `run_after` is
+            // the zero this loop just wrote, which is not a refusal's delay.
+            match delay(&core).await {
+                g if g > 0 => gaps.push(g),
+                _ => {}
+            }
+        }
+
+        assert!(
+            gaps.last() > gaps.first(),
+            "a refusal must back off further each time, not poll a dead endpoint \
+             at a fixed interval forever; gaps were {gaps:?}"
+        );
+        // The floor is still the ceiling of the ordinary budget, so a refusal
+        // is never *cheaper* to retry than a failure to connect.
+        assert!(
+            gaps.iter().all(|g| *g >= backoff_secs(MAX_ATTEMPTS)),
+            "gaps were {gaps:?}"
+        );
+        // And the document does not hang waiting on a window nobody will take.
+        assert_eq!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Failed
         );
     }
 

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -104,7 +104,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                 // is simply not configured, which is a wait, not a failure.
                 (Stage::Describe, _) if exhausted && core.describer.is_some() => {
                     tracing::warn!(error = %e, "could not read this image; parking it");
-                    describe::park_failed(core, &job.target_id, &e.to_string()).await?;
+                    park_failed_if_still_there(core, &job.target_id, &e).await?;
                     core.store.complete_job(job.id).await?;
                 }
                 // A whole source failing together usually means the endpoint is
@@ -135,7 +135,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
                 (Stage::Embed, "corpus") => split_or_fail(core, &job, &e).await?,
                 (Stage::Embed, _) => settle_failed_artifact(core, &job, &e).await?,
                 (Stage::Describe, _) => {
-                    describe::park_failed(core, &job.target_id, &e.to_string()).await?;
+                    park_failed_if_still_there(core, &job.target_id, &e).await?;
                     core.store.complete_job(job.id).await?;
                 }
                 _ => {
@@ -146,6 +146,24 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
             }
             Ok(true)
         }
+    }
+}
+
+/// Park an image that could not be read, tolerating its corpus having been
+/// deleted in the meantime.
+///
+/// A corpus deleted before the job ran is caught far above, by the `NotFound`
+/// arm that simply closes the unit. This is the narrower race: deleted between
+/// the failed read and this write. Letting that `NotFound` out of `run_claimed`
+/// would leave the job `running` until `reclaim_stuck` picks it up ten minutes
+/// later, only to lose the same race again.
+async fn park_failed_if_still_there(core: &Core, corpus_id: &str, e: &Error) -> Result<()> {
+    match describe::park_failed(core, corpus_id, &e.to_string()).await {
+        Err(Error::NotFound) => {
+            tracing::info!(corpus_id, "corpus went away before it could be parked");
+            Ok(())
+        }
+        other => other,
     }
 }
 

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -52,6 +52,7 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
         (Stage::Dedupe, _) => dedupe::run(core, &job.target_id).await,
         (Stage::Relate, _) => relate::run(core, &job.target_id).await,
+        (Stage::Describe, _) => Err(Error::Internal("describe stage not wired yet".into())),
     };
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,12 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
     } else {
         tracing::info!("rerank not configured; search returns vector order");
     }
+    if let Some(v) = &cfg.infer.vision {
+        let (base_url, api_key) = v.resolve(&cfg.infer.synthesize);
+        engram::infer::openai::probe("vision", &base_url, api_key.as_deref()).await;
+    } else {
+        tracing::info!("vision not configured; the image door is closed");
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,6 +388,7 @@ mod startup_tests {
                     reasoning_effort: None,
                 },
                 rerank: None,
+                vision: None,
             },
             auth: AuthConfig {
                 mode: AuthMode::Local,

--- a/src/store/attachments.rs
+++ b/src/store/attachments.rs
@@ -33,27 +33,62 @@ pub struct NewAttachment<'a> {
     pub height: Option<i64>,
 }
 
+/// An attachment for a corpus that does not exist yet: `NewAttachment` minus
+/// the id, for the door that writes row and attachment in one transaction.
+pub struct NewImage<'a> {
+    pub kind: &'a str,
+    pub mime: &'a str,
+    pub filename: Option<&'a str>,
+    pub bytes: &'a [u8],
+    pub preview: &'a [u8],
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+}
+
+impl<'a> NewImage<'a> {
+    pub fn for_corpus(&self, corpus_id: &'a str) -> NewAttachment<'a> {
+        NewAttachment {
+            corpus_id,
+            kind: self.kind,
+            mime: self.mime,
+            filename: self.filename,
+            bytes: self.bytes,
+            preview: self.preview,
+            width: self.width,
+            height: self.height,
+        }
+    }
+}
+
+/// `insert_attachment` on whatever executor the caller is inside.
+pub(crate) async fn insert_attachment_with<'e>(
+    exec: impl sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    a: &NewAttachment<'_>,
+) -> Result<i64> {
+    let res = sqlx::query(
+        "INSERT INTO attachments (corpus_id, kind, mime, filename, bytes, preview, width, height, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(a.corpus_id)
+    .bind(a.kind)
+    .bind(a.mime)
+    .bind(a.filename)
+    .bind(a.bytes)
+    .bind(a.preview)
+    .bind(a.width)
+    .bind(a.height)
+    .bind(now())
+    .execute(exec)
+    .await?;
+    Ok(res.last_insert_rowid())
+}
+
 /// What every preview is encoded as. See `core::image::prepare`.
 pub const PREVIEW_MIME: &str = "image/jpeg";
 
 impl Store {
     pub async fn insert_attachment(&self, a: &NewAttachment<'_>) -> Result<i64> {
-        let res = sqlx::query(
-            "INSERT INTO attachments (corpus_id, kind, mime, filename, bytes, preview, width, height, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(a.corpus_id)
-        .bind(a.kind)
-        .bind(a.mime)
-        .bind(a.filename)
-        .bind(a.bytes)
-        .bind(a.preview)
-        .bind(a.width)
-        .bind(a.height)
-        .bind(now())
-        .execute(&self.pool)
-        .await?;
-        Ok(res.last_insert_rowid())
+        insert_attachment_with(&self.pool, a).await
     }
 
     pub async fn attachment_for_corpus(&self, corpus_id: &str) -> Result<Option<Attachment>> {
@@ -107,11 +142,7 @@ mod tests {
     #[tokio::test]
     async fn an_attachment_round_trips_and_goes_with_its_corpus() {
         let s = Store::memory().await.unwrap();
-        let src = s
-            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
-            .await
-            .unwrap()
-            .into_corpus();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
         s.insert_attachment(&NewAttachment {
             corpus_id: &src.id,
             kind: "image",

--- a/src/store/attachments.rs
+++ b/src/store/attachments.rs
@@ -113,6 +113,20 @@ impl Store {
         }))
     }
 
+    /// Whether this corpus is a capture at all. Separate from the two readers
+    /// below for the same reason they are separate from each other: answering
+    /// yes or no must not pull `image_max_bytes` of original off disk and into
+    /// memory to do it.
+    pub async fn has_attachment(&self, corpus_id: &str) -> Result<bool> {
+        Ok(
+            sqlx::query_scalar::<_, i64>("SELECT 1 FROM attachments WHERE corpus_id = ? LIMIT 1")
+                .bind(corpus_id)
+                .fetch_optional(&self.pool)
+                .await?
+                .is_some(),
+        )
+    }
+
     /// The preview alone. Separate from `attachment_for_corpus` so serving a
     /// thumbnail does not read the original's megabytes off disk.
     pub async fn attachment_preview(&self, corpus_id: &str) -> Result<Option<(String, Vec<u8>)>> {
@@ -138,6 +152,30 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn a_corpus_is_known_to_be_a_capture_without_its_bytes_being_read() {
+        let s = Store::memory().await.unwrap();
+        let text = s.insert_corpus("raw", "web", None).await.unwrap();
+        assert!(!s.has_attachment(&text.id).await.unwrap());
+
+        let img = s.insert_corpus("raw", "image", None).await.unwrap();
+        let original = vec![7u8; 4096];
+        s.insert_attachment(&NewAttachment {
+            corpus_id: &img.id,
+            kind: "image",
+            mime: "image/png",
+            filename: Some("a.png"),
+            bytes: &original,
+            preview: b"prev",
+            width: Some(4),
+            height: Some(4),
+        })
+        .await
+        .unwrap();
+        assert!(s.has_attachment(&img.id).await.unwrap());
+        assert!(!s.has_attachment("no-such-corpus").await.unwrap());
+    }
 
     #[tokio::test]
     async fn an_attachment_round_trips_and_goes_with_its_corpus() {

--- a/src/store/attachments.rs
+++ b/src/store/attachments.rs
@@ -1,0 +1,145 @@
+//! The bytes a corpus was captured from, when it was not text.
+//!
+//! One row per image corpus today. The original is kept exactly as uploaded —
+//! that is the verbatim source, the way `raw_text` is for a paste — and the
+//! preview is derived once, for the model and the screen.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+#[derive(Debug, Clone)]
+pub struct Attachment {
+    pub id: i64,
+    pub corpus_id: String,
+    pub kind: String,
+    pub mime: String,
+    pub filename: Option<String>,
+    pub bytes: Vec<u8>,
+    pub preview: Vec<u8>,
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+    pub created_at: i64,
+}
+
+pub struct NewAttachment<'a> {
+    pub corpus_id: &'a str,
+    pub kind: &'a str,
+    pub mime: &'a str,
+    pub filename: Option<&'a str>,
+    pub bytes: &'a [u8],
+    pub preview: &'a [u8],
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+}
+
+/// What every preview is encoded as. See `core::image::prepare`.
+pub const PREVIEW_MIME: &str = "image/jpeg";
+
+impl Store {
+    pub async fn insert_attachment(&self, a: &NewAttachment<'_>) -> Result<i64> {
+        let res = sqlx::query(
+            "INSERT INTO attachments (corpus_id, kind, mime, filename, bytes, preview, width, height, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(a.corpus_id)
+        .bind(a.kind)
+        .bind(a.mime)
+        .bind(a.filename)
+        .bind(a.bytes)
+        .bind(a.preview)
+        .bind(a.width)
+        .bind(a.height)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.last_insert_rowid())
+    }
+
+    pub async fn attachment_for_corpus(&self, corpus_id: &str) -> Result<Option<Attachment>> {
+        let row = sqlx::query(
+            "SELECT id, corpus_id, kind, mime, filename, bytes, preview, width, height, created_at
+             FROM attachments WHERE corpus_id = ? ORDER BY id LIMIT 1",
+        )
+        .bind(corpus_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| Attachment {
+            id: r.get("id"),
+            corpus_id: r.get("corpus_id"),
+            kind: r.get("kind"),
+            mime: r.get("mime"),
+            filename: r.get("filename"),
+            bytes: r.get("bytes"),
+            preview: r.get("preview"),
+            width: r.get("width"),
+            height: r.get("height"),
+            created_at: r.get("created_at"),
+        }))
+    }
+
+    /// The preview alone. Separate from `attachment_for_corpus` so serving a
+    /// thumbnail does not read the original's megabytes off disk.
+    pub async fn attachment_preview(&self, corpus_id: &str) -> Result<Option<(String, Vec<u8>)>> {
+        let row =
+            sqlx::query("SELECT preview FROM attachments WHERE corpus_id = ? ORDER BY id LIMIT 1")
+                .bind(corpus_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|r| (PREVIEW_MIME.to_string(), r.get("preview"))))
+    }
+
+    pub async fn attachment_original(&self, corpus_id: &str) -> Result<Option<(String, Vec<u8>)>> {
+        let row = sqlx::query(
+            "SELECT mime, bytes FROM attachments WHERE corpus_id = ? ORDER BY id LIMIT 1",
+        )
+        .bind(corpus_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| (r.get("mime"), r.get("bytes"))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn an_attachment_round_trips_and_goes_with_its_corpus() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        s.insert_attachment(&NewAttachment {
+            corpus_id: &src.id,
+            kind: "image",
+            mime: "image/png",
+            filename: Some("x.png"),
+            bytes: b"orig",
+            preview: b"prev",
+            width: Some(10),
+            height: Some(20),
+        })
+        .await
+        .unwrap();
+
+        let a = s.attachment_for_corpus(&src.id).await.unwrap().unwrap();
+        assert_eq!(a.bytes, b"orig");
+        assert_eq!(a.preview, b"prev");
+        assert_eq!(a.mime, "image/png");
+        assert_eq!((a.width, a.height), (Some(10), Some(20)));
+        assert_eq!(
+            s.attachment_preview(&src.id).await.unwrap().unwrap(),
+            (PREVIEW_MIME.to_string(), b"prev".to_vec())
+        );
+        assert_eq!(
+            s.attachment_original(&src.id).await.unwrap().unwrap(),
+            ("image/png".to_string(), b"orig".to_vec())
+        );
+
+        s.delete_corpus(&src.id).await.unwrap();
+        assert!(s.attachment_for_corpus(&src.id).await.unwrap().is_none());
+    }
+}

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -1,3 +1,4 @@
+use super::jobs::Stage;
 use super::{Store, new_id, now};
 use crate::error::{Error, Result};
 use sha2::{Digest, Sha256};
@@ -118,6 +119,49 @@ pub struct NearDuplicate {
 /// The dedupe key of a corpus: text for a capture, the file's bytes for an
 /// image. One function, so the two doors can never drift onto different keys
 /// for the same column.
+/// What a capture wants done in the same transaction as its row.
+#[derive(Debug, Clone)]
+pub enum Followup {
+    /// Just the row. Tests and tools that drive the queue themselves.
+    Nothing,
+    /// Queue this stage. Text captures queue Synthesize; images queue Describe.
+    Queue(Stage),
+    /// Park beside a near-duplicate: `near_dupe_of`, its score, and
+    /// `needs_review`, written on the row itself. No job.
+    Park { of: String, similarity: f64 },
+}
+
+/// The one INSERT every captured corpus row goes through, on whatever executor
+/// the caller is inside. `ON CONFLICT(content_hash) DO NOTHING`; answers
+/// whether the row was written.
+async fn insert_corpus_row<'e>(
+    exec: impl sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    src: &Corpus,
+) -> Result<bool> {
+    let res = sqlx::query(
+        "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at,
+                              shingles, source_url, metadata, near_dupe_of, near_dupe_score)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(content_hash) DO NOTHING",
+    )
+    .bind(&src.id)
+    .bind(&src.raw_text)
+    .bind(&src.origin)
+    .bind(&src.title_hint)
+    .bind(&src.content_hash)
+    .bind(src.status.as_str())
+    .bind(src.created_at)
+    .bind(src.updated_at)
+    .bind(super::shingle::encode(&src.shingles))
+    .bind(&src.source_url)
+    .bind(src.metadata.to_string())
+    .bind(&src.near_dupe_of)
+    .bind(src.near_dupe_score)
+    .execute(exec)
+    .await?;
+    Ok(res.rows_affected() > 0)
+}
+
 pub fn content_hash(bytes: impl AsRef<[u8]>) -> String {
     hex::encode(Sha256::digest(bytes.as_ref()))
 }
@@ -164,6 +208,7 @@ impl Store {
                 sig,
                 None,
                 &serde_json::json!({}),
+                Followup::Nothing,
             )
             .await?
             .into_corpus())
@@ -182,6 +227,11 @@ impl Store {
     /// check and this insert grows with the base. Two identical captures in
     /// flight (a double-submitted form, an agent retrying) both pass the check.
     /// The loser must get the winner's row back, not a UNIQUE-constraint 500.
+    ///
+    /// The follow-up — the job, or the park — is written in the same
+    /// transaction as the row: a process that dies between the two would
+    /// otherwise leave a `raw` corpus nothing will ever pick up.
+    #[allow(clippy::too_many_arguments)]
     pub async fn insert_corpus_with_signature(
         &self,
         raw_text: &str,
@@ -190,44 +240,37 @@ impl Store {
         shingles: Vec<u64>,
         source_url: Option<&str>,
         metadata: &serde_json::Value,
+        followup: Followup,
     ) -> Result<Insertion> {
+        let (status, near_dupe_of, near_dupe_score) = match &followup {
+            Followup::Park { of, similarity } => (
+                CorpusStatus::NeedsReview,
+                Some(of.clone()),
+                Some(*similarity),
+            ),
+            Followup::Queue(_) | Followup::Nothing => (CorpusStatus::Raw, None, None),
+        };
         let src = Corpus {
             id: new_id(),
             raw_text: raw_text.to_string(),
             origin: origin.to_string(),
             title_hint: title_hint.map(str::to_string),
             content_hash: content_hash(raw_text),
-            status: CorpusStatus::Raw,
+            status,
             created_at: now(),
             updated_at: now(),
             coverage: None,
             shingles,
-            near_dupe_of: None,
-            near_dupe_score: None,
+            near_dupe_of,
+            near_dupe_score,
             source_url: source_url.map(str::to_string),
             // A capture, not a placeholder. See `ensure_restored_corpus`.
             restored_at: None,
             metadata: metadata.clone(),
         };
-        let res = sqlx::query(
-            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, source_url, metadata)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(content_hash) DO NOTHING",
-        )
-        .bind(&src.id)
-        .bind(&src.raw_text)
-        .bind(&src.origin)
-        .bind(&src.title_hint)
-        .bind(&src.content_hash)
-        .bind(src.status.as_str())
-        .bind(src.created_at)
-        .bind(src.updated_at)
-        .bind(super::shingle::encode(&src.shingles))
-        .bind(&src.source_url)
-        .bind(src.metadata.to_string())
-        .execute(&self.pool)
-        .await?;
-        if res.rows_affected() == 0 {
+        let mut tx = self.pool.begin().await?;
+        if !insert_corpus_row(&mut *tx, &src).await? {
+            tx.rollback().await?;
             // Somebody else got there between the caller's hash check and this
             // statement. Their row is as good as ours would have been — same
             // bytes, by definition of the constraint that rejected us.
@@ -238,6 +281,10 @@ impl Store {
             })?;
             return Ok(Insertion::Existing(existing));
         }
+        if let Followup::Queue(stage) = followup {
+            super::jobs::enqueue_with(&mut *tx, stage, "corpus", &src.id).await?;
+        }
+        tx.commit().await?;
         Ok(Insertion::Created(src))
     }
 
@@ -463,39 +510,48 @@ impl Store {
     /// The row for a captured image. There is no text yet — the vision stage
     /// writes it — so the hash is the caller's, over the image bytes, and the
     /// row starts in `describing`. Same conflict handling as a text capture:
-    /// the same photo twice is one row.
+    /// the same photo twice is one row. Row, attachment and the Describe unit
+    /// land in one transaction: a photo with no attachment, or one no job will
+    /// ever read, is a row that lies about what it holds.
     pub async fn insert_image_corpus(
         &self,
         content_hash: &str,
         origin: &str,
         title_hint: Option<&str>,
         metadata: &serde_json::Value,
+        attachment: &super::attachments::NewImage<'_>,
     ) -> Result<Insertion> {
         let at = now();
-        let id = new_id();
-        let res = sqlx::query(
-            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, metadata)
-             VALUES (?, '', ?, ?, ?, ?, ?, ?, '', ?)
-             ON CONFLICT(content_hash) DO NOTHING",
-        )
-        .bind(&id)
-        .bind(origin)
-        .bind(title_hint)
-        .bind(content_hash)
-        .bind(CorpusStatus::Describing.as_str())
-        .bind(at)
-        .bind(at)
-        .bind(metadata.to_string())
-        .execute(&self.pool)
-        .await?;
-        let existing = self.find_by_hash(content_hash).await?.ok_or_else(|| {
-            Error::Store("image capture conflicted with a corpus that then vanished".into())
-        })?;
-        Ok(if res.rows_affected() == 0 {
-            Insertion::Existing(existing)
-        } else {
-            Insertion::Created(existing)
-        })
+        let src = Corpus {
+            id: new_id(),
+            raw_text: String::new(),
+            origin: origin.to_string(),
+            title_hint: title_hint.map(str::to_string),
+            content_hash: content_hash.to_string(),
+            status: CorpusStatus::Describing,
+            created_at: at,
+            updated_at: at,
+            coverage: None,
+            shingles: vec![],
+            near_dupe_of: None,
+            near_dupe_score: None,
+            source_url: None,
+            restored_at: None,
+            metadata: metadata.clone(),
+        };
+        let mut tx = self.pool.begin().await?;
+        if !insert_corpus_row(&mut *tx, &src).await? {
+            tx.rollback().await?;
+            let existing = self.find_by_hash(content_hash).await?.ok_or_else(|| {
+                Error::Store("image capture conflicted with a corpus that then vanished".into())
+            })?;
+            return Ok(Insertion::Existing(existing));
+        }
+        super::attachments::insert_attachment_with(&mut *tx, &attachment.for_corpus(&src.id))
+            .await?;
+        super::jobs::enqueue_with(&mut *tx, Stage::Describe, "corpus", &src.id).await?;
+        tx.commit().await?;
+        Ok(Insertion::Created(src))
     }
 
     /// The reverse of `set_described_text`, for a re-read: no text and no
@@ -589,6 +645,7 @@ mod tests {
                 sig.clone(),
                 None,
                 &serde_json::json!({}),
+                Followup::Nothing,
             )
             .await
             .unwrap();
@@ -600,6 +657,7 @@ mod tests {
                 sig,
                 None,
                 &serde_json::json!({}),
+                Followup::Nothing,
             )
             .await
             .unwrap();
@@ -850,12 +908,104 @@ mod tests {
         assert!(s.get_corpus(&src.id).await.unwrap().near_dupe_of.is_none());
     }
 
+    fn a_test_image() -> super::super::attachments::NewImage<'static> {
+        super::super::attachments::NewImage {
+            kind: "image",
+            mime: "image/png",
+            filename: Some("x.png"),
+            bytes: b"orig",
+            preview: b"prev",
+            width: Some(10),
+            height: Some(20),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_text_capture_and_its_job_land_together() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_corpus_with_signature(
+                "hello",
+                "web",
+                None,
+                vec![],
+                None,
+                &serde_json::json!({}),
+                Followup::Queue(Stage::Synthesize),
+            )
+            .await
+            .unwrap()
+            .into_corpus();
+        assert_eq!(src.status, CorpusStatus::Raw);
+        assert!(s.live_job(Stage::Synthesize, &src.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_parked_capture_is_written_parked_with_no_job() {
+        let s = Store::memory().await.unwrap();
+        let other = s.insert_corpus("other", "web", None).await.unwrap();
+        let src = s
+            .insert_corpus_with_signature(
+                "hello",
+                "web",
+                None,
+                vec![],
+                None,
+                &serde_json::json!({}),
+                Followup::Park {
+                    of: other.id.clone(),
+                    similarity: 0.9,
+                },
+            )
+            .await
+            .unwrap()
+            .into_corpus();
+        assert_eq!(src.status, CorpusStatus::NeedsReview);
+        assert_eq!(src.near_dupe_of.as_deref(), Some(other.id.as_str()));
+        let back = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(back.status, CorpusStatus::NeedsReview);
+        assert_eq!(back.near_dupe_score, Some(0.9));
+        assert!(!s.live_job(Stage::Synthesize, &src.id).await.unwrap());
+        assert_eq!(s.parked_corpora(10).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn an_image_row_its_attachment_and_its_job_land_together() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_image_corpus(
+                "hash-1",
+                "image",
+                None,
+                &serde_json::json!({}),
+                &a_test_image(),
+            )
+            .await
+            .unwrap()
+            .into_corpus();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert!(s.attachment_for_corpus(&src.id).await.unwrap().is_some());
+        assert!(s.live_job(Stage::Describe, &src.id).await.unwrap());
+        // The same hash again: Existing, and nothing new written.
+        assert!(matches!(
+            s.insert_image_corpus("hash-1", "image", None, &serde_json::json!({}), &a_test_image())
+                .await
+                .unwrap(),
+            Insertion::Existing(e) if e.id == src.id
+        ));
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attachments")
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+
     #[tokio::test]
     async fn an_image_corpus_starts_describing_with_no_text_and_its_metadata() {
         let s = Store::memory().await.unwrap();
         let meta = serde_json::json!({"file": {"name": "a.jpg"}, "note": "whiteboard"});
         let ins = s
-            .insert_image_corpus("hash-1", "image", Some("a.jpg"), &meta)
+            .insert_image_corpus("hash-1", "image", Some("a.jpg"), &meta, &a_test_image())
             .await
             .unwrap();
         let src = ins.into_corpus();
@@ -868,7 +1018,9 @@ mod tests {
 
         // The same photo again is the same row.
         assert!(matches!(
-            s.insert_image_corpus("hash-1", "image", None, &meta).await.unwrap(),
+            s.insert_image_corpus("hash-1", "image", None, &meta, &a_test_image())
+                .await
+                .unwrap(),
             Insertion::Existing(e) if e.id == src.id
         ));
     }
@@ -877,7 +1029,13 @@ mod tests {
     async fn describing_writes_the_text_and_signature_but_keeps_the_hash() {
         let s = Store::memory().await.unwrap();
         let src = s
-            .insert_image_corpus("hash-2", "image", None, &serde_json::json!({}))
+            .insert_image_corpus(
+                "hash-2",
+                "image",
+                None,
+                &serde_json::json!({}),
+                &a_test_image(),
+            )
             .await
             .unwrap()
             .into_corpus();

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -27,6 +27,8 @@ impl Insertion {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CorpusStatus {
+    /// An image whose text has not been read yet. Only image corpora hold it.
+    Describing,
     Raw,
     /// Captured, stored, and deliberately not queued for synthesis: something
     /// near-identical is already in the base, and segmenting it would pay a
@@ -44,6 +46,7 @@ pub enum CorpusStatus {
 impl CorpusStatus {
     pub fn as_str(&self) -> &'static str {
         match self {
+            CorpusStatus::Describing => "describing",
             CorpusStatus::Raw => "raw",
             CorpusStatus::NeedsReview => "needs_review",
             CorpusStatus::Segmenting => "segmenting",
@@ -56,6 +59,7 @@ impl CorpusStatus {
     }
     pub fn parse(s: &str) -> CorpusStatus {
         match s {
+            "describing" => CorpusStatus::Describing,
             "needs_review" => CorpusStatus::NeedsReview,
             "segmenting" => CorpusStatus::Segmenting,
             "segmented" => CorpusStatus::Segmented,
@@ -98,6 +102,9 @@ pub struct Corpus {
     /// document, so nothing that reasons about the original text should trust
     /// it. `None` for every ordinary capture.
     pub restored_at: Option<i64>,
+    /// What the door knew about the capture beyond the text: a `note`, `file`
+    /// facts, `exif`. Namespaced JSON; `{}` when nothing was recorded.
+    pub metadata: serde_json::Value,
 }
 
 /// A stored corpus that a new capture looks like.
@@ -131,6 +138,10 @@ fn row_to_corpus(r: &sqlx::sqlite::SqliteRow) -> Corpus {
         near_dupe_score: r.get("near_dupe_score"),
         source_url: r.get("source_url"),
         restored_at: r.get("restored_at"),
+        metadata: r
+            .get::<Option<String>, _>("metadata")
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_else(|| serde_json::json!({})),
     }
 }
 
@@ -143,7 +154,14 @@ impl Store {
     ) -> Result<Corpus> {
         let sig = super::shingle::signature(raw_text);
         Ok(self
-            .insert_corpus_with_signature(raw_text, origin, title_hint, sig, None)
+            .insert_corpus_with_signature(
+                raw_text,
+                origin,
+                title_hint,
+                sig,
+                None,
+                &serde_json::json!({}),
+            )
             .await?
             .into_corpus())
     }
@@ -168,6 +186,7 @@ impl Store {
         title_hint: Option<&str>,
         shingles: Vec<u64>,
         source_url: Option<&str>,
+        metadata: &serde_json::Value,
     ) -> Result<Insertion> {
         let src = Corpus {
             id: new_id(),
@@ -185,10 +204,11 @@ impl Store {
             source_url: source_url.map(str::to_string),
             // A capture, not a placeholder. See `ensure_restored_corpus`.
             restored_at: None,
+            metadata: metadata.clone(),
         };
         let res = sqlx::query(
-            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, source_url)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, source_url, metadata)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(content_hash) DO NOTHING",
         )
         .bind(&src.id)
@@ -201,6 +221,7 @@ impl Store {
         .bind(src.updated_at)
         .bind(super::shingle::encode(&src.shingles))
         .bind(&src.source_url)
+        .bind(src.metadata.to_string())
         .execute(&self.pool)
         .await?;
         if res.rows_affected() == 0 {
@@ -436,6 +457,76 @@ impl Store {
         Ok(rows.iter().map(row_to_corpus).collect())
     }
 
+    /// The row for a captured image. There is no text yet — the vision stage
+    /// writes it — so the hash is the caller's, over the image bytes, and the
+    /// row starts in `describing`. Same conflict handling as a text capture:
+    /// the same photo twice is one row.
+    pub async fn insert_image_corpus(
+        &self,
+        content_hash: &str,
+        origin: &str,
+        title_hint: Option<&str>,
+        metadata: &serde_json::Value,
+    ) -> Result<Insertion> {
+        let at = now();
+        let id = new_id();
+        let res = sqlx::query(
+            "INSERT INTO corpora (id, raw_text, origin, title_hint, content_hash, status, created_at, updated_at, shingles, metadata)
+             VALUES (?, '', ?, ?, ?, ?, ?, ?, '', ?)
+             ON CONFLICT(content_hash) DO NOTHING",
+        )
+        .bind(&id)
+        .bind(origin)
+        .bind(title_hint)
+        .bind(content_hash)
+        .bind(CorpusStatus::Describing.as_str())
+        .bind(at)
+        .bind(at)
+        .bind(metadata.to_string())
+        .execute(&self.pool)
+        .await?;
+        let existing = self.find_by_hash(content_hash).await?.ok_or_else(|| {
+            Error::Store("image capture conflicted with a corpus that then vanished".into())
+        })?;
+        Ok(if res.rows_affected() == 0 {
+            Insertion::Existing(existing)
+        } else {
+            Insertion::Created(existing)
+        })
+    }
+
+    /// What the vision stage read. Text and signature together, so the row is
+    /// never comparable-by-shingle to something it does not say. Status is
+    /// left to the caller, who knows whether this parks or proceeds.
+    pub async fn set_described_text(&self, id: &str, text: &str, shingles: Vec<u64>) -> Result<()> {
+        let res = sqlx::query(
+            "UPDATE corpora SET raw_text = ?, shingles = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(text)
+        .bind(super::shingle::encode(&shingles))
+        .bind(now())
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Err(Error::NotFound);
+        }
+        Ok(())
+    }
+
+    pub async fn set_corpus_metadata(&self, id: &str, metadata: &serde_json::Value) -> Result<()> {
+        let res = sqlx::query("UPDATE corpora SET metadata = ?, updated_at = ? WHERE id = ?")
+            .bind(metadata.to_string())
+            .bind(now())
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Err(Error::NotFound);
+        }
+        Ok(())
+    }
+
     pub async fn delete_corpus(&self, id: &str) -> Result<()> {
         let res = sqlx::query("DELETE FROM corpora WHERE id = ?")
             .bind(id)
@@ -477,11 +568,25 @@ mod tests {
         let s = Store::memory().await.unwrap();
         let sig = super::super::shingle::signature("the same text");
         let first = s
-            .insert_corpus_with_signature("the same text", "web", None, sig.clone(), None)
+            .insert_corpus_with_signature(
+                "the same text",
+                "web",
+                None,
+                sig.clone(),
+                None,
+                &serde_json::json!({}),
+            )
             .await
             .unwrap();
         let second = s
-            .insert_corpus_with_signature("the same text", "mcp", Some("later"), sig, None)
+            .insert_corpus_with_signature(
+                "the same text",
+                "mcp",
+                Some("later"),
+                sig,
+                None,
+                &serde_json::json!({}),
+            )
             .await
             .unwrap();
 
@@ -723,5 +828,59 @@ mod tests {
         // Clearing it is what "keep both" does, and it must actually clear.
         s.set_near_dupe(&src.id, None, None).await.unwrap();
         assert!(s.get_corpus(&src.id).await.unwrap().near_dupe_of.is_none());
+    }
+
+    #[tokio::test]
+    async fn an_image_corpus_starts_describing_with_no_text_and_its_metadata() {
+        let s = Store::memory().await.unwrap();
+        let meta = serde_json::json!({"file": {"name": "a.jpg"}, "note": "whiteboard"});
+        let ins = s
+            .insert_image_corpus("hash-1", "image", Some("a.jpg"), &meta)
+            .await
+            .unwrap();
+        let src = ins.into_corpus();
+        assert_eq!(src.status, CorpusStatus::Describing);
+        assert_eq!(src.raw_text, "");
+        assert_eq!(src.content_hash, "hash-1");
+        let back = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(back.metadata["note"], "whiteboard");
+        assert_eq!(back.status, CorpusStatus::Describing);
+
+        // The same photo again is the same row.
+        assert!(matches!(
+            s.insert_image_corpus("hash-1", "image", None, &meta).await.unwrap(),
+            Insertion::Existing(e) if e.id == src.id
+        ));
+    }
+
+    #[tokio::test]
+    async fn describing_writes_the_text_and_signature_but_keeps_the_hash() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_image_corpus("hash-2", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        let sig = crate::store::shingle::signature("hello world");
+        s.set_described_text(&src.id, "hello world", sig.clone())
+            .await
+            .unwrap();
+        let back = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(back.raw_text, "hello world");
+        assert_eq!(back.shingles, sig);
+        assert_eq!(back.content_hash, "hash-2");
+        // Status is the caller's decision, not this write's.
+        assert_eq!(back.status, CorpusStatus::Describing);
+    }
+
+    #[tokio::test]
+    async fn metadata_defaults_to_an_empty_object_and_can_be_replaced() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("plain", "web", None).await.unwrap();
+        assert_eq!(src.metadata, serde_json::json!({}));
+        s.set_corpus_metadata(&src.id, &serde_json::json!({"note": "n"}))
+            .await
+            .unwrap();
+        assert_eq!(s.get_corpus(&src.id).await.unwrap().metadata["note"], "n");
     }
 }

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -346,6 +346,46 @@ impl Store {
         Ok(row.as_ref().map(row_to_corpus))
     }
 
+    /// Write a follow-up onto a corpus that already has a row — the same three
+    /// outcomes `insert_corpus_with_signature` writes beside a new one, and for
+    /// the same reason: status and job in one transaction.
+    ///
+    /// The path here is the one an image takes. Its row is written at capture
+    /// and its text only exists once the vision stage has read it, so the fork
+    /// between "queue this for synthesis" and "park it beside what it looks
+    /// like" happens long after the insert. Left as two statements, a process
+    /// that died between them left the corpus `raw` with no job: the reclaimed
+    /// Describe unit sees a status it is done with and returns, and `reconcile`
+    /// passes over a corpus that has no windows. The read had been paid for and
+    /// nothing would ever pick it up again.
+    pub async fn apply_followup(&self, corpus_id: &str, followup: Followup) -> Result<()> {
+        let (status, near_dupe_of, near_dupe_score) = match &followup {
+            Followup::Park { of, similarity } => (
+                CorpusStatus::NeedsReview,
+                Some(of.clone()),
+                Some(*similarity),
+            ),
+            Followup::Queue(_) | Followup::Nothing => (CorpusStatus::Raw, None, None),
+        };
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            "UPDATE corpora SET status = ?, near_dupe_of = ?, near_dupe_score = ?, updated_at = ?
+              WHERE id = ?",
+        )
+        .bind(status.as_str())
+        .bind(&near_dupe_of)
+        .bind(near_dupe_score)
+        .bind(now())
+        .bind(corpus_id)
+        .execute(&mut *tx)
+        .await?;
+        if let Followup::Queue(stage) = followup {
+            super::jobs::enqueue_with(&mut *tx, stage, "corpus", corpus_id).await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
     pub async fn set_corpus_status(&self, id: &str, status: CorpusStatus) -> Result<()> {
         sqlx::query("UPDATE corpora SET status = ?, updated_at = ? WHERE id = ?")
             .bind(status.as_str())
@@ -743,6 +783,54 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn a_followup_writes_the_status_and_the_job_it_implies_together() {
+        // An image reaches this fork after its read, long after its row. Two
+        // statements left a window where the corpus was `raw` with nothing
+        // queued, and nothing in the system looks for that state.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("x", "image", None).await.unwrap();
+        s.set_corpus_status(&src.id, CorpusStatus::Describing)
+            .await
+            .unwrap();
+
+        s.apply_followup(&src.id, Followup::Queue(Stage::Synthesize))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.get_corpus(&src.id).await.unwrap().status,
+            CorpusStatus::Raw
+        );
+        assert!(
+            s.live_job(Stage::Synthesize, &src.id).await.unwrap(),
+            "a raw corpus with no job is a corpus nothing will pick up"
+        );
+    }
+
+    #[tokio::test]
+    async fn parking_a_followup_names_what_it_parked_beside_and_queues_nothing() {
+        let s = Store::memory().await.unwrap();
+        let other = s.insert_corpus("older", "web", None).await.unwrap();
+        let src = s.insert_corpus("x", "image", None).await.unwrap();
+
+        s.apply_followup(
+            &src.id,
+            Followup::Park {
+                of: other.id.clone(),
+                similarity: 0.94,
+            },
+        )
+        .await
+        .unwrap();
+
+        let got = s.get_corpus(&src.id).await.unwrap();
+        assert_eq!(got.status, CorpusStatus::NeedsReview);
+        assert_eq!(got.near_dupe_of.as_deref(), Some(other.id.as_str()));
+        assert_eq!(got.near_dupe_score, Some(0.94));
+        assert!(!s.live_job(Stage::Synthesize, &src.id).await.unwrap());
     }
 
     #[tokio::test]

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -495,6 +495,17 @@ impl Store {
         })
     }
 
+    /// The reverse of `set_described_text`, for a re-read: no text and no
+    /// signature, so the row is comparable to nothing until the model speaks.
+    pub async fn clear_described_text(&self, id: &str) -> Result<()> {
+        sqlx::query("UPDATE corpora SET raw_text = '', shingles = '', updated_at = ? WHERE id = ?")
+            .bind(now())
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// What the vision stage read. Text and signature together, so the row is
     /// never comparable-by-shingle to something it does not say. Status is
     /// left to the caller, who knows whether this parks or proceeds.

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -272,7 +272,7 @@ impl Store {
         .bind(id)
         .bind(raw_text)
         .bind("restored:vector-store")
-        .bind(content_hash(&format!("restored:{id}")))
+        .bind(content_hash(format!("restored:{id}")))
         .bind(CorpusStatus::Partial.as_str())
         .bind(at)
         .bind(at)

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -115,8 +115,11 @@ pub struct NearDuplicate {
     pub similarity: f64,
 }
 
-pub fn content_hash(text: &str) -> String {
-    hex::encode(Sha256::digest(text.as_bytes()))
+/// The dedupe key of a corpus: text for a capture, the file's bytes for an
+/// image. One function, so the two doors can never drift onto different keys
+/// for the same column.
+pub fn content_hash(bytes: impl AsRef<[u8]>) -> String {
+    hex::encode(Sha256::digest(bytes.as_ref()))
 }
 
 fn row_to_corpus(r: &sqlx::sqlite::SqliteRow) -> Corpus {
@@ -662,6 +665,12 @@ mod tests {
             got.title_hint.as_deref(),
             Some("Unattended Upgrades on Debian")
         );
+    }
+
+    #[test]
+    fn content_hash_is_one_function_for_text_and_bytes() {
+        assert_eq!(content_hash("abc"), content_hash(b"abc"));
+        assert_eq!(content_hash("abc"), hex::encode(Sha256::digest(b"abc")));
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -35,6 +35,9 @@ pub enum Stage {
     /// which decays quadratically and leaves a given pair waiting years on a
     /// large base.
     Relate,
+    /// One image, one vision call: reads a captured image into the markdown
+    /// that becomes its `raw_text`, then hands off to `Synthesize`.
+    Describe,
 }
 
 impl Stage {
@@ -48,6 +51,7 @@ impl Stage {
             Stage::Consolidate => "consolidate",
             Stage::Dedupe => "dedupe",
             Stage::Relate => "relate",
+            Stage::Describe => "describe",
         }
     }
     pub fn parse(s: &str) -> Option<Stage> {
@@ -60,6 +64,7 @@ impl Stage {
             "consolidate" => Some(Stage::Consolidate),
             "dedupe" => Some(Stage::Dedupe),
             "relate" => Some(Stage::Relate),
+            "describe" => Some(Stage::Describe),
             _ => None,
         }
     }
@@ -867,5 +872,11 @@ mod tests {
             s.claim_job().await.unwrap().is_none(),
             "a legacy judge row survived migration and was claimed"
         );
+    }
+
+    #[test]
+    fn describe_is_a_stage_that_round_trips_its_name() {
+        assert_eq!(Stage::Describe.as_str(), "describe");
+        assert_eq!(Stage::parse("describe"), Some(Stage::Describe));
     }
 }

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -125,6 +125,37 @@ enum Guard {
     Closed,
 }
 
+/// `enqueue`, on whatever executor the caller is inside — a capture's
+/// transaction, so the row and the unit that processes it land together or
+/// not at all.
+pub(crate) async fn enqueue_with<'e>(
+    exec: impl sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    stage: Stage,
+    target_kind: &str,
+    target_id: &str,
+) -> Result<()> {
+    upsert_job_with(exec, stage, target_kind, target_id, 0, Guard::Any).await
+}
+
+async fn upsert_job_with<'e>(
+    exec: impl sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    stage: Stage,
+    target_kind: &str,
+    target_id: &str,
+    seq: i64,
+    guard: Guard,
+) -> Result<()> {
+    sqlx::query(guard.statement())
+        .bind(stage.as_str())
+        .bind(target_kind)
+        .bind(target_id)
+        .bind(now())
+        .bind(seq)
+        .execute(exec)
+        .await?;
+    Ok(())
+}
+
 /// The upsert the three guards share, spelled out once per guard because a
 /// statement assembled at runtime is a statement nobody can read in the source.
 macro_rules! arm_job {
@@ -207,15 +238,7 @@ impl Store {
         seq: i64,
         guard: Guard,
     ) -> Result<()> {
-        sqlx::query(guard.statement())
-            .bind(stage.as_str())
-            .bind(target_kind)
-            .bind(target_id)
-            .bind(now())
-            .bind(seq)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+        upsert_job_with(&self.pool, stage, target_kind, target_id, seq, guard).await
     }
 
     /// The `seq` a job currently carries, so a unit that re-arms itself can

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,4 +1,5 @@
 pub mod artifacts;
+pub mod attachments;
 pub mod auth;
 pub mod corpora;
 pub mod feedback;
@@ -107,6 +108,9 @@ impl Store {
             // existing row, which is correct: nothing predating the column
             // was explicitly restored.
             ("artifact_sources", "restored", "INTEGER NOT NULL DEFAULT 0"),
+            // Arrived with image capture. Every corpus predating it recorded
+            // nothing beyond its text, which is what the empty object says.
+            ("corpora", "metadata", "TEXT NOT NULL DEFAULT '{}'"),
         ];
 
         // Before the schema, not after. `schema.sql` builds an index over `seq`,
@@ -310,7 +314,14 @@ mod tests {
 
         // And a capture still works against the upgraded base.
         let c = store
-            .insert_corpus_with_signature("alpha\n\nbeta", "web", None, vec![], None)
+            .insert_corpus_with_signature(
+                "alpha\n\nbeta",
+                "web",
+                None,
+                vec![],
+                None,
+                &serde_json::json!({}),
+            )
             .await
             .unwrap()
             .into_corpus();
@@ -405,7 +416,14 @@ mod tests {
         // And the defaults have to be the truth about an artifact that predates
         // merging, or every one of them reads back as a merge with no sources.
         let c = store
-            .insert_corpus_with_signature("alpha\n\nbeta", "web", None, vec![], None)
+            .insert_corpus_with_signature(
+                "alpha\n\nbeta",
+                "web",
+                None,
+                vec![],
+                None,
+                &serde_json::json!({}),
+            )
             .await
             .unwrap()
             .into_corpus();

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -321,6 +321,7 @@ mod tests {
                 vec![],
                 None,
                 &serde_json::json!({}),
+                crate::store::corpora::Followup::Nothing,
             )
             .await
             .unwrap()
@@ -423,6 +424,7 @@ mod tests {
                 vec![],
                 None,
                 &serde_json::json!({}),
+                crate::store::corpora::Followup::Nothing,
             )
             .await
             .unwrap()

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -42,8 +42,28 @@ CREATE TABLE IF NOT EXISTS corpora (
   -- channel it arrived through and this is the location it came from; one
   -- column cannot be both without losing the channel.
   source_url      TEXT,
-  restored_at     INTEGER
+  restored_at     INTEGER,
+  -- What a door knew about the capture beyond the text: a note, file facts,
+  -- EXIF. Namespaced JSON, '{}' when nothing was recorded.
+  metadata        TEXT NOT NULL DEFAULT '{}'
 );
+
+-- The bytes an image corpus was captured from. `bytes` is the upload exactly
+-- as it arrived — the verbatim source, as `raw_text` is for a paste — and
+-- `preview` is the one derived copy: orientation applied, downscaled, JPEG.
+CREATE TABLE IF NOT EXISTS attachments (
+  id         INTEGER PRIMARY KEY,
+  corpus_id  TEXT    NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+  kind       TEXT    NOT NULL,
+  mime       TEXT    NOT NULL,
+  filename   TEXT,
+  bytes      BLOB    NOT NULL,
+  preview    BLOB    NOT NULL,
+  width      INTEGER,
+  height     INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS attachments_corpus ON attachments(corpus_id);
 CREATE INDEX IF NOT EXISTS idx_corpora_status  ON corpora(status);
 CREATE INDEX IF NOT EXISTS idx_corpora_created ON corpora(created_at DESC);
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -281,58 +281,184 @@ async fn upload(
     _id: Identity,
     mut multipart: axum::extract::Multipart,
 ) -> Result<(StatusCode, Json<crate::core::ingest::IngestOutcome>)> {
+    let mut note: Option<String> = None;
+    // (filename, declared type, bytes). Collected rather than acted on in the
+    // loop, because a `note` part may come before or after the file.
+    let mut file: Option<(Option<String>, String, axum::body::Bytes)> = None;
     while let Some(field) = multipart
         .next_field()
         .await
         .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
     {
-        if field.name() != Some("file") {
-            continue;
-        }
-        let filename = field.file_name().map(str::to_string);
-        // A part may legally carry no `Content-Type` at all, and letting that
-        // skip the check turns "`.txt` and nothing else" into "anything whose
-        // bytes happen to be UTF-8" — a `.csv`, a `.json`, a page of HTML.
-        // An absent type is not a pass; it just moves the question to the
-        // name, which is the only other thing the sender told us.
-        let declared = field.content_type().unwrap_or("").to_string();
-        if declared.is_empty() {
-            if !named_txt(filename.as_deref()) {
-                return Err(Error::Validation(
-                    "that upload declares no type and is not named `.txt` — \
-                     only text/plain is accepted"
-                        .into(),
-                ));
+        match field.name() {
+            Some("note") => {
+                note = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?,
+                )
             }
-        } else if !declared.starts_with("text/plain") {
-            return Err(Error::Validation(format!(
-                "that file is `{declared}` — only text/plain is accepted"
-            )));
+            Some("file") => {
+                let filename = field.file_name().map(str::to_string);
+                let declared = field.content_type().unwrap_or("").to_string();
+                let bytes = field
+                    .bytes()
+                    .await
+                    .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
+                file = Some((filename, declared, bytes));
+            }
+            _ => {}
         }
-        let bytes = field
-            .bytes()
-            .await
-            .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
-        // Refused rather than lossily converted: a corpus is quoted back
-        // verbatim, so text that arrived mangled would be a fidelity loss
-        // nothing downstream could detect.
-        let text = String::from_utf8(bytes.to_vec())
-            .map_err(|_| Error::Validation("that file is not valid UTF-8 text".into()))?;
-
-        let out = st
-            .core
-            .ingest_capture(
-                crate::core::ingest::Capture::new(text, ORIGIN_UPLOAD).with_title(filename),
-            )
-            .await?;
-        let code = if out.duplicate {
-            StatusCode::OK
-        } else {
-            StatusCode::CREATED
-        };
-        return Ok((code, Json(out)));
     }
-    Err(Error::Validation("no file in the upload".into()))
+    let Some((filename, declared, bytes)) = file else {
+        return Err(Error::Validation("no file in the upload".into()));
+    };
+    // A part may legally carry no `Content-Type` at all, and letting that
+    // skip the check turns "`.txt` and nothing else" into "anything whose
+    // bytes happen to be UTF-8" — a `.csv`, a `.json`, a page of HTML.
+    // An absent type is not a pass; it just moves the question to the
+    // name, which is the only other thing the sender told us.
+    if declared.is_empty() {
+        if !named_txt(filename.as_deref()) {
+            return Err(Error::Validation(
+                "that upload declares no type and is not named `.txt` — \
+                 only text/plain is accepted"
+                    .into(),
+            ));
+        }
+    } else if !declared.starts_with("text/plain") {
+        return Err(Error::Validation(format!(
+            "that file is `{declared}` — only text/plain is accepted"
+        )));
+    }
+    // Refused rather than lossily converted: a corpus is quoted back
+    // verbatim, so text that arrived mangled would be a fidelity loss
+    // nothing downstream could detect.
+    let text = String::from_utf8(bytes.to_vec())
+        .map_err(|_| Error::Validation("that file is not valid UTF-8 text".into()))?;
+    let size = bytes.len();
+
+    let out = st
+        .core
+        .ingest_capture(
+            crate::core::ingest::Capture::new(text, ORIGIN_UPLOAD)
+                .with_title(filename.clone())
+                .with_note(note)
+                .with_file(filename.as_deref(), size, "text/plain"),
+        )
+        .await?;
+    let code = if out.duplicate {
+        StatusCode::OK
+    } else {
+        StatusCode::CREATED
+    };
+    Ok((code, Json(out)))
+}
+
+/// The image door. Parts: `image` (required), `title_hint`, `note`. The
+/// bytes are validated and stored here; the reading happens in a job.
+async fn upload_image(
+    State(st): State<AppState>,
+    _id: Identity,
+    mut multipart: axum::extract::Multipart,
+) -> Result<(StatusCode, Json<crate::core::ingest::IngestOutcome>)> {
+    let mut note = None;
+    let mut title_hint = None;
+    let mut image: Option<(Option<String>, axum::body::Bytes)> = None;
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
+    {
+        match field.name() {
+            Some("note") => {
+                note = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?,
+                )
+            }
+            Some("title_hint") => {
+                title_hint = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?,
+                )
+                .filter(|t: &String| !t.trim().is_empty())
+            }
+            Some("image") => {
+                let filename = field.file_name().map(str::to_string);
+                let bytes = field
+                    .bytes()
+                    .await
+                    .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
+                image = Some((filename, bytes));
+            }
+            _ => {}
+        }
+    }
+    let Some((filename, bytes)) = image else {
+        return Err(Error::Validation("no image in the upload".into()));
+    };
+    let out = st
+        .core
+        .ingest_image(crate::core::ingest::ImageCapture {
+            bytes: bytes.to_vec(),
+            filename,
+            title_hint,
+            note,
+        })
+        .await?;
+    // 202, not 201: stored, but the reading — the part that makes it a corpus
+    // anyone can search — is still queued.
+    let code = if out.duplicate {
+        StatusCode::OK
+    } else {
+        StatusCode::ACCEPTED
+    };
+    Ok((code, Json(out)))
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ImageQuery {
+    #[serde(default)]
+    original: Option<String>,
+}
+
+/// The preview by default; `?original=1` for the bytes as uploaded.
+async fn get_image(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(id): Path<String>,
+    Query(q): Query<ImageQuery>,
+) -> Result<axum::response::Response> {
+    use axum::response::IntoResponse;
+    let want_original = q
+        .original
+        .as_deref()
+        .is_some_and(|v| v == "1" || v == "true");
+    let found = if want_original {
+        st.core.store.attachment_original(&id).await?
+    } else {
+        st.core.store.attachment_preview(&id).await?
+    };
+    let Some((mime, bytes)) = found else {
+        return Err(Error::NotFound);
+    };
+    Ok((
+        [
+            (axum::http::header::CONTENT_TYPE, mime),
+            (
+                axum::http::header::CACHE_CONTROL,
+                "private, max-age=3600".to_string(),
+            ),
+        ],
+        bytes,
+    )
+        .into_response())
 }
 
 #[derive(serde::Deserialize)]
@@ -695,11 +821,17 @@ async fn status(State(st): State<AppState>, _id: Identity) -> Result<Json<Status
     }))
 }
 
-pub fn api_router() -> Router<AppState> {
+pub fn api_router(image_max_bytes: usize) -> Router<AppState> {
     Router::new()
         .route("/corpora", post(ingest).get(list_corpora))
         .route("/corpora/upload", post(upload))
+        // Its own ceiling: a phone photo is several times the global limit.
+        .route(
+            "/corpora/image",
+            post(upload_image).layer(axum::extract::DefaultBodyLimit::max(image_max_bytes)),
+        )
         .route("/corpora/{id}", get(get_corpus).delete(delete_corpus))
+        .route("/corpora/{id}/image", get(get_image))
         .route("/corpora/{id}/reprocess", post(reprocess))
         .route("/corpora/{id}/resolve", post(resolve_near_dupe))
         .route("/search", get(search))
@@ -822,6 +954,293 @@ pub(crate) mod tests {
             .header("content-type", format!("multipart/form-data; boundary={B}"))
             .body(Body::from(buf))
             .unwrap()
+    }
+
+    /// Like `post_file`, with text fields sent before the file part.
+    fn post_file_with(
+        uri: &str,
+        token: &str,
+        fields: &[(&str, &str)],
+        field_name: &str,
+        filename: &str,
+        mime: Option<&str>,
+        body: &[u8],
+    ) -> Request<Body> {
+        const B: &str = "engramtestboundary";
+        let mut buf: Vec<u8> = Vec::new();
+        for (k, v) in fields {
+            buf.extend_from_slice(
+                format!("--{B}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n")
+                    .as_bytes(),
+            );
+        }
+        let typed = match mime {
+            Some(m) => format!("Content-Type: {m}\r\n"),
+            None => String::new(),
+        };
+        buf.extend_from_slice(
+            format!(
+                "--{B}\r\nContent-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n{typed}\r\n"
+            )
+            .as_bytes(),
+        );
+        buf.extend_from_slice(body);
+        buf.extend_from_slice(format!("\r\n--{B}--\r\n").as_bytes());
+        Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", format!("multipart/form-data; boundary={B}"))
+            .body(Body::from(buf))
+            .unwrap()
+    }
+
+    fn a_png() -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(24, 12, |x, _| Rgb([x as u8 * 10, 0, 0]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    #[tokio::test]
+    async fn an_image_upload_is_accepted_with_its_note_and_queued() {
+        let (app, token, core) = app_token_and_core().await;
+        let res = app
+            .clone()
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[
+                    ("note", "front of the router"),
+                    ("title_hint", "Router label"),
+                ],
+                "image",
+                "IMG_9.png",
+                Some("image/png"),
+                &a_png(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+        let body = json_of(res).await;
+        assert_eq!(body["status"], "describing");
+        let id = body["id"].as_str().unwrap().to_string();
+        let src = core.store.get_corpus(&id).await.unwrap();
+        assert_eq!(src.title_hint.as_deref(), Some("Router label"));
+        assert_eq!(src.metadata["note"], "front of the router");
+        assert_eq!(src.origin, "image");
+
+        // The same bytes again: 200, same id.
+        let res = app
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[],
+                "image",
+                "IMG_9.png",
+                Some("image/png"),
+                &a_png(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(json_of(res).await["id"], id);
+    }
+
+    #[tokio::test]
+    async fn the_image_door_refuses_junk_missing_parts_and_a_closed_door() {
+        let (app, token, core) = app_token_and_core().await;
+        let res = app
+            .clone()
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[],
+                "image",
+                "x.jpg",
+                Some("image/jpeg"),
+                b"not really",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            json_of(res).await["error"]
+                .as_str()
+                .unwrap()
+                .contains("supported image")
+        );
+
+        let res = app
+            .clone()
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[("note", "n")],
+                "file",
+                "x.png",
+                Some("image/png"),
+                &a_png(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::BAD_REQUEST,
+            "wrong part name is 'no image in the upload'"
+        );
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+
+        let (app, token, _) =
+            app_from_core(crate::core::test_support::test_core_without_vision().await).await;
+        let res = app
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[],
+                "image",
+                "x.png",
+                Some("image/png"),
+                &a_png(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            json_of(res).await["error"]
+                .as_str()
+                .unwrap()
+                .contains("not configured")
+        );
+    }
+
+    #[tokio::test]
+    async fn the_image_door_has_its_own_larger_body_limit() {
+        // Over the global 8 MB, under the image ceiling: the multipart parser
+        // gets to see it, so the answer is the handler's (junk → 400), not the
+        // framework's 413.
+        let (app, token) = app_and_token().await;
+        let big = vec![0u8; crate::web::MAX_BODY_BYTES + 1024];
+        let res = app
+            .clone()
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[],
+                "image",
+                "big.png",
+                Some("image/png"),
+                &big,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        // And the text door still stops at 8 MB. Multipart streams, so the
+        // limit surfaces as a parse error inside the handler rather than a
+        // 413 from the framework; either way nothing is stored.
+        let (app, token, core) = app_token_and_core().await;
+        let res = app
+            .oneshot(post_file(
+                "/api/v1/corpora/upload",
+                &token,
+                "big.txt",
+                Some("text/plain"),
+                &big,
+            ))
+            .await
+            .unwrap();
+        assert!(
+            matches!(
+                res.status(),
+                StatusCode::BAD_REQUEST | StatusCode::PAYLOAD_TOO_LARGE
+            ),
+            "{}",
+            res.status()
+        );
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_preview_and_the_original_are_served() {
+        let (app, token, _core) = app_token_and_core().await;
+        let res = app
+            .clone()
+            .oneshot(post_file_with(
+                "/api/v1/corpora/image",
+                &token,
+                &[],
+                "image",
+                "p.png",
+                Some("image/png"),
+                &a_png(),
+            ))
+            .await
+            .unwrap();
+        let id = json_of(res).await["id"].as_str().unwrap().to_string();
+
+        let res = app
+            .clone()
+            .oneshot(get(&format!("/api/v1/corpora/{id}/image"), Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["content-type"], "image/jpeg");
+        let bytes = axum::body::to_bytes(res.into_body(), 1 << 22)
+            .await
+            .unwrap();
+        assert!(image::load_from_memory(&bytes).is_ok());
+
+        let res = app
+            .clone()
+            .oneshot(get(
+                &format!("/api/v1/corpora/{id}/image?original=1"),
+                Some(&token),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.headers()["content-type"], "image/png");
+        let bytes = axum::body::to_bytes(res.into_body(), 1 << 22)
+            .await
+            .unwrap();
+        assert_eq!(bytes.to_vec(), a_png());
+
+        let res = app
+            .clone()
+            .oneshot(get(&format!("/api/v1/corpora/{id}/image"), None))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+        let res = app
+            .oneshot(get("/api/v1/corpora/nope/image", Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn a_text_upload_records_its_note_and_file_facts() {
+        let (app, token, core) = app_token_and_core().await;
+        let res = app
+            .oneshot(post_file_with(
+                "/api/v1/corpora/upload",
+                &token,
+                &[("note", "from the printer")],
+                "file",
+                "notes.txt",
+                Some("text/plain"),
+                b"hello there",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+        let id = json_of(res).await["id"].as_str().unwrap().to_string();
+        let m = core.store.get_corpus(&id).await.unwrap().metadata;
+        assert_eq!(m["note"], "from the printer");
+        assert_eq!(m["file"]["name"], "notes.txt");
+        assert_eq!(m["file"]["size"], 11);
     }
 
     #[tokio::test]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -343,7 +343,6 @@ async fn upload(
         .core
         .ingest_capture(
             crate::core::ingest::Capture::new(text, ORIGIN_UPLOAD)
-                .with_title(filename.clone())
                 .with_note(note)
                 .with_file(filename.as_deref(), size, "text/plain"),
         )
@@ -1392,7 +1391,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn an_uploaded_filename_becomes_the_title_hint() {
+    async fn an_uploaded_filename_is_a_file_fact_not_a_title() {
         let (app, token, core) = app_token_and_core().await;
         let res = app
             .oneshot(post_file(
@@ -1407,7 +1406,11 @@ pub(crate) mod tests {
         assert_eq!(res.status(), StatusCode::CREATED);
         let id = json_of(res).await["id"].as_str().unwrap().to_string();
         let src = core.store.get_corpus(&id).await.unwrap();
-        assert_eq!(src.title_hint.as_deref(), Some("mounting-notes.txt"));
+        assert_eq!(
+            src.title_hint, None,
+            "the Title stage names it; the filename is not a name"
+        );
+        assert_eq!(src.metadata["file"]["name"], "mounting-notes.txt");
         assert_eq!(src.origin, "upload");
         assert_eq!(src.source_url, None);
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -273,47 +273,91 @@ fn named_txt(filename: Option<&str>) -> bool {
     })
 }
 
+/// One file part of a multipart upload.
+struct FilePart {
+    filename: Option<String>,
+    /// The part's `Content-Type`, or "" when it carried none.
+    declared: String,
+    bytes: axum::body::Bytes,
+}
+
+struct UploadParts {
+    file: Option<FilePart>,
+    /// The text fields asked for, by name; only non-blank values are kept.
+    fields: std::collections::HashMap<&'static str, String>,
+}
+
+/// Drain a multipart body: one file part under `file_field`, any of
+/// `text_fields` as text. Order-independent, because a browser sends `note`
+/// before or after the file depending on the form. A second part under
+/// `file_field` is refused rather than silently winning or losing: two files
+/// in one request is a client bug, and whichever we picked would be wrong for
+/// half of them.
+async fn read_upload(
+    mut multipart: axum::extract::Multipart,
+    file_field: &'static str,
+    text_fields: &[&'static str],
+) -> Result<UploadParts> {
+    let mut out = UploadParts {
+        file: None,
+        fields: Default::default(),
+    };
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
+    {
+        let Some(name) = field.name().map(str::to_string) else {
+            continue;
+        };
+        if name == file_field {
+            if out.file.is_some() {
+                return Err(Error::Validation(format!(
+                    "more than one `{file_field}` part — send one file per request"
+                )));
+            }
+            let filename = field.file_name().map(str::to_string);
+            let declared = field.content_type().unwrap_or("").to_string();
+            let bytes = field
+                .bytes()
+                .await
+                .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
+            out.file = Some(FilePart {
+                filename,
+                declared,
+                bytes,
+            });
+        } else if let Some(key) = text_fields.iter().copied().find(|k| *k == name) {
+            let text = field
+                .text()
+                .await
+                .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?;
+            if !text.trim().is_empty() {
+                out.fields.insert(key, text);
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// `.txt` and nothing else, for now. PDF is a `SourceView` implementation and
 /// a later plan; refusing everything else by name is what keeps this one from
 /// quietly ingesting the bytes of a format it cannot read.
 async fn upload(
     State(st): State<AppState>,
     _id: Identity,
-    mut multipart: axum::extract::Multipart,
+    multipart: axum::extract::Multipart,
 ) -> Result<(StatusCode, Json<crate::core::ingest::IngestOutcome>)> {
-    let mut note: Option<String> = None;
-    // (filename, declared type, bytes). Collected rather than acted on in the
-    // loop, because a `note` part may come before or after the file.
-    let mut file: Option<(Option<String>, String, axum::body::Bytes)> = None;
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
-    {
-        match field.name() {
-            Some("note") => {
-                note = Some(
-                    field
-                        .text()
-                        .await
-                        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?,
-                )
-            }
-            Some("file") => {
-                let filename = field.file_name().map(str::to_string);
-                let declared = field.content_type().unwrap_or("").to_string();
-                let bytes = field
-                    .bytes()
-                    .await
-                    .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
-                file = Some((filename, declared, bytes));
-            }
-            _ => {}
-        }
-    }
-    let Some((filename, declared, bytes)) = file else {
+    let parts = read_upload(multipart, "file", &["note"]).await?;
+    let Some(FilePart {
+        filename,
+        declared,
+        bytes,
+    }) = parts.file
+    else {
         return Err(Error::Validation("no file in the upload".into()));
     };
+    let note = parts.fields.get("note").cloned();
     // A part may legally carry no `Content-Type` at all, and letting that
     // skip the check turns "`.txt` and nothing else" into "anything whose
     // bytes happen to be UTF-8" — a `.csv`, a `.json`, a page of HTML.
@@ -360,46 +404,13 @@ async fn upload(
 async fn upload_image(
     State(st): State<AppState>,
     _id: Identity,
-    mut multipart: axum::extract::Multipart,
+    multipart: axum::extract::Multipart,
 ) -> Result<(StatusCode, Json<crate::core::ingest::IngestOutcome>)> {
-    let mut note = None;
-    let mut title_hint = None;
-    let mut image: Option<(Option<String>, axum::body::Bytes)> = None;
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?
-    {
-        match field.name() {
-            Some("note") => {
-                note = Some(
-                    field
-                        .text()
-                        .await
-                        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?,
-                )
-            }
-            Some("title_hint") => {
-                title_hint = Some(
-                    field
-                        .text()
-                        .await
-                        .map_err(|e| Error::Validation(format!("malformed upload: {e}")))?,
-                )
-                .filter(|t: &String| !t.trim().is_empty())
-            }
-            Some("image") => {
-                let filename = field.file_name().map(str::to_string);
-                let bytes = field
-                    .bytes()
-                    .await
-                    .map_err(|e| Error::Validation(format!("upload failed: {e}")))?;
-                image = Some((filename, bytes));
-            }
-            _ => {}
-        }
-    }
-    let Some((filename, bytes)) = image else {
+    let mut parts = read_upload(multipart, "image", &["note", "title_hint"]).await?;
+    let Some(FilePart {
+        filename, bytes, ..
+    }) = parts.file
+    else {
         return Err(Error::Validation("no image in the upload".into()));
     };
     let out = st
@@ -407,8 +418,8 @@ async fn upload_image(
         .ingest_image(crate::core::ingest::ImageCapture {
             bytes: bytes.to_vec(),
             filename,
-            title_hint,
-            note,
+            title_hint: parts.fields.remove("title_hint"),
+            note: parts.fields.remove("note"),
         })
         .await?;
     // 202, not 201: stored, but the reading — the part that makes it a corpus
@@ -992,6 +1003,45 @@ pub(crate) mod tests {
             .header("content-type", format!("multipart/form-data; boundary={B}"))
             .body(Body::from(buf))
             .unwrap()
+    }
+
+    /// Two parts under the same file field, which no browser form sends and
+    /// no handler should guess about.
+    fn post_two_files(uri: &str, token: &str, field_name: &str, mime: &str) -> Request<Body> {
+        const B: &str = "engramtestboundary";
+        let mut buf = String::new();
+        for (name, body) in [("a", "first"), ("b", "second")] {
+            buf.push_str(&format!(
+                "--{B}\r\nContent-Disposition: form-data; name=\"{field_name}\"; filename=\"{name}.txt\"\r\nContent-Type: {mime}\r\n\r\n{body}\r\n"
+            ));
+        }
+        buf.push_str(&format!("--{B}--\r\n"));
+        Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", format!("multipart/form-data; boundary={B}"))
+            .body(Body::from(buf))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn an_upload_with_two_file_parts_is_refused() {
+        let (app, token, core) = app_token_and_core().await;
+        for (uri, field, mime) in [
+            ("/api/v1/corpora/upload", "file", "text/plain"),
+            ("/api/v1/corpora/image", "image", "image/png"),
+        ] {
+            let res = app
+                .clone()
+                .oneshot(post_two_files(uri, &token, field, mime))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::BAD_REQUEST, "{uri}");
+            let err = json_of(res).await["error"].as_str().unwrap().to_string();
+            assert!(err.contains("one file"), "{uri}: {err}");
+        }
+        assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
     }
 
     fn a_png() -> Vec<u8> {

--- a/src/web/corpus_view.rs
+++ b/src/web/corpus_view.rs
@@ -162,7 +162,21 @@ mod tests {
     async fn an_image_corpus_labels_its_lines_as_transcription() {
         let s = crate::store::Store::memory().await.unwrap();
         let src = s
-            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .insert_image_corpus(
+                "h",
+                "image",
+                None,
+                &serde_json::json!({}),
+                &crate::store::attachments::NewImage {
+                    kind: "image",
+                    mime: "image/png",
+                    filename: None,
+                    bytes: b"orig",
+                    preview: b"prev",
+                    width: Some(1),
+                    height: Some(1),
+                },
+            )
             .await
             .unwrap()
             .into_corpus();

--- a/src/web/corpus_view.rs
+++ b/src/web/corpus_view.rs
@@ -1,10 +1,11 @@
 //! How the right-hand pane gets at the text a chunk claims to come from.
 //!
 //! A trait rather than a function because the answer depends on what the
-//! source is. Today every source is raw text and `TextLines` answers all of
-//! them. A PDF source will implement the same trait — its label reads
-//! `page 42` and its lines come from extracted text — and nothing in the pane
-//! needs to know which implementation answered.
+//! source is. A text source is answered by `TextLines`; an image source by
+//! `ImageTranscript`, whose lines are the model's reading of the picture. A
+//! PDF source will implement the same trait — its label reads `page 42` and
+//! its lines come from extracted text — and nothing in the pane needs to know
+//! which implementation answered.
 
 use crate::store::artifacts::CorpusSpan;
 use crate::store::corpora::Corpus;
@@ -75,10 +76,29 @@ impl CorpusView for TextLines {
     }
 }
 
-/// The view for a source. One implementation today; this is where a PDF source
-/// will branch.
-pub fn for_corpus(_source: &Corpus) -> Box<dyn CorpusView> {
-    Box::new(TextLines)
+/// An image corpus: the lines are the model's reading of the picture, and the
+/// label says so, because a span into a transcription is a claim about what
+/// the model wrote, not about what the photo shows.
+pub struct ImageTranscript;
+
+impl CorpusView for ImageTranscript {
+    fn slice(&self, source: &Corpus, span: Option<&CorpusSpan>, context: usize) -> CorpusSlice {
+        let mut s = TextLines.slice(source, span, context);
+        s.label = match span {
+            Some(sp) => format!("transcription lines {}–{}", sp.start_line, sp.end_line),
+            None => "transcription".into(),
+        };
+        s
+    }
+}
+
+/// The view for a source. This is where a PDF source will branch too.
+pub fn for_corpus(source: &Corpus) -> Box<dyn CorpusView> {
+    if source.origin == crate::core::ingest::ORIGIN_IMAGE {
+        Box::new(ImageTranscript)
+    } else {
+        Box::new(TextLines)
+    }
 }
 
 #[cfg(test)]
@@ -136,5 +156,33 @@ mod tests {
             2,
         );
         assert!(slice.lines.iter().all(|l| l.number <= 2));
+    }
+
+    #[tokio::test]
+    async fn an_image_corpus_labels_its_lines_as_transcription() {
+        let s = crate::store::Store::memory().await.unwrap();
+        let src = s
+            .insert_image_corpus("h", "image", None, &serde_json::json!({}))
+            .await
+            .unwrap()
+            .into_corpus();
+        s.set_described_text(&src.id, "a\nb\nc", vec![])
+            .await
+            .unwrap();
+        let src = s.get_corpus(&src.id).await.unwrap();
+        let view = for_corpus(&src);
+        assert_eq!(
+            view.slice(
+                &src,
+                Some(&CorpusSpan {
+                    start_line: 2,
+                    end_line: 2
+                }),
+                0
+            )
+            .label,
+            "transcription lines 2–2"
+        );
+        assert_eq!(view.slice(&src, None, 0).label, "transcription");
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -60,7 +60,10 @@ pub fn router(state: AppState) -> Router {
         .merge(extension::extension_router())
         .merge(judge::judge_router())
         .merge(crate::mcp::mcp_router(state.clone()))
-        .nest("/api/v1", api::api_router())
+        .nest(
+            "/api/v1",
+            api::api_router(state.core.capture.image_max_bytes),
+        )
         .layer(axum::middleware::from_fn(redirect_unauthenticated_browsers))
         .layer(axum::extract::DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(tower_http::trace::TraceLayer::new_for_http())

--- a/src/web/templates/capture.html
+++ b/src/web/templates/capture.html
@@ -26,14 +26,24 @@
      and this one is multipart. #}
   <label class="row muted" id="drop"
          style="border:1px dashed var(--line);padding:.6rem;border-radius:.4rem">
+    {% if vision_enabled %}
+    <input type="file" name="file" accept=".txt,text/plain,image/*" hidden>
+    <span>…or drop a <code>.txt</code> file or an image here — on a phone, tap to take a photo.</span>
+    {% else %}
     <input type="file" name="file" accept=".txt,text/plain" hidden>
     <span>…or drop a <code>.txt</code> file here.</span>
+    {% endif %}
   </label>
   <div class="row">
     <button class="btn btn-accent" type="submit">Capture</button>
     <span class="spinner">saving…</span>
   </div>
 </form>
+{# Context for whatever file comes next: a sentence about what it is. Sent
+   with the file, then cleared. For an image the vision model reads it too.
+   Outside the form above on purpose, so a text paste does not send it. #}
+<input class="input" type="text" name="note" maxlength="2000" style="margin-top:.6rem;width:100%"
+       placeholder="Add context for the file (optional) — what is it, why keep it?">
 <div id="capture-result" style="margin-top:1rem"></div>
 
 {% if !pairs.is_empty() %}
@@ -72,17 +82,27 @@
 
     var drop = document.getElementById('drop');
     var picker = drop && drop.querySelector('input[type=file]');
+    var noteBox = document.querySelector('input[name="note"]');
+    var VISION = {% if vision_enabled %}true{% else %}false{% endif %};
     function send(file) {
       if (!file) return;
+      var isImage = file.type.indexOf('image/') === 0;
+      var result = document.getElementById('capture-result');
+      if (isImage && !VISION) {
+        result.textContent = 'Image capture is not configured on this server.';
+        return;
+      }
       var payload = new FormData();
-      payload.append('file', file);
+      if (noteBox && noteBox.value.trim()) payload.append('note', noteBox.value.trim());
+      payload.append(isImage ? 'image' : 'file', file, file.name || (isImage ? 'photo.jpg' : 'paste.txt'));
+      var url = isImage ? '/api/v1/corpora/image' : '/api/v1/corpora/upload';
       // The session cookie authenticates this: it is same-origin, so no token
       // is involved.
-      fetch('/api/v1/corpora/upload', { method: 'POST', body: payload })
-        // Not every failure answers in JSON. A file over the 8 MB body limit
-        // is rejected by the framework before the handler sees it, and that
-        // reply is plain text — parsing it threw, and with nothing catching
-        // the throw the drop zone sat there having visibly done nothing.
+      fetch(url, { method: 'POST', body: payload })
+        // Not every failure answers in JSON. A file over the body limit is
+        // rejected before the handler sees it, and that reply is plain text —
+        // parsing it threw, and with nothing catching the throw the drop zone
+        // sat there having visibly done nothing.
         .then(function (r) {
           return r.json()
             .catch(function () { return { error: 'engram answered ' + r.status + '.' }; })
@@ -90,12 +110,16 @@
         })
         .catch(function () { return [false, { error: 'engram is unreachable.' }]; })
         .then(function (pair) {
-          var result = document.getElementById('capture-result');
           // The server's reason, verbatim. A generic "upload failed" would
-          // hide the two things that actually go wrong here: wrong type and
-          // wrong encoding.
-          result.textContent = pair[0] ? 'Captured.' : (pair[1].error || 'Upload failed.');
-          if (pair[0]) htmx.trigger(document.body, 'captured');
+          // hide what actually goes wrong here: wrong type, wrong encoding,
+          // an image door that is closed.
+          result.textContent = pair[0]
+            ? (isImage ? 'Captured — the photo is queued to be read.' : 'Captured.')
+            : (pair[1].error || 'Upload failed.');
+          if (pair[0]) {
+            if (noteBox) noteBox.value = '';
+            htmx.trigger(document.body, 'captured');
+          }
         });
     }
     if (drop) {
@@ -106,6 +130,17 @@
         send(e.dataTransfer.files[0]);
       });
     }
+    // A pasted screenshot goes the same way as a dropped one.
+    document.addEventListener('paste', function (e) {
+      var items = (e.clipboardData && e.clipboardData.items) || [];
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].kind === 'file' && items[i].type.indexOf('image/') === 0) {
+          e.preventDefault();
+          send(items[i].getAsFile());
+          return;
+        }
+      }
+    });
   })();
 </script>
 {% endblock %}

--- a/src/web/templates/capture.html
+++ b/src/web/templates/capture.html
@@ -130,8 +130,14 @@
         send(e.dataTransfer.files[0]);
       });
     }
-    // A pasted screenshot goes the same way as a dropped one.
+    // A pasted screenshot goes the same way as a dropped one — unless the
+    // paste is on its way somewhere that takes text. A clipboard from Sheets,
+    // Excel or Word carries the selection twice, as text and as a picture of
+    // itself, so taking the picture while the caret sat in the note box
+    // uploaded a screenshot and swallowed the paste the user asked for.
     document.addEventListener('paste', function (e) {
+      var t = e.target;
+      if (t && t.closest && t.closest('textarea, input, [contenteditable]')) return;
       var items = (e.clipboardData && e.clipboardData.items) || [];
       for (var i = 0; i < items.length; i++) {
         if (items[i].kind === 'file' && items[i].type.indexOf('image/') === 0) {

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -5,10 +5,18 @@
   <span class="badge {{ badge }}">{{ status }}</span>
   <span class="spacer"></span>
   {# Re-segmenting a placeholder would delete the restored artifacts and pay the
-     model to re-derive them from their own text. Nothing to re-segment. #}
-  {% if !restored %}
+     model to re-derive them from their own text. Nothing to re-segment. An
+     image with no reading yet has nothing to re-segment either. #}
+  {% if !restored && !unread %}
   <form method="post" action="/ui/corpora/{{ id }}/reprocess" style="display:inline">
     <button class="btn btn-sm" type="submit">Re-segment</button>
+  </form>
+  {% endif %}
+  {% if image %}
+  <form method="post" action="/ui/corpora/{{ id }}/reprocess" style="display:inline"
+        onsubmit="return confirm('Read the photo again? The current reading and its artifacts are replaced.')">
+    <input type="hidden" name="stage" value="describe">
+    <button class="btn btn-sm" type="submit">Re-read</button>
   </form>
   {% endif %}
   <form method="post" action="/ui/corpora/{{ id }}/delete" style="display:inline"

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -33,6 +33,28 @@
 {% endif %}
 {% endif %}
 
+{% if image %}
+<div class="card">
+  <div class="card-head">
+    <span class="card-title">Photo</span>
+    <span class="spacer"></span>
+    <a class="quiet-link" href="/api/v1/corpora/{{ id }}/image?original=1">original</a>
+  </div>
+  <a href="/api/v1/corpora/{{ id }}/image?original=1">
+    <img src="/api/v1/corpora/{{ id }}/image" alt="captured image"
+         style="max-width:100%;height:auto;border-radius:.4rem">
+  </a>
+  {% if let Some(n) = note %}<p><b>Note:</b> {{ n }}</p>{% endif %}
+  {% if !meta_rows.is_empty() %}
+  <table class="meta">
+    {% for r in meta_rows %}<tr><td class="muted">{{ r.0 }}</td><td>{{ r.1 }}</td></tr>{% endfor %}
+  </table>
+  {% endif %}
+</div>
+{% else if let Some(n) = note %}
+<p><b>Note:</b> {{ n }}</p>
+{% endif %}
+
 {% if restored %}
 <div class="flag" role="status">
   <div aria-hidden="true">⚠</div>
@@ -48,8 +70,12 @@
 
 <div class="card">
   <div class="card-head">
-    <span class="card-title">{% if restored %}Restored artifacts{% else %}Raw corpus{% endif %}</span>
+    <span class="card-title">{% if restored %}Restored artifacts{% else if image %}Transcription{% else %}Raw corpus{% endif %}</span>
+    {% if image %}<span class="muted">— the model's reading of the photo, not the source itself</span>{% endif %}
   </div>
+  {% if image && lines.is_empty() %}
+  <p class="muted">Not read yet — the photo is queued for the vision model.</p>
+  {% endif %}
   {# Every line is anchored, so an artifact's "open at these lines" link lands
      on the exact lines it was drawn from instead of the top of the document.
      Same markup and highlighting as the excerpt in the artifact pane. #}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -304,6 +304,9 @@ struct CaptureTemplate {
     /// How many more are behind the ones shown. Said once under the list, so a
     /// short list does not read as an empty queue when it is a capped one.
     more_pairs: i64,
+    /// Whether the image door is open, i.e. `[infer.vision]` is configured.
+    /// Off, the page offers text only rather than a picker that fails.
+    vision_enabled: bool,
 }
 
 #[derive(Template)]
@@ -379,6 +382,12 @@ struct CorpusTemplate {
     /// hop back to where the text came from, which is otherwise unrecoverable
     /// once the tab is closed.
     source_url: Option<String>,
+    /// An image corpus: the page shows the photo, and the lines below are the
+    /// model's reading of it rather than the source itself.
+    image: bool,
+    /// Rows of what the door recorded about the capture, already formatted.
+    meta_rows: Vec<(String, String)>,
+    note: Option<String>,
 }
 
 #[derive(Template)]
@@ -505,6 +514,7 @@ async fn capture_page(State(st): State<AppState>, _id: Identity) -> Result<Respo
         judge_pending: crate::web::state::judge_pending(&st).await,
         pairs,
         more_pairs,
+        vision_enabled: st.core.describer.is_some(),
     })
     .into_response())
 }
@@ -741,10 +751,13 @@ async fn queue_fragment(State(st): State<AppState>, _id: Identity) -> Result<Res
             // thing that tells three captures pasted in a row apart. `unnamed`
             // is what says the name is still coming; the label itself is not
             // the place to say it.
-            label: s
-                .title_hint
-                .clone()
-                .unwrap_or_else(|| markdown::snippet(&s.raw_text, 60)),
+            label: s.title_hint.clone().unwrap_or_else(|| {
+                if s.origin == crate::core::ingest::ORIGIN_IMAGE && s.raw_text.is_empty() {
+                    "photo".into()
+                } else {
+                    markdown::snippet(&s.raw_text, 60)
+                }
+            }),
             unnamed: s.title_hint.is_none() && in_flight,
             in_flight,
             settled: matches!(s.status, CorpusStatus::Ready),
@@ -801,6 +814,9 @@ async fn corpus_detail(
             }
         })
         .collect();
+    let image = s.origin == crate::core::ingest::ORIGIN_IMAGE;
+    let note = s.metadata["note"].as_str().map(str::to_string);
+    let meta_rows = metadata_rows(&s.metadata);
     Ok(HtmlTemplate(CorpusTemplate {
         theme: "light".into(),
         judge_pending: crate::web::state::judge_pending(&st).await,
@@ -810,9 +826,39 @@ async fn corpus_detail(
         status: s.status.as_str().to_string(),
         restored: s.restored_at.is_some(),
         source_url: s.source_url.clone(),
+        image,
+        meta_rows,
+        note,
         artifacts,
     })
     .into_response())
+}
+
+/// The metadata worth a row on the corpus page, in reading order. Everything
+/// else the file carried is in the JSON, one API call away.
+fn metadata_rows(m: &serde_json::Value) -> Vec<(String, String)> {
+    let mut rows = Vec::new();
+    let exif = &m["exif"];
+    if let Some(t) = exif["taken_at"].as_str() {
+        rows.push(("Taken".into(), t.into()));
+    }
+    if let Some(c) = exif["camera"].as_str() {
+        rows.push(("Camera".into(), c.into()));
+    }
+    if let (Some(lat), Some(lon)) = (exif["gps"]["lat"].as_f64(), exif["gps"]["lon"].as_f64()) {
+        rows.push(("Location".into(), format!("{lat}, {lon}")));
+    }
+    let f = &m["file"];
+    if let Some(n) = f["name"].as_str() {
+        rows.push(("File".into(), n.into()));
+    }
+    if let (Some(w), Some(h)) = (f["width"].as_u64(), f["height"].as_u64()) {
+        rows.push(("Size".into(), format!("{w}×{h}")));
+    }
+    if let Some(e) = m["describe"]["error"].as_str() {
+        rows.push(("Reading".into(), e.into()));
+    }
+    rows
 }
 
 #[derive(serde::Deserialize)]
@@ -1939,6 +1985,80 @@ mod tests {
     /// attribute pair does not also assert where the template wrapped a line.
     fn flat(html: &str) -> String {
         html.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// A session on the given core, for pages that need a core built a
+    /// particular way.
+    async fn app_for(core: crate::core::Core) -> (axum::Router, String) {
+        let cid = crate::store::new_id();
+        core.store
+            .insert_session(&cid, "user-1", None, 3600)
+            .await
+            .unwrap();
+        let state = crate::web::state::AppState {
+            core,
+            auth: std::sync::Arc::new(crate::web::state::AuthContext {
+                mode: crate::config::AuthMode::Local,
+                local: None,
+                oidc: None,
+                pending: crate::auth::oidc::PendingStore::new(),
+                secure_cookies: false,
+            }),
+        };
+        (crate::web::router(state), format!("engram_session={cid}"))
+    }
+
+    #[tokio::test]
+    async fn the_capture_page_offers_images_only_when_vision_is_configured() {
+        let (app, cookie) = app_for(crate::core::test_support::test_core().await).await;
+        let html = get(&app, "/ui/capture", &cookie).await;
+        assert!(html.contains("image/*"), "picker accepts images");
+        assert!(html.contains("name=\"note\""), "the context field is there");
+
+        let (app, cookie) =
+            app_for(crate::core::test_support::test_core_without_vision().await).await;
+        let html = get(&app, "/ui/capture", &cookie).await;
+        assert!(!html.contains("image/*"));
+        assert!(html.contains("accept=\".txt,text/plain\""));
+    }
+
+    #[tokio::test]
+    async fn an_image_corpus_page_shows_the_photo_its_facts_and_the_reading_as_derived() {
+        let core = crate::core::test_support::test_core().await;
+        let src = core
+            .store
+            .insert_image_corpus(
+                "h",
+                "image",
+                Some("IMG.png"),
+                &serde_json::json!({
+                    "note": "front porch",
+                    "file": {"name": "IMG.png", "width": 4, "height": 2},
+                    "exif": {"taken_at": "2026-08-09T14:12:03", "camera": "Pixel",
+                             "gps": {"lat": 1.5, "lon": 2.5}}
+                }),
+            )
+            .await
+            .unwrap()
+            .into_corpus();
+        core.store
+            .set_described_text(&src.id, "# Porch\n\nblue door", vec![])
+            .await
+            .unwrap();
+        let (app, cookie) = app_for(core).await;
+        let html = get(&app, &format!("/ui/corpora/{}", src.id), &cookie).await;
+        assert!(
+            html.contains(&format!("/api/v1/corpora/{}/image", src.id)),
+            "img src"
+        );
+        assert!(html.contains("front porch"));
+        assert!(html.contains("2026-08-09T14:12:03"));
+        assert!(html.contains("1.5"));
+        assert!(
+            html.contains("Transcription"),
+            "the text is labelled as derived, not 'Raw corpus'"
+        );
+        assert!(html.contains("blue door"));
     }
 
     async fn get(app: &axum::Router, uri: &str, cookie: &str) -> String {

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2053,6 +2053,15 @@ mod tests {
                     "exif": {"taken_at": "2026-08-09T14:12:03", "camera": "Pixel",
                              "gps": {"lat": 1.5, "lon": 2.5}}
                 }),
+                &crate::store::attachments::NewImage {
+                    kind: "image",
+                    mime: "image/png",
+                    filename: Some("IMG.png"),
+                    bytes: b"orig",
+                    preview: b"prev",
+                    width: Some(4),
+                    height: Some(2),
+                },
             )
             .await
             .unwrap()

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -227,7 +227,7 @@ pub fn status_badge(status: &crate::store::corpora::CorpusStatus) -> &'static st
         // A parked capture is waiting on a person, not on a worker. It reads as
         // a warning because nothing will advance it on its own.
         NeedsReview => "badge-warning",
-        Raw | Segmenting | Segmented | Embedding => "badge-accent",
+        Describing | Raw | Segmenting | Segmented | Embedding => "badge-accent",
     }
 }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -385,6 +385,9 @@ struct CorpusTemplate {
     /// An image corpus: the page shows the photo, and the lines below are the
     /// model's reading of it rather than the source itself.
     image: bool,
+    /// An image whose reading has not landed — still `describing`, or parked
+    /// before any text was read. Nothing to re-segment; only re-read.
+    unread: bool,
     /// Rows of what the door recorded about the capture, already formatted.
     meta_rows: Vec<(String, String)>,
     note: Option<String>,
@@ -815,6 +818,7 @@ async fn corpus_detail(
         })
         .collect();
     let image = s.origin == crate::core::ingest::ORIGIN_IMAGE;
+    let unread = image && (s.status == CorpusStatus::Describing || s.raw_text.trim().is_empty());
     let note = s.metadata["note"].as_str().map(str::to_string);
     let meta_rows = metadata_rows(&s.metadata);
     Ok(HtmlTemplate(CorpusTemplate {
@@ -827,6 +831,7 @@ async fn corpus_detail(
         restored: s.restored_at.is_some(),
         source_url: s.source_url.clone(),
         image,
+        unread,
         meta_rows,
         note,
         artifacts,
@@ -932,14 +937,25 @@ async fn delete_artifact_ui(
     })
 }
 
+#[derive(serde::Deserialize, Default)]
+struct ReprocessForm {
+    #[serde(default)]
+    stage: Option<String>,
+}
+
+/// Re-segment by default; `stage=describe` re-reads a captured image.
 async fn reprocess_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(cid): Path<String>,
+    Form(form): Form<ReprocessForm>,
 ) -> Result<Response> {
-    st.core
-        .reprocess(&cid, crate::store::jobs::Stage::Synthesize)
-        .await?;
+    let stage = match form.stage {
+        None => crate::store::jobs::Stage::Synthesize,
+        Some(s) => crate::store::jobs::Stage::parse(&s)
+            .ok_or_else(|| Error::Validation(format!("unknown stage `{s}`")))?,
+    };
+    st.core.reprocess(&cid, stage).await?;
     Ok(Redirect::to(&format!("/ui/corpora/{cid}")).into_response())
 }
 
@@ -2059,6 +2075,61 @@ mod tests {
             "the text is labelled as derived, not 'Raw corpus'"
         );
         assert!(html.contains("blue door"));
+    }
+
+    fn a_png() -> Vec<u8> {
+        use image::{ImageBuffer, Rgb};
+        let img = ImageBuffer::from_fn(8, 8, |x, y| Rgb([x as u8 * 30, y as u8 * 30, 0]));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    async fn an_unread_image(core: &crate::core::Core) -> String {
+        core.ingest_image(crate::core::ingest::ImageCapture {
+            bytes: a_png(),
+            filename: Some("p.png".into()),
+            title_hint: None,
+            note: None,
+        })
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn an_unread_image_page_offers_re_read_and_not_re_segment() {
+        let core = crate::core::test_support::test_core().await;
+        let id = an_unread_image(&core).await;
+        let (app, cookie) = app_for(core).await;
+        let html = get(&app, &format!("/ui/corpora/{id}"), &cookie).await;
+        assert!(html.contains("Re-read"));
+        assert!(!html.contains("Re-segment"));
+    }
+
+    #[tokio::test]
+    async fn the_re_read_button_queues_describe() {
+        let core = crate::core::test_support::test_core().await;
+        let id = an_unread_image(&core).await;
+        crate::jobs::describe::park_failed(&core, &id, "HTTP 400")
+            .await
+            .unwrap();
+        let (app, cookie) = app_for(core.clone()).await;
+        let res = app
+            .oneshot(form(
+                &format!("/ui/corpora/{id}/reprocess"),
+                &cookie,
+                "stage=describe",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            core.store.get_corpus(&id).await.unwrap().status,
+            CorpusStatus::Describing
+        );
     }
 
     async fn get(app: &axum::Router, uri: &str, cookie: &str) -> String {

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -334,6 +334,10 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         )),
         corpus_locks: Default::default(),
         lifecycle_lock: Default::default(),
+        // The benchmark ingests no images, so nothing ever takes a permit.
+        decodes: Arc::new(tokio::sync::Semaphore::new(
+            engram::core::image::MAX_CONCURRENT_DECODES,
+        )),
     };
     let translated = index(&core, &artifacts).await;
 

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -317,6 +317,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         embedder: Arc::new(engram::infer::fake::FakeEmbedder::new(8)),
         reranker: None,
         completer: Arc::new(engram::infer::fake::FakeCompleter::default()),
+        describer: None,
         counter: Arc::new(engram::infer::budget::TokenCounter::Estimate),
         background: Arc::new(engram::core::background::Background::default()),
         query_cache: Arc::new(std::sync::Mutex::new(engram::core::QueryCache::new(


### PR DESCRIPTION
## Summary

Photos and images become first-class corpora. Uploaded instantly, stored verbatim, read into markdown by a vision model in a background job, then processed by the existing text pipeline untouched.

- **Config**: optional `[infer.vision]` role — absent = image door closed; `model` only = reuse the synthesize endpoint; own `base_url`/`api_key` = dedicated endpoint. `capture.image_max_bytes` (25 MB) and `capture.image_preview_edge` (2048).
- **Store**: `attachments` table (original bytes untouched + oriented/downscaled JPEG preview); generic `corpora.metadata` JSON (`note`, `file`, `exif` incl. GPS and all tags, `describe.error`); new corpus status `describing`; new job stage `describe`.
- **Door**: `POST /api/v1/corpora/image` (multipart `image`, `note`, `title_hint`) — no inference in the request path, byte-hash dedupe before any model cost, per-route body limit. `GET /api/v1/corpora/{id}/image[?original=1]` serves preview/original. The `.txt` upload door gains `note` + file facts.
- **Pipeline**: `Stage::Describe` calls the new `Describer` trait through the shared inference gate, writes the reading into `raw_text`, runs the existing near-duplicate check, hands off to `Synthesize`. Empty reading parks as `needs_review` with the reason; model failure retries with backoff; nothing is ever lost.
- **UI**: capture page accepts images via picker (phone camera through the PWA), drag-and-drop, and clipboard paste, with an optional context note; corpus page shows the photo, its facts, and the transcription labelled as derived. Image affordances hidden when vision is not configured.

Spec: `docs/superpowers/specs/2026-08-15-image-capture-design.md` · Plan: `docs/superpowers/plans/2026-08-15-image-capture.md`

## Test plan

- [x] `cargo test` — 859 passed (31 new: config modes, EXIF/GPS/orientation/preview, HTTP describer wire format via wiremock, image door + dedupe + closed door, describe job incl. full pipeline photo → ready, API refusals + serving + body limits, UI rendering)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manual: point `[infer.vision]` at a multimodal model, drop a photo on `/ui/capture`, watch `image read; queued for synthesis` in the log and the corpus page render the photo + transcription

🤖 Generated with [Claude Code](https://claude.com/claude-code)