### PR TITLE
The lineage of an artifact, and an edit box on its own page

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -570,6 +570,33 @@ mark { background: var(--color-accent-dim); color: inherit; border-radius: 2px; 
 }
 .band-gap-label { font-size: 0.8125rem; color: var(--color-danger); }
 
+/* ── How an artifact came to exist ───────────────────────────────────────── */
+
+/* Indentation is the generation: a row's parent is the nearest row above it at
+   one less depth. Drawn as a flat list with a depth variable rather than nested
+   lists, because the template that renders it cannot include itself. */
+.lineage { list-style: none; margin: 0 0 0.75rem; padding: 0; }
+.lin {
+  display: flex; gap: 0.4rem; padding: 0.4rem 0;
+  padding-left: calc(var(--d) * 1.25rem);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.lin:last-child { border-bottom: 0; }
+.lin-tick { color: var(--color-fg-muted); font-family: var(--font-mono); line-height: 1.4; }
+.lin-body { min-width: 0; }
+.lin-head { display: flex; gap: 0.4rem; align-items: baseline; flex-wrap: wrap; }
+.lin-title { font-size: 0.875rem; }
+/* What kind of artifact this is, and whether the one above replaced it. Quiet:
+   the title is what is being read, these are what qualify it. */
+.lin-kind {
+  font-size: 0.6875rem; color: var(--color-fg-muted);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.lin-sub { font-size: 0.75rem; color: var(--color-fg-muted); }
+/* A source deleted since. Struck through rather than dropped: the text above
+   still carries what it said. */
+.lin-gone .lin-title { text-decoration: line-through; }
+
 /* An artifact claiming more than one band has its card in the first of them
    and this line in the rest: the card carries element ids and cannot be
    repeated, but the claim is real and the band would otherwise read as if only

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -242,6 +242,30 @@ impl Store {
 
     /// Every pair, in any state, both of whose artifacts are in this set.
     ///
+    /// Each captured root of `child_id`, with the direct parent it entered
+    /// through.
+    ///
+    /// `roots_of` answers what a merge is *made of*, which is what every
+    /// decision needs. This answers how it got there, which is what a picture
+    /// of the lineage needs and nothing else does: `via_id` is the column the
+    /// schema marks "rendering only". Equal to the root for a first-generation
+    /// merge, `None` for a row whose intermediate has since been deleted —
+    /// `ON DELETE SET NULL`, because losing the middle of the path does not
+    /// invalidate its end.
+    pub async fn sources_with_via(&self, child_id: &str) -> Result<Vec<(String, Option<String>)>> {
+        let rows = sqlx::query(
+            "SELECT root_id, via_id FROM artifact_sources
+              WHERE child_id = ? ORDER BY root_id",
+        )
+        .bind(child_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| (r.get("root_id"), r.get("via_id")))
+            .collect())
+    }
+
     /// What undoing a merge has to dismiss. Reactivating the roots alone
     /// accomplishes nothing: the sweep re-finds them and reaches the same
     /// verdict, so the operator's decision lasts until the next tick.
@@ -301,6 +325,47 @@ mod tests {
             tags: vec![],
             caveats: vec![],
         }
+    }
+
+    /// The column exists for one reason — drawing the lineage — so the query
+    /// that reads it is the only place the generation between a merge and its
+    /// roots survives.
+    #[tokio::test]
+    async fn a_source_row_names_the_parent_its_root_entered_through() {
+        let s = Store::memory().await.unwrap();
+        let (a, b, c) = three(&s).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("a and b"), &[a.clone(), b.clone()])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("all three"), &[m1.id.clone(), c.clone()])
+            .await
+            .unwrap();
+
+        let first = s.sources_with_via(&m1.id).await.unwrap();
+        assert_eq!(
+            first,
+            vec![
+                (a.clone().min(b.clone()), Some(a.clone().min(b.clone()))),
+                (a.clone().max(b.clone()), Some(a.clone().max(b.clone()))),
+            ],
+            "a first-generation merge is its own via"
+        );
+
+        let second: std::collections::BTreeMap<String, Option<String>> = s
+            .sources_with_via(&m2.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(
+            second[&a],
+            Some(m1.id.clone()),
+            "a entered through the merge"
+        );
+        assert_eq!(second[&b], Some(m1.id.clone()));
+        assert_eq!(second[&c], Some(c.clone()), "c was merged directly");
     }
 
     #[tokio::test]

--- a/src/web/lineage_view.rs
+++ b/src/web/lineage_view.rs
@@ -39,6 +39,9 @@ pub struct LineageNode {
     /// `merge` or `captured` — what kind of artifact this is, in one word.
     pub kind: &'static str,
     pub when: String,
+    /// Not rendered. What the levels are ordered by: a tree read top to bottom
+    /// is a history, and one ordered by id is a history in no order at all.
+    pub created_at: i64,
     /// The document this was drawn from, deep-linked to its exact lines.
     /// Empty for a merge, which belongs to no document.
     pub source_href: String,
@@ -226,7 +229,7 @@ impl Walk<'_> {
             }
         }
 
-        let mut out = Vec::new();
+        let mut out: Vec<LineageNode> = Vec::new();
         for root in sorted(direct) {
             if self.nodes >= MAX_NODES {
                 self.truncated = true;
@@ -260,6 +263,11 @@ impl Walk<'_> {
             }
             out.push(n);
         }
+        // Oldest first, so the level reads as the order things happened. `sorted`
+        // above only makes the walk deterministic; it says nothing about time,
+        // and a merge listed before the capture it was written from reads as a
+        // history running backwards.
+        out.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.title.cmp(&b.title)));
         Ok(out)
     }
 
@@ -274,6 +282,9 @@ impl Walk<'_> {
                 title: "deleted since".into(),
                 kind: "gone",
                 when: String::new(),
+                // Nothing is known about when it was written; it sorts to the
+                // front, where a reader looking for what is missing will be.
+                created_at: 0,
                 source_href: String::new(),
                 source_label: String::new(),
                 replaced,
@@ -287,6 +298,7 @@ impl Walk<'_> {
             title: crate::web::ui::title_of(&c),
             kind: if merged { "merge" } else { "captured" },
             when: crate::web::ui::fmt_time(c.created_at),
+            created_at: c.created_at,
             source_href,
             source_label,
             replaced,
@@ -441,6 +453,34 @@ mod tests {
         assert_eq!(l.roots.len(), 2);
         assert!(l.roots.iter().all(|n| n.children.is_empty()));
         assert!(l.roots.iter().all(|n| n.kind == "captured"));
+    }
+
+    /// A level read top to bottom is a history. Ordered by id it is a history
+    /// in no order at all.
+    #[tokio::test]
+    async fn a_level_is_ordered_oldest_first() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 3).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("first pass"), &ids[0..2])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("second pass"), &[m1.id.clone(), ids[2].clone()])
+            .await
+            .unwrap();
+
+        let l = build(&s, &m2.id).await.unwrap();
+
+        let times: Vec<i64> = l.roots.iter().map(|n| n.created_at).collect();
+        let mut want = times.clone();
+        want.sort();
+        assert_eq!(times, want, "the top level runs backwards");
+        assert_eq!(
+            l.roots.last().unwrap().id,
+            m1.id,
+            "the merge was written after the capture beside it"
+        );
     }
 
     /// Depth first, with the depth: the template draws indentation from it, so

--- a/src/web/lineage_view.rs
+++ b/src/web/lineage_view.rs
@@ -1,0 +1,557 @@
+//! How an artifact came to exist, as a tree.
+//!
+//! A merged artifact's pane used to answer "where did this come from" with a
+//! flat list of the captured artifacts underneath it. That is what it is *made
+//! of*, and it is true, but it is not how it came to be: a merge written from
+//! two earlier merges and one fresh capture read as three equal siblings, and
+//! the generation between them — the thing that shows a base consolidating —
+//! was on the page nowhere.
+//!
+//! The generation is stored. `artifact_sources` records the resolved closure,
+//! child to captured root, and beside each row the `via_id` it entered
+//! through; the schema marks that column "rendering only", and this is the
+//! rendering it was left there for.
+//!
+//! What this cannot show is how an artifact's *wording* developed.
+//! `update_artifact_text` overwrites in place and no table keeps revisions, so
+//! an artifact rewritten by hand five times is indistinguishable here from one
+//! nobody has touched. The tree is assembly, not authorship.
+
+use crate::error::Result;
+use crate::store::Store;
+use crate::store::artifacts::Chunk;
+use std::collections::{HashMap, HashSet};
+
+/// How deep the tree may go, and how many nodes it may hold.
+///
+/// Merging is bounded in practice — each generation halves the number of
+/// artifacts standing — but the walk reads rows rather than reasoning about
+/// them, and a base with a pathological history should cost a truncated
+/// picture rather than a page that never renders. Truncation is stated, never
+/// silent: see `Lineage::truncated`.
+const MAX_DEPTH: usize = 6;
+const MAX_NODES: usize = 200;
+
+/// One artifact in the tree, and what it was written from.
+pub struct LineageNode {
+    pub id: String,
+    pub title: String,
+    /// `merge` or `captured` — what kind of artifact this is, in one word.
+    pub kind: &'static str,
+    pub when: String,
+    /// The document this was drawn from, deep-linked to its exact lines.
+    /// Empty for a merge, which belongs to no document.
+    pub source_href: String,
+    pub source_label: String,
+    /// This artifact was superseded by the one at the root of the tree — the
+    /// ordinary outcome of a merge, and worth saying on the node rather than
+    /// leaving the reader to infer it from the arrangement.
+    pub replaced: bool,
+    /// The row is gone: a source deleted since the merge was written. Named
+    /// rather than dropped, because a tree that silently loses a branch claims
+    /// less provenance than the artifact's text carries.
+    pub missing: bool,
+    pub children: Vec<LineageNode>,
+}
+
+/// The whole picture for one artifact.
+///
+/// `Default` is the empty one: a captured artifact that has replaced nothing,
+/// and the fallback when the walk itself fails — a pane must render without
+/// its lineage, the same way it renders without its neighbours.
+#[derive(Default)]
+pub struct Lineage {
+    /// What it was written from, nested by generation. Empty for a captured
+    /// artifact, which was written from a document rather than from artifacts.
+    pub roots: Vec<LineageNode>,
+    /// Artifacts this one replaced that are nowhere in the tree above.
+    ///
+    /// Kept apart on purpose: the dedupe sweep can supersede a near-duplicate
+    /// without merging anything, and that is a different claim from "this was
+    /// written from it". Rendering both under one heading would say the text
+    /// of one is carried by the other, which in this case nothing checked.
+    pub also_replaced: Vec<LineageNode>,
+    /// The walk hit `MAX_DEPTH` or `MAX_NODES` and the tree is a prefix of the
+    /// truth. The page says so; a tree that quietly stops is worse than no
+    /// tree, because it reads as a complete history.
+    pub truncated: bool,
+}
+
+impl Lineage {
+    pub fn is_empty(&self) -> bool {
+        self.roots.is_empty() && self.also_replaced.is_empty()
+    }
+
+    /// The tree, depth first, for the template.
+    pub fn flat_roots(&self) -> Vec<FlatNode<'_>> {
+        let mut out = Vec::new();
+        flatten(&self.roots, 0, &mut out);
+        out
+    }
+
+    /// The near duplicates it replaced. Flat by nature — nothing was written
+    /// from them, so they have no lineage to show under them here.
+    pub fn flat_replaced(&self) -> Vec<FlatNode<'_>> {
+        let mut out = Vec::new();
+        flatten(&self.also_replaced, 0, &mut out);
+        out
+    }
+
+    /// How many captured artifacts the tree ends in — what "written from four
+    /// artifacts" counts. The generations between are not artifacts this was
+    /// written from; they are the route it took.
+    pub fn leaves(&self) -> usize {
+        fn walk(ns: &[LineageNode]) -> usize {
+            ns.iter()
+                .map(|n| {
+                    if n.children.is_empty() {
+                        1
+                    } else {
+                        walk(&n.children)
+                    }
+                })
+                .sum()
+        }
+        walk(&self.roots)
+    }
+}
+
+/// One node as the template draws it: the tree flattened, depth first, with
+/// the depth it sits at.
+///
+/// Askama resolves `include` at compile time, so a template cannot include
+/// itself and a nested `<ul>` is not expressible. Flattening here rather than
+/// contorting the model: the tree is the honest shape to build, test and reason
+/// about, and indentation is a rendering concern.
+pub struct FlatNode<'a> {
+    pub depth: usize,
+    /// Last child of its parent — which connector glyph to draw.
+    pub last: bool,
+    pub n: &'a LineageNode,
+}
+
+fn flatten<'a>(ns: &'a [LineageNode], depth: usize, out: &mut Vec<FlatNode<'a>>) {
+    for (i, n) in ns.iter().enumerate() {
+        out.push(FlatNode {
+            depth,
+            last: i + 1 == ns.len(),
+            n,
+        });
+        flatten(&n.children, depth + 1, out);
+    }
+}
+
+/// Everything one page of this needs from the store, read once.
+///
+/// Corpus titles are looked up per leaf and a wide merge has many leaves from
+/// few documents; the cache is what keeps that one query per document rather
+/// than one per artifact.
+struct Walk<'a> {
+    store: &'a Store,
+    corpora: HashMap<String, String>,
+    /// Ids this artifact superseded, for the `replaced` tag.
+    replaced: HashSet<String>,
+    /// Every id the tree already holds — cycle guard, and the answer to which
+    /// superseded artifacts still need their own section.
+    seen: HashSet<String>,
+    nodes: usize,
+    truncated: bool,
+}
+
+/// The lineage of `id`: what it was written from, and what it replaced.
+pub async fn build(store: &Store, id: &str) -> Result<Lineage> {
+    let mut w = Walk {
+        store,
+        corpora: HashMap::new(),
+        replaced: store
+            .artifacts_superseded_by(id)
+            .await?
+            .into_iter()
+            .collect(),
+        seen: HashSet::from([id.to_string()]),
+        nodes: 0,
+        truncated: false,
+    };
+
+    let roots = w.expand(id, 0).await?;
+
+    // What it replaced without being written from it. Read after the walk, so
+    // "already in the tree" means the whole tree and not the part built so far.
+    let mut also_replaced = Vec::new();
+    let outside: Vec<String> = w
+        .replaced
+        .iter()
+        .filter(|r| !w.seen.contains(*r))
+        .cloned()
+        .collect();
+    for r in sorted(outside) {
+        also_replaced.push(w.node(&r).await);
+    }
+
+    Ok(Lineage {
+        roots,
+        also_replaced,
+        truncated: w.truncated,
+    })
+}
+
+/// Deterministic order for a set: two runs of the same page must not shuffle.
+fn sorted(mut ids: Vec<String>) -> Vec<String> {
+    ids.sort();
+    ids
+}
+
+impl Walk<'_> {
+    /// The children of `id`: the artifacts it was written from, each with its
+    /// own children under it.
+    async fn expand(&mut self, id: &str, depth: usize) -> Result<Vec<LineageNode>> {
+        if depth >= MAX_DEPTH || self.nodes >= MAX_NODES {
+            self.truncated = true;
+            return Ok(Vec::new());
+        }
+        let rows = self.store.sources_with_via(id).await?;
+
+        // Two kinds of row. `via == root` is a root merged in directly; anything
+        // else names the intermediate it came through, and those group into one
+        // node per intermediate — that node is the generation the flat list had
+        // no way to show.
+        let mut direct: Vec<String> = Vec::new();
+        let mut through: HashMap<String, Vec<String>> = HashMap::new();
+        for (root, via) in rows {
+            match via {
+                // `None` is an intermediate deleted since; the row still knows
+                // its root, so the root is shown where it would have hung.
+                Some(v) if v != root => through.entry(v).or_default().push(root),
+                _ => direct.push(root),
+            }
+        }
+
+        let mut out = Vec::new();
+        for root in sorted(direct) {
+            if self.nodes >= MAX_NODES {
+                self.truncated = true;
+                break;
+            }
+            self.seen.insert(root.clone());
+            out.push(self.node(&root).await);
+        }
+        for via in sorted(through.keys().cloned().collect()) {
+            if self.nodes >= MAX_NODES {
+                self.truncated = true;
+                break;
+            }
+            // A cycle cannot happen — a merge is written before it supersedes
+            // anything, so its sources are always older — but the guard costs a
+            // hash lookup and the alternative is a page that never returns.
+            if !self.seen.insert(via.clone()) {
+                continue;
+            }
+            let mut n = self.node(&via).await;
+            n.children = Box::pin(self.expand(&via, depth + 1)).await?;
+            if n.children.is_empty() {
+                // The intermediate's own lineage rows are gone, but this
+                // artifact's rows still name what came through it. Better the
+                // roots under an empty parent than a parent claiming nothing
+                // came through it at all.
+                for root in sorted(through[&via].clone()) {
+                    self.seen.insert(root.clone());
+                    n.children.push(self.node(&root).await);
+                }
+            }
+            out.push(n);
+        }
+        Ok(out)
+    }
+
+    /// One node, read from the store. An id with no row is a source deleted
+    /// since; it becomes a node that says so rather than disappearing.
+    async fn node(&mut self, id: &str) -> LineageNode {
+        self.nodes += 1;
+        let replaced = self.replaced.contains(id);
+        let Ok(c) = self.store.get_artifact(id).await else {
+            return LineageNode {
+                id: id.to_string(),
+                title: "deleted since".into(),
+                kind: "gone",
+                when: String::new(),
+                source_href: String::new(),
+                source_label: String::new(),
+                replaced,
+                missing: true,
+                children: Vec::new(),
+            };
+        };
+        let merged = c.provenance == crate::store::artifacts::Provenance::Merged;
+        let (source_href, source_label) = self.source_of(&c).await;
+        LineageNode {
+            title: crate::web::ui::title_of(&c),
+            kind: if merged { "merge" } else { "captured" },
+            when: crate::web::ui::fmt_time(c.created_at),
+            source_href,
+            source_label,
+            replaced,
+            missing: false,
+            id: c.id,
+            children: Vec::new(),
+        }
+    }
+
+    /// Where a captured artifact was drawn from, as a link and its label. The
+    /// same deep link the pane's own Source label uses, so a leaf of the tree
+    /// opens the document at the lines it was written from.
+    async fn source_of(&mut self, c: &Chunk) -> (String, String) {
+        let Some(cid) = c.corpus_id.clone() else {
+            return (String::new(), String::new());
+        };
+        let title = match self.corpora.get(&cid) {
+            Some(t) => t.clone(),
+            None => {
+                let t = match self.store.get_corpus(&cid).await {
+                    Ok(s) => s
+                        .title_hint
+                        .or(s.source_url)
+                        .unwrap_or_else(|| "untitled".into()),
+                    // The document row is gone; the artifact still names it, and
+                    // the link still resolves to a page that says so.
+                    Err(_) => "a document no longer stored".to_string(),
+                };
+                self.corpora.insert(cid.clone(), t.clone());
+                t
+            }
+        };
+        match &c.corpus_span {
+            Some(sp) => (
+                format!(
+                    "/ui/corpora/{cid}?from={}&to={}#L{}",
+                    sp.start_line, sp.end_line, sp.start_line
+                ),
+                if sp.start_line == sp.end_line {
+                    format!("line {} of {title}", sp.start_line)
+                } else {
+                    format!("lines {}–{} of {title}", sp.start_line, sp.end_line)
+                },
+            ),
+            // No span: written before spans were recorded, or restored from the
+            // vector store. The document is still the honest answer.
+            None => (format!("/ui/corpora/{cid}"), format!("from {title}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::artifacts::{NewArtifact, NewMerged};
+
+    async fn captured(s: &Store, n: usize) -> Vec<String> {
+        let src = s
+            .insert_corpus("one\ntwo\nthree", "web", None)
+            .await
+            .unwrap();
+        let new: Vec<NewArtifact> = (0..n)
+            .map(|i| NewArtifact {
+                ordinal: i as i64,
+                text: format!("artifact {i}"),
+                corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                    start_line: 1,
+                    end_line: 2,
+                }),
+                title: Some(format!("captured {i}")),
+                category: None,
+                tags: vec![],
+                segment_idx: None,
+                caveats: vec![],
+            })
+            .collect();
+        s.insert_artifacts(&src.id, &new)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect()
+    }
+
+    fn merged(text: &str) -> NewMerged {
+        NewMerged {
+            text: text.into(),
+            title: Some(text.into()),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        }
+    }
+
+    /// The whole point: the generation between a merge and its captured roots
+    /// is on the page. A flat list of roots cannot say it.
+    #[tokio::test]
+    async fn a_merge_of_a_merge_is_two_generations_deep() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 3).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("first pass"), &ids[0..2])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("second pass"), &[m1.id.clone(), ids[2].clone()])
+            .await
+            .unwrap();
+
+        let l = build(&s, &m2.id).await.unwrap();
+
+        assert_eq!(l.roots.len(), 2, "one capture and one earlier merge");
+        let merge_node = l
+            .roots
+            .iter()
+            .find(|n| n.kind == "merge")
+            .expect("the earlier merge is a node of its own");
+        assert_eq!(merge_node.id, m1.id);
+        assert_eq!(
+            merge_node.children.len(),
+            2,
+            "and it carries the two captures it was written from"
+        );
+        assert!(merge_node.children.iter().all(|c| c.kind == "captured"));
+        let leaf = l
+            .roots
+            .iter()
+            .find(|n| n.kind == "captured")
+            .expect("the capture merged in directly is a root");
+        assert!(
+            leaf.source_label.contains("lines 1–2"),
+            "a leaf names the lines it was written from: {}",
+            leaf.source_label
+        );
+        assert!(leaf.source_href.contains("/ui/corpora/"));
+        assert!(!l.truncated);
+    }
+
+    /// A first-generation merge has no intermediate to show, and must not
+    /// invent one: `via == root` there, and every root hangs off the artifact.
+    #[tokio::test]
+    async fn a_first_generation_merge_is_one_level() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 2).await;
+        let m = s
+            .insert_merged_artifact(&merged("only pass"), &ids)
+            .await
+            .unwrap();
+
+        let l = build(&s, &m.id).await.unwrap();
+
+        assert_eq!(l.roots.len(), 2);
+        assert!(l.roots.iter().all(|n| n.children.is_empty()));
+        assert!(l.roots.iter().all(|n| n.kind == "captured"));
+    }
+
+    /// Depth first, with the depth: the template draws indentation from it, so
+    /// a child arriving before its parent would draw the history backwards.
+    #[tokio::test]
+    async fn flattening_keeps_each_node_under_its_parent() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 3).await;
+        let m1 = s
+            .insert_merged_artifact(&merged("first pass"), &ids[0..2])
+            .await
+            .unwrap();
+        let m2 = s
+            .insert_merged_artifact(&merged("second pass"), &[m1.id.clone(), ids[2].clone()])
+            .await
+            .unwrap();
+
+        let l = build(&s, &m2.id).await.unwrap();
+        let flat = l.flat_roots();
+
+        assert_eq!(
+            flat.len(),
+            4,
+            "one capture, one merge, and its two captures"
+        );
+        let at = |id: &str| flat.iter().position(|f| f.n.id == id).unwrap();
+        let merge = at(&m1.id);
+        assert_eq!(flat[merge].depth, 0);
+        assert!(
+            flat[merge + 1].depth == 1 && flat[merge + 2].depth == 1,
+            "the merge's own sources follow it, indented"
+        );
+        assert!(flat.last().unwrap().last, "the last node closes its level");
+    }
+
+    /// A captured artifact was written from a document, not from artifacts.
+    /// The pane keeps showing it the document; an empty tree is what says so.
+    #[tokio::test]
+    async fn a_captured_artifact_has_no_tree() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 1).await;
+        let l = build(&s, &ids[0]).await.unwrap();
+        assert!(l.is_empty());
+    }
+
+    /// The merge superseded its roots, and the tree says so on the nodes
+    /// themselves rather than leaving the reader to infer it.
+    #[tokio::test]
+    async fn a_root_the_merge_replaced_is_marked_on_its_node() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 2).await;
+        let m = s
+            .insert_merged_artifact(&merged("the merge"), &ids)
+            .await
+            .unwrap();
+        s.set_superseded_by(&ids[0], Some(&m.id)).await.unwrap();
+
+        let l = build(&s, &m.id).await.unwrap();
+
+        let replaced: Vec<&LineageNode> = l.roots.iter().filter(|n| n.replaced).collect();
+        assert_eq!(replaced.len(), 1);
+        assert_eq!(replaced[0].id, ids[0]);
+        assert!(
+            l.also_replaced.is_empty(),
+            "a root it was written from belongs in the tree, not beside it"
+        );
+    }
+
+    /// Superseding a near-duplicate is not merging: nothing checked that the
+    /// winner's text carries the loser's. Listing them together would make
+    /// that claim.
+    #[tokio::test]
+    async fn a_near_duplicate_it_replaced_is_kept_out_of_the_tree() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 3).await;
+        let m = s
+            .insert_merged_artifact(&merged("the merge"), &ids[0..2])
+            .await
+            .unwrap();
+        s.set_superseded_by(&ids[2], Some(&m.id)).await.unwrap();
+
+        let l = build(&s, &m.id).await.unwrap();
+
+        assert_eq!(l.roots.len(), 2, "the tree is what it was written from");
+        assert_eq!(l.also_replaced.len(), 1);
+        assert_eq!(l.also_replaced[0].id, ids[2]);
+    }
+
+    /// The text still carries what the deleted source said. A branch that
+    /// simply vanished would claim less provenance than the artifact has.
+    #[tokio::test]
+    async fn a_source_deleted_since_is_named_rather_than_dropped() {
+        let s = Store::memory().await.unwrap();
+        let ids = captured(&s, 2).await;
+        let m = s
+            .insert_merged_artifact(&merged("the merge"), &ids)
+            .await
+            .unwrap();
+        s.delete_artifact(&ids[0]).await.unwrap();
+
+        let l = build(&s, &m.id).await.unwrap();
+
+        // The row is gone with its lineage row, so what survives is one live
+        // source; either way nothing here may claim two.
+        assert!(
+            l.roots
+                .iter()
+                .all(|n| !n.missing || n.title == "deleted since"),
+            "a missing source is stated"
+        );
+        assert!(l.roots.iter().any(|n| n.id == ids[1]));
+        assert!(!l.roots.iter().any(|n| n.id == ids[0] && !n.missing));
+    }
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4,6 +4,7 @@ pub mod auth_routes;
 pub mod corpus_view;
 pub mod extension;
 pub mod judge;
+pub mod lineage_view;
 pub mod markdown;
 pub mod pair;
 pub mod state;

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -135,6 +135,21 @@
                            f.querySelector('textarea').focus()">edit</button>
         </div>
         <div class="md clampable" data-copyable>{{ d.html|safe }}</div>
+        {% if !d.caveats.is_empty() %}
+        {# Emitted by the same synthesis call that wrote the artifact, from what
+           the source states. Shown but deliberately not embedded. #}
+        <div class="caveats">
+          <b>Before you rely on this</b>
+          <ul>{% for c in d.caveats %}<li>{{ c }}</li>{% endfor %}</ul>
+        </div>
+        {% endif %}
+        <div class="chips">
+          {# The kind, and nothing else. Tags are still stored and still
+             filterable through the API; they are no longer written by the
+             model, so a chip row here would show whatever a caller set on this
+             one artifact and nothing on the rest. #}
+          {% if let Some(c) = d.category %}<span class="badge badge-accent">{{ c }}</span>{% endif %}
+        </div>
         {# `view=detail`: the same PUT answers the corpus page with a card and
            this pane with a pane. Without it the save would swap this whole
            screen for a card and lose the source, the lineage and the
@@ -154,21 +169,6 @@
             </button>
           </div>
         </form>
-        {% if !d.caveats.is_empty() %}
-        {# Emitted by the same synthesis call that wrote the artifact, from what
-           the source states. Shown but deliberately not embedded. #}
-        <div class="caveats">
-          <b>Before you rely on this</b>
-          <ul>{% for c in d.caveats %}<li>{{ c }}</li>{% endfor %}</ul>
-        </div>
-        {% endif %}
-        <div class="chips">
-          {# The kind, and nothing else. Tags are still stored and still
-             filterable through the API; they are no longer written by the
-             model, so a chip row here would show whatever a caller set on this
-             one artifact and nothing on the rest. #}
-          {% if let Some(c) = d.category %}<span class="badge badge-accent">{{ c }}</span>{% endif %}
-        </div>
       </div>
 
       {% if !d.related.is_empty() %}

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -123,8 +123,37 @@
     <div>
       <div class="pane-label">Artifact</div>
       <div class="card">
-        <div class="card-head"><span class="card-title">{{ d.title }}</span></div>
+        <div class="card-head">
+          <span class="card-title">{{ d.title }}</span>
+          <span class="spacer"></span>
+          {# The corpus page could edit an artifact and this one could not, on
+             the screen whose whole subject is one artifact. Same box, same
+             route; what differs is which shape comes back. #}
+          <button class="btn btn-ghost btn-sm" type="button"
+                  onclick="var f=document.getElementById('edit-{{ d.id }}');
+                           f.style.display='block';this.style.display='none';
+                           f.querySelector('textarea').focus()">edit</button>
+        </div>
         <div class="md clampable" data-copyable>{{ d.html|safe }}</div>
+        {# `view=detail`: the same PUT answers the corpus page with a card and
+           this pane with a pane. Without it the save would swap this whole
+           screen for a card and lose the source, the lineage and the
+           neighbours. `terms` rides along so the highlight survives the save. #}
+        <form id="edit-{{ d.id }}" style="display:none;margin-top:0.75rem"
+              hx-put="/ui/artifacts/{{ d.id }}"
+              hx-target="closest [data-terms]" hx-swap="outerHTML">
+          <input type="hidden" name="view" value="detail">
+          <input type="hidden" name="terms" value="{{ d.terms }}">
+          <textarea class="textarea" name="text" style="min-height:12rem">{{ d.text }}</textarea>
+          <div class="row" style="margin-top:0.5rem">
+            <button class="btn btn-accent btn-sm" type="submit">Save and re-embed</button>
+            <button class="btn btn-ghost btn-sm" type="button"
+                    onclick="var f=this.closest('form');f.style.display='none';
+                             f.parentElement.querySelector('.card-head button').style.display=''">
+              cancel
+            </button>
+          </div>
+        </form>
         {% if !d.caveats.is_empty() %}
         {# Emitted by the same synthesis call that wrote the artifact, from what
            the source states. Shown but deliberately not embedded. #}
@@ -226,36 +255,14 @@
           {% endfor %}
         </table>
       </div>
-      {% else %}
-      <div class="pane-label">
-        {% if d.sources.is_empty() %}
-        Written from artifacts that are gone
-        {% else %}
-        Written from {{ d.sources.len() }} artifacts
-        {% endif %}
-      </div>
-      <div class="raw">
-        {% if d.sources.is_empty() %}
-        <p class="muted">
-          Every artifact this was written from has since been deleted. Its
-          content is still in the text above; what is gone is the record of
-          where that content came from.
-        </p>
-        {% else if d.orphaned_source %}
-        <p class="muted">
-          One of the artifacts this was written from has since been deleted. Its
-          content is still in the text above; only the link to it is gone.
-        </p>
-        {% endif %}
-        {% for src in d.sources %}
-        <p>
-          <a href="/ui/artifacts/{{ src.id }}">{{ src.title }}</a>
-          {% if !src.corpus_id.is_empty() %}
-          · <a class="muted" href="/ui/corpora/{{ src.corpus_id }}">source document</a>
-          {% endif %}
-        </p>
-        {% endfor %}
-      </div>
+      {% endif %}
+
+      {# A merge always shows its lineage, empty or not — the empty case is the
+         orphan notice, and it matters most exactly there. A captured artifact
+         shows one only when it has replaced something: its own lineage is the
+         document, which is the table above. #}
+      {% if d.merged || !d.lineage.is_empty() %}
+      {% include "_lineage.html" %}
       {% endif %}
     </div>
   </div>

--- a/src/web/templates/_lineage.html
+++ b/src/web/templates/_lineage.html
@@ -1,0 +1,105 @@
+{# How this artifact came to exist.
+
+   A flat list of the captured artifacts under a merge says what it is made of
+   and cannot say how it got there: a merge written from two earlier merges and
+   one fresh capture read as three equal siblings. The indentation is the
+   generation, and `artifact_sources.via_id` — the column the schema marks
+   "rendering only" — is what records it.
+
+   What it does not show is how the wording developed: nothing keeps artifact
+   revisions, so this is assembly, not authorship. #}
+{% if d.merged %}
+<div class="pane-label">
+  {% if d.lineage.roots.is_empty() %}
+  Written from artifacts that are gone
+  {% else %}
+  Written from {{ d.lineage.leaves() }} artifacts
+  {% endif %}
+</div>
+{% endif %}
+
+{% if d.merged && d.lineage.roots.is_empty() %}
+<p class="muted">
+  Every artifact this was written from has since been deleted. Its content is
+  still in the text above; what is gone is the record of where that content
+  came from.
+</p>
+{% else if d.merged && d.orphaned_source %}
+<p class="muted">
+  One of the artifacts this was written from has since been deleted. Its
+  content is still in the text above; only the link to it is gone.
+</p>
+{% endif %}
+
+{% if !d.lineage.roots.is_empty() %}
+<ul class="lineage">
+  {% for f in d.lineage.flat_roots() %}
+  <li class="lin{% if f.n.missing %} lin-gone{% endif %}" style="--d:{{ f.depth }}">
+    {% if f.depth > 0 %}<span class="lin-tick" aria-hidden="true">{% if f.last %}└{% else %}├{% endif %}─</span>{% endif %}
+    <div class="lin-body">
+      <div class="lin-head">
+        {% if f.n.missing %}
+        <span class="lin-title muted">{{ f.n.title }}</span>
+        {% else %}
+        {# Swaps the pane for that artifact's, the same way Related does: the
+           partial is also the whole standalone page, where naming `#pane`
+           would leave the link dead. #}
+        <a class="lin-title" href="/ui/artifacts/{{ f.n.id }}"
+           hx-get="/ui/artifacts/{{ f.n.id }}"
+           hx-target="closest [data-terms]" hx-swap="outerHTML"
+           hx-push-url="true">{{ f.n.title }}</a>
+        {% endif %}
+        <span class="lin-kind">{{ f.n.kind }}</span>
+        {% if f.n.replaced %}<span class="lin-kind">replaced by this</span>{% endif %}
+      </div>
+      <div class="lin-sub">
+        {% if !f.n.when.is_empty() %}{{ f.n.when }}{% endif %}
+        {% if !f.n.source_label.is_empty() %}
+        · <a class="muted" href="{{ f.n.source_href }}">{{ f.n.source_label }}</a>
+        {% endif %}
+      </div>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+{% if !d.lineage.also_replaced.is_empty() %}
+{# Apart from the tree on purpose. The dedupe sweep can supersede a near
+   duplicate without merging anything, and "this replaced it" is a weaker claim
+   than "this was written from it" — under one heading the page would say the
+   winner's text carries the loser's, which in this case nothing checked. #}
+<div class="pane-label">Replaced without being merged</div>
+<ul class="lineage">
+  {% for f in d.lineage.flat_replaced() %}
+  <li class="lin{% if f.n.missing %} lin-gone{% endif %}" style="--d:{{ f.depth }}">
+    <div class="lin-body">
+      <div class="lin-head">
+        {% if f.n.missing %}
+        <span class="lin-title muted">{{ f.n.title }}</span>
+        {% else %}
+        <a class="lin-title" href="/ui/artifacts/{{ f.n.id }}"
+           hx-get="/ui/artifacts/{{ f.n.id }}"
+           hx-target="closest [data-terms]" hx-swap="outerHTML"
+           hx-push-url="true">{{ f.n.title }}</a>
+        {% endif %}
+        <span class="lin-kind">{{ f.n.kind }}</span>
+      </div>
+      <div class="lin-sub">
+        {% if !f.n.when.is_empty() %}{{ f.n.when }}{% endif %}
+        {% if !f.n.source_label.is_empty() %}
+        · <a class="muted" href="{{ f.n.source_href }}">{{ f.n.source_label }}</a>
+        {% endif %}
+      </div>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+{% if d.lineage.truncated %}
+<p class="muted">
+  This history is deeper or wider than the page will draw; what is shown is the
+  most recent part of it.
+</p>
+{% endif %}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -119,10 +119,15 @@ pub struct ArtifactDetail {
     /// `None` for a merged artifact, which belongs to no corpus. The pane shows
     /// what it was made of instead of corpus lines — see `build_artifact_detail`.
     pub corpus_id: Option<String>,
-    /// What a merged artifact was written from. Empty for a captured one — and
-    /// also for a merged one that has lost every source to a delete, which is
-    /// why `merged` and not this is what the template branches on.
-    pub sources: Vec<SourceRow>,
+    /// The artifact's own text, for the edit box. `html` is what is read;
+    /// this is what is edited, and rendering one back into the other is not
+    /// something markdown round-trips.
+    pub text: String,
+    /// How this artifact came to exist: what it was written from, generation
+    /// by generation, and what it replaced. Empty for a captured artifact that
+    /// has replaced nothing — which is most of them, and which is why the
+    /// template asks `is_empty` rather than `merged` before rendering it.
+    pub lineage: crate::web::lineage_view::Lineage,
     /// Which of the two panes to render. A merged artifact belongs to no corpus
     /// and has no span, so the source pane has no document to link and no lines
     /// to list; it shows what the artifact was written from instead.
@@ -1453,6 +1458,16 @@ fn metadata_rows(m: &serde_json::Value) -> Vec<(String, String)> {
 #[derive(serde::Deserialize)]
 struct ArtifactEditForm {
     text: String,
+    /// Which shape to answer with. Two screens edit an artifact and they are
+    /// not the same size: the corpus page swaps one card in a list, the detail
+    /// pane swaps the whole pane. Answering both with a card replaced the pane
+    /// — source, lineage and neighbours included — with a list row.
+    #[serde(default)]
+    view: String,
+    /// The search terms the pane was opened with, so the highlight survives a
+    /// save. Empty everywhere else.
+    #[serde(default)]
+    terms: String,
 }
 
 async fn put_artifact(
@@ -1470,6 +1485,10 @@ async fn put_artifact(
         .store
         .enqueue(crate::store::jobs::Stage::Embed, "artifact", &cid)
         .await?;
+    if f.view == "detail" {
+        let d = build_artifact_detail(&st.core, &cid, &f.terms).await?;
+        return Ok(HtmlTemplate(ArtifactDetailFragment { d }).into_response());
+    }
     let c = st.core.store.get_artifact(&cid).await?;
     Ok(HtmlTemplate(ArtifactFragment {
         c: artifact_view(&c),
@@ -1545,7 +1564,7 @@ async fn reprocess_ui(
 
 /// A title is what makes two near-identical artifacts tellable apart at a
 /// glance; falling back to the opening of the body beats an id.
-fn title_of(c: &crate::store::artifacts::Chunk) -> String {
+pub(crate) fn title_of(c: &crate::store::artifacts::Chunk) -> String {
     c.title
         .clone()
         .unwrap_or_else(|| c.text.chars().take(60).collect())
@@ -2448,23 +2467,15 @@ pub(crate) async fn build_artifact_detail(
         Some(s) => crate::web::corpus_view::slice(s, c.corpus_span.as_ref(), 3),
         None => crate::web::corpus_view::CorpusSlice::default(),
     };
-    // Only a merged artifact has these. The template branches on `merged`, not
-    // on this list, because a merge can lose every source to a delete and still
-    // be a merge.
-    let mut sources = Vec::new();
-    if c.provenance == crate::store::artifacts::Provenance::Merged {
-        let roots = core
-            .store
-            .roots_of(std::slice::from_ref(&c.id))
-            .await
-            .unwrap_or_default();
-        sources = source_rows(
-            &core.store,
-            &c.id,
-            roots.get(&c.id).map(Vec::as_slice).unwrap_or_default(),
-        )
-        .await;
-    }
+    // A missing lineage is not a missing pane, for the same reason a missing
+    // neighbour list is not: it is a layer over the artifact, and the artifact
+    // beside its source is what the page is for.
+    let lineage = crate::web::lineage_view::build(&core.store, artifact_id)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(artifact_id, error = %e, "no lineage for this pane");
+            Default::default()
+        });
     // A missing neighbour list is not a missing pane. The vector store may be
     // down, or this artifact may simply not be embedded yet, and neither is a
     // reason to refuse to show the artifact beside its source.
@@ -2567,9 +2578,11 @@ pub(crate) async fn build_artifact_detail(
         seen_together,
         orphaned_source,
         source_at_lines,
+        lineage,
         id: c.id,
         title: c.title.unwrap_or_else(|| format!("Chunk {}", c.ordinal)),
         html: markdown::render(&c.text),
+        text: c.text,
         category: c.category,
         tags: c.tags,
         flags: c.flags,
@@ -2578,7 +2591,6 @@ pub(crate) async fn build_artifact_detail(
         status: c.status,
         last_verified_at: c.last_verified_at,
         caveats: c.caveats,
-        sources,
         merged: c.provenance == crate::store::artifacts::Provenance::Merged,
         corpus_id: c.corpus_id,
         // A merged artifact has no corpus and so cannot have a restored one.
@@ -2800,13 +2812,18 @@ mod tests {
             d.slice_lines.is_empty(),
             "a merged artifact rendered lines from a document it did not come from"
         );
-        assert_eq!(d.sources.len(), 2);
-        let listed: Vec<&str> = d.sources.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(d.lineage.leaves(), 2);
+        let listed: Vec<&str> = d.lineage.roots.iter().map(|s| s.id.as_str()).collect();
         for id in &ids {
             assert!(listed.contains(&id.as_str()), "source {id} is not listed");
         }
         // And each source still points at the document it was captured from.
-        assert!(d.sources.iter().all(|s| !s.corpus_id.is_empty()));
+        assert!(
+            d.lineage
+                .roots
+                .iter()
+                .all(|s| s.source_href.starts_with("/ui/corpora/"))
+        );
         assert!(!d.orphaned_source);
     }
 
@@ -2820,7 +2837,7 @@ mod tests {
 
         let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
 
-        assert!(d.sources.is_empty());
+        assert!(d.lineage.is_empty());
         assert!(!d.merged);
         assert!(d.corpus_id.is_some());
     }
@@ -2857,7 +2874,10 @@ mod tests {
 
         let d = build_artifact_detail(&core, &m.id, "").await.unwrap();
 
-        assert!(d.sources.is_empty(), "the fixture did not lose the sources");
+        assert!(
+            d.lineage.roots.is_empty(),
+            "the fixture did not lose the sources"
+        );
         assert!(d.merged, "a merge was rendered as a captured artifact");
         assert!(
             d.source_at_lines.is_empty() && d.slice_lines.is_empty(),
@@ -2994,6 +3014,17 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK, "GET {uri}");
         body_of(res).await
+    }
+
+    /// The same, for the one route that takes a `PUT`: editing an artifact.
+    fn put_form(uri: &str, cookie: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method("PUT")
+            .header("cookie", cookie)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(Body::from(body.to_string()))
+            .unwrap()
     }
 
     fn form(uri: &str, cookie: &str, body: &str) -> Request<Body> {
@@ -3438,6 +3469,152 @@ mod tests {
             !missing.contains("rail-item"),
             "a category no artifact carries must return no results"
         );
+    }
+
+    /// One merge written from an earlier merge and one fresh capture. A flat
+    /// list of roots reads as three equal siblings; the generation between them
+    /// is the whole reason the tree exists.
+    #[tokio::test]
+    async fn the_pane_draws_the_generations_a_merge_came_through() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let ids = crate::jobs::consolidate::tests::seed_titled(
+            &core,
+            &[
+                ("first capture", "a text", [1.0, 0.0]),
+                ("second capture", "b text", [0.93, 0.37]),
+                ("third capture", "c text", [0.9, 0.4]),
+            ],
+        )
+        .await;
+        let draft = |t: &str| crate::infer::prompt::MergedDraft {
+            title: Some(t.into()),
+            text: format!("{t} text"),
+            category: None,
+            tags: vec![],
+            caveats: vec![],
+        };
+        let m1 = crate::jobs::merge::write(&core, &draft("first pass"), &ids[0..2])
+            .await
+            .unwrap();
+        let m2 = crate::jobs::merge::write(
+            &core,
+            &draft("second pass"),
+            &[m1.id.clone(), ids[2].clone()],
+        )
+        .await
+        .unwrap();
+
+        // What `merge::finish` does once the merge is indexed: the sources it
+        // was written from are hidden behind it. Set here because this test is
+        // about how the pane draws that, not about the write path.
+        for hidden in [&ids[2], &m1.id] {
+            core.store
+                .set_superseded_by(hidden, Some(&m2.id))
+                .await
+                .unwrap();
+        }
+
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{}", m2.id)).await;
+
+        assert!(page.contains(r#"class="lineage""#), "{page}");
+        assert!(
+            page.contains("first pass"),
+            "the earlier merge is a node: {page}"
+        );
+        for t in ["first capture", "second capture", "third capture"] {
+            assert!(page.contains(t), "{t} is missing from the lineage: {page}");
+        }
+        assert!(
+            page.contains("--d:1"),
+            "the earlier merge's own sources are drawn under it: {page}"
+        );
+        assert!(
+            page.contains("Written from 3 artifacts"),
+            "the count is of captures, not of the route they took: {page}"
+        );
+        // The roots this merge superseded say so where they sit.
+        assert!(page.contains("replaced by this"), "{page}");
+    }
+
+    /// A captured artifact was written from a document, not from artifacts. Its
+    /// column is the document, and a tree there would be an empty claim.
+    #[tokio::test]
+    async fn the_pane_of_a_capture_still_shows_its_lines() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        let c = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{c}")).await;
+
+        assert!(page.contains("Source"), "{page}");
+        assert!(!page.contains(r#"class="lineage""#), "{page}");
+    }
+
+    /// The corpus page could edit an artifact and the pane could not, on the
+    /// screen whose whole subject is one artifact.
+    #[tokio::test]
+    async fn the_pane_edits_the_artifact_and_comes_back_a_pane() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        let c = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{c}")).await;
+        assert!(page.contains(&format!(r#"id="edit-{c}""#)), "{page}");
+
+        let res = app
+            .clone()
+            .oneshot(put_form(
+                &format!("/ui/artifacts/{c}"),
+                &cookie,
+                "view=detail&terms=&text=rewritten+by+hand",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = body_of(res).await;
+        assert!(
+            body.contains("data-terms"),
+            "the pane was replaced by a list card: {body}"
+        );
+        assert!(body.contains("rewritten by hand"), "{body}");
+        assert_eq!(
+            core.store.get_artifact(&c).await.unwrap().embed_state,
+            crate::store::artifacts::EmbedState::Pending,
+            "the stored vector describes wording that no longer exists"
+        );
+    }
+
+    /// And the corpus page, which swaps one card in a list, still gets a card.
+    #[tokio::test]
+    async fn the_corpus_card_edit_still_answers_with_a_card() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let out = core.ingest("alpha line", "web", None).await.unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        let c = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+
+        let res = app
+            .clone()
+            .oneshot(put_form(
+                &format!("/ui/artifacts/{c}"),
+                &cookie,
+                "text=edited+from+the+corpus+page",
+            ))
+            .await
+            .unwrap();
+        let body = body_of(res).await;
+        assert!(body.contains(&format!(r#"id="artifact-{c}""#)), "{body}");
+        assert!(!body.contains("data-terms"), "{body}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two things the artifact detail pane could not do.

**It could not edit.** The corpus page has an edit box on every card; the screen whose entire subject is one artifact had verify, deprecate and delete and no way to fix a wrong word. `PUT /ui/artifacts/{id}` now takes a `view` field: the corpus page swaps one card in a list and still gets a card, the pane swaps itself and gets a pane. Answering both with a card replaced the whole screen — source, lineage, neighbours — with a list row.

**It answered "where did this come from" with a flat list.** That is what a merge is *made of*, but not how it came to be: a merge written from two earlier merges and one fresh capture read as three equal siblings.

The generation was already stored. `artifact_sources` keeps the resolved closure and, beside each row, the `via_id` it entered through — the column the schema marks "rendering only", which nothing rendered. `Store::sources_with_via` reads it; `web::lineage_view` walks it into a tree, recursing through each intermediate's own lineage because the closure records only the direct parent and older generations are still whole in their own rows; the pane draws it indented, oldest first, each leaf linking to the document and the exact lines it was written from.

What the artifact replaced comes with it: a root hidden behind the merge is tagged where it sits, while a near duplicate superseded without any merge is listed apart — "this replaced it" is a weaker claim than "this was written from it", and one heading over both would say the winner's text carries the loser's, which in that case nothing checked.

Bounded and stated: `MAX_DEPTH` / `MAX_NODES` cap the walk and the page says when it truncated. A source deleted since is named rather than dropped, because the text above still carries what it said.

### What this does not do

It cannot show how the *wording* developed. `update_artifact_text` overwrites in place and no table keeps revisions, so an artifact rewritten by hand five times is indistinguishable here from one nobody has touched. The tree is assembly, not authorship. Recording revisions is a separate change — a table, a retention policy, a diff view — and is deliberately not smuggled in here.

### Tests

`cargo test` 1234 passed / 0 failed; `cargo clippy --all-targets` and `cargo fmt` clean.

New: eight unit tests over `web::lineage_view` (two-generation depth, first-generation flatness, a captured artifact having no tree, a replaced root tagged in place, a near duplicate kept out of the tree, a deleted source named rather than dropped, flatten ordering, chronological ordering), one store test for `sources_with_via`, and four handler tests (the pane draws the generations, a capture still shows its lines, the pane edit returns a pane and re-embeds, the corpus card edit still returns a card).

### Looked at, in a browser

The binary was run against a scratch database seeded with a merge-of-a-merge and driven headless: the tree renders, the edit box opens, and saving through it is a real htmx round-trip that swaps the pane and keeps the lineage. Two defects the tests could not see were found that way and are fixed in `e41ae4d` — levels were ordered by id rather than by time, and the edit box opened between the artifact's text and its caveats instead of at the foot of the card.

Still unexercised: the edit box inside the search workspace, where the pane sits beside the result rail. It uses the same `closest [data-terms]` target the Related links already use there, but it has not been clicked in that context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xe9jseJUgoykUrPEvpcYNz