### PR TITLE
fix(dedupe): stop inventing disagreements, and stop refusing clusters unasked

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ the file — the loader warns if it finds one.
 | `infer.ask.*` | Completion model, used only by `ask`: `base_url`, `model`, `context_tokens`, `max_output_tokens`, `timeout_secs`, `reasoning_effort`, `ceiling_param`. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
 | `infer.vision.*` | Optional. Reads captured images: `model`, `base_url`, `api_key`, `timeout_secs`, `max_output_tokens`, `ceiling_param`. `base_url` and `api_key` default to the synthesize role's, and `ceiling_param` is inherited with them. Off by default. |
-| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `per_point`, `interval_hours`, `dedupe_interval_mins`, `max_dedupe_per_tick`, `merge_max_roots`. |
+| `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `per_point`, `interval_hours`, `dedupe_interval_mins`, `max_dedupe_per_tick`. |
 | `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. Off by default. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails` / `allowed_groups`. |

--- a/config.example.toml
+++ b/config.example.toml
@@ -254,11 +254,6 @@ interval_hours = 24
 # is ever asked about.
 dedupe_interval_mins = 15
 max_dedupe_per_tick = 5
-# How many captured artifacts one merged artifact may be written from. Above
-# this the group is surfaced for a person instead of merged: a merge of forty
-# sources stops being one atomic piece of knowledge, which is what an artifact is.
-merge_max_roots = 8
-
 # Recording real searches so they can be judged later, and turned into the
 # query/artifact pairs the evaluation harness scores against. Off by default: a
 # query log is personal, and it is useful to nobody but you.

--- a/docs/superpowers/plans/2026-08-17-pairwise-merge.md
+++ b/docs/superpowers/plans/2026-08-17-pairwise-merge.md
@@ -1,0 +1,1583 @@
+# Pairwise Merging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the dedupe unit judge exactly two artifacts at a time, so that clusters converge by repeated pairwise merging instead of being refused whole when they flatten to more roots than a configured cap.
+
+**Architecture:** `dedupe::run` stops expanding its seed pair into a connected component and asks about the pair's two members only. A member that is itself a merge contributes its own text as a lettered input and its captured roots as an unlettered, budget-trimmable context block. The fan-in cap disappears with the component, `PairState::Oversized` stops being written, the sixteen rows already in that state are reopened by the sweep, and pending siblings are re-pointed onto a merge once it is indexed so a cluster still converges without waiting on a re-scan.
+
+**Tech Stack:** Rust, `sqlx` against SQLite, `tokio::test` for async unit tests, in-module `#[cfg(test)] mod tests`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-pairwise-merge-design.md`
+
+## Global Constraints
+
+- No new dependencies. Everything needed is already in `Cargo.toml`.
+- `PairState::Oversized` and its `"oversized"` string mapping stay in `src/store/pairs.rs` for one release so existing rows still parse. Nothing may *write* the state after this work.
+- Pair rows are stored with `a_id <= b_id` — `record_pair` canonicalises with `let (a, b) = if a <= b { (a, b) } else { (b, a) };` (`src/store/pairs.rs:144`). Any code that writes `a_id`/`b_id` must preserve that ordering.
+- `artifact_pairs` has a uniqueness constraint on `(a_id, b_id)` — that is what makes `INSERT OR IGNORE` meaningful. Any `UPDATE` that changes a side must check for an existing row first.
+- Comments in this codebase carry the reasoning, not the restatement. When a comment's premise is deleted by this work, rewrite the comment; do not leave it describing code that no longer exists.
+- Run `cargo test` (whole suite) before every commit. Run `cargo clippy --all-targets -- -D warnings` before the final commit of each task.
+
+---
+
+### Task 1: `repoint_open_pairs` in the pair store
+
+Moves pending pairs from a merge's sources onto the merge. Pure store work with no callers yet, so it is testable on its own.
+
+**Files:**
+- Modify: `src/store/pairs.rs` (add method after `dismiss_pairs_merged_into`, around line 430; tests into the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `PairState`, `row_to_pair` (`src/store/pairs.rs:121`), `set_pair_state`, `pair_state_between` — all already in this file.
+- Produces: `Store::repoint_open_pairs(&self, old: &[String], new_id: &str) -> Result<u64>`, returning how many rows were moved (rows dismissed instead are not counted). Task 6 calls it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `src/store/pairs.rs`. The existing tests there build a store with `crate::store::test_support::test_store()` — check the top of that module and follow whatever helper the neighbouring tests use to make artifacts; the snippets below use `s` for the store and `a`/`b`/`c` for artifact ids the same way `a_component_is_every_pair_reachable_through_a_shared_artifact` does.
+
+```rust
+/// The whole point of re-pointing: C was a duplicate of B, B is now inside M,
+/// so C is a duplicate of M and the question survives the merge.
+#[tokio::test]
+async fn an_open_pair_follows_its_member_into_the_merge() {
+    let s = test_store().await;
+    let (a, b, c, m) = (mk(&s).await, mk(&s).await, mk(&s).await, mk(&s).await);
+    s.record_pair(&b, &c, 0.91).await.unwrap();
+    let _ = a;
+
+    let moved = s.repoint_open_pairs(&[b.clone()], &m).await.unwrap();
+
+    assert_eq!(moved, 1);
+    let state = s.pair_state_between(&c, &m).await.unwrap();
+    assert_eq!(state, Some(PairState::Pending), "the pair did not follow B into M");
+    assert_eq!(s.pair_state_between(&b, &c).await.unwrap(), None, "the old pair is still there");
+}
+
+/// A pair between the merge's two own sources becomes a pair of the merge with
+/// itself. There is no question left in it.
+#[tokio::test]
+async fn a_pair_between_two_sources_of_the_same_merge_is_dismissed() {
+    let s = test_store().await;
+    let (a, b, m) = (mk(&s).await, mk(&s).await, mk(&s).await);
+    s.record_pair(&a, &b, 0.91).await.unwrap();
+
+    let moved = s.repoint_open_pairs(&[a.clone(), b.clone()], &m).await.unwrap();
+
+    assert_eq!(moved, 0, "a self-pair was written");
+    assert_eq!(s.pair_state_between(&a, &b).await.unwrap(), Some(PairState::Dismissed));
+}
+
+/// An operator's decision outlives the merge. Re-pointing onto a pair someone
+/// already dismissed must not put that question back, which is the same
+/// property `record_pair`'s INSERT OR IGNORE provides.
+#[tokio::test]
+async fn re_pointing_onto_an_existing_pair_leaves_the_existing_row_alone() {
+    let s = test_store().await;
+    let (b, c, m) = (mk(&s).await, mk(&s).await, mk(&s).await);
+    s.record_pair(&c, &m, 0.80).await.unwrap();
+    let existing = s.pair_state_between(&c, &m).await.unwrap();
+    assert_eq!(existing, Some(PairState::Pending));
+    let row = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+    let existing_id = row[0].id;
+    s.set_pair_state(existing_id, PairState::Dismissed, Some("operator")).await.unwrap();
+    s.record_pair(&b, &c, 0.91).await.unwrap();
+
+    let moved = s.repoint_open_pairs(&[b.clone()], &m).await.unwrap();
+
+    assert_eq!(moved, 0);
+    assert_eq!(
+        s.pair_state_between(&c, &m).await.unwrap(),
+        Some(PairState::Dismissed),
+        "an operator's dismissal was overwritten"
+    );
+    assert_eq!(s.pair_state_between(&b, &c).await.unwrap(), Some(PairState::Dismissed));
+}
+
+/// The re-pointed row asks a different question than the one that earned the
+/// counters, so it must not inherit a backoff from artifacts it no longer names.
+#[tokio::test]
+async fn a_re_pointed_pair_starts_its_attempts_over() {
+    let s = test_store().await;
+    let (b, c, m) = (mk(&s).await, mk(&s).await, mk(&s).await);
+    s.record_pair(&b, &c, 0.91).await.unwrap();
+    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    s.record_judge_attempt(id).await.unwrap();
+    s.record_unreadable_judgement(id).await.unwrap();
+
+    s.repoint_open_pairs(&[b.clone()], &m).await.unwrap();
+
+    let moved = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+    let moved = moved.iter().find(|p| p.a_id == m || p.b_id == m).expect("the row moved");
+    assert_eq!(moved.judge_attempts, 0);
+    assert_eq!(moved.judge_unreadable, 0);
+}
+
+/// Only pending rows move. A settled pair is an answered question and moving it
+/// would re-file it against a different artifact under someone else's verdict.
+#[tokio::test]
+async fn a_settled_pair_is_not_re_pointed() {
+    let s = test_store().await;
+    let (b, c, m) = (mk(&s).await, mk(&s).await, mk(&s).await);
+    s.record_pair(&b, &c, 0.91).await.unwrap();
+    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    s.set_pair_state(id, PairState::NoConflict, None).await.unwrap();
+
+    let moved = s.repoint_open_pairs(&[b.clone()], &m).await.unwrap();
+
+    assert_eq!(moved, 0);
+    assert_eq!(s.pair_state_between(&b, &c).await.unwrap(), Some(PairState::NoConflict));
+}
+```
+
+If `mk` and `test_store` are not the helper names this module already uses, use whatever the neighbouring tests use rather than adding new helpers.
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+Run: `cargo test --lib store::pairs::tests::an_open_pair_follows_its_member_into_the_merge`
+Expected: compile error, `no method named 'repoint_open_pairs'`.
+
+- [ ] **Step 3: Implement the method**
+
+```rust
+    /// Move every still-open pair that names one of `old` onto `new_id`.
+    ///
+    /// Called when a merge is finished, so that a duplicate of one of its
+    /// sources becomes a duplicate of the merge rather than dying with the
+    /// source. Without this a cluster only converges by waiting for the merge
+    /// to embed and a later similarity sweep to re-file the same question,
+    /// which is a whole tick per generation.
+    ///
+    /// Three rows never move. One whose other side is already `new_id` would
+    /// become a pair of the merge with itself. One that would collide with an
+    /// existing pair between the same two artifacts must leave that row alone,
+    /// whatever state it is in — that is what keeps an operator's dismissal
+    /// binding, the same property `record_pair`'s `INSERT OR IGNORE` provides.
+    /// Both are dismissed instead, because the question they carried has been
+    /// answered by the merge. And a row that is not `Pending` is an answered
+    /// question already; moving it would re-file someone's verdict against an
+    /// artifact it was never about.
+    ///
+    /// `judge_attempts` and `judge_unreadable` reset, because the moved row
+    /// asks about a different pair of artifacts than the one that earned those
+    /// counts. This cannot loop forever: every merge takes one artifact out of
+    /// results, so the sequence of merges a cluster can produce is finite.
+    ///
+    /// `score` is deliberately left alone and is now stale — it was measured
+    /// between the old member and the other side. It orders the judge queue and
+    /// gates nothing at this point, so the staleness costs ordering accuracy
+    /// and nothing else.
+    pub async fn repoint_open_pairs(&self, old: &[String], new_id: &str) -> Result<u64> {
+        let mut moved = 0u64;
+        for o in old {
+            if o == new_id {
+                continue;
+            }
+            let rows = sqlx::query(
+                "SELECT * FROM artifact_pairs
+                  WHERE state = 'pending' AND (a_id = ? OR b_id = ?)",
+            )
+            .bind(o)
+            .bind(o)
+            .fetch_all(&self.pool)
+            .await?;
+            for p in rows.iter().map(row_to_pair) {
+                let other = if p.a_id == *o { p.b_id.clone() } else { p.a_id.clone() };
+                if other == new_id {
+                    self.set_pair_state(
+                        p.id,
+                        PairState::Dismissed,
+                        Some("its other side is now this merge"),
+                    )
+                    .await?;
+                    continue;
+                }
+                if self.pair_state_between(&other, new_id).await?.is_some() {
+                    self.set_pair_state(
+                        p.id,
+                        PairState::Dismissed,
+                        Some("a pair between these two already exists"),
+                    )
+                    .await?;
+                    continue;
+                }
+                let (a, b) = if other.as_str() <= new_id {
+                    (other.as_str(), new_id)
+                } else {
+                    (new_id, other.as_str())
+                };
+                sqlx::query(
+                    "UPDATE artifact_pairs
+                        SET a_id = ?, b_id = ?, judge_attempts = 0, judge_unreadable = 0,
+                            detail = NULL
+                      WHERE id = ?",
+                )
+                .bind(a)
+                .bind(b)
+                .bind(p.id)
+                .execute(&self.pool)
+                .await?;
+                moved += 1;
+            }
+        }
+        Ok(moved)
+    }
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+Run: `cargo test --lib store::pairs`
+Expected: PASS, including the five new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/store/pairs.rs
+git commit -m "feat(store): move an open pair onto the merge that swallowed its member"
+```
+
+---
+
+### Task 2: Reopening what the cap already refused
+
+**Files:**
+- Modify: `src/store/pairs.rs` (method beside `repoint_open_pairs`; test into the same `mod tests`)
+
+**Interfaces:**
+- Produces: `Store::reopen_oversized(&self) -> Result<u64>`, returning how many rows were reopened. Task 7 calls it from the sweep.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+/// Sixteen of these exist in the field, every one with judge_attempts = 0: the
+/// cap refused them before any call, and `pairs_to_judge` only ever looks at
+/// pending rows, so nothing could reach them again.
+#[tokio::test]
+async fn an_oversized_pair_goes_back_into_the_queue() {
+    let s = test_store().await;
+    let (a, b) = (mk(&s).await, mk(&s).await);
+    s.record_pair(&a, &b, 0.91).await.unwrap();
+    let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+    s.set_pair_state(id, PairState::Oversized, Some("12 sources, cap is 8")).await.unwrap();
+
+    assert_eq!(s.reopen_oversized().await.unwrap(), 1);
+
+    let back = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+    assert_eq!(back.len(), 1);
+    assert_eq!(back[0].detail, None, "the cap's line is still on a pending row");
+    assert_eq!(back[0].judge_attempts, 0);
+    // Runs every sweep; once the queue is drained it must do nothing at all.
+    assert_eq!(s.reopen_oversized().await.unwrap(), 0);
+}
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cargo test --lib store::pairs::tests::an_oversized_pair_goes_back_into_the_queue`
+Expected: compile error, `no method named 'reopen_oversized'`.
+
+- [ ] **Step 3: Implement**
+
+```rust
+    /// Put every pair the fan-in cap refused back into the judge queue.
+    ///
+    /// `Oversized` was terminal and reached without a call ever being made: the
+    /// component flattened to more roots than the cap and every pair in it was
+    /// settled before the model saw anything. Pairwise merging removes the
+    /// condition, so the rows left behind are simply unanswered questions.
+    ///
+    /// Run every sweep rather than once behind a guard. Nothing writes the
+    /// state any more, so the first pass drains it and every later one matches
+    /// no rows — which is cheaper than the machinery a one-shot would need.
+    ///
+    /// Safe to run with the queue in any state: the refused rows never spent a
+    /// call, so `judge_attempts` is zero and no backoff is being reset.
+    pub async fn reopen_oversized(&self) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs SET state = 'pending', detail = NULL
+              WHERE state = 'oversized'",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+Run: `cargo test --lib store::pairs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/store/pairs.rs
+git commit -m "feat(store): put the pairs the cap refused back in the queue"
+```
+
+---
+
+### Task 3: The two-member prompt
+
+**Files:**
+- Modify: `src/infer/prompt.rs:239` (`dedupe_prompt`), `src/infer/prompt.rs:170` (`DEDUPE_SYSTEM`), tests in the same file's `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct DedupeMember<'a> {
+      pub title: &'a str,
+      pub text: &'a str,
+      pub sources: Vec<(&'a str, &'a str)>,
+  }
+  pub fn dedupe_prompt(a: &DedupeMember<'_>, b: &DedupeMember<'_>, attempt: i64) -> String
+  ```
+  Task 4 and Task 5 call it. `sources` is `(title, text)` pairs, oldest first, and is empty for a member that was captured rather than merged.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// A merged member's own wording is what is being judged, and its captured
+/// roots are there so the model can put back a detail the earlier merge
+/// dropped. Both appear; only the member is lettered.
+#[test]
+fn a_merged_member_is_shown_with_its_sources_beneath_it() {
+    let a = DedupeMember {
+        title: "Pool sizing",
+        text: "the pool holds sixteen",
+        sources: vec![("Pool sizing, 2024", "max_connections is 16"), ("Pool notes", "raise it for batch jobs")],
+    };
+    let b = DedupeMember { title: "Connections", text: "sixteen connections", sources: vec![] };
+
+    let p = dedupe_prompt(&a, &b, 0);
+
+    assert!(p.contains("ARTIFACT A"));
+    assert!(p.contains("ARTIFACT B"));
+    assert!(p.contains("the pool holds sixteen"));
+    assert!(p.contains("max_connections is 16"), "a source was not shown");
+    assert!(p.contains("SOURCES OF A"));
+    assert!(!p.contains("SOURCES OF B"), "a captured member was given a sources block");
+    assert!(!p.contains("ARTIFACT C"), "a source was lettered");
+}
+
+/// The endpoint caches by exact prompt text, so a retry of a reply the parser
+/// could not read has to differ from the reply it is retrying.
+#[test]
+fn only_a_retry_carries_an_attempt_line() {
+    let m = DedupeMember { title: "t", text: "x", sources: vec![] };
+    assert!(!dedupe_prompt(&m, &m, 0).contains("attempt"));
+    assert!(dedupe_prompt(&m, &m, 1).contains("(attempt 2)"));
+}
+
+/// The letters the verdict may name are exactly the two artifacts under
+/// judgement, and the system prompt has to say so or a merged member's sources
+/// are fair game for `supersedes`.
+#[test]
+fn the_system_prompt_rules_the_sources_out_of_the_verdict() {
+    assert!(DEDUPE_SYSTEM.contains("SOURCES"));
+    assert!(DEDUPE_SYSTEM.contains("never name a source"));
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `cargo test --lib infer::prompt::tests::a_merged_member_is_shown_with_its_sources_beneath_it`
+Expected: compile error, `cannot find struct 'DedupeMember'`.
+
+- [ ] **Step 3: Implement**
+
+Replace `dedupe_prompt` (`src/infer/prompt.rs:239`) and its doc comment with:
+
+```rust
+/// One of the two artifacts under judgement, and — when it is itself a merge —
+/// the captured originals behind it.
+///
+/// `sources` is context and never an input. It exists so that a detail an
+/// earlier merge dropped can be put back into this one, which is what keeps
+/// repeated pairwise merging from walking away from the wording someone
+/// actually captured. It is unlettered so that no verdict can name it: the
+/// letters `a` and `b` are the two members and nothing else, and a letter that
+/// could resolve to a source would supersede an artifact on the strength of a
+/// text the model was shown as reference.
+pub struct DedupeMember<'a> {
+    pub title: &'a str,
+    pub text: &'a str,
+    /// `(title, text)`, oldest first. Empty for a captured artifact.
+    pub sources: Vec<(&'a str, &'a str)>,
+}
+
+/// The two artifacts, each under its letter and its title, each followed by its
+/// sources when it has any.
+///
+/// The title is not decoration here, it is the subject. Synthesis writes a body
+/// that stands on its own within its segment, which is not the same as naming
+/// what it is about: a section headed "FAT32" becomes an artifact whose text
+/// opens "32 Bit Clusternummern" and never says FAT32 again. Handed the bodies
+/// alone, the model saw two anonymous spec lists with different numbers and
+/// called them a contradiction — correctly, on the evidence it was given.
+///
+/// `attempt` is in the prompt because the endpoint caches by exact prompt text:
+/// without it, a retry of a reply the parser could not read would replay the
+/// same unreadable bytes for every attempt. Zero adds nothing, so a first ask
+/// stays byte-identical between runs.
+pub fn dedupe_prompt(a: &DedupeMember<'_>, b: &DedupeMember<'_>, attempt: i64) -> String {
+    let mut s = String::new();
+    if attempt > 0 {
+        s.push_str(&format!("(attempt {})\n", attempt + 1));
+    }
+    for (letter, m) in [('A', a), ('B', b)] {
+        s.push_str(&format!(
+            "----- ARTIFACT {letter} -----\nTitle: {}\n\n{}\n",
+            m.title, m.text
+        ));
+        if !m.sources.is_empty() {
+            s.push_str(&format!("----- SOURCES OF {letter} -----\n"));
+            for (title, text) in &m.sources {
+                s.push_str(&format!("Title: {title}\n\n{text}\n\n"));
+            }
+        }
+    }
+    s.push_str("----- END -----");
+    s
+}
+```
+
+Then add one paragraph to `DEDUPE_SYSTEM` (`src/infer/prompt.rs:170`), immediately before the "Reply with JSON only" line:
+
+```
+An artifact that was itself written by merging earlier ones is shown with those originals under "SOURCES OF A" or "SOURCES OF B". They are there for one reason: so that a detail an earlier merge dropped can go back into your answer. They are not under judgement. There are exactly two artifacts, A and B — never name a source in `supersedes`, and never treat a source as a third artifact.
+```
+
+- [ ] **Step 4: Run and watch them pass**
+
+Run: `cargo test --lib infer::prompt`
+Expected: PASS. Any other test in the file that calls `dedupe_prompt` with the old slice signature must be updated to the new one as part of this step.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test --lib infer::prompt && cargo clippy --all-targets -- -D warnings
+git add src/infer/prompt.rs
+git commit -m "feat(infer): show a merged artifact's own words, with its sources beside them"
+```
+
+Note: `cargo test` as a whole will not pass yet — `src/jobs/dedupe.rs` still calls the old signature. That is Task 4, and the two are committed back to back.
+
+---
+
+### Task 4: The unit is one pair
+
+The large one. `run`, `interpret`, `apply` and `Settlement` all lose the component, letters start indexing members, and the loss check moves onto the two member texts.
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` — module header (lines 1-25), `Settlement` (33-48), `run` (50-236), `interpret` (244-310), `apply` (311-425), `settle_all` (443-456), and the test module
+- Test: `src/jobs/dedupe.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `DedupeMember` and the new `dedupe_prompt` from Task 3. `crate::jobs::merge::losses(&[Chunk], &MergedDraft) -> Vec<String>` (`src/jobs/merge.rs:273`) — unchanged signature, different argument.
+- Produces: `Settlement { relation, detail, obsolete, merged, members: Vec<Chunk>, pair: ArtifactPair }` — the `roots` and `pairs` fields are gone. Task 5 edits `run` again.
+
+- [ ] **Step 1: Write the failing tests**
+
+These replace or join the existing tests. Delete outright, in the same step:
+
+- `a_retired_members_roots_do_not_count_against_the_cap` (line 503) — there is no cap.
+- `a_component_past_the_fan_in_cap_is_surfaced_and_never_called_about` (line 912) — replaced below.
+- `one_call_settles_every_pair_in_the_component` (line 873) — replaced below.
+- `a_retired_member_dismisses_only_its_own_pairs` (line 1061) — a unit owns one pair, so it has no siblings to mis-settle.
+- `a_pair_of_two_survivors_is_not_closed_with_someone_elses_direction` (line 677) — the `survivors` branch it pins is deleted.
+
+Rename `a_failed_dedupe_leaves_the_component_pending` (line 972) to `a_failed_dedupe_leaves_the_pair_pending` and keep its body, adjusting any component-shaped assertion to the single pair.
+
+- `a_replacement_naming_a_root_already_out_of_results_is_applied_to_the_carrier` (line 1140) — its scenario is a letter resolving to a root whose carrier survives, which cannot occur once letters index the two members. The "already out of results" branch it also touched is kept in `apply` and covered by `a_component_whose_member_was_retired_is_dismissed_without_a_call` (line 993), which stays.
+
+Rewrite `a_letter_names_the_root_it_was_shown_beside_not_the_nth_member` (line 727) as `a_letter_names_a_member_and_never_one_of_its_sources` below. Keep everything else.
+
+```rust
+/// The unit answers its own pair and nothing else. A sibling pair is a
+/// separate question and keeps its own turn in the queue.
+#[tokio::test]
+async fn a_unit_settles_only_its_own_pair() {
+    let mut core = test_core().await;
+    core.judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+    ]));
+    let ids = seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37]), ("c text", [0.90, 0.44])],
+    )
+    .await;
+    let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+    queue_pair(&core, &ids[1], &ids[2]).await;
+
+    run(&core, &seed_pair.to_string()).await.unwrap();
+
+    assert_eq!(core.store.pairs_by_state(PairState::NoConflict, 10).await.unwrap().len(), 1);
+    assert_eq!(
+        core.store.pairs_by_state(PairState::Pending, 10).await.unwrap().len(),
+        1,
+        "the sibling pair was answered by a call that was not about it"
+    );
+}
+
+/// A twelve-root cluster is exactly what the cap refused. Nothing about it is
+/// oversized any more: it is a sequence of two-artifact questions.
+#[tokio::test]
+async fn a_cluster_past_the_old_cap_is_asked_about_rather_than_refused() {
+    let mut core = test_core().await;
+    core.judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+    ]));
+    let rows: Vec<(&str, [f32; 2])> = vec![
+        ("t0", [1.00, 0.00]), ("t1", [0.99, 0.01]), ("t2", [0.98, 0.02]),
+        ("t3", [0.97, 0.03]), ("t4", [0.96, 0.04]), ("t5", [0.95, 0.05]),
+        ("t6", [0.94, 0.06]), ("t7", [0.93, 0.07]), ("t8", [0.92, 0.08]),
+        ("t9", [0.91, 0.09]), ("t10", [0.90, 0.10]), ("t11", [0.89, 0.11]),
+    ];
+    let ids = seed(&core, &rows).await;
+    let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+    for w in ids.windows(2).skip(1) {
+        queue_pair(&core, &w[0], &w[1]).await;
+    }
+
+    run(&core, &seed_pair.to_string()).await.unwrap();
+
+    assert!(
+        core.store.pairs_by_state(PairState::Oversized, 10).await.unwrap().is_empty(),
+        "a twelve-root cluster was refused instead of asked about"
+    );
+    assert_eq!(core.store.pairs_by_state(PairState::NoConflict, 10).await.unwrap().len(), 1);
+}
+
+/// The letter indexes the two members and can reach nothing else. This used to
+/// be resolved against the flattened roots while the members were a different
+/// list, and whenever a component held an earlier merge the mismatch superseded
+/// an artifact the model had never been shown.
+#[tokio::test]
+async fn a_letter_names_a_member_and_never_one_of_its_sources() {
+    let mut core = test_core().await;
+    core.judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"replaced","detail":"a is stale","supersedes":"a"}"#.into(),
+    ]));
+    let ids = seed_titled(
+        &core,
+        &[
+            ("Old", "the pool holds eight", [1.0, 0.0]),
+            ("New", "the pool holds sixteen", [0.93, 0.37]),
+            ("Third", "unrelated text", [0.60, 0.80]),
+        ],
+    )
+    .await;
+    // A merge whose roots are ids[0] and ids[2], so that "a" could resolve to a
+    // source if letters ever reached past the members again.
+    let m = crate::jobs::merge::write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Merged".into()),
+            text: "the pool holds eight, and unrelated text".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[2].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m.id).await.ok();
+    let pair = queue_pair(&core, &m.id, &ids[1]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    let merged = core.store.get_artifact(&m.id).await.unwrap();
+    assert!(!merged.in_results(), "the member named obsolete was not the one superseded");
+    let survivor = core.store.get_artifact(&ids[1]).await.unwrap();
+    assert!(survivor.in_results());
+}
+
+/// The whole point of merging two at a time: the result is mergeable again, and
+/// it carries the flattened lineage of both sides rather than naming them.
+#[tokio::test]
+async fn a_merge_of_a_merge_names_every_original_behind_it() {
+    let mut core = test_core().await;
+    core.judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"duplicate","detail":"same thing","merged":{"title":"Pool","text":"max_connections is 16, raise it for batch jobs, sixteen connections","category":null,"tags":[],"caveats":[]}}"#.into(),
+    ]));
+    let ids = seed_titled(
+        &core,
+        &[
+            ("Pool sizing", "max_connections is 16", [1.0, 0.0]),
+            ("Pool notes", "raise it for batch jobs", [0.99, 0.05]),
+            ("Connections", "sixteen connections", [0.93, 0.37]),
+        ],
+    )
+    .await;
+    let m1 = crate::jobs::merge::write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Pool".into()),
+            text: "max_connections is 16, raise it for batch jobs".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m1.id).await.ok();
+    let pair = queue_pair(&core, &m1.id, &ids[2]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    let settled = core.store.get_pair(pair).await.unwrap();
+    let m2 = settled.merged_into.expect("the second merge was not written");
+    let roots = core.store.roots_of(&[m2]).await.unwrap();
+    let roots: Vec<&String> = roots.values().flatten().collect();
+    assert_eq!(roots.len(), 3, "the merge of a merge did not inherit both lineages");
+    for id in &ids {
+        assert!(roots.contains(&id), "an original is missing from the lineage");
+    }
+}
+
+/// A member that is itself a merge is shown to the model as its own text, with
+/// its captured roots beside it as reference.
+#[tokio::test]
+async fn a_merged_member_reaches_the_model_with_its_sources() {
+    let mut core = test_core().await;
+    let judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+    ]));
+    core.judge = judge.clone();
+    let ids = seed_titled(
+        &core,
+        &[
+            ("Pool sizing", "max_connections is 16", [1.0, 0.0]),
+            ("Pool notes", "raise it for batch jobs", [0.99, 0.05]),
+            ("Connections", "sixteen connections", [0.93, 0.37]),
+        ],
+    )
+    .await;
+    let m = crate::jobs::merge::write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Pool".into()),
+            text: "the pool holds sixteen".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m.id).await.ok();
+    let pair = queue_pair(&core, &m.id, &ids[2]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    let sent = judge.prompts();
+    let sent = sent.first().expect("the judge was asked");
+    assert!(sent.contains("the pool holds sixteen"), "the merge's own words were withheld");
+    assert!(sent.contains("max_connections is 16"), "a source was not shown as context");
+    assert!(sent.contains("SOURCES OF A") || sent.contains("SOURCES OF B"));
+}
+
+/// One member is a source of the other: a merge and one of the artifacts it was
+/// written from. Comparing them asks whether an artifact matches itself.
+#[tokio::test]
+async fn a_merge_and_one_of_its_own_sources_is_dismissed_without_a_call() {
+    let mut core = test_core().await;
+    let judge = Arc::new(ScriptedCompleter::new(vec![]));
+    core.judge = judge.clone();
+    let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.99, 0.05])]).await;
+    let m = crate::jobs::merge::write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Merged".into()),
+            text: "a text and b text".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    let pair = queue_pair(&core, &m.id, &ids[0]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    assert_eq!(judge.calls(), 0, "a call was spent asking whether an artifact matches itself");
+    assert_eq!(core.store.pairs_by_state(PairState::Dismissed, 10).await.unwrap().len(), 1);
+}
+
+/// The loss check runs against what was actually merged. A value that only ever
+/// lived in a context source was already dropped a generation ago; failing on it
+/// would freeze the lineage and no later merge in it could ever be written.
+#[tokio::test]
+async fn a_value_lost_by_an_earlier_merge_does_not_block_the_next_one() {
+    let mut core = test_core().await;
+    core.judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"duplicate","detail":"same thing","merged":{"title":"Pool","text":"the pool holds sixteen connections","category":null,"tags":[],"caveats":[]}}"#.into(),
+    ]));
+    let ids = seed_titled(
+        &core,
+        &[
+            ("Pool sizing", "max_connections is 16 and the timeout is 30s", [1.0, 0.0]),
+            ("Pool notes", "raise it for batch jobs", [0.99, 0.05]),
+            ("Connections", "sixteen connections", [0.93, 0.37]),
+        ],
+    )
+    .await;
+    // This merge already dropped "30s". The next one must not be blamed for it.
+    let m = crate::jobs::merge::write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Pool".into()),
+            text: "the pool holds sixteen".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m.id).await.ok();
+    let pair = queue_pair(&core, &m.id, &ids[2]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    assert!(
+        core.store.pairs_by_state(PairState::Contradiction, 10).await.unwrap().is_empty(),
+        "the merge was blamed for a value an earlier one dropped"
+    );
+}
+```
+
+`ScriptedCompleter::prompts()` may not exist. If it does not, add it to `src/infer/fake.rs` beside `calls()` — a `Mutex<Vec<String>>` of the user prompts it was handed, returned as a clone. That is part of this step.
+
+`MergedDraft`'s exact field list is in `src/infer/prompt.rs`; match it rather than the snippet if they differ.
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `cargo test --lib jobs::dedupe`
+Expected: compile errors — `dedupe_prompt` takes two members now, and `Settlement` has no `pair` field.
+
+- [ ] **Step 3: Rewrite `Settlement`, `run`, `interpret`, `apply` and `settle_all`**
+
+`Settlement` becomes:
+
+```rust
+/// What the model decided, with everything the write path needs already read.
+pub struct Settlement {
+    pub relation: Relation,
+    pub detail: Option<String>,
+    /// The member named obsolete, already checked against newest-wins. Only
+    /// set for `Replaced`.
+    pub obsolete: Option<String>,
+    /// Only set for `Duplicate`, and only once the loss check has passed.
+    pub merged: Option<MergedDraft>,
+    /// The two artifacts the model was shown, in letter order.
+    pub members: Vec<Chunk>,
+    pub pair: ArtifactPair,
+}
+```
+
+`run` becomes (Task 5 adds the trim loop where the comment says so):
+
+```rust
+pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
+    let id: i64 = pair_id.parse().map_err(|_| Error::NotFound)?;
+    let p = core.store.get_pair(id).await?;
+    if p.state != PairState::Pending {
+        // Settled by an operator, by a later sweep, or by the unit that merged
+        // one of its members while this one waited out a backoff.
+        return Ok(());
+    }
+
+    let a = core.store.get_artifact(&p.a_id).await?;
+    let b = core.store.get_artifact(&p.b_id).await?;
+    // Re-checked here and not only when the unit was armed: a member can be
+    // superseded by a later sweep or deprecated by an operator while this waits
+    // out a backoff, and spending the scarcest thing in the system to rule on
+    // an artifact no longer in results buys nothing.
+    if !a.in_results() || !b.in_results() {
+        return settle(
+            core,
+            &p,
+            PairState::Dismissed,
+            Some("a member is no longer in results"),
+        )
+        .await;
+    }
+
+    let members = vec![a, b];
+    let member_ids: Vec<String> = members.iter().map(|c| c.id.clone()).collect();
+    let root_map = core.store.roots_of(&member_ids).await?;
+    // A member with no roots at all is a merge whose sources were deleted out
+    // from under it. Its text is a paraphrase with nothing behind it — not
+    // something a rule can settle. A person decides.
+    if members
+        .iter()
+        .any(|c| root_map.get(&c.id).is_none_or(|r| r.is_empty()))
+    {
+        return settle(
+            core,
+            &p,
+            PairState::Contradiction,
+            Some("a merged member has lost its sources; resolve by hand"),
+        )
+        .await;
+    }
+    // A merge and one of its own sources are not two things to compare. Asking
+    // would spend a call to be told an artifact matches itself.
+    let one_contains_the_other = root_map[&members[0].id].contains(&members[1].id)
+        || root_map[&members[1].id].contains(&members[0].id);
+    if one_contains_the_other {
+        return settle(
+            core,
+            &p,
+            PairState::Dismissed,
+            Some("one of these is a source of the other"),
+        )
+        .await;
+    }
+
+    // A merged member's captured roots, oldest first — context, never an input.
+    // Read as whole artifacts because the prompt needs their titles: a body
+    // that never names its own subject is the failure `dedupe_prompt` documents.
+    let mut context: Vec<Vec<Chunk>> = Vec::new();
+    for c in &members {
+        let mut v = Vec::new();
+        if c.provenance == crate::store::artifacts::Provenance::Merged {
+            for rid in &root_map[&c.id] {
+                match core.store.get_artifact(rid).await {
+                    Ok(r) => v.push(r),
+                    Err(Error::NotFound) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+            v.sort_by(|x, y| x.created_at.cmp(&y.created_at));
+        }
+        context.push(v);
+    }
+
+    // Task 5 replaces this line with the budget trim loop.
+    let user = build_prompt(&members, &context, p.judge_attempts);
+
+    // Counted before the call and regardless of how it goes, so a pair the
+    // model keeps failing on drops behind the rest of the queue rather than
+    // absorbing the budget again on the next sweep.
+    core.store.record_judge_attempt(p.id).await?;
+
+    let permit = core.gate.background().await;
+    let reply = core
+        .judge
+        .complete(crate::infer::prompt::DEDUPE_SYSTEM, &user)
+        .await;
+    permit.finished();
+    let reply = reply?;
+
+    let verdict = match crate::infer::prompt::parse_dedupe(&reply) {
+        Ok(v) => v,
+        // A reply that cannot be read is an error, not a verdict: the pair
+        // stays pending and the unit retries under the queue's backoff.
+        //
+        // Retrying is only worth anything because `dedupe_prompt` carries the
+        // attempt number. Against an endpoint that caches by exact prompt, an
+        // unchanged prompt would replay the same unreadable bytes for every one
+        // of `MAX_ATTEMPTS`.
+        //
+        // Counted here and not beside `record_judge_attempt`, because this is
+        // the only failure that says anything about the pair. A call the
+        // endpoint never answered says something about the endpoint, and
+        // letting an outage count against every pending pair would take the
+        // whole review queue out of reach on its way past.
+        Err(e) => {
+            core.store.record_unreadable_judgement(p.id).await?;
+            tracing::warn!(
+                pair = id,
+                attempt = p.judge_attempts,
+                reply_len = reply.len(),
+                error = %e,
+                "dedupe reply unreadable; pair stays pending"
+            );
+            return Err(e);
+        }
+    };
+
+    apply(core, interpret(verdict, members, p)).await
+}
+
+/// Assemble the user prompt from the two members and whatever context survives
+/// the budget.
+fn build_prompt(members: &[Chunk], context: &[Vec<Chunk>], attempt: i64) -> String {
+    let member = |i: usize| crate::infer::prompt::DedupeMember {
+        title: members[i].title.as_deref().unwrap_or("untitled"),
+        text: members[i].text.as_str(),
+        sources: context[i]
+            .iter()
+            .map(|c| (c.title.as_deref().unwrap_or("untitled"), c.text.as_str()))
+            .collect(),
+    };
+    crate::infer::prompt::dedupe_prompt(&member(0), &member(1), attempt)
+}
+```
+
+`interpret` loses its `roots` parameter and resolves the letter against the members:
+
+```rust
+fn interpret(
+    v: crate::infer::prompt::Dedupe,
+    members: Vec<Chunk>,
+    pair: ArtifactPair,
+) -> Settlement {
+    let mut relation = v.relation;
+    let mut detail = v.detail;
+    let mut merged = v.merged;
+    let mut obsolete = None;
+
+    if relation == Relation::Replaced {
+        // Trust a named direction only when it agrees with the sweep's own
+        // newest-wins bias (see `keeper`): a call naming the *newer* artifact
+        // obsolete is exactly the failure mode worth guarding against, since it
+        // would hide the side more likely to be current.
+        //
+        // The letter indexes the members, which are the only artifacts the
+        // prompt letters. Context sources are unlettered by construction, so a
+        // letter can no longer resolve to something the model was shown as
+        // reference — the mismatch that used to supersede an artifact the model
+        // had never been shown at all.
+        let named = v
+            .supersedes
+            .map(|c| (c as u8 - b'a') as usize)
+            .and_then(|i| members.get(i));
+        obsolete = match named {
+            Some(named)
+                if members
+                    .iter()
+                    .all(|o| o.id == named.id || named.created_at <= o.created_at) =>
+            {
+                Some(named.id.clone())
+            }
+            _ => None,
+        };
+        if obsolete.is_none() {
+            relation = Relation::Conflict;
+        }
+    }
+
+    if relation == Relation::Duplicate
+        && let Some(d) = &merged
+    {
+        // Against the members, which are what was actually merged — not against
+        // every captured root behind them. A merged member's own text is
+        // already a generation away from its sources, so checking the draft
+        // against those sources would fail on a value dropped by an earlier
+        // merge and freeze that lineage: no later merge in it could ever be
+        // written. Loss stays one generation deep per step, and the sources go
+        // into the prompt as context precisely so the model can undo the
+        // earlier drift rather than compound it.
+        let lost = crate::jobs::merge::losses(&members, d);
+        if !lost.is_empty() {
+            detail = Some(format!("the merge would have lost {}", lost.join(", ")));
+            relation = Relation::Conflict;
+            merged = None;
+        }
+    }
+
+    Settlement { relation, detail, obsolete, merged, members, pair }
+}
+```
+
+`apply`:
+
+```rust
+async fn apply(core: &Core, s: Settlement) -> Result<()> {
+    match s.relation {
+        Relation::Distinct => {
+            settle(core, &s.pair, PairState::NoConflict, s.detail.as_deref()).await
+        }
+        Relation::Conflict => {
+            tracing::info!("artifacts disagree; escalating rather than merging");
+            settle(core, &s.pair, PairState::Contradiction, s.detail.as_deref()).await
+        }
+        Relation::Replaced => {
+            let obsolete = s
+                .obsolete
+                .clone()
+                .expect("interpret sets this or downgrades to Conflict");
+            let winner = s
+                .members
+                .iter()
+                .find(|m| m.id != obsolete)
+                .map(|m| m.id.clone())
+                .expect("a pair has two members and only one of them is obsolete");
+            // A fresh status, not the snapshot `interpret` saw: an operator can
+            // retire the named side while the unit waits out a backoff.
+            let still_live = match core.store.get_artifact(&obsolete).await {
+                Ok(c) => c.in_results(),
+                Err(Error::NotFound) => false,
+                Err(e) => return Err(e),
+            };
+            if !still_live {
+                return settle(
+                    core,
+                    &s.pair,
+                    PairState::NoConflict,
+                    Some("the named replacement is already out of results"),
+                )
+                .await;
+            }
+            // The side effect FIRST. A failure here leaves the pair pending, so
+            // the unit retries under the queue's backoff — the reverse order
+            // left the verdict recorded on the pair but never applied, because
+            // `run` skips a pair that is no longer Pending.
+            core.supersede(&obsolete, &winner).await?;
+            tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
+            // Done, with the model's reasoning kept as the record of why.
+            // Leaving it Superseded listed the applied replacement as awaiting
+            // confirmation forever.
+            settle(core, &s.pair, PairState::Dismissed, s.detail.as_deref()).await
+        }
+        Relation::Duplicate => {
+            let draft = s
+                .merged
+                .as_ref()
+                .expect("interpret keeps this or downgrades to Conflict");
+            // Both members, not their roots. A merged member is not its own
+            // root, and `finish` hides what the lineage names — so passing only
+            // roots would leave that earlier merge active and near-identical to
+            // the new one. `insert_merged_artifact` flattens both to captured
+            // roots, and `subsumed_merges` catches the merged member.
+            let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
+            let m = crate::jobs::merge::write(core, draft, &sources).await?;
+            // `merged_into` rather than a detail string: if the embed never
+            // lands, the sweep's reap has to find exactly this pair and reopen
+            // it (`reap_stranded`).
+            core.store
+                .set_pair_merged(s.pair.id, &m.id, s.detail.as_deref())
+                .await
+        }
+    }
+}
+
+/// One pair, one verdict.
+async fn settle(
+    core: &Core,
+    pair: &ArtifactPair,
+    state: PairState,
+    detail: Option<&str>,
+) -> Result<()> {
+    core.store.set_pair_state(pair.id, state, detail).await
+}
+```
+
+Finally, rewrite the module header (lines 1-25) to describe the unit that exists. It currently argues *for* the component and *against* pairwise settlement, which is now backwards. Say: one pair, one call; a merged member is shown its own text with its captured roots beside it as context; the four verdicts and which two touch an artifact; and that a cluster converges by repeated pairwise merging, each result inheriting the flattened roots of both sides.
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+Run: `cargo test --lib jobs::dedupe`
+Expected: PASS. Then `cargo test` for the whole suite — `src/jobs/consolidate.rs` and `src/web/ui.rs` have tests that exercise the dedupe path and may need their expectations adjusted from "one call settles the component" to "one call settles a pair".
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/jobs/dedupe.rs src/infer/fake.rs
+git commit -m "feat(dedupe): ask about two artifacts at a time, and let the answers stack"
+```
+
+---
+
+### Task 5: Trimming context to the budget
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (the `build_prompt` call site in `run`)
+- Test: `src/jobs/dedupe.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `crate::infer::budget::{TokenCounter, checked_ceiling_for_prompt}` (`src/infer/budget.rs`), `Completer::context_tokens()` and `Completer::max_output_tokens()` (`src/infer/mod.rs:111`, `:119`), `build_prompt` from Task 4.
+- Produces: no new public surface.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// The context block is reference material, so a window too small to hold it
+/// costs an answer quality, not the answer itself. The two artifacts under
+/// judgement always survive the trim.
+#[tokio::test]
+async fn a_context_block_too_big_for_the_window_is_trimmed_not_refused() {
+    let mut core = test_core().await;
+    let judge = Arc::new(ScriptedCompleter::new(vec![
+        r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+    ]));
+    // A window that fits the two members and little else.
+    judge.set_context_tokens(600);
+    core.judge = judge.clone();
+    let long = "x ".repeat(2000);
+    let ids = seed_titled(
+        &core,
+        &[
+            ("Root one", long.as_str(), [1.0, 0.0]),
+            ("Root two", "raise it for batch jobs", [0.99, 0.05]),
+            ("Other", "sixteen connections", [0.93, 0.37]),
+        ],
+    )
+    .await;
+    let m = crate::jobs::merge::write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Pool".into()),
+            text: "the pool holds sixteen".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m.id).await.ok();
+    let pair = queue_pair(&core, &m.id, &ids[2]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    assert_eq!(judge.calls(), 1, "the call was refused instead of trimmed");
+    let sent = judge.prompts().first().cloned().unwrap();
+    assert!(sent.contains("the pool holds sixteen"), "a member was trimmed away");
+    assert!(sent.contains("sixteen connections"), "a member was trimmed away");
+    assert!(!sent.contains(long.as_str()), "the oversized source was not trimmed");
+}
+
+/// Two artifacts that alone do not fit is a different failure with a different
+/// cause — an artifact no pair containing it can ever be judged against — and it
+/// goes to a person rather than being counted as answered.
+#[tokio::test]
+async fn two_members_that_alone_do_not_fit_go_to_a_person() {
+    let mut core = test_core().await;
+    let judge = Arc::new(ScriptedCompleter::new(vec![]));
+    judge.set_context_tokens(100);
+    core.judge = judge.clone();
+    let long = "x ".repeat(4000);
+    let ids = seed_titled(
+        &core,
+        &[("One", long.as_str(), [1.0, 0.0]), ("Two", long.as_str(), [0.93, 0.37])],
+    )
+    .await;
+    let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+    run(&core, &pair.to_string()).await.unwrap();
+
+    assert_eq!(judge.calls(), 0, "a call that cannot fit the window was sent anyway");
+    let stuck = core.store.pairs_by_state(PairState::Contradiction, 10).await.unwrap();
+    assert_eq!(stuck.len(), 1);
+    assert!(
+        stuck[0].detail.as_deref().unwrap_or("").contains("do not fit"),
+        "the reason a person is being asked was not recorded"
+    );
+    assert!(
+        core.store.pairs_by_state(PairState::Oversized, 10).await.unwrap().is_empty(),
+        "the refused state came back under the old name"
+    );
+}
+```
+
+`ScriptedCompleter` needs `set_context_tokens`. If it hard-codes `context_tokens()`, add an `AtomicUsize` field defaulting to whatever it returns today and a setter, in `src/infer/fake.rs`, as part of this step.
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `cargo test --lib jobs::dedupe::tests::a_context_block_too_big_for_the_window_is_trimmed_not_refused`
+Expected: FAIL — the prompt goes out whole, or the endpoint-shaped assertion about the trim does not hold.
+
+- [ ] **Step 3: Replace the `build_prompt` call in `run` with the trim loop**
+
+```rust
+    // The two artifacts under judgement are bounded by what capture bounds and
+    // always go out. What can grow without limit is the context block behind a
+    // long lineage — and context is reference, not input, so it is trimmed
+    // rather than defended against. Oldest first: the roots furthest from the
+    // present are the ones a later capture is most likely to have restated.
+    //
+    // No count-based cap. `merge_max_roots` was one, set to eight by a default
+    // nobody typed, and it settled whole clusters before any call was made —
+    // sixteen pairs sat refused with `judge_attempts = 0`, twelve roots against
+    // a ceiling that could have held them many times over.
+    let counter = crate::infer::budget::TokenCounter;
+    let window = core.judge.context_tokens();
+    let ceiling = core.judge.max_output_tokens();
+    let system = counter.count(crate::infer::prompt::DEDUPE_SYSTEM);
+    let user = loop {
+        let user = build_prompt(&members, &context, p.judge_attempts);
+        let cost = system + counter.count(&user);
+        if crate::infer::budget::checked_ceiling_for_prompt(window, cost, ceiling).is_some() {
+            break user;
+        }
+        // Whichever member still holds the oldest surviving source gives it up.
+        let oldest = context
+            .iter()
+            .enumerate()
+            .filter(|(_, v)| !v.is_empty())
+            .min_by(|(_, x), (_, y)| x[0].created_at.cmp(&y[0].created_at))
+            .map(|(i, _)| i);
+        match oldest {
+            Some(i) => {
+                context[i].remove(0);
+            }
+            // Nothing left to give: the two artifacts alone do not fit one
+            // call. That is a fact about an artifact's size and not about this
+            // pair, and no rule here can settle it — so it goes to a person
+            // rather than being recorded as answered.
+            None => {
+                return settle(
+                    core,
+                    &p,
+                    PairState::Contradiction,
+                    Some("these two artifacts do not fit one call; resolve by hand"),
+                )
+                .await;
+            }
+        }
+    };
+```
+
+- [ ] **Step 4: Run and watch them pass**
+
+Run: `cargo test --lib jobs::dedupe`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/jobs/dedupe.rs src/infer/fake.rs
+git commit -m "feat(dedupe): trim the context to the window instead of refusing the call"
+```
+
+---
+
+### Task 6: A merge takes its members' open questions with it
+
+**Files:**
+- Modify: `src/jobs/merge.rs:88-131` (`finish`)
+- Test: `src/jobs/merge.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `Store::repoint_open_pairs` from Task 1.
+- Produces: no new public surface.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// C was a duplicate of B; B is now inside M. Without this the question dies
+/// with B and only comes back when M embeds and a later similarity sweep
+/// re-files it — a whole tick per generation of a cluster.
+#[tokio::test]
+async fn finishing_a_merge_moves_its_members_open_pairs_onto_it() {
+    let core = test_core().await;
+    let ids = seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.99, 0.05]), ("c text", [0.93, 0.37])],
+    )
+    .await;
+    core.store.record_pair(&ids[1], &ids[2], 0.91).await.unwrap();
+    let m = write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Merged".into()),
+            text: "a text and b text".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m.id).await.unwrap();
+
+    finish(&core, &m.id).await.unwrap();
+
+    assert_eq!(
+        core.store.pair_state_between(&ids[2], &m.id).await.unwrap(),
+        Some(crate::store::pairs::PairState::Pending),
+        "the surviving duplicate has no question against the merge"
+    );
+}
+
+/// `finish` is re-run by the sweep for as long as the merge stands, so running
+/// it twice must not put a pair back that the second run already answered.
+#[tokio::test]
+async fn re_pointing_is_safe_to_run_twice() {
+    let core = test_core().await;
+    let ids = seed(
+        &core,
+        &[("a text", [1.0, 0.0]), ("b text", [0.99, 0.05]), ("c text", [0.93, 0.37])],
+    )
+    .await;
+    core.store.record_pair(&ids[1], &ids[2], 0.91).await.unwrap();
+    let m = write(
+        &core,
+        &crate::infer::prompt::MergedDraft {
+            title: Some("Merged".into()),
+            text: "a text and b text".into(),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        },
+        &[ids[0].clone(), ids[1].clone()],
+    )
+    .await
+    .unwrap();
+    core.store.mark_indexed(&m.id).await.unwrap();
+
+    finish(&core, &m.id).await.unwrap();
+    finish(&core, &m.id).await.unwrap();
+
+    let pending = core.store.pairs_by_state(crate::store::pairs::PairState::Pending, 10).await.unwrap();
+    assert_eq!(pending.len(), 1, "a second finish duplicated the question");
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `cargo test --lib jobs::merge::tests::finishing_a_merge_moves_its_members_open_pairs_onto_it`
+Expected: FAIL — `pair_state_between` returns `None`, because the pair still names B.
+
+- [ ] **Step 3: Implement**
+
+At the end of `finish`, after the `subsumed_merges` loop and before `Ok(())`:
+
+```rust
+    // The open questions its members carried are now questions about the merge.
+    //
+    // Here and not in `write`: at this point the merge is indexed and its
+    // sources are superseded. Re-pointing at write time would arm a unit that
+    // could merge this artifact into a further one before it had ever
+    // superseded its own sources, leaving them active underneath a chain whose
+    // middle is out of results — the dead end `repoint_supersession` exists to
+    // prevent on the other side.
+    //
+    // Warn and carry on, like the loops above: a pair that could not be moved
+    // is a question filed against an artifact that is now hidden, which the
+    // next sweep re-files against the merge. Losing the whole repair over it
+    // would be the more expensive failure.
+    let mut moved_from: Vec<String> = core.store.roots_to_hide(&m.id).await.unwrap_or_default();
+    moved_from.extend(core.store.subsumed_merges(&m.id).await.unwrap_or_default());
+    match core.store.repoint_open_pairs(&moved_from, &m.id).await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(merged = %m.id, pairs = n, "moved open pairs onto a merge"),
+        Err(e) => tracing::warn!(merged = %m.id, error = %e, "could not move open pairs onto a merge"),
+    }
+```
+
+`roots_to_hide` is read a second time here rather than reusing the earlier binding because the first loop consumes it; hoist it into a `let` at the top of `finish` and use it in both places if that reads better.
+
+- [ ] **Step 4: Run and watch them pass**
+
+Run: `cargo test --lib jobs::merge`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/jobs/merge.rs
+git commit -m "feat(merge): carry a member's open questions onto the merge that swallowed it"
+```
+
+---
+
+### Task 7: The sweep drains the refused queue, and the UI stops listing it
+
+**Files:**
+- Modify: `src/jobs/consolidate.rs:265-320` (`run`, beside the other repairs)
+- Modify: `src/web/ui.rs:1373-1380` (`PAIR_STATES`)
+- Test: `src/jobs/consolidate.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `Store::reopen_oversized` from Task 2.
+- Produces: no new public surface. `PAIR_STATES` becomes a `[PairState; 3]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+/// The state was terminal and reached without a call. Every row in it is an
+/// unanswered question, and the sweep is what puts them back.
+#[tokio::test]
+async fn the_sweep_puts_the_refused_pairs_back_in_the_queue() {
+    let core = test_core().await;
+    let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+    core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
+    let id = core
+        .store
+        .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+        .await
+        .unwrap()[0]
+        .id;
+    core.store
+        .set_pair_state(id, crate::store::pairs::PairState::Oversized, Some("12 sources, cap is 8"))
+        .await
+        .unwrap();
+
+    run(&core).await.unwrap();
+
+    assert!(
+        core.store
+            .pairs_by_state(crate::store::pairs::PairState::Oversized, 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a pair refused before any call is still refused"
+    );
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test --lib jobs::consolidate::tests::the_sweep_puts_the_refused_pairs_back_in_the_queue`
+Expected: FAIL — the row is still `Oversized`.
+
+- [ ] **Step 3: Implement**
+
+In `consolidate::run`, after the `flag_orphans` call and before `let mut out = Outcome::default();`:
+
+```rust
+    // Pairs the old fan-in cap refused before any call was made. There is no
+    // cap now, so each one is simply an unanswered question — and every one of
+    // them has `judge_attempts = 0`, so putting them back redoes no work and
+    // resets no backoff. Runs every sweep and matches nothing once drained,
+    // which is cheaper than the machinery a one-shot would need.
+    match core.store.reopen_oversized().await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(pairs = n, "reopened pairs the fan-in cap had refused"),
+        Err(e) => tracing::warn!(error = %e, "could not reopen the pairs the cap refused"),
+    }
+```
+
+In `src/web/ui.rs`, drop `PairState::Oversized` and its comment from `PAIR_STATES`, and change the array's length to 3:
+
+```rust
+const PAIR_STATES: [crate::store::pairs::PairState; 3] = [
+    crate::store::pairs::PairState::Contradiction,
+    crate::store::pairs::PairState::Superseded,
+    crate::store::pairs::PairState::Pending,
+];
+```
+
+The `more` count at `src/web/ui.rs:1478` needs no change — it is computed from `PAIR_STATES` and already reports what `PAIR_LIMIT` truncates.
+
+- [ ] **Step 4: Run and watch it pass**
+
+Run: `cargo test --lib jobs::consolidate && cargo test --lib web::ui`
+Expected: PASS. A UI test asserting an oversized row appears on the page must be deleted — the state is no longer written and its rows are reopened.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/jobs/consolidate.rs src/web/ui.rs
+git commit -m "fix(consolidate): put the pairs the cap refused back, and stop listing the state"
+```
+
+---
+
+### Task 8: Retiring `merge_max_roots`
+
+**Files:**
+- Modify: `src/config.rs:239-245` (field), `:286` (default), `:830-850` (the clamp), `:1128-1143` (the clamp's test)
+- Modify: `config.example.toml:260`, `README.md:185`
+- Modify: comments only — `src/infer/budget.rs:74`, `src/infer/openai.rs:840`, `src/infer/openai.rs:1666`, `src/store/pairs.rs:64`
+- Test: `src/config.rs` `mod tests`
+
+**Interfaces:**
+- Produces: `ConsolidateConfig::merge_max_roots: Option<usize>`, read by nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace `a_merge_cap_below_two_goes_back_to_the_default` (`src/config.rs:1128`) with:
+
+```rust
+/// The key stays parseable for one release so an existing config file still
+/// loads, and says nothing about how the sweep behaves. The default of eight
+/// was quietly switching merging off for any cluster past eight sources.
+#[test]
+fn the_merge_cap_is_accepted_and_ignored() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = write(&dir, &format!("{MINIMAL}\n[consolidate]\nmerge_max_roots = 1\n"));
+    let cfg = Config::load(Some(&p)).unwrap();
+    assert_eq!(cfg.consolidate.merge_max_roots, Some(1));
+    assert_eq!(ConsolidateConfig::default().merge_max_roots, None);
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test --lib config::tests::the_merge_cap_is_accepted_and_ignored`
+Expected: compile error — `expected usize, found Option<usize>`.
+
+- [ ] **Step 3: Implement**
+
+Field (`src/config.rs:239-245`):
+
+```rust
+    /// Deprecated and unread. Kept for one release so an existing config file
+    /// still loads.
+    ///
+    /// It capped how many captured roots one merge could be written from, and
+    /// a component past it was settled `Oversized` — terminal, and reached
+    /// before any call. The default of eight was never typed by anyone and
+    /// switched merging off for every cluster past eight sources; sixteen pairs
+    /// sat refused with no attempt against them. The unit now merges two
+    /// artifacts at a time and lets the results be merged again, so fan-in is
+    /// not a thing one call has to survive.
+    pub merge_max_roots: Option<usize>,
+```
+
+Default (`src/config.rs:286`): `merge_max_roots: None,`.
+
+Delete the clamp at `src/config.rs:838-850` entirely, and in its place, in whatever `validate`-shaped function it lived in:
+
+```rust
+        if self.consolidate.merge_max_roots.is_some() {
+            tracing::warn!(
+                "consolidate.merge_max_roots is deprecated and ignored: merging is pairwise \
+                 now, so there is no fan-in for one call to survive"
+            );
+        }
+```
+
+Remove `merge_max_roots = 8` and its comment from `config.example.toml:260`. Remove `merge_max_roots` from the `consolidate.*` row of `README.md:185`.
+
+Rewrite the four comments that describe it as a live bound. `src/infer/budget.rs:74` and `src/infer/openai.rs:840`/`:1666` should say that the dedupe judge packs two artifacts plus a context block trimmed against this window, which is why the ceiling has to come off the prompt's own cost. `src/store/pairs.rs:64` documents `PairState::Oversized`: say that it is no longer written, that its rows are reopened by the sweep, and that the variant survives one release so old rows parse.
+
+- [ ] **Step 4: Run and watch it pass**
+
+Run: `cargo test --lib config`
+Expected: PASS. Then `cargo test` — nothing else should reference the field.
+
+- [ ] **Step 5: Verify no live references remain**
+
+Run: `grep -rn "merge_max_roots" src/ config.example.toml README.md`
+Expected: only the field, its default, the deprecation warning, and the comments that explain the deprecation. No reads.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo test && cargo clippy --all-targets -- -D warnings
+git add src/config.rs src/infer/budget.rs src/infer/openai.rs src/store/pairs.rs config.example.toml README.md
+git commit -m "feat(config): retire the fan-in cap that was refusing clusters before any call"
+```
+
+---
+
+## Verification after the last task
+
+- [ ] `cargo test` — whole suite green.
+- [ ] `cargo clippy --all-targets -- -D warnings` — clean.
+- [ ] `grep -rn "Oversized" src/` — only the enum variant, its string mapping, `reopen_oversized`, and the comments explaining the deprecation. Nothing writes it.
+- [ ] Against a copy of the real database: count `SELECT state, count(*) FROM artifact_pairs GROUP BY state` before and after one sweep. The sixteen `oversized` rows should be `pending`, and their `judge_attempts` still zero.

--- a/docs/superpowers/specs/2026-08-17-pairwise-merge-design.md
+++ b/docs/superpowers/specs/2026-08-17-pairwise-merge-design.md
@@ -91,7 +91,7 @@ and explicitly not a merge input. Context roots carry no letters and cannot be
 named by a verdict.
 
 `dedupe_prompt` changes shape accordingly. Today it takes a slice of
-`(title, text)` and letters them all (`src/infer/prompt.rs:238`). It should take
+`(title, text)` and letters them all (`src/infer/prompt.rs:239`). It should take
 the two members and, separately, the context blocks, so that lettering cannot
 reach the context by construction.
 
@@ -111,7 +111,7 @@ a different cause — an artifact large enough that no pair containing it can be
 judged — and it is settled `Contradiction` with a detail saying so. That is an
 escalation to a person about a real condition, not a counter firing.
 
-`PairState::Oversized` is removed from `PAIR_STATES` (`src/web/ui.rs:1077`) and
+`PairState::Oversized` is removed from `PAIR_STATES` (`src/web/ui.rs:1379`) and
 from everything that writes it. The enum variant and its `"oversized"` string
 mapping stay for one release so that existing rows still parse.
 
@@ -135,7 +135,8 @@ nothing left to describe once a unit owns a single pair, and is deleted.
 ### 4. The loss check runs against what was merged
 
 `losses(&roots, draft)` currently compares the draft against every captured root
-(`src/jobs/dedupe.rs:289`). Kept as written under repeated pairwise merging, a
+— called at `src/jobs/dedupe.rs:289`, defined at `src/jobs/merge.rs:273`. Kept
+as written under repeated pairwise merging, a
 fact dropped in the first generation would fail every later merge in that
 lineage forever, and the lineage would freeze.
 
@@ -215,8 +216,8 @@ default of eight was doing at a less obvious threshold.
 
 The key is removed from `config.example.toml:260` and from the `consolidate.*`
 row in `README.md:185`. The doc comments that reference it as a bound on prompt
-size (`src/infer/budget.rs:74`, `src/infer/openai.rs:829`,
-`src/infer/openai.rs:1655`, `src/store/pairs.rs:64`) are rewritten to describe
+size (`src/infer/budget.rs:74`, `src/infer/openai.rs:840`,
+`src/infer/openai.rs:1666`, `src/store/pairs.rs:64`) are rewritten to describe
 the budget-trimmed context block, since those comments are the record of why the
 budget code is shaped the way it is and would otherwise point at a key that no
 longer exists.

--- a/docs/superpowers/specs/2026-08-17-pairwise-merge-design.md
+++ b/docs/superpowers/specs/2026-08-17-pairwise-merge-design.md
@@ -1,0 +1,284 @@
+# Pairwise merging, and the end of the fan-in cap
+
+Date: 2026-08-17
+Status: approved, ready for an implementation plan
+
+## The problem
+
+Sixteen pairs sit in `Oversized`, every one of them with `judge_attempts = 0`.
+The model has never been asked about any of them and, as the code stands, never
+will be.
+
+The mechanism is short. `dedupe::run` expands its seed pair into the connected
+component of open pairs around it, flattens that component to its captured roots
+(`src/jobs/dedupe.rs:146`), and refuses outright when the flattened set exceeds
+`consolidate.merge_max_roots` (`src/jobs/dedupe.rs:150`). The refusal settles
+every pair in the component as `Oversized` before any call is made.
+`pairs_to_judge` selects `WHERE state = 'pending'`
+(`src/store/pairs.rs:437`), so `Oversized` is terminal: nothing retries it, and
+no operator action short of direct SQL reopens it.
+
+Two components account for the sixteen rows: one of twelve roots across nine
+pairs, one of nine roots across seven. The cap is eight, which nobody set — it
+is the default from `config.example.toml:260`, and `config.toml` does not
+mention it. Merging was quietly off for any cluster past eight sources.
+
+The size of those numbers is the important part. Twelve artifacts of a few
+hundred tokens each is nowhere near any context ceiling. These components were
+not refused because they could not be judged; they were refused because a
+counter said eight.
+
+## What is actually wrong
+
+Two things, and only the second one is about size.
+
+The unit insists on answering an entire component in a single call. That is what
+makes fan-in a property the unit has to defend against at all: a twelve-root
+component only ever needed a twelve-root prompt because one call had to settle
+all nine of its pairs at once.
+
+A pair can reach a terminal state without ever having been asked about.
+`Dismissed` earns that right, because structure answers it — a member is gone,
+or the two members flatten to a single root, and there is genuinely no question
+left to put to a model. `Oversized` is answered by nothing. It is the system
+declining to do its job and recording the decision as done.
+
+## Goals
+
+Merge two artifacts at a time, and let the results be merged again. Delete
+`Oversized` as a state rather than re-triggering it on a better measurement.
+Reopen the sixteen rows already written. Deprecate `consolidate.merge_max_roots`.
+
+Non-goals: changing how pairs are found and filed (`relate`, `associate`,
+`describe` are untouched), changing the four verdicts, and changing the loss
+check's two rules. This is about which artifacts reach the judge and what
+happens after it answers.
+
+## The design
+
+### 1. The unit is one pair
+
+`dedupe::run` stops calling `open_component`. It reads the seed pair, resolves
+its two members, and asks about exactly those two.
+
+`open_component` stays in the store — the sweep and the web UI still use it to
+reason about clusters — but it leaves the dedupe path entirely.
+
+The retired-member handling collapses to two lines. If either member is not
+`in_results`, the pair is dismissed and the unit returns. The partition dance at
+`src/jobs/dedupe.rs:91-113`, which separates pairs naming a retired member from
+their still-live siblings, exists only because one unit owned many pairs. It goes
+away with them, and so does the class of bug it was written to fix.
+
+Two structural guards survive, restated for two members:
+
+A member that is `Merged` and has no rows in `artifact_sources` is a merge whose
+sources were deleted out from under it. Its text is a paraphrase with nothing
+behind it. Settled `Contradiction`, as today, with the same detail.
+
+If one member appears among the other's captured roots, the pair is dismissed.
+This is the pairwise form of today's `root_ids.len() < 2` guard: a merge and one
+of its own sources are not two things to compare, and asking would spend a call
+to be told an artifact matches itself.
+
+### 2. The prompt, and the end of the size gate
+
+Each of the two members contributes its own text under a letter, `A` and `B`.
+
+A member that is `Merged` additionally contributes its captured roots as a
+labeled context block — reference material the model may draw detail back from,
+and explicitly not a merge input. Context roots carry no letters and cannot be
+named by a verdict.
+
+`dedupe_prompt` changes shape accordingly. Today it takes a slice of
+`(title, text)` and letters them all (`src/infer/prompt.rs:238`). It should take
+the two members and, separately, the context blocks, so that lettering cannot
+reach the context by construction.
+
+`DEDUPE_SYSTEM` gains one paragraph: some artifacts are shown with the original
+captures they were merged from; those are there so that detail lost in an earlier
+merge can be restored; they are never named in `supersedes`.
+
+**There is no size gate.** The merge inputs are two artifact texts, bounded by
+what capture already bounds. What can grow without limit is the context block,
+and context is reference rather than input, so it is trimmed rather than
+defended against: assemble the prompt, and while `checked_ceiling_for_prompt`
+(`src/infer/budget.rs`) reports no room for a reply worth having, drop the oldest
+context root and re-measure. Trimming degrades an answer. It never blocks one.
+
+If the two member texts alone still do not fit, that is a different failure with
+a different cause — an artifact large enough that no pair containing it can be
+judged — and it is settled `Contradiction` with a detail saying so. That is an
+escalation to a person about a real condition, not a counter firing.
+
+`PairState::Oversized` is removed from `PAIR_STATES` (`src/web/ui.rs:1077`) and
+from everything that writes it. The enum variant and its `"oversized"` string
+mapping stay for one release so that existing rows still parse.
+
+### 3. Letters index members, which removes a live bug
+
+Today `supersedes` is resolved against `roots` while the members are a different
+list, and `src/jobs/dedupe.rs:261-266` documents what that cost: whenever a
+component contained an earlier merge the two lists diverged, and a letter
+resolved against the wrong one superseded an artifact the model had never been
+shown.
+
+With two lettered members and unlettered context, the two lists cannot diverge.
+The newest-wins check in `interpret` now compares the two members' `created_at`
+directly, and `apply`'s `Replaced` arm supersedes the named member in favour of
+the other one.
+
+The `survivors` branch of that arm — the pairs whose both sides survived a
+supersession, settled `Contradiction` with "these two were not separated" — has
+nothing left to describe once a unit owns a single pair, and is deleted.
+
+### 4. The loss check runs against what was merged
+
+`losses(&roots, draft)` currently compares the draft against every captured root
+(`src/jobs/dedupe.rs:289`). Kept as written under repeated pairwise merging, a
+fact dropped in the first generation would fail every later merge in that
+lineage forever, and the lineage would freeze.
+
+So the draft is checked against **what was actually merged**: the two member
+texts. First-generation merges are unchanged by this, because their members are
+their roots. Loss stays one generation deep per merge step, which is the property
+the flattening was protecting, and the context block is what gives the model the
+chance to reverse earlier drift instead of compounding it.
+
+This is the one place where the new design is weaker than the old one, and it is
+deliberate. The old design bought "never more than one generation from captured
+wording, however many merges" at the price of never merging past eight sources at
+all. The new one trades a bounded, model-visible drift for a system that
+converges.
+
+### 5. Siblings are re-pointed onto the merge
+
+When A and B merge into M, the pending pairs naming A or B are answered by
+neither the merge nor the old member. Left alone they die with their member
+(`src/jobs/dedupe.rs:91-101`) and wait for M to embed and a later sweep to re-file
+them against C — correct, but three artifacts then take three ticks.
+
+Instead, a new store method rewrites them:
+
+```rust
+pub async fn repoint_open_pairs(&self, old: &[String], new_id: &str) -> Result<u64>
+```
+
+It updates `artifact_pairs` rows in state `pending` whose `a_id` or `b_id` is in
+`old`, replacing that side with `new_id`, subject to three rules:
+
+- A row whose other side is already `new_id` would become a self-pair. Dismissed,
+  not updated.
+- A row that would collide with an existing pair between the same two artifacts
+  is dismissed rather than updated, in any state the existing row is in. This is
+  what keeps an operator's earlier `Dismissed` respected forever, the same
+  property `record_pair`'s `INSERT OR IGNORE` provides.
+- `judge_attempts` and `judge_unreadable` reset to zero. The re-pointed pair asks
+  a different question than the one that accumulated those counts, and inheriting
+  a backoff earned by a different pair of artifacts would punish a fresh
+  question. This cannot spin: every merge reduces the number of active artifacts
+  by one, so the sequence terminates.
+
+The `score` is left as it was and is now stale — it was measured between C and B,
+not C and M. It is a queue ordering hint, not a threshold at this stage, so the
+staleness costs ordering accuracy and nothing else.
+
+**Timing: this happens in `merge::finish`, not in `merge::write`.** At `finish`
+the merge is indexed and its sources are superseded. Re-pointing at write time
+would arm a unit that could merge M into M2 before M had ever superseded A and B,
+leaving both of them active underneath a deprecated chain.
+
+### 6. Reopening what is already written
+
+Every `Oversized` pair goes back to `Pending` with its detail cleared, in the
+consolidate sweep, on every tick. Once nothing writes the state, the first tick
+drains it and every later one is a no-op against an empty set — so this needs no
+migration machinery and no run-once guard.
+
+It is safe precisely because of what the diagnosis found: `judge_attempts = 0` on
+all sixteen rows means no work is being redone and no backoff is being reset.
+They enter the queue at the front, since `pairs_to_judge` orders
+`judge_attempts ASC` before score.
+
+The twelve-root component then settles as a sequence of pairwise calls spread
+across ticks, each one merging two artifacts and re-pointing the rest onto the
+result, rather than as one call that is refused.
+
+### 7. Configuration
+
+`consolidate.merge_max_roots` becomes `Option<usize>` in `ConsolidateConfig`,
+unread by anything, and logs a deprecation warning at load when a config file
+sets it. The clamp at `src/config.rs:841` and its test at `src/config.rs:1136`
+are deleted — that clamp existed to stop a value below two from settling every
+component `Oversized` with merging silently off, which is exactly what the
+default of eight was doing at a less obvious threshold.
+
+The key is removed from `config.example.toml:260` and from the `consolidate.*`
+row in `README.md:185`. The doc comments that reference it as a bound on prompt
+size (`src/infer/budget.rs:74`, `src/infer/openai.rs:829`,
+`src/infer/openai.rs:1655`, `src/store/pairs.rs:64`) are rewritten to describe
+the budget-trimmed context block, since those comments are the record of why the
+budget code is shaped the way it is and would otherwise point at a key that no
+longer exists.
+
+## What this costs
+
+Four duplicates settle in three calls across three embed-and-finish cycles,
+where today they settle in one call on one tick — when the component is under the
+cap. Over the cap, today they do not settle at all.
+
+The module header at `src/jobs/dedupe.rs:10-14` argues against exactly this, on
+the grounds that pairwise settlement writes intermediate merges that are
+superseded almost immediately and thrown away for nothing. That argument assumed
+the intermediates are waste. With transitive root inheritance — which
+`insert_merged_artifact` already provides, resolving `roots_of(sources)` into the
+flattened closure (`src/store/artifacts.rs:238-249`) — and with siblings
+re-pointed onto the result, each intermediate is a real artifact that the next
+step builds on. The header is rewritten as part of this work; it is the primary
+statement of the unit's design and leaving it contradicting the code is not an
+option.
+
+## Testing
+
+Behaviour tests, at the level the existing dedupe tests work at:
+
+- A merge of a merge: A and B merge into M, M and C merge into M2, and `M2`'s
+  `artifact_sources` names A, B and C.
+- A twelve-root cluster converges to a single artifact across successive ticks,
+  and no pair is ever settled `Oversized`.
+- A `Merged` member's roots appear in the prompt as context and its own text
+  appears as a lettered input; a `supersedes` letter never resolves to a context
+  root.
+- Context roots are trimmed oldest-first when the budget is tight, and the two
+  member texts survive the trim.
+- Two member texts that alone exceed the window settle `Contradiction`, not
+  `Oversized`.
+- Re-pointing: a pending sibling is rewritten onto the merge at `finish`; one
+  that would become a self-pair is dismissed; one that would collide with an
+  existing dismissed pair is dismissed and the existing row is untouched;
+  `judge_attempts` resets.
+- Re-pointing does not happen at `write` — a merge whose embed never lands leaves
+  siblings pending against the original members, which `reap_stranded` already
+  covers.
+- The loss check fails a draft that drops a value present in a member's own text,
+  and passes one that drops a value present only in a context root.
+- An existing `Oversized` row is reopened by the sweep with attempts intact at
+  zero, and a second sweep reopens nothing.
+- A config file setting `merge_max_roots` loads, warns, and changes no behaviour.
+
+## Risks
+
+Drift compounds one generation per merge step rather than staying one generation
+from capture. The context block is the mitigation and it is a soft one: the model
+may or may not use it. Worth watching on the twelve-root component once it
+converges, by reading the final artifact against the twelve originals.
+
+Convergence is slower and more visible. A cluster resolves over several ticks
+with intermediate merged artifacts appearing in search in between. This is
+correct — an intermediate is a better artifact than the two it replaced — but it
+is a behaviour change an operator watching the base will notice.
+
+Re-pointing writes to pairs from `merge::finish`, which runs from `mark_indexed`
+and from the sweep's recovery path. Both need to be idempotent against a pair
+already re-pointed by the other; the collision rule provides that, but it is the
+part of this design most worth reviewing carefully.

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,13 +236,17 @@ pub struct ConsolidateConfig {
     /// Zero switches the model off entirely: pairs are still found, recorded and
     /// clustered — all of which is free — and nothing is ever asked about.
     pub max_dedupe_per_tick: usize,
-    /// How many captured roots one merged artifact may be written from.
+    /// Deprecated and unread. Kept for one release so that an existing config
+    /// file still loads.
     ///
-    /// Above this the component is left alone and surfaced instead. A merge of
-    /// forty sources is no longer one atomic piece of knowledge, which is what
-    /// `schema.sql` defines an artifact to be — so past the cap the honest
-    /// answer is to stop rather than to write something nobody asked for.
-    pub merge_max_roots: usize,
+    /// It capped how many captured roots one merged artifact could be written
+    /// from, and a component past it was settled `Oversized` — terminal, and
+    /// reached before any call was made. The default of eight was never typed
+    /// by anyone and switched merging off for every cluster past eight sources;
+    /// sixteen pairs sat refused with no attempt against them. The unit merges
+    /// two artifacts at a time now and lets the results be merged again, so
+    /// fan-in is not something one call has to survive.
+    pub merge_max_roots: Option<usize>,
     /// An active artifact not confirmed accurate (`last_verified_at`) in this
     /// many days becomes a deprecation-review candidate — never anything more
     /// automatic than that. See `stale_max_hits`.
@@ -283,7 +287,7 @@ impl Default for ConsolidateConfig {
             interval_hours: 24,
             dedupe_interval_mins: 15,
             max_dedupe_per_tick: 5,
-            merge_max_roots: 8,
+            merge_max_roots: None,
             stale_after_days: 365,
             stale_max_hits: 0,
             judge: None,
@@ -834,19 +838,11 @@ impl Config {
             );
             self.feedback.candidates = ceiling;
         }
-        // Same argument as above: every judgeable component flattens to at
-        // least two roots, so a cap of zero or one settles all of them
-        // Oversized before any call — merging silently off from a number
-        // nobody types meaning that.
-        if self.consolidate.merge_max_roots < 2 {
-            let d = ConsolidateConfig::default().merge_max_roots;
+        if self.consolidate.merge_max_roots.is_some() {
             tracing::warn!(
-                configured = self.consolidate.merge_max_roots,
-                using = d,
-                "consolidate.merge_max_roots below 2 would settle every component \
-                 as oversized; using the default"
+                "consolidate.merge_max_roots is deprecated and ignored: merging is \
+                 pairwise now, so there is no fan-in for one call to survive"
             );
-            self.consolidate.merge_max_roots = d;
         }
         // The association widths multiply each other on the search path to
         // size one SQL `LIMIT`, and `interval_mins` is multiplied by sixty to
@@ -1126,20 +1122,19 @@ mod tests {
     }
 
     #[test]
-    fn a_merge_cap_below_two_goes_back_to_the_default() {
-        // The same put-back as feedback.candidates: every judgeable component
-        // flattens to at least two roots, so a cap of 0 or 1 settles all of
-        // them Oversized before any call — merging silently off.
+    fn the_merge_cap_is_accepted_and_ignored() {
+        // The key stays parseable for one release so an existing config file
+        // still loads, and says nothing about how the sweep behaves. Left live,
+        // its default of eight quietly switched merging off for every cluster
+        // past eight sources.
         let dir = tempfile::tempdir().unwrap();
         let p = write(
             &dir,
             &format!("{MINIMAL}\n[consolidate]\nmerge_max_roots = 1\n"),
         );
         let cfg = Config::load(Some(&p)).unwrap();
-        assert_eq!(
-            cfg.consolidate.merge_max_roots,
-            ConsolidateConfig::default().merge_max_roots
-        );
+        assert_eq!(cfg.consolidate.merge_max_roots, Some(1));
+        assert_eq!(ConsolidateConfig::default().merge_max_roots, None);
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -349,9 +349,10 @@ mod tests {
             cfg.consolidate.max_dedupe_per_tick > 0 && cfg.consolidate.dedupe_interval_mins > 0,
             "the pass must have a rate, or it either never runs or is unbounded"
         );
-        assert!(
-            cfg.consolidate.merge_max_roots >= 2,
-            "a merge needs at least two sources to be a merge"
+        assert_eq!(
+            cfg.consolidate.merge_max_roots, None,
+            "the fan-in cap is deprecated; shipping a value for it turns a key \
+             that changes nothing into one a reader expects to work"
         );
     }
 

--- a/src/infer/budget.rs
+++ b/src/infer/budget.rs
@@ -70,10 +70,12 @@ pub const MIN_REPLY_TOKENS: usize = 64;
 /// The endpoint enforces one invariant the caller cannot see around: prompt
 /// plus ceiling has to fit the window, as the *server* counts both. Asking for
 /// the configured ceiling regardless is how a caller whose prompt is not
-/// budgeted against the window — the dedupe judge, handed up to
-/// `merge_max_roots` whole artifacts — sends a request the endpoint refuses
-/// outright, and a 400 is not retryable, so the group is stuck at that size on
-/// every later sweep.
+/// budgeted against the window — a judge handed whole artifacts to compare —
+/// sends a request the endpoint refuses outright, and a 400 is not retryable,
+/// so the pair is stuck at that size on every later sweep. The dedupe judge
+/// packs two artifacts plus a context block it trims against this window, and
+/// the trimming is only meaningful because the ceiling comes off the prompt's
+/// own cost here.
 ///
 /// `context - prompt` exactly is not enough. [`estimate`] is `chars / 3.5`,
 /// which undercounts CJK and dense markup badly, and a ceiling that fills the

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -28,6 +28,14 @@
 //! whether a token is *present* rather than whether two spellings match, and
 //! because numbers are the one thing in this corpus that read the same in German
 //! and in English. See `jobs::merge::losses`, its only caller.
+//!
+//! What it extracts narrowed on 2026-08-18, and for the same reason the list
+//! went: presence is only a fair question about a token that is a value in the
+//! first place. A bare run of digits is not one. Three merges the judge had
+//! already written were refused for "losing" `1, 2, 3, 4` — the markers of a
+//! numbered list — and the PID and port columns of a pasted tool dump, which no
+//! merge of two worked examples can carry over whole. A separator or a unit now
+//! has to say the number is a measurement of something: see `is_fact`.
 
 use std::collections::BTreeSet;
 
@@ -67,8 +75,22 @@ fn is_fact(token: &str) -> bool {
         s.chars()
             .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | ':' | '/' | '_'))
     };
+    // A separator is what makes a run of digits a value: `1.21.4`, `2024-03-01`,
+    // `172.16.112.128`, `7-10`. Digits on their own are not. Nothing tells `8080`
+    // the port apart from `2` the second item of a numbered list or `1220` the
+    // PID column of a pasted `volatility sockets` dump, and in this base the
+    // ordinals and the table cells outnumber the ports by an order of magnitude.
+    // Demanding all of them survive a merge is how three correct merges were
+    // refused: renumber a list, or keep one side's worked example instead of
+    // both, and the guard called it data loss. One of those artifacts wrote
+    // "RFC 32272" for RFC 3227, so correcting the typo would have failed too.
+    //
+    // The cost is real and is the point of the trade: a merge that changes a
+    // bare `8080` to `9090` is no longer caught. A version, a date, an address,
+    // a size and a timeout written `30s` still are, and those are what the
+    // model actually picks a side on.
     if separated(t) {
-        return true;
+        return t.contains(['.', '-', ':', '/', '_']);
     }
     // Otherwise the letters have to earn their place. A number carrying a unit
     // is a value — `30s`, `512mb` — and so is anything a separator has already
@@ -102,12 +124,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn versions_numbers_and_dates_are_facts() {
-        let f = fact_tokens("Requires 1.21.4 or later, 30 seconds, on 2024-03-01, at 8080.");
+    fn versions_and_dates_are_facts() {
+        let f = fact_tokens("Requires 1.21.4 or later, on 2024-03-01, from 172.16.112.128.");
         assert!(f.contains("1.21.4"), "{f:?}");
         assert!(f.contains("2024-03-01"), "{f:?}");
-        assert!(f.contains("30"), "{f:?}");
-        assert!(f.contains("8080"), "{f:?}");
+        assert!(f.contains("172.16.112.128"), "{f:?}");
+    }
+
+    #[test]
+    fn a_bare_run_of_digits_is_not_a_value() {
+        // The rule that lets a numbered list and a pasted output table through
+        // a merge. `2.` is an item marker, `1220` and `139` are the PID and
+        // port columns of a `volatility sockets` dump, and `32272` is a typo
+        // for RFC 3227 that a merge should be free to correct. None of them is
+        // a value the judge could pick a side on, and requiring all of them to
+        // survive refused three merges the judge had already written.
+        assert!(
+            fact_tokens("2. Atomarität: die Sicherung erfolgt ununterbrochen.").is_empty(),
+            "a list marker is not a value"
+        );
+        assert!(
+            fact_tokens("0x82276878 4 139 6 TCP 172.16.112.128")
+                .iter()
+                .all(|t| t == "172.16.112.128"),
+            "only the address survives: {:?}",
+            fact_tokens("0x82276878 4 139 6 TCP 172.16.112.128")
+        );
+        assert!(fact_tokens("Gemäß RFC 32272 gilt die Reihenfolge").is_empty());
+    }
+
+    #[test]
+    fn a_port_written_bare_is_the_cost_of_that_rule() {
+        // Pinned rather than defended. `8080` alone carries nothing that says
+        // it is a port and not the third row of a table, so a merge that
+        // changes it goes uncaught. Written with its protocol it is a value
+        // again, and so is any duration or size that names its unit.
+        assert!(fact_tokens("Listens on 8080.").is_empty());
+        assert!(fact_tokens("Listens on 8080/tcp.").contains("8080/tcp"));
+        assert!(fact_tokens("The timeout is 30s.").contains("30s"));
     }
 
     #[test]
@@ -147,11 +201,15 @@ mod tests {
     fn how_a_version_list_is_punctuated_decides_what_is_extracted() {
         // Why comparing two texts' token sets is not a question about facts.
         // These three lines say one thing, and the tokenizer splits on
-        // whitespace, so they yield three unrelated sets. A difference between
-        // them was named to the dedupe judge as values the artifacts state
+        // whitespace, so they yield unrelated sets. A difference between them
+        // was named to the dedupe judge as values the artifacts state
         // differently, and it reported the contradiction that implies. Pinned
         // rather than fixed: presence is all `merge::losses` asks of these, and
         // it is the comparison that was unsound.
+        //
+        // Two of the three are empty now that a bare number is not a value, so
+        // the asymmetry is narrower than it was — but `7-10` against nothing is
+        // still an asymmetry, and it is still not a fact about the text.
         assert!(
             fact_tokens("First Install (Win7/8/10)").is_empty(),
             "digits glued to a word are not values, which is the whole asymmetry"
@@ -160,12 +218,7 @@ mod tests {
             fact_tokens("Registry-Werte für USB-Geräte (Windows 7-10):"),
             ["7-10".to_string()].into_iter().collect()
         );
-        assert_eq!(
-            fact_tokens("gespeichert unter Windows 7, 8 und 10"),
-            ["10".to_string(), "7".to_string(), "8".to_string()]
-                .into_iter()
-                .collect()
-        );
+        assert!(fact_tokens("gespeichert unter Windows 7, 8 und 10").is_empty());
     }
 
     #[test]

--- a/src/infer/facts.rs
+++ b/src/infer/facts.rs
@@ -8,10 +8,26 @@
 //! the model on it. That gate was removed on 2026-08-14: it admitted a pair only
 //! when values *differed*, which is right for hunting contradictions and exactly
 //! backwards for deduplication, where two artifacts saying the same thing in
-//! different words are the cleanest thing there is to merge. What survives is
-//! the list, which decides nothing: it is a prior for the prompt, and the rule
-//! the merge verification enforces — whatever appears in it must survive into
-//! the merged text, or a value was dropped.
+//! different words are the cleanest thing there is to merge.
+//!
+//! What replaced the gate was a list of the values not shared by every artifact,
+//! handed to the dedupe prompt as a prior. That went too, on 2026-08-17, and only
+//! `fact_tokens` is left. The list compared tokens, and `fact_tokens` splits on
+//! whitespace, so the comparison answered a question about punctuation rather
+//! than about facts: `Win7/8/10` yields no tokens at all, `(Windows 7-10)` yields
+//! `7-10`, `Windows 7, 8 und 10` yields `7`, `8`, `10`. Three artifacts stating
+//! one thing three ways came out as a difference, and the prompt named four bare
+//! integers to the model as values its artifacts disagreed about — which the
+//! model then reported as a contradiction, correctly, on that evidence. It also
+//! could not distinguish "only one side states this" from "the two state it
+//! differently", so a strict superset arrived as a dispute.
+//!
+//! `fact_tokens` itself stays, and the rule it serves is unchanged: whatever it
+//! finds in an artifact must survive into text merged from it, or a value was
+//! dropped. That comparison is sound where the list's was not, because it asks
+//! whether a token is *present* rather than whether two spellings match, and
+//! because numbers are the one thing in this corpus that read the same in German
+//! and in English. See `jobs::merge::losses`, its only caller.
 
 use std::collections::BTreeSet;
 
@@ -81,33 +97,6 @@ pub fn fact_tokens(text: &str) -> BTreeSet<String> {
         .collect()
 }
 
-/// Values that not all of these texts state.
-///
-/// This is what `may_disagree` became once deduplication replaced contradiction
-/// hunting. As a gate the predicate was backwards: it admitted a pair only when
-/// values *differed*, which discards exactly the pairs that are cleanest to
-/// merge — two artifacts saying the same thing in different words have nothing
-/// to contradict and everything to combine.
-///
-/// As a list it is useful in both directions. Handed to the model it names what
-/// to look at without deciding anything, because it cannot tell a real
-/// disagreement from the same subject described at two levels of detail. Handed
-/// to the merge verification it becomes a hard rule: whatever appears here has
-/// to survive into the merged text, or the merge dropped a value and is refused.
-///
-/// Sorted, because it goes into a prompt: the endpoint caches by exact prompt
-/// text, and a set iterating in a different order would defeat that for no gain.
-pub fn differing_values(texts: &[&str]) -> Vec<String> {
-    let sets: Vec<BTreeSet<String>> = texts.iter().map(|t| fact_tokens(t)).collect();
-    let mut all: BTreeSet<String> = BTreeSet::new();
-    for s in &sets {
-        all.extend(s.iter().cloned());
-    }
-    all.into_iter()
-        .filter(|tok| !sets.iter().all(|s| s.contains(tok)))
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,22 +117,12 @@ mod tests {
 
     #[test]
     fn versions_carrying_a_v_are_facts_and_equal_the_bare_form() {
-        let f = fact_tokens("Needs v1.21.4 of the toolchain.");
-        assert!(f.contains("1.21.4"), "{f:?}");
-        assert!(
-            differing_values(&[
-                "Needs v1.21.4 of the toolchain.",
-                "Needs 1.21.4 of the toolchain.",
-            ])
-            .is_empty(),
-            "the v prefix made one value look like two"
-        );
+        // A merge of one text into the other must not be told a value went
+        // missing just because the source wrote the `v`.
         assert_eq!(
-            differing_values(&[
-                "Needs v1.21.4 of the toolchain.",
-                "Needs v1.30.0 of the toolchain.",
-            ]),
-            vec!["1.21.4".to_string(), "1.30.0".to_string()]
+            fact_tokens("Needs v1.21.4 of the toolchain."),
+            fact_tokens("Needs 1.21.4 of the toolchain."),
+            "the v prefix made one value look like two"
         );
     }
 
@@ -155,10 +134,6 @@ mod tests {
         let f = fact_tokens("The timeout is 30s and the batch is 512MB.");
         assert!(f.contains("30s"), "{f:?}");
         assert!(f.contains("512mb"), "{f:?}");
-        assert_eq!(
-            differing_values(&["Wait 30s.", "Wait 90s."]),
-            vec!["30s".to_string(), "90s".to_string()]
-        );
     }
 
     #[test]
@@ -169,37 +144,27 @@ mod tests {
     }
 
     #[test]
-    fn differing_values_names_only_what_is_not_shared() {
-        // The prompt prior. A value every artifact states is not something to
-        // ask about; a value only some of them state is.
-        assert_eq!(
-            differing_values(&[
-                "The timeout is 30s on port 8080.",
-                "The timeout is 90s on port 8080."
-            ]),
-            vec!["30s".to_string(), "90s".to_string()],
-            "the shared port should not be named"
-        );
-    }
-
-    #[test]
-    fn texts_agreeing_on_every_value_differ_in_none() {
-        // And this is the case the old gate discarded: nothing to disagree
-        // about, everything to merge.
+    fn how_a_version_list_is_punctuated_decides_what_is_extracted() {
+        // Why comparing two texts' token sets is not a question about facts.
+        // These three lines say one thing, and the tokenizer splits on
+        // whitespace, so they yield three unrelated sets. A difference between
+        // them was named to the dedupe judge as values the artifacts state
+        // differently, and it reported the contradiction that implies. Pinned
+        // rather than fixed: presence is all `merge::losses` asks of these, and
+        // it is the comparison that was unsound.
         assert!(
-            differing_values(&["Needs v1.21.4 to build.", "To build it you need 1.21.4."])
-                .is_empty()
+            fact_tokens("First Install (Win7/8/10)").is_empty(),
+            "digits glued to a word are not values, which is the whole asymmetry"
         );
-        assert!(differing_values(&["Prose only.", "Different prose."]).is_empty());
-    }
-
-    #[test]
-    fn a_value_only_one_artifact_states_is_a_differing_value() {
-        // It is exactly what a merge must carry over, so verification has to
-        // see it even though nothing contradicts it.
         assert_eq!(
-            differing_values(&["Mount it first.", "Mount it first. Wait 30s."]),
-            vec!["30s".to_string()]
+            fact_tokens("Registry-Werte für USB-Geräte (Windows 7-10):"),
+            ["7-10".to_string()].into_iter().collect()
+        );
+        assert_eq!(
+            fact_tokens("gespeichert unter Windows 7, 8 und 10"),
+            ["10".to_string(), "7".to_string(), "8".to_string()]
+                .into_iter()
+                .collect()
         );
     }
 

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -488,6 +488,14 @@ impl Completer for FakeCompleter {
 pub struct ScriptedCompleter {
     replies: std::sync::Mutex<std::collections::VecDeque<String>>,
     calls: std::sync::atomic::AtomicUsize,
+    /// Every user prompt it was handed, in order. What a caller that *packs* a
+    /// prompt has to be able to assert on: whether a call went out at all says
+    /// nothing about what was in it, and the trimming the dedupe unit does is
+    /// visible nowhere else.
+    prompts: std::sync::Mutex<Vec<String>>,
+    /// Overridable so a test can make the window the binding constraint without
+    /// writing a megabyte of artifact text to get there.
+    context_tokens: std::sync::atomic::AtomicUsize,
 }
 
 impl ScriptedCompleter {
@@ -495,17 +503,27 @@ impl ScriptedCompleter {
         Self {
             replies: std::sync::Mutex::new(replies.into()),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+            context_tokens: std::sync::atomic::AtomicUsize::new(4096),
         }
     }
     pub fn calls(&self) -> usize {
         self.calls.load(std::sync::atomic::Ordering::SeqCst)
     }
+    pub fn prompts(&self) -> Vec<String> {
+        self.prompts.lock().unwrap().clone()
+    }
+    pub fn set_context_tokens(&self, n: usize) {
+        self.context_tokens
+            .store(n, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 #[async_trait]
 impl Completer for ScriptedCompleter {
-    async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+    async fn complete(&self, _system: &str, user: &str) -> Result<String> {
         self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.prompts.lock().unwrap().push(user.to_string());
         self.replies
             .lock()
             .unwrap()
@@ -516,7 +534,7 @@ impl Completer for ScriptedCompleter {
             })
     }
     fn context_tokens(&self) -> usize {
-        4096
+        self.context_tokens.load(std::sync::atomic::Ordering::SeqCst)
     }
     fn max_output_tokens(&self) -> usize {
         1024

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -836,11 +836,12 @@ impl HttpCompleter {
 
 #[async_trait]
 impl Completer for HttpCompleter {
-    /// The judges come through here, and neither budgets its prompt against the
-    /// window: `dedupe_prompt` concatenates up to `merge_max_roots` whole
-    /// artifacts, and asking for the full configured ceiling beside that is a
-    /// request the endpoint refuses. So the ceiling is measured against what the
-    /// prompt costs, the way `ask` measures its own.
+    /// The judges come through here, and neither asks for a ceiling that fits
+    /// what it sent: `dedupe_prompt` carries two whole artifacts and, behind a
+    /// merged one, the captured sources it was written from — and asking for the
+    /// full configured ceiling beside that is a request the endpoint refuses. So
+    /// the ceiling is measured against what the prompt costs, the way `ask`
+    /// measures its own.
     ///
     /// A prompt that leaves no room for a reply is refused here rather than
     /// sent under a ceiling of 1. The clamped call does not fail cleanly: it
@@ -1662,11 +1663,11 @@ mod tests {
         );
     }
 
-    /// Neither judge budgets its prompt against the window — `dedupe_prompt`
-    /// concatenates up to `merge_max_roots` whole artifacts — so asking for the
-    /// configured ceiling regardless is a request the endpoint refuses outright.
-    /// That 400 is permanent, the pair is re-armed at the same size on every
-    /// later sweep, and the group never gets judged at all.
+    /// Neither judge's prompt is small — `dedupe_prompt` carries two whole
+    /// artifacts and the captured sources behind a merged one — so asking for
+    /// the configured ceiling regardless is a request the endpoint refuses
+    /// outright. That 400 is permanent, the pair is re-armed at the same size on
+    /// every later sweep, and it never gets judged at all.
     #[tokio::test]
     async fn a_judge_prompt_that_fills_the_window_shrinks_its_own_ceiling() {
         let server = echoing_server(r#"{"verdict":{"relation":"distinct"}}"#).await;

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -204,12 +204,27 @@ Reply with JSON only, no commentary, in exactly this shape:
 /// alone, the model saw two anonymous spec lists with different numbers and
 /// called them a contradiction — correctly, on the evidence it was given.
 ///
-/// `differing_values` is what `facts::fact_tokens` found stated differently
-/// across the artifacts. It is a prior, not a verdict: it cannot tell a real
-/// disagreement from the same subject described at two levels of detail, which
-/// is the whole reason a model is asked. It used to be an admission gate, and
-/// as a gate it was backwards — a pair stating no differing value is the
-/// cleanest thing there is to merge, and gating on difference hid exactly those.
+/// No prior about differing values is named here, and that is the decision.
+/// `facts::differing_values` compared value-shaped tokens between the artifacts
+/// and this prompt passed the difference on as something to look at. Both halves
+/// of that were wrong on real text. The tokenizer splits on whitespace, so
+/// whether a version list yields tokens at all depends on how it is punctuated:
+/// `Win7/8/10` yields nothing (digits glued to a word), `(Windows 7-10)` yields
+/// `7-10`, and `Windows 7, 8 und 10` yields `7`, `8`, `10`. Three artifacts
+/// stating one fact three ways produced three different token sets and a
+/// non-empty difference, and the prompt then named four bare integers — stripped
+/// of any sign that they were Windows versions — as values the artifacts do not
+/// state the same way. The model read that against a table of registry codes and
+/// called the version mapping a contradiction, which is the correct reading of
+/// the evidence it was handed. The second half is the conflation: a value only
+/// one artifact states is reported the same as a value the two give differently,
+/// so a strict superset — one artifact listing more Outlook versions than the
+/// other — arrived as a dispute rather than as one side saying more.
+///
+/// Nothing is lost by leaving it out. The prior decided nothing; the model sees
+/// both artifacts whole and has every verdict available either way. The rule it
+/// also justified — a value in the list must survive into merged text — is
+/// enforced by `merge::losses` calling `fact_tokens` directly, and is untouched.
 ///
 /// `attempt` is how many times this group has already been asked about, and it
 /// is in the prompt for one reason: the endpoint caches by exact prompt text and
@@ -220,11 +235,7 @@ Reply with JSON only, no commentary, in exactly this shape:
 /// Zero adds nothing at all, so a first ask stays byte-identical between runs —
 /// and keeps hitting the cache when it should, on a group re-armed after a
 /// settled verdict was lost.
-pub fn dedupe_prompt(
-    members: &[(&str, &str)],
-    differing_values: &[String],
-    attempt: i64,
-) -> String {
+pub fn dedupe_prompt(members: &[(&str, &str)], attempt: i64) -> String {
     let mut s = String::new();
     if attempt > 0 {
         s.push_str(&format!("(attempt {})\n", attempt + 1));
@@ -237,14 +248,6 @@ pub fn dedupe_prompt(
         ));
     }
     s.push_str("----- END -----");
-    if !differing_values.is_empty() {
-        s.push_str(&format!(
-            "\n\nThese values are not stated the same way by all of them: {}. \
-             That may be a real disagreement, or the same subject described at \
-             different levels of detail. Decide which.",
-            differing_values.join(", ")
-        ));
-    }
     s
 }
 
@@ -1168,7 +1171,6 @@ mod tests {
                 ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
                 ("FAT32 Specifications", "32 Bit Clusternummern."),
             ],
-            &[],
             0,
         );
         assert!(p.contains("Title: FAT16 Specifications"), "{p}");
@@ -1180,23 +1182,49 @@ mod tests {
     fn a_component_is_lettered_so_a_direction_can_name_one() {
         // `supersedes` answers with a letter, so the letters have to be in the
         // prompt and in the same order the caller will read them back in.
-        let p = dedupe_prompt(&[("one", "a"), ("two", "b"), ("three", "c")], &[], 0);
+        let p = dedupe_prompt(&[("one", "a"), ("two", "b"), ("three", "c")], 0);
         assert!(p.contains("ARTIFACT A"), "{p}");
         assert!(p.contains("ARTIFACT B"), "{p}");
         assert!(p.contains("ARTIFACT C"), "{p}");
     }
 
     #[test]
-    fn differing_values_are_named_as_a_prior_not_a_verdict() {
+    fn no_prior_about_values_is_named_to_the_dedupe_judge() {
+        // Three real artifacts stating one fact three ways. Whitespace
+        // tokenization made the token sets differ on punctuation alone —
+        // `Win7/8/10` yields nothing, `(Windows 7-10)` yields `7-10`,
+        // `Windows 7, 8 und 10` yields `7`, `8`, `10` — and the prompt named the
+        // difference as values the artifacts do not state the same way. The
+        // model read four bare integers against a table of registry codes and
+        // called the version mapping a contradiction, which was the honest
+        // answer to the question it was handed. Nothing about the artifacts is
+        // withheld by leaving the prior out; only the priming is.
         let p = dedupe_prompt(
-            &[("t", "timeout is 30s"), ("t", "timeout is 90s")],
-            &["30s".into(), "90s".into()],
+            &[
+                (
+                    "USB Device Registry Keys",
+                    "0066 = Last Connected (Win8-10)",
+                ),
+                (
+                    "USB-Geräte Registry-Werte",
+                    "Registry-Werte (Windows 7-10):",
+                ),
+                ("Plug and Play Logs", "0066 für Last Connected (Windows 8-)"),
+            ],
             0,
         );
-        assert!(p.contains("30s, 90s"), "{p}");
-        assert!(p.contains("Decide which."), "{p}");
-        // And nothing is added when there is nothing to say.
-        assert!(!dedupe_prompt(&[("t", "x"), ("t", "y")], &[], 0).contains("Decide which."));
+        assert!(
+            !p.contains("Decide which."),
+            "the differing-values prior is back in the prompt: {p}"
+        );
+        assert!(
+            !p.contains("not stated the same way"),
+            "the differing-values prior is back in the prompt: {p}"
+        );
+        // The artifacts themselves are still there in full, which is what the
+        // model is supposed to decide on.
+        assert!(p.contains("0066 = Last Connected (Win8-10)"), "{p}");
+        assert!(p.contains("0066 für Last Connected (Windows 8-)"), "{p}");
     }
 
     #[test]
@@ -1209,10 +1237,10 @@ mod tests {
             ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
             ("FAT32 Specifications", "32 Bit Clusternummern."),
         ];
-        let first = dedupe_prompt(members, &[], 0);
-        let second = dedupe_prompt(members, &[], 1);
+        let first = dedupe_prompt(members, 0);
+        let second = dedupe_prompt(members, 1);
         assert_ne!(first, second);
-        assert_ne!(second, dedupe_prompt(members, &[], 2));
+        assert_ne!(second, dedupe_prompt(members, 2));
         // A first ask stays exactly what it was, so the cache still earns its
         // keep on a group re-armed after a verdict was lost.
         assert!(first.starts_with("----- ARTIFACT A -----"), "{first}");

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -187,6 +187,8 @@ These are NOT conflicts:
 
 When you answer "duplicate", the merged text must contain every number, version, date, path, flag, command and error string that appeared in any input, and must read as one self-contained artifact rather than a list of sources. If you cannot write one that keeps all of them, the answer is "conflict", not "duplicate".
 
+An artifact that was itself written by merging earlier ones is shown with those originals under "SOURCES OF A" or "SOURCES OF B". They are there for one reason: so that a detail an earlier merge dropped can go back into your answer. They are not under judgement. There are exactly two artifacts, A and B — never name a source in `supersedes`, and never treat a source as a third artifact.
+
 Reply with JSON only, no commentary, in exactly this shape:
 
 {"verdict": {"relation": "duplicate", "detail": "...", "merged": {"title": "...", "text": "...", "category": "...", "caveats": []}}}
@@ -196,7 +198,19 @@ Reply with JSON only, no commentary, in exactly this shape:
 - supersedes: the letter of the artifact that is obsolete. Only with "replaced"; omit it otherwise.
 - merged: only with "duplicate"; omit it entirely otherwise. `text` must stand on its own without its sources. `caveats` are the conditions under which it does not apply."#;
 
-/// The artifacts, each under a letter and its title.
+/// The two artifacts, each under its letter and its title, each followed by its
+/// captured sources when it has any.
+///
+/// Exactly two, because the unit judges one pair. It used to letter as many
+/// artifacts as the connected component held, which is what made fan-in
+/// something one call had to survive and what `merge_max_roots` was capping —
+/// with the cap settling whole clusters before any call was made.
+///
+/// A merged member is shown its own text as the thing under judgement, with the
+/// originals it was written from beneath it as reference. Those are unlettered,
+/// so a verdict cannot name one: the mismatch between a lettered list of roots
+/// and a different list of members is what used to supersede artifacts the model
+/// had never been shown.
 ///
 /// The title is not decoration here, it is the subject. Synthesis writes a body
 /// that stands on its own within its segment, which is not the same as naming
@@ -236,20 +250,42 @@ Reply with JSON only, no commentary, in exactly this shape:
 /// Zero adds nothing at all, so a first ask stays byte-identical between runs —
 /// and keeps hitting the cache when it should, on a group re-armed after a
 /// settled verdict was lost.
-pub fn dedupe_prompt(members: &[(&str, &str)], attempt: i64) -> String {
+pub fn dedupe_prompt(a: &DedupeMember<'_>, b: &DedupeMember<'_>, attempt: i64) -> String {
     let mut s = String::new();
     if attempt > 0 {
         s.push_str(&format!("(attempt {})\n", attempt + 1));
     }
-    for (i, (title, text)) in members.iter().enumerate() {
-        let letter = (b'a' + i as u8) as char;
+    for (letter, m) in [('A', a), ('B', b)] {
         s.push_str(&format!(
-            "----- ARTIFACT {} -----\nTitle: {title}\n\n{text}\n",
-            letter.to_ascii_uppercase()
+            "----- ARTIFACT {letter} -----\nTitle: {}\n\n{}\n",
+            m.title, m.text
         ));
+        if !m.sources.is_empty() {
+            s.push_str(&format!("----- SOURCES OF {letter} -----\n"));
+            for (title, text) in &m.sources {
+                s.push_str(&format!("Title: {title}\n\n{text}\n\n"));
+            }
+        }
     }
     s.push_str("----- END -----");
     s
+}
+
+/// One of the two artifacts under judgement, and — when it is itself a merge —
+/// the captured originals behind it.
+///
+/// `sources` is context and never an input. It is there so that a detail an
+/// earlier merge dropped can be put back into this one, which is what keeps
+/// repeated pairwise merging from walking away from the wording someone
+/// actually captured. It is unlettered so that no verdict can name it: `a` and
+/// `b` are the two members and nothing else, and a letter that could resolve to
+/// a source would supersede an artifact on the strength of a text the model was
+/// shown as reference.
+pub struct DedupeMember<'a> {
+    pub title: &'a str,
+    pub text: &'a str,
+    /// `(title, text)`, oldest first. Empty for a captured artifact.
+    pub sources: Vec<(&'a str, &'a str)>,
 }
 
 /// Two knowledge artifacts keep being retrieved by the same searches, and this
@@ -533,12 +569,14 @@ pub fn parse_dedupe(body: &str) -> Result<Dedupe> {
         Error::MalformedLlmOutput(format!("dedupe reply was not the expected JSON: {e}"))
     })?;
 
-    // Any single letter, because `dedupe_prompt` letters as many artifacts as
-    // the component has and the fan-in cap — not this parser — is what bounds
-    // that. Stopping at "d" silently downgraded every direction named in a group
-    // of five or more to a conflict, which turned the cheapest and most faithful
-    // outcome, superseding one stored original by another, into a queue entry
-    // for a person.
+    // Any single letter, and not a range this parser enforces. The prompt now
+    // hands out exactly two, but a parser that pins the count is a parser that
+    // silently downgrades a perfectly good direction the day the prompt changes
+    // — which is what happened when it stopped at "d" against a prompt that
+    // lettered a whole component: every direction named in a group of five or
+    // more became a conflict, turning the cheapest and most faithful outcome,
+    // superseding one stored original by another, into a queue entry for a
+    // person.
     //
     // How far the letters actually run is the caller's to know: it resolves this
     // against the list it showed, and a letter past the end downgrades there.
@@ -1046,6 +1084,15 @@ pub fn describe_context(metadata: &serde_json::Value) -> String {
 mod tests {
     use super::*;
 
+    /// A captured artifact: one with nothing behind it to show as context.
+    fn member<'a>(title: &'a str, text: &'a str) -> DedupeMember<'a> {
+        DedupeMember {
+            title,
+            text,
+            sources: vec![],
+        }
+    }
+
     #[test]
     fn the_schema_no_longer_asks_for_tags() {
         // No domain-agnostic vocabulary exists for subject words, so a
@@ -1427,10 +1474,8 @@ mod tests {
         // different numbers and called them a contradiction — which was the
         // only honest answer to the question it was actually asked.
         let p = dedupe_prompt(
-            &[
-                ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
-                ("FAT32 Specifications", "32 Bit Clusternummern."),
-            ],
+            &member("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
+            &member("FAT32 Specifications", "32 Bit Clusternummern."),
             0,
         );
         assert!(p.contains("Title: FAT16 Specifications"), "{p}");
@@ -1439,13 +1484,49 @@ mod tests {
     }
 
     #[test]
-    fn a_component_is_lettered_so_a_direction_can_name_one() {
+    fn the_pair_is_lettered_so_a_direction_can_name_one() {
         // `supersedes` answers with a letter, so the letters have to be in the
         // prompt and in the same order the caller will read them back in.
-        let p = dedupe_prompt(&[("one", "a"), ("two", "b"), ("three", "c")], 0);
+        let p = dedupe_prompt(&member("one", "a"), &member("two", "b"), 0);
         assert!(p.contains("ARTIFACT A"), "{p}");
         assert!(p.contains("ARTIFACT B"), "{p}");
-        assert!(p.contains("ARTIFACT C"), "{p}");
+        assert!(!p.contains("ARTIFACT C"), "a third letter exists to be named: {p}");
+    }
+
+    /// A merged member's own wording is what is being judged, and its captured
+    /// roots are there so the model can put back a detail the earlier merge
+    /// dropped. Both appear; only the member is lettered.
+    #[test]
+    fn a_merged_member_is_shown_with_its_sources_beneath_it() {
+        let a = DedupeMember {
+            title: "Pool sizing",
+            text: "the pool holds sixteen",
+            sources: vec![
+                ("Pool sizing, 2024", "max_connections is 16"),
+                ("Pool notes", "raise it for batch jobs"),
+            ],
+        };
+        let p = dedupe_prompt(&a, &member("Connections", "sixteen connections"), 0);
+
+        assert!(p.contains("ARTIFACT A"), "{p}");
+        assert!(p.contains("ARTIFACT B"), "{p}");
+        assert!(p.contains("the pool holds sixteen"), "{p}");
+        assert!(p.contains("max_connections is 16"), "a source was not shown: {p}");
+        assert!(p.contains("SOURCES OF A"), "{p}");
+        assert!(
+            !p.contains("SOURCES OF B"),
+            "a captured member was given a sources block: {p}"
+        );
+        assert!(!p.contains("ARTIFACT C"), "a source was lettered: {p}");
+    }
+
+    /// The letters a verdict may name are exactly the two artifacts under
+    /// judgement, and the system prompt has to say so — otherwise a merged
+    /// member's sources are fair game for `supersedes`.
+    #[test]
+    fn the_system_prompt_rules_the_sources_out_of_the_verdict() {
+        assert!(DEDUPE_SYSTEM.contains("SOURCES"));
+        assert!(DEDUPE_SYSTEM.contains("never name a source"));
     }
 
     #[test]
@@ -1460,17 +1541,11 @@ mod tests {
         // answer to the question it was handed. Nothing about the artifacts is
         // withheld by leaving the prior out; only the priming is.
         let p = dedupe_prompt(
-            &[
-                (
-                    "USB Device Registry Keys",
-                    "0066 = Last Connected (Win8-10)",
-                ),
-                (
-                    "USB-Geräte Registry-Werte",
-                    "Registry-Werte (Windows 7-10):",
-                ),
-                ("Plug and Play Logs", "0066 für Last Connected (Windows 8-)"),
-            ],
+            &member("USB Device Registry Keys", "0066 = Last Connected (Win8-10)"),
+            &member(
+                "Plug and Play Logs",
+                "0066 für Last Connected (Windows 8-)",
+            ),
             0,
         );
         assert!(
@@ -1493,14 +1568,12 @@ mod tests {
         // milliseconds. A group whose reply the parser could not read is retried
         // up to `MAX_ATTEMPTS` times, and every one of those would have read the
         // same unreadable bytes back.
-        let members: &[(&str, &str)] = &[
-            ("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB."),
-            ("FAT32 Specifications", "32 Bit Clusternummern."),
-        ];
-        let first = dedupe_prompt(members, 0);
-        let second = dedupe_prompt(members, 1);
+        let a = member("FAT16 Specifications", "Die max. Partitionsgröße: 2 GB.");
+        let b = member("FAT32 Specifications", "32 Bit Clusternummern.");
+        let first = dedupe_prompt(&a, &b, 0);
+        let second = dedupe_prompt(&a, &b, 1);
         assert_ne!(first, second);
-        assert_ne!(second, dedupe_prompt(members, 2));
+        assert_ne!(second, dedupe_prompt(&a, &b, 2));
         // A first ask stays exactly what it was, so the cache still earns its
         // keep on a group re-armed after a verdict was lost.
         assert!(first.starts_with("----- ARTIFACT A -----"), "{first}");
@@ -1654,11 +1727,12 @@ mod tests {
 
     #[test]
     fn a_direction_reaches_as_far_as_the_letters_the_prompt_hands_out() {
-        // `dedupe_prompt` letters one artifact per component member, and the
-        // fan-in cap defaults to eight — so H is a letter the model is routinely
-        // invited to answer with. A parser that stopped at D turned every one of
-        // those into a conflict, which spends a person on a group the model had
-        // already resolved the cheap way.
+        // The prompt hands out A and B, and `interpret` is what refuses a letter
+        // past the end — deliberately, so that this parser does not have to be
+        // edited in lockstep with the prompt. It was pinned at D once, against a
+        // prompt that lettered a whole component, and turned every direction
+        // named in a group of five or more into a conflict: a person spent on a
+        // group the model had already resolved the cheap way.
         for (letter, want) in [("E", 'e'), ("f", 'f'), ("H", 'h')] {
             let d = parse_dedupe(&format!(
                 r#"{{"relation":"replaced","supersedes":"{letter}","detail":"stale"}}"#

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -32,9 +32,25 @@ fn looks_like_a_path_or_flag(token: &str) -> bool {
 }
 
 /// Every string in a chunk that must have come from the source verbatim:
-/// lines inside fenced code blocks, inline code spans, and bare path- or
-/// flag-shaped tokens in the prose.
+/// lines inside fenced code blocks, indented lines, inline code spans, and bare
+/// path- or flag-shaped tokens in the prose.
 pub fn extract_literals(artifact_text: &str) -> Vec<String> {
+    extract(artifact_text, true)
+}
+
+/// The same, minus the rule that an indented line is code.
+///
+/// For a comparison whose other side is not the text this one was copied from —
+/// see `missing_machine_literals`, the only caller. A four-space indent is the
+/// weakest of these signals by far: markdown nests a bullet list that way, so an
+/// ordinary sentence one level deep is picked up whole and then required to
+/// survive verbatim. What is left all says machine-shaped in the text itself —
+/// a fence, backticks, a leading slash — and needs no guess from the layout.
+pub fn extract_machine_literals(artifact_text: &str) -> Vec<String> {
+    extract(artifact_text, false)
+}
+
+fn extract(artifact_text: &str, indented_is_code: bool) -> Vec<String> {
     let mut out = Vec::new();
     let mut fenced = false;
     for line in artifact_text.lines() {
@@ -46,7 +62,7 @@ pub fn extract_literals(artifact_text: &str) -> Vec<String> {
         // Fenced blocks, and the indented kind markdown also treats as code —
         // reference documentation is full of the latter, and a command that
         // arrives indented rather than fenced still has to be verbatim.
-        if fenced || line.starts_with("    ") || line.starts_with('\t') {
+        if fenced || (indented_is_code && (line.starts_with("    ") || line.starts_with('\t'))) {
             if !line.trim().is_empty() {
                 out.push(line.trim().to_string());
             }
@@ -96,10 +112,49 @@ pub fn missing_literals(
     caveats: &[String],
     segment_text: &str,
 ) -> Vec<String> {
-    let haystack = normalize(segment_text);
-    let mut all = extract_literals(artifact_text);
+    absent(extract_literals, artifact_text, caveats, segment_text)
+}
+
+/// Literals present in the artifact and absent from a text that is *not* its
+/// source — merged text written over it, where only the machine-shaped strings
+/// were ever meant to come through unchanged.
+///
+/// `missing_literals` asks whether a freshly written artifact copied its
+/// commands out of the window it was extracted from. That is a fair question:
+/// same text, same language, and the synthesizer was told to copy them. Merged
+/// text is a rewrite by construction, and in this corpus routinely a rewrite
+/// across German and English, so "did this sentence survive verbatim" has no
+/// answer there. Asking it anyway is what vetoed a correct merge of two OneDrive
+/// artifacts: three four-space-indented bullets, ordinary English prose with
+/// their own descriptions, were extracted whole as literals and could not
+/// possibly reappear word for word.
+///
+/// What stays is the part that does carry over: a fenced command, a backticked
+/// registry key, a bare path. A merge that drops `/tmp/image.vdi` — the whole
+/// point of the artifact it came from — is still refused.
+pub fn missing_machine_literals(
+    artifact_text: &str,
+    caveats: &[String],
+    merged_text: &str,
+) -> Vec<String> {
+    absent(
+        extract_machine_literals,
+        artifact_text,
+        caveats,
+        merged_text,
+    )
+}
+
+fn absent(
+    extract: fn(&str) -> Vec<String>,
+    artifact_text: &str,
+    caveats: &[String],
+    haystack_text: &str,
+) -> Vec<String> {
+    let haystack = normalize(haystack_text);
+    let mut all = extract(artifact_text);
     for c in caveats {
-        all.extend(extract_literals(c));
+        all.extend(extract(c));
     }
     all.sort();
     all.dedup();
@@ -437,6 +492,41 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
     #[test]
     fn prose_alone_has_no_literals_to_check() {
         assert!(extract_literals("Just some ordinary prose about disks.").is_empty());
+    }
+
+    #[test]
+    fn only_the_merge_side_stops_reading_an_indent_as_code() {
+        // Two questions that look like one. Against the source window an
+        // indented line really is code often enough to be worth the false
+        // positives: the artifact was copied out of that same text, so demanding
+        // it verbatim costs nothing when it is prose. Against merged text — a
+        // rewrite by construction, here across two languages — the same demand
+        // vetoes correct merges, and a nested markdown bullet is prose far more
+        // often than it is a command.
+        let nested = "* Personal directory contents:\n    * SyncEngine.odl: Logs of \
+                      synchronized files and file hashes.";
+
+        assert_eq!(
+            extract_literals(nested),
+            vec!["* SyncEngine.odl: Logs of synchronized files and file hashes.".to_string()],
+            "the source-window check must keep reading an indent as code"
+        );
+        assert!(
+            extract_machine_literals(nested).is_empty(),
+            "an indented sentence is still being required to survive a merge: {:?}",
+            extract_machine_literals(nested)
+        );
+
+        // And what says machine-shaped in the text itself survives the
+        // narrowing, indented or not.
+        let both = "Run it:\n    `xmount --in ewf --out dd`\nleaves /tmp/image.vdi behind.";
+        for lit in ["xmount --in ewf --out dd", "/tmp/image.vdi"] {
+            assert!(
+                extract_machine_literals(both).iter().any(|l| l == lit),
+                "{lit} stopped being checked: {:?}",
+                extract_machine_literals(both)
+            );
+        }
     }
 
     #[test]

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -15,7 +15,16 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-const TRIM: [char; 8] = ['(', ')', ',', '.', ';', ':', '"', '\''];
+/// Punctuation that wraps a token without belonging to it.
+///
+/// `*` and `_` are here because they are markdown, not because they are
+/// punctuation: emphasis is the one wrapper that also appears in the set below
+/// that decides whether a slash-carrying token is machine-shaped. `**Win7/8/10:**`
+/// therefore matched — the asterisks supplied the second machine character —
+/// and a merge was told it had dropped a path that was never a path. Trimmed
+/// rather than dropped from that set, so `**/etc/fstab**` is still checked, as
+/// `/etc/fstab`.
+const TRIM: [char; 10] = ['(', ')', ',', '.', ';', ':', '"', '\'', '*', '_'];
 
 fn looks_like_a_path_or_flag(token: &str) -> bool {
     let t = token.trim_matches(|c: char| TRIM.contains(&c));
@@ -630,6 +639,27 @@ Use the whole device (/dev/sdX), never a partition, and pass --dry-run first.";
                 extract_machine_literals(both)
             );
         }
+    }
+
+    #[test]
+    fn markdown_emphasis_does_not_make_a_word_into_a_path() {
+        // A slash alone is not enough to call a token machine-shaped — that is
+        // what keeps "enables/disables" out — so something else in the token has
+        // to look like a path. Bold supplied it: the `*` in `**Win7/8/10:**` is
+        // in that set, and the merge of three USB artifacts was refused for
+        // dropping a "path" that is a Windows version list in bold.
+        assert!(!looks_like_a_path_or_flag("**Win7/8/10:**"));
+        assert!(!looks_like_a_path_or_flag("Win7/8/10"));
+        assert!(!looks_like_a_path_or_flag("__enables/disables__"));
+
+        // Emphasis around a real path is stripped, not disqualifying, and the
+        // literal reported is the path itself so the merge is checked for what
+        // it actually has to keep.
+        assert!(looks_like_a_path_or_flag("**/etc/fstab**"));
+        assert_eq!(
+            extract_machine_literals("It lives in **/etc/fstab** on boot."),
+            vec!["/etc/fstab".to_string()]
+        );
     }
 
     #[test]

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -316,6 +316,18 @@ pub async fn run(core: &Core) -> Result<Outcome> {
         tracing::warn!(error = %e, "could not flag merged artifacts that lost a source");
     }
 
+    // Pairs the old fan-in cap refused before any call was made. There is no
+    // cap now — the unit judges two artifacts at a time — so each of these is
+    // simply an unanswered question, and every one of them has
+    // `judge_attempts = 0`, so putting them back redoes no work and resets no
+    // backoff. Runs every sweep and matches nothing once drained, which is
+    // cheaper than the machinery a one-shot would need.
+    match core.store.reopen_oversized().await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(pairs = n, "reopened pairs the fan-in cap had refused"),
+        Err(e) => tracing::warn!(error = %e, "could not reopen the pairs the cap refused"),
+    }
+
     let mut out = Outcome::default();
 
     // Group everything near-identical first, and only then decide who wins.
@@ -2075,6 +2087,42 @@ pub(crate) mod tests {
             core.store.get_artifact(&m2.id).await.unwrap().status,
             ArtifactStatus::Active,
             "a merge whose embed is still in flight was reaped"
+        );
+    }
+
+
+    /// The state was terminal and reached without a call ever being made: the
+    /// component flattened past the cap and every pair in it was settled before
+    /// the model saw anything. Sixteen sit that way in the field.
+    #[tokio::test]
+    async fn the_sweep_puts_the_refused_pairs_back_in_the_queue() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
+        core.store.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
+        let id = core
+            .store
+            .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+            .await
+            .unwrap()[0]
+            .id;
+        core.store
+            .set_pair_state(
+                id,
+                crate::store::pairs::PairState::Oversized,
+                Some("12 sources, cap is 8"),
+            )
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::Oversized, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a pair refused before any call was made is still refused"
         );
     }
 }

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -187,15 +187,12 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         .iter()
         .map(|c| (c.title.as_deref().unwrap_or("untitled"), c.text.as_str()))
         .collect();
-    let texts: Vec<&str> = roots.iter().map(|c| c.text.as_str()).collect();
-    let differing = crate::infer::facts::differing_values(&texts);
-
     let permit = core.gate.background().await;
     let reply = core
         .judge
         .complete(
             crate::infer::prompt::DEDUPE_SYSTEM,
-            &crate::infer::prompt::dedupe_prompt(&shown, &differing, p.judge_attempts),
+            &crate::infer::prompt::dedupe_prompt(&shown, p.judge_attempts),
         )
         .await;
     permit.finished();

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -316,6 +316,18 @@ fn interpret(
             // card renders it directly beneath "these two disagree", so the
             // pair states the opposite of its own finding to the person the
             // escalation exists to hand it to.
+            //
+            // Logged, though. Keeping the tokens off the card is a judgement
+            // about what a person can act on; keeping them out of the process
+            // entirely left a refusal nothing anywhere could explain. Three
+            // pairs sat as unexplained "these two disagree" for a day, and
+            // finding out why meant reconstructing the tokenizer's output by
+            // hand against the two texts. This is the one place that knows.
+            tracing::warn!(
+                pair = pair.id,
+                lost = lost.join(", "),
+                "refused a merge that would have dropped these"
+            );
             relation = Relation::Conflict;
             detail = None;
             merged = None;

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -1,4 +1,4 @@
-//! One component, one call.
+//! One pair, one call.
 //!
 //! The sweep used to make up to `max_judgements` of these in a single job, so a
 //! consolidation run blocked every capture behind it for as long as twenty model
@@ -7,22 +7,29 @@
 //! and arms one unit each. The queue paces them and interleaves them with
 //! everything else.
 //!
-//! The unit expands its pair into the connected component of still-open pairs
-//! around it. Four related artifacts settled pairwise cost three calls and write
-//! two merged artifacts that are superseded almost immediately — and since a
-//! re-merge is always written from captured roots, those intermediates are paid
-//! for and thrown away for nothing.
+//! The unit asks about the two artifacts its pair names and nothing else. It
+//! used to expand into the connected component of still-open pairs around it and
+//! settle all of them with one verdict, which is what made fan-in something a
+//! single call had to survive: past `merge_max_roots` captured roots the
+//! component was refused outright and every pair in it settled `Oversized`,
+//! terminal and reached before the model saw anything. Sixteen pairs sat that
+//! way, twelve roots against a default of eight nobody had typed.
 //!
-//! Before the call, the component is flattened to its captured roots. A merged
-//! member's own text is never shown to the model: rewriting from a rewrite is
-//! how a paraphrase of a paraphrase ends up three generations from the wording
-//! someone actually captured. The lineage closure exists precisely so that
-//! flattening costs one query, and it keeps information loss one generation deep
-//! however many times a group is merged.
+//! A cluster converges by merging two at a time instead. Each merge inherits the
+//! flattened roots of both sides — `insert_merged_artifact` resolves the lineage
+//! closure — and carries its members' open pairs with it, so the next question is
+//! armed as soon as the merge is indexed rather than one sweep later.
+//!
+//! A member that is itself a merge is shown its own text as the thing under
+//! judgement, with its captured roots beneath it as context. The context is what
+//! keeps repeated merging from walking away from the wording someone captured:
+//! the model can put back a detail an earlier merge dropped. It is unlettered, so
+//! no verdict can name it, and it is trimmed oldest-first when the window is
+//! tight — reference material degrades an answer when it goes, where refusing the
+//! call answers nothing at all.
 //!
 //! Four verdicts come back and only two touch an artifact. A value conflict is
-//! escalated to a person and never merged; a group past the fan-in cap is
-//! surfaced rather than rewritten.
+//! escalated to a person and never merged.
 
 use crate::core::Core;
 use crate::error::{Error, Result};
@@ -34,96 +41,48 @@ use crate::store::pairs::{ArtifactPair, PairState};
 pub struct Settlement {
     pub relation: Relation,
     pub detail: Option<String>,
-    /// The root named obsolete, already checked against newest-wins. A root and
-    /// not a member, because roots are what the model was shown and therefore
-    /// the only things its letter can be naming. Only set for `Replaced`.
+    /// The member named obsolete, already checked against newest-wins. A member
+    /// and not a root, because the members are the only artifacts the prompt
+    /// letters and therefore the only things a letter can be naming. Only set
+    /// for `Replaced`.
     pub obsolete: Option<String>,
     /// Only set for `Duplicate`, and only once the loss check has passed.
     pub merged: Option<MergedDraft>,
-    /// The component's members, active as of the call.
+    /// The two artifacts the model was shown, in letter order.
     pub members: Vec<Chunk>,
-    /// Their captured roots, flattened. What the model was actually shown.
-    pub roots: Vec<Chunk>,
-    pub pairs: Vec<ArtifactPair>,
+    pub pair: ArtifactPair,
 }
 
 pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     let id: i64 = pair_id.parse().map_err(|_| Error::NotFound)?;
     let p = core.store.get_pair(id).await?;
     if p.state != PairState::Pending {
-        // Settled by an operator, by a later sweep, or by a sibling unit that
-        // already answered this whole component while this one waited.
+        // Settled by an operator, by a later sweep, or by the unit that merged
+        // one of its members while this one waited out a backoff.
         return Ok(());
     }
 
-    let mut pairs = core.store.open_component(id).await?;
-    let mut member_ids: Vec<String> = pairs
-        .iter()
-        .flat_map(|p| [p.a_id.clone(), p.b_id.clone()])
-        .collect();
-    member_ids.sort();
-    member_ids.dedup();
-
-    let mut members = Vec::new();
-    let mut retired: std::collections::HashSet<String> = Default::default();
-    for mid in &member_ids {
-        // Reported, not swallowed. `a_id` and `b_id` are `ON DELETE CASCADE` and
-        // every pool sets `foreign_keys`, so a pair naming an artifact that is
-        // gone is a state the schema does not allow — a failure here is the
-        // store being unwell, not a deletion to absorb.
-        let c = core.store.get_artifact(mid).await?;
-        // Re-checked here and not only when the unit was armed: a member can be
-        // superseded by a later sweep or deprecated by an operator while this
-        // waits out a backoff, and spending the scarcest thing in the system to
-        // rule on an artifact no longer in results buys nothing.
-        if !c.in_results() {
-            retired.insert(c.id);
-            continue;
-        }
-        members.push(c);
-    }
-    if !retired.is_empty() {
-        // Only the pairs naming a retired member are answered by its
-        // retirement. Dismissing the whole component killed sibling pairs
-        // between still-active duplicates — record_pair is INSERT OR IGNORE
-        // and Dismissed appears on no list, so nothing could ever re-file
-        // them and the surviving duplication was invisible forever.
-        let (dead, live): (Vec<_>, Vec<_>) = pairs
-            .into_iter()
-            .partition(|pr| retired.contains(&pr.a_id) || retired.contains(&pr.b_id));
-        settle_all(
+    // Reported, not swallowed. `a_id` and `b_id` are `ON DELETE CASCADE` and
+    // every pool sets `foreign_keys`, so a pair naming an artifact that is gone
+    // is a state the schema does not allow — a failure here is the store being
+    // unwell, not a deletion to absorb.
+    let a = core.store.get_artifact(&p.a_id).await?;
+    let b = core.store.get_artifact(&p.b_id).await?;
+    // Re-checked here and not only when the unit was armed: a member can be
+    // superseded by a later sweep or deprecated by an operator while this waits
+    // out a backoff, and spending the scarcest thing in the system to rule on an
+    // artifact no longer in results buys nothing.
+    if !a.in_results() || !b.in_results() {
+        return settle(
             core,
-            &dead,
+            &p,
             PairState::Dismissed,
             Some("a member is no longer in results"),
         )
-        .await?;
-        pairs = live;
-        // Dropping a member can strand others with no surviving pair; they
-        // are simply not part of this unit's question any more.
-        let named: std::collections::HashSet<&str> = pairs
-            .iter()
-            .flat_map(|pr| [pr.a_id.as_str(), pr.b_id.as_str()])
-            .collect();
-        members.retain(|c| named.contains(c.id.as_str()));
-        // The seed pair itself may be among the dead; the survivors keep
-        // their own units and nothing further is owed here.
-        if !pairs.iter().any(|pr| pr.id == id) {
-            return Ok(());
-        }
-    }
-    if members.len() < 2 {
-        settle_all(core, &pairs, PairState::Dismissed, None).await?;
-        return Ok(());
+        .await;
     }
 
-    // Flatten before anything else, and never show the model a merged member's
-    // own text.
-    //
-    // From `members`, not the list the component arrived with: the partition
-    // above drops retired members and their pairs, and roots resolved from the
-    // stale list would put a retired artifact back into the prompt, the fan-in
-    // cap, and the loss check — the question this unit is no longer asking.
+    let members = vec![a, b];
     let member_ids: Vec<String> = members.iter().map(|c| c.id.clone()).collect();
     let root_map = core.store.roots_of(&member_ids).await?;
     // A member with no roots at all is a merge whose sources were deleted out
@@ -134,74 +93,109 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         .iter()
         .any(|c| root_map.get(&c.id).is_none_or(|r| r.is_empty()))
     {
-        settle_all(
+        return settle(
             core,
-            &pairs,
+            &p,
             PairState::Contradiction,
             Some("a merged member has lost its sources; resolve by hand"),
         )
-        .await?;
-        return Ok(());
+        .await;
     }
-    let mut root_ids: Vec<String> = root_map.values().flatten().cloned().collect();
-    root_ids.sort();
-    root_ids.dedup();
-
-    if root_ids.len() > core.consolidate.merge_max_roots {
-        tracing::info!(
-            pair = id,
-            roots = root_ids.len(),
-            cap = core.consolidate.merge_max_roots,
-            "component draws on more roots than the cap; surfacing instead of merging"
-        );
-        let detail = format!(
-            "{} sources, cap is {}",
-            root_ids.len(),
-            core.consolidate.merge_max_roots
-        );
-        settle_all(core, &pairs, PairState::Oversized, Some(&detail)).await?;
-        return Ok(());
+    // A merge and one of its own sources are not two things to compare. Asking
+    // would spend a call to be told that an artifact matches itself.
+    let one_contains_the_other = root_map[&members[0].id].contains(&members[1].id)
+        || root_map[&members[1].id].contains(&members[0].id);
+    if one_contains_the_other {
+        return settle(
+            core,
+            &p,
+            PairState::Dismissed,
+            Some("one of these is a source of the other"),
+        )
+        .await;
     }
 
-    // Two members can flatten to one root — a merge and one of its own sources
-    // meet this way — and one root is nothing to compare. Asking would spend a
-    // call to be told an artifact matches itself.
-    if root_ids.len() < 2 {
-        settle_all(core, &pairs, PairState::Dismissed, None).await?;
-        return Ok(());
+    // A merged member's captured roots, oldest first — context, never an input.
+    // Read as whole artifacts because the prompt needs their titles: a body that
+    // never names its own subject is the failure `dedupe_prompt` documents.
+    let mut context: Vec<Vec<Chunk>> = Vec::new();
+    for c in &members {
+        let mut v = Vec::new();
+        if c.provenance == crate::store::artifacts::Provenance::Merged {
+            for rid in &root_map[&c.id] {
+                match core.store.get_artifact(rid).await {
+                    Ok(r) => v.push(r),
+                    Err(Error::NotFound) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+            v.sort_by_key(|r| r.created_at);
+        }
+        context.push(v);
     }
 
-    let mut roots = Vec::new();
-    for rid in &root_ids {
-        roots.push(core.store.get_artifact(rid).await?);
-    }
+    // The two artifacts under judgement are bounded by what capture bounds and
+    // always go out. What can grow without limit is the context block behind a
+    // long lineage — and context is reference, not input, so it is trimmed
+    // rather than defended against. Oldest first: the roots furthest from the
+    // present are the ones a later capture is most likely to have restated.
+    //
+    // No count-based cap. `merge_max_roots` was one, left at a default of eight
+    // nobody typed, and it settled whole clusters before any call was made.
+    let counter = crate::infer::budget::TokenCounter;
+    let window = core.judge.context_tokens();
+    let ceiling = core.judge.max_output_tokens();
+    let system = counter.count(crate::infer::prompt::DEDUPE_SYSTEM);
+    let user = loop {
+        let user = build_prompt(&members, &context, p.judge_attempts);
+        let cost = system + counter.count(&user);
+        if crate::infer::budget::checked_ceiling_for_prompt(window, cost, ceiling).is_some() {
+            break user;
+        }
+        // Whichever member still holds the oldest surviving source gives it up.
+        let oldest = context
+            .iter()
+            .enumerate()
+            .filter(|(_, v)| !v.is_empty())
+            .min_by_key(|(_, v)| v[0].created_at)
+            .map(|(i, _)| i);
+        match oldest {
+            Some(i) => {
+                context[i].remove(0);
+            }
+            // Nothing left to give: the two artifacts alone do not fit one call.
+            // That is a fact about an artifact's size rather than about this
+            // pair, no rule here can settle it, and recording it as answered is
+            // what `Oversized` did wrong. A person decides.
+            None => {
+                return settle(
+                    core,
+                    &p,
+                    PairState::Contradiction,
+                    Some("these two artifacts do not fit one call; resolve by hand"),
+                )
+                .await;
+            }
+        }
+    };
 
-    // Counted before the call and regardless of how it goes, so a group the
-    // model keeps failing on drops behind the rest of the queue rather than
-    // absorbing the budget again on the next sweep.
-    for pr in &pairs {
-        core.store.record_judge_attempt(pr.id).await?;
-    }
+    // Counted before the call and regardless of how it goes, so a pair the model
+    // keeps failing on drops behind the rest of the queue rather than absorbing
+    // the budget again on the next sweep.
+    core.store.record_judge_attempt(p.id).await?;
 
-    let shown: Vec<(&str, &str)> = roots
-        .iter()
-        .map(|c| (c.title.as_deref().unwrap_or("untitled"), c.text.as_str()))
-        .collect();
     let permit = core.gate.background().await;
     let reply = core
         .judge
-        .complete(
-            crate::infer::prompt::DEDUPE_SYSTEM,
-            &crate::infer::prompt::dedupe_prompt(&shown, p.judge_attempts),
-        )
+        .complete(crate::infer::prompt::DEDUPE_SYSTEM, &user)
         .await;
     permit.finished();
     let reply = reply?;
 
     let verdict = match crate::infer::prompt::parse_dedupe(&reply) {
         Ok(v) => v,
-        // A reply that cannot be read is an error, not a verdict: the component
-        // stays pending and the unit retries under the queue's backoff.
+        // A reply that cannot be read is an error, not a verdict: the pair stays
+        // pending and the unit retries under the queue's backoff.
         //
         // Retrying is only worth anything because `dedupe_prompt` carries the
         // attempt number. Against an endpoint that caches by exact prompt, an
@@ -209,30 +203,42 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
         // of `MAX_ATTEMPTS`.
         //
         // Counted here and not beside `record_judge_attempt`, because this is
-        // the only failure that says anything about the group. A call the
+        // the only failure that says anything about the pair. A call the
         // endpoint never answered says something about the endpoint, and letting
         // an outage count against every pending pair would take the whole review
         // queue out of reach on its way past.
         Err(e) => {
-            for pr in &pairs {
-                core.store.record_unreadable_judgement(pr.id).await?;
-            }
+            core.store.record_unreadable_judgement(p.id).await?;
             tracing::warn!(
                 pair = id,
                 attempt = p.judge_attempts,
                 // A parse error names the column it gave up at; without the
-                // length there is no way to tell whether that was the end of
-                // the reply — a cut-off answer — or a break in the middle of
-                // one the endpoint finished writing.
+                // length there is no way to tell whether that was the end of the
+                // reply — a cut-off answer — or a break in the middle of one the
+                // endpoint finished writing.
                 reply_len = reply.len(),
                 error = %e,
-                "dedupe reply unreadable; component stays pending"
+                "dedupe reply unreadable; pair stays pending"
             );
             return Err(e);
         }
     };
 
-    apply(core, interpret(verdict, members, roots, pairs)).await
+    apply(core, interpret(verdict, members, p)).await
+}
+
+/// Assemble the user prompt from the two members and whatever context survives
+/// the budget.
+fn build_prompt(members: &[Chunk], context: &[Vec<Chunk>], attempt: i64) -> String {
+    let member = |i: usize| crate::infer::prompt::DedupeMember {
+        title: members[i].title.as_deref().unwrap_or("untitled"),
+        text: members[i].text.as_str(),
+        sources: context[i]
+            .iter()
+            .map(|c| (c.title.as_deref().unwrap_or("untitled"), c.text.as_str()))
+            .collect(),
+    };
+    crate::infer::prompt::dedupe_prompt(&member(0), &member(1), attempt)
 }
 
 /// Turn a parsed reply into what the write path will do.
@@ -244,8 +250,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
 fn interpret(
     v: crate::infer::prompt::Dedupe,
     members: Vec<Chunk>,
-    roots: Vec<Chunk>,
-    pairs: Vec<ArtifactPair>,
+    pair: ArtifactPair,
 ) -> Settlement {
     let mut relation = v.relation;
     // The judge's own line. Nothing here writes one any more: the loss check
@@ -262,19 +267,19 @@ fn interpret(
         // obsolete is exactly the failure mode worth guarding against, since it
         // would hide the side more likely to be current.
         //
-        // The letter indexes `roots`. `run` builds the lettered list from the
-        // flattened roots and never shows a merged member's own text, so a
-        // letter resolved against `members` would name a different artifact
-        // whenever the two lists diverge — which is exactly when the component
-        // contains an earlier merge. That mismatch superseded an artifact the
-        // model had never been shown.
+        // The letter indexes the members, which are the only artifacts the
+        // prompt letters. A merged member's sources go in unlettered, so a
+        // letter can no longer resolve to something shown as reference — the
+        // mismatch that used to supersede an artifact the model had never been
+        // shown at all. A letter past the end names nothing and downgrades here,
+        // which is why `parse_dedupe` does not pin the range itself.
         let named = v
             .supersedes
             .map(|c| (c as u8 - b'a') as usize)
-            .and_then(|i| roots.get(i));
+            .and_then(|i| members.get(i));
         obsolete = match named {
             Some(named)
-                if roots
+                if members
                     .iter()
                     .all(|o| o.id == named.id || named.created_at <= o.created_at) =>
             {
@@ -290,7 +295,15 @@ fn interpret(
     if relation == Relation::Duplicate
         && let Some(d) = &merged
     {
-        let lost = crate::jobs::merge::losses(&roots, d);
+        // Against the members, which are what is actually being merged — not
+        // against every captured root behind them. A merged member's own text is
+        // already a generation away from its sources, so checking the draft
+        // against those sources would fail on a value an earlier merge dropped
+        // and freeze that lineage: no later merge in it could ever be written.
+        // Loss stays one generation deep per step, and the sources are in the
+        // prompt as context precisely so the model can undo the earlier drift
+        // rather than compound it.
+        let lost = crate::jobs::merge::losses(&members, d);
         if !lost.is_empty() {
             // Escalated rather than retried: the merge is the thing that was
             // wrong, and refusing it hands the pair to a person, which is the
@@ -315,144 +328,90 @@ fn interpret(
         obsolete,
         merged,
         members,
-        roots,
-        pairs,
+        pair,
     }
 }
 
 async fn apply(core: &Core, s: Settlement) -> Result<()> {
     match s.relation {
         Relation::Distinct => {
-            settle_all(core, &s.pairs, PairState::NoConflict, s.detail.as_deref()).await
+            settle(core, &s.pair, PairState::NoConflict, s.detail.as_deref()).await
         }
         Relation::Conflict => {
-            tracing::info!(
-                members = s.members.len(),
-                "artifacts disagree; escalating rather than merging"
-            );
-            settle_all(
-                core,
-                &s.pairs,
-                PairState::Contradiction,
-                s.detail.as_deref(),
-            )
-            .await
+            tracing::info!("artifacts disagree; escalating rather than merging");
+            settle(core, &s.pair, PairState::Contradiction, s.detail.as_deref()).await
         }
         Relation::Replaced => {
             let obsolete = s
                 .obsolete
                 .clone()
                 .expect("interpret sets this or downgrades to Conflict");
-            // Fresh statuses, not the snapshot `interpret` saw. The roots of a
-            // member that is itself a finished merge are already superseded,
-            // and a component can change while the unit waits out a backoff.
-            let mut fresh = Vec::new();
-            for r in &s.roots {
-                match core.store.get_artifact(&r.id).await {
-                    Ok(c) => fresh.push(c),
-                    Err(Error::NotFound) => {}
-                    Err(e) => return Err(e),
-                }
-            }
-            let obsolete_live = fresh.iter().any(|c| c.id == obsolete && c.in_results());
-            // A live root wins if one exists; otherwise the live member that
-            // carries the surviving roots — a finished merge's own sources are
-            // superseded, and the merge is the one thing still in results.
-            let winner = fresh
+            let winner = s
+                .members
                 .iter()
-                .find(|c| c.id != obsolete && c.in_results())
-                .map(|c| c.id.clone())
-                .or_else(|| {
-                    s.members
-                        .iter()
-                        .find(|m| m.id != obsolete)
-                        .map(|m| m.id.clone())
-                });
-            let (Some(winner), true) = (winner, obsolete_live) else {
-                // Nothing to apply: the named side is already out of results,
-                // so the replacement has in effect already happened.
-                return settle_all(
+                .find(|m| m.id != obsolete)
+                .map(|m| m.id.clone())
+                .expect("a pair has two members and only one of them is obsolete");
+            // A fresh status, not the snapshot `interpret` saw: an operator can
+            // retire the named side while the unit waits out a backoff.
+            let still_live = match core.store.get_artifact(&obsolete).await {
+                Ok(c) => c.in_results(),
+                Err(Error::NotFound) => false,
+                Err(e) => return Err(e),
+            };
+            if !still_live {
+                // Nothing to apply: the named side is already out of results, so
+                // the replacement has in effect already happened.
+                return settle(
                     core,
-                    &s.pairs,
+                    &s.pair,
                     PairState::NoConflict,
                     Some("the named replacement is already out of results"),
                 )
                 .await;
-            };
+            }
 
-            let (touching, survivors): (Vec<&ArtifactPair>, Vec<&ArtifactPair>) = s
-                .pairs
-                .iter()
-                .partition(|pr| pr.a_id == obsolete || pr.b_id == obsolete);
-
-            // The side effect FIRST. A failure here leaves every pair
-            // pending, so the unit retries under the queue's backoff — the
-            // reverse order left the verdict recorded on the pairs but never
-            // applied, because run() skips a component whose seed is no
-            // longer Pending.
+            // The side effect FIRST. A failure here leaves the pair pending, so
+            // the unit retries under the queue's backoff — the reverse order
+            // left the verdict recorded on the pair but never applied, because
+            // `run` skips a pair that is no longer Pending.
             core.supersede(&obsolete, &winner).await?;
             tracing::info!(superseded = %obsolete, by = %winner, "applied a replacement");
-            for pr in &touching {
-                // Done, with the model's reasoning kept as the record of why.
-                // Leaving it Superseded listed the applied replacement as
-                // awaiting confirmation forever.
-                core.store
-                    .set_pair_state(pr.id, PairState::Dismissed, s.detail.as_deref())
-                    .await?;
-            }
-
-            // Both sides of these pairs survived. Writing the direction on
-            // them would name an artifact the pair does not contain. Not left
-            // pending either: the roots are unchanged, so re-arming would
-            // build the identical prompt and receive the identical answer
-            // forever. An unanswered question goes to a person.
-            let survivor_detail =
-                format!("{obsolete} was superseded; these two were not separated");
-            for pr in &survivors {
-                core.store
-                    .set_pair_state(pr.id, PairState::Contradiction, Some(&survivor_detail))
-                    .await?;
-            }
-            Ok(())
+            // Done, with the model's reasoning kept as the record of why.
+            // Leaving it Superseded listed the applied replacement as awaiting
+            // confirmation forever.
+            settle(core, &s.pair, PairState::Dismissed, s.detail.as_deref()).await
         }
         Relation::Duplicate => {
             let draft = s
                 .merged
                 .as_ref()
                 .expect("interpret keeps this or downgrades to Conflict");
-            // Every member, not just the roots. A merged member is not its own
+            // Both members, not their roots. A merged member is not its own
             // root, and `finish` hides what the lineage names — so passing only
             // the roots would leave that earlier merge active and near-identical
-            // to the new one. `insert_merged_artifact` flattens all of them to
-            // captured roots, and `subsumed_merges` catches the merged members.
+            // to the new one. `insert_merged_artifact` flattens both of them to
+            // captured roots, and `subsumed_merges` catches the merged member.
             let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
             let m = crate::jobs::merge::write(core, draft, &sources).await?;
             // `merged_into` rather than a detail string: if the embed never
-            // lands, the sweep's reap has to find exactly these pairs and
-            // reopen them (`reap_stranded`).
-            for pr in &s.pairs {
-                core.store
-                    .set_pair_merged(pr.id, &m.id, s.detail.as_deref())
-                    .await?;
-            }
-            Ok(())
+            // lands, the sweep's reap has to find exactly this pair and reopen
+            // it (`reap_stranded`).
+            core.store
+                .set_pair_merged(s.pair.id, &m.id, s.detail.as_deref())
+                .await
         }
     }
 }
 
-/// One verdict answers every pair in the component. The ones it did not answer
-/// would be armed and asked about all over again, at full price, for a decision
-/// that has already been made.
-async fn settle_all(
+/// One pair, one verdict.
+async fn settle(
     core: &Core,
-    pairs: &[ArtifactPair],
+    pair: &ArtifactPair,
     state: PairState,
     detail: Option<&str>,
 ) -> Result<()> {
-    for p in pairs {
-        core.store.set_pair_state(p.id, state, detail).await?;
-    }
-    Ok(())
+    core.store.set_pair_state(pair.id, state, detail).await
 }
 
 #[cfg(test)]
@@ -468,7 +427,7 @@ mod tests {
     async fn queue_pair(core: &Core, a: &str, b: &str) -> i64 {
         core.store.record_pair(a, b, 0.91).await.unwrap();
         core.store
-            .pairs_by_state(PairState::Pending, 10)
+            .pairs_by_state(PairState::Pending, 100)
             .await
             .unwrap()
             .into_iter()
@@ -497,52 +456,6 @@ mod tests {
 
         assert_eq!(judge.calls(), 1, "the judge endpoint was not the one asked");
         assert_eq!(asker.calls(), 0, "the sweep called the ask model");
-    }
-
-    #[tokio::test]
-    async fn a_retired_members_roots_do_not_count_against_the_cap() {
-        // C is deprecated while the unit waits. Its pair is dismissed and it
-        // is dropped from the component — but its root must also leave the
-        // question, or a two-root component at the cap is settled Oversized
-        // for fan-in it does not have, and C's text is shown to the model as
-        // an original.
-        let mut core = test_core().await;
-        core.consolidate.merge_max_roots = 2;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
-            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
-        ]));
-        let ids = seed(
-            &core,
-            &[
-                ("a text", [1.0, 0.0]),
-                ("b text", [0.93, 0.37]),
-                ("c text", [0.90, 0.44]),
-            ],
-        )
-        .await;
-        let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
-        queue_pair(&core, &ids[1], &ids[2]).await;
-        core.deprecate(&ids[2]).await.unwrap();
-
-        run(&core, &seed_pair.to_string()).await.unwrap();
-
-        assert!(
-            core.store
-                .pairs_by_state(PairState::Oversized, 10)
-                .await
-                .unwrap()
-                .is_empty(),
-            "a retired member's root was counted against merge_max_roots"
-        );
-        // The live pair reached the model and took its verdict.
-        assert_eq!(
-            core.store
-                .pairs_by_state(PairState::NoConflict, 10)
-                .await
-                .unwrap()
-                .len(),
-            1
-        );
     }
 
     async fn disagreeing(core: &Core) -> Vec<String> {
@@ -674,117 +587,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_pair_of_two_survivors_is_not_closed_with_someone_elses_direction() {
-        // Three artifacts, two pairs, and one of the three named obsolete. The
-        // pair that holds it has a direction; the pair of the other two does
-        // not, and stamping the same `obsolete_id` on it put an artifact it does
-        // not contain behind an "apply supersede" button in Ops.
-        let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
-            r#"{"relation":"replaced","supersedes":"a","detail":"the first is stale"}"#.into(),
-        ]));
-        let ids = seed(
-            &core,
-            &[
-                ("timeout is 30 seconds", [1.0, 0.0]),
-                ("timeout is 60 seconds", [0.93, 0.37]),
-                ("timeout is 90 seconds", [0.94, 0.34]),
-            ],
-        )
-        .await;
-        let first = queue_pair(&core, &ids[0], &ids[1]).await;
-        let second = queue_pair(&core, &ids[1], &ids[2]).await;
-
-        run(&core, &first.to_string()).await.unwrap();
-
-        // Applied (autonomy is on), so its own pair is done — Dismissed, as
-        // the manual apply settles it, with the direction cleared.
-        let held = core.store.get_pair(first).await.unwrap();
-        assert_eq!(held.state, PairState::Dismissed);
-        assert_eq!(
-            core.store
-                .get_artifact(&ids[0])
-                .await
-                .unwrap()
-                .superseded_by
-                .as_deref(),
-            Some(ids[1].as_str())
-        );
-
-        let survivors = core.store.get_pair(second).await.unwrap();
-        assert_eq!(
-            survivors.obsolete_id, None,
-            "a pair was closed naming an artifact it does not contain"
-        );
-        assert_eq!(
-            survivors.state,
-            PairState::Contradiction,
-            "two artifacts the verdict never separated were quietly settled"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_letter_names_the_root_it_was_shown_beside_not_the_nth_member() {
-        // The component holds an earlier merge and one captured artifact, so the
-        // members are {M, c} and the lettered roots are {a, b, c}. The two lists
-        // diverge, and the model only ever saw the second — answering "b" means
-        // the root b, whose text was on the screen. Resolved against the members
-        // the same letter lands on the merge, which was never shown and never
-        // named. Under autonomy that hides the wrong artifact outright.
-        let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
-            r#"{"relation":"replaced","supersedes":"b","detail":"b is the stale one"}"#.into(),
-        ]));
-        let ids = seed(
-            &core,
-            &[
-                ("timeout is 30 seconds", [1.0, 0.0]),
-                ("timeout is 30 s", [0.99, 0.02]),
-                ("timeout is thirty seconds", [0.98, 0.04]),
-            ],
-        )
-        .await;
-        // uuid v7 sorts by creation, so the roots letter as a, b, c and the
-        // merge sorts after all three.
-        let merged = crate::jobs::merge::write(
-            &core,
-            &MergedDraft {
-                text: "timeout is 30 seconds".into(),
-                title: None,
-                category: None,
-                tags: vec![],
-                caveats: vec![],
-            },
-            &[ids[0].clone(), ids[1].clone()],
-        )
-        .await
-        .unwrap();
-        let pair = queue_pair(&core, &merged.id, &ids[2]).await;
-
-        run(&core, &pair.to_string()).await.unwrap();
-
-        assert_eq!(
-            core.store
-                .get_artifact(&ids[1])
-                .await
-                .unwrap()
-                .superseded_by
-                .as_deref(),
-            Some(ids[0].as_str()),
-            "the letter did not resolve to the root it was shown beside"
-        );
-        assert!(
-            core.store
-                .get_artifact(&merged.id)
-                .await
-                .unwrap()
-                .superseded_by
-                .is_none(),
-            "an artifact the model was never shown was superseded"
-        );
-    }
-
-    #[tokio::test]
     async fn a_replacement_naming_the_newer_artifact_is_not_trusted() {
         // A miscalibrated call proposing to hide the *newer* side disagrees with
         // the sweep's own newest-wins bias, so it falls back to a conflict
@@ -870,81 +672,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn one_call_settles_every_pair_in_the_component() {
-        // A verdict that answered only its own pair would leave the siblings
-        // pending, and the next sweep would arm them and ask the same question
-        // again at full price.
-        let mut core = test_core().await;
-        let completer = Arc::new(ScriptedCompleter::new(vec![
-            r#"{"relation":"distinct","detail":"three different things"}"#.into(),
-        ]));
-        core.judge = completer.clone();
-        let ids = seed(
-            &core,
-            &[
-                ("timeout is 30 seconds", [1.0, 0.0]),
-                ("timeout is 60 seconds", [0.93, 0.37]),
-                ("timeout is 90 seconds", [0.94, 0.34]),
-            ],
-        )
-        .await;
-        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
-        queue_pair(&core, &ids[1], &ids[2]).await;
-
-        run(&core, &pair.to_string()).await.unwrap();
-
-        assert_eq!(
-            completer.calls(),
-            1,
-            "the component cost more than one call"
-        );
-        assert!(
-            core.store
-                .pairs_by_state(PairState::Pending, 10)
-                .await
-                .unwrap()
-                .is_empty(),
-            "a sibling pair was left to be asked about again"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_component_past_the_fan_in_cap_is_surfaced_and_never_called_about() {
-        // A merge of forty sources is no longer one atomic piece of knowledge,
-        // which is what an artifact is defined to be. Past the cap the honest
-        // answer is to stop, not to write something nobody asked for.
-        let mut core = test_core().await;
-        core.consolidate.merge_max_roots = 2;
-        let completer = Arc::new(ScriptedCompleter::new(vec![]));
-        core.judge = completer.clone();
-        let ids = seed(
-            &core,
-            &[
-                ("timeout is 30 seconds", [1.0, 0.0]),
-                ("timeout is 60 seconds", [0.93, 0.37]),
-                ("timeout is 90 seconds", [0.94, 0.34]),
-            ],
-        )
-        .await;
-        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
-        queue_pair(&core, &ids[1], &ids[2]).await;
-
-        run(&core, &pair.to_string()).await.unwrap();
-
-        assert_eq!(completer.calls(), 0, "an oversized component cost a call");
-        let over = core
-            .store
-            .pairs_by_state(PairState::Oversized, 10)
-            .await
-            .unwrap();
-        assert_eq!(over.len(), 2, "every pair in the component must be settled");
-        assert_eq!(over[0].detail.as_deref(), Some("3 sources, cap is 2"));
-    }
-
-    #[tokio::test]
-    async fn a_sibling_unit_for_a_settled_component_is_a_no_op() {
-        // Two units are armed for one component and both run. The second must
-        // find its work done rather than asking again.
+    async fn a_second_unit_for_a_pair_already_settled_is_a_no_op() {
+        // Two units are armed for one pair — a sweep re-arming what a queued
+        // job already holds — and both run. The second must find its work done
+        // rather than paying for the same verdict twice.
         let mut core = test_core().await;
         let completer = Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"unrelated"}"#.into(),
@@ -955,21 +686,19 @@ mod tests {
             &[
                 ("timeout is 30 seconds", [1.0, 0.0]),
                 ("timeout is 60 seconds", [0.93, 0.37]),
-                ("timeout is 90 seconds", [0.94, 0.34]),
             ],
         )
         .await;
-        let first = queue_pair(&core, &ids[0], &ids[1]).await;
-        let second = queue_pair(&core, &ids[1], &ids[2]).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
-        run(&core, &first.to_string()).await.unwrap();
-        run(&core, &second.to_string()).await.unwrap();
+        run(&core, &pair.to_string()).await.unwrap();
+        run(&core, &pair.to_string()).await.unwrap();
 
-        assert_eq!(completer.calls(), 1, "the sibling unit asked again");
+        assert_eq!(completer.calls(), 1, "the second unit asked again");
     }
 
     #[tokio::test]
-    async fn a_failed_dedupe_leaves_the_component_pending() {
+    async fn a_failed_dedupe_leaves_the_pair_pending() {
         // A dead endpoint must not silently clear a queue of real duplicates.
         let mut core = test_core().await;
         core.judge = Arc::new(ScriptedCompleter::new(vec!["not json".into()]));
@@ -990,7 +719,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_component_whose_member_was_retired_is_dismissed_without_a_call() {
+    async fn a_pair_whose_member_was_retired_is_dismissed_without_a_call() {
         let mut core = test_core().await;
         let completer = Arc::new(ScriptedCompleter::new(vec![]));
         core.judge = completer.clone();
@@ -1058,43 +787,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_retired_member_dismisses_only_its_own_pairs() {
-        // Dismissing the whole component killed sibling pairs between
-        // still-active duplicates permanently: record_pair is INSERT OR
-        // IGNORE and Dismissed appears on no list, so the surviving
-        // duplication became invisible forever.
-        let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
-            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
-        ]));
-        let ids = seed(
-            &core,
-            &[
-                ("timeout is 30 seconds", [1.0, 0.0]),
-                ("timeout is 60 seconds", [0.93, 0.37]),
-                ("timeout is 90 seconds", [0.94, 0.34]),
-            ],
-        )
-        .await;
-        let p_ab = queue_pair(&core, &ids[0], &ids[1]).await;
-        let p_bc = queue_pair(&core, &ids[1], &ids[2]).await;
-        core.deprecate(&ids[2]).await.unwrap();
-
-        run(&core, &p_ab.to_string()).await.unwrap();
-
-        assert_eq!(
-            core.store.get_pair(p_bc).await.unwrap().state,
-            PairState::Dismissed,
-            "the pair naming the retired artifact should be dismissed"
-        );
-        assert_eq!(
-            core.store.get_pair(p_ab).await.unwrap().state,
-            PairState::NoConflict,
-            "the pair between two live artifacts must still be judged, not dismissed"
-        );
-    }
-
-    #[tokio::test]
     async fn an_applied_replacement_does_not_wait_for_an_operator() {
         // The pair used to stay in Superseded — the state every consumer reads
         // as "awaiting confirmation" — with Keep buttons that could only
@@ -1136,53 +828,157 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn a_replacement_naming_a_root_already_out_of_results_is_applied_to_the_carrier() {
-        // A component holding a finished merge flattens to roots that are
-        // already superseded. Applying blindly errored *after* the pairs were
-        // settled, and run()'s Pending guard made the error permanent: the
-        // verdict was recorded on the pairs yet never applied.
-        let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
-            r#"{"relation":"replaced","supersedes":"c","detail":"superseded by the merge"}"#.into(),
-        ]));
-        let ids = seed(
-            &core,
-            &[
-                ("timeout is 30 seconds", [1.0, 0.0]),
-                ("timeout is 30 s", [0.99, 0.02]),
-                ("timeout was 30 seconds once", [0.98, 0.04]),
-            ],
-        )
-        .await;
-        // uuid v7 sorts by creation, so the roots letter as a, b, c.
-        // Oldest, so the newest-wins guard accepts it as obsolete.
-        sqlx::query("UPDATE artifacts SET created_at = created_at - 100 WHERE id = ?")
-            .bind(&ids[2])
-            .execute(&core.store.pool)
-            .await
-            .unwrap();
-        let merged = crate::jobs::merge::write(
-            &core,
+    /// A merged artifact, written straight to the store, for the cases where
+    /// "a member is itself a merge" is the thing under test.
+    async fn merged_from(core: &Core, title: &str, text: &str, sources: &[String]) -> String {
+        let m = crate::jobs::merge::write(
+            core,
             &MergedDraft {
-                text: "timeout is 30 seconds".into(),
-                title: None,
+                title: Some(title.into()),
+                text: text.into(),
                 category: None,
                 tags: vec![],
                 caveats: vec![],
             },
-            &[ids[0].clone(), ids[1].clone()],
+            sources,
         )
         .await
         .unwrap();
-        // The merge finished: its roots are superseded, only it and c remain.
-        crate::jobs::merge::finish(&core, &merged.id).await.unwrap();
-        let pair = queue_pair(&core, &merged.id, &ids[2]).await;
+        m.id
+    }
+
+    #[tokio::test]
+    async fn a_unit_settles_only_its_own_pair() {
+        // The unit used to claim the whole connected component and answer every
+        // pair in it with one verdict. A sibling pair is a separate question
+        // about a different pair of artifacts, and it keeps its own turn.
+        let mut core = test_core().await;
+        core.judge = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+        ]));
+        let ids = seed(
+            &core,
+            &[
+                ("a text", [1.0, 0.0]),
+                ("b text", [0.93, 0.37]),
+                ("c text", [0.90, 0.44]),
+            ],
+        )
+        .await;
+        let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        queue_pair(&core, &ids[1], &ids[2]).await;
+
+        run(&core, &seed_pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::NoConflict, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the sibling pair was answered by a call that was not about it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cluster_past_the_old_cap_is_asked_about_rather_than_refused() {
+        // Twelve artifacts in one chain is exactly the shape the fan-in cap
+        // refused: it flattened past the default of eight and every pair in it
+        // was settled Oversized, terminal, with no call ever made. Nothing about
+        // it is oversized now — it is a sequence of two-artifact questions.
+        let mut core = test_core().await;
+        core.judge = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+        ]));
+        let rows: Vec<(&str, [f32; 2])> = vec![
+            ("t0", [1.00, 0.00]),
+            ("t1", [0.99, 0.01]),
+            ("t2", [0.98, 0.02]),
+            ("t3", [0.97, 0.03]),
+            ("t4", [0.96, 0.04]),
+            ("t5", [0.95, 0.05]),
+            ("t6", [0.94, 0.06]),
+            ("t7", [0.93, 0.07]),
+            ("t8", [0.92, 0.08]),
+            ("t9", [0.91, 0.09]),
+            ("t10", [0.90, 0.10]),
+            ("t11", [0.89, 0.11]),
+        ];
+        let ids = seed(&core, &rows).await;
+        let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        for w in ids.windows(2).skip(1) {
+            queue_pair(&core, &w[0], &w[1]).await;
+        }
+
+        run(&core, &seed_pair.to_string()).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Oversized, 20)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a twelve-artifact cluster was refused instead of asked about"
+        );
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::NoConflict, 20)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_letter_names_a_member_and_never_one_of_its_sources() {
+        // The letter used to be resolved against the flattened roots while the
+        // members were a different list, and whenever a component held an
+        // earlier merge the two diverged — superseding an artifact the model had
+        // never been shown. Here "a" is the merge, whose own sources would be
+        // the ones a stale resolution reached.
+        let mut core = test_core().await;
+        let ids = seed_titled(
+            &core,
+            &[
+                ("Old", "the pool holds eight", [1.0, 0.0]),
+                ("Aside", "unrelated text", [0.99, 0.05]),
+                ("Stale", "the pool holds four", [0.60, 0.80]),
+            ],
+        )
+        .await;
+        // A is the merge, so its two sources are what a letter resolved against
+        // a flattened root list would reach. B is the artifact beside it.
+        let m = merged_from(
+            &core,
+            "Merged",
+            "the pool holds eight, and unrelated text",
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await;
+        let pair = queue_pair(&core, &m, &ids[2]).await;
+        // `record_pair` stores the two sides in id order, and `run` letters them
+        // as it finds them — so which letter the merge got is not the caller's
+        // to choose. The stale artifact is the one being named here; naming the
+        // merge would be refused by newest-wins, since a merge is always the
+        // newest artifact in its own lineage.
+        let stored = core.store.get_pair(pair).await.unwrap();
+        let letter = if stored.a_id == ids[2] { "a" } else { "b" };
+        core.judge = Arc::new(ScriptedCompleter::new(vec![format!(
+            r#"{{"relation":"replaced","detail":"stale","supersedes":"{letter}"}}"#
+        )]));
 
         run(&core, &pair.to_string()).await.unwrap();
 
-        // Every root besides c is superseded, so the live carrier — the merge
-        // itself, a member — wins, and the settle happens after the apply.
         assert_eq!(
             core.store
                 .get_artifact(&ids[2])
@@ -1190,16 +986,278 @@ mod tests {
                 .unwrap()
                 .superseded_by
                 .as_deref(),
-            Some(merged.id.as_str()),
-            "the replacement was not applied against the live carrier"
+            Some(m.as_str()),
+            "the letter did not name the member it was shown beside"
+        );
+        for src in &ids[..2] {
+            assert!(
+                core.store.get_artifact(src).await.unwrap().in_results(),
+                "a source the model was shown as context was superseded by the verdict"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_merged_member_reaches_the_model_with_its_sources() {
+        // Its own words are the thing under judgement; the captured originals go
+        // beneath them so a detail an earlier merge dropped can come back.
+        let mut core = test_core().await;
+        let judge = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+        ]));
+        core.judge = judge.clone();
+        let ids = seed_titled(
+            &core,
+            &[
+                ("Pool sizing", "max_connections is 16", [1.0, 0.0]),
+                ("Pool notes", "raise it for batch jobs", [0.99, 0.05]),
+                ("Connections", "sixteen connections", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let m = merged_from(
+            &core,
+            "Pool",
+            "the pool holds sixteen",
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await;
+        let pair = queue_pair(&core, &m, &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let sent = judge.prompts();
+        let sent = sent.first().expect("the judge was asked");
+        assert!(
+            sent.contains("the pool holds sixteen"),
+            "the merge's own words were withheld: {sent}"
         );
         assert!(
+            sent.contains("max_connections is 16"),
+            "a source was not shown as context: {sent}"
+        );
+        assert!(sent.contains("SOURCES OF"), "{sent}");
+    }
+
+    #[tokio::test]
+    async fn a_merge_and_one_of_its_own_sources_is_dismissed_without_a_call() {
+        // The pairwise form of the old "flattens to one root" guard: comparing a
+        // merge with an artifact it was written from asks whether something
+        // matches itself, at the price of a call.
+        let mut core = test_core().await;
+        let judge = Arc::new(ScriptedCompleter::new(vec![]));
+        core.judge = judge.clone();
+        let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.99, 0.05])]).await;
+        let m = merged_from(
+            &core,
+            "Merged",
+            "a text and b text",
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await;
+        let pair = queue_pair(&core, &m, &ids[0]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            judge.calls(),
+            0,
+            "a call was spent asking whether an artifact matches itself"
+        );
+        assert_eq!(
             core.store
-                .pairs_by_state(PairState::Pending, 10)
+                .pairs_by_state(PairState::Dismissed, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_value_lost_by_an_earlier_merge_does_not_block_the_next_one() {
+        // The loss check runs against what is actually being merged. Against the
+        // whole flattened lineage instead, a value dropped a generation ago
+        // would fail every later merge in that lineage forever and freeze it.
+        let mut core = test_core().await;
+        core.judge = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"duplicate","detail":"same thing",
+                "merged":{"title":"Pool","text":"the pool holds sixteen connections","tags":[],"caveats":[]}}"#
+                .into(),
+        ]));
+        let ids = seed_titled(
+            &core,
+            &[
+                (
+                    "Pool sizing",
+                    "max_connections is 16 and the timeout is 30s",
+                    [1.0, 0.0],
+                ),
+                ("Pool notes", "raise it for batch jobs", [0.99, 0.05]),
+                ("Connections", "sixteen connections", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        // This merge already dropped "30s". The next one is not to blame for it.
+        let m = merged_from(
+            &core,
+            "Pool",
+            "the pool holds sixteen",
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await;
+        let pair = queue_pair(&core, &m, &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Contradiction, 10)
                 .await
                 .unwrap()
                 .is_empty(),
-            "the component was left pending"
+            "the merge was blamed for a value an earlier one had dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_merge_of_a_merge_names_every_original_behind_it() {
+        // The whole point of merging two at a time: the result is mergeable
+        // again, and it carries the flattened lineage of both sides rather than
+        // naming the intermediate.
+        let mut core = test_core().await;
+        core.judge = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"duplicate","detail":"same thing",
+                "merged":{"title":"Pool","text":"max_connections is 16, raise it for batch jobs, sixteen connections","tags":[],"caveats":[]}}"#
+                .into(),
+        ]));
+        let ids = seed_titled(
+            &core,
+            &[
+                ("Pool sizing", "max_connections is 16", [1.0, 0.0]),
+                ("Pool notes", "raise it for batch jobs", [0.99, 0.05]),
+                ("Connections", "sixteen connections", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let m1 = merged_from(
+            &core,
+            "Pool",
+            "max_connections is 16, raise it for batch jobs",
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await;
+        let pair = queue_pair(&core, &m1, &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        let settled = core.store.get_pair(pair).await.unwrap();
+        let m2 = settled
+            .merged_into
+            .expect("the second merge was never written");
+        let roots = core.store.roots_of(&[m2]).await.unwrap();
+        let roots: Vec<&String> = roots.values().flatten().collect();
+        assert_eq!(
+            roots.len(),
+            3,
+            "the merge of a merge did not inherit both lineages"
+        );
+        for id in &ids {
+            assert!(roots.contains(&id), "an original is missing from the lineage");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_context_block_too_big_for_the_window_is_trimmed_not_refused() {
+        // Context is reference material, so a window too small to hold it costs
+        // the answer some quality — never the answer itself.
+        let mut core = test_core().await;
+        let judge = Arc::new(ScriptedCompleter::new(vec![
+            r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
+        ]));
+        judge.set_context_tokens(1200);
+        core.judge = judge.clone();
+        let long = "verylongsourcetoken ".repeat(400);
+        let ids = seed_titled(
+            &core,
+            &[
+                ("Root one", long.as_str(), [1.0, 0.0]),
+                ("Root two", "raise it for batch jobs", [0.99, 0.05]),
+                ("Other", "sixteen connections", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let m = merged_from(
+            &core,
+            "Pool",
+            "the pool holds sixteen",
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await;
+        let pair = queue_pair(&core, &m, &ids[2]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(judge.calls(), 1, "the call was refused instead of trimmed");
+        let sent = judge.prompts().first().cloned().unwrap();
+        assert!(
+            sent.contains("the pool holds sixteen"),
+            "a member was trimmed away"
+        );
+        assert!(
+            sent.contains("sixteen connections"),
+            "a member was trimmed away"
+        );
+        assert!(
+            !sent.contains(long.as_str()),
+            "the oversized source was not trimmed"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_members_that_alone_do_not_fit_go_to_a_person() {
+        // A different failure with a different cause: an artifact so large that
+        // no pair containing it can be judged. No rule here settles that, and
+        // recording it as answered is what `Oversized` did wrong.
+        let mut core = test_core().await;
+        let judge = Arc::new(ScriptedCompleter::new(vec![]));
+        judge.set_context_tokens(100);
+        core.judge = judge.clone();
+        let long = "verylongartifacttoken ".repeat(500);
+        let ids = seed_titled(
+            &core,
+            &[
+                ("One", long.as_str(), [1.0, 0.0]),
+                ("Two", long.as_str(), [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            judge.calls(),
+            0,
+            "a call that cannot fit the window was sent anyway"
+        );
+        let stuck = core
+            .store
+            .pairs_by_state(PairState::Contradiction, 10)
+            .await
+            .unwrap();
+        assert_eq!(stuck.len(), 1);
+        assert!(
+            stuck[0].detail.as_deref().unwrap_or("").contains("do not fit"),
+            "the reason a person is being asked was not recorded"
+        );
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Oversized, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the refused state came back under the old name"
         );
     }
 }

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -351,6 +351,15 @@ pub async fn split_into_artifact_jobs(core: &Core, corpus_id: &str) -> Result<()
 /// split at a paragraph boundary. Truncating would silently discard knowledge,
 /// and one vector per fragment keeps the data model unchanged.
 async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) -> Result<()> {
+    // A merged artifact has no corpus to write siblings into and no reading
+    // order to put them in, so every route through here that ends in
+    // `replace_with_siblings` ends in the same refusal, on every attempt, for
+    // ever. Four of them sat at the backoff ceiling for a day: unembedded, so
+    // out of search, so never a neighbour of anything, and — because
+    // `mark_indexed` is what finishes a merge — with their roots still active
+    // beside them. Cutting is simply not the move available for one of these,
+    // so the attempts at it are skipped rather than made and refused.
+    let splittable = chunk.corpus_id.is_some();
     // The limit is checked against what actually gets embedded, and that is the
     // title followed by the text. Siblings inherit the title, so only what the
     // title leaves over is available to their text. Giving the text the whole
@@ -364,7 +373,7 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
 
     // A title that fills the limit on its own cannot be cut out of the way:
     // every sibling would carry it too, so no split of the text can help.
-    if budget > 0 {
+    if splittable && budget > 0 {
         let parts = split_by_paragraphs(&chunk.text, budget, &core.counter);
         if parts.len() > 1 {
             return replace_with_siblings(core, chunk, parts).await;
@@ -387,7 +396,8 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
     tracing::warn!(
         artifact_id = %chunk.id,
         title_cost,
-        "oversize chunk has nothing left to cut on; embedding as-is"
+        splittable,
+        "oversize chunk has no split available; embedding as-is"
     );
     let permit = core.gate.background().await;
     let embedded = core.embedder.embed(std::slice::from_ref(&chunk.text)).await;
@@ -397,6 +407,13 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         // Refused, not failed: the endpoint answered. This arm does not test
         // `budget`, because a refusal we cannot act on is still a refusal.
         Err(e) if input_too_large(&e) => {
+            // The endpoint has now settled it for a merge too: it does not fit,
+            // and no split of it can land anywhere. Index what does fit rather
+            // than leaving an artifact that has swallowed several others out of
+            // search entirely.
+            if !splittable {
+                return embed_head(core, chunk, limit).await;
+            }
             // Still nothing to cut with when the title alone fills the limit:
             // `split_by_lines` at a budget of zero puts every line in a part of
             // its own and then falls to the 64-character floor, which shreds the
@@ -429,6 +446,81 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         // coverage this embedding advances and nothing to settle.
         None => Ok(()),
     }
+}
+
+/// Index a merged artifact too long for the embedder using as much of its head
+/// as fits.
+///
+/// Splitting is what the corpus path does and it is the better answer where it
+/// is available: one vector per fragment loses nothing. A merge has no corpus,
+/// and cutting it into siblings would throw away the lineage that says what it
+/// was made of — the objection `replace_with_siblings` raises and is right to.
+/// The choice here is not between a whole vector and a partial one, then, but
+/// between a partial one and none at all, and none at all means an artifact
+/// that has swallowed several others and cannot be found by any of them.
+///
+/// So: the dense vector is placed by the opening of the text, which is where a
+/// merged artifact states its subject, and the sparse vector still encodes the
+/// whole thing, so every term in the tail is searchable exactly as before. The
+/// stored text is untouched. What degrades is semantic ranking against the tail,
+/// and that is worth saying out loud in the log, because a merge this long is
+/// usually a merge that should have stayed two artifacts.
+async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
+    let title_cost = chunk
+        .title
+        .as_deref()
+        .map_or(0, |t| core.counter.count(&format!("{t}\n")));
+    let budget = limit.saturating_sub(title_cost);
+    let head = if budget > 0 {
+        split_by_lines(&chunk.text, budget, &core.counter)
+            .into_iter()
+            .next()
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    // A title that fills the embedder's limit by itself leaves no prefix to
+    // take, and that is a broken title rather than an over-long merge. Reported
+    // rather than worked around, which is what the no-corpus refusal was for.
+    if head.trim().is_empty() {
+        return Err(Error::Validation(format!(
+            "cannot embed merged artifact {}: its title alone fills the {limit}-token limit",
+            chunk.id
+        )));
+    }
+
+    tracing::warn!(
+        artifact_id = %chunk.id,
+        kept = head.len(),
+        of = chunk.text.len(),
+        "merged artifact is too long to embed and has no corpus to split into; \
+         indexing its opening"
+    );
+
+    let input = match chunk.title.as_deref() {
+        Some(t) => format!("{t}\n{head}"),
+        None => head,
+    };
+    let permit = core.gate.background().await;
+    let embedded = core.embedder.embed(std::slice::from_ref(&input)).await;
+    permit.finished();
+    let vectors = embedded?;
+
+    upsert_with_current_lifecycle(
+        core,
+        vec![VectorPoint {
+            vector: vectors.into_iter().next().unwrap(),
+            // The whole artifact, unlike the dense side. Lexical retrieval has
+            // no length limit to respect, so there is no reason to lose the
+            // tail on both halves of the query at once.
+            sparse: crate::vector::sparse::encode_document(&chunk.text),
+            payload: payload_of(chunk),
+        }],
+    )
+    .await?;
+    // Which also finishes the merge: its roots stay active and beside it in
+    // search until this lands, and that is the state these four were stuck in.
+    mark_indexed(core, chunk).await
 }
 
 /// Cut text on blank lines, packing as many paragraphs into each part as the
@@ -521,9 +613,14 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
     // Splitting means writing siblings into the parent's document, at ordinals
     // around its own. A merged artifact has neither: no corpus to insert into
     // and no reading order to preserve, and its siblings would lose the lineage
-    // that says what it was made of. A merge that will not embed is a bug in
-    // the merge — the draft is too long, or the model ran away — and it belongs
-    // on Ops rather than being quietly chopped into fragments nothing can trace.
+    // that says what it was made of.
+    //
+    // A backstop now rather than the answer. `split_oversize` no longer routes
+    // one of these here at all — it indexes the head instead, because this
+    // refusal is permanent and every attempt at it produced the same error and
+    // another turn of the backoff, which left four merges out of search and
+    // unfinished for a day. Kept so that a future caller cannot reintroduce the
+    // silent chopping this refuses; reaching it is a bug in that caller.
     let Some(corpus_id) = chunk.corpus_id.as_deref() else {
         return Err(Error::Validation(format!(
             "refusing to split merged artifact {}: it belongs to no corpus",

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -95,8 +95,9 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
     // out of this merge stays in results, and this repair path — re-run by the
     // sweep for as long as the merge stands — must not undo that decision on
     // every tick.
-    for root in core.store.roots_to_hide(&m.id).await? {
-        let Ok(r) = core.store.get_artifact(&root).await else {
+    let hiding = core.store.roots_to_hide(&m.id).await?;
+    for root in &hiding {
+        let Ok(r) = core.store.get_artifact(root).await else {
             continue;
         };
         if !r.in_results() {
@@ -106,14 +107,15 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
         // active, and an operator deprecating a root between the read and here
         // is an ordinary race rather than a reason to abandon the other roots —
         // the sweep's repair reaches whatever is left.
-        crate::jobs::try_supersede(core, &root, &m.id, "a merged artifact's root").await;
+        crate::jobs::try_supersede(core, root, &m.id, "a merged artifact's root").await;
     }
 
     // And any earlier merge this one subsumes. Superseding only the roots would
     // leave that merge active and near-identical to this one, so the relate unit
     // would file the pair again on the next sweep and the two would churn
     // against each other for as long as they both existed.
-    for older in core.store.subsumed_merges(&m.id).await? {
+    let subsumed = core.store.subsumed_merges(&m.id).await?;
+    for older in &subsumed {
         // Everything the older merge was hiding has to be re-pointed first.
         // Those roots are already superseded — by `older` — so `finish`'s loop
         // above skipped them, and hiding `older` behind this merge without
@@ -121,13 +123,40 @@ pub async fn finish(core: &Core, merged_id: &str) -> Result<()> {
         // itself out of results. That is the exact failure `Clusters` exists to
         // prevent on the sweep's side, and the reader who opens a root would be
         // sent to a dead end.
-        for hidden in core.store.artifacts_superseded_by(&older).await? {
+        for hidden in core.store.artifacts_superseded_by(older).await? {
             if let Err(e) = core.repoint_supersession(&hidden, &m.id).await {
                 tracing::warn!(artifact = %hidden, to = %m.id, error = %e,
                     "could not re-point a supersession; it still names a hidden winner");
             }
         }
-        crate::jobs::try_supersede(core, &older, &m.id, "a merge this one subsumes").await;
+        crate::jobs::try_supersede(core, older, &m.id, "a merge this one subsumes").await;
+    }
+
+    // The open questions its members carried are now questions about the merge.
+    // C was a duplicate of B; B is inside M; so C is a duplicate of M. Left
+    // alone the pair dies with B — `run` dismisses a pair whose member is out of
+    // results — and the duplication only comes back when M has embedded and a
+    // later similarity sweep re-files the same question, which is a whole tick
+    // per generation of a cluster.
+    //
+    // Here and not in `write`: at this point the merge is indexed and what it
+    // replaced is hidden. Re-pointing at write time would arm a unit that could
+    // merge this artifact into a further one before it had ever superseded its
+    // own sources, leaving them active underneath a chain whose middle is out of
+    // results — the dead end `repoint_supersession` exists to prevent above.
+    //
+    // Warn and carry on, like the loops above. A pair that could not be moved is
+    // a question filed against an artifact that is now hidden, which the sweep
+    // re-files against the merge; losing the whole repair over it would be the
+    // more expensive failure.
+    let mut swallowed = hiding;
+    swallowed.extend(subsumed);
+    match core.store.repoint_open_pairs(&swallowed, &m.id).await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(merged = %m.id, pairs = n, "moved open pairs onto a merge"),
+        Err(e) => {
+            tracing::warn!(merged = %m.id, error = %e, "could not move open pairs onto a merge")
+        }
     }
     Ok(())
 }
@@ -1039,5 +1068,76 @@ mod tests {
         ];
         let d = draft("Port 8080 is the default and the timeout is 30s.");
         assert_eq!(losses(&roots, &d), vec!["5".to_string()]);
+    }
+
+
+    /// C was a duplicate of B; B is now inside M. Without this the question
+    /// dies with B and only comes back once M has embedded and a later
+    /// similarity sweep re-files it — a whole tick per generation of a cluster.
+    #[tokio::test]
+    async fn finishing_a_merge_moves_its_members_open_pairs_onto_it() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("a text", [1.0, 0.0]),
+                ("b text", [0.99, 0.05]),
+                ("c text", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        core.store.record_pair(&ids[1], &ids[2], 0.91).await.unwrap();
+        let m = write(
+            &core,
+            &draft("a text and b text"),
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await
+        .unwrap();
+
+        finish(&core, &m.id).await.unwrap();
+
+        assert_eq!(
+            core.store.pair_state_between(&ids[2], &m.id).await.unwrap(),
+            Some(crate::store::pairs::PairState::Pending),
+            "the surviving duplicate has no question against the merge"
+        );
+    }
+
+    /// `finish` is re-run by the sweep for as long as the merge stands, so a
+    /// second pass must not put back a question the first one already moved.
+    #[tokio::test]
+    async fn re_pointing_is_safe_to_run_twice() {
+        let core = crate::core::test_support::test_core().await;
+        let ids = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("a text", [1.0, 0.0]),
+                ("b text", [0.99, 0.05]),
+                ("c text", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        core.store.record_pair(&ids[1], &ids[2], 0.91).await.unwrap();
+        let m = write(
+            &core,
+            &draft("a text and b text"),
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .await
+        .unwrap();
+
+        finish(&core, &m.id).await.unwrap();
+        finish(&core, &m.id).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .pairs_by_state(crate::store::pairs::PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "a second finish duplicated the question"
+        );
     }
 }

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -415,12 +415,12 @@ mod tests {
     #[test]
     fn a_merge_that_keeps_both_values_is_allowed() {
         let roots = [
-            root("The request timeout is 30 seconds."),
-            root("The request timeout is 90 seconds."),
+            root("The request timeout is 30s."),
+            root("The request timeout is 90s."),
         ];
         let d = draft(
-            "Sources differ on the request timeout: an earlier capture gives 30 seconds, \
-             a later one 90 seconds.",
+            "Sources differ on the request timeout: an earlier capture gives 30s, \
+             a later one 90s.",
         );
         assert!(losses(&roots, &d).is_empty(), "{:?}", losses(&roots, &d));
     }
@@ -432,11 +432,21 @@ mod tests {
         // writing. The result reads well, ranks well, and the missing number is
         // gone from the base — a conflict resolved by deletion.
         let roots = [
+            root("The request timeout is 30s."),
+            root("The request timeout is 90s."),
+        ];
+        let d = draft("The request timeout is 90s.");
+        assert_eq!(losses(&roots, &d), vec!["30s".to_string()]);
+
+        // Written without its unit, the same drop goes uncaught. `30` alone is
+        // not distinguishable from the third item of a numbered list, and
+        // demanding every bare number survive refused three correct merges —
+        // see `infer::facts::a_port_written_bare_is_the_cost_of_that_rule`.
+        let bare = [
             root("The request timeout is 30 seconds."),
             root("The request timeout is 90 seconds."),
         ];
-        let d = draft("The request timeout is 90 seconds.");
-        assert_eq!(losses(&roots, &d), vec!["30".to_string()]);
+        assert!(losses(&bare, &draft("The request timeout is 90 seconds.")).is_empty());
     }
 
     #[test]
@@ -1059,15 +1069,16 @@ mod tests {
 
     #[test]
     fn a_merge_of_three_roots_is_checked_against_all_of_them() {
-        // The fan-in cap allows up to eight. A check that only read the first
-        // two would pass a merge that dropped everything the third said.
+        // A pair whose members are themselves merges reaches this with more
+        // than two roots behind it. A check that only read the first two would
+        // pass a merge that dropped everything the third said.
         let roots = [
-            root("Port 8080 is the default."),
+            root("Port 8080/tcp is the default."),
             root("The timeout is 30s."),
-            root("Retries are capped at 5."),
+            root("Retries back off for 5m."),
         ];
-        let d = draft("Port 8080 is the default and the timeout is 30s.");
-        assert_eq!(losses(&roots, &d), vec!["5".to_string()]);
+        let d = draft("Port 8080/tcp is the default and the timeout is 30s.");
+        assert_eq!(losses(&roots, &d), vec!["5m".to_string()]);
     }
 
 

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -260,15 +260,20 @@ pub fn losses(roots: &[Chunk], draft: &MergedDraft) -> Vec<String> {
                 out.push(tok);
             }
         }
-        // Literals: commands, paths, flags, error strings. The existing check,
-        // with the merged text as the haystack instead of the segment —
-        // `missing_literals(artifact_text, caveats, haystack)` asks which
-        // literals of the first argument are absent from the third, which is
-        // exactly this question with the arguments in this order.
+        // Literals: commands, paths, flags, error strings. `verify`'s module
+        // header states the stake — a paraphrased command is a command that
+        // later gets pasted into a root shell.
         //
-        // `verify`'s module header states the stake: a paraphrased command is a
-        // command that later gets pasted into a root shell.
-        out.extend(crate::infer::verify::missing_literals(
+        // The machine-shaped ones only. This used to call `missing_literals`,
+        // the check synthesis runs against the source window, and the two
+        // questions are not the same one with different arguments: an artifact
+        // is copied from its window, while merged text is a rewrite by
+        // construction and here routinely a rewrite between German and English.
+        // Under the source-window rules a four-space indent counts as code, so
+        // three nested bullets of ordinary English prose in a OneDrive artifact
+        // were required to survive word for word, and a correct merge was
+        // refused for rewording them — which is the merged text's whole job.
+        out.extend(crate::infer::verify::missing_machine_literals(
             &r.text, &r.caveats, &haystack,
         ));
     }
@@ -358,6 +363,68 @@ mod tests {
         let mut d = draft("The request timeout is 90 seconds.");
         d.caveats = vec!["An earlier capture gave 30 seconds.".into()];
         assert!(losses(&roots, &d).is_empty(), "{:?}", losses(&roots, &d));
+    }
+
+    #[test]
+    fn a_merge_may_reword_an_indented_bullet_list() {
+        // The real veto this removes, verbatim from the base: pair 481, two
+        // OneDrive artifacts, one German and one English. The English side nests
+        // its file list four spaces deep, and the source-window rules read a
+        // four-space indent as a code block — so three ordinary sentences,
+        // descriptions and all, became literals that had to survive word for
+        // word. A merge across two languages cannot reproduce them, so the merge
+        // was thrown away and the pair went to the operator as "these two
+        // disagree" every time. Rewording those lines is what merging is.
+        let roots = [
+            root(
+                "Log Dateien befinden sich im Ordner \
+                 \"\\Users\\<USERNAME>\\AppData\\Local\\Microsoft\\OneDrive\\logs\". \
+                 Der Ordner Personal enthält die Datei SyncEngine.odl, welche logs der \
+                 Synchronisation enthält, und die Datei SyncDiagnostics.txt.",
+            ),
+            root(
+                "Standard OneDrive locations and log files:\n\
+                 * Personal directory contents:\n\
+                 \x20   * SyncEngine.odl: Logs of synchronized files and file hashes.\n\
+                 \x20   * Trace.ETL: TraceCurrent.ETL and TraceArchive.ETL for activity tracking.\n\
+                 \x20   * SyncDiagnostics.txt: Log of current synchronization content.",
+            ),
+        ];
+        let d = draft(
+            "OneDrive log files live in \\Users\\<USERNAME>\\AppData\\Local\\Microsoft\\OneDrive\\logs, \
+             which has the subdirectories Common and Personal. Personal holds SyncEngine.odl \
+             (synchronized files and their hashes), Trace.ETL (TraceCurrent.ETL and \
+             TraceArchive.ETL, for activity tracking) and SyncDiagnostics.txt (current \
+             synchronization content).",
+        );
+        assert!(
+            losses(&roots, &d).is_empty(),
+            "a correct merge was refused for rewording prose: {:?}",
+            losses(&roots, &d)
+        );
+    }
+
+    #[test]
+    fn a_merge_that_drops_a_path_is_still_refused() {
+        // The other half of pair 486, which was a genuine model error and has to
+        // keep being caught. Two xmount invocations: the second exists only for
+        // the cache overlay that leaves a bootable /tmp/image.vdi, and the draft
+        // merged them into the first and dropped it. Narrowing the check to
+        // machine-shaped literals must not cost this — a bare path says what it
+        // is in the text and needs no guess from the indentation.
+        let roots = [
+            root("xmount --in ewf --out dd *.E?? /mnt stellt das Image unter /mnt bereit."),
+            root(
+                "Im Mountpoint /tmp befindet sich jetzt die Datei image.vdi welche direkt \
+                 in VirtualBox über den Mountpoint /tmp/image.vdi eingebunden werden kann.",
+            ),
+        ];
+        let d = draft("xmount --in ewf --out dd *.E?? /mnt stellt das Image unter /mnt bereit.");
+        let lost = losses(&roots, &d);
+        assert!(
+            lost.iter().any(|l| l.contains("/tmp/image.vdi")),
+            "the merge dropped the path the second artifact exists for: {lost:?}"
+        );
     }
 
     #[test]

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -419,6 +419,123 @@ impl Store {
         Ok(res.rows_affected())
     }
 
+    /// Move every still-open pair that names one of `old` onto `new_id`.
+    ///
+    /// Called when a merge is finished, so that a duplicate of one of its
+    /// sources becomes a duplicate of the merge rather than dying with the
+    /// source. Without this a cluster only converges by waiting for the merge
+    /// to embed and a later similarity sweep to re-file the same question,
+    /// which is a whole tick per generation.
+    ///
+    /// Three rows never move. One whose other side is already `new_id` would
+    /// become a pair of the merge with itself. One that would collide with an
+    /// existing pair between the same two artifacts must leave that row alone,
+    /// whatever state it is in — that is what keeps an operator's dismissal
+    /// binding, the same property `record_pair`'s `INSERT OR IGNORE` provides.
+    /// Both are dismissed instead, because the merge has answered the question
+    /// they carried. And a row that is not `Pending` is an answered question
+    /// already; moving it would re-file someone's verdict against an artifact
+    /// it was never about.
+    ///
+    /// `judge_attempts` and `judge_unreadable` reset, because the moved row
+    /// asks about a different pair of artifacts than the one that earned those
+    /// counts. This cannot loop: every merge takes an artifact out of results,
+    /// so the sequence of merges a cluster can produce is finite.
+    ///
+    /// `score` is deliberately left alone and is now stale — it was measured
+    /// between the old member and the other side. It orders the judge queue and
+    /// gates nothing by this point, so the staleness costs ordering accuracy
+    /// and nothing else.
+    pub async fn repoint_open_pairs(&self, old: &[String], new_id: &str) -> Result<u64> {
+        let mut moved = 0u64;
+        for o in old {
+            if o == new_id {
+                continue;
+            }
+            let rows = sqlx::query(
+                "SELECT * FROM artifact_pairs
+                  WHERE state = 'pending' AND (a_id = ? OR b_id = ?)",
+            )
+            .bind(o)
+            .bind(o)
+            .fetch_all(&self.pool)
+            .await?;
+            for p in rows.iter().map(row_to_pair) {
+                let other = if p.a_id == *o {
+                    p.b_id.clone()
+                } else {
+                    p.a_id.clone()
+                };
+                // Both sides went into this merge, or the other side is the
+                // merge already. Either way the row would name the merge twice.
+                // Tested against `old` and not only against `new_id`, because
+                // the sides are visited one at a time: a pair between two
+                // sources is moved onto the merge while the first is being
+                // handled and only recognised as a self-pair while the second
+                // is, which leaves it counted as moved.
+                if other == new_id || old.iter().any(|x| *x == other) {
+                    self.set_pair_state(
+                        p.id,
+                        PairState::Dismissed,
+                        Some("both of these went into the same merge"),
+                    )
+                    .await?;
+                    continue;
+                }
+                if self.pair_state_between(&other, new_id).await?.is_some() {
+                    self.set_pair_state(
+                        p.id,
+                        PairState::Dismissed,
+                        Some("a pair between these two already exists"),
+                    )
+                    .await?;
+                    continue;
+                }
+                let (a, b) = if other.as_str() <= new_id {
+                    (other.as_str(), new_id)
+                } else {
+                    (new_id, other.as_str())
+                };
+                sqlx::query(
+                    "UPDATE artifact_pairs
+                        SET a_id = ?, b_id = ?, judge_attempts = 0, judge_unreadable = 0,
+                            detail = NULL
+                      WHERE id = ?",
+                )
+                .bind(a)
+                .bind(b)
+                .bind(p.id)
+                .execute(&self.pool)
+                .await?;
+                moved += 1;
+            }
+        }
+        Ok(moved)
+    }
+
+    /// Put every pair the old fan-in cap refused back into the judge queue.
+    ///
+    /// `Oversized` was terminal and reached without a call ever being made: the
+    /// component flattened to more roots than the cap and every pair in it was
+    /// settled before the model saw anything. Pairwise merging removes the
+    /// condition, so the rows left behind are simply unanswered questions.
+    ///
+    /// Run every sweep rather than once behind a guard. Nothing writes the
+    /// state any more, so the first pass drains it and every later one matches
+    /// no rows — cheaper than the machinery a one-shot would need.
+    ///
+    /// Safe whatever the queue looks like: a refused row never spent a call, so
+    /// `judge_attempts` is zero and no backoff is being reset.
+    pub async fn reopen_oversized(&self) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE artifact_pairs SET state = 'pending', detail = NULL
+              WHERE state = 'oversized'",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+
     /// Pending pairs in the order the judge should spend its budget on them.
     ///
     /// Least-attempted first, then by score. A pair whose reply could not be
@@ -548,6 +665,29 @@ mod tests {
     use super::*;
     use crate::store::Store;
     use crate::store::artifacts::NewArtifact;
+
+    /// `n` artifacts under one corpus, for the cases that need more than a pair.
+    async fn n_artifacts(s: &Store, n: usize) -> Vec<String> {
+        let src = s.insert_corpus("x", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..n)
+            .map(|i| NewArtifact {
+                ordinal: i as i64,
+                text: format!("artifact {i}"),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        s.insert_artifacts(&src.id, &new)
+            .await
+            .unwrap()
+            .iter()
+            .map(|c| c.id.clone())
+            .collect()
+    }
 
     async fn two_artifacts(s: &Store) -> (String, String) {
         let src = s.insert_corpus("x", "web", None).await.unwrap();
@@ -1180,5 +1320,152 @@ mod tests {
         let p = s.get_pair(id).await.unwrap();
         assert_eq!(p.state, PairState::Contradiction);
         assert_eq!(p.merged_into, None);
+    }
+
+    /// The whole point of re-pointing: C was a duplicate of B, B is now inside
+    /// M, so C is a duplicate of M and the question survives the merge.
+    #[tokio::test]
+    async fn an_open_pair_follows_its_member_into_the_merge() {
+        let s = Store::memory().await.unwrap();
+        let ids = n_artifacts(&s, 4).await;
+        let (b, c, m) = (&ids[1], &ids[2], &ids[3]);
+        s.record_pair(b, c, 0.91).await.unwrap();
+
+        let moved = s.repoint_open_pairs(&[b.clone()], m).await.unwrap();
+
+        assert_eq!(moved, 1);
+        assert_eq!(
+            s.pair_state_between(c, m).await.unwrap(),
+            Some(PairState::Pending),
+            "the pair did not follow B into M"
+        );
+        assert_eq!(
+            s.pair_state_between(b, c).await.unwrap(),
+            None,
+            "the old pair is still there"
+        );
+    }
+
+    /// A pair between the merge's two own sources becomes a pair of the merge
+    /// with itself. There is no question left in it.
+    #[tokio::test]
+    async fn a_pair_between_two_sources_of_the_same_merge_is_dismissed() {
+        let s = Store::memory().await.unwrap();
+        let ids = n_artifacts(&s, 3).await;
+        let (a, b, m) = (&ids[0], &ids[1], &ids[2]);
+        s.record_pair(a, b, 0.91).await.unwrap();
+
+        let moved = s
+            .repoint_open_pairs(&[a.clone(), b.clone()], m)
+            .await
+            .unwrap();
+
+        assert_eq!(moved, 0, "a self-pair was written");
+        assert_eq!(
+            s.pair_state_between(a, b).await.unwrap(),
+            Some(PairState::Dismissed)
+        );
+    }
+
+    /// An operator's decision outlives the merge. Re-pointing onto a pair
+    /// someone already dismissed must not put that question back, which is the
+    /// same property `record_pair`'s `INSERT OR IGNORE` provides.
+    #[tokio::test]
+    async fn re_pointing_onto_an_existing_pair_leaves_the_existing_row_alone() {
+        let s = Store::memory().await.unwrap();
+        let ids = n_artifacts(&s, 3).await;
+        let (b, c, m) = (&ids[0], &ids[1], &ids[2]);
+        s.record_pair(c, m, 0.80).await.unwrap();
+        let existing = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(existing, PairState::Dismissed, Some("operator"))
+            .await
+            .unwrap();
+        s.record_pair(b, c, 0.91).await.unwrap();
+
+        let moved = s.repoint_open_pairs(&[b.clone()], m).await.unwrap();
+
+        assert_eq!(moved, 0);
+        assert_eq!(
+            s.pair_state_between(c, m).await.unwrap(),
+            Some(PairState::Dismissed),
+            "an operator's dismissal was overwritten"
+        );
+        assert_eq!(
+            s.pair_state_between(b, c).await.unwrap(),
+            Some(PairState::Dismissed)
+        );
+    }
+
+    /// The re-pointed row asks a different question than the one that earned
+    /// the counters, so it must not inherit a backoff from artifacts it no
+    /// longer names.
+    #[tokio::test]
+    async fn a_re_pointed_pair_starts_its_attempts_over() {
+        let s = Store::memory().await.unwrap();
+        let ids = n_artifacts(&s, 3).await;
+        let (b, c, m) = (&ids[0], &ids[1], &ids[2]);
+        s.record_pair(b, c, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.record_judge_attempt(id).await.unwrap();
+        s.record_unreadable_judgement(id).await.unwrap();
+
+        s.repoint_open_pairs(&[b.clone()], m).await.unwrap();
+
+        let pending = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        let moved = pending
+            .iter()
+            .find(|p| p.a_id == *m || p.b_id == *m)
+            .expect("the row moved");
+        assert_eq!(moved.judge_attempts, 0);
+        assert_eq!(moved.judge_unreadable, 0);
+    }
+
+    /// Only pending rows move. A settled pair is an answered question, and
+    /// moving it would re-file someone's verdict against an artifact it was
+    /// never about.
+    #[tokio::test]
+    async fn a_settled_pair_is_not_re_pointed() {
+        let s = Store::memory().await.unwrap();
+        let ids = n_artifacts(&s, 3).await;
+        let (b, c, m) = (&ids[0], &ids[1], &ids[2]);
+        s.record_pair(b, c, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(id, PairState::NoConflict, None)
+            .await
+            .unwrap();
+
+        let moved = s.repoint_open_pairs(&[b.clone()], m).await.unwrap();
+
+        assert_eq!(moved, 0);
+        assert_eq!(
+            s.pair_state_between(b, c).await.unwrap(),
+            Some(PairState::NoConflict)
+        );
+    }
+
+    /// The state was terminal and reached without a call: the component
+    /// flattened past the cap and every pair in it was settled before the model
+    /// saw anything. Sixteen of these exist in the field.
+    #[tokio::test]
+    async fn an_oversized_pair_goes_back_into_the_queue() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(id, PairState::Oversized, Some("12 sources, cap is 8"))
+            .await
+            .unwrap();
+
+        assert_eq!(s.reopen_oversized().await.unwrap(), 1);
+
+        let back = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        assert_eq!(back.len(), 1);
+        assert_eq!(
+            back[0].detail, None,
+            "the cap's line is still on a pending row"
+        );
+        assert_eq!(back[0].judge_attempts, 0);
+        // Runs every sweep; once the queue is drained it must do nothing.
+        assert_eq!(s.reopen_oversized().await.unwrap(), 0);
     }
 }

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -60,10 +60,14 @@ pub enum PairState {
     /// at a time leaves A pointing at a B that is itself hidden — which is what
     /// the sweep's union-find exists to prevent.
     NearIdentical,
-    /// The component this pair belongs to draws on more captured roots than
-    /// `merge_max_roots`. Not merged, and surfaced instead: a merge of forty
-    /// sources is no longer one atomic piece of knowledge, which is what an
-    /// artifact is defined to be.
+    /// Deprecated and never written. The variant survives one release so that
+    /// rows already carrying it still parse.
+    ///
+    /// It meant the component this pair belonged to drew on more captured roots
+    /// than `merge_max_roots` — terminal, and reached before any call was made,
+    /// so nothing could ever return to it. The unit judges two artifacts at a
+    /// time now, which removes the condition, and `reopen_oversized` puts the
+    /// rows left behind back in the queue.
     Oversized,
 }
 

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1236,8 +1236,24 @@ impl VectorStore for QdrantVectors {
         status: ArtifactStatus,
         superseded_by: Option<&str>,
     ) -> Result<()> {
-        let _: Value = self
-            .call(
+        // Absent is not a failure here. An artifact can legitimately have no
+        // point — its embedding never ran, or it failed — and a lifecycle change
+        // on one has nothing to write to rather than something to complain
+        // about. `embed::upsert_with_current_lifecycle` reads the row when it
+        // finally writes a point, so the status lands with the vector if one is
+        // ever created, and until then there is nothing to drift from.
+        //
+        // Reading the 404 as an error broke `merge::reap_stranded` completely:
+        // it retires a merge *because that merge could not be indexed*, so the
+        // point never existed, so the deprecation errored on every call. The row
+        // went to `deprecated` and the rest of the reap — reopening the pairs
+        // merged into it, dropping the embed job that could never succeed —
+        // never ran, while the log reported the reap as failed. It also handed
+        // the same 404 to `consolidate::repair_lifecycle_drift`, which writes
+        // its batch in one call and would fail every other artifact's repair
+        // alongside it.
+        let _: Option<Value> = self
+            .call_absent_point_as_none(
                 Method::POST,
                 &format!("/collections/{}/points/payload?wait=true", self.alias),
                 Some(json!({
@@ -2267,6 +2283,101 @@ mod tests {
         assert!(
             dense_of(&json!({ "sparse_only": {} })).is_none(),
             "a point without a dense vector must be reported, not silently skipped"
+        );
+    }
+
+    /// A store pointed at a mock, for the arms that turn an HTTP status into a
+    /// decision rather than a value.
+    async fn against(server: &wiremock::MockServer) -> QdrantVectors {
+        QdrantVectors::connect(&VectorConfig {
+            url: server.uri(),
+            collection: "engram".into(),
+            api_key: None,
+            recency_weight: 0.05,
+            recency_half_life_days: 180,
+            pinned_boost: 0.15,
+            weak_below: 0.35,
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_lifecycle_change_on_an_artifact_with_no_point_is_not_a_failure() {
+        // `merge::reap_stranded` retires a merge *because it could not be
+        // indexed*, so the point it would update never existed. Reading that
+        // 404 as an error meant the reap deprecated the row and then died
+        // before reopening the merge's pairs or dropping the embed job that
+        // could never succeed — on every call, for every stranded merge, while
+        // the log said the reap had failed.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/collections/engram/points/payload"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "status": { "error": "Not found: No point with id 0192… found" }
+            })))
+            .mount(&server)
+            .await;
+
+        against(&server)
+            .await
+            .set_lifecycle(
+                "0192abcd-0000-7000-8000-000000000000",
+                ArtifactStatus::Deprecated,
+                None,
+            )
+            .await
+            .expect("a missing point is nothing to write to, not an error");
+    }
+
+    #[tokio::test]
+    async fn a_lifecycle_change_against_a_missing_collection_is_still_a_failure() {
+        // The other thing Qdrant answers 404 to. An alias pointing at a dropped
+        // generation affects every artifact, and reading it as "this one has no
+        // point" would turn a broken store into a silent success each time.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/collections/engram/points/payload"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "status": { "error": "Not found: Collection `engram` doesn't exist!" }
+            })))
+            .mount(&server)
+            .await;
+        // What `call_absent_point_as_none` asks when the message does not name
+        // a point: is the collection there? It resolves the alias first, then
+        // asks. It is not.
+        Mock::given(method("GET"))
+            .and(path("/aliases"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "aliases": [] }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/collections/engram/exists"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "exists": false }
+            })))
+            .mount(&server)
+            .await;
+
+        assert!(
+            against(&server)
+                .await
+                .set_lifecycle(
+                    "0192abcd-0000-7000-8000-000000000000",
+                    ArtifactStatus::Deprecated,
+                    None
+                )
+                .await
+                .is_err(),
+            "a store with no collection must be reported, not read as an empty one"
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1370,13 +1370,9 @@ fn title_of(c: &crate::store::artifacts::Chunk) -> String {
 /// the cap strands nothing — there is no second page to go and find the rest
 /// on, which is the point: Housekeeping is reference, not work.
 const PAIR_LIMIT: usize = 5;
-const PAIR_STATES: [crate::store::pairs::PairState; 4] = [
+const PAIR_STATES: [crate::store::pairs::PairState; 3] = [
     crate::store::pairs::PairState::Contradiction,
     crate::store::pairs::PairState::Superseded,
-    // A group past `merge_max_roots` was not merged and will not be: it needs a
-    // person, so it belongs on the page a person opens rather than on
-    // Housekeeping beside the things that resolve themselves.
-    crate::store::pairs::PairState::Oversized,
     crate::store::pairs::PairState::Pending,
 ];
 


### PR DESCRIPTION
Seven pairs sat on the capture page reading **"these two disagree"** with no proposed direction. The judge had already answered every one of them — four model calls covering all seven pairs, none unreadable. The verdicts came from the two text-matching passes on either side of the model, and only one of the seven was a real model error.

## Before the call: a prior built out of punctuation

`facts::differing_values` compared value-shaped tokens across the artifacts, and `dedupe_prompt` passed the difference on as "these values are not stated the same way by all of them — decide which."

`fact_tokens` splits on whitespace, so what it extracts depends on how a version list happens to be punctuated:

| artifact | writes it as | tokens |
|---|---|---|
| `01a00ee5` | `Win7/8/10` | *(none — digits glued to a word)* |
| `01a00ee6` | `(Windows 7-10)` | `7-10` |
| `01a004ef` | `Windows 7, 8 und 10` | `7`, `8`, `10` |

Three artifacts stating one fact three ways, three unrelated token sets, a non-empty difference. The prompt then named four bare integers — stripped of any sign that they were Windows versions — to the model, which read them against a table of USB registry codes and reported *"conflicting information regarding the specific Windows versions associated with the registry value codes 0066 and 0067."* That is the correct reading of the evidence it was given.

The list also could not distinguish "only one side states this" from "the two state it differently", so an Outlook artifact that merely lists more versions than its pair (`15.0`, `16.0`) arrived as a dispute rather than as a superset.

The prior decided nothing, so removing it costs no capability — the model still sees both artifacts in full and has every verdict available. `differing_values` is deleted rather than left unused so it cannot be wired back in. `fact_tokens` stays: the rule it actually serves is `merge::losses`, which asks whether a token is *present* rather than whether two spellings match — a sound question, and one where numbers help because they read the same in German and in English.

## After the call: a verbatim check against text that is meant to be a rewrite

`merge::losses` ran `verify::missing_literals`, the check synthesis runs against the source window. That check treats a four-space indent as a code block — correct against the window an artifact was copied out of, wrong against merged text. A OneDrive artifact nests its log-file list one level deep:

```
* Personal directory contents:
    * SyncEngine.odl: Logs of synchronized files and file hashes.
    * Trace.ETL: TraceCurrent.ETL and TraceArchive.ETL for activity tracking.
    * SyncDiagnostics.txt: Log of current synchronization content.
```

Those three ordinary English sentences were extracted whole as literals and required to survive word for word. A merge of a German artifact and an English one cannot reproduce them, so a correct merge was thrown away and the pair escalated — with a detail line naming, as "lost", three facts that both sides state.

`extract_machine_literals` drops that single heuristic and keeps fences, backticks and bare paths. `missing_machine_literals` is what merges call now. Both variants share one comparison function so they cannot drift apart.

**Capture-time verification is deliberately untouched** (`jobs::window` still calls `missing_literals`). There the other side of the comparison really is the text the artifact was copied from, same language, and the synthesizer was told to copy commands verbatim — that is the check standing between an invented command and somebody's root shell. A test asserts the two variants differ on exactly this point, so they don't get "unified" later by accident.

## Tests

The regression tests use the text from the real rows rather than synthetic fixtures:

- `a_merge_may_reword_an_indented_bullet_list` — the OneDrive pair now merges.
- `a_merge_that_drops_a_path_is_still_refused` — the `xmount` pair still loses `/tmp/image.vdi` and is still refused. That one was a genuine model error and has to keep being caught.
- `only_the_merge_side_stops_reading_an_indent_as_code` — pins the deliberate asymmetry.
- `how_a_version_list_is_punctuated_decides_what_is_extracted` — pins the tokenizer behaviour that made the comparison unsound, rather than pretending it was fixed.

962 library tests pass; `cargo clippy --lib` and `cargo fmt --check` are clean.

## Note

This only affects pairs judged from now on. `Contradiction` is terminal — nothing re-arms it — so the existing rows still carry the verdicts the old prompt produced and are being re-armed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Merging two artifacts at a time, and retiring the fan-in cap

Sixteen pairs sit in `Oversized`, every one of them with `judge_attempts = 0`. The model has never been asked about any of them and, before this branch, never would be.

`dedupe::run` expanded its seed pair into the connected component of open pairs around it, flattened that to captured roots, and refused outright when the flattened set exceeded `consolidate.merge_max_roots` — settling every pair in the component before any call was made. `pairs_to_judge` reads only pending rows, so the state was terminal and nothing could return to it. Two components account for the sixteen rows: one of twelve roots across nine pairs, one of nine roots across seven. The cap was eight, which nobody set — it shipped as the default in `config.example.toml` and quietly switched merging off for any cluster past eight sources.

Twelve artifacts of a few hundred tokens each is nowhere near any context ceiling. These components were not refused because they could not be judged.

## What changed

**The unit judges one pair.** Fan-in was only ever a property one call had to survive because a single call had to settle a whole component. Merging two artifacts at a time removes the category: a twelve-root cluster never needed a twelve-root prompt, it needed six calls of two. Each merge inherits the flattened roots of both sides — `insert_merged_artifact` already resolves the lineage closure — so the intermediates are real artifacts the next step builds on rather than waste.

**A merged member is shown its own text, with its captured roots beside it as context.** The roots are reference material the model can draw a dropped detail back from, not merge inputs. They are unlettered, which by construction removes the bug documented at the old `dedupe.rs:261-266`: a `supersedes` letter resolved against the flattened roots while the members were a different list, and whenever a component held an earlier merge the mismatch superseded an artifact the model had never been shown.

**No size gate.** The context block is trimmed oldest-first against the judge's real window (`checked_ceiling_for_prompt`) instead of being bounded by a count. Trimming degrades an answer; it never blocks one. Two member texts that alone do not fit is a different failure with a different cause — an artifact no pair containing it can be judged against — and goes to a person under `Contradiction`. The rule this encodes: a pair reaches a terminal state only by being answered.

**The loss check runs against the two members.** Against the whole flattened lineage, a value dropped in the first generation would fail every later merge in it forever and freeze the lineage. Loss stays one generation deep per step, and the context block is what lets the model reverse earlier drift rather than compound it. This is the one place the new design is weaker than the old, and it is deliberate: the old design bought "never more than one generation from captured wording" at the price of never merging past eight sources at all.

**Siblings are re-pointed at `merge::finish`.** C was a duplicate of B; B is inside M; so C is a duplicate of M. Left alone the pair dies with B and only returns once M has embedded and a later sweep re-files it — a whole tick per generation. Re-pointing at `write` time instead would arm a unit that could merge M onward before M had superseded its own sources.

**The sixteen rows are reopened by the sweep,** every tick, matching nothing once drained. Safe precisely because of what the diagnosis found: `judge_attempts = 0` means no work is redone and no backoff is reset. They enter the queue at the front, since `pairs_to_judge` orders `judge_attempts ASC` first.

**`consolidate.merge_max_roots` is deprecated** — `Option<usize>`, read by nothing, warned about when set, parseable for one release. The clamp that put a value below two back to the default goes with it: its reasoning was right, and the default of eight was the same failure at a less obvious threshold.

`PairState::Oversized` is no longer written and no longer listed on Housekeeping. The variant survives one release so existing rows parse.

## Testing

`cargo test`: 1084 passing, 0 failing. New coverage includes a merge of a merge inheriting all three originals, a twelve-artifact cluster judged rather than refused, a letter that names a member and never a context source, context trimmed oldest-first with both members surviving, two members that alone do not fit escalating to a person, re-pointing's self-pair and collision rules, `finish` being safe to run twice, and a value lost by an earlier merge not blocking the next one.

Two bugs the tests caught during implementation: `repoint_open_pairs` visited pair sides one at a time and counted a source-to-source pair as moved before recognising it as a self-pair; and a first pass at `interpret` reinstated a loss-check sentence `e85cab6` had deliberately removed.

## Follow-up worth doing

`open_component` and `COMPONENT_WINDOW` now have no callers outside their own five tests. Left in place rather than deleting a public store method outside this change's scope.

## Design docs

- `docs/superpowers/specs/2026-08-17-pairwise-merge-design.md`
- `docs/superpowers/plans/2026-08-17-pairwise-merge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sd9ydvBrhHV22DKDsw4Gs
