### PR TITLE
feat(associate): links and activation learned from use

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,9 @@ must not alter; filter chips from facet counts; nearest neighbours in the
 detail pane; near-duplicate detection at capture; autonomous consolidation with
 complete pair coverage, merge-loss checks and undo; caveats on artifacts; text
 and image capture; hybrid search inside Qdrant; the evaluation harness fed from
-judged real searches (`cargo test --test eval`, `/ui/judge`, `--export-eval`).
+judged real searches (`cargo test --test eval`, `/ui/judge`, `--export-eval`);
+Hebbian links learned from co-retrieval with bounded priming and one-hop
+association in the results.
 Design records live in `docs/superpowers/specs/`.
 
 Three constraints decide what is on this list and what was cut from it.
@@ -43,11 +45,11 @@ moves only after it has been run.
 
 ## [Associative Memory]
 
-Spec: `docs/superpowers/specs/2026-08-16-associative-memory-design.md` —
+Spec: `docs/superpowers/specs/2026-08-16-associative-memory-design.md` — built:
 Hebbian links learned from co-retrieval, decaying activation per artifact,
 bounded priming and one-hop association in the results, a sparse judge on
-strong cross-corpus links. The items below are the mechanisms that come after
-it, in order.
+strong cross-corpus links, switched on with `[associate]` and `[activation]`
+in config. The items below are the mechanisms that come after it, in order.
 
 - **Sleep as an explicit cycle.** The background work already exists — link
   replay, activation decay, pruning, relate/dedupe, retention. It becomes phases

--- a/assets/app.css
+++ b/assets/app.css
@@ -345,6 +345,16 @@ body { overflow-x: hidden; }
 }
 .pane { min-width: 0; }
 
+/* Association is a second list on the same page, not a continuation of the
+   first: the rule and label are what keep a reader from reading straight
+   through and treating a recalled hit as the next-best answer. */
+.assoc-rule {
+  margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid var(--color-border-subtle);
+  font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em;
+  color: var(--color-fg-muted);
+}
+.rail-why { font-size: 0.8125rem; color: var(--color-fg-muted); margin-top: 0.25rem; }
+
 /* Neighbours under the artifact. Narrower than the rail on purpose: this is a
    way out of the pane, not a second set of results competing with it. */
 .related { display: flex; flex-direction: column; gap: 0.375rem; }

--- a/assets/app.css
+++ b/assets/app.css
@@ -360,6 +360,21 @@ body { overflow-x: hidden; }
 .related { display: flex; flex-direction: column; gap: 0.375rem; }
 .related .rail-item { padding: 0.5rem 0.625rem; }
 
+/* Same shape as `.rail-row`: the dismiss control sits beside the link rather
+   than inside it, revealed on hover or focus. `.muted` is the same-corpus
+   case — two passages of one document needing each other is not the finding
+   that a cross-corpus pair is, so it recedes instead of competing for
+   attention. */
+.seen-row { position: relative; }
+.seen-row .rail-item { padding-right: 2.75rem; }
+.seen-row .rail-del {
+  position: absolute; top: 0.5rem; right: 0.5rem;
+  opacity: 0; transition: opacity 120ms ease;
+}
+.seen-row:hover .rail-del, .seen-row .rail-del:focus-within { opacity: 1; }
+@media (hover: none) { .seen-row .rail-del { opacity: 1; } }
+.seen-row.muted .rail-item { opacity: 0.75; }
+
 /* ── Filter chips ────────────────────────────────────────────────────────── */
 
 /* A radio styled as a chip. The input is the state — checked, focusable,

--- a/config.example.toml
+++ b/config.example.toml
@@ -246,6 +246,48 @@ retain_days = 0
 # checking more often than this, and the sweep is a single DELETE.
 sweep_hours = 6
 
+# Links learned from co-retrieval, and a decaying accessibility per artifact.
+# Both are learned from use and neither touches what is stored: the trace is
+# fixed, access is plastic. Needs `feedback.enabled` — without recorded searches
+# there is nothing to learn from, and saying otherwise is a warning at startup.
+[associate]
+enabled = true
+# How often the sweep replays the search log. Pure SQLite, no model call.
+interval_mins = 30
+# A link unused for this long has half the strength it had. One co-appearance is
+# +1 and one confirmed answer is +2, so these numbers are in "uses".
+half_life_days = 30
+# Below this, a link nobody has ruled on is forgotten. A judged one never is: a
+# verified relation is about content, not use.
+prune_below = 0.5
+# Strength at which a link is worth showing, and at which it is worth one call.
+show_min = 2.0
+judge_min = 4.0
+# Distinct questions a link needs before it is judged. One question asked six
+# times is one question, and this is what keeps the judge cheap.
+judge_min_queries = 3
+judge_per_sweep = 10
+# How many top hits are asked what they are linked to, and how many associated
+# hits may be appended after the ranked list — outside `limit`, never instead
+# of a ranked hit.
+spread_from = 3
+spread_max = 3
+# How much more accessible a hit must be than the one above it to pass it, as a
+# fraction of the most accessible hit in that list; and how many places it may
+# climb. 0 turns priming off. Neither default moves until the eval harness has
+# been run with it off and on against the frozen corpus.
+prime_margin = 0.5
+prime_lift = 2
+
+[activation]
+half_life_days = 14
+# Returned by a deliberate search, opened in the pane, judged the answer. Being
+# surfaced *because* of activation — resurfaced, or recalled by a link — raises
+# nothing: that is the loop this design exists to close.
+retrieved = 1.0
+opened = 0.5
+confirmed = 3.0
+
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share
 # one GPU, so a per-role cooldown could not bound total load. Upgrading: this

--- a/docs/superpowers/plans/2026-08-16-associative-memory.md
+++ b/docs/superpowers/plans/2026-08-16-associative-memory.md
@@ -1,0 +1,4087 @@
+# Associative Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give engram two usage-learned associative mechanisms — Hebbian links between co-retrieved artifacts and a decaying per-artifact activation — surfaced only in the search results and the detail pane, without changing what is stored.
+
+**Architecture:** A new SQLite table `artifact_links` holds pair weights that are bumped by a background sweep replaying `search_events`, and read through a lazy decay (never decayed in place). Two new columns on `artifacts` hold activation the same way. The query path gains exactly one indexed SQLite read, which can only add: bounded priming of the ranked order and one hop of association appended outside `limit`. A sparse `LinkJudge` unit names strong cross-corpus relations through the existing job queue.
+
+**Tech Stack:** Rust, sqlx/SQLite, axum + askama (web UI), tokio tickers, the existing `jobs` queue and `infer::Completer` judge role.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-associative-memory-design.md`
+
+## Global Constraints
+
+Copied verbatim from the spec; every task's requirements implicitly include these.
+
+- **The trace is fixed; access is plastic.** Content is verbatim and never changes silently. Everything about how it is found — associations, activation, what surfaces first — learns from use, within visible bounds.
+- **Bounded.** Priming moves a hit at most `prime_lift` positions and never displaces rank 1. Association adds hits beside the ranked list; it never removes or reorders one.
+- **Visible.** A primed hit says so; an associated hit says which hit recalled it. Nothing about the order is silent.
+- **One-way.** Associated hits do not feed the learning that produced them. Priming does not raise activation by more than an ordinary retrieval would.
+- **No inference in the query path.** The judge runs in the background, on few links, through the existing queue and pacing.
+- Additive schema only: `ADD COLUMN` with defaults and new tables. No `DROP COLUMN`, no column retyped, no route or config key deleted.
+- The layer crossing is optional: if the SQLite read fails, search returns exactly what it returns today, with one warning.
+- CI gates every task: `cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked`.
+- Default values, exact: `associate.enabled = true`, `interval_mins = 30`, `half_life_days = 30`, `prune_below = 0.5`, `show_min = 2.0`, `judge_min = 4.0`, `judge_min_queries = 3`, `judge_per_sweep = 10`, `spread_from = 3`, `spread_max = 3`, `prime_margin = 0.5`, `prime_lift = 2`; `activation.half_life_days = 14`, `retrieved = 1.0`, `opened = 0.5`, `confirmed = 3.0`.
+
+---
+
+## Task 1: The link table, its types, and the watermarks
+
+**Files:**
+- Create: `src/store/links.rs`
+- Modify: `src/store/schema.sql` (append two tables before the Auth section)
+- Modify: `src/store/mod.rs:1-10` (module declaration)
+- Test: `src/store/links.rs` (inline `mod tests`, the repo's convention)
+
+**Interfaces:**
+- Consumes: `crate::store::{Store, now}`, `crate::error::Result`.
+- Produces: `LinkState` (`Learning|Related|Unrelated|Dismissed`, `as_str`/`parse`), `Cue { q: String, n: i64 }`, `Link { a_id, b_id, weight: f64, bumped_at: i64, queries: i64, cues: Vec<Cue>, state: LinkState, reason: Option<String>, judged_rev_a: Option<i64>, judged_rev_b: Option<i64>, judge_attempts: i64, created_at: i64 }`, `canonical(&str,&str) -> (&str,&str)`, `normalize_query(&str) -> String`, `decayed(f64, i64, i64, f64) -> f64`, `MAX_CUES: usize`, and on `Store`: `bump_link`, `get_link`, `meta_get`, `meta_set`.
+
+- [ ] **Step 1: Add the two tables to the schema**
+
+Append to `src/store/schema.sql`, immediately before the `-- ── Auth ──` section. One column per line — `migrate`'s checker parses this file.
+
+```sql
+-- ── Association ──────────────────────────────────────────────────────────────
+-- Two artifacts that keep being retrieved by the same searches. The other half
+-- of relatedness: `artifact_pairs` is about two texts saying the same thing,
+-- this is about two texts being needed together. A pair can be both — filed by
+-- `Relate` at 0.89 and judged distinct, and co-retrieved and related — and one
+-- row cannot hold two verdicts, so they are separate tables.
+CREATE TABLE IF NOT EXISTS artifact_links (
+  a_id        TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  b_id        TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- Strength as of `bumped_at`. Read through decay; never decayed in place, so
+  -- learning is one UPDATE and forgetting costs no writes at all.
+  weight      REAL NOT NULL,
+  bumped_at   INTEGER NOT NULL,
+  -- Distinct normalised query texts that bound this pair. What separates a
+  -- link from one search typed twice.
+  queries     INTEGER NOT NULL DEFAULT 1,
+  -- Up to three binding queries with counts, JSON: [{"q":..,"n":..}].
+  cues        TEXT NOT NULL DEFAULT '[]',
+  -- 'learning' | 'related' | 'unrelated' | 'dismissed'
+  state       TEXT NOT NULL DEFAULT 'learning',
+  -- The judge's one line, for `related`.
+  reason      TEXT,
+  -- Revisions the judge read. A re-embed of either side reopens the verdict:
+  -- the text changed under it.
+  judged_rev_a INTEGER,
+  judged_rev_b INTEGER,
+  judge_attempts INTEGER NOT NULL DEFAULT 0,
+  created_at  INTEGER NOT NULL,
+  PRIMARY KEY (a_id, b_id),
+  CHECK (a_id < b_id)
+);
+CREATE INDEX IF NOT EXISTS idx_links_b ON artifact_links(b_id);
+CREATE INDEX IF NOT EXISTS idx_links_state ON artifact_links(state, weight DESC);
+
+-- Cursors that have no row to live on. Two keys so far:
+-- `associate.events_after` and `associate.judged_after`.
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+```
+
+- [ ] **Step 2: Declare the module**
+
+In `src/store/mod.rs`, add to the module list (alphabetical, after `jobs`):
+
+```rust
+pub mod lineage;
+pub mod links;
+pub mod pairs;
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `src/store/links.rs` with only this test module plus `use super::*;` at the top of it — the implementation comes in step 5.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::artifacts::NewArtifact;
+
+    /// Two artifacts in one corpus, returned as their ids.
+    async fn two(store: &Store) -> (String, String) {
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = ["alpha", "beta"]
+            .iter()
+            .enumerate()
+            .map(|(i, t)| NewArtifact {
+                ordinal: i as i64,
+                text: (*t).into(),
+                corpus_span: None,
+                title: Some((*t).into()),
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        let made = store.insert_artifacts(&src.id, &new).await.unwrap();
+        (made[0].id.clone(), made[1].id.clone())
+    }
+
+    #[test]
+    fn a_pair_is_filed_the_same_way_round_however_it_is_named() {
+        // The primary key is (a_id, b_id) with a CHECK that a < b, so a lookup
+        // by either side is two indexed reads and there is no "which way round"
+        // bug to have.
+        assert_eq!(canonical("b", "a"), ("a", "b"));
+        assert_eq!(canonical("a", "b"), ("a", "b"));
+    }
+
+    #[test]
+    fn a_query_is_the_same_cue_however_it_was_typed() {
+        assert_eq!(normalize_query("  Loop   Device \n"), "loop device");
+    }
+
+    #[test]
+    fn weight_halves_over_one_half_life() {
+        // Lazy decay is what makes forgetting free: no sweep walks every row to
+        // subtract from it, so this function is the only place decay happens.
+        let day = 86_400;
+        assert!((decayed(4.0, 0, 30 * day, 30.0) - 2.0).abs() < 1e-9);
+        assert!((decayed(4.0, 0, 60 * day, 30.0) - 1.0).abs() < 1e-9);
+        // Not yet moved, and never grown by a clock running backwards.
+        assert!((decayed(4.0, 100, 100, 30.0) - 4.0).abs() < 1e-9);
+        assert!((decayed(4.0, 100, 0, 30.0) - 4.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn bumping_folds_the_decay_in_rather_than_adding_to_a_stale_number() {
+        // `weight` means "strength as of bumped_at". Adding to it without
+        // folding the decay in would make a link that was strong a year ago and
+        // used once today as strong as one used constantly.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        let day = 86_400;
+        store
+            .bump_link(&a, &b, 4.0, Some("fat32"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .bump_link(&b, &a, 1.0, Some("fat32"), 30.0, 30 * day)
+            .await
+            .unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().expect("the link");
+        assert!((l.weight - 3.0).abs() < 1e-6, "weight was {}", l.weight);
+        assert_eq!(l.bumped_at, 30 * day);
+        // Named the other way round the second time, and still one row.
+        assert_eq!(l.a_id, a.min(b.clone()));
+    }
+
+    #[tokio::test]
+    async fn the_same_query_twice_is_one_binding_query() {
+        // What separates a link from one search typed twice. The cue count
+        // still climbs, because that is how the top three are chosen.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        for _ in 0..3 {
+            store
+                .bump_link(&a, &b, 1.0, Some("fat32"), 30.0, 0)
+                .await
+                .unwrap();
+        }
+        store
+            .bump_link(&a, &b, 1.0, Some("ntfs"), 30.0, 0)
+            .await
+            .unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.queries, 2);
+        assert_eq!(l.cues[0].q, "fat32");
+        assert_eq!(l.cues[0].n, 3);
+        assert_eq!(l.cues.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn only_three_binding_queries_are_kept_and_the_busiest_lead() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        for q in ["one", "two", "three", "four"] {
+            store.bump_link(&a, &b, 1.0, Some(q), 30.0, 0).await.unwrap();
+        }
+        store.bump_link(&a, &b, 1.0, Some("two"), 30.0, 0).await.unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.cues.len(), MAX_CUES);
+        assert_eq!(l.cues[0].q, "two", "the busiest cue must lead");
+    }
+
+    #[tokio::test]
+    async fn an_artifact_linking_to_itself_is_not_a_link() {
+        let store = Store::memory().await.unwrap();
+        let (a, _) = two(&store).await;
+        store.bump_link(&a, &a, 1.0, Some("q"), 30.0, 0).await.unwrap();
+        assert!(store.get_link(&a, &a).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_watermark_reads_back_what_was_written_and_nothing_otherwise() {
+        let store = Store::memory().await.unwrap();
+        assert_eq!(store.meta_get("associate.events_after").await.unwrap(), None);
+        store.meta_set("associate.events_after", "42").await.unwrap();
+        store.meta_set("associate.events_after", "99").await.unwrap();
+        assert_eq!(
+            store.meta_get("associate.events_after").await.unwrap(),
+            Some("99".to_string())
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `cargo test --lib store::links`
+Expected: compile failure — `cannot find function canonical`, `no method named bump_link`.
+
+- [ ] **Step 5: Write the implementation**
+
+Put this above the `mod tests` block in `src/store/links.rs`.
+
+```rust
+//! What was reached together.
+//!
+//! `artifact_pairs` is about two texts saying the same thing; this is about two
+//! texts being *needed* together — the config passage and the troubleshooting
+//! passage for one subsystem are strangers to the embedding and inseparable to
+//! the person who needed both to answer one question.
+//!
+//! Every strength here is stored as a value and the stamp it was true at, and
+//! read through `decayed`. Nothing is ever decayed in place: learning is one
+//! UPDATE and forgetting costs no writes, which is what lets a sweep run every
+//! half hour on a base of any size.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+/// Binding queries kept per link. Three is what a person reads in the pane;
+/// the count of *distinct* ones is `queries`, which is not bounded by this.
+pub const MAX_CUES: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkState {
+    /// Bound by use, nothing has ruled on it. Shown, prunable, judgeable.
+    Learning,
+    /// The judge named the relation. Shown with its reason, and never pruned by
+    /// decay: a verified relation is about content, not use.
+    Related,
+    /// A coincidence of retrieval. Kept so it is not asked again, hidden from
+    /// the pane, reopened only if either text changes.
+    Unrelated,
+    /// The operator said no. Never shown, never judged, never pruned.
+    Dismissed,
+}
+
+impl LinkState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LinkState::Learning => "learning",
+            LinkState::Related => "related",
+            LinkState::Unrelated => "unrelated",
+            LinkState::Dismissed => "dismissed",
+        }
+    }
+    pub fn parse(s: &str) -> LinkState {
+        match s {
+            "related" => LinkState::Related,
+            "unrelated" => LinkState::Unrelated,
+            "dismissed" => LinkState::Dismissed,
+            _ => LinkState::Learning,
+        }
+    }
+}
+
+/// One binding query and how often it bound this pair.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Cue {
+    pub q: String,
+    pub n: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Link {
+    pub a_id: String,
+    pub b_id: String,
+    /// Strength as of `bumped_at`. Read it through `decayed`, never directly.
+    pub weight: f64,
+    pub bumped_at: i64,
+    pub queries: i64,
+    pub cues: Vec<Cue>,
+    pub state: LinkState,
+    pub reason: Option<String>,
+    pub judged_rev_a: Option<i64>,
+    pub judged_rev_b: Option<i64>,
+    pub judge_attempts: i64,
+    pub created_at: i64,
+}
+
+/// The pair in the order the table stores it. `a_id < b_id` is a CHECK, so this
+/// is not a convention that can be forgotten at one call site.
+pub fn canonical<'a>(a: &'a str, b: &'a str) -> (&'a str, &'a str) {
+    if a <= b { (a, b) } else { (b, a) }
+}
+
+/// Two spellings of one question are one cue: lowercased, whitespace collapsed.
+pub fn normalize_query(q: &str) -> String {
+    q.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Strength now, from strength then. `half_life_days <= 0` turns decay off.
+///
+/// A clock that moved backwards — a restored database, an NTP correction —
+/// must not *grow* a weight, so the elapsed time is floored at zero.
+pub fn decayed(weight: f64, bumped_at: i64, at: i64, half_life_days: f64) -> f64 {
+    if half_life_days <= 0.0 {
+        return weight;
+    }
+    let elapsed = (at - bumped_at).max(0) as f64;
+    weight * 2f64.powf(-elapsed / (half_life_days * 86_400.0))
+}
+
+pub(crate) fn row_to_link(r: &sqlx::sqlite::SqliteRow) -> Link {
+    Link {
+        a_id: r.get("a_id"),
+        b_id: r.get("b_id"),
+        weight: r.get("weight"),
+        bumped_at: r.get("bumped_at"),
+        queries: r.get("queries"),
+        cues: serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default(),
+        state: LinkState::parse(r.get::<String, _>("state").as_str()),
+        reason: r.get("reason"),
+        judged_rev_a: r.get("judged_rev_a"),
+        judged_rev_b: r.get("judged_rev_b"),
+        judge_attempts: r.get("judge_attempts"),
+        created_at: r.get("created_at"),
+    }
+}
+
+/// Fold one query into the cue list. Returns whether it was new to this link.
+///
+/// Only the busiest `MAX_CUES` survive, and a cue that falls off the end can be
+/// counted as new again later — so `queries` is a floor on the number of
+/// distinct questions that bound this pair rather than an exact count. Exactness
+/// would cost a second table for a number that only gates the judge.
+fn bump_cue(cues: &mut Vec<Cue>, q: &str) -> bool {
+    if let Some(c) = cues.iter_mut().find(|c| c.q == q) {
+        c.n += 1;
+        return false;
+    }
+    cues.push(Cue {
+        q: q.to_string(),
+        n: 1,
+    });
+    cues.sort_by(|x, y| y.n.cmp(&x.n));
+    cues.truncate(MAX_CUES);
+    true
+}
+
+impl Store {
+    /// Strengthen the link between two artifacts, folding the decay in.
+    ///
+    /// `cue` is the normalised query that bound them, where there is one. A
+    /// bump with no cue — a confirmation replayed for an event whose
+    /// co-appearance was already folded in — strengthens without claiming a new
+    /// binding question.
+    ///
+    /// One transaction per pair. An event with ten shown candidates is 45 of
+    /// these, which is a few milliseconds of local SQLite and no network at all.
+    pub async fn bump_link(
+        &self,
+        a: &str,
+        b: &str,
+        delta: f64,
+        cue: Option<&str>,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        // An artifact is not linked to itself, and the CHECK would refuse it
+        // anyway — caught here so a caller enumerating pairs need not.
+        if a == b {
+            return Ok(());
+        }
+        let (a, b) = canonical(a, b);
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query(
+            "SELECT weight, bumped_at, queries, cues FROM artifact_links
+              WHERE a_id = ? AND b_id = ?",
+        )
+        .bind(a)
+        .bind(b)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        match row {
+            Some(r) => {
+                let mut cues: Vec<Cue> =
+                    serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default();
+                let fresh = cue.is_some_and(|q| bump_cue(&mut cues, q));
+                let weight =
+                    decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days) + delta;
+                sqlx::query(
+                    "UPDATE artifact_links
+                        SET weight = ?, bumped_at = ?, queries = ?, cues = ?
+                      WHERE a_id = ? AND b_id = ?",
+                )
+                .bind(weight)
+                .bind(at)
+                .bind(r.get::<i64, _>("queries") + i64::from(fresh))
+                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+                .bind(a)
+                .bind(b)
+                .execute(&mut *tx)
+                .await?;
+            }
+            None => {
+                let mut cues = Vec::new();
+                if let Some(q) = cue {
+                    bump_cue(&mut cues, q);
+                }
+                sqlx::query(
+                    "INSERT INTO artifact_links
+                       (a_id, b_id, weight, bumped_at, queries, cues, state, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?, 'learning', ?)",
+                )
+                .bind(a)
+                .bind(b)
+                .bind(delta)
+                .bind(at)
+                .bind(cues.len() as i64)
+                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+                .bind(now())
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// One link, whichever way round it is named.
+    pub async fn get_link(&self, a: &str, b: &str) -> Result<Option<Link>> {
+        let (a, b) = canonical(a, b);
+        Ok(sqlx::query("SELECT * FROM artifact_links WHERE a_id = ? AND b_id = ?")
+            .bind(a)
+            .bind(b)
+            .fetch_optional(&self.pool)
+            .await?
+            .as_ref()
+            .map(row_to_link))
+    }
+
+    pub async fn meta_get(&self, key: &str) -> Result<Option<String>> {
+        Ok(sqlx::query_scalar("SELECT value FROM meta WHERE key = ?")
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await?)
+    }
+
+    pub async fn meta_set(&self, key: &str, value: &str) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO meta (key, value) VALUES (?, ?)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --lib store::links`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 7: Check the whole suite still passes**
+
+Run: `cargo fmt --all && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked`
+Expected: PASS. In particular `store::tests::a_fresh_file_database_gets_the_whole_schema` and `the_schema_parses_into_the_columns_it_declares` must still pass — they read `schema.sql` back.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/store/links.rs src/store/mod.rs src/store/schema.sql
+git commit -m "feat(links): store co-retrieval links and their watermarks"
+```
+
+---
+
+## Task 2: Reading links back — lists, pruning, reopening, verdicts
+
+**Files:**
+- Modify: `src/store/links.rs` (append to the `impl Store` block and the test module)
+- Test: `src/store/links.rs`
+
+**Interfaces:**
+- Consumes: everything Task 1 produced.
+- Produces: on `Store` — `links_from(anchors: &[String], states: &[LinkState], half_life_days: f64, at: i64, min_weight: f64) -> Result<Vec<LinkedTo>>`, `links_to_judge(min_weight: f64, min_queries: i64, half_life_days: f64, at: i64, limit: i64) -> Result<Vec<Link>>`, `prune_learning_links(below: f64, half_life_days: f64, at: i64, scan_limit: i64) -> Result<u64>`, `reopen_stale_judged_links(limit: i64) -> Result<u64>`, `set_link_state(a, b, state, reason: Option<&str>, judged_revs: Option<(i64, i64)>) -> Result<()>`, `record_link_judge_attempt(a, b) -> Result<i64>`, `link_counts() -> Result<LinkCounts>`; and the struct `LinkedTo { via: String, other: String, weight: f64, state: LinkState, reason: Option<String>, cues: Vec<Cue>, cross_corpus: bool }` plus `LinkCounts { total: i64, related: i64, judge_queue: i64 }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `mod tests` block in `src/store/links.rs`.
+
+```rust
+    /// Two artifacts in two different corpora, so a link between them is a
+    /// cross-corpus one — the only kind the judge is ever asked about.
+    async fn two_corpora(store: &Store) -> (String, String) {
+        let mut ids = Vec::new();
+        for (raw, text) in [("raw one", "alpha"), ("raw two", "beta")] {
+            let src = store.insert_corpus(raw, "web", None).await.unwrap();
+            let made = store
+                .insert_artifacts(
+                    &src.id,
+                    &[NewArtifact {
+                        ordinal: 0,
+                        text: text.into(),
+                        corpus_span: None,
+                        title: Some(text.into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    }],
+                )
+                .await
+                .unwrap();
+            ids.push(made[0].id.clone());
+        }
+        (ids[0].clone(), ids[1].clone())
+    }
+
+    #[tokio::test]
+    async fn a_link_is_found_from_either_of_its_ends() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store.bump_link(&a, &b, 3.0, Some("q"), 30.0, 0).await.unwrap();
+
+        for anchor in [&a, &b] {
+            let out = store
+                .links_from(&[anchor.clone()], &[LinkState::Learning], 30.0, 0, 2.0)
+                .await
+                .unwrap();
+            assert_eq!(out.len(), 1, "anchored at {anchor}");
+            assert_eq!(&out[0].via, anchor);
+            assert_ne!(&out[0].other, anchor);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_link_below_the_threshold_once_decayed_is_not_shown() {
+        // The stored weight is strength as of `bumped_at`. Filtering on it
+        // directly would keep showing a link that has not been used in a year.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store.bump_link(&a, &b, 3.0, Some("q"), 30.0, 0).await.unwrap();
+
+        let now = store
+            .links_from(&[a.clone()], &[LinkState::Learning], 30.0, 0, 2.0)
+            .await
+            .unwrap();
+        assert_eq!(now.len(), 1);
+        let later = store
+            .links_from(&[a.clone()], &[LinkState::Learning], 30.0, 60 * 86_400, 2.0)
+            .await
+            .unwrap();
+        assert!(later.is_empty(), "a link decayed to 0.75 was still shown");
+    }
+
+    #[tokio::test]
+    async fn a_link_whose_other_side_is_hidden_is_not_shown() {
+        // Superseded and deprecated endpoints are filtered at read time, so
+        // undoing a merge brings its links back without a write.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store.bump_link(&a, &b, 3.0, Some("q"), 30.0, 0).await.unwrap();
+        store
+            .set_artifact_status(&b, crate::store::artifacts::ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .links_from(&[a], &[LinkState::Learning], 30.0, 0, 2.0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dismissed_link_is_never_returned() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store.bump_link(&a, &b, 9.0, Some("q"), 30.0, 0).await.unwrap();
+        store
+            .set_link_state(&a, &b, LinkState::Dismissed, None, None)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .links_from(&[a], &[LinkState::Learning, LinkState::Related], 30.0, 0, 0.0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn only_a_strong_cross_corpus_link_is_offered_to_the_judge() {
+        // Two passages of one document being related is not information, so a
+        // same-corpus link is shown and never judged.
+        let store = Store::memory().await.unwrap();
+        let (same_a, same_b) = two(&store).await;
+        let (cross_a, cross_b) = two_corpora(&store).await;
+        for (a, b) in [(&same_a, &same_b), (&cross_a, &cross_b)] {
+            for q in ["one", "two", "three"] {
+                store.bump_link(a, b, 2.0, Some(q), 30.0, 0).await.unwrap();
+            }
+        }
+
+        let armed = store.links_to_judge(4.0, 3, 30.0, 0, 10).await.unwrap();
+        assert_eq!(armed.len(), 1, "got {armed:?}");
+        assert_eq!(canonical(&cross_a, &cross_b), (armed[0].a_id.as_str(), armed[0].b_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn a_link_bound_by_too_few_questions_is_not_judged() {
+        // One question asked six times is one question. The judge is the only
+        // thing here that costs a model call, and this is what bounds it.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two_corpora(&store).await;
+        for _ in 0..6 {
+            store.bump_link(&a, &b, 1.0, Some("same"), 30.0, 0).await.unwrap();
+        }
+        assert!(store.links_to_judge(4.0, 3, 30.0, 0, 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pruning_drops_faded_learning_links_and_spares_judged_ones() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        let (c, d) = two_corpora(&store).await;
+        store.bump_link(&a, &b, 1.0, Some("q"), 30.0, 0).await.unwrap();
+        store.bump_link(&c, &d, 1.0, Some("q"), 30.0, 0).await.unwrap();
+        store
+            .set_link_state(&c, &d, LinkState::Related, Some("both about disks"), Some((0, 0)))
+            .await
+            .unwrap();
+
+        // A year on, both have decayed to almost nothing.
+        let dropped = store
+            .prune_learning_links(0.5, 30.0, 365 * 86_400, 5_000)
+            .await
+            .unwrap();
+        assert_eq!(dropped, 1);
+        assert!(store.get_link(&a, &b).await.unwrap().is_none());
+        assert!(
+            store.get_link(&c, &d).await.unwrap().is_some(),
+            "a verified relation is about content, not use"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_judged_link_reopens_when_either_text_changes_under_it() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two_corpora(&store).await;
+        store.bump_link(&a, &b, 5.0, Some("q"), 30.0, 0).await.unwrap();
+        store
+            .set_link_state(&a, &b, LinkState::Related, Some("a reason"), Some((0, 0)))
+            .await
+            .unwrap();
+
+        assert_eq!(store.reopen_stale_judged_links(100).await.unwrap(), 0);
+
+        store.update_artifact_text(&a, "alpha, rewritten").await.unwrap();
+        assert_eq!(store.reopen_stale_judged_links(100).await.unwrap(), 1);
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Learning);
+        assert_eq!(l.reason, None, "the judge read text that no longer exists");
+    }
+
+    #[tokio::test]
+    async fn the_counts_say_how_many_links_there_are_and_how_many_are_named() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        let (c, d) = two_corpora(&store).await;
+        store.bump_link(&a, &b, 1.0, Some("q"), 30.0, 0).await.unwrap();
+        store.bump_link(&c, &d, 9.0, Some("q"), 30.0, 0).await.unwrap();
+        store
+            .set_link_state(&c, &d, LinkState::Related, Some("why"), Some((0, 0)))
+            .await
+            .unwrap();
+
+        let n = store.link_counts().await.unwrap();
+        assert_eq!((n.total, n.related), (2, 1));
+    }
+
+    #[tokio::test]
+    async fn a_judge_attempt_is_counted_and_reported_back() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store.bump_link(&a, &b, 1.0, Some("q"), 30.0, 0).await.unwrap();
+        assert_eq!(store.record_link_judge_attempt(&a, &b).await.unwrap(), 1);
+        assert_eq!(store.record_link_judge_attempt(&b, &a).await.unwrap(), 2);
+    }
+```
+
+Two store methods used above already exist; confirm their exact names before running — `set_artifact_status` and `update_artifact_text` in `src/store/artifacts.rs`. If either differs, use the real one (the point of the test is the status filter and the `embed_rev` bump, not the setter's name).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib store::links`
+Expected: FAIL — `no method named links_from`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to the `impl Store` block in `src/store/links.rs`, and put the two structs above it.
+
+```rust
+/// One end of a link, seen from an anchor that is already in the result list.
+#[derive(Debug, Clone)]
+pub struct LinkedTo {
+    /// The ranked hit that recalled it.
+    pub via: String,
+    pub other: String,
+    /// Already decayed to the caller's clock. There is no stale number here.
+    pub weight: f64,
+    pub state: LinkState,
+    pub reason: Option<String>,
+    pub cues: Vec<Cue>,
+    /// The two sides come from different documents — or one of them is a merge,
+    /// which belongs to no document and always counts as differing.
+    pub cross_corpus: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LinkCounts {
+    pub total: i64,
+    pub related: i64,
+    /// Links whose judgement is queued or running.
+    pub judge_queue: i64,
+}
+```
+
+```rust
+    /// Every live link out of these anchors, strongest first.
+    ///
+    /// One statement per anchor rather than one `IN` over all of them: the
+    /// anchor list is `spread_from` long (three), the repo builds no SQL
+    /// strings from data, and a link has to be found from either end — which is
+    /// an `OR` over two indexed columns, not a set membership test.
+    ///
+    /// The endpoint's status is joined rather than stored, so undoing a merge
+    /// brings its links back without a write.
+    pub async fn links_from(
+        &self,
+        anchors: &[String],
+        states: &[LinkState],
+        half_life_days: f64,
+        at: i64,
+        min_weight: f64,
+    ) -> Result<Vec<LinkedTo>> {
+        let allowed: Vec<&str> = states.iter().map(|s| s.as_str()).collect();
+        let mut out: Vec<LinkedTo> = Vec::new();
+        for anchor in anchors {
+            let rows = sqlx::query(
+                // `weight >= ?` is a necessary condition, not the answer: decay
+                // only ever lowers it, so this narrows the scan with the index
+                // and the exact test happens below in Rust. Doing it in SQL
+                // would need a `pow` that is not in every SQLite build.
+                "SELECT l.a_id AS a_id, l.b_id AS b_id, l.weight AS weight,
+                        l.bumped_at AS bumped_at, l.state AS state, l.reason AS reason,
+                        l.cues AS cues,
+                        a.corpus_id AS a_corpus, b.corpus_id AS b_corpus
+                   FROM artifact_links l
+                   JOIN artifacts a ON a.id = l.a_id
+                   JOIN artifacts b ON b.id = l.b_id
+                  WHERE (l.a_id = ? OR l.b_id = ?)
+                    AND l.weight >= ?
+                    AND a.status = 'active' AND a.superseded_by IS NULL
+                    AND b.status = 'active' AND b.superseded_by IS NULL
+                  ORDER BY l.weight DESC",
+            )
+            .bind(anchor)
+            .bind(anchor)
+            .bind(min_weight)
+            .fetch_all(&self.pool)
+            .await?;
+
+            for r in &rows {
+                let state = LinkState::parse(r.get::<String, _>("state").as_str());
+                if !allowed.contains(&state.as_str()) {
+                    continue;
+                }
+                let weight = decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days);
+                if weight < min_weight {
+                    continue;
+                }
+                let a_id: String = r.get("a_id");
+                let b_id: String = r.get("b_id");
+                let other = if &a_id == anchor { b_id } else { a_id };
+                let a_corpus: Option<String> = r.get("a_corpus");
+                let b_corpus: Option<String> = r.get("b_corpus");
+                out.push(LinkedTo {
+                    via: anchor.clone(),
+                    other,
+                    weight,
+                    state,
+                    reason: r.get("reason"),
+                    cues: serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default(),
+                    // A merged artifact belongs to no corpus, so it can never be
+                    // "the same document" as anything.
+                    cross_corpus: match (a_corpus, b_corpus) {
+                        (Some(x), Some(y)) => x != y,
+                        _ => true,
+                    },
+                });
+            }
+        }
+        out.sort_by(|x, y| y.weight.total_cmp(&x.weight));
+        Ok(out)
+    }
+
+    /// Links strong enough, various enough, live enough and cross-corpus enough
+    /// to be worth one model call. Strongest first.
+    ///
+    /// Same two-step as `links_from`: the raw weight narrows with the index and
+    /// the decayed weight decides. Four times the caller's limit is fetched so
+    /// that rows failing the exact test do not eat the budget.
+    pub async fn links_to_judge(
+        &self,
+        min_weight: f64,
+        min_queries: i64,
+        half_life_days: f64,
+        at: i64,
+        limit: i64,
+    ) -> Result<Vec<Link>> {
+        let rows = sqlx::query(
+            "SELECT l.* FROM artifact_links l
+               JOIN artifacts a ON a.id = l.a_id
+               JOIN artifacts b ON b.id = l.b_id
+              WHERE l.state = 'learning'
+                AND l.weight >= ? AND l.queries >= ?
+                AND a.status = 'active' AND a.superseded_by IS NULL
+                AND b.status = 'active' AND b.superseded_by IS NULL
+                AND (a.corpus_id IS NULL OR b.corpus_id IS NULL OR a.corpus_id <> b.corpus_id)
+              ORDER BY l.weight DESC LIMIT ?",
+        )
+        .bind(min_weight)
+        .bind(min_queries)
+        .bind(limit.saturating_mul(4))
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .iter()
+            .map(row_to_link)
+            .filter(|l| decayed(l.weight, l.bumped_at, at, half_life_days) >= min_weight)
+            .take(limit.max(0) as usize)
+            .collect())
+    }
+
+    /// Delete `learning` links that have faded below the floor.
+    ///
+    /// The only write a quiet link ever costs. Rows whose *stored* weight is
+    /// already under the floor go in one statement; the rest are read back and
+    /// tested exactly, capped at `scan_limit` so one sweep cannot walk an
+    /// unbounded table. Whatever the cap leaves is pruned by the next sweep.
+    pub async fn prune_learning_links(
+        &self,
+        below: f64,
+        half_life_days: f64,
+        at: i64,
+        scan_limit: i64,
+    ) -> Result<u64> {
+        let mut dropped = sqlx::query("DELETE FROM artifact_links WHERE state = 'learning' AND weight < ?")
+            .bind(below)
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+
+        let rows = sqlx::query(
+            "SELECT a_id, b_id, weight, bumped_at FROM artifact_links
+              WHERE state = 'learning' ORDER BY bumped_at ASC LIMIT ?",
+        )
+        .bind(scan_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        for r in &rows {
+            if decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days) >= below {
+                continue;
+            }
+            dropped += sqlx::query("DELETE FROM artifact_links WHERE a_id = ? AND b_id = ?")
+                .bind(r.get::<String, _>("a_id"))
+                .bind(r.get::<String, _>("b_id"))
+                .execute(&self.pool)
+                .await?
+                .rows_affected();
+        }
+        if rows.len() as i64 == scan_limit {
+            tracing::info!(scan_limit, "prune scan hit its cap; the rest waits for the next sweep");
+        }
+        Ok(dropped)
+    }
+
+    /// Put judged links back to `learning` where either side has been re-embedded
+    /// since. The judge read text that no longer exists.
+    pub async fn reopen_stale_judged_links(&self, limit: i64) -> Result<u64> {
+        Ok(sqlx::query(
+            "UPDATE artifact_links
+                SET state = 'learning', reason = NULL,
+                    judged_rev_a = NULL, judged_rev_b = NULL
+              WHERE (a_id, b_id) IN (
+                SELECT l.a_id, l.b_id FROM artifact_links l
+                  JOIN artifacts a ON a.id = l.a_id
+                  JOIN artifacts b ON b.id = l.b_id
+                 WHERE l.state IN ('related', 'unrelated')
+                   AND (a.embed_rev IS NOT l.judged_rev_a OR b.embed_rev IS NOT l.judged_rev_b)
+                 LIMIT ?
+              )",
+        )
+        .bind(limit)
+        .execute(&self.pool)
+        .await?
+        .rows_affected())
+    }
+
+    /// Record a verdict. `judged_revs` is `(embed_rev of a, embed_rev of b)` as
+    /// read by whoever judged, which is what `reopen_stale_judged_links`
+    /// compares against later.
+    pub async fn set_link_state(
+        &self,
+        a: &str,
+        b: &str,
+        state: LinkState,
+        reason: Option<&str>,
+        judged_revs: Option<(i64, i64)>,
+    ) -> Result<()> {
+        let (a, b) = canonical(a, b);
+        let (rev_a, rev_b) = match judged_revs {
+            Some((x, y)) => (Some(x), Some(y)),
+            None => (None, None),
+        };
+        sqlx::query(
+            "UPDATE artifact_links
+                SET state = ?, reason = ?, judged_rev_a = ?, judged_rev_b = ?
+              WHERE a_id = ? AND b_id = ?",
+        )
+        .bind(state.as_str())
+        .bind(reason)
+        .bind(rev_a)
+        .bind(rev_b)
+        .bind(a)
+        .bind(b)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Count one call against a link and report the new total.
+    ///
+    /// Counted only where the answer said something about the *link* — an
+    /// unreadable reply. A call an outage ate says something about the endpoint,
+    /// and shelving a link for that would empty the pane every time the model is
+    /// down.
+    pub async fn record_link_judge_attempt(&self, a: &str, b: &str) -> Result<i64> {
+        let (a, b) = canonical(a, b);
+        Ok(sqlx::query_scalar(
+            "UPDATE artifact_links SET judge_attempts = judge_attempts + 1
+              WHERE a_id = ? AND b_id = ? RETURNING judge_attempts",
+        )
+        .bind(a)
+        .bind(b)
+        .fetch_optional(&self.pool)
+        .await?
+        .unwrap_or(0))
+    }
+
+    /// The three numbers Ops shows.
+    pub async fn link_counts(&self) -> Result<LinkCounts> {
+        Ok(LinkCounts {
+            total: sqlx::query_scalar("SELECT COUNT(*) FROM artifact_links")
+                .fetch_one(&self.pool)
+                .await?,
+            related: sqlx::query_scalar(
+                "SELECT COUNT(*) FROM artifact_links WHERE state = 'related'",
+            )
+            .fetch_one(&self.pool)
+            .await?,
+            judge_queue: sqlx::query_scalar(
+                "SELECT COUNT(*) FROM jobs
+                  WHERE stage = 'link_judge' AND state IN ('pending', 'running')",
+            )
+            .fetch_one(&self.pool)
+            .await?,
+        })
+    }
+```
+
+Note on `reopen_stale_judged_links`: `IS NOT` rather than `<>` because `judged_rev_*` is nullable and `NULL <> 0` is NULL, which would never reopen a link judged before the column carried a revision.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib store::links`
+Expected: PASS, 17 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/links.rs
+git commit -m "feat(links): read links through decay, prune, reopen and judge them"
+```
+
+---
+
+## Task 3: Activation on artifacts
+
+**Files:**
+- Modify: `src/store/schema.sql` (two columns on `artifacts`)
+- Modify: `src/store/mod.rs` (`ADDED_COLUMNS`, one backfill statement)
+- Modify: `src/store/artifacts.rs:277-290` and `:348-362` (both INSERT statements)
+- Modify: `src/store/links.rs` (activation accessors — same feature, same module)
+- Test: `src/store/links.rs`, `src/store/mod.rs`
+
+**Interfaces:**
+- Consumes: `decayed` from Task 1.
+- Produces: on `Store` — `activation_of(ids: &[String]) -> Result<HashMap<String, (f64, i64)>>` and `bump_activation(ids: &[String], delta: f64, half_life_days: f64, at: i64) -> Result<()>`.
+
+- [ ] **Step 1: Add the columns**
+
+In `src/store/schema.sql`, inside `CREATE TABLE IF NOT EXISTS artifacts`, after `last_verified_at`:
+
+```sql
+  -- Current accessibility. Raised by being captured, retrieved, opened and
+  -- confirmed; read through the same lazy decay as a link's weight. In SQLite
+  -- rather than the vector payload because the query path already needs one
+  -- SQLite read for links, and the same read returns this — one crossing.
+  activation       REAL    NOT NULL DEFAULT 1.0,
+  activated_at     INTEGER NOT NULL DEFAULT 0
+```
+
+- [ ] **Step 2: Teach `migrate` about them**
+
+In `src/store/mod.rs`, append to `ADDED_COLUMNS`:
+
+```rust
+            // Arrived with associative memory. Both have defaults that are the
+            // truth about an artifact captured before it existed — full
+            // accessibility, no stamp — and the stamp is backfilled below from
+            // `created_at`, which is when it was in fact last activated.
+            ("artifacts", "activation", "REAL NOT NULL DEFAULT 1.0"),
+            ("artifacts", "activated_at", "INTEGER NOT NULL DEFAULT 0"),
+```
+
+And after `sqlx::raw_sql(SCHEMA)` has been applied, beside the two other post-schema statements:
+
+```rust
+        // The one default an append cannot state: `activated_at` has to be the
+        // artifact's own creation time, not zero. Left at zero every artifact
+        // predating this column reads as decayed to nothing since 1970 — the
+        // whole base equally inaccessible, which is the opposite of the truth.
+        sqlx::query("UPDATE artifacts SET activated_at = created_at WHERE activated_at = 0")
+            .execute(&self.pool)
+            .await?;
+```
+
+- [ ] **Step 3: Stamp new artifacts**
+
+In `src/store/artifacts.rs`, the merged insert at line 277 and the captured insert at line 348 both need the two columns. Add `, activation, activated_at` to each column list and `, 1.0, ?` to each `VALUES` list, binding `c.created_at` at that position (place the bind in the same order as the placeholder). For the captured insert the value is the artifact's `created_at`; for the merged one likewise.
+
+- [ ] **Step 4: Write the failing tests**
+
+In `src/store/links.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn a_fresh_artifact_starts_fully_activated_and_stamped() {
+        // Left unstamped, every artifact in the base reads as having decayed
+        // since 1970 — equally inaccessible, which is the opposite of true.
+        let store = Store::memory().await.unwrap();
+        let (a, _) = two(&store).await;
+        let act = store.activation_of(&[a.clone()]).await.unwrap();
+        let (value, stamp) = act.get(&a).copied().expect("an artifact carries activation");
+        assert!((value - 1.0).abs() < 1e-9);
+        assert!(stamp > 0, "activated_at was never set at insert");
+    }
+
+    #[tokio::test]
+    async fn a_bump_folds_the_decay_in_like_a_link_does() {
+        let store = Store::memory().await.unwrap();
+        let (a, _) = two(&store).await;
+        sqlx::query("UPDATE artifacts SET activation = 4.0, activated_at = 0 WHERE id = ?")
+            .bind(&a)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        store
+            .bump_activation(&[a.clone()], 1.0, 14.0, 14 * 86_400)
+            .await
+            .unwrap();
+
+        let (value, stamp) = store.activation_of(&[a.clone()]).await.unwrap()[&a];
+        assert!((value - 3.0).abs() < 1e-6, "value was {value}");
+        assert_eq!(stamp, 14 * 86_400);
+    }
+
+    #[tokio::test]
+    async fn bumping_nothing_is_not_a_write() {
+        let store = Store::memory().await.unwrap();
+        store.bump_activation(&[], 1.0, 14.0, 0).await.unwrap();
+        assert!(store.activation_of(&[]).await.unwrap().is_empty());
+    }
+```
+
+In `src/store/mod.rs` tests, the upgrade path:
+
+```rust
+    #[tokio::test]
+    async fn a_base_captured_before_activation_gains_it_with_a_real_stamp() {
+        // The append can only state a constant, and zero is the wrong stamp:
+        // it reads as an artifact last reached in 1970. The backfill is what
+        // makes the column true of a base that predates it.
+        let store = Store::memory().await.unwrap();
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        store
+            .insert_artifacts(
+                &src.id,
+                &[artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "alpha".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        for stmt in [
+            "ALTER TABLE artifacts DROP COLUMN activation",
+            "ALTER TABLE artifacts DROP COLUMN activated_at",
+        ] {
+            sqlx::query(stmt)
+                .execute(&store.pool)
+                .await
+                .expect("the fixture needs an artifacts table from before activation");
+        }
+
+        store
+            .migrate()
+            .await
+            .expect("migrate refused a base captured before activation");
+
+        let (value, stamp): (f64, i64) =
+            sqlx::query_as("SELECT activation, activated_at FROM artifacts")
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert!((value - 1.0).abs() < 1e-9);
+        assert!(stamp > 0, "activated_at was left at the epoch");
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they fail**
+
+Run: `cargo test --lib store::`
+Expected: FAIL — `no method named activation_of`.
+
+- [ ] **Step 6: Write the implementation**
+
+Append to the `impl Store` block in `src/store/links.rs`:
+
+```rust
+    /// Each artifact's stored activation and the stamp it was true at.
+    ///
+    /// One statement for the whole candidate list: this is on the query path,
+    /// and fifty round trips to answer one search is exactly the layer crossing
+    /// the design promises not to be. The SQL is built only from `?`
+    /// placeholders — one per id, never a value — so nothing from a request
+    /// reaches the statement text.
+    pub async fn activation_of(
+        &self,
+        ids: &[String],
+    ) -> Result<std::collections::HashMap<String, (f64, i64)>> {
+        if ids.is_empty() {
+            return Ok(Default::default());
+        }
+        let holes = std::iter::repeat_n("?", ids.len()).collect::<Vec<_>>().join(",");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT id, activation, activated_at FROM artifacts WHERE id IN ({holes})"
+        )));
+        for id in ids {
+            q = q.bind(id);
+        }
+        Ok(q.fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(|r| {
+                (
+                    r.get::<String, _>("id"),
+                    (r.get::<f64, _>("activation"), r.get::<i64, _>("activated_at")),
+                )
+            })
+            .collect())
+    }
+
+    /// Raise the accessibility of these artifacts, folding the decay in.
+    ///
+    /// Read-then-write per artifact rather than one arithmetic UPDATE, for the
+    /// same reason `bump_link` does it: the decay is an exponential, and not
+    /// every SQLite build ships the math functions to express one in SQL.
+    pub async fn bump_activation(
+        &self,
+        ids: &[String],
+        delta: f64,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        if ids.is_empty() || delta == 0.0 {
+            return Ok(());
+        }
+        let current = self.activation_of(ids).await?;
+        for id in ids {
+            let Some((value, stamp)) = current.get(id).copied() else {
+                continue;
+            };
+            sqlx::query("UPDATE artifacts SET activation = ?, activated_at = ? WHERE id = ?")
+                .bind(decayed(value, stamp, at, half_life_days) + delta)
+                .bind(at)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
+    }
+```
+
+`sqlx::AssertSqlSafe` is already used in `migrate`; the audit it asks for is in the doc comment — the only interpolation is a run of `?`.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cargo test --lib store::`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/store/schema.sql src/store/mod.rs src/store/artifacts.rs src/store/links.rs
+git commit -m "feat(activation): give every artifact a decaying accessibility"
+```
+
+---
+
+## Task 4: Configuration and wiring
+
+**Files:**
+- Modify: `src/config.rs` (two config structs, `Config` fields, one warning)
+- Modify: `src/core/mod.rs` (two `Core` fields, `from_config`, `test_support::build`)
+- Test: `src/config.rs`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `AssociateConfig { enabled: bool, interval_mins: u64, half_life_days: f64, prune_below: f64, show_min: f64, judge_min: f64, judge_min_queries: i64, judge_per_sweep: i64, spread_from: usize, spread_max: usize, prime_margin: f64, prime_lift: usize }`, `ActivationConfig { half_life_days: f64, retrieved: f64, opened: f64, confirmed: f64 }`, `Config::associate`, `Config::activation`, `Core::associate`, `Core::activation`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/config.rs` tests:
+
+```rust
+    #[test]
+    fn the_association_defaults_are_the_documented_ones() {
+        let a = AssociateConfig::default();
+        assert!(a.enabled);
+        assert_eq!(a.interval_mins, 30);
+        assert_eq!(a.half_life_days, 30.0);
+        assert_eq!((a.show_min, a.judge_min, a.prune_below), (2.0, 4.0, 0.5));
+        assert_eq!((a.spread_from, a.spread_max), (3, 3));
+        assert_eq!((a.prime_margin, a.prime_lift), (0.5, 2));
+        let v = ActivationConfig::default();
+        assert_eq!(v.half_life_days, 14.0);
+        assert_eq!((v.retrieved, v.opened, v.confirmed), (1.0, 0.5, 3.0));
+    }
+
+    #[test]
+    fn a_config_with_no_association_block_still_gets_one() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, MINIMAL);
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert!(cfg.associate.enabled);
+        // ...and the feature is inert regardless, because there is nothing to
+        // learn from until searches are recorded.
+        assert!(!cfg.feedback.enabled);
+    }
+
+    #[test]
+    fn the_example_config_carries_the_association_block() {
+        let cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
+        assert_eq!(cfg.associate.spread_max, 3);
+    }
+```
+
+The third test fails until Task 14 adds the block to `config.example.toml`; `#[serde(default)]` on the section means it passes on the defaults alone, so it is safe to write now.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib config::`
+Expected: FAIL — `cannot find type AssociateConfig`.
+
+- [ ] **Step 3: Write the config**
+
+In `src/config.rs`, after `FeedbackConfig`:
+
+```rust
+/// Links learned from co-retrieval, and what they are allowed to do.
+///
+/// Every threshold here is a weight in the same units: one co-appearance is
+/// `+1`, one confirmed answer is `+2`, and a half-life of thirty days is what
+/// makes those numbers mean "lately" rather than "ever".
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct AssociateConfig {
+    /// Requires `feedback.enabled`. Without recorded searches there is nothing
+    /// to learn from, and that combination is a warning at startup.
+    pub enabled: bool,
+    pub interval_mins: u64,
+    pub half_life_days: f64,
+    /// Decayed weight under which a `learning` link is deleted.
+    pub prune_below: f64,
+    /// Decayed weight at which a link is worth showing.
+    pub show_min: f64,
+    /// ...and at which it is worth one model call.
+    pub judge_min: f64,
+    /// Distinct binding questions a link needs before it is judged. One question
+    /// asked six times is one question.
+    pub judge_min_queries: i64,
+    pub judge_per_sweep: i64,
+    /// How many of the top ranked hits are asked what they are linked to.
+    pub spread_from: usize,
+    /// How many associated hits may be appended, outside `limit`.
+    pub spread_max: usize,
+    /// How much more activated a hit must be than the one above it to pass it.
+    /// Normalised within one result list, so this is a fraction, not a weight.
+    pub prime_margin: f64,
+    /// Positions a hit may climb. `0` turns priming off.
+    pub prime_lift: usize,
+}
+
+impl Default for AssociateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_mins: 30,
+            half_life_days: 30.0,
+            prune_below: 0.5,
+            show_min: 2.0,
+            judge_min: 4.0,
+            judge_min_queries: 3,
+            judge_per_sweep: 10,
+            spread_from: 3,
+            spread_max: 3,
+            prime_margin: 0.5,
+            prime_lift: 2,
+        }
+    }
+}
+
+/// How accessible an artifact is, and what raises it.
+///
+/// Being surfaced *because* of activation raises nothing: `resurface` and
+/// association both leave it alone. Loops that reinforce themselves are the
+/// failure mode of this whole idea, and they are closed by construction.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ActivationConfig {
+    pub half_life_days: f64,
+    /// Returned by a search the caller marked as seen.
+    pub retrieved: f64,
+    /// Opened in the detail pane.
+    pub opened: f64,
+    /// Judged the answer to a real question. The strong signal.
+    pub confirmed: f64,
+}
+
+impl Default for ActivationConfig {
+    fn default() -> Self {
+        Self {
+            half_life_days: 14.0,
+            retrieved: 1.0,
+            opened: 0.5,
+            confirmed: 3.0,
+        }
+    }
+}
+```
+
+Add to `Config`:
+
+```rust
+    #[serde(default)]
+    pub associate: AssociateConfig,
+    #[serde(default)]
+    pub activation: ActivationConfig,
+```
+
+And in `warn_on_moved_keys` — which is where startup says what is quietly not happening — add:
+
+```rust
+        if self.associate.enabled && !self.feedback.enabled {
+            tracing::warn!(
+                "associate.enabled has no effect while feedback.enabled is false: links are \
+                 learned from recorded searches, and none are being recorded. Recording queries \
+                 is a privacy decision, so it keeps its own switch."
+            );
+        }
+```
+
+- [ ] **Step 4: Wire it into `Core`**
+
+In `src/core/mod.rs`, add the fields to `Core` beside `feedback`:
+
+```rust
+    /// Link learning, priming and association. Read on the search path and by
+    /// the sweep, so it lives here rather than being threaded down.
+    pub associate: crate::config::AssociateConfig,
+    pub activation: crate::config::ActivationConfig,
+```
+
+Set them in `from_config` (`associate: cfg.associate.clone(), activation: cfg.activation.clone(),`) and in `test_support::build`:
+
+```rust
+            // On, like the shipped default — and inert in most tests, because
+            // nothing has learned a link yet. The association tests seed one.
+            associate: crate::config::AssociateConfig::default(),
+            activation: crate::config::ActivationConfig::default(),
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test --locked`
+Expected: PASS (the whole suite — `Core` gained fields, so every construction site had to be updated).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.rs src/core/mod.rs
+git commit -m "feat(associate): add the [associate] and [activation] settings"
+```
+
+---
+
+## Task 5: The stages, the ticker, and the dispatch
+
+**Files:**
+- Modify: `src/store/jobs.rs:12-71` (`Stage`)
+- Modify: `src/jobs/mod.rs` (module list, `run_claimed` arms)
+- Create: `src/jobs/associate.rs` (skeleton: `run` and `judge` that do nothing yet)
+- Modify: `src/core/background.rs` (`spawn_associate_ticker`, `ASSOCIATE_TARGET`)
+- Modify: `src/main.rs` (spawn the ticker)
+- Test: `src/core/background.rs`
+
+**Interfaces:**
+- Consumes: `AssociateConfig` from Task 4.
+- Produces: `Stage::Associate` (`"associate"`), `Stage::LinkJudge` (`"link_judge"`), `background::ASSOCIATE_TARGET`, `background::spawn_associate_ticker(core, shutdown) -> JoinHandle<()>`, `jobs::associate::{run, judge}`.
+
+- [ ] **Step 1: Add the stages**
+
+In `src/store/jobs.rs`, add to the `Stage` enum, `as_str` and `parse`:
+
+```rust
+    /// The periodic association sweep. Its target is the collection rather than
+    /// any one artifact, so the `UNIQUE(stage, target_id)` on `jobs` guarantees
+    /// at most one queued sweep however often the ticker fires. Local work: it
+    /// replays the search log and arms `LinkJudge` units, and calls no model.
+    Associate,
+    /// One strong cross-corpus link, one call. Target is `"<a_id>|<b_id>"`.
+    LinkJudge,
+```
+
+```rust
+            Stage::Associate => "associate",
+            Stage::LinkJudge => "link_judge",
+```
+```rust
+            "associate" => Some(Stage::Associate),
+            "link_judge" => Some(Stage::LinkJudge),
+```
+
+- [ ] **Step 2: Add the skeleton unit**
+
+Create `src/jobs/associate.rs`:
+
+```rust
+//! Learning what belongs together, and saying so.
+//!
+//! Two things happen here and they are deliberately not the same job. The sweep
+//! is pure SQLite: it replays the search log, strengthens the pairs that were
+//! reached together, fades and prunes the ones that were not, and decides which
+//! links are worth asking about. The judge is one model call on one link, armed
+//! by the sweep and paced by the queue like every other call in the system.
+
+use crate::core::Core;
+use crate::error::Result;
+
+/// One sweep over everything learned since the last one.
+pub async fn run(core: &Core) -> Result<()> {
+    if !core.associate.enabled || !core.feedback.enabled {
+        return Ok(());
+    }
+    Ok(())
+}
+
+/// One link, one call. `target` is `"<a_id>|<b_id>"`.
+pub async fn judge(core: &Core, target: &str) -> Result<()> {
+    let _ = (core, target);
+    Ok(())
+}
+```
+
+And in `src/jobs/mod.rs`, `pub mod associate;` at the top of the module list, plus two arms in `run_claimed`'s match, beside `Stage::Consolidate`:
+
+```rust
+        // The sweep looks at the whole collection, so it ignores the target.
+        (Stage::Associate, _) => associate::run(core).await,
+        (Stage::LinkJudge, _) => associate::judge(core, &job.target_id).await,
+```
+
+`LinkJudge` deliberately gets no arm in the exhausted-attempts match below: a dead endpoint leaves the unit queued at the backoff ceiling like every other unit, and the link stays visible as `learning` in the meantime.
+
+- [ ] **Step 3: Write the failing test**
+
+In `src/core/background.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn the_association_ticker_queues_exactly_one_sweep() {
+        // Same reasoning as the consolidation sweep: `jobs` is unique on
+        // (stage, target), so a ticker firing while a sweep is still queued
+        // collapses onto the same row rather than stacking sweeps.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let h = spawn_associate_ticker(core.clone(), rx);
+        for _ in 0..50 {
+            if core.store.job_counts().await.unwrap().iter().any(|(_, n)| *n > 0) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let _ = tx.send(true);
+        let _ = h.await;
+
+        let j = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("the ticker queued nothing");
+        assert_eq!(j.stage, crate::store::jobs::Stage::Associate);
+        assert_eq!(j.target_id, ASSOCIATE_TARGET);
+        assert!(core.store.claim_job().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn no_recorded_searches_means_no_association_ticker_at_all() {
+        // `associate.enabled` without `feedback.enabled` is a warning at startup
+        // and nothing else: there is nothing to learn from.
+        let core = crate::core::test_support::test_core().await; // feedback off
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        // Returns rather than looping, so awaiting it cannot hang.
+        let _ = spawn_associate_ticker(core.clone(), rx).await;
+        assert!(core.store.claim_job().await.unwrap().is_none());
+    }
+```
+
+- [ ] **Step 4: Run to verify it fails**
+
+Run: `cargo test --lib core::background`
+Expected: FAIL — `cannot find function spawn_associate_ticker`.
+
+- [ ] **Step 5: Write the ticker**
+
+In `src/core/background.rs`, after `spawn_dedupe_ticker`:
+
+```rust
+/// The association sweep's job target. A constant rather than an artifact id:
+/// the sweep replays the whole log, and `UNIQUE(stage, target_id)` then bounds
+/// the queue to one of them however often the ticker fires.
+pub const ASSOCIATE_TARGET: &str = "collection";
+
+/// Queue an association sweep now and every `associate.interval_mins` after.
+///
+/// Its own ticker, like retention and dedupe: the rhythm of replaying a search
+/// log has nothing to do with the rhythm of duplicate discovery, and coupling
+/// the two is how switching one feature off silently switches another one off.
+///
+/// Returns before its loop when there is nothing to learn from — either the
+/// feature is off, or searches are not being recorded, which is the same thing.
+pub fn spawn_associate_ticker(
+    core: crate::core::Core,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !core.associate.enabled || !core.feedback.enabled {
+            tracing::info!("association sweep disabled");
+            return;
+        }
+        let period = std::time::Duration::from_secs(core.associate.interval_mins.max(1) * 60);
+        let mut tick = tokio::time::interval(period);
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = tick.tick() => {
+                    if let Err(e) = core
+                        .store
+                        .enqueue(crate::store::jobs::Stage::Associate, "collection", ASSOCIATE_TARGET)
+                        .await
+                    {
+                        tracing::warn!(error = %e, "could not queue the association sweep");
+                    }
+                }
+            }
+        }
+        tracing::info!("association ticker stopped");
+    })
+}
+```
+
+- [ ] **Step 6: Spawn it at startup**
+
+In `src/main.rs`, after the `repair` binding at line 299:
+
+```rust
+    let associate =
+        engram::core::background::spawn_associate_ticker(core.clone(), shutdown_rx.clone());
+```
+
+and beside `handles.push(repair);` at line 306:
+
+```rust
+    handles.push(associate);
+```
+
+Both go before `Worker::spawn` consumes `core`, which is why every other ticker is bound above that line too. Joined with the workers so shutdown waits for it rather than leaving a task the runtime drops mid-enqueue.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `cargo test --locked`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/store/jobs.rs src/jobs/mod.rs src/jobs/associate.rs src/core/background.rs src/main.rs
+git commit -m "feat(associate): add the sweep and judge stages and their ticker"
+```
+
+---
+
+## Task 6: The sweep replays what fired together
+
+**Files:**
+- Modify: `src/jobs/associate.rs`
+- Test: `src/jobs/associate.rs`
+
+**Interfaces:**
+- Consumes: `Store::{bump_link, bump_activation, meta_get, meta_set}`, `links::normalize_query`, `Core::{associate, activation, feedback}`.
+- Produces: `associate::run` now performs steps 1–3 of the spec's sweep; the private helpers `replay_events`, `replay_verdicts`, and the constants `EVENTS_AFTER: &str = "associate.events_after"`, `JUDGED_AFTER: &str = "associate.judged_after"`, `REPLAY_LIMIT: i64 = 2_000`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/jobs/associate.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::artifacts::NewArtifact;
+    use crate::store::feedback::{Door, NewCandidate, NewEvent, Verdict};
+    use crate::store::links::LinkState;
+
+    /// `n` artifacts, each in its own corpus, so every link between them is a
+    /// cross-corpus one.
+    async fn seed(core: &Core, n: usize) -> Vec<String> {
+        let mut ids = Vec::new();
+        for i in 0..n {
+            let src = core
+                .store
+                .insert_corpus(&format!("raw {i}"), "web", None)
+                .await
+                .unwrap();
+            let made = core
+                .store
+                .insert_artifacts(
+                    &src.id,
+                    &[NewArtifact {
+                        ordinal: 0,
+                        text: format!("artifact {i}"),
+                        corpus_span: None,
+                        title: Some(format!("t{i}")),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    }],
+                )
+                .await
+                .unwrap();
+            ids.push(made[0].id.clone());
+        }
+        ids
+    }
+
+    /// One recorded search, with `shown` deciding what the searcher saw.
+    async fn record(core: &Core, query: &str, shown: &[&String], unshown: &[&String]) -> String {
+        let candidates = shown
+            .iter()
+            .map(|id| NewCandidate {
+                artifact_id: (*id).clone(),
+                score: 1.0,
+                similarity: Some(0.9),
+                shown: true,
+            })
+            .chain(unshown.iter().map(|id| NewCandidate {
+                artifact_id: (*id).clone(),
+                score: 0.1,
+                similarity: Some(0.2),
+                shown: false,
+            }))
+            .collect();
+        core.store
+            .record_search(
+                NewEvent {
+                    query: query.into(),
+                    door: Door::Ui,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![0.0],
+                    embed_model: "fake".into(),
+                    candidates,
+                },
+                0,
+            )
+            .await
+            .unwrap()
+    }
+
+    /// Age every recorded event past the coalescing window, so the sweep will
+    /// look at it: a folding event is still moving.
+    async fn settle(core: &Core) {
+        sqlx::query("UPDATE search_events SET created_at = created_at - 3600")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+    }
+
+    async fn on(core: &mut Core) {
+        core.feedback.enabled = true;
+    }
+
+    #[tokio::test]
+    async fn two_searches_showing_the_same_pair_bind_it_twice() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "fat32 cluster", &[&ids[0], &ids[1]], &[]).await;
+        record(&core, "ntfs journal", &[&ids[0], &ids[1]], &[]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert!((l.weight - 2.0).abs() < 1e-6, "weight was {}", l.weight);
+        assert_eq!(l.queries, 2, "two different questions bound this pair");
+        assert_eq!(l.state, LinkState::Learning);
+    }
+
+    #[tokio::test]
+    async fn the_same_question_asked_twice_is_one_binding_query() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "fat32", &[&ids[0], &ids[1]], &[]).await;
+        // Coalescing is off in `record`, so this is a second event with the
+        // same words — which is a second use, and one question.
+        record(&core, "  FAT32  ", &[&ids[0], &ids[1]], &[]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert!((l.weight - 2.0).abs() < 1e-6);
+        assert_eq!(l.queries, 1);
+    }
+
+    #[tokio::test]
+    async fn only_what_the_searcher_saw_fires_together() {
+        // The stored pool is wider than the answer for evaluation's sake. An
+        // artifact nobody was shown was not reached, and did not fire.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        record(&core, "q", &[&ids[0], &ids[1]], &[&ids[2]]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        assert!(core.store.get_link(&ids[0], &ids[1]).await.unwrap().is_some());
+        assert!(core.store.get_link(&ids[0], &ids[2]).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn an_event_still_folding_is_left_for_the_next_sweep() {
+        // A typing burst is one event, and it is not finished until the
+        // coalescing window has passed. Replaying it early would bind the pairs
+        // of a half-typed query and then bind the finished one again.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "fat", &[&ids[0], &ids[1]], &[]).await;
+
+        run(&core).await.unwrap();
+        assert!(core.store.get_link(&ids[0], &ids[1]).await.unwrap().is_none());
+
+        settle(&core).await;
+        run(&core).await.unwrap();
+        assert!(core.store.get_link(&ids[0], &ids[1]).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_replayed_event_is_never_replayed_again() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "q", &[&ids[0], &ids[1]], &[]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+        run(&core).await.unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert!((l.weight - 1.0).abs() < 1e-6, "the event was replayed twice");
+    }
+
+    #[tokio::test]
+    async fn a_confirmed_answer_binds_harder_and_raises_its_activation() {
+        // Confirmation is the strong signal; co-appearance is the weak one.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        let ev = record(&core, "q", &[&ids[0], &ids[1], &ids[2]], &[]).await;
+        core.store.judge_hit(&ev, &ids[0]).await.unwrap();
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        // +1 for co-appearance, +2 more for the pairs containing the answer.
+        let with = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        let without = core.store.get_link(&ids[1], &ids[2]).await.unwrap().unwrap();
+        assert!((with.weight - 3.0).abs() < 1e-6, "weight was {}", with.weight);
+        assert!((without.weight - 1.0).abs() < 1e-6);
+
+        let act = core.store.activation_of(&ids).await.unwrap();
+        assert!(
+            act[&ids[0]].0 > act[&ids[1]].0,
+            "the confirmed answer gained no activation"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_gap_and_a_discard_teach_nothing_about_pairs() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        let g = record(&core, "nothing about this", &[&ids[0], &ids[1]], &[]).await;
+        core.store.judge(&g, Verdict::Gap).await.unwrap();
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        // Co-appearance still counts — the searcher did see both — but the
+        // verdict adds nothing on top of it.
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert!((l.weight - 1.0).abs() < 1e-6, "weight was {}", l.weight);
+    }
+
+    #[tokio::test]
+    async fn the_sweep_does_nothing_at_all_while_nothing_is_recorded() {
+        let core = test_core().await; // feedback off, associate on
+        let ids = seed(&core, 2).await;
+        run(&core).await.unwrap();
+        assert!(core.store.get_link(&ids[0], &ids[1]).await.unwrap().is_none());
+        assert_eq!(core.store.meta_get(EVENTS_AFTER).await.unwrap(), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::associate`
+Expected: FAIL — assertions about links that were never written.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace `run` in `src/jobs/associate.rs` and add the helpers:
+
+```rust
+use crate::store::links::normalize_query;
+use sqlx::Row;
+
+/// Last `search_events.created_at` folded into links.
+pub const EVENTS_AFTER: &str = "associate.events_after";
+/// Last `search_events.judged_at` folded into links.
+pub const JUDGED_AFTER: &str = "associate.judged_after";
+/// Events read per sweep. A ceiling rather than a budget: at 30-minute ticks
+/// nothing real reaches it, and a base that has been offline for a month
+/// catches up over a few sweeps instead of holding one worker for minutes.
+const REPLAY_LIMIT: i64 = 2_000;
+
+/// One sweep over everything learned since the last one.
+pub async fn run(core: &Core) -> Result<()> {
+    if !core.associate.enabled || !core.feedback.enabled {
+        return Ok(());
+    }
+    let at = crate::store::now();
+    let bound = replay_events(core, at).await?;
+    let confirmed = replay_verdicts(core, at).await?;
+    tracing::info!(events = bound, verdicts = confirmed, "association sweep");
+    Ok(())
+}
+
+/// Every pair of shown candidates in every settled event past the watermark.
+///
+/// "Settled" is the whole of the read condition beyond the watermark: an event
+/// inside `feedback.coalesce_secs` of now is still moving — a typing burst folds
+/// into one row — and binding the pairs of a half-typed query would then be
+/// followed by binding the finished one.
+async fn replay_events(core: &Core, at: i64) -> Result<usize> {
+    let after: i64 = core
+        .store
+        .meta_get(EVENTS_AFTER)
+        .await?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let settled = at - core.feedback.coalesce_secs.max(0);
+
+    let events = sqlx::query(
+        "SELECT id, query, created_at FROM search_events
+          WHERE created_at > ? AND created_at <= ?
+          ORDER BY created_at ASC, id ASC LIMIT ?",
+    )
+    .bind(after)
+    .bind(settled)
+    .bind(REPLAY_LIMIT)
+    .fetch_all(&core.store.pool)
+    .await?;
+
+    let mut high = after;
+    for e in &events {
+        let id: String = e.get("id");
+        let cue = normalize_query(&e.get::<String, _>("query"));
+        let shown = shown_candidates(core, &id).await?;
+        for i in 0..shown.len() {
+            for j in (i + 1)..shown.len() {
+                core.store
+                    .bump_link(
+                        &shown[i],
+                        &shown[j],
+                        1.0,
+                        Some(&cue),
+                        core.associate.half_life_days,
+                        at,
+                    )
+                    .await?;
+            }
+        }
+        high = high.max(e.get::<i64, _>("created_at"));
+    }
+
+    if high > after {
+        core.store.meta_set(EVENTS_AFTER, &high.to_string()).await?;
+    }
+    Ok(events.len())
+}
+
+/// Every hit verdict past the second watermark: the pairs containing the
+/// confirmed answer bind harder, and the answer itself becomes more accessible.
+///
+/// Its own cursor, because a verdict arrives days after the event it is about —
+/// one cursor would either replay the event's pairs again or skip the verdict.
+/// `gap` and `discard` are not read here: neither says anything about a pair.
+async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
+    let after: i64 = core
+        .store
+        .meta_get(JUDGED_AFTER)
+        .await?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let events = sqlx::query(
+        "SELECT id, expect_id, judged_at FROM search_events
+          WHERE judged_at > ? AND verdict = 'hit' AND expect_id IS NOT NULL
+          ORDER BY judged_at ASC, id ASC LIMIT ?",
+    )
+    .bind(after)
+    .bind(REPLAY_LIMIT)
+    .fetch_all(&core.store.pool)
+    .await?;
+
+    let mut high = after;
+    for e in &events {
+        let id: String = e.get("id");
+        let expect: String = e.get("expect_id");
+        let shown = shown_candidates(core, &id).await?;
+        for other in shown.iter().filter(|c| **c != expect) {
+            // No cue: this event's words were already folded in as a binding
+            // query when its co-appearance was replayed, and counting them
+            // twice would say two questions bound this pair.
+            core.store
+                .bump_link(&expect, other, 2.0, None, core.associate.half_life_days, at)
+                .await?;
+        }
+        // Raised whether or not the answer was in the pool at all — an artifact
+        // the ranking never returned and a person confirmed anyway is the most
+        // valuable confirmation there is.
+        core.store
+            .bump_activation(
+                std::slice::from_ref(&expect),
+                core.activation.confirmed,
+                core.activation.half_life_days,
+                at,
+            )
+            .await?;
+        high = high.max(e.get::<i64, _>("judged_at"));
+    }
+
+    if high > after {
+        core.store.meta_set(JUDGED_AFTER, &high.to_string()).await?;
+    }
+    Ok(events.len())
+}
+
+/// What one event actually put in front of the searcher, in rank order.
+async fn shown_candidates(core: &Core, event_id: &str) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT artifact_id FROM search_candidates
+          WHERE event_id = ? AND shown = 1 ORDER BY rank",
+    )
+    .bind(event_id)
+    .fetch_all(&core.store.pool)
+    .await?)
+}
+```
+
+Note: `bump_link` has a foreign key to `artifacts`, and a candidate row can name an artifact that has since been deleted. Wrap the bump so that is not a sweep failure — change the two call sites to:
+
+```rust
+                if let Err(e) = core.store.bump_link(...).await {
+                    tracing::debug!(error = %e, "could not bind a pair; one side is gone");
+                }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib jobs::associate`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/associate.rs
+git commit -m "feat(associate): bind what was reached together, once each"
+```
+
+---
+
+## Task 7: The sweep forgets, reopens, and arms the judge
+
+**Files:**
+- Modify: `src/jobs/associate.rs`
+- Test: `src/jobs/associate.rs`
+
+**Interfaces:**
+- Consumes: `Store::{prune_learning_links, reopen_stale_judged_links, links_to_judge, rearm_idle_seq, live_job}`.
+- Produces: `associate::link_target(a: &str, b: &str) -> String` (public — the judge parses it back), `PRUNE_SCAN_LIMIT: i64 = 5_000`, and `run` completing steps 4–6.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the tests in `src/jobs/associate.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_faded_link_is_forgotten_and_a_judged_one_is_not() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 4).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        core.store
+            .bump_link(&ids[2], &ids[3], 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(&ids[2], &ids[3], LinkState::Related, Some("why"), Some((0, 0)))
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store.get_link(&ids[0], &ids[1]).await.unwrap().is_none(),
+            "a link last used at the epoch has decayed to nothing"
+        );
+        assert!(core.store.get_link(&ids[2], &ids[3]).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_strong_cross_corpus_link_is_armed_for_the_judge_exactly_once() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        for q in ["one", "two", "three", "four"] {
+            core.store
+                .bump_link(&ids[0], &ids[1], 1.0, Some(q), 30.0, crate::store::now())
+                .await
+                .unwrap();
+        }
+
+        run(&core).await.unwrap();
+        let target = link_target(&ids[0], &ids[1]);
+        assert!(
+            core.store
+                .live_job(crate::store::jobs::Stage::LinkJudge, &target)
+                .await
+                .unwrap()
+        );
+
+        // A second sweep must not wind the queued unit's attempts back.
+        run(&core).await.unwrap();
+        let mut seen = 0;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            if j.stage == crate::store::jobs::Stage::LinkJudge {
+                seen += 1;
+                assert_eq!(j.attempts, 1, "the unit was re-armed underneath itself");
+            }
+        }
+        assert_eq!(seen, 1);
+    }
+
+    #[tokio::test]
+    async fn a_judged_link_is_reopened_when_its_text_changes_under_it() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 9.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(&ids[0], &ids[1], LinkState::Unrelated, Some("coincidence"), Some((0, 0)))
+            .await
+            .unwrap();
+        core.store
+            .update_artifact_text(&ids[0], "rewritten")
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Learning, "the judge read text that is gone");
+    }
+
+    #[test]
+    fn a_link_names_itself_the_same_way_round_however_it_is_armed() {
+        assert_eq!(link_target("b", "a"), link_target("a", "b"));
+        assert_eq!(link_target("a", "b"), "a|b");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::associate`
+Expected: FAIL — `cannot find function link_target`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `src/jobs/associate.rs`:
+
+```rust
+/// Learning links read per prune pass. Whatever the cap leaves is pruned by the
+/// next sweep — a bound on one tick's work, not on what is eventually forgotten.
+const PRUNE_SCAN_LIMIT: i64 = 5_000;
+
+/// The queue name of one link. Canonical, so the same pair never gets two units.
+pub fn link_target(a: &str, b: &str) -> String {
+    let (a, b) = crate::store::links::canonical(a, b);
+    format!("{a}|{b}")
+}
+```
+
+and extend `run`:
+
+```rust
+pub async fn run(core: &Core) -> Result<()> {
+    if !core.associate.enabled || !core.feedback.enabled {
+        return Ok(());
+    }
+    let at = crate::store::now();
+    let bound = replay_events(core, at).await?;
+    let confirmed = replay_verdicts(core, at).await?;
+
+    let forgotten = core
+        .store
+        .prune_learning_links(
+            core.associate.prune_below,
+            core.associate.half_life_days,
+            at,
+            PRUNE_SCAN_LIMIT,
+        )
+        .await?;
+    // A re-embed of either side reopens the verdict before anything is armed,
+    // so a link whose text changed is re-asked in this same sweep rather than
+    // waiting out another interval.
+    let reopened = core.store.reopen_stale_judged_links(PRUNE_SCAN_LIMIT).await?;
+
+    let mut armed = 0;
+    for l in core
+        .store
+        .links_to_judge(
+            core.associate.judge_min,
+            core.associate.judge_min_queries,
+            core.associate.half_life_days,
+            at,
+            core.associate.judge_per_sweep,
+        )
+        .await?
+    {
+        let target = link_target(&l.a_id, &l.b_id);
+        // A link whose judgement is already queued is already going to be
+        // judged; arming it again is a no-op that costs another link its turn.
+        if core.store.live_job(crate::store::jobs::Stage::LinkJudge, &target).await? {
+            continue;
+        }
+        core.store
+            .rearm_idle_seq(crate::store::jobs::Stage::LinkJudge, "link", &target, armed)
+            .await?;
+        armed += 1;
+    }
+
+    tracing::info!(
+        events = bound,
+        verdicts = confirmed,
+        forgotten,
+        reopened,
+        armed,
+        "association sweep"
+    );
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib jobs::associate`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/associate.rs
+git commit -m "feat(associate): forget faded links, reopen stale verdicts, arm the judge"
+```
+
+---
+
+## Task 8: The judge
+
+**Files:**
+- Modify: `src/infer/prompt.rs` (system prompt and prompt builder, beside the dedupe ones)
+- Modify: `src/jobs/associate.rs` (`judge`, the parser)
+- Test: `src/infer/prompt.rs`, `src/jobs/associate.rs`
+
+**Interfaces:**
+- Consumes: `Core::judge` (`Arc<dyn Completer>`), `Core::gate`, `Store::{get_link, get_artifact, set_link_state, record_link_judge_attempt, record_pair_with_detail}`.
+- Produces: `prompt::LINK_SYSTEM: &str`, `prompt::link_prompt(a: (&str, &str), b: (&str, &str), cues: &[String], attempt: i64) -> String`; in `associate`: `LinkVerdict { Related, Unrelated, Duplicate }`, `parse_link(&str) -> Result<(LinkVerdict, String)>`, `MAX_UNREADABLE_LINK_JUDGEMENTS: i64 = 3`.
+- Also produces on `Store`: `record_pair_with_detail(a, b, score, detail) -> Result<bool>` in `src/store/pairs.rs`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/infer/prompt.rs` tests:
+
+```rust
+    #[test]
+    fn the_link_prompt_carries_both_titles_and_the_questions_that_bound_them() {
+        // The binding queries are the evidence. Without them the model is being
+        // asked whether two arbitrary texts are related, which is a different
+        // and much worse question than why these two keep being needed at once.
+        let p = link_prompt(
+            ("Mounting E01 images", "ewfmount /dev/..."),
+            ("Loop device limits", "max_loop=64"),
+            &["mount forensic image".into()],
+            0,
+        );
+        assert!(p.contains("Mounting E01 images"));
+        assert!(p.contains("max_loop=64"));
+        assert!(p.contains("mount forensic image"));
+        assert!(!p.contains("attempt"), "a first ask must stay cache-identical");
+        assert!(link_prompt(("a", "b"), ("c", "d"), &[], 2).contains("attempt 3"));
+    }
+```
+
+In `src/jobs/associate.rs` tests:
+
+```rust
+    #[test]
+    fn a_verdict_is_read_out_of_the_reply_and_an_unreadable_one_is_an_error() {
+        let (v, why) = parse_link(r#"{"relation":"related","reason":"both about mounting"}"#).unwrap();
+        assert_eq!(v, LinkVerdict::Related);
+        assert_eq!(why, "both about mounting");
+        assert_eq!(
+            parse_link(r#"{"relation":"duplicate","reason":"same thing"}"#).unwrap().0,
+            LinkVerdict::Duplicate
+        );
+        assert!(parse_link("I think they are related!").is_err());
+        assert!(parse_link(r#"{"relation":"maybe","reason":"x"}"#).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_related_verdict_names_the_relation_and_stops_the_decay() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter::replying(
+            r#"{"relation":"related","reason":"the config and its errors"}"#,
+        ));
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Related);
+        assert_eq!(l.reason.as_deref(), Some("the config and its errors"));
+        assert_eq!(l.judged_rev_a, Some(0));
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_verdict_is_stored_so_it_is_not_asked_again() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter::replying(
+            r#"{"relation":"unrelated","reason":"a coincidence of retrieval"}"#,
+        ));
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(
+            core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap().state,
+            LinkState::Unrelated
+        );
+        // ...and it is never armed again, however strong it becomes.
+        run(&core).await.unwrap();
+        assert!(
+            !core
+                .store
+                .live_job(crate::store::jobs::Stage::LinkJudge, &link_target(&ids[0], &ids[1]))
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_disguised_duplicate_is_handed_to_consolidation_and_still_shown() {
+        // The embedding failed to notice; the reader should still see the
+        // connection while dedupe decides what to do about it.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter::replying(
+            r#"{"relation":"duplicate","reason":"the same procedure twice"}"#,
+        ));
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        let pair = core
+            .store
+            .pair_state_between(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .expect("consolidation was never told");
+        assert_eq!(pair, crate::store::pairs::PairState::Pending);
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Related);
+        assert!(l.reason.as_deref().unwrap().contains("consolidation"));
+    }
+
+    #[tokio::test]
+    async fn three_unreadable_replies_shelve_the_link_rather_than_asking_forever() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter::replying(
+            "no idea, sorry",
+        ));
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        let target = link_target(&ids[0], &ids[1]);
+
+        for _ in 0..2 {
+            assert!(judge(&core, &target).await.is_err(), "an unreadable reply is an error");
+            assert_eq!(
+                core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap().state,
+                LinkState::Learning,
+                "the link stays visible while it is still being asked about"
+            );
+        }
+        judge(&core, &target).await.unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Unrelated);
+        assert_eq!(l.reason.as_deref(), Some("unreadable"));
+    }
+
+    #[tokio::test]
+    async fn a_link_that_has_already_been_answered_costs_no_call() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(&ids[0], &ids[1], LinkState::Dismissed, None, None)
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(
+            core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap().state,
+            LinkState::Dismissed
+        );
+    }
+```
+
+`FakeCompleter::replying` may not exist — check `src/infer/fake.rs` and add it if not, in the shape the other fakes use (a stored `String` returned from `complete`). That is part of this step.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::associate infer::prompt`
+Expected: FAIL — `cannot find function link_prompt`, `parse_link`.
+
+- [ ] **Step 3: Write the prompt**
+
+In `src/infer/prompt.rs`, after `dedupe_prompt`:
+
+```rust
+pub const LINK_SYSTEM: &str = r#"Two knowledge artifacts keep being retrieved by the same searches. You say what that means, in one line a reader would find useful.
+
+Choose exactly one:
+
+- "related" — being needed together makes sense: one is the configuration and the other its failure mode, one is the procedure and the other the tool it needs, one explains why the other is done. Say what the relation is, in the reader's own terms, in one sentence.
+- "unrelated" — the searches that returned both were about something else, and there is no connection worth showing. A shared word is not a connection.
+- "duplicate" — they say the same thing in different words. Only this, and not "related", when neither adds anything the other lacks.
+
+Judge the relation between the artifacts, not their similarity. Two texts that share no vocabulary at all can be strongly related; two that read alike can be about different subjects.
+
+Reply with JSON only, no commentary, in exactly this shape:
+
+{"relation": "related", "reason": "..."}
+
+- relation: one of "related", "unrelated", "duplicate".
+- reason: one sentence. For "related" it is shown to the reader beside the link, so write it for them and not about the task."#;
+
+/// Two artifacts, and the questions that kept returning both.
+///
+/// The cues are the evidence. Without them this asks whether two arbitrary texts
+/// are related, which is a worse question with a worse answer: what is being
+/// judged is why these two keep being *needed at once*.
+///
+/// `attempt` is in the prompt for the same reason it is in `dedupe_prompt`: the
+/// endpoint caches by exact prompt text, and a retry of a reply the parser could
+/// not read would otherwise re-read the same unreadable bytes. Zero adds
+/// nothing, so a first ask stays byte-identical between runs.
+pub fn link_prompt(
+    a: (&str, &str),
+    b: (&str, &str),
+    cues: &[String],
+    attempt: i64,
+) -> String {
+    let mut s = String::new();
+    if attempt > 0 {
+        s.push_str(&format!("(attempt {})\n", attempt + 1));
+    }
+    s.push_str(&format!(
+        "----- ARTIFACT A -----\nTitle: {}\n\n{}\n----- ARTIFACT B -----\nTitle: {}\n\n{}\n----- END -----",
+        a.0, a.1, b.0, b.1
+    ));
+    if !cues.is_empty() {
+        s.push_str(&format!(
+            "\n\nBoth were returned by these searches: {}.",
+            cues.join("; ")
+        ));
+    }
+    s
+}
+```
+
+- [ ] **Step 4: Add the pair-with-detail writer**
+
+In `src/store/pairs.rs`, beside `record_pair`:
+
+```rust
+    /// File a pair for review, saying where it came from.
+    ///
+    /// `record_pair` with a `detail`, for the one producer that is not the
+    /// similarity sweep: a link the judge found to be a disguised duplicate has
+    /// no cosine behind it, so its `score` is genuinely zero and the detail is
+    /// what explains the row on a page that otherwise renders a percentage.
+    pub async fn record_pair_with_detail(
+        &self,
+        a: &str,
+        b: &str,
+        score: f32,
+        detail: &str,
+    ) -> Result<bool> {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, detail, created_at)
+             VALUES (?, ?, ?, 'pending', ?, ?)",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(score as f64)
+        .bind(detail)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+```
+
+`INSERT OR IGNORE`, like `record_pair`: a pair an operator already dismissed must not be re-filed by a link.
+
+- [ ] **Step 5: Write the judge**
+
+In `src/jobs/associate.rs`:
+
+```rust
+use crate::error::Error;
+use crate::store::links::LinkState;
+
+/// Unreadable replies after which a link is shelved rather than asked forever.
+pub const MAX_UNREADABLE_LINK_JUDGEMENTS: i64 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkVerdict {
+    Related,
+    Unrelated,
+    /// The two say the same thing and the embedding failed to notice.
+    Duplicate,
+}
+
+/// A reply that cannot be read is an error, not a verdict.
+///
+/// Defaulting to `unrelated` would quietly close real relations; defaulting to
+/// `related` would show the reader a line the model never wrote. Failing leaves
+/// the link `learning` — still visible, still binding — and the unit retries
+/// under the queue's backoff with a prompt that differs by its attempt number.
+pub fn parse_link(body: &str) -> Result<(LinkVerdict, String)> {
+    #[derive(serde::Deserialize)]
+    struct Raw {
+        relation: String,
+        #[serde(default)]
+        reason: Option<String>,
+    }
+    let r: Raw = serde_json::from_str(crate::infer::prompt::extract_json(body)).map_err(|e| {
+        Error::MalformedLlmOutput(format!("link reply was not the expected JSON: {e}"))
+    })?;
+    let verdict = match r.relation.as_str() {
+        "related" => LinkVerdict::Related,
+        "unrelated" => LinkVerdict::Unrelated,
+        "duplicate" => LinkVerdict::Duplicate,
+        other => {
+            return Err(Error::MalformedLlmOutput(format!(
+                "link reply named no relation this understands: {other}"
+            )));
+        }
+    };
+    Ok((verdict, r.reason.unwrap_or_default()))
+}
+
+/// One link, one call.
+pub async fn judge(core: &Core, target: &str) -> Result<()> {
+    let (a_id, b_id) = target.split_once('|').ok_or(Error::NotFound)?;
+    let Some(link) = core.store.get_link(a_id, b_id).await? else {
+        // Pruned, or one side deleted, while the unit waited out a backoff.
+        return Ok(());
+    };
+    if link.state != LinkState::Learning {
+        // Answered by an operator's dismissal, or by a sweep that reopened and
+        // a sibling unit that then settled it.
+        return Ok(());
+    }
+    let a = core.store.get_artifact(&link.a_id).await?;
+    let b = core.store.get_artifact(&link.b_id).await?;
+    // Re-checked here and not only when the unit was armed: a side can be
+    // superseded or deprecated while this waits, and spending the scarcest
+    // thing in the system on an artifact nobody will be shown buys nothing.
+    if !a.in_results() || !b.in_results() {
+        return Ok(());
+    }
+
+    let cues: Vec<String> = link.cues.iter().map(|c| c.q.clone()).collect();
+    let permit = core.gate.background().await;
+    let reply = core
+        .judge
+        .complete(
+            crate::infer::prompt::LINK_SYSTEM,
+            &crate::infer::prompt::link_prompt(
+                (a.title.as_deref().unwrap_or("untitled"), &a.text),
+                (b.title.as_deref().unwrap_or("untitled"), &b.text),
+                &cues,
+                link.judge_attempts,
+            ),
+        )
+        .await;
+    permit.finished();
+    // A call the endpoint never answered says nothing about the link: it stays
+    // `learning`, stays visible, and the queue backs the unit off.
+    let reply = reply?;
+
+    let revs = Some((a.embed_rev, b.embed_rev));
+    let (verdict, reason) = match parse_link(&reply) {
+        Ok(v) => v,
+        Err(e) => {
+            // Counted only here, because this is the only failure that says
+            // anything about the link itself.
+            let attempts = core.store.record_link_judge_attempt(&link.a_id, &link.b_id).await?;
+            if attempts >= MAX_UNREADABLE_LINK_JUDGEMENTS {
+                tracing::warn!(target, attempts, "shelving a link the model will not answer for");
+                core.store
+                    .set_link_state(&link.a_id, &link.b_id, LinkState::Unrelated, Some("unreadable"), revs)
+                    .await?;
+                return Ok(());
+            }
+            tracing::warn!(target, attempts, reply_len = reply.len(), error = %e, "link reply unreadable");
+            return Err(e);
+        }
+    };
+
+    match verdict {
+        LinkVerdict::Related => {
+            core.store
+                .set_link_state(&link.a_id, &link.b_id, LinkState::Related, Some(&reason), revs)
+                .await?;
+        }
+        LinkVerdict::Unrelated => {
+            core.store
+                .set_link_state(&link.a_id, &link.b_id, LinkState::Unrelated, Some(&reason), revs)
+                .await?;
+        }
+        LinkVerdict::Duplicate => {
+            // Handed over rather than acted on: consolidation owns every
+            // decision that hides an artifact, with its own guards and its own
+            // undo. The score is zero because no cosine was ever measured —
+            // that is what `detail` is there to explain on the review page.
+            core.store
+                .record_pair_with_detail(&link.a_id, &link.b_id, 0.0, "link")
+                .await?;
+            core.store
+                .set_link_state(
+                    &link.a_id,
+                    &link.b_id,
+                    LinkState::Related,
+                    Some("same content; handed to consolidation"),
+                    revs,
+                )
+                .await?;
+        }
+    }
+    Ok(())
+}
+```
+
+`extract_json` in `src/infer/prompt.rs` is private today — make it `pub(crate)` so the parser here can reuse the same fence-stripping the dedupe parser gets.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test --lib jobs::associate infer::prompt store::pairs`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/infer/prompt.rs src/infer/fake.rs src/jobs/associate.rs src/store/pairs.rs
+git commit -m "feat(associate): name what a strong cross-corpus link is"
+```
+
+---
+
+## Task 9: Priming the ranked order
+
+**Files:**
+- Modify: `src/core/search.rs` (`SearchResult::primed`, `prime`, one read in `search_with`)
+- Test: `src/core/search.rs`
+
+**Interfaces:**
+- Consumes: `Store::activation_of`, `links::decayed`, `Core::{associate, activation}`.
+- Produces: `SearchResult.primed: bool` (skipped when false), private `fn prime(Vec<SearchResult>, &HashMap<String, f64>, f64, usize) -> Vec<SearchResult>`, private `async fn activation_now(&self, ids: &[String]) -> HashMap<String, f64>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/core/search.rs` tests:
+
+```rust
+    fn ranked(ids: &[&str]) -> Vec<SearchResult> {
+        ids.iter()
+            .map(|id| SearchResult {
+                artifact_id: (*id).into(),
+                corpus_id: "c".into(),
+                title: None,
+                text: String::new(),
+                category: None,
+                tags: vec![],
+                score: 0.5,
+                status: None,
+                superseded_by: None,
+                last_verified_at: None,
+                weak: false,
+                primed: false,
+            })
+            .collect()
+    }
+
+    fn order(rs: &[SearchResult]) -> Vec<&str> {
+        rs.iter().map(|r| r.artifact_id.as_str()).collect()
+    }
+
+    #[test]
+    fn a_hit_climbs_at_most_two_places_and_never_past_the_first() {
+        // Rank-based rather than score-based on purpose: hybrid scores are
+        // fused ranks and mean nothing across queries, while "moved up two
+        // places" means the same thing every time — and can be tested here.
+        let act = HashMap::from([("d".to_string(), 4.0)]);
+        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 2);
+        assert_eq!(order(&out), vec!["a", "d", "b", "c"]);
+        assert!(out[1].primed, "the hit that moved must say so");
+        assert!(!out[2].primed, "the hit it passed did not move up");
+    }
+
+    #[test]
+    fn the_most_active_hit_cannot_displace_an_exact_match() {
+        let act = HashMap::from([("b".to_string(), 9.0)]);
+        let out = prime(ranked(&["a", "b", "c"]), &act, 0.5, 2);
+        assert_eq!(order(&out), vec!["a", "b", "c"]);
+        assert!(out.iter().all(|r| !r.primed));
+    }
+
+    #[test]
+    fn a_lift_of_zero_turns_priming_off_entirely() {
+        let act = HashMap::from([("d".to_string(), 4.0)]);
+        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 0);
+        assert_eq!(order(&out), vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn activation_that_is_merely_higher_does_not_move_anything() {
+        // The margin is what keeps this from reshuffling every list: two hits
+        // that are both somewhat active stay in the order the ranking gave.
+        let act = HashMap::from([("c".to_string(), 4.0), ("d".to_string(), 3.6)]);
+        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 2);
+        assert_eq!(order(&out), vec!["a", "c", "b", "d"], "only c clears the margin");
+    }
+
+    #[tokio::test]
+    async fn priming_changes_the_order_a_search_returns_and_says_which_hit_moved() {
+        let mut core = test_core().await;
+        core.associate.prime_lift = 2;
+        let texts: Vec<(&str, &str, &[&str])> = (0..6)
+            .map(|_| ("alpha text about it", "note", &[][..]))
+            .collect();
+        seed(&core, &texts).await;
+        reembed_all(&core).await;
+
+        let plain = {
+            let mut off = core.clone();
+            off.associate.prime_lift = 0;
+            off.search(&q("alpha text about it"), Door::Ui).await.unwrap()
+        };
+        assert!(plain.len() >= 4, "this test needs a list to reorder");
+        assert!(plain.iter().all(|r| !r.primed));
+
+        // The one at the bottom is the one people actually keep confirming.
+        let bottom = plain.last().unwrap().artifact_id.clone();
+        sqlx::query("UPDATE artifacts SET activation = 100.0, activated_at = ? WHERE id = ?")
+            .bind(now_secs())
+            .bind(&bottom)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let primed = core.search(&q("alpha text about it"), Door::Ui).await.unwrap();
+        let moved = primed.iter().position(|r| r.artifact_id == bottom).unwrap();
+        assert!(
+            moved < plain.len() - 1,
+            "activation did not reach the ranked list at all"
+        );
+        assert!(primed[moved].primed, "a hit that moved must say so");
+        assert_ne!(primed[0].artifact_id, bottom, "rank 1 was displaced");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib core::search`
+Expected: FAIL — `struct SearchResult has no field named primed`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the field to `SearchResult` (after `weak`):
+
+```rust
+    /// This hit moved up because it is more accessible than the ones it passed
+    /// — recently and often reached. Bounded by `associate.prime_lift`, never
+    /// past rank 1, and said out loud wherever it happened: nothing about the
+    /// order is silent.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub primed: bool,
+```
+
+Set `primed: false` in `impl From<SearchHit> for SearchResult` and at the one other construction site in `search_with`.
+
+Add the two functions:
+
+```rust
+/// Move hits up on activation, within hard bounds.
+///
+/// Rank-based rather than score-based: hybrid scores are fused ranks and mean
+/// nothing across queries, while "moved up two places" means the same thing
+/// every time. The activation is normalised within this one list, so `margin` is
+/// a fraction of the most accessible hit here rather than an absolute weight —
+/// which is what makes one default work for a list of ones and a list of
+/// hundreds.
+///
+/// Index 0 is untouchable and index 1 cannot move, because moving it would
+/// displace rank 1. An exact match is never buried.
+fn prime(
+    results: Vec<SearchResult>,
+    activation: &HashMap<String, f64>,
+    margin: f64,
+    lift: usize,
+) -> Vec<SearchResult> {
+    if lift == 0 || results.len() < 3 {
+        return results;
+    }
+    let max = activation.values().copied().fold(0.0f64, f64::max);
+    if max <= 0.0 {
+        return results;
+    }
+    let mut rows: Vec<(SearchResult, f64, usize)> = results
+        .into_iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let a = activation.get(&r.artifact_id).copied().unwrap_or(0.0) / max;
+            (r, a, i)
+        })
+        .collect();
+
+    for i in 2..rows.len() {
+        let mut j = i;
+        let mut moved = 0;
+        while j > 1 && moved < lift && rows[j].1 - rows[j - 1].1 > margin {
+            rows.swap(j - 1, j);
+            j -= 1;
+            moved += 1;
+        }
+    }
+
+    rows.into_iter()
+        .enumerate()
+        .map(|(pos, (mut r, _, was))| {
+            // Only a climb is priming. A hit that was passed did not move up,
+            // and labelling it would say something untrue about it.
+            r.primed = pos < was;
+            r
+        })
+        .collect()
+}
+```
+
+and on `Core`:
+
+```rust
+    /// Each artifact's activation, already decayed to now.
+    ///
+    /// The one SQLite read the query path takes. It can only add: a failure is
+    /// one warning and an empty map, and everything downstream then behaves
+    /// exactly as it did before any of this existed.
+    async fn activation_now(&self, ids: &[String]) -> HashMap<String, f64> {
+        let at = now_secs();
+        match self.store.activation_of(ids).await {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(id, (value, stamp))| {
+                    (
+                        id,
+                        crate::store::links::decayed(
+                            value,
+                            stamp,
+                            at,
+                            self.activation.half_life_days,
+                        ),
+                    )
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not read activation; results are unprimed");
+                HashMap::new()
+            }
+        }
+    }
+```
+
+In `search_with`, immediately after the rerank block and before the feedback capture block:
+
+```rust
+        // Before capture and before the truncate, so the pool that is recorded
+        // is the order the searcher was actually shown — a judged rank has to
+        // be a rank that happened. Bounded by `prime_lift` and never past rank
+        // 1, so this can reorder near-ties and nothing else.
+        if self.associate.enabled && self.associate.prime_lift > 0 {
+            let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
+            let activation = self.activation_now(&ids).await;
+            results = prime(
+                results,
+                &activation,
+                self.associate.prime_margin,
+                self.associate.prime_lift,
+            );
+        }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib core::search`
+Expected: PASS.
+
+- [ ] **Step 5: Check nothing else moved**
+
+Run: `cargo test --locked`
+Expected: PASS. `tests/eval.rs` in particular: priming is off in `test_core` only if `prime_lift` is 0 — it is not, so if an eval assertion moves, that is the harness telling you priming changed ranking. Record the before/after numbers in the commit message rather than adjusting the assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/search.rs
+git commit -m "feat(search): let activation prime the order, visibly and within bounds"
+```
+
+---
+
+## Task 10: One hop of association
+
+**Files:**
+- Modify: `src/core/search.rs`
+- Test: `src/core/search.rs`
+
+**Interfaces:**
+- Consumes: `Store::links_from`, `Store::get_artifact`, `LinkedTo`.
+- Produces: `SearchResult.via: Option<String>`, `SearchResult.reason: Option<String>`, private `async fn associated(&self, results: &[SearchResult]) -> Vec<SearchResult>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/core/search.rs` tests. Every one of them needs to name a specific
+artifact, and `list_all_artifact_ids` promises no order — so they look ids up by
+the text they were seeded with:
+
+```rust
+    /// The id of the artifact whose text is exactly this. Ordering from
+    /// `list_all_artifact_ids` is not promised, and a test that assumed one
+    /// would pass or fail on which row SQLite happened to return first.
+    async fn id_of(core: &crate::core::Core, text: &str) -> String {
+        sqlx::query_scalar("SELECT id FROM artifacts WHERE text = ?")
+            .bind(text)
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap()
+    }
+```
+
+```rust
+    #[tokio::test]
+    async fn a_linked_artifact_is_recalled_beside_the_answer_and_says_what_recalled_it() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("both of these"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        let out = core.search(&query, Door::Ui).await.unwrap();
+
+        assert_eq!(out.len(), 2, "the association was not appended: {out:?}");
+        assert_eq!(out[0].artifact_id, a);
+        assert_eq!(out[0].via, None, "a ranked hit was not recalled by anything");
+        assert_eq!(out[1].artifact_id, b);
+        assert_eq!(out[1].via.as_deref(), Some(a.as_str()));
+    }
+
+    #[tokio::test]
+    async fn an_artifact_already_in_the_answer_is_not_recalled_again() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[]), ("alpha other", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "alpha other").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let out = core.search(&q("alpha"), Door::Ui).await.unwrap();
+        let seen: std::collections::HashSet<&str> =
+            out.iter().map(|r| r.artifact_id.as_str()).collect();
+        assert_eq!(seen.len(), out.len(), "an artifact was returned twice");
+    }
+
+    #[tokio::test]
+    async fn a_recalled_artifact_does_not_feed_the_learning_that_produced_it() {
+        // The failure mode of any Hebbian system: a link recalls an artifact, is
+        // strengthened by having done so, and recalls it harder next time. The
+        // recalled hit is not written as a candidate and does not count as a
+        // retrieval — both loops are closed by construction.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+        let before = core.store.activation_of(&[b.clone()]).await.unwrap()[&b].0;
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        core.search(&query, Door::Ui).await.unwrap();
+        core.background.wait_idle().await;
+
+        let recorded: Vec<String> = sqlx::query_scalar("SELECT artifact_id FROM search_candidates")
+            .fetch_all(&core.store.pool)
+            .await
+            .unwrap();
+        assert!(!recorded.contains(&b), "the recalled artifact was recorded as a candidate");
+        let after = core.store.activation_of(&[b.clone()]).await.unwrap()[&b].0;
+        assert!((after - before).abs() < 1e-9, "being recalled raised activation");
+    }
+
+    #[tokio::test]
+    async fn a_hidden_artifact_is_never_recalled_by_association() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+        core.deprecate(&b).await.unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        assert_eq!(core.search(&query, Door::Ui).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_weak_link_is_not_strong_enough_to_recall_anything() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        // One co-appearance, against a `show_min` of 2.0.
+        core.store
+            .bump_link(&a, &b, 1.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        assert_eq!(core.search(&query, Door::Ui).await.unwrap().len(), 1);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib core::search`
+Expected: FAIL — `struct SearchResult has no field named via`.
+
+- [ ] **Step 3: Write the implementation**
+
+Two more fields on `SearchResult`:
+
+```rust
+    /// The ranked hit that recalled this one. `None` for a ranked hit — which
+    /// is every hit inside `limit`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
+    /// What the judge said the relation is, where a link has been judged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+```
+
+Set both to `None` at every existing construction site — including the `ranked` test helper Task 9 added, which is a struct literal and will not compile without them.
+
+```rust
+    /// Artifacts linked to the top of the answer, appended beside it.
+    ///
+    /// One hop only. Spreading further is what a graph view would be for, and
+    /// there is none. Everything here is additive: it never removes or reorders
+    /// a ranked hit, and a store that will not answer produces an empty list and
+    /// one warning.
+    async fn associated(&self, results: &[SearchResult]) -> Vec<SearchResult> {
+        let anchors: Vec<String> = results
+            .iter()
+            .take(self.associate.spread_from)
+            .map(|r| r.artifact_id.clone())
+            .collect();
+        if anchors.is_empty() || self.associate.spread_max == 0 {
+            return Vec::new();
+        }
+        let links = match self
+            .store
+            .links_from(
+                &anchors,
+                &[
+                    crate::store::links::LinkState::Learning,
+                    crate::store::links::LinkState::Related,
+                ],
+                self.associate.half_life_days,
+                now_secs(),
+                self.associate.show_min,
+            )
+            .await
+        {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(error = %e, "could not read links; results are unassociated");
+                return Vec::new();
+            }
+        };
+
+        let mut have: std::collections::HashSet<String> =
+            results.iter().map(|r| r.artifact_id.clone()).collect();
+        let mut out = Vec::new();
+        for l in links {
+            if out.len() >= self.associate.spread_max {
+                break;
+            }
+            if !have.insert(l.other.clone()) {
+                continue;
+            }
+            // Read from SQLite rather than the vector store: the row is already
+            // one connection away, and the payload adds nothing this needs.
+            let Ok(c) = self.store.get_artifact(&l.other).await else {
+                continue;
+            };
+            out.push(SearchResult {
+                artifact_id: c.id,
+                corpus_id: c.corpus_id.unwrap_or_default(),
+                title: c.title,
+                text: c.text,
+                category: c.category,
+                tags: c.tags,
+                // Not a rank and not a similarity: this hit did not compete for
+                // a place in the list, it was recalled beside it.
+                score: 0.0,
+                status: Some(c.status),
+                superseded_by: c.superseded_by,
+                last_verified_at: c.last_verified_at,
+                weak: false,
+                primed: false,
+                via: Some(l.via),
+                reason: l.reason,
+            });
+        }
+        out
+    }
+```
+
+In `search_with`, at the very end — after `results.truncate(limit)` and after the `mark_seen` for the ranked list:
+
+```rust
+        results.truncate(limit);
+        if query.mark {
+            // A query answered these, so they count as retrievals.
+            self.mark_seen(&results, &hit_counts, true);
+        }
+        // After the truncate and after capture, so an association can only ever
+        // add: it is outside `limit`, outside the recorded pool, and outside the
+        // retrieval count. See `Touch::shown`.
+        if self.associate.enabled {
+            let recalled = self.associated(&results).await;
+            if !recalled.is_empty() {
+                self.mark_seen(&recalled, &HashMap::new(), false);
+                results.extend(recalled);
+            }
+        }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib core::search`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/search.rs
+git commit -m "feat(search): recall what was reached together, beside the ranked list"
+```
+
+---
+
+## Task 11: Retrieval and opening raise activation
+
+**Files:**
+- Modify: `src/core/search.rs` (`mark_seen`, `mark_artifact_seen`)
+- Test: `src/core/search.rs`
+
+**Interfaces:**
+- Consumes: `Store::bump_activation`, `Core::activation`.
+- Produces: no new API — the two existing touch points gain a second background write.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn a_deliberate_search_makes_what_it_returned_more_accessible() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0;
+
+        core.search(&q("alpha"), Door::Ui).await.unwrap();
+        core.background.wait_idle().await;
+
+        let after = core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0;
+        assert!(after > before, "a retrieval raised nothing");
+    }
+
+    #[tokio::test]
+    async fn typing_does_not_make_what_it_happened_to_match_more_accessible() {
+        // The same rule as `last_seen_at`: an incremental request is not a
+        // retrieval, and letting every keystroke raise activation would make
+        // accessibility a function of how slowly someone types.
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0;
+
+        let mut query = q("alpha");
+        query.mark = false;
+        core.search(&query, Door::Ui).await.unwrap();
+        core.background.wait_idle().await;
+
+        assert_eq!(core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0, before);
+    }
+
+    #[tokio::test]
+    async fn being_drawn_at_random_raises_nothing() {
+        // `resurface` shows what has been forgotten. Counting that as a reason
+        // to be more accessible is the loop this whole design is built to close.
+        let core = test_core().await;
+        seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
+        sqlx::query("UPDATE artifacts SET created_at = ?")
+            .bind(now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0;
+
+        core.resurface(10).await.unwrap();
+        core.background.wait_idle().await;
+
+        assert_eq!(core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0, before);
+    }
+
+    #[tokio::test]
+    async fn opening_an_artifact_makes_it_more_accessible_by_less_than_a_retrieval() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0;
+
+        core.mark_artifact_seen(&id);
+        core.background.wait_idle().await;
+
+        let after = core.store.activation_of(&[id.clone()]).await.unwrap()[&id].0;
+        assert!((after - before - core.activation.opened).abs() < 1e-6);
+        assert!(core.activation.opened < core.activation.retrieved);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib core::search`
+Expected: FAIL — activation unchanged.
+
+- [ ] **Step 3: Write the implementation**
+
+In `mark_seen`, after the existing `self.background.spawn(...)` block:
+
+```rust
+        // Only a retrieval raises accessibility. A list nobody asked for —
+        // `resurface`, an association — is shown, not reached, and the row in
+        // §5.4 that reads zero is the one-way guard this implements.
+        if counts_as_hit {
+            let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
+            let store = self.store.clone();
+            let (delta, half_life) = (self.activation.retrieved, self.activation.half_life_days);
+            let at = now_secs();
+            self.background.spawn(async move {
+                if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                    tracing::warn!(error = %e, "could not raise activation for a search");
+                }
+            });
+        }
+```
+
+In `mark_artifact_seen`, the same shape with `self.activation.opened` and `std::slice::from_ref`-style single-id vec, and the comment:
+
+```rust
+        // An open is a deliberate act and counts for less than a retrieval:
+        // clicking a candidate says you looked, not that it answered.
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --locked`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/search.rs
+git commit -m "feat(activation): raise it on retrieval and on opening, and nowhere else"
+```
+
+---
+
+## Task 12: Associated hits in the results, and in MCP
+
+**Files:**
+- Modify: `src/web/ui.rs` (`RenderedResult`, `ResultsTemplate`, `render_hit`, `search_results`)
+- Modify: `src/web/templates/_results.html`
+- Modify: `src/assets/app.css` (one rule for the divider)
+- Modify: `src/mcp/mod.rs` (`format_search_results`)
+- Test: `src/web/ui.rs`, `src/mcp/mod.rs`
+
+**Interfaces:**
+- Consumes: `SearchResult.{primed, via, reason}`.
+- Produces: `RenderedResult.{primed: bool, via_title: Option<String>, reason: Option<String>}`, `ResultsTemplate.associated: Vec<RenderedResult>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/web/ui.rs` tests. The harness is the module's own `app_session_and_core`
+and `get_body`, as every other page test uses; `artifacts` seeds one corpus and
+returns the ids in the order it was given the titles.
+
+```rust
+    #[tokio::test]
+    fn rendered(via: Option<&str>, reason: Option<&str>) -> RenderedResult {
+        RenderedResult {
+            artifact_id: "a1".into(),
+            title: "The one that was recalled".into(),
+            html: String::new(),
+            snippet: "a snippet".into(),
+            category: None,
+            tags: vec![],
+            corpus_id: "c1".into(),
+            rank: String::new(),
+            weak: false,
+            primed: false,
+            via_title: via.map(str::to_string),
+            reason: reason.map(str::to_string),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_results_name_what_recalled_an_associated_hit() {
+        // An associated hit says which hit recalled it, or it is an unexplained
+        // result in a list the reader believes is ranked. Rendered directly
+        // rather than driven through a search: the UI handler asks for the
+        // default limit, so on any base small enough to reason about, every
+        // artifact is already ranked and there is nothing left to recall. What
+        // this task changed is the split and the copy, and that is what this
+        // pins.
+        let template = ResultsTemplate {
+            results: vec![],
+            associated: vec![rendered(Some("Mounting E01 images"), None)],
+            all_weak: false,
+            terms: String::new(),
+            timing: String::new(),
+        };
+        let body = template.render().unwrap();
+        assert!(body.contains("Recalled by association"), "{body}");
+        assert!(body.contains("seen together with"), "{body}");
+        assert!(body.contains("Mounting E01 images"), "{body}");
+
+        // A judged link says what the relation is instead of what was asked.
+        let judged = ResultsTemplate {
+            results: vec![],
+            associated: vec![rendered(Some("Mounting E01 images"), Some("the tool and its errors"))],
+            all_weak: false,
+            terms: String::new(),
+            timing: String::new(),
+        };
+        let body = judged.render().unwrap();
+        assert!(body.contains("the tool and its errors"), "{body}");
+        assert!(!body.contains("seen together with"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn an_association_cannot_make_the_answer_look_worse_than_it_was() {
+        // `all_weak` is a statement about how well the *query* was answered. An
+        // associated hit did not answer the query at all, so counting it either
+        // way would put a warning over a good list, or take one off a bad one.
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["alpha text"]).await;
+        crate::jobs::embed::run(&core, &ids[0]).await.unwrap();
+
+        let body = get_body(&app, &cookie, "/ui/search/results?q=alpha").await;
+        assert!(!body.contains("Recalled by association"), "{body}");
+    }
+```
+
+`ResultsTemplate` and `RenderedResult` are private to the module, which is where
+this test lives; `render()` comes from `askama::Template`, already in scope.
+
+In `src/mcp/mod.rs` tests:
+
+```rust
+    #[test]
+    fn an_associated_result_says_it_was_recalled_rather_than_ranked() {
+        // Straight into an agent's context: without this the extra result reads
+        // as the fourth-best match for the query, which it is not.
+        let out = format_search_results(&[hit("ranked", None), hit("recalled", Some("ranked"))]);
+        assert!(out.contains("recalled beside"), "{out}");
+    }
+```
+
+with a small `fn hit(id: &str, via: Option<&str>) -> SearchResult` helper in that test module.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib web::ui mcp::`
+Expected: FAIL.
+
+- [ ] **Step 3: Split the list in the handler**
+
+In `src/web/ui.rs`:
+
+```rust
+pub struct RenderedResult {
+    ...existing fields...
+    /// This hit moved up on activation. A small marker, because the claim is
+    /// small: it passed a near-tie, it did not become a better match.
+    pub primed: bool,
+    /// The title of the ranked hit that recalled this one. Set only on an
+    /// associated hit, and it is what the row names.
+    pub via_title: Option<String>,
+    /// The judge's line, where the link was judged.
+    pub reason: Option<String>,
+}
+```
+
+`ResultsTemplate` gains `associated: Vec<RenderedResult>`.
+
+In `search_results`, after the search returns:
+
+```rust
+    // The ranked answer and what it recalled are two lists on the page, and one
+    // list here: an associated hit carries the id of the hit that recalled it,
+    // and the title is looked up among the ranked ones rather than fetched.
+    let titles: std::collections::HashMap<String, String> = hits
+        .iter()
+        .filter(|h| h.via.is_none())
+        .map(|h| {
+            (
+                h.artifact_id.clone(),
+                h.title.clone().unwrap_or_else(|| "Untitled".into()),
+            )
+        })
+        .collect();
+    let (ranked, recalled): (Vec<_>, Vec<_>) = hits.into_iter().partition(|h| h.via.is_none());
+    let results: Vec<RenderedResult> = ranked
+        .into_iter()
+        .enumerate()
+        .map(|(i, h)| render_hit(i, h, &titles))
+        .collect();
+    let associated: Vec<RenderedResult> = recalled
+        .into_iter()
+        .map(|h| render_hit(0, h, &titles))
+        .collect();
+```
+
+`render_hit` gains the map as a third parameter and fills the three new fields; an associated hit gets `rank: String::new()` (it has no rank — the same reasoning that drops the rank on a weak hit), `primed: h.primed`, `via_title: h.via.as_ref().and_then(|v| titles.get(v).cloned())`, `reason: h.reason.clone()`.
+
+Four other call sites take the new parameter: the answer citations at `src/web/ui.rs:1467`, and the three tests at `:1712`, `:2435` and `:2438`. All four pass `&Default::default()` — a citation and a rendered test fixture are ranked hits, so there is no `via` to resolve.
+
+`all_weak` must be computed from `results` only: an association is not an answer to the query and cannot make the answer look better or worse than it was.
+
+- [ ] **Step 4: Render it**
+
+In `src/web/templates/_results.html`, before the closing `</div>` of the `data-terms` block:
+
+```html
+  {% if !associated.is_empty() %}
+  {# Below a rule and under its own heading: these were not ranked against the
+     query, they were recalled by something that was. Presenting them in the
+     same list would be a claim about relevance that nothing here supports. #}
+  <div class="assoc-rule" role="separator">Recalled by association</div>
+  {% for r in associated %}
+  <div class="rail-row">
+    <a class="rail-item rail-assoc" role="option" aria-selected="false"
+       href="/ui/artifacts/{{ r.artifact_id }}"
+       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}"
+       hx-target="#pane" hx-swap="innerHTML" hx-push-url="true">
+      <div class="rail-head">
+        <span class="rail-title">{{ r.title }}</span>
+      </div>
+      {% if let Some(why) = r.reason %}
+      <div class="rail-why">{{ why }}</div>
+      {% else if let Some(via) = r.via_title %}
+      <div class="rail-why">seen together with “{{ via }}”</div>
+      {% endif %}
+      <div class="rail-snippet">{{ r.snippet }}</div>
+    </a>
+  </div>
+  {% endfor %}
+  {% endif %}
+```
+
+and in the ranked loop, beside the rank span:
+
+```html
+        {% if r.primed %}
+        <span class="badge" title="Moved up: you reach this one often">primed</span>
+        {% endif %}
+```
+
+In `assets/app.css`, add `.assoc-rule` (a muted small-caps label with a top border) and `.rail-why` (muted, one line) in the style of the neighbouring rules.
+
+- [ ] **Step 5: Say it in MCP too**
+
+In `src/mcp/mod.rs`, inside the `map`:
+
+```rust
+            // An agent reads this as a ranked list unless it is told otherwise,
+            // and an associated hit did not compete for its place.
+            let how = match (&r.via, &r.reason) {
+                (Some(_), Some(why)) => format!("recalled beside the answer — {why}"),
+                (Some(_), None) => "recalled beside the answer".to_string(),
+                (None, _) => format!("score {:.3}", r.score),
+            };
+```
+and use `how` where `format!("_score {:.3}...")` used the score.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test --locked`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/ui.rs src/web/templates/_results.html assets/app.css src/mcp/mod.rs
+git commit -m "feat(ui): show what association recalled, and what priming moved"
+```
+
+---
+
+## Task 13: "Seen together" in the detail pane
+
+**Files:**
+- Modify: `src/web/ui.rs` (`ArtifactDetail`, `build_artifact_detail`, one new route)
+- Modify: `src/web/templates/_artifact_detail.html`
+- Modify: `assets/app.css`
+- Test: `src/web/ui.rs`
+
+**Interfaces:**
+- Consumes: `Store::{links_from, set_link_state, get_corpus}`.
+- Produces: `pub struct SeenTogether { id, title, snippet, why: Option<String>, corpus_title: String, cross_corpus: bool }`, `ArtifactDetail.seen_together: Vec<SeenTogether>`, route `POST /ui/artifacts/{id}/links/{other}/dismiss`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn the_pane_lists_what_this_artifact_is_seen_together_with() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("mount forensic image"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        assert_eq!(d.seen_together.len(), 1);
+        assert_eq!(d.seen_together[0].id, ids[1]);
+        assert_eq!(
+            d.seen_together[0].why.as_deref(),
+            Some("when asking: mount forensic image"),
+            "an unjudged link explains itself with the question that bound it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_judged_link_shows_the_judges_line_instead_of_the_query() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(
+                &ids[0],
+                &ids[1],
+                crate::store::links::LinkState::Related,
+                Some("the tool and the error it prints"),
+                Some((0, 0)),
+            )
+            .await
+            .unwrap();
+
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        assert_eq!(
+            d.seen_together[0].why.as_deref(),
+            Some("the tool and the error it prints")
+        );
+    }
+
+    #[tokio::test]
+    async fn dismissing_a_link_takes_it_out_for_good_without_losing_the_evidence() {
+        // The weight stays, so the decision is auditable; the state is final,
+        // so it is never shown, judged or pruned again.
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{}/links/{}/dismiss", ids[0], ids[1]),
+                &cookie,
+                "",
+            ))
+            .await
+            .unwrap();
+
+        let l = core.store.get_link(&ids[0], &ids[1]).await.unwrap().unwrap();
+        assert_eq!(l.state, crate::store::links::LinkState::Dismissed);
+        assert!(l.weight > 0.0, "the evidence was thrown away with the decision");
+        assert!(
+            build_artifact_detail(&core, &ids[0], "").await.unwrap().seen_together.is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pane_still_renders_when_the_links_cannot_be_read() {
+        // The associative layer can only add. It is not a reason to refuse to
+        // show an artifact beside its source.
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text"]).await;
+        sqlx::query("DROP TABLE artifact_links")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        assert!(d.seen_together.is_empty());
+    }
+```
+
+`form` is the module's existing POST helper (see `ops_lists_a_superseded_artifact_and_can_undo_it` around line 2988). The route must therefore accept a form POST with an empty body, like `unsupersede` does.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib web::ui`
+Expected: FAIL — `no field seen_together`.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+/// A link, as one line in the pane. Beside the nearest neighbours, not instead
+/// of them: one list is what this artifact resembles, the other is what it has
+/// been needed alongside, and they answer different questions.
+pub struct SeenTogether {
+    pub id: String,
+    pub title: String,
+    pub snippet: String,
+    /// The judge's line, or the question that bound the pair. `None` only for a
+    /// link with neither, which is a link nothing can explain yet.
+    pub why: Option<String>,
+    pub corpus_title: String,
+    /// Rendered emphasised: two documents needing each other is the finding.
+    /// Two passages of one document needing each other is not.
+    pub cross_corpus: bool,
+}
+```
+
+`ArtifactDetail` gains `pub seen_together: Vec<SeenTogether>`, filled in `build_artifact_detail` beside `related`:
+
+```rust
+    // Unreadable links are not a missing pane, for the same reason a missing
+    // neighbour list is not: this layer can only ever add.
+    let anchor = vec![c.id.clone()];
+    let seen_together = match core
+        .store
+        .links_from(
+            &anchor,
+            &[
+                crate::store::links::LinkState::Learning,
+                crate::store::links::LinkState::Related,
+            ],
+            core.associate.half_life_days,
+            crate::store::now(),
+            core.associate.show_min,
+        )
+        .await
+    {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(artifact_id, error = %e, "no links for this pane");
+            vec![]
+        }
+    };
+    let mut seen = Vec::new();
+    for l in seen_together.into_iter().take(RELATED_LIMIT) {
+        let Ok(other) = core.store.get_artifact(&l.other).await else {
+            continue;
+        };
+        let corpus_title = match &other.corpus_id {
+            Some(id) => core
+                .store
+                .get_corpus(id)
+                .await
+                .ok()
+                .and_then(|s| s.title_hint)
+                .unwrap_or_else(|| "untitled".into()),
+            // A merged artifact belongs to no document, which is worth saying
+            // rather than leaving blank.
+            None => "merged".to_string(),
+        };
+        seen.push(SeenTogether {
+            title: title_of(&other),
+            snippet: markdown::snippet(&other.text, 90),
+            // The judge's line where there is one; otherwise the question that
+            // bound them, which is the link's own explanation and free.
+            why: l.reason.clone().or_else(|| {
+                l.cues.first().map(|c| format!("when asking: {}", c.q))
+            }),
+            corpus_title,
+            cross_corpus: l.cross_corpus,
+            id: other.id,
+        });
+    }
+```
+
+Set `seen_together: seen` in the returned struct.
+
+The route, registered beside the other artifact POSTs in this module's `Router`:
+
+```rust
+/// The operator saying this pair does not belong together.
+///
+/// Final for that pair: never shown, never judged, never pruned. The weight is
+/// left exactly as it is, so the decision stays auditable against the evidence
+/// that produced it — undoing one is out of scope, and Ops is where it would go.
+async fn dismiss_link(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path((artifact_id, other_id)): Path<(String, String)>,
+) -> Result<Response> {
+    st.core
+        .store
+        .set_link_state(
+            &artifact_id,
+            &other_id,
+            crate::store::links::LinkState::Dismissed,
+            None,
+            None,
+        )
+        .await?;
+    // The row swaps itself out and leaves the pane alone, so the artifact you
+    // were reading is still on screen afterwards.
+    Ok(axum::response::Html(String::new()).into_response())
+}
+```
+
+- [ ] **Step 4: Render it**
+
+In `src/web/templates/_artifact_detail.html`, directly after the existing `Related` block's `{% endif %}`:
+
+```html
+      {% if !d.seen_together.is_empty() %}
+      {# Beside the nearest neighbours, not instead of them: one list is what
+         this resembles, the other is what it has been needed alongside. #}
+      <div class="pane-label">Seen together</div>
+      <div class="related">
+        {% for r in d.seen_together %}
+        <div class="seen-row{% if !r.cross_corpus %} muted{% endif %}">
+          <a class="rail-item" href="/ui/artifacts/{{ r.id }}"
+             hx-get="/ui/artifacts/{{ r.id }}"
+             hx-target="closest [data-terms]" hx-swap="outerHTML"
+             hx-push-url="true">
+            <div class="rail-head"><span class="rail-title">{{ r.title }}</span></div>
+            {% if let Some(why) = r.why %}<div class="rail-why">{{ why }}</div>{% endif %}
+            <div class="rail-snippet">{{ r.snippet }} · {{ r.corpus_title }}</div>
+          </a>
+          <div class="rail-del">
+            <button class="btn-icon" title="Not related" aria-label="Not related"
+                    hx-post="/ui/artifacts/{{ d.id }}/links/{{ r.id }}/dismiss"
+                    hx-target="closest .seen-row" hx-swap="outerHTML">
+              {% include "_icon_hide.html" %}
+            </button>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+```
+
+Add `.seen-row` to `assets/app.css` in the shape of `.rail-row`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test --locked`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/ui.rs src/web/templates/_artifact_detail.html assets/app.css
+git commit -m "feat(ui): list what an artifact has been seen together with"
+```
+
+---
+
+## Task 14: Ops, the example config, and the roadmap
+
+**Files:**
+- Modify: `src/web/ui.rs` (`OpsTemplate`, `ops`)
+- Modify: `src/web/templates/ops.html`
+- Modify: `config.example.toml`
+- Modify: `ROADMAP.md`
+- Test: `src/web/ui.rs`, `src/config.rs`
+
+**Interfaces:**
+- Consumes: `Store::link_counts`, `LinkCounts`.
+- Produces: `OpsTemplate.links: Option<crate::store::links::LinkCounts>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn ops_says_how_many_links_there_are_and_how_many_are_named() {
+        let (app, cookie, core) = app_session_and_core_with_feedback().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, "/ui/ops").await;
+        assert!(page.contains("2 links"), "{page}");
+    }
+```
+
+`app_session_and_core` builds its core from `test_core()`, where `feedback.enabled` is false — and the Ops block is `None` in that case, so this test would assert against a section that renders nothing. Add a sibling helper beside it rather than mutating a core the router already holds:
+
+```rust
+    /// A session whose core records searches, which is what the association
+    /// features are gated on. `app_session_and_core` cannot be reused: the
+    /// router owns its own clone of the core, so flipping a flag afterwards
+    /// changes the handle and not the app.
+    async fn app_session_and_core_with_feedback() -> (axum::Router, String, crate::core::Core) {
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        (app, cookie, handle)
+    }
+```
+
+and call that in the test instead. The same applies to any later UI test that needs recorded searches switched on.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib web::ui`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the numbers**
+
+`OpsTemplate` gains:
+
+```rust
+    /// `None` when nothing is being learned, which renders nothing at all: a
+    /// count of links on a base that records no searches is a line about a
+    /// feature that is switched off.
+    links: Option<crate::store::links::LinkCounts>,
+```
+
+In `ops`:
+
+```rust
+        links: match st.core.associate.enabled && st.core.feedback.enabled {
+            true => Some(st.core.store.link_counts().await?),
+            false => None,
+        },
+```
+
+In `ops.html`, inside the existing counts paragraph:
+
+```html
+  {% if let Some(l) = links %}
+  {{ l.total }} links, {{ l.related }} named, {{ l.judge_queue }} waiting on the judge.
+  {% endif %}
+```
+
+- [ ] **Step 4: Document the settings**
+
+Append to `config.example.toml`, after the `[feedback]` block:
+
+```toml
+# Links learned from co-retrieval, and a decaying accessibility per artifact.
+# Both are learned from use and neither touches what is stored: the trace is
+# fixed, access is plastic. Needs `feedback.enabled` — without recorded searches
+# there is nothing to learn from, and saying otherwise is a warning at startup.
+[associate]
+enabled = true
+# How often the sweep replays the search log. Pure SQLite, no model call.
+interval_mins = 30
+# A link unused for this long has half the strength it had. One co-appearance is
+# +1 and one confirmed answer is +2, so these numbers are in "uses".
+half_life_days = 30
+# Below this, a link nobody has ruled on is forgotten. A judged one never is: a
+# verified relation is about content, not use.
+prune_below = 0.5
+# Strength at which a link is worth showing, and at which it is worth one call.
+show_min = 2.0
+judge_min = 4.0
+# Distinct questions a link needs before it is judged. One question asked six
+# times is one question, and this is what keeps the judge cheap.
+judge_min_queries = 3
+judge_per_sweep = 10
+# How many top hits are asked what they are linked to, and how many associated
+# hits may be appended after the ranked list — outside `limit`, never instead
+# of a ranked hit.
+spread_from = 3
+spread_max = 3
+# How much more accessible a hit must be than the one above it to pass it, as a
+# fraction of the most accessible hit in that list; and how many places it may
+# climb. 0 turns priming off. Neither default moves until the eval harness has
+# been run with it off and on against the frozen corpus.
+prime_margin = 0.5
+prime_lift = 2
+
+[activation]
+half_life_days = 14
+# Returned by a deliberate search, opened in the pane, judged the answer. Being
+# surfaced *because* of activation — resurfaced, or recalled by a link — raises
+# nothing: that is the loop this design exists to close.
+retrieved = 1.0
+opened = 0.5
+confirmed = 3.0
+```
+
+- [ ] **Step 5: Update the roadmap**
+
+In `ROADMAP.md`, the "What is built" paragraph ends with the eval harness. Add to that list, before the closing sentence about design records:
+
+```
+Hebbian links learned from co-retrieval with bounded priming and one-hop
+association in the results;
+```
+
+and under `## [Associative Memory]`, change the spec line's framing from what will be built to what was: replace "Spec: ... — Hebbian links learned from co-retrieval, ... The items below are the mechanisms that come after it, in order." with a sentence saying it is built, naming `[associate]` and `[activation]` as its switches, and keeping the list of what comes after unchanged.
+
+- [ ] **Step 6: Run everything**
+
+Run: `cargo fmt --all && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked`
+Expected: PASS. `config::tests::the_example_config_carries_the_association_block` now reads the real block.
+
+- [ ] **Step 7: Measure the layer crossing**
+
+The spec requires this before merge: `total_ms` with and without the SQLite read. Run one search against a populated base with `associate.enabled = true` and once with `enabled = false`, and record both `total_ms` values (the UI prints them under the rail; the log line does too). Put the two numbers in the commit message. If the difference is more than a few milliseconds, stop and say so rather than merging.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/web/ui.rs src/web/templates/ops.html config.example.toml ROADMAP.md
+git commit -m "feat(associate): report links on Ops and document the settings"
+```
+
+---
+
+## After the plan
+
+Two things the spec asks for that are deliberately not tasks here:
+
+- **Tuning `prime_margin` / `prime_lift`.** The defaults ship as written. Moving either is a separate change, made only after `cargo test --test eval` has been run against the frozen corpus with priming off and on, with both numbers recorded.
+- **No backfill of historical links.** The watermarks start at the first sweep. An operator who wants the log replayed sets `associate.events_after = 0` in `meta` by hand — documented here, not automated.

--- a/docs/superpowers/specs/2026-08-16-associative-memory-design.md
+++ b/docs/superpowers/specs/2026-08-16-associative-memory-design.md
@@ -249,6 +249,15 @@ Rank-based rather than score-based on purpose: hybrid scores are fused ranks
 and mean nothing across queries, while "moved up two places" means the same
 thing every time and can be tested with a table.
 
+Held off the `Ask` and `Judge` doors, the same two association is held off, for
+the same reason in a different shape. `ask` never shows this list to anyone: it
+turns the head of it into excerpts and, when they do not all fit the context
+window, keeps a prefix and drops the tail on the stated grounds that the tail
+matched the question least. Reordering by accessibility makes that untrue, and
+the excerpt dropped is then the one that answered best — a silent change to the
+answer on a path where nobody can see what was cut. `judge` needs the pool it
+labels to be the pool the ranking produced.
+
 ### 6.2 Association
 
 For the top `associate.spread_from` (3) ranked hits, fetch their links with
@@ -258,6 +267,13 @@ result list. Up to `associate.spread_max` (3) are appended after the ranked
 hits, outside `limit`, each carrying `via: <artifact_id>` and, for a judged
 link, `reason`. They are `Touch::shown`, not retrieved (§5.4), and not
 recorded as candidates (§5.2).
+
+An association obeys the caller's own narrowing. `tags` and `category` are a
+statement about what the searcher will accept, not a hint to the ranker, so a
+recalled artifact that fails either is dropped rather than appended — otherwise
+narrowing a search to one category hands back rows from every other one. Being
+outside `limit` is deliberate and is documented on the API parameter: a client
+that wants only what it asked for filters on `via`.
 
 One hop only. Spreading further is what a graph view would be for, and there
 is none.
@@ -374,10 +390,17 @@ moves.
 
 Additive schema (`ADD COLUMN`, two new tables). Feature off until
 `feedback.enabled`; existing installs see nothing change until they opt in.
-No backfill of links from the historical log — the watermarks start at the
-first sweep, and the log is a record, not a curriculum. (An operator who wants
-the history replayed sets `associate.events_after = 0` in `meta`; documented,
-not automated.)
+No backfill of links from the historical log — the log is a record, not a
+curriculum. An absent watermark reads as the epoch, so the migration that adds
+`artifacts.activated_at` to an existing base seeds both watermarks to the
+moment of adoption in the same breath as the `activated_at` backfill: those two
+fixups belong to the one boot that adopts the feature, not to every boot.
+Without the seeding, a base that has been recording searches for months folds
+that entire log in on its first tick — thousands of pairs at once, every one of
+them stamped with the sweep's clock and therefore undecayed, feeding priming and
+the judge queue from a past nobody asked to relive. (An operator who *wants* the
+history replayed sets `associate.events_after = 0` in `meta`; documented, not
+automated.)
 
 ## 12. Risks
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -714,6 +714,55 @@ impl Config {
             );
             self.consolidate.merge_max_roots = d;
         }
+        // The association widths multiply each other on the search path to
+        // size one SQL `LIMIT`, and `interval_mins` is multiplied by sixty to
+        // make a `Duration`. None of the three has a ceiling that comes from
+        // anywhere else, so it is stated here: past these, the number has
+        // stopped describing a search someone would run or a rhythm someone
+        // would wait for, and the arithmetic is the only thing still reading
+        // it. Clamped rather than refused — an oversized width is a typo, not
+        // a config that destroys anything.
+        const MAX_SPREAD_FROM: usize = 64;
+        const MAX_SPREAD_MAX: usize = 64;
+        const MAX_PRIME_LIFT: usize = 64;
+        // A year. Longer than this and the ticker fires once and effectively
+        // never again, which the operator can say by setting `enabled = false`.
+        const MAX_INTERVAL_MINS: u64 = 525_600;
+        for (name, value, ceiling) in [
+            (
+                "associate.spread_from",
+                &mut self.associate.spread_from,
+                MAX_SPREAD_FROM,
+            ),
+            (
+                "associate.spread_max",
+                &mut self.associate.spread_max,
+                MAX_SPREAD_MAX,
+            ),
+            (
+                "associate.prime_lift",
+                &mut self.associate.prime_lift,
+                MAX_PRIME_LIFT,
+            ),
+        ] {
+            if *value > ceiling {
+                tracing::warn!(
+                    setting = name,
+                    configured = *value,
+                    using = ceiling,
+                    "association width is far past anything a result list can use; capping it"
+                );
+                *value = ceiling;
+            }
+        }
+        if self.associate.interval_mins > MAX_INTERVAL_MINS {
+            tracing::warn!(
+                configured = self.associate.interval_mins,
+                using = MAX_INTERVAL_MINS,
+                "associate.interval_mins is longer than a year; capping it"
+            );
+            self.associate.interval_mins = MAX_INTERVAL_MINS;
+        }
     }
 
     /// Rules that a config can satisfy syntactically and still be wrong.

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,10 @@ pub struct Config {
     pub pacing: PacingConfig,
     #[serde(default)]
     pub capture: CaptureConfig,
+    #[serde(default)]
+    pub associate: AssociateConfig,
+    #[serde(default)]
+    pub activation: ActivationConfig,
 }
 
 /// What the two supplied-from-outside capture paths are allowed to cost.
@@ -111,6 +115,87 @@ impl Default for FeedbackConfig {
             coalesce_secs: 15,
             retain_days: 0,
             sweep_hours: 6,
+        }
+    }
+}
+
+/// Links learned from co-retrieval, and what they are allowed to do.
+///
+/// Every threshold here is a weight in the same units: one co-appearance is
+/// `+1`, one confirmed answer is `+2`, and a half-life of thirty days is what
+/// makes those numbers mean "lately" rather than "ever".
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct AssociateConfig {
+    /// Requires `feedback.enabled`. Without recorded searches there is nothing
+    /// to learn from, and that combination is a warning at startup.
+    pub enabled: bool,
+    pub interval_mins: u64,
+    pub half_life_days: f64,
+    /// Decayed weight under which a `learning` link is deleted.
+    pub prune_below: f64,
+    /// Decayed weight at which a link is worth showing.
+    pub show_min: f64,
+    /// ...and at which it is worth one model call.
+    pub judge_min: f64,
+    /// Distinct binding questions a link needs before it is judged. One question
+    /// asked six times is one question.
+    pub judge_min_queries: i64,
+    pub judge_per_sweep: i64,
+    /// How many of the top ranked hits are asked what they are linked to.
+    pub spread_from: usize,
+    /// How many associated hits may be appended, outside `limit`.
+    pub spread_max: usize,
+    /// How much more activated a hit must be than the one above it to pass it.
+    /// Normalised within one result list, so this is a fraction, not a weight.
+    pub prime_margin: f64,
+    /// Positions a hit may climb. `0` turns priming off.
+    pub prime_lift: usize,
+}
+
+impl Default for AssociateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_mins: 30,
+            half_life_days: 30.0,
+            prune_below: 0.5,
+            show_min: 2.0,
+            judge_min: 4.0,
+            judge_min_queries: 3,
+            judge_per_sweep: 10,
+            spread_from: 3,
+            spread_max: 3,
+            prime_margin: 0.5,
+            prime_lift: 2,
+        }
+    }
+}
+
+/// How accessible an artifact is, and what raises it.
+///
+/// Being surfaced *because* of activation raises nothing: `resurface` and
+/// association both leave it alone. Loops that reinforce themselves are the
+/// failure mode of this whole idea, and they are closed by construction.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ActivationConfig {
+    pub half_life_days: f64,
+    /// Returned by a search the caller marked as seen.
+    pub retrieved: f64,
+    /// Opened in the detail pane.
+    pub opened: f64,
+    /// Judged the answer to a real question. The strong signal.
+    pub confirmed: f64,
+}
+
+impl Default for ActivationConfig {
+    fn default() -> Self {
+        Self {
+            half_life_days: 14.0,
+            retrieved: 1.0,
+            opened: 0.5,
+            confirmed: 3.0,
         }
     }
 }
@@ -674,6 +759,13 @@ impl Config {
                  longer be set per role"
             );
         }
+        if self.associate.enabled && !self.feedback.enabled {
+            tracing::warn!(
+                "associate.enabled has no effect while feedback.enabled is false: links are \
+                 learned from recorded searches, and none are being recorded. Recording queries \
+                 is a privacy decision, so it keeps its own switch."
+            );
+        }
     }
 
     /// Secrets belong in the environment. A secret sitting in the config file
@@ -1022,5 +1114,37 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             "example config must show the vision block"
         );
         assert!(text.contains("image_max_bytes"));
+    }
+
+    #[test]
+    fn the_association_defaults_are_the_documented_ones() {
+        let a = AssociateConfig::default();
+        assert!(a.enabled);
+        assert_eq!(a.interval_mins, 30);
+        assert_eq!(a.half_life_days, 30.0);
+        assert_eq!((a.show_min, a.judge_min, a.prune_below), (2.0, 4.0, 0.5));
+        assert_eq!((a.spread_from, a.spread_max), (3, 3));
+        assert_eq!((a.prime_margin, a.prime_lift), (0.5, 2));
+        let v = ActivationConfig::default();
+        assert_eq!(v.half_life_days, 14.0);
+        assert_eq!((v.retrieved, v.opened, v.confirmed), (1.0, 0.5, 3.0));
+    }
+
+    #[test]
+    fn a_config_with_no_association_block_still_gets_one() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, MINIMAL);
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert!(cfg.associate.enabled);
+        // ...and the feature is inert regardless, because there is nothing to
+        // learn from until searches are recorded.
+        assert!(!cfg.feedback.enabled);
+    }
+
+    #[test]
+    fn the_example_config_carries_the_association_block() {
+        let cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
+        assert_eq!(cfg.associate.spread_max, 3);
     }
 }

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -354,7 +354,11 @@ pub fn spawn_associate_ticker(
             tracing::info!("association sweep disabled");
             return;
         }
-        let period = std::time::Duration::from_secs(core.associate.interval_mins.max(1) * 60);
+        // Saturating: the operand is operator-typed, and a wrap here would turn
+        // a very long configured interval into a very short one — a sweep
+        // hammering the queue is the opposite of what was asked for.
+        let period =
+            std::time::Duration::from_secs(core.associate.interval_mins.max(1).saturating_mul(60));
         let mut tick = tokio::time::interval(period);
         loop {
             tokio::select! {

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -614,10 +614,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_association_ticker_queues_exactly_one_sweep() {
-        // Same reasoning as the consolidation sweep: `jobs` is unique on
-        // (stage, target), so a ticker firing while a sweep is still queued
-        // collapses onto the same row rather than stacking sweeps.
+    async fn the_association_sweep_never_stacks_up_in_the_queue() {
+        // `jobs` is unique on (stage, target), so a ticker firing while a
+        // sweep is still queued must collapse onto the same row rather than
+        // stacking sweeps behind a slow one.
+        let core = crate::core::test_support::test_core().await;
+        for _ in 0..3 {
+            core.store
+                .enqueue(
+                    crate::store::jobs::Stage::Associate,
+                    "collection",
+                    ASSOCIATE_TARGET,
+                )
+                .await
+                .unwrap();
+        }
+        let mut seen = 0;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            assert_eq!(j.stage, crate::store::jobs::Stage::Associate);
+            seen += 1;
+        }
+        assert_eq!(seen, 1, "the sweep stacked up in the queue");
+    }
+
+    #[tokio::test]
+    async fn the_association_ticker_queues_a_sweep_as_soon_as_it_starts() {
+        // `tokio::time::interval` fires immediately on its first tick, which
+        // is what makes a restart pick the association sweep up rather than
+        // waiting out a full `interval_mins`.
         let mut core = crate::core::test_support::test_core().await;
         core.feedback.enabled = true;
         let (tx, rx) = tokio::sync::watch::channel(false);

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -332,6 +332,50 @@ pub fn spawn_dedupe_ticker(
     })
 }
 
+/// The association sweep's job target. A constant rather than an artifact id:
+/// the sweep replays the whole log, and `UNIQUE(stage, target_id)` then bounds
+/// the queue to one of them however often the ticker fires.
+pub const ASSOCIATE_TARGET: &str = "collection";
+
+/// Queue an association sweep now and every `associate.interval_mins` after.
+///
+/// Its own ticker, like retention and dedupe: the rhythm of replaying a search
+/// log has nothing to do with the rhythm of duplicate discovery, and coupling
+/// the two is how switching one feature off silently switches another one off.
+///
+/// Returns before its loop when there is nothing to learn from — either the
+/// feature is off, or searches are not being recorded, which is the same thing.
+pub fn spawn_associate_ticker(
+    core: crate::core::Core,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !core.associate.enabled || !core.feedback.enabled {
+            tracing::info!("association sweep disabled");
+            return;
+        }
+        let period = std::time::Duration::from_secs(core.associate.interval_mins.max(1) * 60);
+        let mut tick = tokio::time::interval(period);
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = tick.tick() => {
+                    if let Err(e) = core
+                        .store
+                        .enqueue(crate::store::jobs::Stage::Associate, "collection", ASSOCIATE_TARGET)
+                        .await
+                    {
+                        tracing::warn!(error = %e, "could not queue the association sweep");
+                    }
+                }
+            }
+        }
+        tracing::info!("association ticker stopped");
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -567,6 +611,53 @@ mod tests {
             .expect("the ticker queued nothing");
         assert_eq!(j.stage, crate::store::jobs::Stage::Consolidate);
         assert_eq!(j.target_id, CONSOLIDATE_TARGET);
+    }
+
+    #[tokio::test]
+    async fn the_association_ticker_queues_exactly_one_sweep() {
+        // Same reasoning as the consolidation sweep: `jobs` is unique on
+        // (stage, target), so a ticker firing while a sweep is still queued
+        // collapses onto the same row rather than stacking sweeps.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let h = spawn_associate_ticker(core.clone(), rx);
+        for _ in 0..50 {
+            if core
+                .store
+                .job_counts()
+                .await
+                .unwrap()
+                .iter()
+                .any(|(_, n)| *n > 0)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let _ = tx.send(true);
+        let _ = h.await;
+
+        let j = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("the ticker queued nothing");
+        assert_eq!(j.stage, crate::store::jobs::Stage::Associate);
+        assert_eq!(j.target_id, ASSOCIATE_TARGET);
+        assert!(core.store.claim_job().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn no_recorded_searches_means_no_association_ticker_at_all() {
+        // `associate.enabled` without `feedback.enabled` is a warning at startup
+        // and nothing else: there is nothing to learn from.
+        let core = crate::core::test_support::test_core().await; // feedback off
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        // Returns rather than looping, so awaiting it cannot hang.
+        let _ = spawn_associate_ticker(core.clone(), rx).await;
+        assert!(core.store.claim_job().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -350,7 +350,7 @@ pub fn spawn_associate_ticker(
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        if !core.associate.enabled || !core.feedback.enabled {
+        if !core.associating() {
             tracing::info!("association sweep disabled");
             return;
         }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -944,19 +944,24 @@ impl Core {
                     .set_corpus_status(&src.id, CorpusStatus::Embedding)
                     .await?;
             }
-            // Consolidation looks at the whole collection, so there is no such
-            // thing as reprocessing one corpus through it. Saying so beats
-            // silently queueing a sweep the caller did not ask for.
-            Stage::Consolidate => {
+            // Consolidation and association both look at the whole collection,
+            // so there is no such thing as reprocessing one corpus through
+            // either. Saying so beats silently queueing a sweep the caller did
+            // not ask for.
+            Stage::Consolidate | Stage::Associate => {
                 return Err(Error::Validation(
-                    "consolidate is a collection-wide sweep, not a per-corpus stage".into(),
+                    "that stage is a collection-wide sweep, not a per-corpus stage".into(),
                 ));
             }
             // Units the queue arms for itself, one per artifact or inference
             // call. An operator reprocesses a document, not one of its windows:
             // asking for `synthesize` re-windows the whole thing and arms them
             // all, and `embed` re-arms a `relate` unit per artifact behind it.
-            Stage::SegmentWindow | Stage::Title | Stage::Dedupe | Stage::Relate => {
+            Stage::SegmentWindow
+            | Stage::Title
+            | Stage::Dedupe
+            | Stage::Relate
+            | Stage::LinkJudge => {
                 return Err(Error::Validation(
                     "that stage is a single inference call the queue arms itself; \
                      reprocess the document instead"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -96,6 +96,10 @@ pub struct Core {
     /// Limits for the upload, link and extension capture paths. Read on the
     /// request path, so it lives here rather than being threaded down.
     pub capture: crate::config::CaptureConfig,
+    /// Link learning, priming and association. Read on the search path and by
+    /// the sweep, so it lives here rather than being threaded down.
+    pub associate: crate::config::AssociateConfig,
+    pub activation: crate::config::ActivationConfig,
     /// The pacer every inference call passes through. Shared by every clone,
     /// because a per-clone gate would pace nothing: the point is one queue of
     /// calls in front of one GPU.
@@ -158,6 +162,8 @@ impl Core {
             weak_below: cfg.vector.weak_below,
             feedback: cfg.feedback.clone(),
             capture: cfg.capture.clone(),
+            associate: cfg.associate.clone(),
+            activation: cfg.activation.clone(),
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::from_secs(cfg.pacing.cooldown_secs),
             )),
@@ -272,6 +278,10 @@ pub mod test_support {
             // Off, like the shipped default. The capture tests switch it on.
             feedback: crate::config::FeedbackConfig::default(),
             capture: crate::config::CaptureConfig::default(),
+            // On, like the shipped default — and inert in most tests, because
+            // nothing has learned a link yet. The association tests seed one.
+            associate: crate::config::AssociateConfig::default(),
+            activation: crate::config::ActivationConfig::default(),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.
             gate: Arc::new(crate::infer::gate::InferenceGate::new(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -207,6 +207,21 @@ impl Core {
         };
         lock.lock_owned().await
     }
+
+    /// Whether the associative layer — links and priming — is actually live,
+    /// not merely configured on.
+    ///
+    /// Links are learned from recorded searches (`search_events`), and
+    /// recording queries is a separate privacy decision the operator makes
+    /// with `feedback.enabled`. Without recordings there is nothing to learn
+    /// from, so `associate.enabled` alone must not let the layer read or
+    /// write anything: every site that primes, associates, bumps activation
+    /// from a search, or renders "seen together" has to check both flags, or
+    /// an install that never opted into `feedback` still has its ranking and
+    /// activation quietly touched.
+    pub fn associating(&self) -> bool {
+        self.associate.enabled && self.feedback.enabled
+    }
 }
 
 #[cfg(test)]
@@ -329,6 +344,23 @@ mod tests {
             cfg.consolidate.merge_max_roots >= 2,
             "a merge needs at least two sources to be a merge"
         );
+    }
+
+    #[tokio::test]
+    async fn associating_requires_both_flags_the_shipped_default_has_only_one() {
+        // Shipped defaults: `associate.enabled = true`, `feedback.enabled =
+        // false`. Links are learned from recorded searches, and recording is
+        // a separate privacy decision, so the layer must stay dark until both
+        // are on.
+        let mut core = test_support::test_core().await;
+        assert!(core.associate.enabled && !core.feedback.enabled);
+        assert!(!core.associating(), "on with only associate.enabled set");
+
+        core.feedback.enabled = true;
+        assert!(core.associating(), "both flags set");
+
+        core.associate.enabled = false;
+        assert!(!core.associating(), "on with only feedback.enabled set");
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -310,7 +310,12 @@ impl Core {
         // Only a retrieval raises accessibility. A list nobody asked for —
         // `resurface`, an association — is shown, not reached, and the row in
         // §5.4 that reads zero is the one-way guard this implements.
-        if counts_as_hit {
+        //
+        // Also gated on `associating()`: activation only exists to feed
+        // priming, and an install that never opted into `feedback` must see
+        // no artifact's activation move, or the ranked order could start
+        // changing under a feature it never turned on.
+        if counts_as_hit && self.associating() {
             let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
             let store = self.store.clone();
             let (delta, half_life) = (self.activation.retrieved, self.activation.half_life_days);
@@ -343,16 +348,21 @@ impl Core {
         });
 
         // An open is a deliberate act and counts for less than a retrieval:
-        // clicking a candidate says you looked, not that it answered.
-        let ids = vec![artifact_id.to_string()];
-        let store = self.store.clone();
-        let (delta, half_life) = (self.activation.opened, self.activation.half_life_days);
-        let at = now_secs();
-        self.background.spawn(async move {
-            if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
-                tracing::warn!(error = %e, "could not raise activation for opening");
-            }
-        });
+        // clicking a candidate says you looked, not that it answered. Gated
+        // on `associating()` for the same reason as `mark_seen`: activation
+        // exists only to feed priming, so it must not move at all while the
+        // layer is off.
+        if self.associating() {
+            let ids = vec![artifact_id.to_string()];
+            let store = self.store.clone();
+            let (delta, half_life) = (self.activation.opened, self.activation.half_life_days);
+            let at = now_secs();
+            self.background.spawn(async move {
+                if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                    tracing::warn!(error = %e, "could not raise activation for opening");
+                }
+            });
+        }
     }
 
     /// Each artifact's activation, already decayed to now.
@@ -410,6 +420,7 @@ impl Core {
                 self.associate.half_life_days,
                 now_secs(),
                 self.associate.show_min,
+                self.associate.spread_max as i64,
             )
             .await
         {
@@ -682,7 +693,7 @@ impl Core {
         // is the order the searcher was actually shown — a judged rank has to
         // be a rank that happened. Bounded by `prime_lift` and never past rank
         // 1, so this can reorder near-ties and nothing else.
-        if self.associate.enabled && self.associate.prime_lift > 0 {
+        if self.associating() && self.associate.prime_lift > 0 {
             let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
             let activation = self.activation_now(&ids).await;
             results = prime(
@@ -750,7 +761,7 @@ impl Core {
         // matched the question must not become source material. `Judge` is
         // excluded because its query is composed in full knowledge of the
         // answer and needs a clean pool to label, not a widened one.
-        if self.associate.enabled && !matches!(door, Door::Ask | Door::Judge) {
+        if self.associating() && !matches!(door, Door::Ask | Door::Judge) {
             let recalled = self.associated(&results).await;
             if !recalled.is_empty() {
                 self.mark_seen(&recalled, &HashMap::new(), false);
@@ -968,7 +979,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_deliberate_search_makes_what_it_returned_more_accessible() {
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
@@ -1057,7 +1069,8 @@ mod tests {
 
     #[tokio::test]
     async fn opening_an_artifact_makes_it_more_accessible_by_less_than_a_retrieval() {
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
         let before = core
@@ -1656,6 +1669,7 @@ mod tests {
     #[tokio::test]
     async fn priming_changes_the_order_a_search_returns_and_says_which_hit_moved() {
         let mut core = test_core().await;
+        core.feedback.enabled = true;
         core.associate.prime_lift = 2;
         let texts: Vec<(&str, &str, &[&str])> = (0..6)
             .map(|_| ("alpha text about it", "note", &[][..]))
@@ -1693,6 +1707,89 @@ mod tests {
         );
         assert!(primed[moved].primed, "a hit that moved must say so");
         assert_ne!(primed[0].artifact_id, bottom, "rank 1 was displaced");
+    }
+
+    #[tokio::test]
+    async fn a_marked_search_does_not_touch_activation_while_feedback_is_off() {
+        // Shipped defaults: `feedback.enabled = false`, `associate.enabled =
+        // true`. Links are learned from recorded searches, and none are being
+        // recorded, so the whole associative layer — including activation,
+        // which exists only to feed priming — must stay dark. `test_core()`
+        // is exactly this combination; nothing here turns `feedback` on.
+        let core = test_core().await;
+        assert!(!core.feedback.enabled && core.associate.enabled);
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
+
+        core.search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        core.background.wait_idle().await;
+
+        let after = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
+        assert_eq!(
+            after, before,
+            "a marked search raised activation with feedback.enabled false"
+        );
+    }
+
+    #[tokio::test]
+    async fn priming_never_reaches_the_order_while_feedback_is_off() {
+        // The spec promise (§11): "existing installs see nothing change until
+        // they opt in." `associate.enabled` alone must not let a large
+        // activation move the ranked order — the order must be byte-identical
+        // to `prime_lift = 0`, not merely bounded.
+        let core = test_core().await;
+        assert!(!core.feedback.enabled && core.associate.enabled);
+        assert_eq!(core.associate.prime_lift, 2, "the shipped default");
+        let texts: Vec<(&str, &str, &[&str])> = (0..6)
+            .map(|_| ("alpha text about it", "note", &[][..]))
+            .collect();
+        seed(&core, &texts).await;
+        reembed_all(&core).await;
+
+        let plain = core
+            .search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        assert!(plain.len() >= 4, "this test needs a list to reorder");
+
+        // The one at the bottom is given a huge activation directly — exactly
+        // what moved the order in the "feature on" test above.
+        let bottom = plain.last().unwrap().artifact_id.clone();
+        sqlx::query("UPDATE artifacts SET activation = 100.0, activated_at = ? WHERE id = ?")
+            .bind(now_secs())
+            .bind(&bottom)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let with_huge_activation = core
+            .search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        let plain_ids: Vec<&str> = plain.iter().map(|r| r.artifact_id.as_str()).collect();
+        let after_ids: Vec<&str> = with_huge_activation
+            .iter()
+            .map(|r| r.artifact_id.as_str())
+            .collect();
+        assert_eq!(
+            plain_ids, after_ids,
+            "the order changed even though feedback.enabled is false"
+        );
+        assert!(with_huge_activation.iter().all(|r| !r.primed));
     }
 
     async fn captured_events(core: &crate::core::Core) -> i64 {
@@ -1884,7 +1981,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_linked_artifact_is_recalled_beside_the_answer_and_says_what_recalled_it() {
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -1920,7 +2018,8 @@ mod tests {
         // the same four doors today. One door alone would not prove the
         // gate is door-shaped rather than coincidental, so this checks both
         // an excluded door and an included one against the same link.
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -1955,7 +2054,8 @@ mod tests {
 
     #[tokio::test]
     async fn an_artifact_already_in_the_answer_is_not_recalled_again() {
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(
             &core,
             "one",
@@ -2087,7 +2187,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_hidden_artifact_is_never_recalled_by_association() {
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -2106,7 +2207,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_weak_link_is_not_strong_enough_to_recall_anything() {
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -1076,7 +1076,14 @@ mod tests {
             .await
             .unwrap()[&id]
             .0;
-        assert!((after - before - core.activation.opened).abs() < 1e-6);
+        // Loose on purpose: `before` is the raw stored activation, but the bump
+        // re-reads it through decay, so the error grows with wall-clock time
+        // between the artifact's creation and the bump (5.7e-7 after one
+        // second, 1.15e-6 after two) and a loaded machine can straddle 1e-6.
+        // 1e-3 still separates `opened` (0.5) from `retrieved` (1.0) by three
+        // orders of magnitude, so it cannot mask a real regression — don't
+        // tighten it back without addressing the decay re-read instead.
+        assert!((after - before - core.activation.opened).abs() < 1e-3);
         assert!(core.activation.opened < core.activation.retrieved);
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -420,7 +420,18 @@ impl Core {
                 self.associate.half_life_days,
                 now_secs(),
                 self.associate.show_min,
-                self.associate.spread_max as i64,
+                // Not `spread_max`: `links_from` returns one row per (anchor,
+                // link) with no dedup across anchors, and it truncates before
+                // the filtering below runs. The rows most likely to be
+                // discarded here are anchor-to-anchor links — both ends
+                // already in `results` — and those are exactly the links
+                // co-retrieval makes most likely to exist. A limit of just
+                // `spread_max` lets such rows consume the whole budget and
+                // leave nothing for genuinely new artifacts. This bound
+                // leaves room for every anchor-to-anchor pair among the
+                // ranked anchors to be discarded and still fill the budget;
+                // the real cap is the `out.len() >= spread_max` check below.
+                (self.associate.spread_max * (self.associate.spread_from + 1)) as i64,
             )
             .await
         {
@@ -1008,7 +1019,8 @@ mod tests {
         // The same rule as `last_seen_at`: an incremental request is not a
         // retrieval, and letting every keystroke raise activation would make
         // accessibility a function of how slowly someone types.
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
@@ -1038,7 +1050,8 @@ mod tests {
     async fn being_drawn_at_random_raises_nothing() {
         // `resurface` shows what has been forgotten. Counting that as a reason
         // to be more accessible is the loop this whole design is built to close.
-        let core = test_core().await;
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
         seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
         sqlx::query("UPDATE artifacts SET created_at = ?")
             .bind(now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1)
@@ -2223,5 +2236,85 @@ mod tests {
         let mut query = q("t0\nalpha text");
         query.limit = 1;
         assert_eq!(core.search(&query, Door::Ui).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn links_between_ranked_hits_do_not_starve_the_association_budget() {
+        // `links_from` returns one row per (anchor, link) with no dedup
+        // across anchors, and truncates at its own limit before `associated`
+        // filters out rows whose other end is already ranked. A link between
+        // two of the top `spread_from` hits is therefore fetched twice — once
+        // per anchor — and those are exactly the rows co-retrieval makes most
+        // likely to exist. If the store limit were just `spread_max`, three
+        // such rows could fill the entire budget and then all be discarded,
+        // leaving nothing for an artifact that is linked to the ranked hits
+        // but did not itself rank. This calls `associated` directly, on
+        // hand-built anchors, so the outcome does not depend on the fake
+        // embedder's incidental ranking of a fifth candidate.
+        let core = test_core().await;
+        seed_from(
+            &core,
+            "one",
+            &[
+                ("alpha one", "note", &[]),
+                ("alpha two", "note", &[]),
+                ("alpha three", "note", &[]),
+                ("alpha four", "note", &[]),
+            ],
+        )
+        .await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha one").await;
+        let b = id_of(&core, "alpha two").await;
+        let c = id_of(&core, "alpha three").await;
+        let d = id_of(&core, "alpha four").await;
+
+        // Every pair among the three ranked hits (a, b, c) is linked more
+        // strongly than the single link from a ranked hit to the one
+        // artifact that never ranks (d) — so a limit that keeps the
+        // strongest rows first keeps the redundant, discardable ones and
+        // drops the useful one, which is exactly the bug.
+        let now = now_secs();
+        core.store
+            .bump_link(&a, &b, 10.0, Some("q"), 30.0, now)
+            .await
+            .unwrap();
+        core.store
+            .bump_link(&a, &c, 10.0, Some("q"), 30.0, now)
+            .await
+            .unwrap();
+        core.store
+            .bump_link(&b, &c, 10.0, Some("q"), 30.0, now)
+            .await
+            .unwrap();
+        core.store
+            .bump_link(&a, &d, 5.0, Some("q"), 30.0, now)
+            .await
+            .unwrap();
+
+        let dummy = |id: String| SearchResult {
+            artifact_id: id,
+            corpus_id: String::new(),
+            title: None,
+            text: String::new(),
+            category: None,
+            tags: vec![],
+            score: 1.0,
+            status: None,
+            superseded_by: None,
+            last_verified_at: None,
+            weak: false,
+            primed: false,
+            via: None,
+            reason: None,
+        };
+        let results = vec![dummy(a.clone()), dummy(b.clone()), dummy(c.clone())];
+
+        let out = core.associated(&results).await;
+        let ids: Vec<&str> = out.iter().map(|r| r.artifact_id.as_str()).collect();
+        assert!(
+            ids.contains(&d.as_str()),
+            "an artifact linked only to the ranked hits, not among them, was not recalled: {ids:?}"
+        );
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -170,6 +170,17 @@ fn counts_of(hits: &[crate::vector::SearchHit]) -> HashMap<String, i64> {
 ///
 /// Index 0 is untouchable and index 1 cannot move, because moving it would
 /// displace rank 1. An exact match is never buried.
+///
+/// Every row's destination is decided against the ORIGINAL ordering in one
+/// pass, then the list is reordered once. An earlier attempt did this by
+/// repeatedly swapping adjacent rows in place, insertion-sort style — but
+/// once a row swaps, the array no longer records which row already spent its
+/// budget: a later position, reached by a *different* row after an earlier
+/// row moved through it, got a fresh budget for free. On a five-element list
+/// with only the last row activated and `lift = 2`, that let it climb three
+/// places instead of two, and on a longer list the overrun only grows. Here
+/// every comparison reads from an activation snapshot untouched by any move,
+/// so no row can ever borrow a gap another row's move opened.
 fn prime(
     results: Vec<SearchResult>,
     activation: &HashMap<String, f64>,
@@ -183,36 +194,54 @@ fn prime(
     if max <= 0.0 {
         return results;
     }
-    let mut rows: Vec<(SearchResult, f64, usize)> = results
-        .into_iter()
-        .enumerate()
-        .map(|(i, r)| {
-            let a = activation.get(&r.artifact_id).copied().unwrap_or(0.0) / max;
-            (r, a, i)
-        })
+    let n = results.len();
+    // Normalised once, against the original list, and never touched again.
+    let acts: Vec<f64> = results
+        .iter()
+        .map(|r| activation.get(&r.artifact_id).copied().unwrap_or(0.0) / max)
         .collect();
 
-    // Bottom-up: a row's climb must be earned by its own margin over its own
-    // original neighbour, never borrowed from a gap another row's earlier
-    // climb happened to open beneath it. Processing the lowest-ranked
-    // candidate first means every later (higher-ranked) row still sees its
-    // true original predecessor before deciding whether to move.
-    for i in (2..rows.len()).rev() {
-        let mut j = i;
-        let mut moved = 0;
-        while j > 1 && moved < lift && rows[j].1 - rows[j - 1].1 > margin {
-            rows.swap(j - 1, j);
-            j -= 1;
-            moved += 1;
+    // For each row, how many of its original predecessors — walked nearest
+    // first — it beats by strictly more than `margin`, stopping at the first
+    // it does not beat, capped at `lift`, and floored so the target index
+    // can never fall below 1: rank 1 is never displaced. Rows 0 and 1 never
+    // move, so the walk only starts at index 2.
+    let mut climb = vec![0usize; n];
+    for (i, slot) in climb.iter_mut().enumerate().skip(2) {
+        let mut c = 0usize;
+        while c < lift {
+            let predecessor = i - c - 1;
+            if predecessor < 1 || acts[i] - acts[predecessor] <= margin {
+                break;
+            }
+            c += 1;
         }
+        *slot = c;
     }
 
-    rows.into_iter()
+    // One stable sort by destination decides the final order. The secondary
+    // key is load-bearing: without it, a climbing row sorts behind the row
+    // it was meant to pass, because its original index is larger.
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by_key(|&i| {
+        let target = i - climb[i];
+        let climbed = climb[i] > 0;
+        (target, u8::from(!climbed), i)
+    });
+
+    let mut slots: Vec<Option<SearchResult>> = results.into_iter().map(Some).collect();
+    order
+        .into_iter()
         .enumerate()
-        .map(|(pos, (mut r, _, was))| {
-            // Only a climb is priming. A hit that was passed did not move up,
-            // and labelling it would say something untrue about it.
-            r.primed = pos < was;
+        .map(|(pos, i)| {
+            let mut r = slots[i]
+                .take()
+                .expect("each original index used exactly once");
+            // Only a climb is priming: this is exactly the row that ended up
+            // at a lower index than it started at. A hit that was merely
+            // displaced by another row's climb did not move up, and
+            // labelling it would say something untrue about it.
+            r.primed = pos < i;
             r
         })
         .collect()
@@ -1347,6 +1376,31 @@ mod tests {
             vec!["a", "c", "b", "d"],
             "only c clears the margin"
         );
+    }
+
+    #[test]
+    fn a_hit_climbs_exactly_the_lift_and_no_further_however_long_the_list_is() {
+        // An insertion-sort-style implementation can let a row that already
+        // spent its climb budget be mistaken for a fresh row once something
+        // else moves through the position it landed on. Five elements is
+        // enough to expose that: `e` should climb exactly two, not three.
+        let act = HashMap::from([("e".to_string(), 1.0)]);
+        let out = prime(ranked(&["a", "b", "c", "d", "e"]), &act, 0.5, 2);
+        assert_eq!(order(&out), vec!["a", "b", "e", "c", "d"]);
+        let moved = order(&out).iter().position(|id| *id == "e").unwrap();
+        assert_eq!(moved, 4 - 2, "e must climb exactly prime_lift positions");
+        assert!(out[moved].primed);
+    }
+
+    #[test]
+    fn the_lift_bound_holds_on_a_longer_list_too() {
+        // Same shape, stretched to seven: the last row must still land
+        // exactly `lift` positions up, at index 4 rather than index 1.
+        let act = HashMap::from([("g".to_string(), 1.0)]);
+        let out = prime(ranked(&["a", "b", "c", "d", "e", "f", "g"]), &act, 0.5, 2);
+        let moved = order(&out).iter().position(|id| *id == "g").unwrap();
+        assert_eq!(moved, 4, "g must land at index 4, not be pulled to index 1");
+        assert_eq!(6 - moved, 2, "the climb must equal prime_lift exactly");
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -1,7 +1,7 @@
 use super::Core;
 use crate::error::{Error, Result};
 use crate::store::artifacts::ArtifactStatus;
-use crate::store::feedback::Origin;
+use crate::store::feedback::{Door, Origin};
 use crate::vector::{SearchFilter, SearchHit};
 use std::collections::HashMap;
 
@@ -742,7 +742,15 @@ impl Core {
         // After the truncate and after capture, so an association can only ever
         // add: it is outside `limit`, outside the recorded pool, and outside the
         // retrieval count. See `Touch::shown`.
-        if self.associate.enabled {
+        //
+        // Gated on the door, not on `captured()` — that predicate means
+        // "recorded for relevance feedback", an unrelated idea that happens
+        // to select the same four doors today. `Ask` is excluded because it
+        // synthesises an answer from `results` as excerpts; text that never
+        // matched the question must not become source material. `Judge` is
+        // excluded because its query is composed in full knowledge of the
+        // answer and needs a clean pool to label, not a widened one.
+        if self.associate.enabled && !matches!(door, Door::Ask | Door::Judge) {
             let recalled = self.associated(&results).await;
             if !recalled.is_empty() {
                 self.mark_seen(&recalled, &HashMap::new(), false);
@@ -1854,6 +1862,54 @@ mod tests {
         );
         assert_eq!(out[1].artifact_id, b);
         assert_eq!(out[1].via.as_deref(), Some(a.as_str()));
+    }
+
+    #[tokio::test]
+    async fn ask_and_judge_never_receive_an_association_but_ui_does() {
+        // `ask` feeds `results` to the model as excerpts to synthesise an
+        // answer from; text that never matched the question must not become
+        // source material. `judge` composes its query in full knowledge of
+        // the answer and needs a clean pool to label. Both are excluded by
+        // door, not by `captured()` — that predicate means something
+        // unrelated (recorded for relevance feedback) that happens to select
+        // the same four doors today. One door alone would not prove the
+        // gate is door-shaped rather than coincidental, so this checks both
+        // an excluded door and an included one against the same link.
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("both of these"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+
+        let ask_out = core.search(&query, Door::Ask).await.unwrap();
+        assert_eq!(
+            ask_out.len(),
+            1,
+            "ask received an association: {ask_out:?}"
+        );
+
+        let judge_out = core.search(&query, Door::Judge).await.unwrap();
+        assert_eq!(
+            judge_out.len(),
+            1,
+            "judge received an association: {judge_out:?}"
+        );
+
+        let ui_out = core.search(&query, Door::Ui).await.unwrap();
+        assert_eq!(
+            ui_out.len(),
+            2,
+            "ui did not receive the association: {ui_out:?}"
+        );
+        assert_eq!(ui_out[1].via.as_deref(), Some(a.as_str()));
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -306,6 +306,21 @@ impl Core {
                 tracing::warn!(error = %e, "could not record which chunks were shown");
             }
         });
+
+        // Only a retrieval raises accessibility. A list nobody asked for —
+        // `resurface`, an association — is shown, not reached, and the row in
+        // §5.4 that reads zero is the one-way guard this implements.
+        if counts_as_hit {
+            let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
+            let store = self.store.clone();
+            let (delta, half_life) = (self.activation.retrieved, self.activation.half_life_days);
+            let at = now_secs();
+            self.background.spawn(async move {
+                if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                    tracing::warn!(error = %e, "could not raise activation for a search");
+                }
+            });
+        }
     }
 
     /// Opening a chunk is the deliberate act that counts as remembering it,
@@ -324,6 +339,18 @@ impl Core {
         self.background.spawn(async move {
             if let Err(e) = vectors.touch(&targets, now).await {
                 tracing::warn!(error = %e, "could not record that a chunk was opened");
+            }
+        });
+
+        // An open is a deliberate act and counts for less than a retrieval:
+        // clicking a candidate says you looked, not that it answered.
+        let ids = vec![artifact_id.to_string()];
+        let store = self.store.clone();
+        let (delta, half_life) = (self.activation.opened, self.activation.half_life_days);
+        let at = now_secs();
+        self.background.spawn(async move {
+            if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                tracing::warn!(error = %e, "could not raise activation for opening");
             }
         });
     }
@@ -929,6 +956,82 @@ mod tests {
             .filter(|h| h.payload.last_seen_at.is_some())
             .count();
         assert!(stamped > 0, "a deliberate search still counts as seeing");
+    }
+
+    #[tokio::test]
+    async fn a_deliberate_search_makes_what_it_returned_more_accessible() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+
+        core.search(&q("alpha"), Door::Ui).await.unwrap();
+        core.background.wait_idle().await;
+
+        let after = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        assert!(after > before, "a retrieval raised nothing");
+    }
+
+    #[tokio::test]
+    async fn typing_does_not_make_what_it_happened_to_match_more_accessible() {
+        // The same rule as `last_seen_at`: an incremental request is not a
+        // retrieval, and letting every keystroke raise activation would make
+        // accessibility a function of how slowly someone types.
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+
+        let mut query = q("alpha");
+        query.mark = false;
+        core.search(&query, Door::Ui).await.unwrap();
+        core.background.wait_idle().await;
+
+        assert_eq!(
+            core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0,
+            before
+        );
+    }
+
+    #[tokio::test]
+    async fn being_drawn_at_random_raises_nothing() {
+        // `resurface` shows what has been forgotten. Counting that as a reason
+        // to be more accessible is the loop this whole design is built to close.
+        let core = test_core().await;
+        seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
+        sqlx::query("UPDATE artifacts SET created_at = ?")
+            .bind(now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        reembed_all(&core).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+
+        core.resurface(10).await.unwrap();
+        core.background.wait_idle().await;
+
+        assert_eq!(
+            core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0,
+            before
+        );
+    }
+
+    #[tokio::test]
+    async fn opening_an_artifact_makes_it_more_accessible_by_less_than_a_retrieval() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
+        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+
+        core.mark_artifact_seen(&id);
+        core.background.wait_idle().await;
+
+        let after = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        assert!((after - before - core.activation.opened).abs() < 1e-6);
+        assert!(core.activation.opened < core.activation.retrieved);
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -79,6 +79,12 @@ pub struct SearchResult {
     /// the benefit of the doubt. Weakness has to be demonstrated, never assumed.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub weak: bool,
+    /// This hit moved up because it is more accessible than the ones it passed
+    /// — recently and often reached. Bounded by `associate.prime_lift`, never
+    /// past rank 1, and said out loud wherever it happened: nothing about the
+    /// order is silent.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub primed: bool,
 }
 
 impl From<SearchHit> for SearchResult {
@@ -95,6 +101,7 @@ impl From<SearchHit> for SearchResult {
             superseded_by: h.payload.superseded_by,
             last_verified_at: h.payload.last_verified_at,
             weak: false,
+            primed: false,
         }
     }
 }
@@ -148,6 +155,65 @@ fn counts_of(hits: &[crate::vector::SearchHit]) -> HashMap<String, i64> {
                 h.payload.artifact_id.clone(),
                 h.payload.hit_count.unwrap_or(0),
             )
+        })
+        .collect()
+}
+
+/// Move hits up on activation, within hard bounds.
+///
+/// Rank-based rather than score-based: hybrid scores are fused ranks and mean
+/// nothing across queries, while "moved up two places" means the same thing
+/// every time. The activation is normalised within this one list, so `margin` is
+/// a fraction of the most accessible hit here rather than an absolute weight —
+/// which is what makes one default work for a list of ones and a list of
+/// hundreds.
+///
+/// Index 0 is untouchable and index 1 cannot move, because moving it would
+/// displace rank 1. An exact match is never buried.
+fn prime(
+    results: Vec<SearchResult>,
+    activation: &HashMap<String, f64>,
+    margin: f64,
+    lift: usize,
+) -> Vec<SearchResult> {
+    if lift == 0 || results.len() < 3 {
+        return results;
+    }
+    let max = activation.values().copied().fold(0.0f64, f64::max);
+    if max <= 0.0 {
+        return results;
+    }
+    let mut rows: Vec<(SearchResult, f64, usize)> = results
+        .into_iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let a = activation.get(&r.artifact_id).copied().unwrap_or(0.0) / max;
+            (r, a, i)
+        })
+        .collect();
+
+    // Bottom-up: a row's climb must be earned by its own margin over its own
+    // original neighbour, never borrowed from a gap another row's earlier
+    // climb happened to open beneath it. Processing the lowest-ranked
+    // candidate first means every later (higher-ranked) row still sees its
+    // true original predecessor before deciding whether to move.
+    for i in (2..rows.len()).rev() {
+        let mut j = i;
+        let mut moved = 0;
+        while j > 1 && moved < lift && rows[j].1 - rows[j - 1].1 > margin {
+            rows.swap(j - 1, j);
+            j -= 1;
+            moved += 1;
+        }
+    }
+
+    rows.into_iter()
+        .enumerate()
+        .map(|(pos, (mut r, _, was))| {
+            // Only a climb is priming. A hit that was passed did not move up,
+            // and labelling it would say something untrue about it.
+            r.primed = pos < was;
+            r
         })
         .collect()
 }
@@ -222,6 +288,35 @@ impl Core {
                 tracing::warn!(error = %e, "could not record that a chunk was opened");
             }
         });
+    }
+
+    /// Each artifact's activation, already decayed to now.
+    ///
+    /// The one SQLite read the query path takes. It can only add: a failure is
+    /// one warning and an empty map, and everything downstream then behaves
+    /// exactly as it did before any of this existed.
+    async fn activation_now(&self, ids: &[String]) -> HashMap<String, f64> {
+        let at = now_secs();
+        match self.store.activation_of(ids).await {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(id, (value, stamp))| {
+                    (
+                        id,
+                        crate::store::links::decayed(
+                            value,
+                            stamp,
+                            at,
+                            self.activation.half_life_days,
+                        ),
+                    )
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not read activation; results are unprimed");
+                HashMap::new()
+            }
+        }
     }
 
     /// A random handful of chunks that have not surfaced in a month.
@@ -443,6 +538,21 @@ impl Core {
                 // order is still a usable answer.
                 Err(e) => tracing::warn!(error = %e, "rerank failed; returning vector order"),
             }
+        }
+
+        // Before capture and before the truncate, so the pool that is recorded
+        // is the order the searcher was actually shown — a judged rank has to
+        // be a rank that happened. Bounded by `prime_lift` and never past rank
+        // 1, so this can reorder near-ties and nothing else.
+        if self.associate.enabled && self.associate.prime_lift > 0 {
+            let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
+            let activation = self.activation_now(&ids).await;
+            results = prime(
+                results,
+                &activation,
+                self.associate.prime_margin,
+                self.associate.prime_lift,
+            );
         }
 
         // Recorded here, where the list is still wider than the answer and the
@@ -1174,6 +1284,111 @@ mod tests {
             vec![&ids[1]],
             "the forgotten list offered an artifact that was just retired"
         );
+    }
+
+    fn ranked(ids: &[&str]) -> Vec<SearchResult> {
+        ids.iter()
+            .map(|id| SearchResult {
+                artifact_id: (*id).into(),
+                corpus_id: "c".into(),
+                title: None,
+                text: String::new(),
+                category: None,
+                tags: vec![],
+                score: 0.5,
+                status: None,
+                superseded_by: None,
+                last_verified_at: None,
+                weak: false,
+                primed: false,
+            })
+            .collect()
+    }
+
+    fn order(rs: &[SearchResult]) -> Vec<&str> {
+        rs.iter().map(|r| r.artifact_id.as_str()).collect()
+    }
+
+    #[test]
+    fn a_hit_climbs_at_most_two_places_and_never_past_the_first() {
+        // Rank-based rather than score-based on purpose: hybrid scores are
+        // fused ranks and mean nothing across queries, while "moved up two
+        // places" means the same thing every time — and can be tested here.
+        let act = HashMap::from([("d".to_string(), 4.0)]);
+        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 2);
+        assert_eq!(order(&out), vec!["a", "d", "b", "c"]);
+        assert!(out[1].primed, "the hit that moved must say so");
+        assert!(!out[2].primed, "the hit it passed did not move up");
+    }
+
+    #[test]
+    fn the_most_active_hit_cannot_displace_an_exact_match() {
+        let act = HashMap::from([("b".to_string(), 9.0)]);
+        let out = prime(ranked(&["a", "b", "c"]), &act, 0.5, 2);
+        assert_eq!(order(&out), vec!["a", "b", "c"]);
+        assert!(out.iter().all(|r| !r.primed));
+    }
+
+    #[test]
+    fn a_lift_of_zero_turns_priming_off_entirely() {
+        let act = HashMap::from([("d".to_string(), 4.0)]);
+        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 0);
+        assert_eq!(order(&out), vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn activation_that_is_merely_higher_does_not_move_anything() {
+        // The margin is what keeps this from reshuffling every list: two hits
+        // that are both somewhat active stay in the order the ranking gave.
+        let act = HashMap::from([("c".to_string(), 4.0), ("d".to_string(), 3.6)]);
+        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 2);
+        assert_eq!(
+            order(&out),
+            vec!["a", "c", "b", "d"],
+            "only c clears the margin"
+        );
+    }
+
+    #[tokio::test]
+    async fn priming_changes_the_order_a_search_returns_and_says_which_hit_moved() {
+        let mut core = test_core().await;
+        core.associate.prime_lift = 2;
+        let texts: Vec<(&str, &str, &[&str])> = (0..6)
+            .map(|_| ("alpha text about it", "note", &[][..]))
+            .collect();
+        seed(&core, &texts).await;
+        reembed_all(&core).await;
+
+        let plain = {
+            let mut off = core.clone();
+            off.associate.prime_lift = 0;
+            off.search(&q("alpha text about it"), Door::Ui)
+                .await
+                .unwrap()
+        };
+        assert!(plain.len() >= 4, "this test needs a list to reorder");
+        assert!(plain.iter().all(|r| !r.primed));
+
+        // The one at the bottom is the one people actually keep confirming.
+        let bottom = plain.last().unwrap().artifact_id.clone();
+        sqlx::query("UPDATE artifacts SET activation = 100.0, activated_at = ? WHERE id = ?")
+            .bind(now_secs())
+            .bind(&bottom)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let primed = core
+            .search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        let moved = primed.iter().position(|r| r.artifact_id == bottom).unwrap();
+        assert!(
+            moved < plain.len() - 1,
+            "activation did not reach the ranked list at all"
+        );
+        assert!(primed[moved].primed, "a hit that moved must say so");
+        assert_ne!(primed[0].artifact_id, bottom, "rank 1 was displaced");
     }
 
     async fn captured_events(core: &crate::core::Core) -> i64 {

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -85,6 +85,13 @@ pub struct SearchResult {
     /// order is silent.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub primed: bool,
+    /// The ranked hit that recalled this one. `None` for a ranked hit — which
+    /// is every hit inside `limit`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
+    /// What the judge said the relation is, where a link has been judged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 impl From<SearchHit> for SearchResult {
@@ -102,6 +109,8 @@ impl From<SearchHit> for SearchResult {
             last_verified_at: h.payload.last_verified_at,
             weak: false,
             primed: false,
+            via: None,
+            reason: None,
         }
     }
 }
@@ -346,6 +355,79 @@ impl Core {
                 HashMap::new()
             }
         }
+    }
+
+    /// Artifacts linked to the top of the answer, appended beside it.
+    ///
+    /// One hop only. Spreading further is what a graph view would be for, and
+    /// there is none. Everything here is additive: it never removes or reorders
+    /// a ranked hit, and a store that will not answer produces an empty list and
+    /// one warning.
+    async fn associated(&self, results: &[SearchResult]) -> Vec<SearchResult> {
+        let anchors: Vec<String> = results
+            .iter()
+            .take(self.associate.spread_from)
+            .map(|r| r.artifact_id.clone())
+            .collect();
+        if anchors.is_empty() || self.associate.spread_max == 0 {
+            return Vec::new();
+        }
+        let links = match self
+            .store
+            .links_from(
+                &anchors,
+                &[
+                    crate::store::links::LinkState::Learning,
+                    crate::store::links::LinkState::Related,
+                ],
+                self.associate.half_life_days,
+                now_secs(),
+                self.associate.show_min,
+            )
+            .await
+        {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(error = %e, "could not read links; results are unassociated");
+                return Vec::new();
+            }
+        };
+
+        let mut have: std::collections::HashSet<String> =
+            results.iter().map(|r| r.artifact_id.clone()).collect();
+        let mut out = Vec::new();
+        for l in links {
+            if out.len() >= self.associate.spread_max {
+                break;
+            }
+            if !have.insert(l.other.clone()) {
+                continue;
+            }
+            // Read from SQLite rather than the vector store: the row is already
+            // one connection away, and the payload adds nothing this needs.
+            let Ok(c) = self.store.get_artifact(&l.other).await else {
+                continue;
+            };
+            out.push(SearchResult {
+                artifact_id: c.id,
+                corpus_id: c.corpus_id.unwrap_or_default(),
+                title: c.title,
+                text: c.text,
+                category: c.category,
+                tags: c.tags,
+                // Not a rank and not a similarity: this hit did not compete for
+                // a place in the list, it was recalled beside it.
+                score: 0.0,
+                status: Some(c.status),
+                superseded_by: c.superseded_by,
+                last_verified_at: c.last_verified_at,
+                weak: false,
+                primed: false,
+                via: Some(l.via),
+                reason: l.reason,
+            });
+        }
+        out
     }
 
     /// A random handful of chunks that have not surfaced in a month.
@@ -629,6 +711,16 @@ impl Core {
         if query.mark {
             // A query answered these, so they count as retrievals.
             self.mark_seen(&results, &hit_counts, true);
+        }
+        // After the truncate and after capture, so an association can only ever
+        // add: it is outside `limit`, outside the recorded pool, and outside the
+        // retrieval count. See `Touch::shown`.
+        if self.associate.enabled {
+            let recalled = self.associated(&results).await;
+            if !recalled.is_empty() {
+                self.mark_seen(&recalled, &HashMap::new(), false);
+                results.extend(recalled);
+            }
         }
         tracing::info!(
             q = %query.q,
@@ -1330,6 +1422,8 @@ mod tests {
                 last_verified_at: None,
                 weak: false,
                 primed: false,
+                via: None,
+                reason: None,
             })
             .collect()
     }
@@ -1619,5 +1713,213 @@ mod tests {
         core.search(&q("alpha text"), Door::Judge).await.unwrap();
         core.search(&q("alpha text"), Door::Ask).await.unwrap();
         assert_eq!(captured_events(&core).await, 0);
+    }
+
+    /// The id of the artifact whose text is exactly this. Ordering from
+    /// `list_all_artifact_ids` is not promised, and a test that assumed one
+    /// would pass or fail on which row SQLite happened to return first.
+    async fn id_of(core: &crate::core::Core, text: &str) -> String {
+        sqlx::query_scalar("SELECT id FROM artifacts WHERE text = ?")
+            .bind(text)
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_linked_artifact_is_recalled_beside_the_answer_and_says_what_recalled_it() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("both of these"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        let out = core.search(&query, Door::Ui).await.unwrap();
+
+        assert_eq!(out.len(), 2, "the association was not appended: {out:?}");
+        assert_eq!(out[0].artifact_id, a);
+        assert_eq!(
+            out[0].via, None,
+            "a ranked hit was not recalled by anything"
+        );
+        assert_eq!(out[1].artifact_id, b);
+        assert_eq!(out[1].via.as_deref(), Some(a.as_str()));
+    }
+
+    #[tokio::test]
+    async fn an_artifact_already_in_the_answer_is_not_recalled_again() {
+        let core = test_core().await;
+        seed_from(
+            &core,
+            "one",
+            &[("alpha text", "note", &[]), ("alpha other", "note", &[])],
+        )
+        .await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "alpha other").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let out = core.search(&q("alpha"), Door::Ui).await.unwrap();
+        let seen: std::collections::HashSet<&str> =
+            out.iter().map(|r| r.artifact_id.as_str()).collect();
+        assert_eq!(seen.len(), out.len(), "an artifact was returned twice");
+    }
+
+    /// The captured pool, as `(role, shown)` ordered by rank — `role` is `"a"`
+    /// or `"b"` depending on which of the two seeded ids the row names, so two
+    /// separately-seeded cores (whose artifact ids are fresh UUIDs and so never
+    /// equal) can still be compared for shape.
+    async fn captured_pool(core: &crate::core::Core, a: &str, b: &str) -> Vec<(&'static str, i64)> {
+        let rows: Vec<(String, i64)> =
+            sqlx::query_as("SELECT artifact_id, shown FROM search_candidates ORDER BY rank")
+                .fetch_all(&core.store.pool)
+                .await
+                .unwrap();
+        rows.into_iter()
+            .map(|(id, shown)| {
+                let role = if id == a {
+                    "a"
+                } else if id == b {
+                    "b"
+                } else {
+                    "?"
+                };
+                (role, shown)
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_recalled_artifact_does_not_feed_the_learning_that_produced_it() {
+        // The failure mode of any Hebbian system: a link recalls an artifact, is
+        // strengthened by having done so, and recalls it harder next time. Both
+        // loops have to be closed by construction: the recalled hit must not be
+        // written as a candidate, and must not count as a retrieval.
+        //
+        // This cannot be checked by asking "is `b` absent from
+        // `search_candidates`" directly: on a base this small, `b` is a
+        // legitimate low-ranked candidate of the plain hybrid search with or
+        // without any link — `feedback.candidates` over-fetches wider than the
+        // two-artifact corpus, so the ordinary capture path records it anyway,
+        // unshown. That is correct and expected, and unrelated to association.
+        // What has to be proven instead is a control comparison: the captured
+        // pool is identical whether or not the link exists, which is what shows
+        // the link changed nothing about what was recorded — plus a check that
+        // the treatment side effect (the link) actually took hold, or the
+        // comparison would pass vacuously on a run where nothing associated at
+        // all. A later reader tempted to simplify this back to a direct
+        // absence check would reintroduce a test that fails on an artifact of
+        // the fixture rather than a bug.
+        async fn seeded() -> (crate::core::Core, String, String) {
+            let mut core = test_core().await;
+            core.feedback.enabled = true;
+            seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+            seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+            reembed_all(&core).await;
+            let a = id_of(&core, "alpha text").await;
+            let b = id_of(&core, "something else entirely").await;
+            (core, a, b)
+        }
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+
+        // Unlinked control.
+        let (unlinked, a_u, b_u) = seeded().await;
+        let unlinked_out = unlinked.search(&query, Door::Ui).await.unwrap();
+        unlinked.background.wait_idle().await;
+        let unlinked_pool = captured_pool(&unlinked, &a_u, &b_u).await;
+
+        // Linked treatment.
+        let (linked, a, b) = seeded().await;
+        linked
+            .store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+        let before = linked
+            .store
+            .activation_of(std::slice::from_ref(&b))
+            .await
+            .unwrap()[&b]
+            .0;
+        let linked_out = linked.search(&query, Door::Ui).await.unwrap();
+        linked.background.wait_idle().await;
+        let linked_pool = captured_pool(&linked, &a, &b).await;
+        let after = linked
+            .store
+            .activation_of(std::slice::from_ref(&b))
+            .await
+            .unwrap()[&b]
+            .0;
+
+        // 3. The treatment actually took effect, or the comparison below is
+        // vacuous.
+        assert_eq!(unlinked_out.len(), 1, "got: {unlinked_out:?}");
+        assert_eq!(linked_out.len(), 2, "got: {linked_out:?}");
+        assert_eq!(linked_out[1].artifact_id, b);
+        assert_eq!(linked_out[1].via.as_deref(), Some(a.as_str()));
+
+        // 1. The captured pool — id and shown, in rank order — is identical
+        // either way: the link changed nothing about what the search recorded.
+        assert_eq!(
+            unlinked_pool, linked_pool,
+            "the link changed what the search recorded as a candidate"
+        );
+
+        // 2. Being recalled did not count as a retrieval.
+        assert!(
+            (after - before).abs() < 1e-9,
+            "being recalled raised activation"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_hidden_artifact_is_never_recalled_by_association() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        core.store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+        core.deprecate(&b).await.unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        assert_eq!(core.search(&query, Door::Ui).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_weak_link_is_not_strong_enough_to_recall_anything() {
+        let core = test_core().await;
+        seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
+        seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
+        reembed_all(&core).await;
+        let a = id_of(&core, "alpha text").await;
+        let b = id_of(&core, "something else entirely").await;
+        // One co-appearance, against a `show_min` of 2.0.
+        core.store
+            .bump_link(&a, &b, 1.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        let mut query = q("t0\nalpha text");
+        query.limit = 1;
+        assert_eq!(core.search(&query, Door::Ui).await.unwrap().len(), 1);
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -972,12 +972,22 @@ mod tests {
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
-        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        let before = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
 
         core.search(&q("alpha"), Door::Ui).await.unwrap();
         core.background.wait_idle().await;
 
-        let after = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        let after = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
         assert!(after > before, "a retrieval raised nothing");
     }
 
@@ -990,7 +1000,12 @@ mod tests {
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
-        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        let before = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
 
         let mut query = q("alpha");
         query.mark = false;
@@ -998,7 +1013,11 @@ mod tests {
         core.background.wait_idle().await;
 
         assert_eq!(
-            core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0,
+            core.store
+                .activation_of(std::slice::from_ref(&id))
+                .await
+                .unwrap()[&id]
+                .0,
             before
         );
     }
@@ -1016,13 +1035,22 @@ mod tests {
             .unwrap();
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
-        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        let before = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
 
         core.resurface(10).await.unwrap();
         core.background.wait_idle().await;
 
         assert_eq!(
-            core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0,
+            core.store
+                .activation_of(std::slice::from_ref(&id))
+                .await
+                .unwrap()[&id]
+                .0,
             before
         );
     }
@@ -1032,12 +1060,22 @@ mod tests {
         let core = test_core().await;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
-        let before = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        let before = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
 
         core.mark_artifact_seen(&id);
         core.background.wait_idle().await;
 
-        let after = core.store.activation_of(std::slice::from_ref(&id)).await.unwrap()[&id].0;
+        let after = core
+            .store
+            .activation_of(std::slice::from_ref(&id))
+            .await
+            .unwrap()[&id]
+            .0;
         assert!((after - before - core.activation.opened).abs() < 1e-6);
         assert!(core.activation.opened < core.activation.retrieved);
     }
@@ -1890,11 +1928,7 @@ mod tests {
         query.limit = 1;
 
         let ask_out = core.search(&query, Door::Ask).await.unwrap();
-        assert_eq!(
-            ask_out.len(),
-            1,
-            "ask received an association: {ask_out:?}"
-        );
+        assert_eq!(ask_out.len(), 1, "ask received an association: {ask_out:?}");
 
         let judge_out = core.search(&query, Door::Judge).await.unwrap();
         assert_eq!(

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -400,7 +400,18 @@ impl Core {
     /// there is none. Everything here is additive: it never removes or reorders
     /// a ranked hit, and a store that will not answer produces an empty list and
     /// one warning.
-    async fn associated(&self, results: &[SearchResult]) -> Vec<SearchResult> {
+    ///
+    /// `filter` is the caller's own narrowing, and it applies here too. A
+    /// search for `category=runbook` is a statement about what the searcher
+    /// will accept, not a hint to the ranker, and an association that walks
+    /// past it hands back exactly the rows they asked not to see. `links_from`
+    /// already excludes anything not active and not live, so what is left to
+    /// re-check here is what the caller typed.
+    async fn associated(
+        &self,
+        results: &[SearchResult],
+        filter: &SearchFilter,
+    ) -> Vec<SearchResult> {
         let anchors: Vec<String> = results
             .iter()
             .take(self.associate.spread_from)
@@ -431,7 +442,19 @@ impl Core {
                 // leaves room for every anchor-to-anchor pair among the
                 // ranked anchors to be discarded and still fill the budget;
                 // the real cap is the `out.len() >= spread_max` check below.
-                (self.associate.spread_max * (self.associate.spread_from + 1)) as i64,
+                //
+                // Saturating, and `try_from` rather than `as`: both operands
+                // are operator-typed. `Config::normalize` clamps them to
+                // something a person could mean, so this cannot overflow in
+                // practice — but `as` on a `usize` that did would wrap to a
+                // negative `i64` and switch association silently off, which is
+                // the one failure nobody would report as a bug.
+                i64::try_from(
+                    self.associate
+                        .spread_max
+                        .saturating_mul(self.associate.spread_from.saturating_add(1)),
+                )
+                .unwrap_or(i64::MAX),
             )
             .await
         {
@@ -457,6 +480,16 @@ impl Core {
             let Ok(c) = self.store.get_artifact(&l.other).await else {
                 continue;
             };
+            // The same predicate the vector store applies, on the same two
+            // fields: every listed tag present, and the category exact.
+            if !filter.tags.iter().all(|t| c.tags.contains(t))
+                || filter
+                    .category
+                    .as_ref()
+                    .is_some_and(|want| c.category.as_ref() != Some(want))
+            {
+                continue;
+            }
             out.push(SearchResult {
                 artifact_id: c.id,
                 corpus_id: c.corpus_id.unwrap_or_default(),
@@ -704,7 +737,20 @@ impl Core {
         // is the order the searcher was actually shown — a judged rank has to
         // be a rank that happened. Bounded by `prime_lift` and never past rank
         // 1, so this can reorder near-ties and nothing else.
-        if self.associating() && self.associate.prime_lift > 0 {
+        //
+        // Held off the same two doors as association below, for the same
+        // reason in a different shape. `Ask` does not show this list to
+        // anybody: it turns the head of it into excerpts and, when they do not
+        // all fit the context window, keeps a prefix and drops the tail on the
+        // stated grounds that the tail matched the question least
+        // (`src/core/ask.rs`). Reordering by accessibility makes that untrue,
+        // and the excerpt lost is then the one that answered best — a silent
+        // change to the answer, on a path where nobody can see what was cut.
+        // `Judge` needs the pool it labels to be the pool the ranking produced.
+        if self.associating()
+            && self.associate.prime_lift > 0
+            && !matches!(door, Door::Ask | Door::Judge)
+        {
             let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
             let activation = self.activation_now(&ids).await;
             results = prime(
@@ -773,7 +819,7 @@ impl Core {
         // excluded because its query is composed in full knowledge of the
         // answer and needs a clean pool to label, not a widened one.
         if self.associating() && !matches!(door, Door::Ask | Door::Judge) {
-            let recalled = self.associated(&results).await;
+            let recalled = self.associated(&results, &filter).await;
             if !recalled.is_empty() {
                 self.mark_seen(&recalled, &HashMap::new(), false);
                 results.extend(recalled);
@@ -1805,6 +1851,115 @@ mod tests {
         assert!(with_huge_activation.iter().all(|r| !r.primed));
     }
 
+    #[tokio::test]
+    async fn priming_never_reaches_the_list_ask_and_judge_are_given() {
+        // `ask` does not show this list to anyone: it turns the head of it into
+        // excerpts and, when they do not all fit the context window, keeps a
+        // prefix and drops the tail — on the stated grounds that the tail
+        // matched the question least. Reorder by accessibility and the excerpt
+        // dropped is the one that answered best, invisibly. `judge` needs the
+        // pool it labels to be the pool the ranking produced.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        core.associate.prime_lift = 2;
+        let texts: Vec<(&str, &str, &[&str])> = (0..6)
+            .map(|_| ("alpha text about it", "note", &[][..]))
+            .collect();
+        seed(&core, &texts).await;
+        reembed_all(&core).await;
+
+        let plain = core
+            .search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        assert!(plain.len() >= 4, "this test needs a list to reorder");
+        let bottom = plain.last().unwrap().artifact_id.clone();
+        sqlx::query("UPDATE artifacts SET activation = 100.0, activated_at = ? WHERE id = ?")
+            .bind(now_secs())
+            .bind(&bottom)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        // The same activation that does move the order on the UI door.
+        let moved = core
+            .search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        assert_ne!(
+            moved.last().unwrap().artifact_id,
+            bottom,
+            "this test proves nothing unless priming is working on some door"
+        );
+
+        for door in [Door::Ask, Door::Judge] {
+            let held = core.search(&q("alpha text about it"), door).await.unwrap();
+            let ids: Vec<&str> = held.iter().map(|r| r.artifact_id.as_str()).collect();
+            let plain_ids: Vec<&str> = plain.iter().map(|r| r.artifact_id.as_str()).collect();
+            assert_eq!(ids, plain_ids, "{door:?} was handed a primed order");
+            assert!(held.iter().all(|r| !r.primed));
+        }
+    }
+
+    #[tokio::test]
+    async fn an_association_obeys_the_filters_the_searcher_typed() {
+        // A category is a statement about what the searcher will accept, not a
+        // hint to the ranker. An artifact recalled beside a hit still has to
+        // satisfy it, or the search hands back exactly the rows they narrowed
+        // away.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        core.associate.show_min = 1.0;
+        seed(
+            &core,
+            &[
+                ("alpha text about it", "runbook", &["ops"][..]),
+                ("something else entirely", "note", &[][..]),
+            ],
+        )
+        .await;
+        reembed_all(&core).await;
+        let ids = core.store.list_all_artifact_ids().await.unwrap();
+        let (hit, other) = {
+            let a = core.store.get_artifact(&ids[0]).await.unwrap();
+            if a.category.as_deref() == Some("runbook") {
+                (ids[0].clone(), ids[1].clone())
+            } else {
+                (ids[1].clone(), ids[0].clone())
+            }
+        };
+        core.store
+            .bump_link(&hit, &other, 9.0, Some("q"), 30.0, now_secs())
+            .await
+            .unwrap();
+
+        // Unfiltered, the linked artifact is recalled beside the ranked hit.
+        let wide = core
+            .search(&q("alpha text about it"), Door::Ui)
+            .await
+            .unwrap();
+        assert!(
+            wide.iter().any(|r| r.artifact_id == other),
+            "the association never fired, so the filter proves nothing"
+        );
+
+        let mut narrowed = q("alpha text about it");
+        narrowed.category = Some("runbook".into());
+        let narrow = core.search(&narrowed, Door::Ui).await.unwrap();
+        assert!(
+            !narrow.iter().any(|r| r.artifact_id == other),
+            "an association walked past the category the searcher typed"
+        );
+
+        let mut tagged = q("alpha text about it");
+        tagged.tags = vec!["ops".into()];
+        let by_tag = core.search(&tagged, Door::Ui).await.unwrap();
+        assert!(
+            !by_tag.iter().any(|r| r.artifact_id == other),
+            "an association walked past the tags the searcher typed"
+        );
+    }
+
     async fn captured_events(core: &crate::core::Core) -> i64 {
         core.background.wait_idle().await;
         sqlx::query_scalar("SELECT count(*) FROM search_events")
@@ -2310,7 +2465,7 @@ mod tests {
         };
         let results = vec![dummy(a.clone()), dummy(b.clone()), dummy(c.clone())];
 
-        let out = core.associated(&results).await;
+        let out = core.associated(&results, &SearchFilter::default()).await;
         let ids: Vec<&str> = out.iter().map(|r| r.artifact_id.as_str()).collect();
         assert!(
             ids.contains(&d.as_str()),

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -248,6 +248,53 @@ pub fn dedupe_prompt(
     s
 }
 
+/// Two knowledge artifacts keep being retrieved by the same searches, and this
+/// call says what that means, in one line a reader would find useful.
+pub const LINK_SYSTEM: &str = r#"Two knowledge artifacts keep being retrieved by the same searches. You say what that means, in one line a reader would find useful.
+
+Choose exactly one:
+
+- "related" — being needed together makes sense: one is the configuration and the other its failure mode, one is the procedure and the other the tool it needs, one explains why the other is done. Say what the relation is, in the reader's own terms, in one sentence.
+- "unrelated" — the searches that returned both were about something else, and there is no connection worth showing. A shared word is not a connection.
+- "duplicate" — they say the same thing in different words. Only this, and not "related", when neither adds anything the other lacks.
+
+Judge the relation between the artifacts, not their similarity. Two texts that share no vocabulary at all can be strongly related; two that read alike can be about different subjects.
+
+Reply with JSON only, no commentary, in exactly this shape:
+
+{"relation": "related", "reason": "..."}
+
+- relation: one of "related", "unrelated", "duplicate".
+- reason: one sentence. For "related" it is shown to the reader beside the link, so write it for them and not about the task."#;
+
+/// Two artifacts, and the questions that kept returning both.
+///
+/// The cues are the evidence. Without them this asks whether two arbitrary texts
+/// are related, which is a worse question with a worse answer: what is being
+/// judged is why these two keep being *needed at once*.
+///
+/// `attempt` is in the prompt for the same reason it is in `dedupe_prompt`: the
+/// endpoint caches by exact prompt text, and a retry of a reply the parser could
+/// not read would otherwise re-read the same unreadable bytes. Zero adds
+/// nothing, so a first ask stays byte-identical between runs.
+pub fn link_prompt(a: (&str, &str), b: (&str, &str), cues: &[String], attempt: i64) -> String {
+    let mut s = String::new();
+    if attempt > 0 {
+        s.push_str(&format!("(attempt {})\n", attempt + 1));
+    }
+    s.push_str(&format!(
+        "----- ARTIFACT A -----\nTitle: {}\n\n{}\n----- ARTIFACT B -----\nTitle: {}\n\n{}\n----- END -----",
+        a.0, a.1, b.0, b.1
+    ));
+    if !cues.is_empty() {
+        s.push_str(&format!(
+            "\n\nBoth were returned by these searches: {}.",
+            cues.join("; ")
+        ));
+    }
+    s
+}
+
 pub const ASK_SYSTEM: &str = "You answer questions using only the provided knowledge-base excerpts. \
 Quote commands, paths and code exactly as they appear. If the excerpts do not contain the answer, \
 say so plainly rather than guessing. Cite excerpts by their number. \
@@ -486,7 +533,7 @@ pub fn dedupe_schema() -> serde_json::Value {
 
 /// Models wrap JSON in fences and preface it with prose no matter what the
 /// prompt says, so slice from the first `{` to the last `}` before parsing.
-fn extract_json(body: &str) -> &str {
+pub(crate) fn extract_json(body: &str) -> &str {
     let start = body.find('{');
     let end = body.rfind('}');
     match (start, end) {
@@ -668,6 +715,27 @@ pub fn describe_context(metadata: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_link_prompt_carries_both_titles_and_the_questions_that_bound_them() {
+        // The binding queries are the evidence. Without them the model is being
+        // asked whether two arbitrary texts are related, which is a different
+        // and much worse question than why these two keep being needed at once.
+        let p = link_prompt(
+            ("Mounting E01 images", "ewfmount /dev/..."),
+            ("Loop device limits", "max_loop=64"),
+            &["mount forensic image".into()],
+            0,
+        );
+        assert!(p.contains("Mounting E01 images"));
+        assert!(p.contains("max_loop=64"));
+        assert!(p.contains("mount forensic image"));
+        assert!(
+            !p.contains("attempt"),
+            "a first ask must stay cache-identical"
+        );
+        assert!(link_prompt(("a", "b"), ("c", "d"), &[], 2).contains("attempt 3"));
+    }
 
     #[test]
     fn context_blocks_are_fenced_and_labelled_as_context_only() {

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -42,7 +42,7 @@ fn settled_cutoff(at: i64, coalesce_secs: i64) -> i64 {
 
 /// One sweep over everything learned since the last one.
 pub async fn run(core: &Core) -> Result<()> {
-    if !core.associate.enabled || !core.feedback.enabled {
+    if !core.associating() {
         return Ok(());
     }
     let at = crate::store::now();
@@ -290,6 +290,13 @@ pub fn parse_link(body: &str) -> Result<(LinkVerdict, String)> {
 
 /// One link, one call. `target` is `"<a_id>|<b_id>"`.
 pub async fn judge(core: &Core, target: &str) -> Result<()> {
+    // A unit already queued when the operator disables the feature should not
+    // spend the one scarce thing in the system after they said stop. The
+    // sweep will not arm more (`run` returns early), but a unit armed before
+    // the flag flipped is still sitting in the queue when this runs.
+    if !core.associate.enabled {
+        return Ok(());
+    }
     let (a_id, b_id) = target.split_once('|').ok_or(Error::NotFound)?;
     let Some(link) = core.store.get_link(a_id, b_id).await? else {
         // Pruned, or one side deleted, while the unit waited out a backoff.
@@ -1151,6 +1158,44 @@ mod tests {
                 .unwrap()
                 .state,
             LinkState::Dismissed
+        );
+    }
+
+    #[tokio::test]
+    async fn a_unit_already_queued_when_the_feature_is_switched_off_spends_no_call() {
+        // The sweep will not arm more once `associate.enabled` is false — see
+        // `the_sweep_does_nothing_at_all_while_nothing_is_recorded` — but a unit
+        // already in the queue when the operator disables the feature must not
+        // spend the one scarce thing in the system after they said stop.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let scripted = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"relation":"related","reason":"should never be read"}"#.into(),
+        ]));
+        core.judge = scripted.clone();
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.associate.enabled = false;
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(
+            scripted.calls(),
+            0,
+            "a call was spent after the feature was off"
+        );
+        assert_eq!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            LinkState::Learning,
+            "an unjudged link stays visible as learning"
         );
     }
 

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -49,7 +49,7 @@ async fn replay_events(core: &Core, at: i64) -> Result<usize> {
 
     let events = sqlx::query(
         "SELECT id, query, created_at FROM search_events
-          WHERE created_at > ? AND created_at <= ?
+          WHERE created_at > ? AND created_at < ?
           ORDER BY created_at ASC, id ASC LIMIT ?",
     )
     .bind(after)
@@ -119,16 +119,26 @@ async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
         let id: String = e.get("id");
         let expect: String = e.get("expect_id");
         let shown = shown_candidates(core, &id).await?;
-        for other in shown.iter().filter(|c| **c != expect) {
-            // No cue: this event's words were already folded in as a binding
-            // query when its co-appearance was replayed, and counting them
-            // twice would say two questions bound this pair.
-            if let Err(err) = core
-                .store
-                .bump_link(&expect, other, 2.0, None, core.associate.half_life_days, at)
-                .await
-            {
-                tracing::debug!(error = %err, "could not bind a pair; one side is gone");
+        // Only a *shown* pair containing the answer is bound harder — a find,
+        // where the operator confirmed an artifact the search never returned,
+        // has no shown pair to strengthen. Binding it against the pool anyway
+        // would invent a co-retrieval that never happened, which is exactly
+        // the rule ("only what the searcher actually saw fires together")
+        // this whole sweep exists to hold. The activation bump below is
+        // unconditional and still fires for a find — that is the one signal a
+        // find is allowed to give.
+        if shown.contains(&expect) {
+            for other in shown.iter().filter(|c| **c != expect) {
+                // No cue: this event's words were already folded in as a
+                // binding query when its co-appearance was replayed, and
+                // counting them twice would say two questions bound this pair.
+                if let Err(err) = core
+                    .store
+                    .bump_link(&expect, other, 2.0, None, core.associate.half_life_days, at)
+                    .await
+                {
+                    tracing::debug!(error = %err, "could not bind a pair; one side is gone");
+                }
             }
         }
         // Raised whether or not the answer was in the pool at all — an artifact
@@ -359,6 +369,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_event_exactly_at_the_fold_boundary_waits_one_more_sweep() {
+        // `record_search` treats an event as still foldable while
+        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs). The
+        // sweep's read must be the complement of that with nothing shared, or
+        // there is an instant where both are true and the sweep binds an
+        // event a further keystroke could still fold into — the exact
+        // double-binding this whole two-watermark design exists to prevent.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.feedback.coalesce_secs = 15;
+        let ids = seed(&core, 2).await;
+        let ev = record(&core, "fat", &[&ids[0], &ids[1]], &[]).await;
+
+        // Aged to exactly the boundary: still foldable, so the sweep must not
+        // replay it yet.
+        sqlx::query("UPDATE search_events SET created_at = created_at - ? WHERE id = ?")
+            .bind(core.feedback.coalesce_secs)
+            .bind(&ev)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_none(),
+            "an event still exactly at the fold boundary was replayed early"
+        );
+
+        // One second further: no longer foldable, so the next sweep replays it.
+        sqlx::query("UPDATE search_events SET created_at = created_at - 1 WHERE id = ?")
+            .bind(&ev)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_some(),
+            "an event one second past the boundary was still withheld"
+        );
+    }
+
+    #[tokio::test]
     async fn a_replayed_event_is_never_replayed_again() {
         let mut core = test_core().await;
         on(&mut core).await;
@@ -417,6 +476,55 @@ mod tests {
         assert!(
             act[&ids[0]].0 > act[&ids[1]].0,
             "the confirmed answer gained no activation"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_answer_the_search_never_showed_raises_activation_but_binds_nothing() {
+        // A find: the operator confirmed an artifact the search never
+        // returned at all. Spec §5.1 step 2 binds harder only the shown pairs
+        // containing the answer — with no shown pair to strengthen, nothing
+        // is bound. Step 3's activation bump has no such condition, and a
+        // find is the most valuable confirmation there is.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        // ids[2] is never offered as a candidate at all.
+        let ev = record(&core, "q", &[&ids[0], &ids[1]], &[]).await;
+        core.store.judge_hit(&ev, &ids[2]).await.unwrap();
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_link(&ids[2], &ids[0])
+                .await
+                .unwrap()
+                .is_none(),
+            "a find bound a pair that was never shown together"
+        );
+        assert!(
+            core.store
+                .get_link(&ids[2], &ids[1])
+                .await
+                .unwrap()
+                .is_none(),
+            "a find bound a pair that was never shown together"
+        );
+        // The shown pair not involving the answer still binds on co-appearance.
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        let act = core.store.activation_of(&ids).await.unwrap();
+        assert!(
+            act[&ids[2]].0 > act[&ids[1]].0,
+            "the find gained no activation"
         );
     }
 

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -20,6 +20,26 @@ pub const JUDGED_AFTER: &str = "associate.judged_after";
 /// catches up over a few sweeps instead of holding one worker for minutes.
 const REPLAY_LIMIT: i64 = 2_000;
 
+/// Learning links read per prune pass. Whatever the cap leaves is pruned by the
+/// next sweep — a bound on one tick's work, not on what is eventually forgotten.
+const PRUNE_SCAN_LIMIT: i64 = 5_000;
+
+/// The queue name of one link. Canonical, so the same pair never gets two units.
+pub fn link_target(a: &str, b: &str) -> String {
+    let (a, b) = crate::store::links::canonical(a, b);
+    format!("{a}|{b}")
+}
+
+/// The newest `created_at` a settled event may still have. An event is
+/// settled once `created_at < settled_cutoff(at, coalesce_secs)` — the exact
+/// complement of `record_search`'s fold predicate at
+/// `src/store/feedback.rs:206` (`at - created <= coalesce_secs`), so there is
+/// no instant where both are true and an event still a keystroke away from
+/// folding gets replayed early.
+fn settled_cutoff(at: i64, coalesce_secs: i64) -> i64 {
+    at - coalesce_secs.max(0)
+}
+
 /// One sweep over everything learned since the last one.
 pub async fn run(core: &Core) -> Result<()> {
     if !core.associate.enabled || !core.feedback.enabled {
@@ -28,7 +48,60 @@ pub async fn run(core: &Core) -> Result<()> {
     let at = crate::store::now();
     let bound = replay_events(core, at).await?;
     let confirmed = replay_verdicts(core, at).await?;
-    tracing::info!(events = bound, verdicts = confirmed, "association sweep");
+
+    let forgotten = core
+        .store
+        .prune_learning_links(
+            core.associate.prune_below,
+            core.associate.half_life_days,
+            at,
+            PRUNE_SCAN_LIMIT,
+        )
+        .await?;
+    // A re-embed of either side reopens the verdict before anything is armed,
+    // so a link whose text changed is re-asked in this same sweep rather than
+    // waiting out another interval.
+    let reopened = core
+        .store
+        .reopen_stale_judged_links(PRUNE_SCAN_LIMIT)
+        .await?;
+
+    let mut armed = 0;
+    for l in core
+        .store
+        .links_to_judge(
+            core.associate.judge_min,
+            core.associate.judge_min_queries,
+            core.associate.half_life_days,
+            at,
+            core.associate.judge_per_sweep,
+        )
+        .await?
+    {
+        let target = link_target(&l.a_id, &l.b_id);
+        // A link whose judgement is already queued is already going to be
+        // judged; arming it again is a no-op that costs another link its turn.
+        if core
+            .store
+            .live_job(crate::store::jobs::Stage::LinkJudge, &target)
+            .await?
+        {
+            continue;
+        }
+        core.store
+            .rearm_idle_seq(crate::store::jobs::Stage::LinkJudge, "link", &target, armed)
+            .await?;
+        armed += 1;
+    }
+
+    tracing::info!(
+        events = bound,
+        verdicts = confirmed,
+        forgotten,
+        reopened,
+        armed,
+        "association sweep"
+    );
     Ok(())
 }
 
@@ -45,7 +118,7 @@ async fn replay_events(core: &Core, at: i64) -> Result<usize> {
         .await?
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
-    let settled = at - core.feedback.coalesce_secs.max(0);
+    let settled = settled_cutoff(at, core.feedback.coalesce_secs);
 
     let events = sqlx::query(
         "SELECT id, query, created_at FROM search_events
@@ -371,26 +444,37 @@ mod tests {
     #[tokio::test]
     async fn an_event_exactly_at_the_fold_boundary_waits_one_more_sweep() {
         // `record_search` treats an event as still foldable while
-        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs). The
-        // sweep's read must be the complement of that with nothing shared, or
-        // there is an instant where both are true and the sweep binds an
-        // event a further keystroke could still fold into — the exact
-        // double-binding this whole two-watermark design exists to prevent.
+        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs:206).
+        // The sweep's read must be the complement of that with nothing
+        // shared, or there is an instant where both are true and the sweep
+        // binds an event a further keystroke could still fold into — the
+        // exact double-binding this whole two-watermark design exists to
+        // prevent.
+        //
+        // `run()` reads `now()` itself, and reading it a second time here to
+        // compute the aged `created_at` would race it: if the two calls
+        // straddle a wall-clock second, the event ends up one second older
+        // than intended and the assertion flips (roughly 1-in-200). So this
+        // reads back the `created_at` `record_search` actually stamped and
+        // derives everything from that one value, and drives `replay_events`
+        // directly with an `at` computed from it — the same arithmetic
+        // `run()` would use, with no live clock involved at all.
         let mut core = test_core().await;
         on(&mut core).await;
         core.feedback.coalesce_secs = 15;
         let ids = seed(&core, 2).await;
         let ev = record(&core, "fat", &[&ids[0], &ids[1]], &[]).await;
+        let created_at: i64 =
+            sqlx::query_scalar("SELECT created_at FROM search_events WHERE id = ?")
+                .bind(&ev)
+                .fetch_one(&core.store.pool)
+                .await
+                .unwrap();
 
-        // Aged to exactly the boundary: still foldable, so the sweep must not
-        // replay it yet.
-        sqlx::query("UPDATE search_events SET created_at = created_at - ? WHERE id = ?")
-            .bind(core.feedback.coalesce_secs)
-            .bind(&ev)
-            .execute(&core.store.pool)
-            .await
-            .unwrap();
-        run(&core).await.unwrap();
+        // `at` placed exactly `coalesce_secs` after the event: still
+        // foldable, so the sweep must not replay it yet.
+        let at = created_at + core.feedback.coalesce_secs;
+        replay_events(&core, at).await.unwrap();
         assert!(
             core.store
                 .get_link(&ids[0], &ids[1])
@@ -401,12 +485,7 @@ mod tests {
         );
 
         // One second further: no longer foldable, so the next sweep replays it.
-        sqlx::query("UPDATE search_events SET created_at = created_at - 1 WHERE id = ?")
-            .bind(&ev)
-            .execute(&core.store.pool)
-            .await
-            .unwrap();
-        run(&core).await.unwrap();
+        replay_events(&core, at + 1).await.unwrap();
         assert!(
             core.store
                 .get_link(&ids[0], &ids[1])
@@ -415,6 +494,38 @@ mod tests {
                 .is_some(),
             "an event one second past the boundary was still withheld"
         );
+    }
+
+    #[test]
+    fn settled_cutoff_is_the_exact_complement_of_the_fold_predicate() {
+        // `replay_events` folds an event's watermark against `settled_cutoff`
+        // with `<`. `record_search` (src/store/feedback.rs:206) treats an
+        // event as still foldable while `at - created <= coalesce_secs`. For
+        // the two to share no instant, `created < settled_cutoff(at, cs)`
+        // must be false exactly where `at - created <= cs` is true, and true
+        // everywhere else — checked here arithmetically, with no clock
+        // involved.
+        let at = 1_000_000;
+        let coalesce_secs = 15;
+        let cutoff = settled_cutoff(at, coalesce_secs);
+
+        let is_fresh = |created: i64| at - created <= coalesce_secs;
+        let is_settled = |created: i64| created < cutoff;
+
+        for created in (at - coalesce_secs - 2)..=(at - coalesce_secs + 2) {
+            assert_eq!(
+                is_settled(created),
+                !is_fresh(created),
+                "created_at {created} disagreed with the fold predicate"
+            );
+        }
+
+        // A window of zero turns folding off entirely, so nothing is ever
+        // "still folding" and the cutoff is `at` itself.
+        assert_eq!(settled_cutoff(at, 0), at);
+        // A clock or config that hands in a negative window must not make
+        // the cutoff run past `at`.
+        assert_eq!(settled_cutoff(at, -5), at);
     }
 
     #[tokio::test]
@@ -548,6 +659,127 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!((l.weight - 1.0).abs() < 1e-6, "weight was {}", l.weight);
+    }
+
+    #[tokio::test]
+    async fn a_faded_link_is_forgotten_and_a_judged_one_is_not() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 4).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        core.store
+            .bump_link(&ids[2], &ids[3], 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(
+                &ids[2],
+                &ids[3],
+                LinkState::Related,
+                Some("why"),
+                Some((0, 0)),
+            )
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_none(),
+            "a link last used at the epoch has decayed to nothing"
+        );
+        assert!(
+            core.store
+                .get_link(&ids[2], &ids[3])
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_strong_cross_corpus_link_is_armed_for_the_judge_exactly_once() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        for q in ["one", "two", "three", "four"] {
+            core.store
+                .bump_link(&ids[0], &ids[1], 1.0, Some(q), 30.0, crate::store::now())
+                .await
+                .unwrap();
+        }
+
+        run(&core).await.unwrap();
+        let target = link_target(&ids[0], &ids[1]);
+        assert!(
+            core.store
+                .live_job(crate::store::jobs::Stage::LinkJudge, &target)
+                .await
+                .unwrap()
+        );
+
+        // A second sweep must not wind the queued unit's attempts back.
+        run(&core).await.unwrap();
+        let mut seen = 0;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            if j.stage == crate::store::jobs::Stage::LinkJudge {
+                seen += 1;
+                assert_eq!(j.attempts, 1, "the unit was re-armed underneath itself");
+            }
+        }
+        assert_eq!(seen, 1);
+    }
+
+    #[tokio::test]
+    async fn a_judged_link_is_reopened_when_its_text_changes_under_it() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 9.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(
+                &ids[0],
+                &ids[1],
+                LinkState::Unrelated,
+                Some("coincidence"),
+                Some((0, 0)),
+            )
+            .await
+            .unwrap();
+        core.store
+            .update_artifact_text(&ids[0], "rewritten")
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            l.state,
+            LinkState::Learning,
+            "the judge read text that is gone"
+        );
+    }
+
+    #[test]
+    fn a_link_names_itself_the_same_way_round_however_it_is_armed() {
+        assert_eq!(link_target("b", "a"), link_target("a", "b"));
+        assert_eq!(link_target("a", "b"), "a|b");
     }
 
     #[tokio::test]

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -8,17 +8,452 @@
 
 use crate::core::Core;
 use crate::error::Result;
+use crate::store::links::normalize_query;
+use sqlx::Row;
+
+/// Last `search_events.created_at` folded into links.
+pub const EVENTS_AFTER: &str = "associate.events_after";
+/// Last `search_events.judged_at` folded into links.
+pub const JUDGED_AFTER: &str = "associate.judged_after";
+/// Events read per sweep. A ceiling rather than a budget: at 30-minute ticks
+/// nothing real reaches it, and a base that has been offline for a month
+/// catches up over a few sweeps instead of holding one worker for minutes.
+const REPLAY_LIMIT: i64 = 2_000;
 
 /// One sweep over everything learned since the last one.
 pub async fn run(core: &Core) -> Result<()> {
     if !core.associate.enabled || !core.feedback.enabled {
         return Ok(());
     }
+    let at = crate::store::now();
+    let bound = replay_events(core, at).await?;
+    let confirmed = replay_verdicts(core, at).await?;
+    tracing::info!(events = bound, verdicts = confirmed, "association sweep");
     Ok(())
+}
+
+/// Every pair of shown candidates in every settled event past the watermark.
+///
+/// "Settled" is the whole of the read condition beyond the watermark: an event
+/// inside `feedback.coalesce_secs` of now is still moving — a typing burst folds
+/// into one row — and binding the pairs of a half-typed query would then be
+/// followed by binding the finished one.
+async fn replay_events(core: &Core, at: i64) -> Result<usize> {
+    let after: i64 = core
+        .store
+        .meta_get(EVENTS_AFTER)
+        .await?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let settled = at - core.feedback.coalesce_secs.max(0);
+
+    let events = sqlx::query(
+        "SELECT id, query, created_at FROM search_events
+          WHERE created_at > ? AND created_at <= ?
+          ORDER BY created_at ASC, id ASC LIMIT ?",
+    )
+    .bind(after)
+    .bind(settled)
+    .bind(REPLAY_LIMIT)
+    .fetch_all(&core.store.pool)
+    .await?;
+
+    let mut high = after;
+    for e in &events {
+        let id: String = e.get("id");
+        let cue = normalize_query(&e.get::<String, _>("query"));
+        let shown = shown_candidates(core, &id).await?;
+        for i in 0..shown.len() {
+            for j in (i + 1)..shown.len() {
+                if let Err(err) = core
+                    .store
+                    .bump_link(
+                        &shown[i],
+                        &shown[j],
+                        1.0,
+                        Some(&cue),
+                        core.associate.half_life_days,
+                        at,
+                    )
+                    .await
+                {
+                    tracing::debug!(error = %err, "could not bind a pair; one side is gone");
+                }
+            }
+        }
+        high = high.max(e.get::<i64, _>("created_at"));
+    }
+
+    if high > after {
+        core.store.meta_set(EVENTS_AFTER, &high.to_string()).await?;
+    }
+    Ok(events.len())
+}
+
+/// Every hit verdict past the second watermark: the pairs containing the
+/// confirmed answer bind harder, and the answer itself becomes more accessible.
+///
+/// Its own cursor, because a verdict arrives days after the event it is about —
+/// one cursor would either replay the event's pairs again or skip the verdict.
+/// `gap` and `discard` are not read here: neither says anything about a pair.
+async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
+    let after: i64 = core
+        .store
+        .meta_get(JUDGED_AFTER)
+        .await?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let events = sqlx::query(
+        "SELECT id, expect_id, judged_at FROM search_events
+          WHERE judged_at > ? AND verdict = 'hit' AND expect_id IS NOT NULL
+          ORDER BY judged_at ASC, id ASC LIMIT ?",
+    )
+    .bind(after)
+    .bind(REPLAY_LIMIT)
+    .fetch_all(&core.store.pool)
+    .await?;
+
+    let mut high = after;
+    for e in &events {
+        let id: String = e.get("id");
+        let expect: String = e.get("expect_id");
+        let shown = shown_candidates(core, &id).await?;
+        for other in shown.iter().filter(|c| **c != expect) {
+            // No cue: this event's words were already folded in as a binding
+            // query when its co-appearance was replayed, and counting them
+            // twice would say two questions bound this pair.
+            if let Err(err) = core
+                .store
+                .bump_link(&expect, other, 2.0, None, core.associate.half_life_days, at)
+                .await
+            {
+                tracing::debug!(error = %err, "could not bind a pair; one side is gone");
+            }
+        }
+        // Raised whether or not the answer was in the pool at all — an artifact
+        // the ranking never returned and a person confirmed anyway is the most
+        // valuable confirmation there is.
+        core.store
+            .bump_activation(
+                std::slice::from_ref(&expect),
+                core.activation.confirmed,
+                core.activation.half_life_days,
+                at,
+            )
+            .await?;
+        high = high.max(e.get::<i64, _>("judged_at"));
+    }
+
+    if high > after {
+        core.store.meta_set(JUDGED_AFTER, &high.to_string()).await?;
+    }
+    Ok(events.len())
+}
+
+/// What one event actually put in front of the searcher, in rank order.
+async fn shown_candidates(core: &Core, event_id: &str) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT artifact_id FROM search_candidates
+          WHERE event_id = ? AND shown = 1 ORDER BY rank",
+    )
+    .bind(event_id)
+    .fetch_all(&core.store.pool)
+    .await?)
 }
 
 /// One link, one call. `target` is `"<a_id>|<b_id>"`.
 pub async fn judge(core: &Core, target: &str) -> Result<()> {
     let _ = (core, target);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::artifacts::NewArtifact;
+    use crate::store::feedback::{Door, NewCandidate, NewEvent, Verdict};
+    use crate::store::links::LinkState;
+
+    /// `n` artifacts, each in its own corpus, so every link between them is a
+    /// cross-corpus one.
+    async fn seed(core: &Core, n: usize) -> Vec<String> {
+        let mut ids = Vec::new();
+        for i in 0..n {
+            let src = core
+                .store
+                .insert_corpus(&format!("raw {i}"), "web", None)
+                .await
+                .unwrap();
+            let made = core
+                .store
+                .insert_artifacts(
+                    &src.id,
+                    &[NewArtifact {
+                        ordinal: 0,
+                        text: format!("artifact {i}"),
+                        corpus_span: None,
+                        title: Some(format!("t{i}")),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    }],
+                )
+                .await
+                .unwrap();
+            ids.push(made[0].id.clone());
+        }
+        ids
+    }
+
+    /// One recorded search, with `shown` deciding what the searcher saw.
+    async fn record(core: &Core, query: &str, shown: &[&String], unshown: &[&String]) -> String {
+        let candidates = shown
+            .iter()
+            .map(|id| NewCandidate {
+                artifact_id: (*id).clone(),
+                score: 1.0,
+                similarity: Some(0.9),
+                shown: true,
+            })
+            .chain(unshown.iter().map(|id| NewCandidate {
+                artifact_id: (*id).clone(),
+                score: 0.1,
+                similarity: Some(0.2),
+                shown: false,
+            }))
+            .collect();
+        core.store
+            .record_search(
+                NewEvent {
+                    query: query.into(),
+                    door: Door::Ui,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![0.0],
+                    embed_model: "fake".into(),
+                    candidates,
+                },
+                0,
+            )
+            .await
+            .unwrap()
+    }
+
+    /// Age every recorded event past the coalescing window, so the sweep will
+    /// look at it: a folding event is still moving.
+    async fn settle(core: &Core) {
+        sqlx::query("UPDATE search_events SET created_at = created_at - 3600")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+    }
+
+    async fn on(core: &mut Core) {
+        core.feedback.enabled = true;
+    }
+
+    #[tokio::test]
+    async fn two_searches_showing_the_same_pair_bind_it_twice() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "fat32 cluster", &[&ids[0], &ids[1]], &[]).await;
+        record(&core, "ntfs journal", &[&ids[0], &ids[1]], &[]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert!((l.weight - 2.0).abs() < 1e-6, "weight was {}", l.weight);
+        assert_eq!(l.queries, 2, "two different questions bound this pair");
+        assert_eq!(l.state, LinkState::Learning);
+    }
+
+    #[tokio::test]
+    async fn the_same_question_asked_twice_is_one_binding_query() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "fat32", &[&ids[0], &ids[1]], &[]).await;
+        // Coalescing is off in `record`, so this is a second event with the
+        // same words — which is a second use, and one question.
+        record(&core, "  FAT32  ", &[&ids[0], &ids[1]], &[]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert!((l.weight - 2.0).abs() < 1e-6);
+        assert_eq!(l.queries, 1);
+    }
+
+    #[tokio::test]
+    async fn only_what_the_searcher_saw_fires_together() {
+        // The stored pool is wider than the answer for evaluation's sake. An
+        // artifact nobody was shown was not reached, and did not fire.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        record(&core, "q", &[&ids[0], &ids[1]], &[&ids[2]]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[2])
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_event_still_folding_is_left_for_the_next_sweep() {
+        // A typing burst is one event, and it is not finished until the
+        // coalescing window has passed. Replaying it early would bind the pairs
+        // of a half-typed query and then bind the finished one again.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "fat", &[&ids[0], &ids[1]], &[]).await;
+
+        run(&core).await.unwrap();
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        settle(&core).await;
+        run(&core).await.unwrap();
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_replayed_event_is_never_replayed_again() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        record(&core, "q", &[&ids[0], &ids[1]], &[]).await;
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+        run(&core).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            (l.weight - 1.0).abs() < 1e-6,
+            "the event was replayed twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_confirmed_answer_binds_harder_and_raises_its_activation() {
+        // Confirmation is the strong signal; co-appearance is the weak one.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        let ev = record(&core, "q", &[&ids[0], &ids[1], &ids[2]], &[]).await;
+        core.store.judge_hit(&ev, &ids[0]).await.unwrap();
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        // +1 for co-appearance, +2 more for the pairs containing the answer.
+        let with = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        let without = core
+            .store
+            .get_link(&ids[1], &ids[2])
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            (with.weight - 3.0).abs() < 1e-6,
+            "weight was {}",
+            with.weight
+        );
+        assert!((without.weight - 1.0).abs() < 1e-6);
+
+        let act = core.store.activation_of(&ids).await.unwrap();
+        assert!(
+            act[&ids[0]].0 > act[&ids[1]].0,
+            "the confirmed answer gained no activation"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_gap_and_a_discard_teach_nothing_about_pairs() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        let g = record(&core, "nothing about this", &[&ids[0], &ids[1]], &[]).await;
+        core.store.judge(&g, Verdict::Gap).await.unwrap();
+        settle(&core).await;
+
+        run(&core).await.unwrap();
+
+        // Co-appearance still counts — the searcher did see both — but the
+        // verdict adds nothing on top of it.
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert!((l.weight - 1.0).abs() < 1e-6, "weight was {}", l.weight);
+    }
+
+    #[tokio::test]
+    async fn the_sweep_does_nothing_at_all_while_nothing_is_recorded() {
+        let core = test_core().await; // feedback off, associate on
+        let ids = seed(&core, 2).await;
+        run(&core).await.unwrap();
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(core.store.meta_get(EVENTS_AFTER).await.unwrap(), None);
+    }
 }

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -366,27 +366,22 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
         }
     };
 
+    // A verdict with no line is still a verdict, so this does not fail the parse.
+    // But it must not be stored as an empty string either: the pane falls back to
+    // the binding query when a link has no reason, and `Some("")` would defeat that
+    // fallback and render a blank explanation instead.
+    let reason = reason.trim();
+    let reason = (!reason.is_empty()).then_some(reason);
+
     match verdict {
         LinkVerdict::Related => {
             core.store
-                .set_link_state(
-                    &link.a_id,
-                    &link.b_id,
-                    LinkState::Related,
-                    Some(&reason),
-                    revs,
-                )
+                .set_link_state(&link.a_id, &link.b_id, LinkState::Related, reason, revs)
                 .await?;
         }
         LinkVerdict::Unrelated => {
             core.store
-                .set_link_state(
-                    &link.a_id,
-                    &link.b_id,
-                    LinkState::Unrelated,
-                    Some(&reason),
-                    revs,
-                )
+                .set_link_state(&link.a_id, &link.b_id, LinkState::Unrelated, reason, revs)
                 .await?;
         }
         LinkVerdict::Duplicate => {
@@ -987,6 +982,35 @@ mod tests {
         assert_eq!(l.state, LinkState::Related);
         assert_eq!(l.reason.as_deref(), Some("the config and its errors"));
         assert_eq!(l.judged_rev_a, Some(0));
+    }
+
+    #[tokio::test]
+    async fn a_verdict_with_no_line_stores_no_reason_rather_than_an_empty_one() {
+        // A `related` reply that omits `reason` is still a usable verdict, and
+        // `parse_link` does not fail it. But `Some("")` would defeat the pane's
+        // fallback to the top binding query, so the empty string must never
+        // reach the row.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"related"}"#.into()),
+        });
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(l.state, LinkState::Related);
+        assert_eq!(l.reason, None, "an empty reason was stored as Some(\"\")");
     }
 
     #[tokio::test]

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -40,6 +40,41 @@ fn settled_cutoff(at: i64, coalesce_secs: i64) -> i64 {
     at - coalesce_secs.max(0)
 }
 
+/// How many rows of a batch it is safe to replay, given the stamps they are
+/// ordered by.
+///
+/// Both reads are `ORDER BY <stamp> ASC, id ASC LIMIT REPLAY_LIMIT` and the
+/// watermark each leaves behind is a stamp, not a row. So a batch that filled
+/// the limit may have cut a group of rows sharing one second in half, and
+/// advancing the watermark past that second would strand the remainder unread
+/// forever. The last second of a full batch is therefore left for the next
+/// sweep, which will read it whole.
+///
+/// The one shape with no smaller step available is a full batch whose every row
+/// shares a single second. Then the remainder of that second is genuinely
+/// skipped — and said so at `warn`, because a gap in what was learned from is
+/// otherwise indistinguishable from there having been nothing to learn.
+fn replayable(stamps: &[i64], limit: usize) -> usize {
+    if stamps.len() < limit {
+        return stamps.len();
+    }
+    let last = match stamps.last() {
+        Some(s) => *s,
+        None => return 0,
+    };
+    let end = stamps.partition_point(|s| *s < last);
+    if end == 0 {
+        tracing::warn!(
+            stamp = last,
+            read = stamps.len(),
+            "more rows share one second than a single sweep reads; \
+             the remainder of that second will not be replayed"
+        );
+        return stamps.len();
+    }
+    end
+}
+
 /// One sweep over everything learned since the last one.
 pub async fn run(core: &Core) -> Result<()> {
     if !core.associating() {
@@ -131,36 +166,46 @@ async fn replay_events(core: &Core, at: i64) -> Result<usize> {
     .fetch_all(&core.store.pool)
     .await?;
 
-    let mut high = after;
-    for e in &events {
+    let stamps: Vec<i64> = events
+        .iter()
+        .map(|e| e.get::<i64, _>("created_at"))
+        .collect();
+    let end = replayable(&stamps, REPLAY_LIMIT as usize);
+
+    for (idx, e) in events[..end].iter().enumerate() {
         let id: String = e.get("id");
         let cue = normalize_query(&e.get::<String, _>("query"));
         let shown = shown_candidates(core, &id).await?;
-        for i in 0..shown.len() {
-            for j in (i + 1)..shown.len() {
-                if let Err(err) = core
-                    .store
-                    .bump_link(
-                        &shown[i],
-                        &shown[j],
-                        1.0,
-                        Some(&cue),
-                        core.associate.half_life_days,
-                        at,
-                    )
-                    .await
-                {
-                    tracing::debug!(error = %err, "could not bind a pair; one side is gone");
-                }
-            }
+        // One transaction for the whole event rather than one per pair: the
+        // pairs are quadratic in what was shown, and each transaction is an
+        // exclusive one. `bump_links` warns about and steps over any single
+        // pair it cannot write.
+        let pairs: Vec<(&str, &str)> = (0..shown.len())
+            .flat_map(|i| ((i + 1)..shown.len()).map(move |j| (i, j)))
+            .map(|(i, j)| (shown[i].as_str(), shown[j].as_str()))
+            .collect();
+        core.store
+            .bump_links(&pairs, 1.0, Some(&cue), core.associate.half_life_days, at)
+            .await?;
+        // Committed as each second finishes rather than once at the end. A
+        // failure below propagates out of the sweep, and a watermark that never
+        // moved would replay every bump already written on the next tick.
+        // Weight is what pruning, showing and judging all decide on, so
+        // counting a co-appearance twice is not cosmetic.
+        if last_of_its_second(&stamps, idx, end) {
+            core.store
+                .meta_set(EVENTS_AFTER, &stamps[idx].to_string())
+                .await?;
         }
-        high = high.max(e.get::<i64, _>("created_at"));
     }
+    Ok(end)
+}
 
-    if high > after {
-        core.store.meta_set(EVENTS_AFTER, &high.to_string()).await?;
-    }
-    Ok(events.len())
+/// Whether `idx` is the last row of the run of equal stamps it belongs to,
+/// within the prefix being replayed. The watermark may only advance to a
+/// second every row of which has been folded in.
+fn last_of_its_second(stamps: &[i64], idx: usize, end: usize) -> bool {
+    idx + 1 == end || stamps[idx + 1] > stamps[idx]
 }
 
 /// Every hit verdict past the second watermark: the pairs containing the
@@ -177,18 +222,34 @@ async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
+    // Bounded above as well as below, for the reason `replay_events` is: the
+    // watermark left behind is a second, not a row, and `last_of_its_second`
+    // only closes that gap *within* a batch. A sweep running during second `at`
+    // that read the verdicts stamped `at` would move the watermark to `at`, and
+    // a verdict recorded moments later in that same second would then fail the
+    // `> at` test on every sweep after — its link bumps and its activation bump
+    // lost with no trace. `at` rather than `settled_cutoff`: nothing coalesces
+    // verdicts the way a typing burst coalesces events, so there is no reason to
+    // hold a confirmation back beyond the second it was written in.
     let events = sqlx::query(
         "SELECT id, expect_id, judged_at FROM search_events
-          WHERE judged_at > ? AND verdict = 'hit' AND expect_id IS NOT NULL
+          WHERE judged_at > ? AND judged_at < ?
+            AND verdict = 'hit' AND expect_id IS NOT NULL
           ORDER BY judged_at ASC, id ASC LIMIT ?",
     )
     .bind(after)
+    .bind(at)
     .bind(REPLAY_LIMIT)
     .fetch_all(&core.store.pool)
     .await?;
 
-    let mut high = after;
-    for e in &events {
+    let stamps: Vec<i64> = events
+        .iter()
+        .map(|e| e.get::<i64, _>("judged_at"))
+        .collect();
+    let end = replayable(&stamps, REPLAY_LIMIT as usize);
+
+    for (idx, e) in events[..end].iter().enumerate() {
         let id: String = e.get("id");
         let expect: String = e.get("expect_id");
         let shown = shown_candidates(core, &id).await?;
@@ -201,18 +262,17 @@ async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
         // unconditional and still fires for a find — that is the one signal a
         // find is allowed to give.
         if shown.contains(&expect) {
-            for other in shown.iter().filter(|c| **c != expect) {
-                // No cue: this event's words were already folded in as a
-                // binding query when its co-appearance was replayed, and
-                // counting them twice would say two questions bound this pair.
-                if let Err(err) = core
-                    .store
-                    .bump_link(&expect, other, 2.0, None, core.associate.half_life_days, at)
-                    .await
-                {
-                    tracing::debug!(error = %err, "could not bind a pair; one side is gone");
-                }
-            }
+            // No cue: this event's words were already folded in as a binding
+            // query when its co-appearance was replayed, and counting them
+            // twice would say two questions bound this pair.
+            let pairs: Vec<(&str, &str)> = shown
+                .iter()
+                .filter(|c| **c != expect)
+                .map(|other| (expect.as_str(), other.as_str()))
+                .collect();
+            core.store
+                .bump_links(&pairs, 2.0, None, core.associate.half_life_days, at)
+                .await?;
         }
         // Raised whether or not the answer was in the pool at all — an artifact
         // the ranking never returned and a person confirmed anyway is the most
@@ -225,13 +285,15 @@ async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
                 at,
             )
             .await?;
-        high = high.max(e.get::<i64, _>("judged_at"));
+        // Same reason as in `replay_events`: the bump above propagates, and a
+        // verdict counted twice raises an artifact's activation twice.
+        if last_of_its_second(&stamps, idx, end) {
+            core.store
+                .meta_set(JUDGED_AFTER, &stamps[idx].to_string())
+                .await?;
+        }
     }
-
-    if high > after {
-        core.store.meta_set(JUDGED_AFTER, &high.to_string()).await?;
-    }
-    Ok(events.len())
+    Ok(end)
 }
 
 /// What one event actually put in front of the searcher, in rank order.
@@ -294,7 +356,13 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
     // spend the one scarce thing in the system after they said stop. The
     // sweep will not arm more (`run` returns early), but a unit armed before
     // the flag flipped is still sitting in the queue when this runs.
-    if !core.associate.enabled {
+    //
+    // `associating()` and not `associate.enabled`: switching search recording
+    // off switches this layer off too — that is what the predicate means, and
+    // every other surface (priming, association, the detail pane, Ops) already
+    // reads it. A verdict written after that switch would name a relation on a
+    // page that no longer shows one.
+    if !core.associating() {
         return Ok(());
     }
     let (a_id, b_id) = target.split_once('|').ok_or(Error::NotFound)?;
@@ -395,8 +463,17 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
             // Handed over rather than acted on: consolidation owns every
             // decision that hides an artifact, with its own guards and its own
             // undo. The score is zero because no cosine was ever measured —
-            // that is what `detail` is there to explain on the review page.
-            core.store
+            // that is what the zero itself says on the review page.
+            //
+            // `INSERT OR IGNORE`, so this hands nothing over when a row for the
+            // pair is already on file: an operator dismissed it, or the dedupe
+            // judge answered it and consolidation is done with it. The verdict
+            // is the same either way — these two say the same thing — but the
+            // reason is rendered verbatim in the "Seen together" pane and in
+            // the associated-results rail, so it must not assert a handover
+            // that did not happen.
+            let handed = core
+                .store
                 .record_pair_with_detail(&link.a_id, &link.b_id, 0.0, "link")
                 .await?;
             core.store
@@ -404,7 +481,11 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
                     &link.a_id,
                     &link.b_id,
                     LinkState::Related,
-                    Some("same content; handed to consolidation"),
+                    Some(if handed {
+                        "same content; handed to consolidation"
+                    } else {
+                        "same content; consolidation already has this pair"
+                    }),
                     revs,
                 )
                 .await?;
@@ -489,11 +570,21 @@ mod tests {
 
     /// Age every recorded event past the coalescing window, so the sweep will
     /// look at it: a folding event is still moving.
+    /// Age everything the sweep reads far enough back that both of its upper
+    /// bounds are cleared — `created_at` below `settled_cutoff`, and `judged_at`
+    /// below the sweep's own clock. A verdict recorded in the second the sweep
+    /// runs in is deliberately left for the next one (`replay_verdicts`), so a
+    /// test that judges and sweeps in the same breath has to say which second
+    /// it means. `judged_at` is NULL on an unjudged event and stays NULL here.
     async fn settle(core: &Core) {
-        sqlx::query("UPDATE search_events SET created_at = created_at - 3600")
-            .execute(&core.store.pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "UPDATE search_events
+                SET created_at = created_at - 3600,
+                    judged_at = judged_at - 3600",
+        )
+        .execute(&core.store.pool)
+        .await
+        .unwrap();
     }
 
     async fn on(core: &mut Core) {
@@ -944,6 +1035,106 @@ mod tests {
     }
 
     #[test]
+    fn a_batch_cut_inside_one_second_leaves_that_second_for_the_next_sweep() {
+        // The watermark is a stamp, not a row. If a full batch ends in the
+        // middle of a group of events sharing one second, advancing past that
+        // second strands its remainder unread forever — so the group is left
+        // whole for the next sweep, which reads it with room to spare.
+        assert_eq!(
+            replayable(&[1, 2, 3, 3], 4),
+            2,
+            "a second the batch may have cut in half was replayed anyway"
+        );
+        // A full batch always holds back its last second, whether or not the
+        // rows read share it: what the limit cut off is invisible from here,
+        // and more rows stamped 4 may be sitting just past it.
+        assert_eq!(replayable(&[1, 2, 3, 4], 4), 3);
+        // Not full: nothing was cut, so everything is replayable including the
+        // last second.
+        assert_eq!(replayable(&[1, 2, 3, 3], 8), 4);
+        assert_eq!(replayable(&[], 8), 0);
+        // A whole full batch inside one second has no smaller step to take.
+        // Replaying it and moving on is the only way forward; `replayable`
+        // says so at `warn` rather than silently.
+        assert_eq!(replayable(&[7, 7, 7], 3), 3);
+    }
+
+    #[tokio::test]
+    async fn the_watermark_advances_only_over_seconds_that_were_replayed_whole() {
+        // Two events in one second and one in the next: the watermark must
+        // never sit between the two, or the second of them is never read.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        record(&core, "a", &[&ids[0], &ids[1]], &[]).await;
+        record(&core, "b", &[&ids[1], &ids[2]], &[]).await;
+        settle(&core).await;
+        sqlx::query("UPDATE search_events SET created_at = 1000")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        replay_events(&core, 100_000).await.unwrap();
+
+        assert_eq!(
+            core.store.meta_get(EVENTS_AFTER).await.unwrap().as_deref(),
+            Some("1000")
+        );
+        // Both were read, not just the first.
+        assert!(
+            core.store
+                .get_link(&ids[1], &ids[2])
+                .await
+                .unwrap()
+                .is_some(),
+            "the second event of the second was skipped"
+        );
+    }
+
+    #[test]
+    fn the_watermarks_named_here_are_the_ones_migrate_seeds() {
+        // `Store::migrate` seeds these two keys when it adopts an existing
+        // database into activation, spelling them out because nothing in
+        // `store` reaches up into `jobs`. Renaming one there and not here
+        // would make the seeding silently stop working.
+        assert_eq!(EVENTS_AFTER, "associate.events_after");
+        assert_eq!(JUDGED_AFTER, "associate.judged_after");
+    }
+
+    #[tokio::test]
+    async fn a_queued_unit_spends_no_call_once_search_recording_is_switched_off() {
+        // `associating()`, not `associate.enabled`: turning capture off turns
+        // this whole layer off — priming, association and the pane all read
+        // that predicate — and a verdict written afterwards would name a
+        // relation on a page that no longer shows one.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let scripted = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            r#"{"relation":"related","reason":"should never be read"}"#.into(),
+        ]));
+        core.judge = scripted.clone();
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.feedback.enabled = false;
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(scripted.calls(), 0);
+        assert_eq!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            LinkState::Learning
+        );
+    }
+
+    #[test]
     fn a_link_names_itself_the_same_way_round_however_it_is_armed() {
         assert_eq!(link_target("b", "a"), link_target("a", "b"));
         assert_eq!(link_target("a", "b"), "a|b");
@@ -1212,5 +1403,142 @@ mod tests {
                 .is_none()
         );
         assert_eq!(core.store.meta_get(EVENTS_AFTER).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_verdict_recorded_in_the_second_the_sweep_ran_is_not_skipped() {
+        // `replay_events` reads below a settled cutoff, so it never consumes
+        // the second it is running in. Verdicts had no upper bound at all: a
+        // sweep at second T read every verdict stamped T and moved the
+        // watermark to T, and a verdict recorded moments later in that same
+        // second was then past the watermark's own `> T` test forever — its
+        // link bumps and its activation bump silently lost.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+
+        let first = record(&core, "one", &[&ids[0], &ids[1]], &[]).await;
+        core.store.judge_hit(&first, &ids[0]).await.unwrap();
+        sqlx::query("UPDATE search_events SET judged_at = 1000 WHERE id = ?")
+            .bind(&first)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        // The sweep that ran during second 1000.
+        replay_verdicts(&core, 1000).await.unwrap();
+
+        // A second verdict written moments later, still inside second 1000.
+        let second = record(&core, "two", &[&ids[0], &ids[2]], &[]).await;
+        core.store.judge_hit(&second, &ids[2]).await.unwrap();
+        sqlx::query("UPDATE search_events SET judged_at = 1000 WHERE id = ?")
+            .bind(&second)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        replay_verdicts(&core, 1001).await.unwrap();
+
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[2])
+                .await
+                .unwrap()
+                .is_some(),
+            "the verdict recorded inside the sweep's own second was lost"
+        );
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_some(),
+            "the verdict the sweep did see was lost too"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_duplicate_verdict_claims_no_handoff_when_the_pair_is_already_settled() {
+        // `record_pair_with_detail` is `INSERT OR IGNORE`. A pair an operator
+        // already dismissed, or one the dedupe judge already closed, is left
+        // exactly as it was — nothing reaches consolidation. The link's reason
+        // is rendered verbatim in the "Seen together" pane, so it must not
+        // assert a handover that did not happen.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"duplicate","reason":"same thing"}"#.into()),
+        });
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        // The pair is already on file and already answered.
+        core.store
+            .record_pair(&ids[0], &ids[1], 0.91)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE artifact_pairs SET state = 'dismissed'")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(l.state, LinkState::Related);
+        assert!(
+            !l.reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("handed to consolidation"),
+            "the link claims a handoff that never happened: {:?}",
+            l.reason
+        );
+    }
+
+    #[tokio::test]
+    async fn one_unbindable_pair_does_not_cost_an_event_its_other_pairs() {
+        // Every pair of one event's shown candidates is now bound in a single
+        // transaction rather than one apiece. A pair that cannot be written —
+        // one side deleted between the search and the sweep — must still be
+        // warned about and stepped over, not take the rest of the event's
+        // learning down with it.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 3).await;
+        record(&core, "three shown", &[&ids[0], &ids[1], &ids[2]], &[]).await;
+        settle(&core).await;
+        // Gone by the time the sweep reads the event it was shown in.
+        sqlx::query("DELETE FROM artifacts WHERE id = ?")
+            .bind(&ids[2])
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        // The premise first: the pairs naming the deleted side really did fail,
+        // rather than this test quietly binding three live artifacts.
+        for gone in [&ids[0], &ids[1]] {
+            assert!(
+                core.store.get_link(gone, &ids[2]).await.unwrap().is_none(),
+                "a link was written against a deleted artifact"
+            );
+        }
+        assert!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .is_some(),
+            "a pair that could not be bound cost the event its other pairs"
+        );
     }
 }

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -1,0 +1,24 @@
+//! Learning what belongs together, and saying so.
+//!
+//! Two things happen here and they are deliberately not the same job. The sweep
+//! is pure SQLite: it replays the search log, strengthens the pairs that were
+//! reached together, fades and prunes the ones that were not, and decides which
+//! links are worth asking about. The judge is one model call on one link, armed
+//! by the sweep and paced by the queue like every other call in the system.
+
+use crate::core::Core;
+use crate::error::Result;
+
+/// One sweep over everything learned since the last one.
+pub async fn run(core: &Core) -> Result<()> {
+    if !core.associate.enabled || !core.feedback.enabled {
+        return Ok(());
+    }
+    Ok(())
+}
+
+/// One link, one call. `target` is `"<a_id>|<b_id>"`.
+pub async fn judge(core: &Core, target: &str) -> Result<()> {
+    let _ = (core, target);
+    Ok(())
+}

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -245,9 +245,169 @@ async fn shown_candidates(core: &Core, event_id: &str) -> Result<Vec<String>> {
     .await?)
 }
 
+use crate::error::Error;
+use crate::store::links::LinkState;
+
+/// Unreadable replies after which a link is shelved rather than asked forever.
+pub const MAX_UNREADABLE_LINK_JUDGEMENTS: i64 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkVerdict {
+    Related,
+    Unrelated,
+    /// The two say the same thing and the embedding failed to notice.
+    Duplicate,
+}
+
+/// A reply that cannot be read is an error, not a verdict.
+///
+/// Defaulting to `unrelated` would quietly close real relations; defaulting to
+/// `related` would show the reader a line the model never wrote. Failing leaves
+/// the link `learning` — still visible, still binding — and the unit retries
+/// under the queue's backoff with a prompt that differs by its attempt number.
+pub fn parse_link(body: &str) -> Result<(LinkVerdict, String)> {
+    #[derive(serde::Deserialize)]
+    struct Raw {
+        relation: String,
+        #[serde(default)]
+        reason: Option<String>,
+    }
+    let r: Raw = serde_json::from_str(crate::infer::prompt::extract_json(body)).map_err(|e| {
+        Error::MalformedLlmOutput(format!("link reply was not the expected JSON: {e}"))
+    })?;
+    let verdict = match r.relation.as_str() {
+        "related" => LinkVerdict::Related,
+        "unrelated" => LinkVerdict::Unrelated,
+        "duplicate" => LinkVerdict::Duplicate,
+        other => {
+            return Err(Error::MalformedLlmOutput(format!(
+                "link reply named no relation this understands: {other}"
+            )));
+        }
+    };
+    Ok((verdict, r.reason.unwrap_or_default()))
+}
+
 /// One link, one call. `target` is `"<a_id>|<b_id>"`.
 pub async fn judge(core: &Core, target: &str) -> Result<()> {
-    let _ = (core, target);
+    let (a_id, b_id) = target.split_once('|').ok_or(Error::NotFound)?;
+    let Some(link) = core.store.get_link(a_id, b_id).await? else {
+        // Pruned, or one side deleted, while the unit waited out a backoff.
+        return Ok(());
+    };
+    if link.state != LinkState::Learning {
+        // Answered by an operator's dismissal, or by a sweep that reopened and
+        // a sibling unit that then settled it.
+        return Ok(());
+    }
+    let a = core.store.get_artifact(&link.a_id).await?;
+    let b = core.store.get_artifact(&link.b_id).await?;
+    // Re-checked here and not only when the unit was armed: a side can be
+    // superseded or deprecated while this waits, and spending the scarcest
+    // thing in the system on an artifact nobody will be shown buys nothing.
+    if !a.in_results() || !b.in_results() {
+        return Ok(());
+    }
+
+    let cues: Vec<String> = link.cues.iter().map(|c| c.q.clone()).collect();
+    let permit = core.gate.background().await;
+    let reply = core
+        .judge
+        .complete(
+            crate::infer::prompt::LINK_SYSTEM,
+            &crate::infer::prompt::link_prompt(
+                (a.title.as_deref().unwrap_or("untitled"), &a.text),
+                (b.title.as_deref().unwrap_or("untitled"), &b.text),
+                &cues,
+                link.judge_attempts,
+            ),
+        )
+        .await;
+    permit.finished();
+    // A call the endpoint never answered says nothing about the link: it stays
+    // `learning`, stays visible, and the queue backs the unit off.
+    let reply = reply?;
+
+    let revs = Some((a.embed_rev, b.embed_rev));
+    let (verdict, reason) = match parse_link(&reply) {
+        Ok(v) => v,
+        Err(e) => {
+            // Counted only here, because this is the only failure that says
+            // anything about the link itself.
+            let attempts = core
+                .store
+                .record_link_judge_attempt(&link.a_id, &link.b_id)
+                .await?;
+            if attempts >= MAX_UNREADABLE_LINK_JUDGEMENTS {
+                tracing::warn!(
+                    target,
+                    attempts,
+                    "shelving a link the model will not answer for"
+                );
+                core.store
+                    .set_link_state(
+                        &link.a_id,
+                        &link.b_id,
+                        LinkState::Unrelated,
+                        Some("unreadable"),
+                        revs,
+                    )
+                    .await?;
+                return Ok(());
+            }
+            tracing::warn!(
+                target,
+                attempts,
+                reply_len = reply.len(),
+                error = %e,
+                "link reply unreadable"
+            );
+            return Err(e);
+        }
+    };
+
+    match verdict {
+        LinkVerdict::Related => {
+            core.store
+                .set_link_state(
+                    &link.a_id,
+                    &link.b_id,
+                    LinkState::Related,
+                    Some(&reason),
+                    revs,
+                )
+                .await?;
+        }
+        LinkVerdict::Unrelated => {
+            core.store
+                .set_link_state(
+                    &link.a_id,
+                    &link.b_id,
+                    LinkState::Unrelated,
+                    Some(&reason),
+                    revs,
+                )
+                .await?;
+        }
+        LinkVerdict::Duplicate => {
+            // Handed over rather than acted on: consolidation owns every
+            // decision that hides an artifact, with its own guards and its own
+            // undo. The score is zero because no cosine was ever measured —
+            // that is what `detail` is there to explain on the review page.
+            core.store
+                .record_pair_with_detail(&link.a_id, &link.b_id, 0.0, "link")
+                .await?;
+            core.store
+                .set_link_state(
+                    &link.a_id,
+                    &link.b_id,
+                    LinkState::Related,
+                    Some("same content; handed to consolidation"),
+                    revs,
+                )
+                .await?;
+        }
+    }
     Ok(())
 }
 
@@ -725,7 +885,12 @@ mod tests {
                 .unwrap()
         );
 
-        // A second sweep must not wind the queued unit's attempts back.
+        // A second sweep must not wind the queued unit's attempts back. (The
+        // guard that actually prevents re-arming here is `rearm_idle_seq`'s own
+        // `WHERE jobs.state = 'done'` SQL condition, src/store/jobs.rs:189 —
+        // not the `live_job` check above, which this assertion does not
+        // isolate. What this pins is real regardless: a second sweep must not
+        // wind a queued unit's attempts back.)
         run(&core).await.unwrap();
         let mut seen = 0;
         while let Some(j) = core.store.claim_job().await.unwrap() {
@@ -780,6 +945,189 @@ mod tests {
     fn a_link_names_itself_the_same_way_round_however_it_is_armed() {
         assert_eq!(link_target("b", "a"), link_target("a", "b"));
         assert_eq!(link_target("a", "b"), "a|b");
+    }
+
+    #[test]
+    fn a_verdict_is_read_out_of_the_reply_and_an_unreadable_one_is_an_error() {
+        let (v, why) =
+            parse_link(r#"{"relation":"related","reason":"both about mounting"}"#).unwrap();
+        assert_eq!(v, LinkVerdict::Related);
+        assert_eq!(why, "both about mounting");
+        assert_eq!(
+            parse_link(r#"{"relation":"duplicate","reason":"same thing"}"#)
+                .unwrap()
+                .0,
+            LinkVerdict::Duplicate
+        );
+        assert!(parse_link("I think they are related!").is_err());
+        assert!(parse_link(r#"{"relation":"maybe","reason":"x"}"#).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_related_verdict_names_the_relation_and_stops_the_decay() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"related","reason":"the config and its errors"}"#.into()),
+        });
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(l.state, LinkState::Related);
+        assert_eq!(l.reason.as_deref(), Some("the config and its errors"));
+        assert_eq!(l.judged_rev_a, Some(0));
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_verdict_is_stored_so_it_is_not_asked_again() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"unrelated","reason":"a coincidence of retrieval"}"#.into()),
+        });
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            LinkState::Unrelated
+        );
+        // ...and it is never armed again, however strong it becomes.
+        run(&core).await.unwrap();
+        assert!(
+            !core
+                .store
+                .live_job(
+                    crate::store::jobs::Stage::LinkJudge,
+                    &link_target(&ids[0], &ids[1])
+                )
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_disguised_duplicate_is_handed_to_consolidation_and_still_shown() {
+        // The embedding failed to notice; the reader should still see the
+        // connection while dedupe decides what to do about it.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"duplicate","reason":"the same procedure twice"}"#.into()),
+        });
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        let pair = core
+            .store
+            .pair_state_between(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .expect("consolidation was never told");
+        assert_eq!(pair, crate::store::pairs::PairState::Pending);
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(l.state, LinkState::Related);
+        assert!(l.reason.as_deref().unwrap().contains("consolidation"));
+    }
+
+    #[tokio::test]
+    async fn three_unreadable_replies_shelve_the_link_rather_than_asking_forever() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some("no idea, sorry".into()),
+        });
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        let target = link_target(&ids[0], &ids[1]);
+
+        for _ in 0..2 {
+            assert!(
+                judge(&core, &target).await.is_err(),
+                "an unreadable reply is an error"
+            );
+            assert_eq!(
+                core.store
+                    .get_link(&ids[0], &ids[1])
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .state,
+                LinkState::Learning,
+                "the link stays visible while it is still being asked about"
+            );
+        }
+        judge(&core, &target).await.unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(l.state, LinkState::Unrelated);
+        assert_eq!(l.reason.as_deref(), Some("unreadable"));
+    }
+
+    #[tokio::test]
+    async fn a_link_that_has_already_been_answered_costs_no_call() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        let ids = seed(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(&ids[0], &ids[1], LinkState::Dismissed, None, None)
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .get_link(&ids[0], &ids[1])
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            LinkState::Dismissed
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,3 +1,4 @@
+pub mod associate;
 pub mod consolidate;
 pub mod dedupe;
 pub mod describe;
@@ -67,6 +68,9 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Embed, _) => embed::run(core, &job.target_id).await,
         // The sweep looks at the whole collection, so it ignores the target.
         (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
+        // The sweep looks at the whole collection, so it ignores the target.
+        (Stage::Associate, _) => associate::run(core).await,
+        (Stage::LinkJudge, _) => associate::judge(core, &job.target_id).await,
         (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
         (Stage::Dedupe, _) => dedupe::run(core, &job.target_id).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,8 @@ async fn main() -> anyhow::Result<()> {
         engram::core::background::spawn_retention_ticker(core.clone(), shutdown_rx.clone());
     let dedupe = engram::core::background::spawn_dedupe_ticker(core.clone(), shutdown_rx.clone());
     let repair = engram::core::background::spawn_repair_ticker(core.clone(), shutdown_rx.clone());
+    let associate =
+        engram::core::background::spawn_associate_ticker(core.clone(), shutdown_rx.clone());
     let mut handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
     // Joined with the workers so shutdown waits for them too, rather than
     // leaving tasks the runtime drops mid-enqueue.
@@ -304,6 +306,7 @@ async fn main() -> anyhow::Result<()> {
     handles.push(retention);
     handles.push(dedupe);
     handles.push(repair);
+    handles.push(associate);
 
     let listener = tokio::net::TcpListener::bind(&cfg.server.bind).await?;
     tracing::info!(bind = %cfg.server.bind, mode = ?cfg.auth.mode, "engram listening");

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,6 +411,8 @@ mod startup_tests {
             feedback: FeedbackConfig::default(),
             capture: CaptureConfig::default(),
             pacing: engram::config::PacingConfig::default(),
+            associate: AssociateConfig::default(),
+            activation: ActivationConfig::default(),
         }
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -12,28 +12,34 @@ pub fn format_search_results(results: &[SearchResult]) -> String {
     if results.is_empty() {
         return "No matches in the knowledge base.".to_string();
     }
+    let mut rank = 0;
     results
         .iter()
-        .enumerate()
-        .map(|(i, r)| {
+        .map(|r| {
             let title = r.title.clone().unwrap_or_else(|| "Untitled".into());
             let tags = if r.tags.is_empty() {
                 String::new()
             } else {
                 format!(" · {}", r.tags.join(", "))
             };
-            // An agent reads this as a ranked list unless it is told otherwise,
-            // and an associated hit did not compete for its place.
+            // An agent reads this as a ranked list unless it is told
+            // otherwise, and a bare ordinal is the strongest ranking signal
+            // there is. An associated hit did not compete for a place, so it
+            // gets no number at all rather than one that continues the count.
+            let heading = if r.via.is_none() {
+                rank += 1;
+                format!("### {rank}. {title}")
+            } else {
+                format!("### {title}")
+            };
             let how = match (&r.via, &r.reason) {
                 (Some(_), Some(why)) => format!("recalled beside the answer — {why}"),
                 (Some(_), None) => "recalled beside the answer".to_string(),
                 (None, _) => format!("score {:.3}", r.score),
             };
             format!(
-                "### {}. {title}\n_{how}{tags} · corpus: {}_\n\n{}",
-                i + 1,
-                r.corpus_id,
-                r.text
+                "{heading}\n_{how}{tags} · corpus: {}_\n\n{}",
+                r.corpus_id, r.text
             )
         })
         .collect::<Vec<_>>()
@@ -296,5 +302,13 @@ mod tests {
         // as the fourth-best match for the query, which it is not.
         let out = format_search_results(&[hit("ranked", None), hit("recalled", Some("ranked"))]);
         assert!(out.contains("recalled beside"), "{out}");
+
+        // A bare ordinal is the strongest ranking signal there is: an agent
+        // reads a numbered list as ranked unless told otherwise. The ranked
+        // hit keeps its number; the associated one gets none, rather than a
+        // number that continues the count as if it had competed for one.
+        assert!(out.contains("### 1. ranked"), "{out}");
+        assert!(out.contains("### recalled"), "{out}");
+        assert!(!out.contains("### 2"), "{out}");
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -22,10 +22,16 @@ pub fn format_search_results(results: &[SearchResult]) -> String {
             } else {
                 format!(" · {}", r.tags.join(", "))
             };
+            // An agent reads this as a ranked list unless it is told otherwise,
+            // and an associated hit did not compete for its place.
+            let how = match (&r.via, &r.reason) {
+                (Some(_), Some(why)) => format!("recalled beside the answer — {why}"),
+                (Some(_), None) => "recalled beside the answer".to_string(),
+                (None, _) => format!("score {:.3}", r.score),
+            };
             format!(
-                "### {}. {title}\n_score {:.3}{tags} · corpus: {}_\n\n{}",
+                "### {}. {title}\n_{how}{tags} · corpus: {}_\n\n{}",
                 i + 1,
-                r.score,
                 r.corpus_id,
                 r.text
             )
@@ -263,5 +269,32 @@ mod tests {
         let text = format_search_results(&[]);
         assert!(!text.trim().is_empty());
         assert!(text.to_lowercase().contains("no match"));
+    }
+
+    fn hit(id: &str, via: Option<&str>) -> SearchResult {
+        SearchResult {
+            artifact_id: id.into(),
+            corpus_id: "c".into(),
+            title: Some(id.into()),
+            text: "body".into(),
+            category: None,
+            tags: vec![],
+            score: 0.5,
+            status: None,
+            superseded_by: None,
+            last_verified_at: None,
+            weak: false,
+            primed: false,
+            via: via.map(str::to_string),
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn an_associated_result_says_it_was_recalled_rather_than_ranked() {
+        // Straight into an agent's context: without this the extra result reads
+        // as the fourth-best match for the query, which it is not.
+        let out = format_search_results(&[hit("ranked", None), hit("recalled", Some("ranked"))]);
+        assert!(out.contains("recalled beside"), "{out}");
     }
 }

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -274,8 +274,8 @@ impl Store {
             last_verified_at: Some(created_at),
         };
         sqlx::query(
-            "INSERT INTO artifacts (id, corpus_id, provenance, source_count, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
-             VALUES (?, NULL, 'merged', ?, 0, ?, NULL, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)",
+            "INSERT INTO artifacts (id, corpus_id, provenance, source_count, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, activation, activated_at)
+             VALUES (?, NULL, 'merged', ?, 0, ?, NULL, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?, 1.0, ?)",
         )
         .bind(&c.id)
         .bind(c.source_count)
@@ -288,6 +288,7 @@ impl Store {
         .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
         .bind(c.status.as_str())
         .bind(c.last_verified_at)
+        .bind(c.created_at)
         .execute(&mut *tx)
         .await?;
 
@@ -345,8 +346,8 @@ impl Store {
                 last_verified_at: Some(created_at),
             };
             sqlx::query(
-                "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at)
-                 VALUES (?, ?, 'captured', ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)",
+                "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, activation, activated_at)
+                 VALUES (?, ?, 'captured', ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 1.0, ?)",
             )
             .bind(&c.id)
             .bind(&c.corpus_id)
@@ -362,6 +363,7 @@ impl Store {
             .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
             .bind(c.status.as_str())
             .bind(c.last_verified_at)
+            .bind(c.created_at)
             .execute(&mut *tx)
             .await?;
             out.push(c);

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -38,6 +38,13 @@ pub enum Stage {
     /// One image, one vision call: reads a captured image into the markdown
     /// that becomes its `raw_text`, then hands off to `Synthesize`.
     Describe,
+    /// The periodic association sweep. Its target is the collection rather than
+    /// any one artifact, so the `UNIQUE(stage, target_id)` on `jobs` guarantees
+    /// at most one queued sweep however often the ticker fires. Local work: it
+    /// replays the search log and arms `LinkJudge` units, and calls no model.
+    Associate,
+    /// One strong cross-corpus link, one call. Target is `"<a_id>|<b_id>"`.
+    LinkJudge,
 }
 
 impl Stage {
@@ -52,6 +59,8 @@ impl Stage {
             Stage::Dedupe => "dedupe",
             Stage::Relate => "relate",
             Stage::Describe => "describe",
+            Stage::Associate => "associate",
+            Stage::LinkJudge => "link_judge",
         }
     }
     pub fn parse(s: &str) -> Option<Stage> {
@@ -65,6 +74,8 @@ impl Stage {
             "dedupe" => Some(Stage::Dedupe),
             "relate" => Some(Stage::Relate),
             "describe" => Some(Stage::Describe),
+            "associate" => Some(Stage::Associate),
+            "link_judge" => Some(Stage::LinkJudge),
             _ => None,
         }
     }

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -1,0 +1,409 @@
+//! What was reached together.
+//!
+//! `artifact_pairs` is about two texts saying the same thing; this is about two
+//! texts being *needed* together — the config passage and the troubleshooting
+//! passage for one subsystem are strangers to the embedding and inseparable to
+//! the person who needed both to answer one question.
+//!
+//! Every strength here is stored as a value and the stamp it was true at, and
+//! read through `decayed`. Nothing is ever decayed in place: learning is one
+//! UPDATE and forgetting costs no writes, which is what lets a sweep run every
+//! half hour on a base of any size.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+/// Binding queries kept per link. Three is what a person reads in the pane;
+/// the count of *distinct* ones is `queries`, which is not bounded by this.
+pub const MAX_CUES: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkState {
+    /// Bound by use, nothing has ruled on it. Shown, prunable, judgeable.
+    Learning,
+    /// The judge named the relation. Shown with its reason, and never pruned by
+    /// decay: a verified relation is about content, not use.
+    Related,
+    /// A coincidence of retrieval. Kept so it is not asked again, hidden from
+    /// the pane, reopened only if either text changes.
+    Unrelated,
+    /// The operator said no. Never shown, never judged, never pruned.
+    Dismissed,
+}
+
+impl LinkState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LinkState::Learning => "learning",
+            LinkState::Related => "related",
+            LinkState::Unrelated => "unrelated",
+            LinkState::Dismissed => "dismissed",
+        }
+    }
+    pub fn parse(s: &str) -> LinkState {
+        match s {
+            "related" => LinkState::Related,
+            "unrelated" => LinkState::Unrelated,
+            "dismissed" => LinkState::Dismissed,
+            _ => LinkState::Learning,
+        }
+    }
+}
+
+/// One binding query and how often it bound this pair.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Cue {
+    pub q: String,
+    pub n: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Link {
+    pub a_id: String,
+    pub b_id: String,
+    /// Strength as of `bumped_at`. Read it through `decayed`, never directly.
+    pub weight: f64,
+    pub bumped_at: i64,
+    pub queries: i64,
+    pub cues: Vec<Cue>,
+    pub state: LinkState,
+    pub reason: Option<String>,
+    pub judged_rev_a: Option<i64>,
+    pub judged_rev_b: Option<i64>,
+    pub judge_attempts: i64,
+    pub created_at: i64,
+}
+
+/// The pair in the order the table stores it. `a_id < b_id` is a CHECK, so this
+/// is not a convention that can be forgotten at one call site.
+pub fn canonical<'a>(a: &'a str, b: &'a str) -> (&'a str, &'a str) {
+    if a <= b { (a, b) } else { (b, a) }
+}
+
+/// Two spellings of one question are one cue: lowercased, whitespace collapsed.
+pub fn normalize_query(q: &str) -> String {
+    q.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Strength now, from strength then. `half_life_days <= 0` turns decay off.
+///
+/// A clock that moved backwards — a restored database, an NTP correction —
+/// must not *grow* a weight, so the elapsed time is floored at zero.
+pub fn decayed(weight: f64, bumped_at: i64, at: i64, half_life_days: f64) -> f64 {
+    if half_life_days <= 0.0 {
+        return weight;
+    }
+    let elapsed = (at - bumped_at).max(0) as f64;
+    weight * 2f64.powf(-elapsed / (half_life_days * 86_400.0))
+}
+
+pub(crate) fn row_to_link(r: &sqlx::sqlite::SqliteRow) -> Link {
+    Link {
+        a_id: r.get("a_id"),
+        b_id: r.get("b_id"),
+        weight: r.get("weight"),
+        bumped_at: r.get("bumped_at"),
+        queries: r.get("queries"),
+        cues: serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default(),
+        state: LinkState::parse(r.get::<String, _>("state").as_str()),
+        reason: r.get("reason"),
+        judged_rev_a: r.get("judged_rev_a"),
+        judged_rev_b: r.get("judged_rev_b"),
+        judge_attempts: r.get("judge_attempts"),
+        created_at: r.get("created_at"),
+    }
+}
+
+/// Fold one query into the cue list. Returns whether it was new to this link.
+///
+/// Only the busiest `MAX_CUES` survive, and a cue that falls off the end can be
+/// counted as new again later — so `queries` is a floor on the number of
+/// distinct questions that bound this pair rather than an exact count. Exactness
+/// would cost a second table for a number that only gates the judge.
+fn bump_cue(cues: &mut Vec<Cue>, q: &str) -> bool {
+    let is_new = if let Some(c) = cues.iter_mut().find(|c| c.q == q) {
+        c.n += 1;
+        false
+    } else {
+        cues.push(Cue {
+            q: q.to_string(),
+            n: 1,
+        });
+        true
+    };
+    cues.sort_by_key(|c| std::cmp::Reverse(c.n));
+    cues.truncate(MAX_CUES);
+    is_new
+}
+
+impl Store {
+    /// Strengthen the link between two artifacts, folding the decay in.
+    ///
+    /// `cue` is the normalised query that bound them, where there is one. A
+    /// bump with no cue — a confirmation replayed for an event whose
+    /// co-appearance was already folded in — strengthens without claiming a new
+    /// binding question.
+    ///
+    /// One transaction per pair. An event with ten shown candidates is 45 of
+    /// these, which is a few milliseconds of local SQLite and no network at all.
+    pub async fn bump_link(
+        &self,
+        a: &str,
+        b: &str,
+        delta: f64,
+        cue: Option<&str>,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        // An artifact is not linked to itself, and the CHECK would refuse it
+        // anyway — caught here so a caller enumerating pairs need not.
+        if a == b {
+            return Ok(());
+        }
+        let (a, b) = canonical(a, b);
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query(
+            "SELECT weight, bumped_at, queries, cues FROM artifact_links
+              WHERE a_id = ? AND b_id = ?",
+        )
+        .bind(a)
+        .bind(b)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        match row {
+            Some(r) => {
+                let mut cues: Vec<Cue> =
+                    serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default();
+                let fresh = cue.is_some_and(|q| bump_cue(&mut cues, q));
+                let weight =
+                    decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days) + delta;
+                sqlx::query(
+                    "UPDATE artifact_links
+                        SET weight = ?, bumped_at = ?, queries = ?, cues = ?
+                      WHERE a_id = ? AND b_id = ?",
+                )
+                .bind(weight)
+                .bind(at)
+                .bind(r.get::<i64, _>("queries") + i64::from(fresh))
+                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+                .bind(a)
+                .bind(b)
+                .execute(&mut *tx)
+                .await?;
+            }
+            None => {
+                let mut cues = Vec::new();
+                if let Some(q) = cue {
+                    bump_cue(&mut cues, q);
+                }
+                sqlx::query(
+                    "INSERT INTO artifact_links
+                       (a_id, b_id, weight, bumped_at, queries, cues, state, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?, 'learning', ?)",
+                )
+                .bind(a)
+                .bind(b)
+                .bind(delta)
+                .bind(at)
+                .bind(cues.len() as i64)
+                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+                .bind(now())
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// One link, whichever way round it is named.
+    pub async fn get_link(&self, a: &str, b: &str) -> Result<Option<Link>> {
+        let (a, b) = canonical(a, b);
+        Ok(
+            sqlx::query("SELECT * FROM artifact_links WHERE a_id = ? AND b_id = ?")
+                .bind(a)
+                .bind(b)
+                .fetch_optional(&self.pool)
+                .await?
+                .as_ref()
+                .map(row_to_link),
+        )
+    }
+
+    pub async fn meta_get(&self, key: &str) -> Result<Option<String>> {
+        Ok(sqlx::query_scalar("SELECT value FROM meta WHERE key = ?")
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await?)
+    }
+
+    pub async fn meta_set(&self, key: &str, value: &str) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO meta (key, value) VALUES (?, ?)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::artifacts::NewArtifact;
+
+    /// Two artifacts in one corpus, returned as their ids.
+    async fn two(store: &Store) -> (String, String) {
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = ["alpha", "beta"]
+            .iter()
+            .enumerate()
+            .map(|(i, t)| NewArtifact {
+                ordinal: i as i64,
+                text: (*t).into(),
+                corpus_span: None,
+                title: Some((*t).into()),
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        let made = store.insert_artifacts(&src.id, &new).await.unwrap();
+        (made[0].id.clone(), made[1].id.clone())
+    }
+
+    #[test]
+    fn a_pair_is_filed_the_same_way_round_however_it_is_named() {
+        // The primary key is (a_id, b_id) with a CHECK that a < b, so a lookup
+        // by either side is two indexed reads and there is no "which way round"
+        // bug to have.
+        assert_eq!(canonical("b", "a"), ("a", "b"));
+        assert_eq!(canonical("a", "b"), ("a", "b"));
+    }
+
+    #[test]
+    fn a_query_is_the_same_cue_however_it_was_typed() {
+        assert_eq!(normalize_query("  Loop   Device \n"), "loop device");
+    }
+
+    #[test]
+    fn weight_halves_over_one_half_life() {
+        // Lazy decay is what makes forgetting free: no sweep walks every row to
+        // subtract from it, so this function is the only place decay happens.
+        let day = 86_400;
+        assert!((decayed(4.0, 0, 30 * day, 30.0) - 2.0).abs() < 1e-9);
+        assert!((decayed(4.0, 0, 60 * day, 30.0) - 1.0).abs() < 1e-9);
+        // Not yet moved, and never grown by a clock running backwards.
+        assert!((decayed(4.0, 100, 100, 30.0) - 4.0).abs() < 1e-9);
+        assert!((decayed(4.0, 100, 0, 30.0) - 4.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn bumping_folds_the_decay_in_rather_than_adding_to_a_stale_number() {
+        // `weight` means "strength as of bumped_at". Adding to it without
+        // folding the decay in would make a link that was strong a year ago and
+        // used once today as strong as one used constantly.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        let day = 86_400;
+        store
+            .bump_link(&a, &b, 4.0, Some("fat32"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .bump_link(&b, &a, 1.0, Some("fat32"), 30.0, 30 * day)
+            .await
+            .unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().expect("the link");
+        assert!((l.weight - 3.0).abs() < 1e-6, "weight was {}", l.weight);
+        assert_eq!(l.bumped_at, 30 * day);
+        // Named the other way round the second time, and still one row.
+        assert_eq!(l.a_id, a.min(b.clone()));
+    }
+
+    #[tokio::test]
+    async fn the_same_query_twice_is_one_binding_query() {
+        // What separates a link from one search typed twice. The cue count
+        // still climbs, because that is how the top three are chosen.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        for _ in 0..3 {
+            store
+                .bump_link(&a, &b, 1.0, Some("fat32"), 30.0, 0)
+                .await
+                .unwrap();
+        }
+        store
+            .bump_link(&a, &b, 1.0, Some("ntfs"), 30.0, 0)
+            .await
+            .unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.queries, 2);
+        assert_eq!(l.cues[0].q, "fat32");
+        assert_eq!(l.cues[0].n, 3);
+        assert_eq!(l.cues.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn only_three_binding_queries_are_kept_and_the_busiest_lead() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        for q in ["one", "two", "three", "four"] {
+            store
+                .bump_link(&a, &b, 1.0, Some(q), 30.0, 0)
+                .await
+                .unwrap();
+        }
+        store
+            .bump_link(&a, &b, 1.0, Some("two"), 30.0, 0)
+            .await
+            .unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.cues.len(), MAX_CUES);
+        assert_eq!(l.cues[0].q, "two", "the busiest cue must lead");
+    }
+
+    #[tokio::test]
+    async fn an_artifact_linking_to_itself_is_not_a_link() {
+        let store = Store::memory().await.unwrap();
+        let (a, _) = two(&store).await;
+        store
+            .bump_link(&a, &a, 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        assert!(store.get_link(&a, &a).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_watermark_reads_back_what_was_written_and_nothing_otherwise() {
+        let store = Store::memory().await.unwrap();
+        assert_eq!(
+            store.meta_get("associate.events_after").await.unwrap(),
+            None
+        );
+        store
+            .meta_set("associate.events_after", "42")
+            .await
+            .unwrap();
+        store
+            .meta_set("associate.events_after", "99")
+            .await
+            .unwrap();
+        assert_eq!(
+            store.meta_get("associate.events_after").await.unwrap(),
+            Some("99".to_string())
+        );
+    }
+}

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -324,7 +324,11 @@ impl Store {
 
             for r in &rows {
                 let state = LinkState::parse(r.get::<String, _>("state").as_str());
-                if !allowed.contains(&state.as_str()) {
+                // The operator's "not related" is final. It does not depend on
+                // callers remembering to leave `Dismissed` out of `states` — a
+                // caller that could opt back into it would make the control a
+                // suggestion, not an invariant.
+                if state == LinkState::Dismissed || !allowed.contains(&state.as_str()) {
                     continue;
                 }
                 let weight = decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days);
@@ -383,7 +387,10 @@ impl Store {
         )
         .bind(min_weight)
         .bind(min_queries)
-        .bind(limit.saturating_mul(4))
+        // SQLite reads a negative LIMIT as unbounded, so the cap must be
+        // clamped at zero — a negative `limit` must still cap the fetch, not
+        // remove it, even though `take(limit.max(0))` below empties it anyway.
+        .bind(limit.max(0).saturating_mul(4))
         .fetch_all(&self.pool)
         .await?;
 
@@ -818,6 +825,36 @@ mod tests {
                 .links_from(
                     &[a],
                     &[LinkState::Learning, LinkState::Related],
+                    30.0,
+                    0,
+                    0.0
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dismissed_link_stays_hidden_even_from_a_caller_that_asks_for_it() {
+        // The operator's decision is final, and an invariant that holds only
+        // while every call site remembers the right argument is not one.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 9.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_link_state(&a, &b, LinkState::Dismissed, None, None)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .links_from(
+                    &[a],
+                    &[LinkState::Dismissed, LinkState::Learning],
                     30.0,
                     0,
                     0.0

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -140,6 +140,30 @@ fn bump_cue(cues: &mut Vec<Cue>, q: &str) -> bool {
     is_new
 }
 
+/// One end of a link, seen from an anchor that is already in the result list.
+#[derive(Debug, Clone)]
+pub struct LinkedTo {
+    /// The ranked hit that recalled it.
+    pub via: String,
+    pub other: String,
+    /// Already decayed to the caller's clock. There is no stale number here.
+    pub weight: f64,
+    pub state: LinkState,
+    pub reason: Option<String>,
+    pub cues: Vec<Cue>,
+    /// The two sides come from different documents — or one of them is a merge,
+    /// which belongs to no document and always counts as differing.
+    pub cross_corpus: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LinkCounts {
+    pub total: i64,
+    pub related: i64,
+    /// Links whose judgement is queued or running.
+    pub judge_queue: i64,
+}
+
 impl Store {
     /// Strengthen the link between two artifacts, folding the decay in.
     ///
@@ -252,6 +276,263 @@ impl Store {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Every live link out of these anchors, strongest first.
+    ///
+    /// One statement per anchor rather than one `IN` over all of them: the
+    /// anchor list is `spread_from` long (three), the repo builds no SQL
+    /// strings from data, and a link has to be found from either end — which is
+    /// an `OR` over two indexed columns, not a set membership test.
+    ///
+    /// The endpoint's status is joined rather than stored, so undoing a merge
+    /// brings its links back without a write.
+    pub async fn links_from(
+        &self,
+        anchors: &[String],
+        states: &[LinkState],
+        half_life_days: f64,
+        at: i64,
+        min_weight: f64,
+    ) -> Result<Vec<LinkedTo>> {
+        let allowed: Vec<&str> = states.iter().map(|s| s.as_str()).collect();
+        let mut out: Vec<LinkedTo> = Vec::new();
+        for anchor in anchors {
+            let rows = sqlx::query(
+                // `weight >= ?` is a necessary condition, not the answer: decay
+                // only ever lowers it, so this narrows the scan with the index
+                // and the exact test happens below in Rust. Doing it in SQL
+                // would need a `pow` that is not in every SQLite build.
+                "SELECT l.a_id AS a_id, l.b_id AS b_id, l.weight AS weight,
+                        l.bumped_at AS bumped_at, l.state AS state, l.reason AS reason,
+                        l.cues AS cues,
+                        a.corpus_id AS a_corpus, b.corpus_id AS b_corpus
+                   FROM artifact_links l
+                   JOIN artifacts a ON a.id = l.a_id
+                   JOIN artifacts b ON b.id = l.b_id
+                  WHERE (l.a_id = ? OR l.b_id = ?)
+                    AND l.weight >= ?
+                    AND a.status = 'active' AND a.superseded_by IS NULL
+                    AND b.status = 'active' AND b.superseded_by IS NULL
+                  ORDER BY l.weight DESC",
+            )
+            .bind(anchor)
+            .bind(anchor)
+            .bind(min_weight)
+            .fetch_all(&self.pool)
+            .await?;
+
+            for r in &rows {
+                let state = LinkState::parse(r.get::<String, _>("state").as_str());
+                if !allowed.contains(&state.as_str()) {
+                    continue;
+                }
+                let weight = decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days);
+                if weight < min_weight {
+                    continue;
+                }
+                let a_id: String = r.get("a_id");
+                let b_id: String = r.get("b_id");
+                let other = if &a_id == anchor { b_id } else { a_id };
+                let a_corpus: Option<String> = r.get("a_corpus");
+                let b_corpus: Option<String> = r.get("b_corpus");
+                out.push(LinkedTo {
+                    via: anchor.clone(),
+                    other,
+                    weight,
+                    state,
+                    reason: r.get("reason"),
+                    cues: serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default(),
+                    // A merged artifact belongs to no corpus, so it can never be
+                    // "the same document" as anything.
+                    cross_corpus: match (a_corpus, b_corpus) {
+                        (Some(x), Some(y)) => x != y,
+                        _ => true,
+                    },
+                });
+            }
+        }
+        out.sort_by(|x, y| y.weight.total_cmp(&x.weight));
+        Ok(out)
+    }
+
+    /// Links strong enough, various enough, live enough and cross-corpus enough
+    /// to be worth one model call. Strongest first.
+    ///
+    /// Same two-step as `links_from`: the raw weight narrows with the index and
+    /// the decayed weight decides. Four times the caller's limit is fetched so
+    /// that rows failing the exact test do not eat the budget.
+    pub async fn links_to_judge(
+        &self,
+        min_weight: f64,
+        min_queries: i64,
+        half_life_days: f64,
+        at: i64,
+        limit: i64,
+    ) -> Result<Vec<Link>> {
+        let rows = sqlx::query(
+            "SELECT l.* FROM artifact_links l
+               JOIN artifacts a ON a.id = l.a_id
+               JOIN artifacts b ON b.id = l.b_id
+              WHERE l.state = 'learning'
+                AND l.weight >= ? AND l.queries >= ?
+                AND a.status = 'active' AND a.superseded_by IS NULL
+                AND b.status = 'active' AND b.superseded_by IS NULL
+                AND (a.corpus_id IS NULL OR b.corpus_id IS NULL OR a.corpus_id <> b.corpus_id)
+              ORDER BY l.weight DESC LIMIT ?",
+        )
+        .bind(min_weight)
+        .bind(min_queries)
+        .bind(limit.saturating_mul(4))
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .iter()
+            .map(row_to_link)
+            .filter(|l| decayed(l.weight, l.bumped_at, at, half_life_days) >= min_weight)
+            .take(limit.max(0) as usize)
+            .collect())
+    }
+
+    /// Delete `learning` links that have faded below the floor.
+    ///
+    /// The only write a quiet link ever costs. Rows whose *stored* weight is
+    /// already under the floor go in one statement; the rest are read back and
+    /// tested exactly, capped at `scan_limit` so one sweep cannot walk an
+    /// unbounded table. Whatever the cap leaves is pruned by the next sweep.
+    pub async fn prune_learning_links(
+        &self,
+        below: f64,
+        half_life_days: f64,
+        at: i64,
+        scan_limit: i64,
+    ) -> Result<u64> {
+        let mut dropped =
+            sqlx::query("DELETE FROM artifact_links WHERE state = 'learning' AND weight < ?")
+                .bind(below)
+                .execute(&self.pool)
+                .await?
+                .rows_affected();
+
+        let rows = sqlx::query(
+            "SELECT a_id, b_id, weight, bumped_at FROM artifact_links
+              WHERE state = 'learning' ORDER BY bumped_at ASC LIMIT ?",
+        )
+        .bind(scan_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        for r in &rows {
+            if decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days) >= below {
+                continue;
+            }
+            dropped += sqlx::query("DELETE FROM artifact_links WHERE a_id = ? AND b_id = ?")
+                .bind(r.get::<String, _>("a_id"))
+                .bind(r.get::<String, _>("b_id"))
+                .execute(&self.pool)
+                .await?
+                .rows_affected();
+        }
+        if rows.len() as i64 == scan_limit {
+            tracing::info!(
+                scan_limit,
+                "prune scan hit its cap; the rest waits for the next sweep"
+            );
+        }
+        Ok(dropped)
+    }
+
+    /// Put judged links back to `learning` where either side has been re-embedded
+    /// since. The judge read text that no longer exists.
+    pub async fn reopen_stale_judged_links(&self, limit: i64) -> Result<u64> {
+        Ok(sqlx::query(
+            "UPDATE artifact_links
+                SET state = 'learning', reason = NULL,
+                    judged_rev_a = NULL, judged_rev_b = NULL
+              WHERE (a_id, b_id) IN (
+                SELECT l.a_id, l.b_id FROM artifact_links l
+                  JOIN artifacts a ON a.id = l.a_id
+                  JOIN artifacts b ON b.id = l.b_id
+                 WHERE l.state IN ('related', 'unrelated')
+                   AND (a.embed_rev IS NOT l.judged_rev_a OR b.embed_rev IS NOT l.judged_rev_b)
+                 LIMIT ?
+              )",
+        )
+        .bind(limit)
+        .execute(&self.pool)
+        .await?
+        .rows_affected())
+    }
+
+    /// Record a verdict. `judged_revs` is `(embed_rev of a, embed_rev of b)` as
+    /// read by whoever judged, which is what `reopen_stale_judged_links`
+    /// compares against later.
+    pub async fn set_link_state(
+        &self,
+        a: &str,
+        b: &str,
+        state: LinkState,
+        reason: Option<&str>,
+        judged_revs: Option<(i64, i64)>,
+    ) -> Result<()> {
+        let (a, b) = canonical(a, b);
+        let (rev_a, rev_b) = match judged_revs {
+            Some((x, y)) => (Some(x), Some(y)),
+            None => (None, None),
+        };
+        sqlx::query(
+            "UPDATE artifact_links
+                SET state = ?, reason = ?, judged_rev_a = ?, judged_rev_b = ?
+              WHERE a_id = ? AND b_id = ?",
+        )
+        .bind(state.as_str())
+        .bind(reason)
+        .bind(rev_a)
+        .bind(rev_b)
+        .bind(a)
+        .bind(b)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Count one call against a link and report the new total.
+    ///
+    /// Counted only where the answer said something about the *link* — an
+    /// unreadable reply. A call an outage ate says something about the endpoint,
+    /// and shelving a link for that would empty the pane every time the model is
+    /// down.
+    pub async fn record_link_judge_attempt(&self, a: &str, b: &str) -> Result<i64> {
+        let (a, b) = canonical(a, b);
+        Ok(sqlx::query_scalar(
+            "UPDATE artifact_links SET judge_attempts = judge_attempts + 1
+              WHERE a_id = ? AND b_id = ? RETURNING judge_attempts",
+        )
+        .bind(a)
+        .bind(b)
+        .fetch_optional(&self.pool)
+        .await?
+        .unwrap_or(0))
+    }
+
+    /// The three numbers Ops shows.
+    pub async fn link_counts(&self) -> Result<LinkCounts> {
+        Ok(LinkCounts {
+            total: sqlx::query_scalar("SELECT COUNT(*) FROM artifact_links")
+                .fetch_one(&self.pool)
+                .await?,
+            related: sqlx::query_scalar(
+                "SELECT COUNT(*) FROM artifact_links WHERE state = 'related'",
+            )
+            .fetch_one(&self.pool)
+            .await?,
+            judge_queue: sqlx::query_scalar(
+                "SELECT COUNT(*) FROM jobs
+                  WHERE stage = 'link_judge' AND state IN ('pending', 'running')",
+            )
+            .fetch_one(&self.pool)
+            .await?,
+        })
     }
 }
 
@@ -405,5 +686,283 @@ mod tests {
             store.meta_get("associate.events_after").await.unwrap(),
             Some("99".to_string())
         );
+    }
+
+    /// Two artifacts in two different corpora, so a link between them is a
+    /// cross-corpus one — the only kind the judge is ever asked about.
+    async fn two_corpora(store: &Store) -> (String, String) {
+        let mut ids = Vec::new();
+        for (raw, text) in [("raw one", "alpha"), ("raw two", "beta")] {
+            let src = store.insert_corpus(raw, "web", None).await.unwrap();
+            let made = store
+                .insert_artifacts(
+                    &src.id,
+                    &[NewArtifact {
+                        ordinal: 0,
+                        text: text.into(),
+                        corpus_span: None,
+                        title: Some(text.into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    }],
+                )
+                .await
+                .unwrap();
+            ids.push(made[0].id.clone());
+        }
+        (ids[0].clone(), ids[1].clone())
+    }
+
+    #[tokio::test]
+    async fn a_link_is_found_from_either_of_its_ends() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 3.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+
+        for anchor in [&a, &b] {
+            let out = store
+                .links_from(
+                    std::slice::from_ref(anchor),
+                    &[LinkState::Learning],
+                    30.0,
+                    0,
+                    2.0,
+                )
+                .await
+                .unwrap();
+            assert_eq!(out.len(), 1, "anchored at {anchor}");
+            assert_eq!(&out[0].via, anchor);
+            assert_ne!(&out[0].other, anchor);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_link_below_the_threshold_once_decayed_is_not_shown() {
+        // The stored weight is strength as of `bumped_at`. Filtering on it
+        // directly would keep showing a link that has not been used in a year.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 3.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+
+        let now = store
+            .links_from(
+                std::slice::from_ref(&a),
+                &[LinkState::Learning],
+                30.0,
+                0,
+                2.0,
+            )
+            .await
+            .unwrap();
+        assert_eq!(now.len(), 1);
+        let later = store
+            .links_from(
+                std::slice::from_ref(&a),
+                &[LinkState::Learning],
+                30.0,
+                60 * 86_400,
+                2.0,
+            )
+            .await
+            .unwrap();
+        assert!(later.is_empty(), "a link decayed to 0.75 was still shown");
+    }
+
+    #[tokio::test]
+    async fn a_link_whose_other_side_is_hidden_is_not_shown() {
+        // Superseded and deprecated endpoints are filtered at read time, so
+        // undoing a merge brings its links back without a write.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 3.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_artifact_status(&b, crate::store::artifacts::ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .links_from(&[a], &[LinkState::Learning], 30.0, 0, 2.0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dismissed_link_is_never_returned() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 9.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_link_state(&a, &b, LinkState::Dismissed, None, None)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .links_from(
+                    &[a],
+                    &[LinkState::Learning, LinkState::Related],
+                    30.0,
+                    0,
+                    0.0
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn only_a_strong_cross_corpus_link_is_offered_to_the_judge() {
+        // Two passages of one document being related is not information, so a
+        // same-corpus link is shown and never judged.
+        let store = Store::memory().await.unwrap();
+        let (same_a, same_b) = two(&store).await;
+        let (cross_a, cross_b) = two_corpora(&store).await;
+        for (a, b) in [(&same_a, &same_b), (&cross_a, &cross_b)] {
+            for q in ["one", "two", "three"] {
+                store.bump_link(a, b, 2.0, Some(q), 30.0, 0).await.unwrap();
+            }
+        }
+
+        let armed = store.links_to_judge(4.0, 3, 30.0, 0, 10).await.unwrap();
+        assert_eq!(armed.len(), 1, "got {armed:?}");
+        assert_eq!(
+            canonical(&cross_a, &cross_b),
+            (armed[0].a_id.as_str(), armed[0].b_id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn a_link_bound_by_too_few_questions_is_not_judged() {
+        // One question asked six times is one question. The judge is the only
+        // thing here that costs a model call, and this is what bounds it.
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two_corpora(&store).await;
+        for _ in 0..6 {
+            store
+                .bump_link(&a, &b, 1.0, Some("same"), 30.0, 0)
+                .await
+                .unwrap();
+        }
+        assert!(
+            store
+                .links_to_judge(4.0, 3, 30.0, 0, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn pruning_drops_faded_learning_links_and_spares_judged_ones() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        let (c, d) = two_corpora(&store).await;
+        store
+            .bump_link(&a, &b, 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .bump_link(&c, &d, 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_link_state(
+                &c,
+                &d,
+                LinkState::Related,
+                Some("both about disks"),
+                Some((0, 0)),
+            )
+            .await
+            .unwrap();
+
+        // A year on, both have decayed to almost nothing.
+        let dropped = store
+            .prune_learning_links(0.5, 30.0, 365 * 86_400, 5_000)
+            .await
+            .unwrap();
+        assert_eq!(dropped, 1);
+        assert!(store.get_link(&a, &b).await.unwrap().is_none());
+        assert!(
+            store.get_link(&c, &d).await.unwrap().is_some(),
+            "a verified relation is about content, not use"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_judged_link_reopens_when_either_text_changes_under_it() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two_corpora(&store).await;
+        store
+            .bump_link(&a, &b, 5.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_link_state(&a, &b, LinkState::Related, Some("a reason"), Some((0, 0)))
+            .await
+            .unwrap();
+
+        assert_eq!(store.reopen_stale_judged_links(100).await.unwrap(), 0);
+
+        store
+            .update_artifact_text(&a, "alpha, rewritten")
+            .await
+            .unwrap();
+        assert_eq!(store.reopen_stale_judged_links(100).await.unwrap(), 1);
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Learning);
+        assert_eq!(l.reason, None, "the judge read text that no longer exists");
+    }
+
+    #[tokio::test]
+    async fn the_counts_say_how_many_links_there_are_and_how_many_are_named() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        let (c, d) = two_corpora(&store).await;
+        store
+            .bump_link(&a, &b, 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .bump_link(&c, &d, 9.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_link_state(&c, &d, LinkState::Related, Some("why"), Some((0, 0)))
+            .await
+            .unwrap();
+
+        let n = store.link_counts().await.unwrap();
+        assert_eq!((n.total, n.related), (2, 1));
+    }
+
+    #[tokio::test]
+    async fn a_judge_attempt_is_counted_and_reported_back() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 1.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        assert_eq!(store.record_link_judge_attempt(&a, &b).await.unwrap(), 1);
+        assert_eq!(store.record_link_judge_attempt(&b, &a).await.unwrap(), 2);
     }
 }

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -18,6 +18,22 @@ use sqlx::Row;
 /// the count of *distinct* ones is `queries`, which is not bounded by this.
 pub const MAX_CUES: usize = 3;
 
+/// How the two read-then-write transactions here open.
+///
+/// SQLite's default `BEGIN` is deferred: it takes no lock until the first
+/// statement, so a transaction that reads and *then* writes holds a read
+/// snapshot when it asks for the write lock. Under WAL, if another connection
+/// committed in between, that upgrade fails immediately with
+/// `SQLITE_BUSY_SNAPSHOT` — the one busy error `busy_timeout` does not retry,
+/// because waiting cannot make a stale snapshot fresh.
+///
+/// Both `bump_link` and `bump_activation` are exactly that shape — read the
+/// current weight, decay it, write it back — and both run from background
+/// tasks while a sweep is writing the same tables from another connection in
+/// the same pool. Taking the write lock up front makes the loser wait instead
+/// of fail, which is what `busy_timeout` is for.
+const IMMEDIATE: &str = "BEGIN IMMEDIATE";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinkState {
     /// Bound by use, nothing has ruled on it. Shown, prunable, judgeable.
@@ -172,8 +188,9 @@ impl Store {
     /// co-appearance was already folded in — strengthens without claiming a new
     /// binding question.
     ///
-    /// One transaction per pair. An event with ten shown candidates is 45 of
-    /// these, which is a few milliseconds of local SQLite and no network at all.
+    /// One transaction. Callers with a whole event's worth of pairs to bind
+    /// should use `bump_links` rather than a loop over this — see its note on
+    /// what a loop costs.
     pub async fn bump_link(
         &self,
         a: &str,
@@ -189,62 +206,124 @@ impl Store {
             return Ok(());
         }
         let (a, b) = canonical(a, b);
-        let mut tx = self.pool.begin().await?;
-        let row = sqlx::query(
-            "SELECT weight, bumped_at, queries, cues FROM artifact_links
-              WHERE a_id = ? AND b_id = ?",
-        )
-        .bind(a)
-        .bind(b)
-        .fetch_optional(&mut *tx)
-        .await?;
+        let mut tx = self.pool.begin_with(IMMEDIATE).await?;
+        bump_one(&mut tx, a, b, delta, cue, half_life_days, at).await?;
+        tx.commit().await?;
+        Ok(())
+    }
 
-        match row {
-            Some(r) => {
-                let mut cues: Vec<Cue> =
-                    serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default();
-                let fresh = cue.is_some_and(|q| bump_cue(&mut cues, q));
-                let weight =
-                    decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days) + delta;
-                sqlx::query(
-                    "UPDATE artifact_links
-                        SET weight = ?, bumped_at = ?, queries = ?, cues = ?
-                      WHERE a_id = ? AND b_id = ?",
-                )
-                .bind(weight)
-                .bind(at)
-                .bind(r.get::<i64, _>("queries") + i64::from(fresh))
-                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
-                .bind(a)
-                .bind(b)
-                .execute(&mut *tx)
-                .await?;
+    /// Every pair of one event's shown candidates, in a single transaction.
+    ///
+    /// The count is quadratic in what the searcher saw — ten shown candidates
+    /// are 45 pairs, and `search.limit` is capped at 50, which is 1225 — and
+    /// each of these transactions is an exclusive one (see `IMMEDIATE`). Bound
+    /// a pair at a time, a single catch-up sweep of `REPLAY_LIMIT` events could
+    /// take the write lock and give it back a million times over, with every
+    /// concurrent search's `bump_activation` queued behind it. Per event it is
+    /// one.
+    ///
+    /// A pair that cannot be written is warned about and stepped over rather
+    /// than failing the batch: one side deleted between the search and the
+    /// sweep is the ordinary cause, and it says nothing about the rest of what
+    /// that event showed. SQLite aborts the statement, not the transaction, so
+    /// the pairs around it still commit.
+    pub async fn bump_links(
+        &self,
+        pairs: &[(&str, &str)],
+        delta: f64,
+        cue: Option<&str>,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        if pairs.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.pool.begin_with(IMMEDIATE).await?;
+        for (a, b) in pairs {
+            if a == b {
+                continue;
             }
-            None => {
-                let mut cues = Vec::new();
-                if let Some(q) = cue {
-                    bump_cue(&mut cues, q);
-                }
-                sqlx::query(
-                    "INSERT INTO artifact_links
-                       (a_id, b_id, weight, bumped_at, queries, cues, state, created_at)
-                     VALUES (?, ?, ?, ?, ?, ?, 'learning', ?)",
-                )
-                .bind(a)
-                .bind(b)
-                .bind(delta)
-                .bind(at)
-                .bind(cues.len() as i64)
-                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
-                .bind(now())
-                .execute(&mut *tx)
-                .await?;
+            let (a, b) = canonical(a, b);
+            if let Err(err) = bump_one(&mut tx, a, b, delta, cue, half_life_days, at).await {
+                // Named as what it is and not as a guess: one side being gone
+                // is one cause, write contention under WAL is another, and an
+                // operator sent looking for a deleted artifact by a line that
+                // means "the database was busy" loses the afternoon. `warn`
+                // rather than `debug` because the bump is dropped, not retried
+                // — this is learning that did not happen.
+                tracing::warn!(error = %err, a, b, "could not bind a pair");
             }
         }
         tx.commit().await?;
         Ok(())
     }
+}
 
+/// One pair's bump, on a connection the caller has already opened a transaction
+/// on. Shared by `bump_link` and `bump_links` so the two can never drift.
+async fn bump_one(
+    tx: &mut sqlx::SqliteConnection,
+    a: &str,
+    b: &str,
+    delta: f64,
+    cue: Option<&str>,
+    half_life_days: f64,
+    at: i64,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT weight, bumped_at, queries, cues FROM artifact_links
+              WHERE a_id = ? AND b_id = ?",
+    )
+    .bind(a)
+    .bind(b)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    match row {
+        Some(r) => {
+            let mut cues: Vec<Cue> =
+                serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default();
+            let fresh = cue.is_some_and(|q| bump_cue(&mut cues, q));
+            let weight = decayed(r.get("weight"), r.get("bumped_at"), at, half_life_days) + delta;
+            sqlx::query(
+                "UPDATE artifact_links
+                        SET weight = ?, bumped_at = ?, queries = ?, cues = ?
+                      WHERE a_id = ? AND b_id = ?",
+            )
+            .bind(weight)
+            .bind(at)
+            .bind(r.get::<i64, _>("queries") + i64::from(fresh))
+            .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+            .bind(a)
+            .bind(b)
+            .execute(&mut *tx)
+            .await?;
+        }
+        None => {
+            let mut cues = Vec::new();
+            if let Some(q) = cue {
+                bump_cue(&mut cues, q);
+            }
+            sqlx::query(
+                "INSERT INTO artifact_links
+                       (a_id, b_id, weight, bumped_at, queries, cues, state, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?, 'learning', ?)",
+            )
+            .bind(a)
+            .bind(b)
+            .bind(delta)
+            .bind(at)
+            .bind(cues.len() as i64)
+            .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+            .bind(now())
+            .execute(&mut *tx)
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+impl Store {
     /// One link, whichever way round it is named.
     pub async fn get_link(&self, a: &str, b: &str) -> Result<Option<Link>> {
         let (a, b) = canonical(a, b);
@@ -621,7 +700,7 @@ impl Store {
             return Ok(());
         }
         for id in ids {
-            let mut tx = self.pool.begin().await?;
+            let mut tx = self.pool.begin_with(IMMEDIATE).await?;
             let row = sqlx::query("SELECT activation, activated_at FROM artifacts WHERE id = ?")
                 .bind(id)
                 .fetch_optional(&mut *tx)

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -522,6 +522,74 @@ impl Store {
         .unwrap_or(0))
     }
 
+    /// Each artifact's stored activation and the stamp it was true at.
+    ///
+    /// One statement for the whole candidate list: this is on the query path,
+    /// and fifty round trips to answer one search is exactly the layer crossing
+    /// the design promises not to be. The SQL is built only from `?`
+    /// placeholders — one per id, never a value — so nothing from a request
+    /// reaches the statement text.
+    pub async fn activation_of(
+        &self,
+        ids: &[String],
+    ) -> Result<std::collections::HashMap<String, (f64, i64)>> {
+        if ids.is_empty() {
+            return Ok(Default::default());
+        }
+        let holes = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT id, activation, activated_at FROM artifacts WHERE id IN ({holes})"
+        )));
+        for id in ids {
+            q = q.bind(id);
+        }
+        Ok(q.fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(|r| {
+                (
+                    r.get::<String, _>("id"),
+                    (
+                        r.get::<f64, _>("activation"),
+                        r.get::<i64, _>("activated_at"),
+                    ),
+                )
+            })
+            .collect())
+    }
+
+    /// Raise the accessibility of these artifacts, folding the decay in.
+    ///
+    /// Read-then-write per artifact rather than one arithmetic UPDATE, for the
+    /// same reason `bump_link` does it: the decay is an exponential, and not
+    /// every SQLite build ships the math functions to express one in SQL.
+    pub async fn bump_activation(
+        &self,
+        ids: &[String],
+        delta: f64,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        if ids.is_empty() || delta == 0.0 {
+            return Ok(());
+        }
+        let current = self.activation_of(ids).await?;
+        for id in ids {
+            let Some((value, stamp)) = current.get(id).copied() else {
+                continue;
+            };
+            sqlx::query("UPDATE artifacts SET activation = ?, activated_at = ? WHERE id = ?")
+                .bind(decayed(value, stamp, at, half_life_days) + delta)
+                .bind(at)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// The three numbers Ops shows.
     pub async fn link_counts(&self) -> Result<LinkCounts> {
         Ok(LinkCounts {
@@ -1001,5 +1069,47 @@ mod tests {
             .unwrap();
         assert_eq!(store.record_link_judge_attempt(&a, &b).await.unwrap(), 1);
         assert_eq!(store.record_link_judge_attempt(&b, &a).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_fresh_artifact_starts_fully_activated_and_stamped() {
+        // Left unstamped, every artifact in the base reads as having decayed
+        // since 1970 — equally inaccessible, which is the opposite of true.
+        let store = Store::memory().await.unwrap();
+        let (a, _) = two(&store).await;
+        let act = store.activation_of(std::slice::from_ref(&a)).await.unwrap();
+        let (value, stamp) = act
+            .get(&a)
+            .copied()
+            .expect("an artifact carries activation");
+        assert!((value - 1.0).abs() < 1e-9);
+        assert!(stamp > 0, "activated_at was never set at insert");
+    }
+
+    #[tokio::test]
+    async fn a_bump_folds_the_decay_in_like_a_link_does() {
+        let store = Store::memory().await.unwrap();
+        let (a, _) = two(&store).await;
+        sqlx::query("UPDATE artifacts SET activation = 4.0, activated_at = 0 WHERE id = ?")
+            .bind(&a)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        store
+            .bump_activation(std::slice::from_ref(&a), 1.0, 14.0, 14 * 86_400)
+            .await
+            .unwrap();
+
+        let (value, stamp) = store.activation_of(std::slice::from_ref(&a)).await.unwrap()[&a];
+        assert!((value - 3.0).abs() < 1e-6, "value was {value}");
+        assert_eq!(stamp, 14 * 86_400);
+    }
+
+    #[tokio::test]
+    async fn bumping_nothing_is_not_a_write() {
+        let store = Store::memory().await.unwrap();
+        store.bump_activation(&[], 1.0, 14.0, 0).await.unwrap();
+        assert!(store.activation_of(&[]).await.unwrap().is_empty());
     }
 }

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -278,7 +278,8 @@ impl Store {
         Ok(())
     }
 
-    /// Every live link out of these anchors, strongest first.
+    /// Every live link out of these anchors, strongest first, capped at
+    /// `limit`.
     ///
     /// One statement per anchor rather than one `IN` over all of them: the
     /// anchor list is `spread_from` long (three), the repo builds no SQL
@@ -287,6 +288,12 @@ impl Store {
     ///
     /// The endpoint's status is joined rather than stored, so undoing a merge
     /// brings its links back without a write.
+    ///
+    /// Same two-step as `links_to_judge`: SQL fetches four times `limit` so
+    /// that rows the exact decayed-weight test in Rust rejects do not eat the
+    /// budget, and the final truncate is what actually bounds a hub artifact
+    /// — one co-shown with many others — to a fixed, small read on every
+    /// search rather than every link above `show_min`.
     pub async fn links_from(
         &self,
         anchors: &[String],
@@ -294,6 +301,7 @@ impl Store {
         half_life_days: f64,
         at: i64,
         min_weight: f64,
+        limit: i64,
     ) -> Result<Vec<LinkedTo>> {
         let allowed: Vec<&str> = states.iter().map(|s| s.as_str()).collect();
         let mut out: Vec<LinkedTo> = Vec::new();
@@ -314,11 +322,14 @@ impl Store {
                     AND l.weight >= ?
                     AND a.status = 'active' AND a.superseded_by IS NULL
                     AND b.status = 'active' AND b.superseded_by IS NULL
-                  ORDER BY l.weight DESC",
+                  ORDER BY l.weight DESC LIMIT ?",
             )
             .bind(anchor)
             .bind(anchor)
             .bind(min_weight)
+            // SQLite reads a negative LIMIT as unbounded, so the cap must be
+            // clamped at zero — a negative `limit` must still cap the fetch.
+            .bind(limit.max(0).saturating_mul(4))
             .fetch_all(&self.pool)
             .await?;
 
@@ -357,6 +368,7 @@ impl Store {
             }
         }
         out.sort_by(|x, y| y.weight.total_cmp(&x.weight));
+        out.truncate(limit.max(0) as usize);
         Ok(out)
     }
 
@@ -453,6 +465,12 @@ impl Store {
     /// since. The judge read text that no longer exists.
     pub async fn reopen_stale_judged_links(&self, limit: i64) -> Result<u64> {
         Ok(sqlx::query(
+            // `judge_attempts` is deliberately left alone here. A link shelved
+            // as `unrelated`/"unreadable" after three attempts and then
+            // reopened by a text change gets exactly one more call before
+            // `judge` (src/jobs/associate.rs) would shelve it again at the
+            // same ceiling — the model has already failed three times on this
+            // pair, and that history is not something a re-embed should erase.
             "UPDATE artifact_links
                 SET state = 'learning', reason = NULL,
                     judged_rev_a = NULL, judged_rev_b = NULL
@@ -585,6 +603,13 @@ impl Store {
     /// Read-then-write per artifact rather than one arithmetic UPDATE, for the
     /// same reason `bump_link` does it: the decay is an exponential, and not
     /// every SQLite build ships the math functions to express one in SQL.
+    ///
+    /// One transaction per artifact, the same shape as `bump_link`: the
+    /// sweep's confirmed bump and a search's retrieval bump can interleave on
+    /// the same artifact, as can two concurrent searches sharing a hit, and
+    /// without a transaction the loser's read is stale by the time it writes,
+    /// silently dropping its delta. An id with no row is skipped, same as
+    /// before.
     pub async fn bump_activation(
         &self,
         ids: &[String],
@@ -595,17 +620,24 @@ impl Store {
         if ids.is_empty() || delta == 0.0 {
             return Ok(());
         }
-        let current = self.activation_of(ids).await?;
         for id in ids {
-            let Some((value, stamp)) = current.get(id).copied() else {
+            let mut tx = self.pool.begin().await?;
+            let row = sqlx::query("SELECT activation, activated_at FROM artifacts WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&mut *tx)
+                .await?;
+            let Some(row) = row else {
                 continue;
             };
+            let value: f64 = row.get("activation");
+            let stamp: i64 = row.get("activated_at");
             sqlx::query("UPDATE artifacts SET activation = ?, activated_at = ? WHERE id = ?")
                 .bind(decayed(value, stamp, at, half_life_days) + delta)
                 .bind(at)
                 .bind(id)
-                .execute(&self.pool)
+                .execute(&mut *tx)
                 .await?;
+            tx.commit().await?;
         }
         Ok(())
     }
@@ -827,6 +859,7 @@ mod tests {
                     30.0,
                     0,
                     2.0,
+                    10,
                 )
                 .await
                 .unwrap();
@@ -854,6 +887,7 @@ mod tests {
                 30.0,
                 0,
                 2.0,
+                10,
             )
             .await
             .unwrap();
@@ -865,6 +899,7 @@ mod tests {
                 30.0,
                 60 * 86_400,
                 2.0,
+                10,
             )
             .await
             .unwrap();
@@ -888,7 +923,7 @@ mod tests {
 
         assert!(
             store
-                .links_from(&[a], &[LinkState::Learning], 30.0, 0, 2.0)
+                .links_from(&[a], &[LinkState::Learning], 30.0, 0, 2.0, 10)
                 .await
                 .unwrap()
                 .is_empty()
@@ -915,7 +950,8 @@ mod tests {
                     &[LinkState::Learning, LinkState::Related],
                     30.0,
                     0,
-                    0.0
+                    0.0,
+                    10
                 )
                 .await
                 .unwrap()
@@ -979,7 +1015,8 @@ mod tests {
                     &[LinkState::Dismissed, LinkState::Learning],
                     30.0,
                     0,
-                    0.0
+                    0.0,
+                    10
                 )
                 .await
                 .unwrap()

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -503,6 +503,26 @@ impl Store {
         Ok(())
     }
 
+    /// The operator saying this pair does not belong together.
+    ///
+    /// Deliberately narrower than `set_link_state`: dismissal records a
+    /// decision, it does not erase what the decision was made about. Weight
+    /// stays so the decision is auditable against the evidence that produced
+    /// it, and the judge's `reason` — where there is one — stays too, because
+    /// it is part of that evidence: an operator overruling "the config and the
+    /// errors it produces" should leave a row that still says both what was
+    /// claimed and that a person overruled it. Only `state` moves.
+    pub async fn dismiss_link(&self, a: &str, b: &str) -> Result<()> {
+        let (a, b) = canonical(a, b);
+        sqlx::query("UPDATE artifact_links SET state = ? WHERE a_id = ? AND b_id = ?")
+            .bind(LinkState::Dismissed.as_str())
+            .bind(a)
+            .bind(b)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Count one call against a link and report the new total.
     ///
     /// Counted only where the answer said something about the *link* — an
@@ -900,6 +920,40 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn dismissing_a_link_records_the_decision_without_erasing_the_evidence() {
+        let store = Store::memory().await.unwrap();
+        let (a, b) = two(&store).await;
+        store
+            .bump_link(&a, &b, 9.0, Some("q"), 30.0, 0)
+            .await
+            .unwrap();
+        store
+            .set_link_state(
+                &a,
+                &b,
+                LinkState::Related,
+                Some("the config and the errors it produces"),
+                Some((0, 0)),
+            )
+            .await
+            .unwrap();
+
+        store.dismiss_link(&a, &b).await.unwrap();
+
+        let l = store.get_link(&a, &b).await.unwrap().unwrap();
+        assert_eq!(l.state, LinkState::Dismissed);
+        assert_eq!(
+            l.weight, 9.0,
+            "the evidence was thrown away with the decision"
+        );
+        assert_eq!(
+            l.reason.as_deref(),
+            Some("the config and the errors it produces"),
+            "the judge's assessment is part of the evidence, not decoration"
         );
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -5,6 +5,7 @@ pub mod corpora;
 pub mod feedback;
 pub mod jobs;
 pub mod lineage;
+pub mod links;
 pub mod pairs;
 pub mod segments;
 pub mod shingle;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -197,9 +197,60 @@ impl Store {
         // artifact's own creation time, not zero. Left at zero every artifact
         // predating this column reads as decayed to nothing since 1970 — the
         // whole base equally inaccessible, which is the opposite of the truth.
-        sqlx::query("UPDATE artifacts SET activated_at = created_at WHERE activated_at = 0")
-            .execute(&self.pool)
-            .await?;
+        //
+        // Keyed on a zeroed stamp rather than on "this call ran the ALTER",
+        // because those are not the same moment. The `corpus_id` check above
+        // returns `Err` after both ALTERs have committed, and the operator it
+        // sends off to rebuild the artifacts table comes back to a database
+        // whose columns already exist — a flag set by the ALTER would be false
+        // from then on, and these fixups would never run at all. A kill inside
+        // the same window does the same thing. A zeroed stamp is what actually
+        // needs fixing, it is what the fix removes, and asking costs one scan
+        // of `artifacts` at boot on a database that no longer has any.
+        let adopting: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM artifacts WHERE activated_at = 0)")
+                .fetch_one(&self.pool)
+                .await?;
+        if adopting {
+            // One transaction, because the watermarks below are keyed on the
+            // same zeroed stamp this backfill erases: committed separately, a
+            // crash between them would leave nothing left to notice that the
+            // second half never happened.
+            let mut tx = self.pool.begin().await?;
+            sqlx::query("UPDATE artifacts SET activated_at = created_at WHERE activated_at = 0")
+                .execute(&mut *tx)
+                .await?;
+            // ...and the same moment decides where the association sweep starts
+            // reading. Absent watermarks mean "from the epoch", which on a base
+            // that has been recording searches for months would fold the entire
+            // historical log in on the first tick — thousands of pairs bound at
+            // once, every one of them stamped with the sweep's clock and so
+            // undecayed, feeding priming and the judge queue from a past nobody
+            // asked to relive. Learning starts now, from what happens next.
+            //
+            // A database with no artifacts at all is not adopting anything and
+            // never reaches here, so a fresh install keeps both watermarks
+            // absent and replays its own short log from the epoch, which is
+            // both correct and free.
+            //
+            // The keys are `jobs::associate::{EVENTS_AFTER, JUDGED_AFTER}`,
+            // spelled out because nothing else in `store` reaches up into
+            // `jobs`; `watermarks_named_here_are_the_ones_the_sweep_reads`
+            // pins them together.
+            let at = now().to_string();
+            for key in ["associate.events_after", "associate.judged_after"] {
+                sqlx::query("INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)")
+                    .bind(key)
+                    .bind(&at)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+            tx.commit().await?;
+            tracing::info!(
+                "adopting associative memory: activation backfilled, \
+                 the search log before now is left unread"
+            );
+        }
 
         let mut missing = Vec::new();
         for (table, columns) in schema_columns(SCHEMA) {
@@ -564,6 +615,50 @@ mod tests {
                 .unwrap();
         assert!((value - 1.0).abs() < 1e-9);
         assert!(stamp > 0, "activated_at was left at the epoch");
+
+        // ...and the same adoption decides where the sweep starts reading. A
+        // base that has been recording searches for months must not have that
+        // whole log folded into links on its first tick.
+        for key in ["associate.events_after", "associate.judged_after"] {
+            let mark: i64 = store
+                .meta_get(key)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("{key} was left unseeded on an adopting base"))
+                .parse()
+                .unwrap();
+            assert!(mark > 0, "{key} was seeded at the epoch");
+        }
+
+        // Once seeded, a later boot leaves the watermark where the sweep put
+        // it — re-seeding would skip everything learned since.
+        store
+            .meta_set("associate.events_after", "42")
+            .await
+            .unwrap();
+        store.migrate().await.unwrap();
+        assert_eq!(
+            store.meta_get("associate.events_after").await.unwrap(),
+            Some("42".into()),
+            "a later boot moved the watermark"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_base_created_with_activation_is_not_treated_as_adopting_it() {
+        // Nothing to backfill and nothing to skip: a database created by this
+        // version has no search log predating the feature, and its watermarks
+        // start where every other counter does.
+        let store = Store::memory().await.unwrap();
+        store.migrate().await.unwrap();
+        assert_eq!(
+            store.meta_get("associate.events_after").await.unwrap(),
+            None
+        );
+        assert_eq!(
+            store.meta_get("associate.judged_after").await.unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
@@ -726,5 +821,66 @@ mod tests {
 
         drop(store);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn the_associative_fixups_finish_on_a_later_boot_when_the_adopting_one_did_not() {
+        // The boot that adds the columns can fail before the fixups below them:
+        // the `corpus_id` check returns `Err` after both ALTERs have committed,
+        // and a kill in the same window does the same. On the boot after, the
+        // columns are already there — so anything keyed on "this call added
+        // them" is false forever, the stamps stay at the epoch and the sweep's
+        // watermarks are never written. An absent watermark reads as "from the
+        // epoch", which folds the entire historical search log in on one tick.
+        // Keyed on the state of the database, so a later boot finishes the job.
+        let store = Store::memory().await.unwrap();
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        let ids = store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        // Exactly what an aborted adopting boot leaves behind: the columns
+        // present, the stamps unbackfilled, the watermarks unwritten.
+        sqlx::query("UPDATE artifacts SET activated_at = 0")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM meta WHERE key LIKE 'associate.%'")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        store.migrate().await.unwrap();
+
+        let stamp: i64 = sqlx::query_scalar("SELECT activated_at FROM artifacts WHERE id = ?")
+            .bind(&ids[0].id)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+        assert_ne!(
+            stamp, 0,
+            "every artifact still reads as decayed to nothing since 1970"
+        );
+        for key in [
+            crate::jobs::associate::EVENTS_AFTER,
+            crate::jobs::associate::JUDGED_AFTER,
+        ] {
+            assert!(
+                store.meta_get(key).await.unwrap().is_some(),
+                "{key} was never seeded; the first sweep replays the whole log"
+            );
+        }
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -112,6 +112,12 @@ impl Store {
             // Arrived with image capture. Every corpus predating it recorded
             // nothing beyond its text, which is what the empty object says.
             ("corpora", "metadata", "TEXT NOT NULL DEFAULT '{}'"),
+            // Arrived with associative memory. Both have defaults that are the
+            // truth about an artifact captured before it existed — full
+            // accessibility, no stamp — and the stamp is backfilled below from
+            // `created_at`, which is when it was in fact last activated.
+            ("artifacts", "activation", "REAL NOT NULL DEFAULT 1.0"),
+            ("artifacts", "activated_at", "INTEGER NOT NULL DEFAULT 0"),
         ];
 
         // Before the schema, not after. `schema.sql` builds an index over `seq`,
@@ -185,6 +191,13 @@ impl Store {
         // Verdicts recorded while acting was switched off. There is no such
         // switch now, so they go back to the judge and are acted on.
         sqlx::query("UPDATE artifact_pairs SET state = 'pending' WHERE state = 'would_merge'")
+            .execute(&self.pool)
+            .await?;
+        // The one default an append cannot state: `activated_at` has to be the
+        // artifact's own creation time, not zero. Left at zero every artifact
+        // predating this column reads as decayed to nothing since 1970 — the
+        // whole base equally inaccessible, which is the opposite of the truth.
+        sqlx::query("UPDATE artifacts SET activated_at = created_at WHERE activated_at = 0")
             .execute(&self.pool)
             .await?;
 
@@ -504,6 +517,53 @@ mod tests {
         let got = store.get_artifact(&made[0].id).await.unwrap();
         assert_eq!(got.provenance, artifacts::Provenance::Captured);
         assert_eq!(got.source_count, 0);
+    }
+
+    #[tokio::test]
+    async fn a_base_captured_before_activation_gains_it_with_a_real_stamp() {
+        // The append can only state a constant, and zero is the wrong stamp:
+        // it reads as an artifact last reached in 1970. The backfill is what
+        // makes the column true of a base that predates it.
+        let store = Store::memory().await.unwrap();
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        store
+            .insert_artifacts(
+                &src.id,
+                &[artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "alpha".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        for stmt in [
+            "ALTER TABLE artifacts DROP COLUMN activation",
+            "ALTER TABLE artifacts DROP COLUMN activated_at",
+        ] {
+            sqlx::query(stmt)
+                .execute(&store.pool)
+                .await
+                .expect("the fixture needs an artifacts table from before activation");
+        }
+
+        store
+            .migrate()
+            .await
+            .expect("migrate refused a base captured before activation");
+
+        let (value, stamp): (f64, i64) =
+            sqlx::query_as("SELECT activation, activated_at FROM artifacts")
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert!((value - 1.0).abs() < 1e-9);
+        assert!(stamp > 0, "activated_at was left at the epoch");
     }
 
     #[tokio::test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -155,6 +155,37 @@ impl Store {
         Ok(res.rows_affected() > 0)
     }
 
+    /// File a pair for review, saying where it came from.
+    ///
+    /// `record_pair` with a `detail`, for the one producer that is not the
+    /// similarity sweep: a link the judge found to be a disguised duplicate has
+    /// no cosine behind it, so its `score` is genuinely zero and the detail is
+    /// what explains the row on a page that otherwise renders a percentage.
+    ///
+    /// `INSERT OR IGNORE`, like `record_pair`: a pair an operator already
+    /// dismissed must not be re-filed by a link.
+    pub async fn record_pair_with_detail(
+        &self,
+        a: &str,
+        b: &str,
+        score: f32,
+        detail: &str,
+    ) -> Result<bool> {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO artifact_pairs (a_id, b_id, score, state, detail, created_at)
+             VALUES (?, ?, ?, 'pending', ?, ?)",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(score as f64)
+        .bind(detail)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
     /// File a pair that is already answered. Returns whether this changed
     /// anything.
     ///

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -116,7 +116,14 @@ CREATE TABLE IF NOT EXISTS artifacts (
   superseded_by    TEXT,
   caveats          TEXT NOT NULL DEFAULT '[]',
   status           TEXT NOT NULL DEFAULT 'active',
-  last_verified_at INTEGER
+  last_verified_at INTEGER,
+  activation       REAL    NOT NULL DEFAULT 1.0,
+  -- Current accessibility above is raised by being captured, retrieved,
+  -- opened and confirmed; read through the same lazy decay as a link's
+  -- weight. In SQLite rather than the vector payload because the query path
+  -- already needs one SQLite read for links, and the same read returns this
+  -- — one crossing.
+  activated_at     INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_artifacts_corpus     ON artifacts(corpus_id, ordinal);
 CREATE INDEX IF NOT EXISTS idx_artifacts_embed      ON artifacts(embed_state);

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -287,6 +287,47 @@ CREATE TABLE IF NOT EXISTS search_candidates (
   PRIMARY KEY (event_id, rank)
 );
 
+-- ── Association ──────────────────────────────────────────────────────────────
+-- Two artifacts that keep being retrieved by the same searches. The other half
+-- of relatedness: `artifact_pairs` is about two texts saying the same thing,
+-- this is about two texts being needed together. A pair can be both — filed by
+-- `Relate` at 0.89 and judged distinct, and co-retrieved and related — and one
+-- row cannot hold two verdicts, so they are separate tables.
+CREATE TABLE IF NOT EXISTS artifact_links (
+  a_id        TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  b_id        TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- Strength as of `bumped_at`. Read through decay; never decayed in place, so
+  -- learning is one UPDATE and forgetting costs no writes at all.
+  weight      REAL NOT NULL,
+  bumped_at   INTEGER NOT NULL,
+  -- Distinct normalised query texts that bound this pair. What separates a
+  -- link from one search typed twice.
+  queries     INTEGER NOT NULL DEFAULT 1,
+  -- Up to three binding queries with counts, JSON: [{"q":..,"n":..}].
+  cues        TEXT NOT NULL DEFAULT '[]',
+  -- 'learning' | 'related' | 'unrelated' | 'dismissed'
+  state       TEXT NOT NULL DEFAULT 'learning',
+  -- The judge's one line, for `related`.
+  reason      TEXT,
+  -- Revisions the judge read. A re-embed of either side reopens the verdict:
+  -- the text changed under it.
+  judged_rev_a INTEGER,
+  judged_rev_b INTEGER,
+  judge_attempts INTEGER NOT NULL DEFAULT 0,
+  created_at  INTEGER NOT NULL,
+  PRIMARY KEY (a_id, b_id),
+  CHECK (a_id < b_id)
+);
+CREATE INDEX IF NOT EXISTS idx_links_b ON artifact_links(b_id);
+CREATE INDEX IF NOT EXISTS idx_links_state ON artifact_links(state, weight DESC);
+
+-- Cursors that have no row to live on. Two keys so far:
+-- `associate.events_after` and `associate.judged_after`.
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
 -- ── Auth ─────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS sessions (
   id         TEXT PRIMARY KEY,

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -283,6 +283,12 @@ CREATE TABLE IF NOT EXISTS search_events (
 );
 CREATE INDEX IF NOT EXISTS idx_events_pending ON search_events(judged_at, skips, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_events_verdict ON search_events(verdict);
+-- The association sweep's own read: `created_at > watermark AND < cutoff`,
+-- ordered by the same column. `idx_events_pending` cannot serve it — it leads
+-- with `judged_at` — so without this the sweep full-scans and sorts the whole
+-- log every `associate.interval_mins`, and with `feedback.retain_days = 0` that
+-- log is never trimmed.
+CREATE INDEX IF NOT EXISTS idx_events_created ON search_events(created_at);
 
 CREATE TABLE IF NOT EXISTS search_candidates (
   event_id    TEXT NOT NULL REFERENCES search_events(id) ON DELETE CASCADE,

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -594,6 +594,20 @@ async fn consolidation(
 #[derive(serde::Deserialize)]
 pub struct SearchParams {
     pub q: String,
+    /// How many *ranked* hits to return. The response can be longer than this:
+    /// with `[associate]` on, up to `associate.spread_max` further artifacts
+    /// are appended — ones the query never matched, recalled because they are
+    /// linked to what it did match. Every such row carries `via` (the ranked
+    /// hit it was recalled beside) and a `score` of 0, so a client that wants
+    /// only what it asked for can drop them by that field. They obey `tags` and
+    /// `category` like any other row.
+    ///
+    /// They do *not* obey the two `include_*` flags: an associated row is always
+    /// an active, unsuperseded artifact, whatever those are set to. Nothing here
+    /// was asked for by name — association is a spread out of what the query did
+    /// match — and a retired artifact recalled that way would be competing with
+    /// the very successor that retired it. A deprecation audit gets what it
+    /// needs from the ranked hits, where both flags do apply.
     pub limit: Option<usize>,
     pub tags: Option<String>,
     pub category: Option<String>,

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -158,6 +158,33 @@
         {% endfor %}
       </div>
       {% endif %}
+
+      {% if !d.seen_together.is_empty() %}
+      {# Beside the nearest neighbours, not instead of them: one list is what
+         this resembles, the other is what it has been needed alongside. #}
+      <div class="pane-label">Seen together</div>
+      <div class="related">
+        {% for r in d.seen_together %}
+        <div class="seen-row{% if !r.cross_corpus %} muted{% endif %}">
+          <a class="rail-item" href="/ui/artifacts/{{ r.id }}"
+             hx-get="/ui/artifacts/{{ r.id }}"
+             hx-target="closest [data-terms]" hx-swap="outerHTML"
+             hx-push-url="true">
+            <div class="rail-head"><span class="rail-title">{{ r.title }}</span></div>
+            {% if let Some(why) = r.why %}<div class="rail-why">{{ why }}</div>{% endif %}
+            <div class="rail-snippet">{{ r.snippet }} · {{ r.corpus_title }}</div>
+          </a>
+          <div class="rail-del">
+            <button class="btn-icon" title="Not related" aria-label="Not related"
+                    hx-post="/ui/artifacts/{{ d.id }}/links/{{ r.id }}/dismiss"
+                    hx-target="closest .seen-row" hx-swap="outerHTML">
+              {% include "_icon_hide.html" %}
+            </button>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
     </div>
     <div>
       {# One statement of which lines these are, and it is the link. The crumb

--- a/src/web/templates/_decide.html
+++ b/src/web/templates/_decide.html
@@ -13,7 +13,10 @@
 <div class="decide">
   <div class="decide-head">
     {% if p.contradiction %}<b>These two disagree</b>{% else %}<b>These two cover the same ground</b>{% endif %}
-    — {{ p.percent }}% alike.
+    {# `via_link` pairs were never scored by embedding — the judge found them
+       through repeated co-retrieval, not cosine — so `percent` would read as a
+       measured similarity that was never computed. #}
+    {% if p.via_link %}— no similarity was measured for this pair.{% else %}— {{ p.percent }}% alike.{% endif %}
     <a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a> and
     <a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a>.
   </div>

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -1,5 +1,5 @@
 <span id="timing-value" hx-swap-oob="innerHTML:#timing">{{ timing }}</span>
-{% if results.is_empty() %}
+{% if results.is_empty() && associated.is_empty() %}
   <p class="muted">No matches.</p>
 {% else %}
 <div data-terms="{{ terms }}">
@@ -33,6 +33,9 @@
         {% else %}
         <span class="rail-rank mono">{{ r.rank }}</span>
         {% endif %}
+        {% if r.primed %}
+        <span class="badge" title="Moved up: you reach this one often">primed</span>
+        {% endif %}
         <span class="rail-title">{{ r.title }}</span>
       </div>
       {# Rank, title, two lines. No tags: the pane beside this lists them in
@@ -54,5 +57,29 @@
     </div>
   </div>
   {% endfor %}
+  {% if !associated.is_empty() %}
+  {# Below a rule and under its own heading: these were not ranked against the
+     query, they were recalled by something that was. Presenting them in the
+     same list would be a claim about relevance that nothing here supports. #}
+  <div class="assoc-rule" role="separator">Recalled by association</div>
+  {% for r in associated %}
+  <div class="rail-row">
+    <a class="rail-item rail-assoc" role="option" aria-selected="false"
+       href="/ui/artifacts/{{ r.artifact_id }}"
+       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}"
+       hx-target="#pane" hx-swap="innerHTML" hx-push-url="true">
+      <div class="rail-head">
+        <span class="rail-title">{{ r.title }}</span>
+      </div>
+      {% if let Some(why) = r.reason %}
+      <div class="rail-why">{{ why }}</div>
+      {% else if let Some(via) = r.via_title %}
+      <div class="rail-why">seen together with "{{ via }}"</div>
+      {% endif %}
+      <div class="rail-snippet">{{ r.snippet }}</div>
+    </a>
+  </div>
+  {% endfor %}
+  {% endif %}
 </div>
 {% endif %}

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -11,6 +11,9 @@
   {{ artifact_count }} artifacts, {{ vector_count }} embedded.
   {% for j in job_counts %}{{ j.1 }} {{ j.0 }}{% if !loop.last %}, {% endif %}{% endfor %}{% if job_counts.is_empty() %}Nothing queued{% endif %}.
   {% if let Some(age) = oldest_pending_secs %}Oldest pending job {{ age }}s old.{% endif %}
+  {% if let Some(l) = links %}
+  {{ l.total }} links, {{ l.related }} named, {{ l.judge_queue }} waiting on the judge.
+  {% endif %}
 </p>
 
 {% if !merged.is_empty() %}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -211,6 +211,12 @@ pub struct PairRow {
     pub b_id: String,
     pub b_title: String,
     pub detail: Option<String>,
+    /// The stored `detail` is exactly `"link"` — the judge's duplicate
+    /// hand-off (§7), a provenance marker, not prose. The row renders a
+    /// sentence explaining that instead, and the percent is not shown as a
+    /// measured similarity, because no cosine was ever computed for a pair
+    /// found by co-retrieval.
+    pub via_link: bool,
     pub contradiction: bool,
     /// Set when the judge named a direction with enough confidence to propose
     /// a supersede. A recommendation only: nothing here has hidden anything,
@@ -1105,6 +1111,20 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
             // `a` obsolete is a recommendation to keep `b`.
             let keeps_a = p.obsolete_id.as_deref() == Some(b.id.as_str());
             let keeps_b = p.obsolete_id.as_deref() == Some(a.id.as_str());
+            // The judge's `duplicate` verdict files this pair with
+            // `detail = "link"` (`src/jobs/associate.rs`) — a provenance
+            // marker meant for code, not the reader. Rendered as a sentence
+            // here rather than the bare token; the stored value is untouched.
+            let via_link = p.detail.as_deref() == Some("link");
+            let detail = if via_link {
+                Some(
+                    "Not found by similarity: these two kept being retrieved together, \
+                     and the judge then found they say the same thing."
+                        .to_string(),
+                )
+            } else {
+                p.detail
+            };
             pairs.push(PairRow {
                 id: p.id,
                 percent: (p.score * 100.0).round() as i64,
@@ -1112,7 +1132,8 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
                 b_title: title_of(&b),
                 a_id: p.a_id,
                 b_id: p.b_id,
-                detail: p.detail,
+                detail,
+                via_link,
                 contradiction: state == crate::store::pairs::PairState::Contradiction,
                 obsolete_title,
                 keeps_a,
@@ -1283,7 +1304,7 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             true => Some(st.core.store.feedback_stats().await?),
             false => None,
         },
-        links: match st.core.associate.enabled && st.core.feedback.enabled {
+        links: match st.core.associating() {
             true => Some(st.core.store.link_counts().await?),
             false => None,
         },
@@ -1605,27 +1626,35 @@ pub(crate) async fn build_artifact_detail(
         })
         .collect();
     // Unreadable links are not a missing pane, for the same reason a missing
-    // neighbour list is not: this layer can only ever add.
+    // neighbour list is not: this layer can only ever add. And gated on
+    // `associating()`, not just `associate.enabled`: a base that learned
+    // links and then had the feature switched off must stop rendering them,
+    // the same as every other associative surface.
     let anchor = vec![c.id.clone()];
-    let seen_together_links = match core
-        .store
-        .links_from(
-            &anchor,
-            &[
-                crate::store::links::LinkState::Learning,
-                crate::store::links::LinkState::Related,
-            ],
-            core.associate.half_life_days,
-            crate::store::now(),
-            core.associate.show_min,
-        )
-        .await
-    {
-        Ok(l) => l,
-        Err(e) => {
-            tracing::warn!(artifact_id, error = %e, "no links for this pane");
-            vec![]
+    let seen_together_links = if core.associating() {
+        match core
+            .store
+            .links_from(
+                &anchor,
+                &[
+                    crate::store::links::LinkState::Learning,
+                    crate::store::links::LinkState::Related,
+                ],
+                core.associate.half_life_days,
+                crate::store::now(),
+                core.associate.show_min,
+                RELATED_LIMIT as i64,
+            )
+            .await
+        {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(artifact_id, error = %e, "no links for this pane");
+                vec![]
+            }
         }
+    } else {
+        vec![]
     };
     let mut seen_together = Vec::new();
     for l in seen_together_links.into_iter().take(RELATED_LIMIT) {
@@ -2442,7 +2471,8 @@ mod tests {
 
     #[tokio::test]
     async fn the_pane_lists_what_this_artifact_is_seen_together_with() {
-        let core = crate::core::test_support::test_core().await;
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
         let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
         core.store
             .bump_link(
@@ -2468,7 +2498,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_judged_link_shows_the_judges_line_instead_of_the_query() {
-        let core = crate::core::test_support::test_core().await;
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
         let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -2536,7 +2567,8 @@ mod tests {
     async fn a_pane_still_renders_when_the_links_cannot_be_read() {
         // The associative layer can only add. It is not a reason to refuse to
         // show an artifact beside its source.
-        let core = crate::core::test_support::test_core().await;
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
         let ids = artifacts(&core, &["alpha text"]).await;
         sqlx::query("DROP TABLE artifact_links")
             .execute(&core.store.pool)
@@ -2551,7 +2583,8 @@ mod tests {
         // "Two documents needing each other is the finding; two passages of one
         // document needing each other is not" is the whole point of the flag —
         // pin it on the data the pane renders, not on a CSS class name.
-        let core = crate::core::test_support::test_core().await;
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
         let ids = artifacts(&core, &["alpha text", "same corpus neighbour"]).await;
         let other_corpus = core.store.insert_corpus("y", "web", None).await.unwrap();
         let made = core

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1111,12 +1111,33 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
             // `a` obsolete is a recommendation to keep `b`.
             let keeps_a = p.obsolete_id.as_deref() == Some(b.id.as_str());
             let keeps_b = p.obsolete_id.as_deref() == Some(a.id.as_str());
-            // The judge's `duplicate` verdict files this pair with
-            // `detail = "link"` (`src/jobs/associate.rs`) — a provenance
-            // marker meant for code, not the reader. Rendered as a sentence
-            // here rather than the bare token; the stored value is untouched.
-            let via_link = p.detail.as_deref() == Some("link");
-            let detail = if via_link {
+            // A score of exactly zero is what "no cosine was ever measured"
+            // looks like in the row: the link judge's `duplicate` verdict files
+            // the pair with one (`src/jobs/associate.rs`), and the similarity
+            // sweep — the only other producer of a pending pair — files the
+            // cosine it found, which cleared `consolidate.review_min` to get
+            // there (`src/jobs/relate.rs:68`).
+            //
+            // That gate is `>=` and `review_min` has no lower bound of its own
+            // — only `auto_supersede > review_min` is enforced — so an operator
+            // who sets it to zero could in principle file a pair measured at
+            // exactly 0.0, and this would call it unmeasured. It takes an exact
+            // float zero out of a real embedding to get there, which is why the
+            // marker is left implicit; if that ever stops being true the fix is
+            // an explicit `origin` column, not a smaller epsilon.
+            //
+            // Not `detail == "link"`, which is only the *initial* detail: the
+            // dedupe judge's `set_pair_state` and `set_pair_superseded`
+            // (`src/store/pairs.rs`) both write their own prose over that
+            // field, so a marker read out of it survives only while the pair is
+            // pending. The score is never rewritten.
+            let via_link = p.score == 0.0;
+            // The bare marker, on the other hand, *is* read out of `detail` —
+            // it is the whole of that field only while the pair is pending, and
+            // that is exactly when there is no judge's line to lose. Once one
+            // has been written the prose is what the reader needs; the score
+            // above still keeps the page from calling it a measurement.
+            let detail = if p.detail.as_deref() == Some("link") {
                 Some(
                     "Not found by similarity: these two kept being retrieved together, \
                      and the judge then found they say the same thing."
@@ -2160,6 +2181,73 @@ mod tests {
     /// particular way.
     async fn app_for(core: crate::core::Core) -> (axum::Router, String) {
         app_with_cookie(core).await
+    }
+
+    #[tokio::test]
+    async fn a_link_derived_pair_never_claims_a_similarity_once_the_judge_has_settled_it() {
+        // The link judge files these with `detail = "link"` and a score of 0.0,
+        // because no cosine was ever measured. But `detail` is where the dedupe
+        // judge then writes its own prose — `set_pair_state` and
+        // `set_pair_superseded` both overwrite it — so provenance read out of
+        // that field survives only while the pair is pending. Once it settles,
+        // the page would go back to rendering the placeholder score, and
+        // "0% alike" reads as a measurement meaning "nothing alike".
+        let core = crate::core::test_support::test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "the first one".into(),
+                        corpus_span: None,
+                        title: Some("first".into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "the second one".into(),
+                        corpus_span: None,
+                        title: Some("second".into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        core.store
+            .record_pair_with_detail(&made[0].id, &made[1].id, 0.0, "link")
+            .await
+            .unwrap();
+        let id: i64 = sqlx::query_scalar("SELECT id FROM artifact_pairs")
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap();
+        // The dedupe judge answers, and writes its line over the marker.
+        core.store
+            .set_pair_state(
+                id,
+                crate::store::pairs::PairState::Contradiction,
+                Some("one says the opposite of the other"),
+            )
+            .await
+            .unwrap();
+
+        let (app, cookie) = app_for(core).await;
+        let html = flat(&get(&app, "/ui/capture", &cookie).await);
+
+        assert!(
+            !html.contains("0% alike"),
+            "a pair no cosine was ever measured for reports a measured similarity"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1730,16 +1730,7 @@ async fn dismiss_link(
     _id: Identity,
     Path((artifact_id, other_id)): Path<(String, String)>,
 ) -> Result<Response> {
-    st.core
-        .store
-        .set_link_state(
-            &artifact_id,
-            &other_id,
-            crate::store::links::LinkState::Dismissed,
-            None,
-            None,
-        )
-        .await?;
+    st.core.store.dismiss_link(&artifact_id, &other_id).await?;
     // The row swaps itself out and leaves the pane alone, so the artifact you
     // were reading is still on screen afterwards.
     Ok(axum::response::Html(String::new()).into_response())
@@ -2533,6 +2524,70 @@ mod tests {
             .unwrap();
         let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
         assert!(d.seen_together.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_cross_corpus_pair_is_marked_and_a_same_corpus_pair_is_not() {
+        // "Two documents needing each other is the finding; two passages of one
+        // document needing each other is not" is the whole point of the flag —
+        // pin it on the data the pane renders, not on a CSS class name.
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text", "same corpus neighbour"]).await;
+        let other_corpus = core.store.insert_corpus("y", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &other_corpus.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "body of other document".to_string(),
+                    corpus_span: None,
+                    title: Some("other document".to_string()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        let cross_id = made[0].id.clone();
+
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q1"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .bump_link(
+                &ids[0],
+                &cross_id,
+                5.0,
+                Some("q2"),
+                30.0,
+                crate::store::now(),
+            )
+            .await
+            .unwrap();
+
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        let same = d
+            .seen_together
+            .iter()
+            .find(|r| r.id == ids[1])
+            .expect("the same-corpus pair should still be listed");
+        let cross = d
+            .seen_together
+            .iter()
+            .find(|r| r.id == cross_id)
+            .expect("the cross-corpus pair should be listed");
+        assert!(
+            !same.cross_corpus,
+            "two passages of one document is not the finding"
+        );
+        assert!(
+            cross.cross_corpus,
+            "two documents needing each other is the finding"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2430,6 +2430,7 @@ mod tests {
             superseded_by: None,
             last_verified_at: None,
             weak,
+            primed: false,
         };
 
         let loose = render_hit(0, result(true));

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2431,6 +2431,8 @@ mod tests {
             last_verified_at: None,
             weak,
             primed: false,
+            via: None,
+            reason: None,
         };
 
         let loose = render_hit(0, result(true));

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -38,6 +38,14 @@ pub struct RenderedResult {
     pub rank: String,
     /// Only loosely related to the query — see `SearchResult::weak`.
     pub weak: bool,
+    /// This hit moved up on activation. A small marker, because the claim is
+    /// small: it passed a near-tie, it did not become a better match.
+    pub primed: bool,
+    /// The title of the ranked hit that recalled this one. Set only on an
+    /// associated hit, and it is what the row names.
+    pub via_title: Option<String>,
+    /// The judge's line, where the link was judged.
+    pub reason: Option<String>,
 }
 
 pub struct QueueRow {
@@ -337,6 +345,9 @@ struct SearchTemplate {
 #[template(path = "_results.html")]
 struct ResultsTemplate {
     results: Vec<RenderedResult>,
+    /// Recalled by association with a ranked hit, never ranked against the
+    /// query itself. Shown below the ranked list, under its own rule.
+    associated: Vec<RenderedResult>,
     /// Every result is only loosely related, so the page says so once above the
     /// list instead of repeating it on each card.
     all_weak: bool,
@@ -645,6 +656,7 @@ async fn search_results(
     if p.q.trim().is_empty() {
         return Ok(HtmlTemplate(ResultsTemplate {
             results: vec![],
+            associated: vec![],
             all_weak: false,
             terms: String::new(),
             timing: String::new(),
@@ -678,25 +690,50 @@ async fn search_results(
         )
         .await?;
 
-    let results: Vec<RenderedResult> = hits
+    // The ranked answer and what it recalled are two lists on the page, and one
+    // list here: an associated hit carries the id of the hit that recalled it,
+    // and the title is looked up among the ranked ones rather than fetched.
+    let titles: std::collections::HashMap<String, String> = hits
+        .iter()
+        .filter(|h| h.via.is_none())
+        .map(|h| {
+            (
+                h.artifact_id.clone(),
+                h.title.clone().unwrap_or_else(|| "Untitled".into()),
+            )
+        })
+        .collect();
+    let (ranked, recalled): (Vec<_>, Vec<_>) = hits.into_iter().partition(|h| h.via.is_none());
+    let results: Vec<RenderedResult> = ranked
         .into_iter()
         .enumerate()
-        .map(|(i, h)| render_hit(i, h))
+        .map(|(i, h)| render_hit(i, h, &titles))
+        .collect();
+    let associated: Vec<RenderedResult> = recalled
+        .into_iter()
+        .map(|h| render_hit(0, h, &titles))
         .collect();
     Ok(HtmlTemplate(ResultsTemplate {
         // Only when *every* result is loose. One weak hit at the bottom of a
         // good list is ordinary — it is the tail of any ranking — and saying
         // "nothing matches" over a list that plainly does would train the
-        // operator to ignore the warning.
+        // operator to ignore the warning. Computed from `results` only: an
+        // association is not an answer to the query and cannot make the
+        // answer look better or worse than it was.
         all_weak: !results.is_empty() && results.iter().all(|r| r.weak),
         results,
+        associated,
         terms,
         timing: format!("embed {}ms · total {}ms", t.embed_ms, t.total_ms),
     })
     .into_response())
 }
 
-fn render_hit(position: usize, h: crate::core::search::SearchResult) -> RenderedResult {
+fn render_hit(
+    position: usize,
+    h: crate::core::search::SearchResult,
+    titles: &std::collections::HashMap<String, String>,
+) -> RenderedResult {
     RenderedResult {
         artifact_id: h.artifact_id,
         title: h.title.unwrap_or_else(|| "Untitled".into()),
@@ -705,12 +742,18 @@ fn render_hit(position: usize, h: crate::core::search::SearchResult) -> Rendered
         category: h.category,
         tags: h.tags,
         corpus_id: h.corpus_id,
-        rank: if h.weak {
+        // No rank on an associated hit — the same reasoning that drops the
+        // rank on a weak one: a rank is a claim about standing among answers,
+        // and this did not compete for one.
+        rank: if h.weak || h.via.is_some() {
             String::new()
         } else {
             format!("#{}", position + 1)
         },
         weak: h.weak,
+        primed: h.primed,
+        via_title: h.via.as_ref().and_then(|v| titles.get(v).cloned()),
+        reason: h.reason.clone(),
     }
 }
 
@@ -1464,7 +1507,7 @@ async fn ask_submit(
             .citations
             .into_iter()
             .enumerate()
-            .map(|(i, h)| render_hit(i, h))
+            .map(|(i, h)| render_hit(i, h, &Default::default()))
             .collect(),
         dropped: out.dropped,
     })
@@ -1709,7 +1752,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let r = super::render_hit(0, hits[0].clone());
+        let r = super::render_hit(0, hits[0].clone(), &Default::default());
 
         assert!(
             !r.artifact_id.is_empty(),
@@ -2435,13 +2478,14 @@ mod tests {
             reason: None,
         };
 
-        let loose = render_hit(0, result(true));
+        let loose = render_hit(0, result(true), &Default::default());
         assert!(loose.weak);
         assert!(loose.rank.is_empty(), "a loose result was presented as #1");
-        assert_eq!(render_hit(0, result(false)).rank, "#1");
+        assert_eq!(render_hit(0, result(false), &Default::default()).rank, "#1");
 
         let html = askama::Template::render(&ResultsTemplate {
             results: vec![loose],
+            associated: vec![],
             all_weak: true,
             terms: String::new(),
             timing: String::new(),
@@ -2449,6 +2493,73 @@ mod tests {
         .unwrap();
         assert!(html.contains("Nothing matches closely"), "{html}");
         assert!(!html.contains("#1"), "{html}");
+    }
+
+    fn rendered(via: Option<&str>, reason: Option<&str>) -> RenderedResult {
+        RenderedResult {
+            artifact_id: "a1".into(),
+            title: "The one that was recalled".into(),
+            html: String::new(),
+            snippet: "a snippet".into(),
+            category: None,
+            tags: vec![],
+            corpus_id: "c1".into(),
+            rank: String::new(),
+            weak: false,
+            primed: false,
+            via_title: via.map(str::to_string),
+            reason: reason.map(str::to_string),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_results_name_what_recalled_an_associated_hit() {
+        // An associated hit says which hit recalled it, or it is an unexplained
+        // result in a list the reader believes is ranked. Rendered directly
+        // rather than driven through a search: the UI handler asks for the
+        // default limit, so on any base small enough to reason about, every
+        // artifact is already ranked and there is nothing left to recall. What
+        // this task changed is the split and the copy, and that is what this
+        // pins.
+        let template = ResultsTemplate {
+            results: vec![],
+            associated: vec![rendered(Some("Mounting E01 images"), None)],
+            all_weak: false,
+            terms: String::new(),
+            timing: String::new(),
+        };
+        let body = template.render().unwrap();
+        assert!(body.contains("Recalled by association"), "{body}");
+        assert!(body.contains("seen together with"), "{body}");
+        assert!(body.contains("Mounting E01 images"), "{body}");
+
+        // A judged link says what the relation is instead of what was asked.
+        let judged = ResultsTemplate {
+            results: vec![],
+            associated: vec![rendered(
+                Some("Mounting E01 images"),
+                Some("the tool and its errors"),
+            )],
+            all_weak: false,
+            terms: String::new(),
+            timing: String::new(),
+        };
+        let body = judged.render().unwrap();
+        assert!(body.contains("the tool and its errors"), "{body}");
+        assert!(!body.contains("seen together with"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn an_association_cannot_make_the_answer_look_worse_than_it_was() {
+        // `all_weak` is a statement about how well the *query* was answered. An
+        // associated hit did not answer the query at all, so counting it either
+        // way would put a warning over a good list, or take one off a bad one.
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["alpha text"]).await;
+        crate::jobs::embed::run(&core, &ids[0]).await.unwrap();
+
+        let body = get_body(&app, &cookie, "/ui/search/results?q=alpha").await;
+        assert!(!body.contains("Recalled by association"), "{body}");
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -144,6 +144,11 @@ pub struct ArtifactDetail {
     /// vector is already stored, so this costs no embedding call and no
     /// completion. Empty while the artifact is still waiting to be embedded.
     pub related: Vec<RelatedArtifact>,
+    /// What this artifact has been needed alongside, learned from co-retrieval
+    /// rather than resemblance. Beside `related`, not instead of it: one list
+    /// is what this resembles, the other is what it has been reached for
+    /// together with, and they answer different questions.
+    pub seen_together: Vec<SeenTogether>,
 }
 
 /// A neighbour, as one line in the pane.
@@ -151,6 +156,22 @@ pub struct RelatedArtifact {
     pub id: String,
     pub title: String,
     pub snippet: String,
+}
+
+/// A link, as one line in the pane. Beside the nearest neighbours, not instead
+/// of them: one list is what this artifact resembles, the other is what it has
+/// been needed alongside, and they answer different questions.
+pub struct SeenTogether {
+    pub id: String,
+    pub title: String,
+    pub snippet: String,
+    /// The judge's line, or the question that bound the pair. `None` only for a
+    /// link with neither, which is a link nothing can explain yet.
+    pub why: Option<String>,
+    pub corpus_title: String,
+    /// Rendered emphasised: two documents needing each other is the finding.
+    /// Two passages of one document needing each other is not.
+    pub cross_corpus: bool,
 }
 
 /// Work that hit something and is waiting to try again by itself.
@@ -1575,6 +1596,60 @@ pub(crate) async fn build_artifact_detail(
             id: h.payload.artifact_id,
         })
         .collect();
+    // Unreadable links are not a missing pane, for the same reason a missing
+    // neighbour list is not: this layer can only ever add.
+    let anchor = vec![c.id.clone()];
+    let seen_together_links = match core
+        .store
+        .links_from(
+            &anchor,
+            &[
+                crate::store::links::LinkState::Learning,
+                crate::store::links::LinkState::Related,
+            ],
+            core.associate.half_life_days,
+            crate::store::now(),
+            core.associate.show_min,
+        )
+        .await
+    {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(artifact_id, error = %e, "no links for this pane");
+            vec![]
+        }
+    };
+    let mut seen_together = Vec::new();
+    for l in seen_together_links.into_iter().take(RELATED_LIMIT) {
+        let Ok(other) = core.store.get_artifact(&l.other).await else {
+            continue;
+        };
+        let corpus_title = match &other.corpus_id {
+            Some(id) => core
+                .store
+                .get_corpus(id)
+                .await
+                .ok()
+                .and_then(|s| s.title_hint)
+                .unwrap_or_else(|| "untitled".into()),
+            // A merged artifact belongs to no document, which is worth saying
+            // rather than leaving blank.
+            None => "merged".to_string(),
+        };
+        seen_together.push(SeenTogether {
+            title: title_of(&other),
+            snippet: markdown::snippet(&other.text, 90),
+            // The judge's line where there is one; otherwise the question that
+            // bound them, which is the link's own explanation and free.
+            why: l
+                .reason
+                .clone()
+                .or_else(|| l.cues.first().map(|c| format!("when asking: {}", c.q))),
+            corpus_title,
+            cross_corpus: l.cross_corpus,
+            id: other.id,
+        });
+    }
     // Built before the struct consumes `c`. The fragment is what makes the
     // browser scroll to the span; the query parameters are what make the page
     // highlight it.
@@ -1591,6 +1666,7 @@ pub(crate) async fn build_artifact_detail(
     let orphaned_source = c.flags.iter().any(|f| f == "orphaned_source");
     Ok(ArtifactDetail {
         related,
+        seen_together,
         orphaned_source,
         source_at_lines,
         id: c.id,
@@ -1644,6 +1720,31 @@ async fn artifact_detail(
     .into_response())
 }
 
+/// The operator saying this pair does not belong together.
+///
+/// Final for that pair: never shown, never judged, never pruned. The weight is
+/// left exactly as it is, so the decision stays auditable against the evidence
+/// that produced it — undoing one is out of scope, and Ops is where it would go.
+async fn dismiss_link(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path((artifact_id, other_id)): Path<(String, String)>,
+) -> Result<Response> {
+    st.core
+        .store
+        .set_link_state(
+            &artifact_id,
+            &other_id,
+            crate::store::links::LinkState::Dismissed,
+            None,
+            None,
+        )
+        .await?;
+    // The row swaps itself out and leaves the pane alone, so the artifact you
+    // were reading is still on screen afterwards.
+    Ok(axum::response::Html(String::new()).into_response())
+}
+
 /// Clearing a flag is a judgement, not a fix: the operator looked at the chunk
 /// beside its source lines and decided the warning was noise.
 async fn mark_artifact_reviewed(
@@ -1682,6 +1783,10 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/corpora/{id}/reprocess", post(reprocess_ui))
         .route("/ui/artifacts/{id}", get(artifact_detail).put(put_artifact))
         .route("/ui/artifacts/{cid}/reviewed", post(mark_artifact_reviewed))
+        .route(
+            "/ui/artifacts/{id}/links/{other}/dismiss",
+            post(dismiss_link),
+        )
         .route("/ui/artifacts/{id}/delete", post(delete_artifact_ui))
         .route("/ui/ask", get(ask_page).post(ask_submit))
         .route("/ui/ops", get(ops))
@@ -2322,6 +2427,112 @@ mod tests {
             "an artifact must not be listed as its own neighbour"
         );
         assert!(d.related.len() <= RELATED_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn the_pane_lists_what_this_artifact_is_seen_together_with() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(
+                &ids[0],
+                &ids[1],
+                5.0,
+                Some("mount forensic image"),
+                30.0,
+                crate::store::now(),
+            )
+            .await
+            .unwrap();
+
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        assert_eq!(d.seen_together.len(), 1);
+        assert_eq!(d.seen_together[0].id, ids[1]);
+        assert_eq!(
+            d.seen_together[0].why.as_deref(),
+            Some("when asking: mount forensic image"),
+            "an unjudged link explains itself with the question that bound it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_judged_link_shows_the_judges_line_instead_of_the_query() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+        core.store
+            .set_link_state(
+                &ids[0],
+                &ids[1],
+                crate::store::links::LinkState::Related,
+                Some("the tool and the error it prints"),
+                Some((0, 0)),
+            )
+            .await
+            .unwrap();
+
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        assert_eq!(
+            d.seen_together[0].why.as_deref(),
+            Some("the tool and the error it prints")
+        );
+    }
+
+    #[tokio::test]
+    async fn dismissing_a_link_takes_it_out_for_good_without_losing_the_evidence() {
+        // The weight stays, so the decision is auditable; the state is final,
+        // so it is never shown, judged or pruned again.
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{}/links/{}/dismiss", ids[0], ids[1]),
+                &cookie,
+                "",
+            ))
+            .await
+            .unwrap();
+
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(l.state, crate::store::links::LinkState::Dismissed);
+        assert!(
+            l.weight > 0.0,
+            "the evidence was thrown away with the decision"
+        );
+        assert!(
+            build_artifact_detail(&core, &ids[0], "")
+                .await
+                .unwrap()
+                .seen_together
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pane_still_renders_when_the_links_cannot_be_read() {
+        // The associative layer can only add. It is not a reason to refuse to
+        // show an artifact beside its source.
+        let core = crate::core::test_support::test_core().await;
+        let ids = artifacts(&core, &["alpha text"]).await;
+        sqlx::query("DROP TABLE artifact_links")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        assert!(d.seen_together.is_empty());
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2550,16 +2550,84 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_association_cannot_make_the_answer_look_worse_than_it_was() {
-        // `all_weak` is a statement about how well the *query* was answered. An
-        // associated hit did not answer the query at all, so counting it either
-        // way would put a warning over a good list, or take one off a bad one.
+    async fn an_unlinked_search_shows_no_association() {
+        // Nothing was linked, so there is nothing to recall. This only pins
+        // the absence of the section on a corpus with no links — the
+        // `all_weak` invariant itself is proven separately below, since this
+        // search never has an association present to prove it against.
         let (app, cookie, core) = app_session_and_core().await;
         let ids = artifacts(&core, &["alpha text"]).await;
         crate::jobs::embed::run(&core, &ids[0]).await.unwrap();
 
         let body = get_body(&app, &cookie, "/ui/search/results?q=alpha").await;
         assert!(!body.contains("Recalled by association"), "{body}");
+    }
+
+    fn ranked(weak: bool) -> RenderedResult {
+        RenderedResult {
+            artifact_id: "r1".into(),
+            title: "The ranked hit".into(),
+            html: String::new(),
+            snippet: "a snippet".into(),
+            category: None,
+            tags: vec![],
+            corpus_id: "c1".into(),
+            rank: if weak { String::new() } else { "#1".into() },
+            weak,
+            primed: false,
+            via_title: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn an_association_cannot_make_the_answer_look_worse_than_it_was() {
+        // `all_weak` is a statement about how well the *query* was answered. An
+        // associated hit did not answer the query at all, so its presence must
+        // not move this verdict either way. Proven both directions: a weak
+        // ranked answer still warns with an association beside it, and a good
+        // ranked answer stays silent with one beside it too.
+        let weak_with_association = ResultsTemplate {
+            results: vec![ranked(true)],
+            associated: vec![rendered(Some("Mounting E01 images"), None)],
+            all_weak: true,
+            terms: String::new(),
+            timing: String::new(),
+        };
+        let body = weak_with_association.render().unwrap();
+        assert!(
+            body.contains("Nothing matches closely"),
+            "an association hid a real warning: {body}"
+        );
+
+        let good_with_association = ResultsTemplate {
+            results: vec![ranked(false)],
+            associated: vec![rendered(Some("Mounting E01 images"), None)],
+            all_weak: false,
+            terms: String::new(),
+            timing: String::new(),
+        };
+        let body = good_with_association.render().unwrap();
+        assert!(
+            !body.contains("Nothing matches closely"),
+            "an association manufactured a warning: {body}"
+        );
+    }
+
+    #[test]
+    fn a_primed_hit_gets_a_small_marker() {
+        let mut r = ranked(false);
+        r.primed = true;
+        let body = ResultsTemplate {
+            results: vec![r],
+            associated: vec![],
+            all_weak: false,
+            terms: String::new(),
+            timing: String::new(),
+        }
+        .render()
+        .unwrap();
+        assert!(body.contains("primed"), "{body}");
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -464,6 +464,10 @@ struct OpsTemplate {
     /// `None` when capture is switched off, which renders nothing at all: a
     /// section about a log nobody is keeping is noise.
     feedback: Option<crate::store::feedback::Stats>,
+    /// `None` when nothing is being learned, which renders nothing at all: a
+    /// count of links on a base that records no searches is a line about a
+    /// feature that is switched off.
+    links: Option<crate::store::links::LinkCounts>,
 }
 
 struct MergedRow {
@@ -1279,6 +1283,10 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             true => Some(st.core.store.feedback_stats().await?),
             false => None,
         },
+        links: match st.core.associate.enabled && st.core.feedback.enabled {
+            true => Some(st.core.store.link_counts().await?),
+            false => None,
+        },
     })
     .into_response())
 }
@@ -2053,6 +2061,18 @@ mod tests {
 
     async fn app_session_and_core() -> (axum::Router, String, crate::core::Core) {
         let core = crate::core::test_support::test_core().await;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        (app, cookie, handle)
+    }
+
+    /// A session whose core records searches, which is what the association
+    /// features are gated on. `app_session_and_core` cannot be reused: the
+    /// router owns its own clone of the core, so flipping a flag afterwards
+    /// changes the handle and not the app.
+    async fn app_session_and_core_with_feedback() -> (axum::Router, String, crate::core::Core) {
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
         let handle = core.clone();
         let (app, cookie) = app_with_cookie(core).await;
         (app, cookie, handle)
@@ -3371,6 +3391,23 @@ mod tests {
         // "None."
         assert!(html.contains("Nothing deprecated"));
         assert!(!html.contains("<h3>Deprecated</h3>"));
+    }
+
+    #[tokio::test]
+    async fn ops_says_how_many_links_there_are_and_how_many_are_named() {
+        let (app, cookie, core) = app_session_and_core_with_feedback().await;
+        let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, "/ui/ops").await;
+        // One `bump_link` call between one pair is one row in `artifact_links`
+        // — see `the_counts_say_how_many_links_there_are_and_how_many_are_named`
+        // in store::links, which needs two calls between two different pairs
+        // to reach a total of two.
+        assert!(page.contains("1 links"), "{page}");
     }
 
     #[tokio::test]

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -328,6 +328,8 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         weak_below: 0.0,
         feedback: engram::config::FeedbackConfig::default(),
         capture: engram::config::CaptureConfig::default(),
+        associate: engram::config::AssociateConfig::default(),
+        activation: engram::config::ActivationConfig::default(),
         // The benchmark makes no background inference call, so the pacer never
         // has anything to hold back.
         gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-16-associative-memory-design.md`.

engram's only notion of relatedness has been semantic — cosine between
embeddings. This adds the other one: things that were *used together*. The
config passage and the troubleshooting passage for one subsystem are
strangers to the embedding and inseparable to the person who needed both to
answer one question.

Two mechanisms, both learned from use, neither touching what is stored:

- **Hebbian links.** Artifacts shown together by the same search grow a link
  (+1 co-appearance, +2 for a confirmed answer). Weights are stored as a value
  plus the stamp it was true at and read through a lazy decay, so forgetting
  costs no writes. Faded links are pruned; strong *cross-corpus* links earn one
  background model call that names the relation, or hands a disguised duplicate
  to consolidation.
- **Activation.** Each artifact carries a decaying accessibility, raised by
  being captured, retrieved, opened and confirmed.

Both surface in exactly two places: the **search results** (bounded priming,
plus one hop of association appended outside `limit`) and the **detail pane**
(a "Seen together" list with the binding queries, cross-corpus rows emphasised).

## The three guards

The design rests on these, and each is enforced and tested:

- **Bounded** — priming moves a hit at most `prime_lift` positions and never
  displaces rank 1. Association appends beside the ranked list; it never
  removes or reorders one.
- **Visible** — a primed hit says so; an associated hit says which hit
  recalled it.
- **One-way** — recalled hits are not written as search candidates and do not
  count as retrievals, so a link can never strengthen itself by having fired.

## Notes for review

Three defects worth knowing about were found and fixed during implementation,
each by a test written before the code:

- The priming algorithm violated its own bound — a hit climbed three places
  with a limit of two, five on a longer list. Adjacent swapping cannot enforce
  a per-row budget; it now decides every destination against the original
  ordering and reorders once.
- Association was reaching `ask`, which synthesises its answer from the hits it
  retrieves. Text that never matched the question was becoming source material.
  Now gated by door.
- The layer was not inert when switched off. Shipping defaults are
  `feedback.enabled = false` and `associate.enabled = true`, and only the sweep
  checked both — so a never-opted-in install wrote activation on every search
  and eventually reordered results. Everything now routes through one
  `Core::associating()` predicate.

## Not done — needs infrastructure

The spec asks for `total_ms` measured with and without the layer, and the eval
harness run with priming off and on against the frozen corpus, **before the
priming defaults move**. Both need a live Qdrant and embedding endpoint, which
the implementation environment did not have (`tests/eval.rs` is `#[ignore]`d
there). No numbers were invented. Worth running before merge — the unbounded
link read fixed in `5450be8` is exactly the kind of thing it would catch.

## Rollout

Additive schema only (two `ADD COLUMN` with defaults, two new tables);
`migrate()` stays idempotent. Inert until `feedback.enabled`. No backfill from
the historical log — the watermarks start at the first sweep.

919 tests passing; `cargo fmt --all --check` and
`cargo clippy --all-targets --locked -- -D warnings` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xUKzBYyQYDU11zneWp4ye
