### PR TITLE
The corpus page in bands, and a nav that holds still

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -528,8 +528,46 @@ mark { background: var(--color-accent-dim); color: inherit; border-radius: 2px; 
 @keyframes qpulse { 0%, 100% { opacity: 1 } 50% { opacity: 0.25 } }
 @media (prefers-reduced-motion: reduce) { .qdot { animation: none } }
 
-/* The stretches of a capture nothing was written from. */
-.uncovered { margin: 0 0 0.75rem; padding-left: 1.25rem; font-size: 0.875rem; }
+/* ── The corpus, band by band ────────────────────────────────────────────── */
+
+/* One row per band: the source on the left, what was written from it on the
+   right. Heights are ragged on purpose — a band is as tall as its source, so
+   an eight-line passage that yielded one short artifact leaves the right cell
+   mostly empty. Folding it would hide source on the page that exists to show
+   source. */
+.bands { display: flex; flex-direction: column; gap: 0.75rem; }
+.band { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; align-items: start; }
+.band > * { min-width: 0; }
+.band-src {
+  background: var(--color-bg-elevated); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); overflow-x: auto;
+}
+.band-src table { border-collapse: collapse; width: 100%;
+                  font-family: var(--font-mono); font-size: 0.8125rem; }
+.band-src td { padding: 1px 0.5rem 1px 2rem; vertical-align: top;
+               white-space: pre-wrap; overflow-wrap: anywhere; text-indent: -1.5rem; }
+.band-src td.ln {
+  width: 3.5rem; text-align: right; color: var(--color-fg-muted); user-select: none;
+  border-right: 1px solid var(--color-border-subtle); font-variant-numeric: tabular-nums;
+  padding: 1px 0.5rem; text-indent: 0;
+}
+.band-src tr.in td { background: var(--color-accent-dim); }
+
+/* Red carries one claim and one only: no artifact says it was written from
+   these lines. Not "the wording changed" — that is the percentage above. */
+.band-gap .band-src { border-color: var(--color-danger); background: var(--color-danger-dim); }
+.band-gap-head {
+  display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+  flex-wrap: wrap;
+}
+.band-gap-label { font-size: 0.8125rem; color: var(--color-danger); }
+
+/* The fallback for a source there is nothing to band. */
+.raw-flat { margin: 0; padding: 0.5rem 0.75rem; white-space: pre-wrap;
+            overflow-wrap: anywhere; font-family: var(--font-mono); font-size: 0.8125rem; }
+
+/* One column on a narrow screen: the source first, then what came of it. */
+@media (max-width: 60rem) { .band { grid-template-columns: 1fr; } }
 
 /* What tells two rows with one title apart: when it was written, and how it
    opens. Quiet, because it is a disambiguator and not a second title. */

--- a/assets/app.css
+++ b/assets/app.css
@@ -117,9 +117,16 @@ h3 { font-size: 0.8125rem; color: var(--color-fg-muted); text-transform: upperca
 /* The one thing on Search that stays narrow. A full-width search box reads as a
    form to fill in; a narrow one reads as a question to ask. */
 .shell-wide #filters { max-width: 48rem; margin-inline: auto; }
+/* Full-bleed, so the rule under the header runs the width of the window
+   instead of stopping at whatever measure the page below happens to use. The
+   row inside it takes the wider of the two measures: it lines up with content
+   on the pages that are that wide, and simply runs wider than the reading
+   column on the pages that are not. Always the same width beats sometimes
+   lining up. */
+.topbar { border-bottom: 1px solid var(--color-border); margin-bottom: 1.5rem; }
 nav.top {
   display: flex; gap: 0.25rem; align-items: center;
-  border-bottom: 1px solid var(--color-border); padding: 0.75rem 0; margin-bottom: 1.5rem;
+  max-width: 110rem; margin: 0 auto; padding: 0.75rem 1rem;
 }
 nav.top a {
   color: var(--color-fg-secondary); text-decoration: none;
@@ -614,6 +621,12 @@ mark { background: var(--color-accent-dim); color: inherit; border-radius: 2px; 
 
   /* The top row keeps identity and the way out; everything else is a thumb
      away at the bottom. */
+  /* The nav used to inherit this from `.shell`; outside it, landscape on a
+     notched phone put the cutout over the sign-out button. */
+  nav.top {
+    padding-left: max(1rem, env(safe-area-inset-left));
+    padding-right: max(1rem, env(safe-area-inset-right));
+  }
   nav.top > a:not(.brand), nav.top .spacer { display: none; }
   nav.top form { margin-left: auto; }
 

--- a/docs/superpowers/plans/2026-08-18-corpus-bands.md
+++ b/docs/superpowers/plans/2026-08-18-corpus-bands.md
@@ -1,0 +1,927 @@
+# Corpus Bands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the corpus page as bands of source beside what was written from each, with unclaimed passages red and individually re-readable — and stop the nav changing width between pages.
+
+**Architecture:** A pure `corpus_view::bands()` cuts the source wherever the set of artifacts claiming it changes; `corpus_detail` maps those bands onto view models and the template renders them as a two-column grid. The re-read endpoint narrows from "every gap" to "the window holding this line". The nav moves out of `.shell` into its own full-bleed header.
+
+**Tech Stack:** Rust, axum, Askama templates (`src/web/templates/`), htmx, SQLite via sqlx.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-corpus-bands-design.md`
+
+## Global Constraints
+
+- Branch `fix/ui-corpus-view` in the worktree at `.claude/worktrees/ui-corpus`, based on PR #20's `fix/dedupe-false-disagreements`. Do not work in the main checkout.
+- Run `cargo test` before every commit; `cargo fmt` and `cargo clippy --all-targets -- -D warnings` before the final commit of each task.
+- Web-layer tests live in `mod tests` inside `src/web/ui.rs` and use the helpers already there: `app_with_session()`, `app_session_and_core()`, `get_body(&app, &cookie, uri)`, `form(uri, &cookie, body)`, `body_of(res)`. Do not add a new harness.
+- `corpus_view.rs` tests use its own local `a_corpus(raw)` helper (`src/web/corpus_view.rs:100`).
+- The colour scheme is deliberate. Add the one red for unclaimed bands; change no existing palette variable.
+- Never rewrite stored `raw_text` or stored artifact text.
+- Comment style: this codebase explains *why* in prose above the code. Match it; never restate the code.
+- Existing tests that assert on removed markup get updated, never deleted, unless the behaviour itself is gone.
+
+---
+
+### Task 1: The nav stops taking its width from the page
+
+**Files:**
+- Modify: `src/web/templates/layout.html:27-58`
+- Modify: `assets/app.css:111-120`
+- Test: `src/web/ui.rs` (`mod tests`)
+
+**Interfaces:**
+- Produces: `nav.top` is wrapped in `<header class="topbar">` which sits **outside** `<div class="shell">`. `.topbar` is full-bleed; `.topbar > nav.top` is capped at `110rem`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `src/web/ui.rs`:
+
+```rust
+    #[tokio::test]
+    async fn the_nav_is_the_same_width_on_every_page() {
+        let (app, cookie) = app_with_session().await;
+        for uri in ["/ui/capture", "/ui/search", "/ui/ops"] {
+            let page = get_body(&app, &cookie, uri).await;
+            let bar = page.find(r#"class="topbar""#).expect("a top bar");
+            let shell = page.find(r#"class="shell"#).expect("a shell");
+            assert!(
+                bar < shell,
+                "the nav must sit outside the shell, or it inherits that page's \
+                 measure and moves as you navigate: {uri}"
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cargo test --lib web::ui::tests::the_nav_is_the_same_width -- --nocapture`
+Expected: FAIL — there is no `topbar`, the nav is inside the shell.
+
+- [ ] **Step 3: Move the nav out of the shell**
+
+In `src/web/templates/layout.html`, the `<body>` currently opens with the shell and puts `{% block nav %}` inside it. Restructure so the header is a sibling that comes first:
+
+```html
+<body>
+  {# Chrome, not content. Inside `.shell` the nav took whichever measure the
+     page had chosen — 60rem on Capture, 110rem on Search — so it changed width
+     as you navigated and its bottom border stopped at a different place on
+     every page. Out here the border spans the window and the row inside it is
+     one width everywhere. #}
+  {% block nav %}
+  <header class="topbar">
+    <nav class="top">
+      ... the existing nav contents, unchanged ...
+    </nav>
+  </header>
+  {% endblock %}
+  <div class="{% block shell_class %}shell{% endblock %}">
+    {% block content %}{% endblock %}
+  </div>
+```
+
+Move the whole existing `<nav class="top">…</nav>` inside the new `<header>` verbatim — the brand link, the three destinations, the Judge badge, the spacer and the sign-out form. Keep the `{% block nav %}` wrapper around the header so `login.html` (which overrides it) still works; check `grep -n "block nav" src/web/templates/*.html` before editing and keep every override valid.
+
+- [ ] **Step 4: Give it a constant measure**
+
+In `assets/app.css`, immediately before the `.shell` rule at line 111:
+
+```css
+/* Full-bleed, so the rule under the header runs the width of the window
+   instead of stopping at whatever measure the page below happens to use. The
+   row inside it takes the wider of the two measures: it lines up with content
+   on the pages that are that wide, and simply runs wider than the reading
+   column on the pages that are not. Always the same width beats sometimes
+   lining up. */
+.topbar { border-bottom: 1px solid var(--color-border); margin-bottom: 1.5rem; }
+.topbar > nav.top { max-width: 110rem; margin: 0 auto; padding: 0.75rem 1rem; border-bottom: none; }
+```
+
+The existing `nav.top` rule at `assets/app.css:112-115` carries `border-bottom` and `padding: 0.75rem 0` and `margin-bottom: 1.5rem`; those move to `.topbar` as above, so delete them from `nav.top` and leave its `display:flex; gap; align-items` alone.
+
+- [ ] **Step 5: Run the test and the suite**
+
+Run: `cargo test`
+Expected: PASS. If a test asserted the nav appears after `class="shell"`, update it — that ordering is exactly what changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/templates/layout.html assets/app.css src/web/ui.rs
+git commit -m "fix(ui): stop the nav taking its width from the page under it
+
+Inside .shell the nav inherited whichever measure the page had chosen, so it
+was 60rem on Capture and 110rem on Search and moved as you navigated — and the
+rule under it stopped at a different place each time. It is chrome; it now has
+its own width and its border spans the window."
+```
+
+---
+
+### Task 2: `bands()`
+
+**Files:**
+- Modify: `src/web/corpus_view.rs` (add to the module and its `mod tests`)
+- Test: `src/web/corpus_view.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `CorpusLine { number: i64, text: String, in_span: bool }` (`corpus_view.rs:13`), `crate::store::artifacts::CorpusSpan { start_line, end_line }`.
+- Produces:
+
+```rust
+pub struct Band {
+    pub from: i64,
+    pub to: i64,
+    pub lines: Vec<CorpusLine>,
+    /// Ids of the artifacts claiming these lines, in the order given. Empty
+    /// means nothing claims them, which is what makes this a gap.
+    pub artifact_ids: Vec<String>,
+}
+impl Band { pub fn gap(&self) -> bool }
+
+pub fn bands(
+    raw_text: &str,
+    spans: &[(String, CorpusSpan)],
+    highlight: Option<(i64, i64)>,
+) -> Vec<Band>
+```
+
+Task 3 calls `bands()` and maps `artifact_ids` onto `ArtifactView`s.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `src/web/corpus_view.rs`:
+
+```rust
+    fn span(a: i64, b: i64) -> CorpusSpan {
+        CorpusSpan { start_line: a, end_line: b }
+    }
+
+    /// `(from, to, ids)` for each band, which is what every case below asserts.
+    fn shape(bs: &[Band]) -> Vec<(i64, i64, Vec<&str>)> {
+        bs.iter()
+            .map(|b| {
+                (
+                    b.from,
+                    b.to,
+                    b.artifact_ids.iter().map(String::as_str).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn adjacent_spans_are_two_bands() {
+        let out = bands(
+            "a\nb\nc\nd",
+            &[("x".into(), span(1, 2)), ("y".into(), span(3, 4))],
+            None,
+        );
+        assert_eq!(shape(&out), vec![(1, 2, vec!["x"]), (3, 4, vec!["y"])]);
+    }
+
+    #[test]
+    fn an_overlap_is_its_own_band() {
+        // Three bands, not a merge and not a tie-break: the middle really is
+        // claimed by both, and saying so is the only honest arrangement.
+        let out = bands(
+            "a\nb\nc\nd\ne",
+            &[("x".into(), span(1, 3)), ("y".into(), span(3, 5))],
+            None,
+        );
+        assert_eq!(
+            shape(&out),
+            vec![(1, 2, vec!["x"]), (3, 3, vec!["x", "y"]), (4, 5, vec!["y"])]
+        );
+    }
+
+    #[test]
+    fn a_run_nothing_claims_is_a_gap_band() {
+        let out = bands("a\nb\nc\nd", &[("x".into(), span(1, 2))], None);
+        assert_eq!(shape(&out), vec![(1, 2, vec!["x"]), (3, 4, vec![])]);
+        assert!(!out[0].gap());
+        assert!(out[1].gap());
+    }
+
+    #[test]
+    fn a_gap_at_the_head_is_an_ordinary_band() {
+        let out = bands("a\nb\nc", &[("x".into(), span(3, 3))], None);
+        assert_eq!(shape(&out), vec![(1, 2, vec![]), (3, 3, vec!["x"])]);
+    }
+
+    #[test]
+    fn blank_lines_between_two_spans_join_the_band_before_them() {
+        // A red sliver between two paragraphs would be noise with nothing to
+        // re-read: there is no content there to have missed.
+        let out = bands(
+            "a\n\n\nb",
+            &[("x".into(), span(1, 1)), ("y".into(), span(4, 4))],
+            None,
+        );
+        assert_eq!(shape(&out), vec![(1, 3, vec!["x"]), (4, 4, vec!["y"])]);
+    }
+
+    #[test]
+    fn a_corpus_nothing_was_written_from_is_one_gap() {
+        let out = bands("a\nb\nc", &[], None);
+        assert_eq!(shape(&out), vec![(1, 3, vec![])]);
+    }
+
+    #[test]
+    fn one_artifact_over_the_whole_document_is_one_band() {
+        let out = bands("a\nb\nc", &[("x".into(), span(1, 3))], None);
+        assert_eq!(shape(&out), vec![(1, 3, vec!["x"])]);
+    }
+
+    #[test]
+    fn a_span_past_the_end_does_not_invent_lines() {
+        let out = bands("a\nb", &[("x".into(), span(1, 9))], None);
+        assert_eq!(shape(&out), vec![(1, 2, vec!["x"])]);
+        assert_eq!(out[0].lines.len(), 2);
+    }
+
+    #[test]
+    fn the_highlight_marks_its_lines_wherever_they_fall() {
+        // The `?from=&to=` deep link an artifact's "open at these lines" uses.
+        let out = bands("a\nb\nc", &[("x".into(), span(1, 3))], Some((2, 3)));
+        let marked: Vec<i64> = out[0]
+            .lines
+            .iter()
+            .filter(|l| l.in_span)
+            .map(|l| l.number)
+            .collect();
+        assert_eq!(marked, vec![2, 3]);
+    }
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `cargo test --lib web::corpus_view`
+Expected: FAIL to compile — `Band` and `bands` do not exist.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/web/corpus_view.rs`, after `slice()`:
+
+```rust
+/// One stretch of the source, and which artifacts claim to have been written
+/// from it.
+pub struct Band {
+    pub from: i64,
+    pub to: i64,
+    pub lines: Vec<CorpusLine>,
+    /// Ids of the artifacts claiming these lines, in the order given. Empty
+    /// means nothing claims them, which is what makes this a gap.
+    pub artifact_ids: Vec<String>,
+}
+
+impl Band {
+    /// Nothing was written from these lines. The whole point of banding: a
+    /// passage the base cannot answer a question about, and can be told to
+    /// read again.
+    pub fn gap(&self) -> bool {
+        self.artifact_ids.is_empty()
+    }
+}
+
+/// Cut the source wherever the set of artifacts claiming it changes.
+///
+/// The page's central arrangement: a band of source beside what came of it.
+/// Overlaps are their own bands rather than merged — where two artifacts both
+/// claim a line, both are shown against it, which is the truth and needs no
+/// tie-break.
+///
+/// `highlight` is the `?from=&to=` deep link, marked on whatever lines it
+/// falls across; banding must not cost the page its "open at these lines".
+pub fn bands(
+    raw_text: &str,
+    spans: &[(String, CorpusSpan)],
+    highlight: Option<(i64, i64)>,
+) -> Vec<Band> {
+    let all: Vec<&str> = raw_text.lines().collect();
+    if all.is_empty() {
+        return Vec::new();
+    }
+
+    let claiming = |n: i64| -> Vec<String> {
+        spans
+            .iter()
+            .filter(|(_, s)| s.start_line <= n && n <= s.end_line)
+            .map(|(id, _)| id.clone())
+            .collect()
+    };
+
+    let mut out: Vec<Band> = Vec::new();
+    for (i, text) in all.iter().enumerate() {
+        let number = i as i64 + 1;
+        let mut ids = claiming(number);
+
+        // A blank line claims nothing and means nothing: left to itself it
+        // would cut a band in two, or open a red sliver between two paragraphs
+        // with no content in it to have missed. It continues whatever band it
+        // follows, and at the head of a document it starts one.
+        if text.trim().is_empty()
+            && let Some(last) = out.last()
+        {
+            ids = last.artifact_ids.clone();
+        }
+
+        let line = CorpusLine {
+            number,
+            text: (*text).to_string(),
+            in_span: highlight.is_some_and(|(f, t)| number >= f && number <= t),
+        };
+
+        match out.last_mut() {
+            Some(b) if b.artifact_ids == ids => {
+                b.to = number;
+                b.lines.push(line);
+            }
+            _ => out.push(Band {
+                from: number,
+                to: number,
+                lines: vec![line],
+                artifact_ids: ids,
+            }),
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::corpus_view`
+Expected: PASS, including the pre-existing `slice()` tests, which this does not touch.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && cargo test
+git add src/web/corpus_view.rs
+git commit -m "feat(corpus): cut the source where the artifacts claiming it change
+
+The arrangement the page needs: a stretch of source beside what came of it,
+and where nothing came of it, a stretch that says so. Overlaps are their own
+bands rather than merged — two artifacts claiming one line is the truth, and
+showing both needs no tie-break."
+```
+
+---
+
+### Task 3: The corpus page renders bands
+
+**Files:**
+- Modify: `src/web/ui.rs` (`CorpusTemplate`, `corpus_detail` at line 1153, add `BandView`)
+- Modify: `src/web/templates/corpus.html:89-134`
+- Modify: `assets/app.css` (add the band grid rules)
+- Test: `src/web/ui.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `corpus_view::bands()` and `corpus_view::Band` from Task 2.
+- Produces: `CorpusTemplate` loses `lines`, `artifacts` and `uncovered`, and gains:
+
+```rust
+struct BandView {
+    from: i64,
+    to: i64,
+    lines: Vec<crate::web::corpus_view::CorpusLine>,
+    artifacts: Vec<ArtifactView>,
+    gap: bool,
+    /// For a gap band, the lines a re-read would actually cover: the whole
+    /// window holding this passage, which is wider than the passage. `None`
+    /// when no window holds it and there is nothing to offer.
+    reread: Option<String>,
+}
+```
+
+plus `bands: Vec<BandView>` and `coverage: Option<String>`. Task 4 relies on the gap band's form posting `from={{ b.from }}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn the_corpus_page_puts_each_passage_beside_what_came_of_it() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(page.contains("band"), "the page is banded: {page}");
+        // The old two-lists arrangement is gone.
+        assert!(!page.contains("Raw corpus"), "{page}");
+        assert!(!page.contains("<h3>Artifacts</h3>"), "{page}");
+        // Every line keeps the anchor an artifact's "open at these lines" uses.
+        assert!(page.contains(r#"id="L1""#), "{page}");
+    }
+
+    #[tokio::test]
+    async fn an_unclaimed_passage_is_a_gap_band_with_its_own_button() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        // Pull every span back onto line 1, leaving the rest of the document
+        // claimed by nobody. Written straight to the column because nothing in
+        // the store edits a span — synthesis computes it and that is the only
+        // writer, which is right everywhere except here.
+        sqlx::query(r#"UPDATE artifacts SET corpus_span = '{"start_line":1,"end_line":1}' WHERE corpus_id = ?"#)
+            .bind(&out.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(page.contains("band-gap"), "the unclaimed run is red: {page}");
+        assert!(
+            page.contains(r#"name="from""#),
+            "a gap band carries a re-read button naming its first line: {page}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_restored_corpus_is_not_banded() {
+        // Its "source" is its own artifacts joined back together, so a span
+        // into it is a claim the arrangement cannot support.
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        sqlx::query("UPDATE corpora SET restored_at = 1 WHERE id = ?")
+            .bind(&out.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(page.contains("Placeholder source"), "{page}");
+        assert!(!page.contains("band-gap"), "{page}");
+    }
+
+    #[tokio::test]
+    async fn the_page_states_the_coverage_the_recent_list_warned_about() {
+        // The two measures answer different questions and can disagree: every
+        // line claimed, and still only half the wording carried. Following the
+        // warning must not land on a page with nothing to see.
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        core.store.set_corpus_coverage(&out.id, Some(0.55)).await.unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(page.contains(r#"id="uncovered""#), "the anchor still lands: {page}");
+        assert!(page.contains("55%"), "{page}");
+    }
+```
+
+Both fixtures write SQL directly rather than through a store method, because
+neither edit has a caller outside these tests: synthesis is the only writer of
+a span, and only the vector-store repair marks a corpus restored. `Store.pool`
+is `pub` and the migrate tests in `src/store/mod.rs` set up fixtures the same
+way. `corpus_span` is stored as the JSON of `CorpusSpan` (`artifacts.rs:186`).
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `cargo test --lib web::ui::tests::the_corpus_page_puts_each_passage`
+Expected: FAIL — the page still renders "Raw corpus" and a separate artifact list.
+
+- [ ] **Step 3: Build the view models in the handler**
+
+In `src/web/ui.rs`, replace the body of `corpus_detail` (lines 1159-1213) so it bands instead of listing. Delete the `uncovered` block and the flat `lines` block:
+
+```rust
+    let s = st.core.store.get_corpus(&cid).await?;
+    let chunks = st.core.store.artifacts_for_corpus(&cid).await?;
+    let restored = s.restored_at.is_some();
+
+    // A restored placeholder's text is its own artifacts joined back together,
+    // so a span into it points at the artifact rather than at a source. It
+    // keeps the flat rendering, and the warning above already says why.
+    let spans: Vec<(String, crate::store::artifacts::CorpusSpan)> = if restored {
+        Vec::new()
+    } else {
+        chunks
+            .iter()
+            .filter_map(|c| c.corpus_span.clone().map(|sp| (c.id.clone(), sp)))
+            .collect()
+    };
+
+    let by_id: std::collections::HashMap<&str, &crate::store::artifacts::Chunk> =
+        chunks.iter().map(|c| (c.id.as_str(), c)).collect();
+    let segments = st.core.store.segments_for_corpus(&cid).await?;
+
+    let bands: Vec<BandView> = crate::web::corpus_view::bands(
+        &s.raw_text,
+        &spans,
+        range.from.map(|f| (f, range.to.unwrap_or(f))),
+    )
+    .into_iter()
+    .map(|b| BandView {
+        // What pressing the button would actually read: the window holding
+        // this passage, which is wider than it. Saying only "lines 51–53" over
+        // a button that reads 1–120 is a promise the button does not keep —
+        // and two red bands in one window really are read together.
+        reread: b.gap().then(|| {
+            segments
+                .iter()
+                .find(|w| w.start_line <= b.from && b.from <= w.end_line)
+                .map(|w| format!("reads lines {}–{}", w.start_line, w.end_line))
+        }).flatten(),
+        from: b.from,
+        to: b.to,
+        gap: b.gap(),
+        artifacts: b
+            .artifact_ids
+            .iter()
+            .filter_map(|id| by_id.get(id.as_str()).map(|c| artifact_view(c)))
+            .collect(),
+        lines: b.lines,
+    })
+    .collect();
+
+    // Stated whether or not anything is red, because the warning on Recent is
+    // computed the other way: a corpus can be 55% covered with every line
+    // claimed, and following that warning has to land somewhere that explains
+    // itself rather than on a page with nothing marked.
+    let coverage = s.coverage.map(|c| format!("{:.0}%", c * 100.0));
+```
+
+Then the remaining locals (`image`, `unread`, `note`, `meta_rows`, `exif_rows`) stay exactly as they are, and the template is constructed with `bands`, `coverage`, `lines_empty` and `restored` in place of `lines`, `artifacts` and `uncovered`.
+
+Add `BandView` beside `UncoveredRange` in the view-model block, and update `CorpusTemplate`'s fields to match. Delete `UncoveredRange` — Task 5 removes the rest of its machinery, but the struct goes with its last use.
+
+For a restored corpus `spans` is empty, so `bands()` returns one gap band over the whole text. That would offer a re-read of a placeholder. Guard it: when `restored`, pass `bands: Vec::new()` and let the template fall back to the flat `.raw` table it renders today.
+
+- [ ] **Step 4: Rewrite the template**
+
+In `src/web/templates/corpus.html`, replace the whole "Raw corpus" card, the "Never reached an artifact" section and the `<h3>Artifacts</h3>` loop (lines 89 to the end of the block) with:
+
+```html
+{% if let Some(c) = coverage %}
+{# Both measures, plainly. The bands say what nothing was written from; this
+   says how much of the wording survived into what was. They answer different
+   questions and can disagree, and the anchor lands here when nothing is red. #}
+<p class="muted" id="uncovered">{{ c }} of this capture's wording survived into an artifact.</p>
+{% endif %}
+
+{% if bands.is_empty() %}
+{# A restored placeholder, or a photo not read yet: nothing to band. #}
+<div class="card">
+  <div class="card-head">
+    <span class="card-title">{% if restored %}Restored artifacts{% else if image %}Transcription{% else %}Raw corpus{% endif %}</span>
+  </div>
+  {% if image && lines_empty %}
+  <p class="muted">Not read yet — the photo is queued for the vision model.</p>
+  {% endif %}
+</div>
+{% else %}
+<div class="bands">
+  {% for b in bands %}
+  <div class="band{% if b.gap %} band-gap{% endif %}">
+    <div class="band-src">
+      <table>
+        {% for l in b.lines %}
+        <tr id="L{{ l.number }}" class="{% if l.in_span %}in{% endif %}">
+          <td class="ln">{{ l.number }}</td><td>{{ l.text }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+    <div class="band-out">
+      {% if b.gap %}
+      <div class="band-gap-head">
+        <span class="band-gap-label">lines {{ b.from }}–{{ b.to }} · nothing was written from these</span>
+        {% if let Some(w) = b.reread %}
+        {# The button names the window, not the band: it is wider than the red
+           lines, which is what lets the model read them in context — and it is
+           what actually happens, including to any other red band inside it. #}
+        <form method="post" action="/ui/corpora/{{ id }}/reread"
+              onsubmit="return confirm('Read this passage again? One model call. Nothing already written from this capture is replaced — what comes back is added to it.')">
+          <input type="hidden" name="from" value="{{ b.from }}">
+          <button class="btn btn-sm" type="submit" title="{{ w }}">Read this again — {{ w }}</button>
+        </form>
+        {% endif %}
+      </div>
+      {% endif %}
+      {% for c in b.artifacts %}{% include "_artifact.html" %}{% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+```
+
+`_artifact.html` iterates a variable named `c`, which the loop above binds — the same contract the old `<h3>Artifacts</h3>` loop used. Add a `lines_empty: bool` field to `CorpusTemplate` set from
+`s.raw_text.trim().is_empty()`, since the flat branch no longer has a `lines`
+list to test. `can_reread` is not a field: whether a band can be re-read is a
+per-band fact and lives on `BandView::reread`.
+
+- [ ] **Step 5: Style the grid**
+
+In `assets/app.css`, beside the `.uncovered` rule added earlier (delete that rule — nothing renders it now):
+
+```css
+/* ── The corpus, band by band ────────────────────────────────────────────── */
+
+/* One row per band: the source on the left, what was written from it on the
+   right. Heights are ragged on purpose — a band is as tall as its source, and
+   an eight-line passage that yielded one short artifact leaves the right cell
+   mostly empty. Folding it would hide source on the page that exists to show
+   source. */
+.bands { display: flex; flex-direction: column; gap: 0.75rem; }
+.band { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; align-items: start; }
+.band > * { min-width: 0; }
+.band-src {
+  background: var(--color-bg-elevated); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); overflow-x: auto;
+}
+.band-src table { border-collapse: collapse; width: 100%;
+                  font-family: var(--font-mono); font-size: 0.8125rem; }
+.band-src td { padding: 1px 0.5rem 1px 2rem; vertical-align: top;
+               white-space: pre-wrap; overflow-wrap: anywhere; text-indent: -1.5rem; }
+.band-src td.ln {
+  width: 3.5rem; text-align: right; color: var(--color-fg-muted); user-select: none;
+  border-right: 1px solid var(--color-border-subtle); font-variant-numeric: tabular-nums;
+  padding: 1px 0.5rem; text-indent: 0;
+}
+.band-src tr.in td { background: var(--color-accent-dim); }
+
+/* Red is one claim and one only: no artifact says it was written from these
+   lines. Not "the wording changed" — that is the percentage above. */
+.band-gap .band-src { border-color: var(--color-danger); background: var(--color-danger-dim); }
+.band-gap-head {
+  display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+  flex-wrap: wrap;
+}
+.band-gap-label { font-size: 0.8125rem; color: var(--color-danger); }
+
+@media (max-width: 60rem) { .band { grid-template-columns: 1fr; } }
+```
+
+`--color-danger` and `--color-danger-dim` are already defined for both themes
+(`assets/app.css:44` and `:79`), so this introduces no new colour.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test`
+Expected: PASS. `a_corpus_shows_which_lines_were_missed_and_offers_to_read_them_again` asserts on `#uncovered`, `Read these again` and `#L3` — rewrite it against the new markup rather than deleting it; its subject (a gap is visible and re-readable) still holds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test
+git add src/web/ui.rs src/web/templates/corpus.html assets/app.css
+git commit -m "feat(ui): the corpus beside what was written from it
+
+The page was two lists that said the same things in places you could not read
+together — the whole source, then every artifact, then a hundred line numbers
+between them naming what had been missed.
+
+One grid now: each passage beside what came of it, and where nothing came of
+it, a red band saying so with a button to read that passage again."
+```
+
+---
+
+### Task 4: Re-read one band
+
+**Files:**
+- Modify: `src/web/ui.rs` (`reread_uncovered_ui` at line 1085)
+- Test: `src/web/ui.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: the gap band's `<input name="from">` from Task 3; `crate::jobs::window::unit_target(cid, idx)`; `Store::reset_segment`, `Store::live_job`, `Store::enqueue`.
+- Produces: `POST /ui/corpora/{id}/reread` takes `Form<RereadForm { from: i64 }>` and resets exactly the window holding that line.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn re_reading_one_passage_leaves_the_other_windows_alone() {
+        let (app, cookie, core) = app_session_and_core().await;
+        // Long enough to be several windows, so "one of them" is meaningful.
+        let body = (1..=400)
+            .map(|i| format!("line {i} of the document"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        let segments = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(segments.len() > 1, "the fixture must span several windows");
+        let target = &segments[0];
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                &format!("from={}", target.start_line),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+
+        let pending = core.store.pending_segments(&out.id).await.unwrap();
+        assert_eq!(
+            pending.iter().map(|w| w.idx).collect::<Vec<_>>(),
+            vec![target.idx],
+            "exactly the window holding that line, and no other"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_reading_a_line_in_no_window_is_not_a_500() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                "from=99999",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER, "nothing to do is not an error");
+    }
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `cargo test --lib web::ui::tests::re_reading_one_passage`
+Expected: FAIL — the handler takes no form and re-reads every window holding a gap.
+
+- [ ] **Step 3: Narrow the handler**
+
+In `src/web/ui.rs`, replace `reread_uncovered_ui` (lines 1085 onward) with:
+
+```rust
+#[derive(serde::Deserialize)]
+struct RereadForm {
+    /// The first line of the band the button sits in.
+    from: i64,
+}
+
+/// Read one passage again.
+///
+/// The window holding that line, not the line itself: a window is wider than
+/// the passage, which is what lets the model read it in its surroundings
+/// rather than stripped of them. One model call.
+///
+/// Nothing already written from this capture is replaced. What comes back is
+/// added, and anything it repeats is folded by the dedupe sweep like any other
+/// near duplicate.
+async fn reread_uncovered_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(cid): Path<String>,
+    Form(f): Form<RereadForm>,
+) -> Result<Response> {
+    let segments = st.core.store.segments_for_corpus(&cid).await?;
+    let Some(w) = segments
+        .iter()
+        .find(|w| w.start_line <= f.from && f.from <= w.end_line)
+    else {
+        // A line in no window belongs to a corpus segmented before per-window
+        // synthesis, or to a stale page. Nothing to read again, and nothing
+        // went wrong.
+        return Ok(Redirect::to(&format!("/ui/corpora/{cid}#L{}", f.from)).into_response());
+    };
+
+    // A window something is already going to read is left alone. `enqueue`
+    // re-arms a conflicting row whatever state it is in, running included, so
+    // pressing this twice handed the same window to a second worker: two paid
+    // model calls and two sets of artifacts for one passage.
+    if !st
+        .core
+        .store
+        .live_job(
+            crate::store::jobs::Stage::SegmentWindow,
+            &crate::jobs::window::unit_target(&cid, w.idx),
+        )
+        .await?
+    {
+        st.core.store.reset_segment(&cid, w.idx).await?;
+        st.core
+            .store
+            .enqueue(
+                crate::store::jobs::Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(&cid, w.idx),
+            )
+            .await?;
+    }
+    Ok(Redirect::to(&format!("/ui/corpora/{cid}#L{}", f.from)).into_response())
+}
+```
+
+The redirect lands on the band the button was in rather than at the top of the page — on a 978-line document, coming back to the top after pressing a button two thirds of the way down loses your place.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test`
+Expected: PASS. `a_corpus_shows_which_lines_were_missed_and_offers_to_read_them_again` posts to `/reread` with an empty body; give it a `from=` or fold it into the Task 3 rewrite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && cargo test
+git add src/web/ui.rs
+git commit -m "feat(ui): read one passage again, not all of them
+
+One button re-read every window holding a gap: on a document with forty of
+them that is forty model calls behind one click, and no way to say 'this
+passage, not the others'. The button now belongs to the band it sits in and
+reads the one window holding it, then comes back to that band rather than to
+the top of the page."
+```
+
+---
+
+### Task 5: Retire the token-recall ranges
+
+**Files:**
+- Modify: `src/infer/verify.rs` (remove `uncovered_ranges` and its tests)
+- Modify: `src/web/ui.rs` (remove `uncovered_for`)
+- Test: `src/infer/verify.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: nothing. This task only removes what Tasks 3 and 4 stopped calling.
+- Produces: `verify::content_coverage` and the private `verify::line_coverage` remain, unchanged.
+
+- [ ] **Step 1: Prove it is dead**
+
+Run:
+
+```bash
+grep -rn "uncovered_ranges\|uncovered_for\|UncoveredRange" src/ tests/
+```
+
+Expected: hits only in `src/infer/verify.rs` (the function and its four tests) and nothing in `src/web/`. If `src/web/ui.rs` still names any of them, Task 3 or 4 is incomplete — finish that before continuing rather than deleting a live caller.
+
+- [ ] **Step 2: Delete the function and its tests**
+
+In `src/infer/verify.rs`, delete `pub fn uncovered_ranges` with its doc comment, and these four tests: `the_ranges_name_the_lines_no_artifact_carried`, `adjacent_uncovered_lines_become_one_range`, `a_line_outside_every_segment_is_uncovered`, `the_ranges_and_the_fraction_agree_on_the_same_input`, `a_fully_covered_source_has_no_ranges`.
+
+Keep `line_coverage` and `content_coverage`. Update `line_coverage`'s doc comment, which currently justifies itself as the shared pass behind the fraction *and the ranges*:
+
+```rust
+/// Which non-empty lines survived, in order, as `(line number, covered)`.
+///
+/// The pass behind `content_coverage`. It asks whether a line's wording
+/// survived the rewrite, which is a different question from whether any
+/// artifact claims the line — the corpus page asks that one, off the spans,
+/// and marks its answer in the source itself.
+```
+
+In `src/web/ui.rs`, delete `uncovered_for` if Task 3 left it behind.
+
+- [ ] **Step 3: Run the suite**
+
+Run: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test`
+Expected: PASS with no dead-code warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/infer/verify.rs src/web/ui.rs
+git commit -m "refactor(verify): drop the ranges nothing reads any more
+
+Token recall calls a faithfully paraphrased line missed, which is what made
+the old list a hundred single-line entries. The page marks unclaimed passages
+off the spans now. The fraction stays — it answers the other question, and the
+Recent list still asks it."
+```
+
+---
+
+## Final verification
+
+- [ ] **Everything**
+
+```bash
+cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
+```
+
+- [ ] **Walk it by hand**
+
+Most of this is markup no test can see. With Qdrant running (`podman compose up -d qdrant`) and a corpus captured:
+
+1. Navigate Capture → Search → Housekeeping → Corpus. The nav must not move or change width, and the rule under it must span the window on every page.
+2. Open a corpus with a known gap: red bands, each with its own button, the source on the left and its artifacts beside it.
+3. Press one button. It should return you to that band, mark one window pending, and leave the others alone.
+4. Follow an artifact's "open at these lines" link and confirm it still lands on the right lines with them highlighted.
+5. Open a corpus whose coverage is below the threshold but which has no red band — the sentence under the heading must explain why there is nothing marked.
+
+- [ ] **Push**
+
+```bash
+git push -u origin fix/ui-corpus-view
+```

--- a/docs/superpowers/specs/2026-08-18-corpus-bands-design.md
+++ b/docs/superpowers/specs/2026-08-18-corpus-bands-design.md
@@ -1,0 +1,177 @@
+# The corpus page in bands, and a nav that holds still
+
+Two things, one branch. The nav width regressed when the page measures split,
+and the corpus page's "never reached an artifact" section shipped as a list of
+a hundred line numbers between the source and the artifacts — technically true
+and useless to act on.
+
+## The nav
+
+`nav.top` is rendered inside `.shell`. When search and housekeeping opted into
+`.shell-wide`, the nav went with them: it is 60rem on Capture, Corpus, Ask,
+Judge and Settings, and 110rem on Search and Housekeeping. Navigating moves it.
+Its bottom border stops at the same varying edge, so the rule under the header
+changes length too.
+
+Chrome should not take its width from the content beneath it. The nav moves out
+of `.shell` into its own full-bleed `<header>`: the border spans the viewport,
+and the row inside it is capped at `110rem` — the wider of the two measures, so
+the nav aligns with content on the pages that use it and simply runs wider than
+the reading column on the pages that do not. Chrome that is always the same
+width is worth more than chrome that sometimes lines up.
+
+## What is wrong with the gap list
+
+Three things, and only the third is cosmetic.
+
+**It measures the wrong thing.** Red comes from `content_coverage`, which asks
+whether over half of a line's distinctive words survived into the artifact text.
+Synthesis rewrites — that is what it is for — so a faithfully paraphrased line
+scores as missed. On a 978-line corpus this produced about a hundred ranges,
+most of them single lines, many of them lines whose content did reach an
+artifact in other words.
+
+**It is detached from what it describes.** A list of `line 3`, `line 7`,
+`line 32` sits between the source and the artifacts, naming lines the reader
+then has to go and find. The anchors help; they do not make the list a place to
+work.
+
+**It cannot be acted on precisely.** One button re-reads every window holding a
+gap. There is no way to say "this passage, not the other forty".
+
+## Red means unclaimed
+
+The measure changes. A line is red when **no artifact claims to have been
+written from it** — when no captured artifact's `corpus_span` covers it.
+
+This is what the heading already says. It is also structural rather than
+statistical: `resolve_span` (`window.rs:280`) computes each artifact's span
+itself from its text, clamped into its own window, using the model's
+`corpus_lines` only as a hint — so every captured artifact has a span, and the
+spans partition the document into passages that were claimed and passages that
+were not. Those come out few and large where the old measure came out many and
+tiny, and every one of them is a real re-read target.
+
+`content_coverage` stays exactly as it is. It still computes the `% covered`
+figure on the Recent list, which answers a different and worth-asking question:
+not *was this passage claimed* but *did its wording survive*.
+
+`verify::uncovered_ranges` has no remaining caller once the page stops using it,
+and is deleted with its tests. The `line_coverage` pass it shares with
+`content_coverage` stays.
+
+### Where the two measures disagree
+
+They will. A corpus can read `55% covered` on Recent and have no unclaimed
+passages at all: every line inside some artifact's span, only the wording
+rewritten. Following the warning would then land on a page with nothing red —
+which is the dead end this whole feature exists to remove.
+
+So the corpus page states both. The bands answer "what was never claimed". One
+line under the heading answers "how much of the wording survived", and the
+`#uncovered` anchor lands on that line when there are no red bands to land on.
+Neither number is presented as the other, and neither is hidden because it is
+inconvenient.
+
+## Bands
+
+`corpus_detail` stops passing a flat list of lines and a separate list of
+artifacts. It passes bands:
+
+```rust
+/// One stretch of the source and whatever was written from it.
+struct Band {
+    from: i64,
+    to: i64,
+    lines: Vec<CorpusLine>,
+    /// Empty for a gap band — the whole point of the band.
+    artifacts: Vec<ArtifactView>,
+    /// The segment holding these lines, for the re-read button. `None` for a
+    /// corpus with no segment rows, which can offer no re-read.
+    window_idx: Option<i64>,
+}
+```
+
+Assembly walks the source once. For each line, the set of captured artifacts
+whose `corpus_span` covers it; a band ends where that set changes. Rules the
+walk has to get right:
+
+- **Overlapping spans** produce a band per distinct set, so two artifacts
+  overlapping on lines 40–45 give three bands: A alone, A+B, B alone. No merging
+  and no arbitrary tie-breaks.
+- **A run covered by nobody** is a gap band, and renders red.
+- **A run of only blank lines** joins the preceding band rather than becoming a
+  gap. `content_coverage` already ignores blank lines; a red sliver between two
+  paragraphs would be noise with nothing to re-read.
+- **A gap at the very head or tail** of the document is an ordinary gap band.
+- **Merged artifacts never appear.** They belong to no corpus and carry no span
+  into one. `artifacts_for_corpus` already returns only this corpus's own.
+
+The bands **replace** the "Raw corpus" card and the "Artifacts" list beneath
+it. Both said the same things in two places that could not be read together,
+which is the complaint. Every captured artifact has a span, so every artifact
+appears in exactly one band and nothing is dropped by removing the list; the
+per-artifact controls (`edit`, delete) move into the band cell with it.
+
+**Every line keeps its `L<n>` anchor.** An artifact's "open at these lines" link
+and the `?from=&to=` highlight both address lines by that id, and banding must
+not break them: the anchors move onto the rows inside the bands, unchanged.
+
+Rendered as a two-column grid, one row per band, heights ragged: a band is as
+tall as its source, and its right cell is as tall as it needs to be. Nothing is
+folded, nothing is hidden, nothing scrolls inside itself. The page is as tall as
+the document, which it already is today.
+
+## Re-read, one band at a time
+
+`POST /ui/corpora/{id}/reread` takes a `from` line naming the band. It finds the
+segment window holding that line, resets it, and enqueues one `SegmentWindow`
+job — the same mechanism as today, aimed at one place instead of all of them.
+The window is wider than the gap, which is what "with the context around it"
+means: the model reads the passage in its surroundings, not stripped of them.
+
+Nothing already written from this capture is replaced. What comes back is added,
+and anything it repeats is folded by the dedupe sweep like any other near
+duplicate. The confirmation says so, because that is not obvious.
+
+Two red bands can fall inside one window, and pressing either re-reads both. The
+button says which lines it will actually read rather than only naming the band
+it sits in.
+
+The page-level "read them all" button is removed. Every re-read is now a
+deliberate, scoped decision, and there is no single click that spends eight
+model calls.
+
+## What keeps today's rendering
+
+- **Restored placeholders.** The page already warns that its text is the corpus's
+  own artifacts joined back together, and that line numbers and spans mean
+  nothing there. Bands would be a claim that arrangement cannot support, so a
+  restored corpus renders as it does now.
+- **An image corpus with no reading yet.** No text, no spans, nothing to band.
+- **An image corpus that has been read** gets bands like any other: its spans
+  point into the transcription, which is what the page shows and labels.
+
+## Testing
+
+Band assembly is a pure function of lines and spans, and is unit tested as one:
+adjacent spans, overlapping spans, a gap at the head, a gap at the tail, a run
+of blank lines between two spans, one artifact spanning the whole document, and
+a corpus with no artifacts at all (one gap band over everything).
+
+Page tests: every line still carries its `L<n>` anchor and a `?from=&to=` deep
+link still highlights; a gap band renders a re-read button carrying the right
+`from`; a
+covered band renders its artifacts in the same row; posting a re-read resets
+exactly one segment and leaves the others alone; a restored corpus renders no
+bands; the `#uncovered` anchor exists whether or not anything is red.
+
+The nav: one test asserting the header renders outside `.shell` on both a narrow
+page and a wide one.
+
+## What this does not do
+
+- No change to how coverage is computed or to the number on Recent.
+- No folding, virtualisation or pagination of long documents.
+- No editing of source text, ever.
+- No change to what synthesis writes — only to how the page reads what it wrote.

--- a/src/infer/verify.rs
+++ b/src/infer/verify.rs
@@ -341,9 +341,10 @@ pub fn content_coverage(raw_text: &str, segments: &[(i64, i64, String)]) -> f64 
 
 /// Which non-empty lines survived, in order, as `(line number, covered)`.
 ///
-/// The single pass both the fraction and the ranges are computed from. Two
-/// passes could disagree about a line, and a warning that points at lines the
-/// percentage did not count against the document is worse than no warning.
+/// The pass behind `content_coverage`. It asks whether a line's *wording*
+/// survived the rewrite, which is a different question from whether any
+/// artifact claims the line — the corpus page asks that one, off the spans,
+/// and marks its answer in the source itself rather than as a number.
 fn line_coverage(raw_text: &str, segments: &[(i64, i64, String)]) -> Vec<(i64, bool)> {
     let indexed: Vec<(i64, i64, std::collections::HashSet<String>)> = segments
         .iter()
@@ -372,107 +373,9 @@ fn line_coverage(raw_text: &str, segments: &[(i64, i64, String)]) -> Vec<(i64, b
         .collect()
 }
 
-/// The line ranges no artifact carried, inclusive and 1-based.
-///
-/// The fraction says how much was lost; this says where, which is the half an
-/// operator can act on. Adjacent uncovered lines are merged into one range — a
-/// list of forty single-line ranges is a wall, and what was missed is a passage
-/// rather than a line. Blank lines are not in the pass at all, so a blank line
-/// between two lost lines does not split the range: the passage is what is
-/// being named.
-pub fn uncovered_ranges(raw_text: &str, segments: &[(i64, i64, String)]) -> Vec<(i64, i64)> {
-    let mut out: Vec<(i64, i64)> = Vec::new();
-    // Whether the line before this one was also lost. Consecutive line numbers
-    // cannot be the test: `line_coverage` has already dropped the blank lines,
-    // so the numbers jump across every paragraph break, and comparing them
-    // splits the range at exactly the places prose puts one.
-    let mut running = false;
-    for (n, ok) in line_coverage(raw_text, segments) {
-        if ok {
-            running = false;
-            continue;
-        }
-        match out.last_mut() {
-            Some(last) if running => last.1 = n,
-            _ => out.push((n, n)),
-        }
-        running = true;
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn the_ranges_name_the_lines_no_artifact_carried() {
-        let raw = "alpha beta gamma\ndelta epsilon zeta\neta theta iota";
-        // One segment covering all three lines, whose artifacts reproduce only
-        // the first line's vocabulary.
-        let made = vec![(1, 3, "alpha beta gamma".to_string())];
-        assert_eq!(uncovered_ranges(raw, &made), vec![(2, 3)]);
-    }
-
-    #[test]
-    fn adjacent_uncovered_lines_become_one_range() {
-        let raw = "alpha beta\nomega sigma\ntau upsilon\nalpha beta";
-        let made = vec![(1, 4, "alpha beta".to_string())];
-        assert_eq!(uncovered_ranges(raw, &made), vec![(2, 3)]);
-    }
-
-    #[test]
-    fn a_blank_line_between_two_lost_lines_does_not_split_the_range() {
-        // What was missed is a passage, and a paragraph break inside it is not
-        // a second loss. Prose is mostly blank-separated, so splitting there
-        // turns one range into the wall of single-line ranges the merge exists
-        // to prevent.
-        let raw = "alpha beta\n\nomega sigma\n\ntau upsilon";
-        let made = vec![(1, 5, "alpha beta".to_string())];
-        assert_eq!(uncovered_ranges(raw, &made), vec![(3, 5)]);
-    }
-
-    #[test]
-    fn a_line_that_was_carried_does_split_the_range() {
-        // The other half of the same rule: a range is broken by something
-        // arriving, never by the shape of the source.
-        let raw = "alpha beta\nomega sigma\ntau upsilon";
-        let made = vec![(1, 3, "omega sigma".to_string())];
-        assert_eq!(uncovered_ranges(raw, &made), vec![(1, 1), (3, 3)]);
-    }
-
-    #[test]
-    fn a_line_outside_every_segment_is_uncovered() {
-        // Not reachable through the splitter, which tiles the document, nor
-        // through a window that failed, which keeps its row and so keeps its
-        // range. It is what the measure does when it is handed a partial
-        // account of the document — a corpus read before per-segment windows
-        // existed, whose ranges are supplied from somewhere else — and the
-        // answer has to be "lost", never "covered".
-        let raw = "alpha beta\nomega sigma";
-        let made = vec![(1, 1, "alpha beta".to_string())];
-        assert_eq!(uncovered_ranges(raw, &made), vec![(2, 2)]);
-    }
-
-    #[test]
-    fn the_ranges_and_the_fraction_agree_on_the_same_input() {
-        let raw = "alpha beta\nomega sigma\ntau upsilon";
-        let made = vec![(1, 3, "alpha beta".to_string())];
-        let missed: i64 = uncovered_ranges(raw, &made)
-            .iter()
-            .map(|(a, b)| b - a + 1)
-            .sum();
-        let total = raw.lines().filter(|l| !l.trim().is_empty()).count() as i64;
-        let from_ranges = (total - missed) as f64 / total as f64;
-        assert!((content_coverage(raw, &made) - from_ranges).abs() < 1e-9);
-    }
-
-    #[test]
-    fn a_fully_covered_source_has_no_ranges() {
-        let raw = "alpha beta\nomega sigma";
-        let made = vec![(1, 2, "alpha beta omega sigma".to_string())];
-        assert!(uncovered_ranges(raw, &made).is_empty());
-    }
 
     const WINDOW: &str = "\
 ### Writing the ISO

--- a/src/web/corpus_view.rs
+++ b/src/web/corpus_view.rs
@@ -92,6 +92,90 @@ pub fn slice(source: &Corpus, span: Option<&CorpusSpan>, context: usize) -> Corp
     }
 }
 
+/// One stretch of the source, and which artifacts claim to have been written
+/// from it.
+pub struct Band {
+    pub from: i64,
+    pub to: i64,
+    pub lines: Vec<CorpusLine>,
+    /// Ids of the artifacts claiming these lines, in the order given. Empty
+    /// means nothing claims them, which is what makes this a gap.
+    pub artifact_ids: Vec<String>,
+}
+
+impl Band {
+    /// Nothing was written from these lines. The whole point of banding: a
+    /// passage the base cannot answer a question about, and one that can be
+    /// told to read itself again.
+    pub fn gap(&self) -> bool {
+        self.artifact_ids.is_empty()
+    }
+}
+
+/// Cut the source wherever the set of artifacts claiming it changes.
+///
+/// The corpus page's central arrangement: a band of source beside what came of
+/// it. Overlaps become their own bands rather than being merged — where two
+/// artifacts both claim a line, both are shown against it, which is the truth
+/// and needs no tie-break.
+///
+/// This asks whether any artifact *claims* a line, which is a different
+/// question from whether the line's wording survived into one. That second
+/// question is `verify::content_coverage`, and it answers it as a fraction: a
+/// faithfully rewritten line is a line whose wording did not survive and whose
+/// content did, and marking it as missed made a hundred single-line warnings
+/// out of one well-read document.
+///
+/// `highlight` is the `?from=&to=` deep link. Banding must not cost the page
+/// its "open at these lines".
+pub fn bands(
+    raw_text: &str,
+    spans: &[(String, CorpusSpan)],
+    highlight: Option<(i64, i64)>,
+) -> Vec<Band> {
+    let mut out: Vec<Band> = Vec::new();
+
+    for (i, text) in raw_text.lines().enumerate() {
+        let number = i as i64 + 1;
+        let mut ids: Vec<String> = spans
+            .iter()
+            .filter(|(_, s)| s.start_line <= number && number <= s.end_line)
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        // A blank line claims nothing and means nothing. Left to itself it
+        // would cut a band in two, or open a red sliver between two paragraphs
+        // with no content in it to have missed. It continues whatever band it
+        // follows; at the head of a document there is nothing to continue, so
+        // it starts one.
+        if text.trim().is_empty()
+            && let Some(last) = out.last()
+        {
+            ids = last.artifact_ids.clone();
+        }
+
+        let line = CorpusLine {
+            number,
+            text: text.to_string(),
+            in_span: highlight.is_some_and(|(f, t)| number >= f && number <= t),
+        };
+
+        match out.last_mut() {
+            Some(b) if b.artifact_ids == ids => {
+                b.to = number;
+                b.lines.push(line);
+            }
+            _ => out.push(Band {
+                from: number,
+                to: number,
+                lines: vec![line],
+                artifact_ids: ids,
+            }),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,6 +184,109 @@ mod tests {
     async fn a_corpus(raw: &str) -> Corpus {
         let s = crate::store::Store::memory().await.unwrap();
         s.insert_corpus(raw, "web", None).await.unwrap()
+    }
+
+    fn span(a: i64, b: i64) -> CorpusSpan {
+        CorpusSpan {
+            start_line: a,
+            end_line: b,
+        }
+    }
+
+    /// `(from, to, ids)` for each band, which is what every case below asserts.
+    fn shape(bs: &[Band]) -> Vec<(i64, i64, Vec<&str>)> {
+        bs.iter()
+            .map(|b| {
+                (
+                    b.from,
+                    b.to,
+                    b.artifact_ids.iter().map(String::as_str).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn adjacent_spans_are_two_bands() {
+        let out = bands(
+            "a\nb\nc\nd",
+            &[("x".into(), span(1, 2)), ("y".into(), span(3, 4))],
+            None,
+        );
+        assert_eq!(shape(&out), vec![(1, 2, vec!["x"]), (3, 4, vec!["y"])]);
+    }
+
+    #[test]
+    fn an_overlap_is_its_own_band() {
+        // Three bands, not a merge and not a tie-break: the middle really is
+        // claimed by both, and saying so is the only honest arrangement.
+        let out = bands(
+            "a\nb\nc\nd\ne",
+            &[("x".into(), span(1, 3)), ("y".into(), span(3, 5))],
+            None,
+        );
+        assert_eq!(
+            shape(&out),
+            vec![(1, 2, vec!["x"]), (3, 3, vec!["x", "y"]), (4, 5, vec!["y"])]
+        );
+    }
+
+    #[test]
+    fn a_run_nothing_claims_is_a_gap_band() {
+        let out = bands("a\nb\nc\nd", &[("x".into(), span(1, 2))], None);
+        assert_eq!(shape(&out), vec![(1, 2, vec!["x"]), (3, 4, vec![])]);
+        assert!(!out[0].gap());
+        assert!(out[1].gap());
+    }
+
+    #[test]
+    fn a_gap_at_the_head_is_an_ordinary_band() {
+        let out = bands("a\nb\nc", &[("x".into(), span(3, 3))], None);
+        assert_eq!(shape(&out), vec![(1, 2, vec![]), (3, 3, vec!["x"])]);
+    }
+
+    #[test]
+    fn blank_lines_between_two_spans_join_the_band_before_them() {
+        // A red sliver between two paragraphs would be noise with nothing to
+        // re-read: there is no content there to have missed.
+        let out = bands(
+            "a\n\n\nb",
+            &[("x".into(), span(1, 1)), ("y".into(), span(4, 4))],
+            None,
+        );
+        assert_eq!(shape(&out), vec![(1, 3, vec!["x"]), (4, 4, vec!["y"])]);
+    }
+
+    #[test]
+    fn a_corpus_nothing_was_written_from_is_one_gap() {
+        let out = bands("a\nb\nc", &[], None);
+        assert_eq!(shape(&out), vec![(1, 3, vec![])]);
+    }
+
+    #[test]
+    fn one_artifact_over_the_whole_document_is_one_band() {
+        let out = bands("a\nb\nc", &[("x".into(), span(1, 3))], None);
+        assert_eq!(shape(&out), vec![(1, 3, vec!["x"])]);
+    }
+
+    #[test]
+    fn a_span_past_the_end_does_not_invent_lines() {
+        let out = bands("a\nb", &[("x".into(), span(1, 9))], None);
+        assert_eq!(shape(&out), vec![(1, 2, vec!["x"])]);
+        assert_eq!(out[0].lines.len(), 2);
+    }
+
+    #[test]
+    fn the_highlight_marks_its_lines_wherever_they_fall() {
+        // The `?from=&to=` deep link an artifact's "open at these lines" uses.
+        let out = bands("a\nb\nc", &[("x".into(), span(1, 3))], Some((2, 3)));
+        let marked: Vec<i64> = out[0]
+            .lines
+            .iter()
+            .filter(|l| l.in_span)
+            .map(|l| l.number)
+            .collect();
+        assert_eq!(marked, vec![2, 3]);
     }
 
     #[tokio::test]

--- a/src/web/templates/_bands.html
+++ b/src/web/templates/_bands.html
@@ -28,6 +28,10 @@
         <form method="post" action="/ui/corpora/{{ id }}/reread"
               onsubmit="return confirm('Read this passage again? One model call. Nothing already written from this capture is replaced — what comes back is added to it, and anything it repeats is folded by the dedupe sweep.')">
           <input type="hidden" name="from" value="{{ b.from }}">
+          {# Both ends: a passage nothing was written from does not stop at a
+             window boundary, and naming only its first line re-read the window
+             the loss opened in and left the rest of it as it was. #}
+          <input type="hidden" name="to" value="{{ b.to }}">
           <button class="btn btn-sm" type="submit">Read this again — {{ w }}</button>
         </form>
         {% endif %}

--- a/src/web/templates/_bands.html
+++ b/src/web/templates/_bands.html
@@ -1,0 +1,40 @@
+{# The corpus, band by band: each stretch of source beside what was written
+   from it, and where nothing was, a red stretch saying so.
+
+   Two lists said these same things before — the whole source, then every
+   artifact, then a hundred line numbers between them naming what had been
+   missed — in three places that could not be read against each other. #}
+<div class="bands">
+  {% for b in bands %}
+  <div class="band{% if b.gap %} band-gap{% endif %}">
+    <div class="band-src">
+      <table>
+        {% for l in b.lines %}
+        <tr id="L{{ l.number }}" class="{% if l.in_span %}in{% endif %}">
+          <td class="ln">{{ l.number }}</td><td>{{ l.text }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+    <div class="band-out">
+      {% if b.gap %}
+      <div class="band-gap-head">
+        <span class="band-gap-label">lines {{ b.from }}–{{ b.to }} · nothing was written from these</span>
+        {% if let Some(w) = b.reread %}
+        {# The button names the window rather than the band: the window is
+           wider, which is what lets the model read the passage in context, and
+           it is what actually happens — including to any other red band inside
+           the same window. #}
+        <form method="post" action="/ui/corpora/{{ id }}/reread"
+              onsubmit="return confirm('Read this passage again? One model call. Nothing already written from this capture is replaced — what comes back is added to it, and anything it repeats is folded by the dedupe sweep.')">
+          <input type="hidden" name="from" value="{{ b.from }}">
+          <button class="btn btn-sm" type="submit">Read this again — {{ w }}</button>
+        </form>
+        {% endif %}
+      </div>
+      {% endif %}
+      {% for c in b.artifacts %}{% include "_artifact.html" %}{% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -86,52 +86,36 @@
 </div>
 {% endif %}
 
+{% if let Some(c) = coverage %}
+{# Both measures, plainly. The bands say what nothing was written from; this
+   says how much of the wording survived into what was. They answer different
+   questions and can disagree — every line claimed and half the wording gone is
+   an ordinary outcome — so the anchor the Recent warning follows lands here
+   when there is no red band for it to land on. #}
+<p class="muted" id="uncovered">{{ c }} of this capture's wording survived into an artifact.</p>
+{% endif %}
+
+{% if bands.is_empty() %}
+{# Nothing to band: a restored placeholder, whose text is its own artifacts
+   joined back together, or a photo the vision model has not read yet. #}
 <div class="card">
   <div class="card-head">
     <span class="card-title">{% if restored %}Restored artifacts{% else if image %}Transcription{% else %}Raw corpus{% endif %}</span>
-    {% if image %}<span class="muted">— the model's reading of the photo, not the source itself</span>{% endif %}
   </div>
-  {% if image && lines.is_empty() %}
+  {% if lines_empty %}
   <p class="muted">Not read yet — the photo is queued for the vision model.</p>
+  {% else %}
+  <div class="raw" style="max-height:none"><pre class="raw-flat">{{ raw_text }}</pre></div>
   {% endif %}
-  {# Every line is anchored, so an artifact's "open at these lines" link lands
-     on the exact lines it was drawn from instead of the top of the document.
-     Same markup and highlighting as the excerpt in the artifact pane. #}
-  <div class="raw" style="max-height:none">
-    <table>
-      {% for l in lines %}
-      <tr id="L{{ l.number }}" class="{% if l.in_span %}in{% endif %}">
-        <td class="ln">{{ l.number }}</td><td>{{ l.text }}</td>
-      </tr>
-      {% endfor %}
-    </table>
-  </div>
 </div>
-
-{% if !uncovered.is_empty() %}
-{# Where the coverage warning on Recent lands. The percentage there says how
-   much of this capture never reached an artifact; this says which parts, and
-   offers the one thing that can be done about it. #}
-<h3 id="uncovered">Never reached an artifact</h3>
-<p class="muted">
-  These lines are stored and readable above, but nothing was written from them
-  — so nothing here answers a search about what they say.
-</p>
-<ul class="uncovered">
-  {% for u in uncovered %}
-  <li><a href="#L{{ u.from }}">{{ u.label }}</a></li>
-  {% endfor %}
-</ul>
-{# Says what it costs and what it does not: nothing already written from this
-   capture is replaced. What comes back is added, and anything it repeats is
-   folded by the dedupe sweep like any other near-duplicate. #}
-<form method="post" action="/ui/corpora/{{ id }}/reread"
-      onsubmit="return confirm('Read these lines again? Each window holding them is one model call. Nothing already written from this capture is replaced — what comes back is added to it.')">
-  <button class="btn btn-sm" type="submit">Read these again</button>
-</form>
+{% else %}
+{% if image %}
+{# The lines below are the model's reading of the photo, and the page has to
+   keep saying so: banded beside the artifacts drawn from them they would
+   otherwise read as captured source. #}
+<h3>Transcription</h3>
+<p class="muted">The model's reading of the photo, not the source itself.</p>
 {% endif %}
-
-<h3>Artifacts</h3>
-{% for c in artifacts %}{% include "_artifact.html" %}{% endfor %}
-{% if artifacts.is_empty() %}<p class="muted">Not synthesised yet.</p>{% endif %}
+{% include "_bands.html" %}
+{% endif %}
 {% endblock %}

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -24,10 +24,13 @@
   <script src="/assets/app.js" defer></script>
 </head>
 <body>
-  {# The reading measure is the default and most pages want it. A page whose
-     content is a table or a three-pane workspace says so by name. #}
-  <div class="{% block shell_class %}shell{% endblock %}">
-    {% block nav %}
+  {# Chrome, not content. Inside `.shell` the nav took whichever measure the
+     page had chosen — 60rem on Capture, 110rem on Search — so it changed width
+     as you navigated, and the rule under it stopped at a different place on
+     every page. Out here the border spans the window and the row inside it is
+     one width everywhere. #}
+  {% block nav %}
+  <header class="topbar">
     <nav class="top">
       <a href="/ui/search" class="brand" aria-label="engram">
         <img src="/assets/logo.svg" alt="" width="22" height="22">
@@ -55,7 +58,11 @@
         <button class="btn btn-ghost btn-sm" type="submit">Sign out</button>
       </form>
     </nav>
-    {% endblock %}
+  </header>
+  {% endblock %}
+  {# The reading measure is the default and most pages want it. A page whose
+     content is a table or a three-pane workspace says so by name. #}
+  <div class="{% block shell_class %}shell{% endblock %}">
     {% block content %}{% endblock %}
   </div>
   {# On a phone the destinations move under the thumb and the top row keeps

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1050,47 +1050,6 @@ fn coverage_final(status: &CorpusStatus) -> bool {
     )
 }
 
-/// The line ranges of `source` that no artifact carried.
-///
-/// Measured against exactly the shape `recompute_coverage` measures the
-/// percentage against — each segment's line range beside the text of every
-/// artifact made from it — because the warning that brings someone here and
-/// the ranges they find must be answering the same question.
-///
-/// Empty for a corpus with no segment rows: one predating per-segment windows
-/// has no ranges to attribute a loss to, and naming the whole document would
-/// offer a re-read of everything. Empty as well until the capture's coverage is
-/// final — see `coverage_final`.
-async fn uncovered_for(
-    st: &AppState,
-    source: &crate::store::corpora::Corpus,
-    chunks: &[crate::store::artifacts::Chunk],
-) -> Result<Vec<(i64, i64)>> {
-    if !coverage_final(&source.status) {
-        return Ok(Vec::new());
-    }
-    let segments = st.core.store.segments_for_corpus(&source.id).await?;
-    if segments.is_empty() {
-        return Ok(Vec::new());
-    }
-    let made: Vec<(i64, i64, String)> = segments
-        .iter()
-        .map(|w| {
-            let text = chunks
-                .iter()
-                .filter(|c| c.segment_idx == Some(w.idx))
-                .map(|c| c.text.as_str())
-                .collect::<Vec<_>>()
-                .join("\n");
-            (w.start_line, w.end_line, text)
-        })
-        .collect();
-    Ok(crate::infer::verify::uncovered_ranges(
-        &source.raw_text,
-        &made,
-    ))
-}
-
 #[derive(serde::Deserialize)]
 struct RereadForm {
     /// The band the button sits in. Both ends, because a passage nothing was

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -441,11 +441,8 @@ struct CorpusTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
     id: String,
-    /// The whole source, one row per line, each anchored so a link can name it.
-    lines: Vec<crate::web::corpus_view::CorpusLine>,
     status: String,
     badge: &'static str,
-    artifacts: Vec<ArtifactView>,
     /// This row is a placeholder for a source that was never captured here, so
     /// `raw_text` is its restored artifacts joined rather than a document. The
     /// page has to say so: it otherwise presents reconstructed fragments under
@@ -469,18 +466,36 @@ struct CorpusTemplate {
     /// — but the original is not stored, so this is the only place they exist.
     exif_rows: Vec<(String, String)>,
     note: Option<String>,
-    /// Stretches of this capture that no artifact carried. Where the coverage
-    /// warning on Recent lands: the percentage says how much was lost, and this
-    /// says which parts, which is the half that can be acted on.
-    uncovered: Vec<UncoveredRange>,
+    /// The source cut where the artifacts claiming it change, each stretch
+    /// beside what came of it. Empty for a source there is nothing to band —
+    /// a restored placeholder, or a photo not read yet — which falls back to
+    /// the flat rendering.
+    bands: Vec<BandView>,
+    /// Nothing was captured here at all, so the flat fallback has nothing to
+    /// show either.
+    lines_empty: bool,
+    /// The source as one block, for the fallback. Unnumbered on purpose: the
+    /// only thing that reaches it is a restored placeholder, where a line
+    /// number is a claim about a document that was never captured here.
+    raw_text: String,
+    /// How much of the wording survived, as the Recent list measures it.
+    /// Stated whether or not a band is red, because the two measures answer
+    /// different questions and can disagree.
+    coverage: Option<String>,
 }
 
-/// A stretch of a capture that no artifact carried, for the corpus page.
-pub struct UncoveredRange {
+/// One stretch of the source on the corpus page, beside what came of it.
+pub struct BandView {
     pub from: i64,
-    /// `line 42` or `lines 42–96` — the same singular rule the source pane
-    /// label follows.
-    pub label: String,
+    pub to: i64,
+    pub lines: Vec<crate::web::corpus_view::CorpusLine>,
+    pub artifacts: Vec<ArtifactView>,
+    /// Nothing was written from these lines.
+    pub gap: bool,
+    /// For a gap band, the lines a re-read would actually cover: the whole
+    /// window holding this passage, which is wider than the passage. `None`
+    /// when no window holds it and there is nothing to offer.
+    pub reread: Option<String>,
 }
 
 #[derive(Template)]
@@ -1158,38 +1173,68 @@ async fn corpus_detail(
 ) -> Result<Response> {
     let s = st.core.store.get_corpus(&cid).await?;
     let chunks = st.core.store.artifacts_for_corpus(&cid).await?;
-    let artifacts = chunks.iter().map(artifact_view).collect();
-    let uncovered = uncovered_for(&st, &s, &chunks)
-        .await?
+    let restored = s.restored_at.is_some();
+
+    // A restored placeholder's text is its own artifacts joined back together,
+    // so a span into it points at an artifact rather than at a source. Banding
+    // it would be a claim that arrangement cannot support; it keeps the flat
+    // rendering, and the warning above it already says why.
+    let spans: Vec<(String, crate::store::artifacts::CorpusSpan)> = if restored {
+        Vec::new()
+    } else {
+        chunks
+            .iter()
+            .filter_map(|c| c.corpus_span.clone().map(|sp| (c.id.clone(), sp)))
+            .collect()
+    };
+    let by_id: std::collections::HashMap<&str, &crate::store::artifacts::Chunk> =
+        chunks.iter().map(|c| (c.id.as_str(), c)).collect();
+    let segments = st.core.store.segments_for_corpus(&cid).await?;
+
+    // Every row still carries its `L<n>` anchor, inside its band: an artifact's
+    // "open at these lines" and the `?from=&to=` highlight both address lines
+    // by that id, and banding must not cost the page either of them.
+    let bands: Vec<BandView> = if restored {
+        Vec::new()
+    } else {
+        crate::web::corpus_view::bands(
+            &s.raw_text,
+            &spans,
+            range.from.map(|f| (f, range.to.unwrap_or(f))),
+        )
         .into_iter()
-        .map(|(from, to)| UncoveredRange {
-            from,
-            label: if from == to {
-                format!("line {from}")
-            } else {
-                format!("lines {from}–{to}")
-            },
+        .map(|b| BandView {
+            // What pressing the button would actually read: the window holding
+            // this passage, which is wider than it. Saying only "lines 51–53"
+            // over a button that reads 1–120 is a promise it does not keep —
+            // and a second red band inside the same window really is read too.
+            reread: b
+                .gap()
+                .then(|| {
+                    segments
+                        .iter()
+                        .find(|w| w.start_line <= b.from && b.from <= w.end_line)
+                        .map(|w| format!("reads lines {}–{}", w.start_line, w.end_line))
+                })
+                .flatten(),
+            gap: b.gap(),
+            from: b.from,
+            to: b.to,
+            artifacts: b
+                .artifact_ids
+                .iter()
+                .filter_map(|id| by_id.get(id.as_str()).map(|c| artifact_view(c)))
+                .collect(),
+            lines: b.lines,
         })
-        .collect();
-    // Numbered rather than one blob of text, so an artifact can link to the
-    // exact lines it was drawn from and the browser can scroll to them. Every
-    // row carries an `L<n>` anchor for that; the range, when given, is
-    // highlighted the same way the pane highlights a span.
-    let lines = s
-        .raw_text
-        .lines()
-        .enumerate()
-        .map(|(i, text)| {
-            let number = i as i64 + 1;
-            crate::web::corpus_view::CorpusLine {
-                number,
-                text: text.to_string(),
-                in_span: range
-                    .from
-                    .is_some_and(|f| number >= f && number <= range.to.unwrap_or(f)),
-            }
-        })
-        .collect();
+        .collect()
+    };
+
+    // Stated whether or not anything is red, because the warning on Recent is
+    // computed the other way round: a corpus can be 55% covered with every
+    // line claimed, and following that warning has to land somewhere that
+    // explains itself rather than on a page with nothing marked.
+    let coverage = s.coverage.map(|c| format!("{:.0}%", c * 100.0));
     let image = s.origin == crate::core::ingest::ORIGIN_IMAGE;
     let unread = image && (s.status == CorpusStatus::Describing || s.raw_text.trim().is_empty());
     let note = s.metadata["note"].as_str().map(str::to_string);
@@ -1198,18 +1243,19 @@ async fn corpus_detail(
     Ok(HtmlTemplate(CorpusTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
         id: s.id,
-        lines,
         badge: status_badge(&s.status),
         status: s.status.as_str().to_string(),
-        restored: s.restored_at.is_some(),
+        restored,
         source_url: s.source_url.clone(),
         image,
         unread,
         meta_rows,
         exif_rows,
         note,
-        artifacts,
-        uncovered,
+        bands,
+        lines_empty: s.raw_text.trim().is_empty(),
+        raw_text: s.raw_text.clone(),
+        coverage,
     })
     .into_response())
 }
@@ -4442,59 +4488,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_corpus_shows_which_lines_were_missed_and_offers_to_read_them_again() {
-        let (app, cookie, core) = app_session_and_core().await;
-        let out = core
-            .ingest(
-                "alpha beta gamma\n\nomega sigma tau\n\ndelta epsilon zeta",
-                "web",
-                None,
-            )
-            .await
-            .unwrap();
-        crate::jobs::synthesize::segment_all(&core, &out.id).await;
-        crate::jobs::embed::run_corpus(&core, &out.id)
-            .await
-            .unwrap();
-        // Force a hole: artifacts carrying only the first line's vocabulary.
-        for c in core.store.artifacts_for_corpus(&out.id).await.unwrap() {
-            core.store
-                .update_artifact_text(&c.id, "alpha beta gamma")
-                .await
-                .unwrap();
-        }
-        crate::jobs::synthesize::recompute_coverage(&core, &out.id)
-            .await
-            .unwrap();
-
-        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
-        assert!(
-            page.contains(r#"id="uncovered""#),
-            "the anchor the warning links to: {page}"
-        );
-        assert!(page.contains("Read these again"), "{page}");
-        assert!(
-            page.contains("#L3"),
-            "a range links to the lines it names: {page}"
-        );
-
-        let res = app
-            .clone()
-            .oneshot(form(&format!("/ui/corpora/{}/reread", out.id), &cookie, ""))
-            .await
-            .unwrap();
-        assert_eq!(res.status(), StatusCode::SEE_OTHER);
-        // The window holding the missed lines is back in the queue's path.
-        let pending = core.store.pending_segments(&out.id).await.unwrap();
-        assert!(!pending.is_empty(), "nothing was queued to be read again");
-    }
-
-    /// `synthesize::plan` writes every window up front as `pending`, so a
-    /// capture still being read has windows and no artifacts for the ones nobody
-    /// has reached. Measured then, the whole unread remainder is a loss — the
-    /// page named lines that were on their way as never reached, and offered to
-    /// pay for reading them again.
-    #[tokio::test]
     async fn a_capture_still_being_read_names_no_loss_and_offers_no_re_read() {
         use crate::store::segments::NewSegment;
         let (app, cookie, core) = app_session_and_core().await;
@@ -4691,7 +4684,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_fully_covered_corpus_shows_no_uncovered_section() {
+    async fn a_fully_covered_corpus_marks_nothing_red() {
+        // The anchor still exists — the Recent warning follows it, and it has
+        // to land on the sentence that explains why nothing is marked. What a
+        // fully claimed corpus has is no red band.
         let (app, cookie, core) = app_session_and_core().await;
         let out = core.ingest("alpha beta gamma", "web", None).await.unwrap();
         crate::jobs::synthesize::segment_all(&core, &out.id).await;
@@ -4700,10 +4696,7 @@ mod tests {
             .unwrap();
 
         let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
-        assert!(
-            !page.contains(r#"id="uncovered""#),
-            "nothing to say: {page}"
-        );
+        assert!(!page.contains("band-gap"), "nothing was missed: {page}");
     }
 
     #[tokio::test]
@@ -5091,6 +5084,98 @@ mod tests {
             page.contains("the file you drop next"),
             "the note must say it is for a file that has not arrived yet: {page}"
         );
+    }
+
+    #[tokio::test]
+    async fn the_corpus_page_puts_each_passage_beside_what_came_of_it() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(page.contains("band"), "the page is banded: {page}");
+        // The old two-lists arrangement is gone.
+        assert!(!page.contains("Raw corpus"), "{page}");
+        assert!(!page.contains("<h3>Artifacts</h3>"), "{page}");
+        // Every line keeps the anchor an artifact's "open at these lines" uses.
+        assert!(page.contains(r#"id="L1""#), "{page}");
+    }
+
+    #[tokio::test]
+    async fn an_unclaimed_passage_is_a_gap_band_with_its_own_button() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        // Pull every span back onto line 1, leaving the rest of the document
+        // claimed by nobody. Written straight to the column because nothing in
+        // the store edits a span — synthesis computes it and is the only
+        // writer, which is right everywhere except here.
+        sqlx::query(
+            r#"UPDATE artifacts SET corpus_span = '{"start_line":1,"end_line":1}' WHERE corpus_id = ?"#,
+        )
+        .bind(&out.id)
+        .execute(&core.store.pool)
+        .await
+        .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(
+            page.contains("band-gap"),
+            "the unclaimed run is red: {page}"
+        );
+        assert!(
+            page.contains(r#"name="from""#),
+            "a gap band carries a re-read button naming its first line: {page}"
+        );
+        assert!(
+            page.contains("reads lines"),
+            "the button says what it will actually read, which is the whole \
+             window and so wider than the band: {page}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_restored_corpus_is_not_banded() {
+        // Its "source" is its own artifacts joined back together, so a span
+        // into it is a claim the arrangement cannot support.
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        sqlx::query("UPDATE corpora SET restored_at = 1 WHERE id = ?")
+            .bind(&out.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(page.contains("Placeholder source"), "{page}");
+        assert!(!page.contains("band-gap"), "{page}");
+    }
+
+    #[tokio::test]
+    async fn the_page_states_the_coverage_the_recent_list_warned_about() {
+        // The two measures answer different questions and can disagree: every
+        // line claimed, and still only half the wording carried. Following the
+        // warning must not land on a page with nothing to see.
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        core.store
+            .set_corpus_coverage(&out.id, Some(0.55))
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", out.id)).await;
+        assert!(
+            page.contains(r#"id="uncovered""#),
+            "the anchor still lands: {page}"
+        );
+        assert!(page.contains("55%"), "{page}");
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -5094,6 +5094,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_nav_is_the_same_width_on_every_page() {
+        let (app, cookie) = app_with_session().await;
+        for uri in ["/ui/capture", "/ui/search", "/ui/ops"] {
+            let page = get_body(&app, &cookie, uri).await;
+            let bar = page.find(r#"class="topbar""#).expect("a top bar");
+            let shell = page.find(r#"class="shell"#).expect("a shell");
+            assert!(
+                bar < shell,
+                "the nav must sit outside the shell, or it inherits that page's \
+                 measure and moves as you navigate: {uri}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn tabular_pages_use_the_wide_measure_and_reading_pages_do_not() {
         let (app, cookie) = app_with_session().await;
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1091,78 +1091,79 @@ async fn uncovered_for(
     ))
 }
 
-/// Read the lines no artifact carried, again.
+#[derive(serde::Deserialize)]
+struct RereadForm {
+    /// The band the button sits in. Both ends, because a passage nothing was
+    /// written from does not stop at a window boundary, and matching on the
+    /// first line alone re-read the window the loss opened in and left the
+    /// rest of it exactly as it was.
+    from: i64,
+    to: i64,
+}
+
+/// Read one passage again.
 ///
-/// One `SegmentWindow` job per window holding a loss, rather than a whole
-/// re-segment: the parts that did arrive are fine, and re-reading them would
-/// pay for the same artifacts twice and then hand the duplicates to the dedupe
-/// sweep to clean up after it.
+/// The window holding that line, not the line itself: a window is wider than
+/// the passage, and that is what lets the model read it in its surroundings
+/// rather than stripped of them. One model call.
+///
+/// Nothing already written from this capture is replaced. What comes back is
+/// added, and anything it repeats is folded by the dedupe sweep like any other
+/// near duplicate.
 async fn reread_uncovered_ui(
     State(st): State<AppState>,
     _id: Identity,
     Path(cid): Path<String>,
+    Form(f): Form<RereadForm>,
 ) -> Result<Response> {
-    let s = st.core.store.get_corpus(&cid).await?;
-    let chunks = st.core.store.artifacts_for_corpus(&cid).await?;
-    let segments = st.core.store.segments_for_corpus(&cid).await?;
+    // Back to the band the button was in. On a nine-hundred-line document,
+    // returning to the top after pressing something two thirds of the way down
+    // loses the reader's place for no reason.
+    let back = Redirect::to(&format!("/ui/corpora/{cid}#L{}", f.from)).into_response();
 
-    // One window can hold several uncovered ranges, and reading it once reads
-    // all of them, so the windows are collected before anything is queued.
-    //
-    // Every window the range overlaps, not the one its first line falls in: a
-    // range is merged across everything that was lost in a row, which does not
-    // stop at a window boundary, and matching on the first line alone re-read
-    // the opening of the loss and left the rest of it exactly as it was.
-    let mut windows: Vec<i64> = Vec::new();
-    for (from, to) in uncovered_for(&st, &s, &chunks).await? {
-        for w in segments
-            .iter()
-            .filter(|w| w.start_line <= to && from <= w.end_line)
-        {
-            if !windows.contains(&w.idx) {
-                windows.push(w.idx);
-            }
-        }
+    // A page left open while the capture was still being read would otherwise
+    // offer to re-read lines that are merely not written yet.
+    let s = st.core.store.get_corpus(&cid).await?;
+    if !coverage_final(&s.status) {
+        return Ok(back);
     }
 
-    for idx in windows {
+    let segments = st.core.store.segments_for_corpus(&cid).await?;
+    for w in segments
+        .iter()
+        .filter(|w| w.start_line <= f.to && f.from <= w.end_line)
+    {
         // A window something is already going to read is left alone. `enqueue`
         // re-arms a conflicting row whatever state it is in, running included,
-        // so pressing this button while an earlier re-read is still in flight
-        // handed the same window to a second worker: two paid model calls and
-        // two sets of artifacts for one loss, then the dedupe sweep to clean up
-        // after them — the outcome reading only the lost windows exists to
-        // avoid.
+        // so pressing this twice handed the same window to a second worker: two
+        // paid model calls and two sets of artifacts for one passage, then the
+        // dedupe sweep to clean up after them.
         if st
             .core
             .store
             .live_job(
                 crate::store::jobs::Stage::SegmentWindow,
-                &crate::jobs::window::unit_target(&cid, idx),
+                &crate::jobs::window::unit_target(&cid, w.idx),
             )
             .await?
         {
             continue;
         }
-        // `window::run` returns early on a window already marked done, so the
-        // state goes back to pending first — this is the "re-run this window"
-        // case `reset_segment` exists for.
-        //
-        // Keeping what the window already produced: those artifacts are the
-        // parts of it that did arrive, they may have been edited, retagged or
-        // verified since, and none of that is what this button is about. A
-        // duplicate of something already captured goes to the dedupe sweep.
-        st.core.store.reset_segment(&cid, idx, true).await?;
+        // `true`: this window was read correctly and missed lines, so it is
+        // being added to rather than replaced. Deleting what it already wrote
+        // would throw away artifacts that may have been edited, tagged or
+        // verified since, for lines that were never the problem.
+        st.core.store.reset_segment(&cid, w.idx, true).await?;
         st.core
             .store
             .enqueue(
                 crate::store::jobs::Stage::SegmentWindow,
                 "segment",
-                &crate::jobs::window::unit_target(&cid, idx),
+                &crate::jobs::window::unit_target(&cid, w.idx),
             )
             .await?;
     }
-    Ok(Redirect::to(&format!("/ui/corpora/{cid}#uncovered")).into_response())
+    Ok(back)
 }
 
 async fn corpus_detail(
@@ -1190,6 +1191,11 @@ async fn corpus_detail(
     let by_id: std::collections::HashMap<&str, &crate::store::artifacts::Chunk> =
         chunks.iter().map(|c| (c.id.as_str(), c)).collect();
     let segments = st.core.store.segments_for_corpus(&cid).await?;
+    // Until the capture has finished being read, a passage nothing claims is
+    // a passage nothing has got to yet. Banded, still — the arrangement is how
+    // the page reads — but not red, and not offering to re-read what is
+    // already on its way.
+    let losses_are_final = coverage_final(&s.status) && !segments.is_empty();
 
     // Every row still carries its `L<n>` anchor, inside its band: an artifact's
     // "open at these lines" and the `?from=&to=` highlight both address lines
@@ -1208,16 +1214,21 @@ async fn corpus_detail(
             // this passage, which is wider than it. Saying only "lines 51–53"
             // over a button that reads 1–120 is a promise it does not keep —
             // and a second red band inside the same window really is read too.
-            reread: b
-                .gap()
+            reread: (b.gap() && losses_are_final)
                 .then(|| {
                     segments
                         .iter()
-                        .find(|w| w.start_line <= b.from && b.from <= w.end_line)
-                        .map(|w| format!("reads lines {}–{}", w.start_line, w.end_line))
+                        .filter(|w| w.start_line <= b.to && b.from <= w.end_line)
+                        .fold(None::<(i64, i64)>, |acc, w| {
+                            Some(match acc {
+                                Some((a, z)) => (a.min(w.start_line), z.max(w.end_line)),
+                                None => (w.start_line, w.end_line),
+                            })
+                        })
+                        .map(|(a, z)| format!("reads lines {a}–{z}"))
                 })
                 .flatten(),
-            gap: b.gap(),
+            gap: b.gap() && losses_are_final,
             from: b.from,
             to: b.to,
             artifacts: b
@@ -4522,7 +4533,11 @@ mod tests {
         // And the form behind that button, reached directly, arms nothing.
         let res = app
             .clone()
-            .oneshot(form(&format!("/ui/corpora/{}/reread", out.id), &cookie, ""))
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                "from=1&to=6",
+            ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::SEE_OTHER);
@@ -4597,7 +4612,11 @@ mod tests {
 
         let res = app
             .clone()
-            .oneshot(form(&format!("/ui/corpora/{}/reread", out.id), &cookie, ""))
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                "from=1&to=6",
+            ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::SEE_OTHER);
@@ -4667,7 +4686,11 @@ mod tests {
 
         let res = app
             .clone()
-            .oneshot(form(&format!("/ui/corpora/{}/reread", out.id), &cookie, ""))
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                "from=1&to=6",
+            ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::SEE_OTHER);
@@ -5087,6 +5110,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn re_reading_one_passage_leaves_the_other_windows_alone() {
+        let (app, cookie, core) = app_session_and_core().await;
+        // Long enough to be several windows, so "one of them" is meaningful.
+        let body = (1..=400)
+            .map(|i| format!("line {i} of the document"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let out = core.ingest(&body, "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        // Settled, or the endpoint rightly refuses: lines a capture has not
+        // been read to the end of are not lines it lost. Set directly because
+        // this test is about where a re-read is aimed, not about the pipeline
+        // that gets a document to Ready.
+        core.store
+            .set_corpus_status(&out.id, CorpusStatus::Ready)
+            .await
+            .unwrap();
+        let segments = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(segments.len() > 1, "the fixture must span several windows");
+        let target = segments[0].clone();
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                &format!("from={}&to={}", target.start_line, target.end_line),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+
+        let pending = core.store.pending_segments(&out.id).await.unwrap();
+        assert_eq!(
+            pending.iter().map(|w| w.idx).collect::<Vec<_>>(),
+            vec![target.idx],
+            "exactly the window holding that line, and no other"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_reading_a_line_in_no_window_is_not_a_500() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/corpora/{}/reread", out.id),
+                &cookie,
+                "from=99999&to=99999",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::SEE_OTHER,
+            "nothing to do is not an error"
+        );
+    }
+
+    #[tokio::test]
     async fn the_corpus_page_puts_each_passage_beside_what_came_of_it() {
         let (app, cookie, core) = app_session_and_core().await;
         let out = core
@@ -5112,6 +5198,11 @@ mod tests {
             .await
             .unwrap();
         crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        // Settled, or nothing is a loss yet: a capture still being read has
+        // lines nothing claims because nothing has got to them.
+        crate::jobs::embed::run_corpus(&core, &out.id)
+            .await
+            .unwrap();
         // Pull every span back onto line 1, leaving the rest of the document
         // claimed by nobody. Written straight to the column because nothing in
         // the store edits a span — synthesis computes it and is the only


### PR DESCRIPTION
Stacked on #20 — it touches `src/web/ui.rs` and the re-read machinery, so this
branches from it rather than from master. Review #20 first.

## The nav

`nav.top` rendered inside `.shell`, so it inherited whichever measure the page
had chosen: 60rem on Capture, 110rem on Search. It changed width as you
navigated and the rule under it stopped at a different place each time. A
regression from the width split, and it is chrome — it now has its own width
outside the shell, and keeps the safe-area padding it used to inherit.

## Red means unclaimed

The gap list measured the wrong thing. `content_coverage` asks whether over
half a line's distinctive words survived the rewrite, so a faithfully
paraphrased line counts as missed — about a hundred ranges on one 978-line
corpus, most of them single lines whose content did reach an artifact.

A line is red now when **no artifact claims to have been written from it**,
which is what the heading always said. `resolve_span` computes every captured
artifact's span from its own text, so the spans partition the document into
passages that were claimed and passages that were not: few, large, and each one
a real re-read target.

`content_coverage` is unchanged and still drives `% covered` on Recent. The two
can disagree — every line claimed and half the wording gone is ordinary — so
the corpus page states both, and the `#uncovered` anchor lands on the sentence
when nothing is red. `verify::uncovered_ranges` is deleted; nothing read it any
more.

## Bands

The source and its artifacts were two lists saying the same things in places
you could not read against each other, with a hundred line numbers between
them. They become one grid: each passage beside what came of it, and where
nothing came of it, a red band saying so.

Overlaps are their own bands rather than merged. Blank-line runs join the band
above rather than opening a red sliver. Every line keeps its `L<n>` anchor, so
"open at these lines" and `?from=&to=` still work.

## Re-read, per band

One button re-read every window holding a gap. It belongs to its band now,
carries both ends (a passage does not stop at a window boundary — #20's
finding, which a first draft of this dropped), skips a window already queued,
passes `keep_artifacts: true`, and returns you to the band rather than the top
of a 978-line page. It stays away entirely until the capture has settled: lines
nothing has got to yet are not lines that were lost.

## Notes for review

- Two of #20's tests caught real regressions here and are unmodified.
- One test was removed rather than updated: it forced its hole by rewriting
  artifact text, which is a token-recall hole and precisely what this stops
  surfacing. `an_unclaimed_passage_is_a_gap_band_with_its_own_button` replaces it.
- 1100 tests pass. Clippy is one warning below the base branch; both `cargo fmt`
  and clippy have pre-existing findings on the base, left alone.
- Verified live against a throwaway database: three bands rendered for a forced
  gap, button reading `reads lines 1–23`. Not verified in a browser — no visual
  check of the grid itself.

Spec: `docs/superpowers/specs/2026-08-18-corpus-bands-design.md`
Plan: `docs/superpowers/plans/2026-08-18-corpus-bands.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)