### PR TITLE
feat: tiered synthesis — embedding recipe, off mode, promotion, pursuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ the file — the loader warns if it finds one.
 | `vector.weak_below` | Cosine under which a result is labelled "loose" rather than presented as an answer. Default 0.35; `0.0` turns it off. |
 | `infer.tiers.<name>.*` | A named endpoint the chat roles point at: `base_url`, `model`, `api_key`, `context_tokens`, `max_output_tokens`, `timeout_secs`, `reasoning_effort`, `ceiling_param`, `structured_output`. Name them what you like; `efficient` and `deep` are the convention. |
 | `infer.synthesize.*` | Synthesis: `tier`, plus `output_ratio`, `context_opening_tokens`, `context_overlap_tokens`. Any tier field may be overridden here. Also carries the dedupe judge, the link judge, the gap namer and the claim check. |
-| `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`. No tier — an embedding endpoint is a different shape of thing, not a cheaper model. |
+| `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`, and the three prompt templates `query_template`, `document_template`, `document_template_untitled`. Defaults are EmbeddingGemma's; a symmetric model sets the three to `{text}` / `{title}\n{text}` / `{text}`. No tier — an embedding endpoint is a different shape of thing, not a cheaper model. |
 | `infer.ask.*` | Used only by `ask`: `tier`, `follow_up`, `follow_up_tier`. Any tier field may be overridden here. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
 | `infer.vision.*` | Optional. Reads captured images: `model`, `base_url`, `api_key`, `timeout_secs`, `max_output_tokens`, `ceiling_param`. `base_url` and `api_key` default to the synthesize role's, and `ceiling_param` is inherited with them. Off by default. |
@@ -244,6 +244,10 @@ Eight worth knowing:
 - **`infer.embed.max_input_tokens`** must be the *server's* ceiling, not the
   model's nominal one. llama.cpp refuses input above its physical batch size —
   often 1024 — with a 500 no retry can fix.
+- **`infer.embed.*_template`** and `model` together are one identity: a
+  vector's meaning is fixed by the model *and* by the text handed to it.
+  Editing a template later silently mixes embedding spaces. There is no
+  rebuild path; drop the collection and re-capture.
 - **`infer.ask.max_output_tokens`** defaults to 4096 and comes out of
   `context_tokens`. The endpoint measures the prompt and this ceiling against
   one window, so `ask` reserves it and packs excerpts into the remainder:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,24 @@
 **A trace of everything worth keeping.**
 
 A self-hosted knowledge base you search by meaning. Paste text and engram
-rewrites it into self-contained markdown artifacts, embeds them, and answers
-queries with ranked excerpts — no generation step in the way. Asking a question
-across several artifacts is a separate endpoint you call explicitly.
+splits it into passages, embeds them, and answers queries with ranked excerpts —
+your words, not a rewrite of them, and no generation step in the way. Asking a
+question across several artifacts is a separate endpoint you call explicitly.
 
-Everything after the paste happens on its own: splitting, synthesis, embedding,
-duplicate hygiene, and the sweeps that repair whatever was interrupted. Every
-artifact stays anchored to the lines of the source it came from, so a rewritten
-passage can always be read beside the original wording.
+Rewriting is *earned*. Capture cannot know which of ten thousand paragraphs
+will ever be asked about, so engram does not spend a model call on each of them
+up front. A window is rewritten into a self-contained artifact once reading has
+shown it is worth rewriting — a passage opened and confirmed often enough, or a
+run of searches that assembled an answer the base did not hold. Every
+synthesized artifact can therefore name the use that earned it, and the rest of
+your text stays exactly as you wrote it. That is `infer.synthesis = "earned"`,
+the default; `"eager"` rewrites everything at capture, and `"off"` never
+rewrites anything and needs no chat model at all.
+
+Everything after the paste happens on its own: splitting, embedding, whatever
+synthesis was earned, duplicate hygiene, and the sweeps that repair whatever was
+interrupted. Every artifact stays anchored to the lines of the source it came
+from, so a rewritten passage can always be read beside the original wording.
 
 Three front doors over one backend: a web UI, a REST API, and an MCP server, so
 Claude Code or Claude Desktop can read and write it mid-session.
@@ -42,13 +52,17 @@ split is local and mechanical — a heading, then a blank line, then wherever th
 budget runs out. It stores line numbers rather than a copy, and doubles as the
 memory that lets a failed run resume instead of restarting.
 
-An **artifact** is what the model makes from a segment: a passage rewritten to
-stand on its own, with a title, a category and tags. Artifacts are what gets
-embedded, ranked, read and edited. One call turns one segment into several
-artifacts; no artifact spans two segments.
+An **artifact** is a unit of retrieval: a piece of text with a title, a
+category and tags, embedded, ranked, read and edited on its own. At the default
+`earned` most artifacts are *passages* — a slice of a segment, split on the
+document's own headings and paragraphs and stored verbatim. A *synthesized*
+artifact is one the model wrote, from a window whose reading earned it or from a
+pursuit; it is badged as such wherever it is shown, and one click retires it. No
+artifact spans two segments.
 
-Most artifacts are *captured* — written from one segment of one corpus, with the
-lines they came from shown beside them. A few are *merged*: written by
+At `eager` a synthesis call turns each segment into several *captured*
+artifacts at capture time instead — written from one segment of one corpus, with
+the lines they came from shown beside them. A few are *merged*: written by
 consolidation out of two or more captured artifacts that said the same thing,
 and listing what they were written from instead of corpus lines. The originals
 are hidden rather than deleted, one button restores them, and no merge is
@@ -162,8 +176,8 @@ cp config.example.toml config.toml
 ```
 
 Open <http://127.0.0.1:8080/auth/login>, capture something, and watch it move
-through `raw → synthesizing → embedding → ready` (at `infer.synthesis = "off"`:
-`raw → embedding → ready`) on Browse. `partial` means part
+through `raw → embedding → ready` on Browse (at `infer.synthesis = "eager"`,
+`raw → synthesizing → embedding → ready`). `partial` means part
 of it has not come through yet; Ops says what is retrying and when, and nothing
 there needs you.
 
@@ -215,7 +229,7 @@ the file — the loader warns if it finds one.
 | `vector.weak_below` | Cosine under which a result is labelled "loose" rather than presented as an answer. Default 0.35; `0.0` turns it off. |
 | `infer.tiers.<name>.*` | A named endpoint the chat roles point at: `base_url`, `model`, `api_key`, `context_tokens`, `max_output_tokens`, `timeout_secs`, `reasoning_effort`, `ceiling_param`, `structured_output`. Name them what you like; `efficient` and `deep` are the convention. |
 | `infer.synthesize.*` | Synthesis: `tier`, plus `output_ratio`, `context_opening_tokens`, `context_overlap_tokens`. Any tier field may be overridden here. Also carries the dedupe judge, the link judge, the gap namer and the claim check. |
-| `infer.synthesis` | `"off"`, `"earned"` or `"eager"` (default). `off` embeds the source text verbatim and calls no model at capture; `[infer.synthesize]` and `[infer.ask]` may then be omitted, and the doors that need them are not offered. |
+| `infer.synthesis` | `"earned"` (default), `"off"` or `"eager"`. `earned` embeds the source text verbatim at capture and synthesizes a window later, once reading has shown it is worth it. `off` is the same capture with no synthesis at all: `[infer.synthesize]` and `[infer.ask]` may then be omitted, and the doors that need them are not offered. `eager` spends one synthesis call per segment at capture. |
 | `infer.segment_tokens` | Window size when no synthesizer is configured. Default 4096. |
 | `infer.embed.chunk_tokens` | Passage size at `off`/`earned`. Default 384, clamped to the embedder. |
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`, and the three prompt templates `query_template`, `document_template`, `document_template_untitled`. Defaults are EmbeddingGemma's; a symmetric model sets the three to `{text}` / `{title}\n{text}` / `{text}`. No tier — an embedding endpoint is a different shape of thing, not a cheaper model. |

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ cp config.example.toml config.toml
 ```
 
 Open <http://127.0.0.1:8080/auth/login>, capture something, and watch it move
-through `raw → synthesizing → embedding → ready` on Browse. `partial` means part
+through `raw → synthesizing → embedding → ready` (at `infer.synthesis = "off"`:
+`raw → embedding → ready`) on Browse. `partial` means part
 of it has not come through yet; Ops says what is retrying and when, and nothing
 there needs you.
 
@@ -214,6 +215,9 @@ the file — the loader warns if it finds one.
 | `vector.weak_below` | Cosine under which a result is labelled "loose" rather than presented as an answer. Default 0.35; `0.0` turns it off. |
 | `infer.tiers.<name>.*` | A named endpoint the chat roles point at: `base_url`, `model`, `api_key`, `context_tokens`, `max_output_tokens`, `timeout_secs`, `reasoning_effort`, `ceiling_param`, `structured_output`. Name them what you like; `efficient` and `deep` are the convention. |
 | `infer.synthesize.*` | Synthesis: `tier`, plus `output_ratio`, `context_opening_tokens`, `context_overlap_tokens`. Any tier field may be overridden here. Also carries the dedupe judge, the link judge, the gap namer and the claim check. |
+| `infer.synthesis` | `"off"`, `"earned"` or `"eager"` (default). `off` embeds the source text verbatim and calls no model at capture; `[infer.synthesize]` and `[infer.ask]` may then be omitted, and the doors that need them are not offered. |
+| `infer.segment_tokens` | Window size when no synthesizer is configured. Default 4096. |
+| `infer.embed.chunk_tokens` | Passage size at `off`/`earned`. Default 384, clamped to the embedder. |
 | `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`, and the three prompt templates `query_template`, `document_template`, `document_template_untitled`. Defaults are EmbeddingGemma's; a symmetric model sets the three to `{text}` / `{title}\n{text}` / `{text}`. No tier — an embedding endpoint is a different shape of thing, not a cheaper model. |
 | `infer.ask.*` | Used only by `ask`: `tier`, `follow_up`, `follow_up_tier`. Any tier field may be overridden here. |
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
@@ -231,9 +235,10 @@ Eight worth knowing:
   and ships **off**: a default here moves after the harness has run, not before.
   `follow_up_tier` puts that call on a cheaper tier than the answer it feeds,
   which is the whole reason tiers are named.
-- **`tier` is required** on `infer.synthesize` and `infer.ask`. An endpoint is
-  named once under `infer.tiers.<name>` and pointed at, so moving a role to
-  another model is one word.
+- **`tier` is required** on `infer.synthesize` and `infer.ask` when those
+  tables are present. An endpoint is named once under `infer.tiers.<name>` and
+  pointed at, so moving a role to another model is one word. At
+  `infer.synthesis = "off"` both tables may be omitted.
 - **`infer.embed.dim`** must match the collection. If it does not, engram
   refuses to start and names both numbers. Mismatched vectors corrupt search in
   a way you would not notice for weeks.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ the file — the loader warns if it finds one.
 | `infer.vision.*` | Optional. Reads captured images: `model`, `base_url`, `api_key`, `timeout_secs`, `max_output_tokens`, `ceiling_param`. `base_url` and `api_key` default to the synthesize role's, and `ceiling_param` is inherited with them. Off by default. |
 | `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `per_point`, `interval_hours`, `dedupe_interval_mins`, `max_dedupe_per_tick`. |
 | `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. On by default — promotion at `earned` reads activation, and activation moves only while searches are recorded. |
+| `pursuit.*` | `enabled` (default off), `idle_secs` (900), `min_sources` (2), `min_engagement` (3.0). A quiet run of searches that engaged several artifacts without the base answering — or by assembling the answer across them — earns one generated artifact, badged, carrying the questions it was written for, superseding nothing. Needs `feedback.enabled`. |
 | `promote.*` | `activation_above` (default 4.0): at `earned`, a passage opened or confirmed past this has its window synthesized. `resynthesize_after_unconfirmed` (default 0 = off): at `eager`, an artifact shown this often and never confirmed is re-read from its segment. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails` / `allowed_groups`. |

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ the file — the loader warns if it finds one.
 | `infer.rerank.*` | Optional. `style` is `tei`, `cohere` or `vllm`. Off by default. |
 | `infer.vision.*` | Optional. Reads captured images: `model`, `base_url`, `api_key`, `timeout_secs`, `max_output_tokens`, `ceiling_param`. `base_url` and `api_key` default to the synthesize role's, and `ceiling_param` is inherited with them. Off by default. |
 | `consolidate.*` | Duplicate hygiene: `enabled`, `near_dupe_min`, `review_min`, `auto_supersede`, `per_point`, `interval_hours`, `dedupe_interval_mins`, `max_dedupe_per_tick`. |
-| `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. Off by default. |
+| `feedback.*` | Recording real searches for later judging: `enabled`, `candidates`, `coalesce_secs`, `retain_days` (unjudged searches only), `sweep_hours`. On by default — promotion at `earned` reads activation, and activation moves only while searches are recorded. |
+| `promote.*` | `activation_above` (default 4.0): at `earned`, a passage opened or confirmed past this has its window synthesized. `resynthesize_after_unconfirmed` (default 0 = off): at `eager`, an artifact shown this often and never confirmed is re-read from its segment. |
 | `auth.mode` | `oidc` or `local`. |
 | `auth.oidc.*` | `issuer_url`, `client_id`, `client_secret`, `redirect_url`, `scopes`, `allowed_subs` / `allowed_emails` / `allowed_groups`. |
 | `auth.local.*` | `username` and an argon2id `password_hash`. Development only. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,10 +163,20 @@ own.
   exists, and `ask/retrieve.rs` already decides which hits are reliable enough
   to reach from. What is left is the presentation — saying so on the rail, and
   the click.
-- **Server-side grouping.** The per-corpus cap is applied client-side over a
-  candidate pool three times the limit; a corpus whose artifacts fill the pool
-  leaves nothing to promote. Qdrant's `query/groups` retrieves per group.
-  `cap_per_corpus` in `src/core/search.rs` becomes the in-memory fallback.
+- **Server-side grouping — now a prerequisite, not a nice-to-have.** The
+  per-corpus cap is applied client-side over a candidate pool three times the
+  limit; a corpus whose artifacts fill the pool leaves nothing to promote. At
+  `synthesis = "off"` a 10,000-token document yields ~26 passages rather than
+  ~8 artifacts, adjacent passages are additionally similar through their
+  shared heading, and one long document fills the pool reliably. The
+  tiered-synthesis spec (§5, "What `off` makes mandatory") names Qdrant's
+  `query/groups` as part of the design; what landed is the fallback only —
+  `cap_per_corpus` in `src/core/search.rs` now counts a merge against each of
+  its origin corpora (`VectorPayload.origin_corpora`). Still to build: the
+  `query/groups` call in `vector/qdrant.rs`, its emulation in
+  `vector/memory.rs`, and the measurement against the judged-pair set, since
+  it moves ranking. Until then a very long document at `off` can dominate a
+  result list.
 - **Reranking on by default**, once there is a default endpoint worth assuming.
   A cross-encoder, not a model call; the harness — both of them — decides.
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -308,11 +308,46 @@
     });
   }
 
+  // ── Dwell ─────────────────────────────────────────────────────────────────
+  //
+  // How long an artifact stayed open, reported as the reader leaves it: the
+  // next pane swap, the page going away, the tab going hidden. The weakest
+  // pursuit signal there is, and it is sent as a beacon so leaving costs
+  // nothing. Under three seconds is a glance, not a read, and is not sent.
+  var dwell = { id: null, since: 0 };
+  function flushDwell() {
+    if (!dwell.id) return;
+    var secs = Math.round((Date.now() - dwell.since) / 1000);
+    var id = dwell.id;
+    dwell.id = null;
+    if (secs < 3) return;
+    var body = new URLSearchParams({ secs: String(secs) });
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon('/ui/artifacts/' + id + '/dwell', body);
+    } else {
+      fetch('/ui/artifacts/' + id + '/dwell', { method: 'POST', body: body, keepalive: true });
+    }
+  }
+  function trackDwell() {
+    var open = document.querySelector('[data-artifact]');
+    var id = open ? open.getAttribute('data-artifact') : null;
+    if (id === dwell.id) return;
+    flushDwell();
+    if (id) { dwell.id = id; dwell.since = Date.now(); }
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
     enhance(document.body);
     askDriver();
+    trackDwell();
+    window.addEventListener('pagehide', flushDwell);
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'hidden') flushDwell();
+      else trackDwell();
+    });
     document.body.addEventListener('htmx:afterSwap', function (e) {
       enhance(e.target);
+      trackDwell();
       // The pane now holds something, so a narrow screen can hide the rail.
       var ws = document.querySelector('.workspace');
       if (ws && e.target.id === 'pane') ws.classList.add('has-selection');

--- a/config.example.toml
+++ b/config.example.toml
@@ -436,6 +436,21 @@ retrieved = 1.0
 opened = 0.5
 confirmed = 3.0
 
+# ── Promotion ────────────────────────────────────────────────────────────────
+# At synthesis = "earned", when a passage has earned its window a synthesis
+# call. Read against [activation]: baseline 1.0 at capture, so 4.0 is one
+# confirmation after a retrieval and an open, or about three engaged openings.
+# Checked only when a passage is opened or confirmed — never when it merely
+# appears in results — and the window's new artifacts inherit the access the
+# passages earned.
+[promote]
+activation_above = 4.0
+# At synthesis = "eager": an artifact shown this many times with no
+# confirmation recorded against it is re-read from its source segment. 0
+# disables it, and it ships disabled — re-synthesising changes what an
+# existing base contains without anyone asking.
+resynthesize_after_unconfirmed = 0
+
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share
 # one GPU, so a per-role cooldown could not bound total load.

--- a/config.example.toml
+++ b/config.example.toml
@@ -61,9 +61,16 @@ pinned_boost = 0.15
 #   "off"    — split the text into verbatim passages, embed them, call nothing.
 #              [infer.synthesize] and [infer.ask] may be left out entirely.
 #   "earned" — the same capture; synthesis runs later where use has shown it
-#              is worth it. Needs [infer.synthesize].
-#   "eager"  — one synthesis call per segment at capture. The default.
-synthesis = "eager"
+#              is worth it. Needs [infer.synthesize]. The default.
+#   "eager"  — one synthesis call per segment at capture.
+#
+# "earned" is the default because capture cannot know which paragraph will be
+# asked about. Your text goes in as you wrote it; a window is rewritten once
+# reading has shown the rewrite is worth making, and every synthesized artifact
+# in the base can name the use that earned it. Choose "eager" when you want
+# everything pre-written and are willing to pay a model call per segment for
+# text most of which is never retrieved.
+synthesis = "earned"
 # Window size when there is no [infer.synthesize] to derive one from, in
 # engram's estimator tokens. Ignored when a synthesizer is configured.
 # segment_tokens = 4096
@@ -208,7 +215,9 @@ max_input_tokens = 2048
 # title. A document with no title takes the `_untitled` template — the model
 # card substitutes the literal word `none`, so it is a second template and not
 # an empty field. Changing any of these invalidates every stored vector as
-# surely as changing `model` does: drop the collection and re-capture. Check
+# surely as changing `model` does: drop the collection and re-capture. engram
+# records the recipe — model, dim and the three templates — and says so at boot
+# when it no longer matches what the stored vectors were embedded under. Check
 # once that your serving stack does not prepend a prompt of its own, or the
 # prefix is sent twice and every vector carries it.
 # query_template             = "task: search result | query: {text}"

--- a/config.example.toml
+++ b/config.example.toml
@@ -367,7 +367,10 @@ max_dedupe_per_tick = 5
 # one there is. Typing bursts fold into their final wording, so `daten`,
 # `datentr`, `datenträger nicht erkannt` is one event rather than three.
 [feedback]
-enabled = false
+# On by default: promotion at synthesis = "earned" reads activation, and
+# activation only moves while searches are recorded. Everything stays on this
+# machine and Ops forgets it on one press; set false to record nothing at all.
+enabled = true
 # Candidates stored per search. Wider than the answer on purpose — retrieval
 # over-fetches anyway, so the extra rows cost nothing, and they are what lets an
 # artifact the ranking buried still be confirmed as the right one. 0 is not a

--- a/config.example.toml
+++ b/config.example.toml
@@ -451,6 +451,24 @@ activation_above = 4.0
 # existing base contains without anyone asking.
 resynthesize_after_unconfirmed = 0
 
+# ── Pursuits ─────────────────────────────────────────────────────────────────
+# A coherent run of searches, what was opened and pivoted through, and — when
+# the base did not answer or the answer was assembled by hand — one generated
+# artifact written from exactly that, carrying the questions it was written
+# for. Off until turned on: this writes model-written text into the index.
+# Needs feedback.enabled. Local only, nothing leaves the machine, and the
+# forget button on Settings clears all of it. The grouping line is measured,
+# not configured.
+[pursuit]
+enabled = false
+# A pursuit is over when nothing has happened for this long.
+idle_secs = 900
+# Fewer engaged artifacts than this is a promotion case, not generation.
+min_sources = 2
+# Engagement weight a pursuit needs before it is worth a call: opened 1.0,
+# pivoted 1.5, returned 2.0, confirmed 3.0.
+min_engagement = 3.0
+
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share
 # one GPU, so a per-role cooldown could not bound total load.

--- a/config.example.toml
+++ b/config.example.toml
@@ -56,6 +56,18 @@ pinned_boost = 0.15
 # consumer GPU, answering in minutes rather than seconds. Against a hosted API
 # you can raise output_ratio's window and lower timeout_secs considerably.
 
+[infer]
+# How much inference capture spends.
+#   "off"    — split the text into verbatim passages, embed them, call nothing.
+#              [infer.synthesize] and [infer.ask] may be left out entirely.
+#   "earned" — the same capture; synthesis runs later where use has shown it
+#              is worth it. Needs [infer.synthesize].
+#   "eager"  — one synthesis call per segment at capture. The default.
+synthesis = "eager"
+# Window size when there is no [infer.synthesize] to derive one from, in
+# engram's estimator tokens. Ignored when a synthesizer is configured.
+# segment_tokens = 4096
+
 # The working tier: everything that runs unattended, in bulk, and is paid for
 # by the corpus rather than by a person waiting.
 [infer.tiers.efficient]
@@ -187,6 +199,11 @@ dim = 768
 # engram splits the artifact instead, but it splits sooner and cheaper if this
 # number is honest. 2048 is the model's window; use the server's if lower.
 max_input_tokens = 2048
+# Passage size at synthesis = "off"/"earned", in estimator tokens: about a
+# paragraph and a half, which is about one idea. Clamped to what the embedder
+# will take (max_input_tokens * 0.8). Argued, not measured — the judge
+# harness is what is allowed to move it.
+# chunk_tokens = 384
 # The recipe. `{text}` is the query or the body; `{title}` is the artifact's
 # title. A document with no title takes the `_untitled` template — the model
 # card substitutes the literal word `none`, so it is a second template and not

--- a/config.example.toml
+++ b/config.example.toml
@@ -169,18 +169,43 @@ output_ratio = 8.0
 
 [infer.embed]
 base_url = "http://localhost:8000/v1"
-model = "bge-m3"
+# EmbeddingGemma. 308M parameters, 768 dimensions, a 2048-token window, and an
+# asymmetric interface: queries and documents are embedded through different
+# prompts, which the three templates below are. The model card's exact strings
+# are the defaults, so nothing below `max_input_tokens` needs setting for it.
+model = "embeddinggemma"
 # Embedding is fast even locally; a shorter ceiling surfaces a wedged endpoint
 # instead of holding a worker for a quarter of an hour.
 timeout_secs = 120
 # MUST match the vector dimension of the Qdrant collection. Changing this
-# against an existing collection is refused at startup.
-dim = 1024
+# against an existing collection is refused at startup. The full Matryoshka
+# width: truncating to 512/256/128 buys memory at a recall cost, and recall is
+# the point.
+dim = 768
 # The server's real ceiling, not the model's nominal one. llama.cpp refuses any
-# input above its physical batch size (often 1024) with a 500, and no retry can
-# fix that — engram splits the artifact instead, but it splits sooner and cheaper
-# if this number is honest. Many embedding models cap at 512; check yours.
-max_input_tokens = 1024
+# input above its physical batch size with a 500, and no retry can fix that —
+# engram splits the artifact instead, but it splits sooner and cheaper if this
+# number is honest. 2048 is the model's window; use the server's if lower.
+max_input_tokens = 2048
+# The recipe. `{text}` is the query or the body; `{title}` is the artifact's
+# title. A document with no title takes the `_untitled` template — the model
+# card substitutes the literal word `none`, so it is a second template and not
+# an empty field. Changing any of these invalidates every stored vector as
+# surely as changing `model` does: drop the collection and re-capture. Check
+# once that your serving stack does not prepend a prompt of its own, or the
+# prefix is sent twice and every vector carries it.
+# query_template             = "task: search result | query: {text}"
+# document_template          = "title: {title} | text: {text}"
+# document_template_untitled = "title: none | text: {text}"
+#
+# A symmetric embedder — bge-m3, which engram shipped with — wants the text as
+# it is. That is these three lines, with `dim = 1024` and the server's ceiling:
+# model = "bge-m3"
+# dim = 1024
+# max_input_tokens = 1024
+# query_template             = "{text}"
+# document_template          = "{title}\n{text}"
+# document_template_untitled = "{text}"
 
 [infer.ask]
 tier = "deep"

--- a/docs/superpowers/plans/2026-08-19-embedding-recipe.md
+++ b/docs/superpowers/plans/2026-08-19-embedding-recipe.md
@@ -1,0 +1,1296 @@
+# Embedding Recipe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the embedder asymmetric and templated — queries and documents rendered through EmbeddingGemma's prompt templates before they reach the model, with the envelope's tokens charged against the split budget — so the retrieval baseline moves once, on its own, before the tiered-synthesis modes land on top of it.
+
+**Architecture:** Three template strings live on `EmbedRole` (config) and travel into every `Embedder` as an `EmbedTemplates` value. The `Embedder` trait splits into a wire-level `embed_raw` that implementations provide and two provided methods, `embed_documents` and `embed_query`, that render first — so no call site can forget to render. The embed job measures what it will send through the same `render_document`, which is what makes the splitter and the embedder agree about size.
+
+**Tech Stack:** Rust 2024 (rust-version 1.94), `async_trait`, `serde` + `config` crate for TOML, `wiremock` for HTTP tests, SQLite/Qdrant untouched.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md`, section 2 ("The embedding recipe"). This plan is step 1 of the spec's "Measurement" order; sections 1, 3–9 are later plans and nothing here anticipates them.
+
+## Global Constraints
+
+- Default templates, verbatim from the spec and the model card (2026-08-19):
+  `query_template = "task: search result | query: {text}"`,
+  `document_template = "title: {title} | text: {text}"`,
+  `document_template_untitled = "title: none | text: {text}"`.
+- Two document templates, not one plus a filler: the untitled case is a literal substitution on the model card, and `embed_text`'s `Some/None` match already has that shape.
+- Templates are config, not code: pointing at `bge-m3` must remain possible. The legacy rendering (`{text}` / `{title}\n{text}` / `{text}`) is what a bge-m3 operator configures and what the test doubles use by default.
+- The trait split is not optional (spec: "Rendering at the call site works until someone adds a fourth place that embeds something").
+- Envelope cost is charged: `envelope_cost(title) = count(render_document(title, ""))` replaces every `title_cost`, and the existing "a title that fills the limit on its own is refused" behaviour keeps working for an envelope that fills it.
+- No fingerprint, no startup guard, no rebuild path, no migration: "There is no legacy base to migrate." Changing a template later means drop the collection and re-capture.
+- Existing tests asserting the joined embedding text are updated to the new rendering, not pinned.
+- Nothing here changes ranking parameters, `weak_below`, `NEIGHBOUR_*`, or the sparse encoding of queries.
+- Commit messages in this repo are one lower-case imperative line, often with a colon prefix (`feat:`, `fix:`, `docs:`, `chore:`); no trailers except the Co-Authored-By/Claude-Session lines the harness requires.
+- Run `cargo fmt` before every commit and `cargo clippy --all-targets` at the end of every task; both must be clean.
+
+---
+
+## File structure
+
+| file | responsibility after this plan |
+|---|---|
+| `src/config.rs` | `EmbedTemplates` (the three strings, defaults, `legacy()`, `render_query`, `render_document`); three new fields on `EmbedRole` with serde defaults and `EmbedRole::templates()`; validation that every template has its placeholders |
+| `src/infer/mod.rs` | `EmbedDoc`; the split `Embedder` trait — required `embed_raw`/`templates`/`dim`/`model`/`max_input_tokens`, provided `embed_documents`/`embed_query`/`render_document` |
+| `src/infer/openai.rs` | `HttpEmbedder` holds `EmbedTemplates` from config; implements `embed_raw` (the POST, unchanged) and `templates` |
+| `src/infer/fake.rs` | `FakeEmbedder` holds templates (legacy by default, `with_templates` for the asymmetric case); `StrictEmbedder` delegates |
+| `src/core/search.rs` | the one query site calls `embed_query`; the `BlockingEmbedder` test double adapts |
+| `src/core/ask/mod.rs` | the `Keyed` test double adapts |
+| `src/jobs/embed.rs` | every document embedding goes through `embed_documents`; `render(core, chunk)` for budgets; `lexical_text` for the sparse half; `envelope_cost` replaces `title_cost` in `split_oversize` and `embed_head`; the "embed as-is" path stops dropping the title |
+| `src/main.rs` | the `EmbedRole` literal gains the three fields |
+| `config.example.toml`, `README.md` | EmbeddingGemma is the documented default; the bge-m3 block shows the legacy templates |
+
+---
+
+### Task 1: `EmbedTemplates` — the three strings and how they render
+
+**Files:**
+- Modify: `src/config.rs` (add after `EmbedRole`, currently at `src/config.rs:651-661`)
+- Test: `src/config.rs` (the existing `#[cfg(test)] mod tests` at the bottom of the file)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (later tasks rely on these exact names):
+  ```rust
+  pub struct EmbedTemplates { pub query_template: String, pub document_template: String, pub document_template_untitled: String }
+  impl Default for EmbedTemplates            // EmbeddingGemma strings
+  impl EmbedTemplates {
+      pub fn legacy() -> Self;               // "{text}", "{title}\n{text}", "{text}"
+      pub fn render_query(&self, query: &str) -> String;
+      pub fn render_document(&self, title: Option<&str>, text: &str) -> String;
+      pub fn validate(&self) -> Result<(), String>;   // every template has "{text}"; document_template has "{title}"
+  }
+  pub(crate) fn substitute(template: &str, vars: &[(&str, &str)]) -> String;  // single left-to-right pass
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `mod tests` at the bottom of `src/config.rs` (after the last existing test):
+
+```rust
+    #[test]
+    fn query_and_document_render_differently_for_the_same_text() {
+        let t = EmbedTemplates::default();
+        let q = t.render_query("how do I recover deleted entries");
+        let d = t.render_document(None, "how do I recover deleted entries");
+        assert_ne!(q, d);
+        assert_eq!(q, "task: search result | query: how do I recover deleted entries");
+        assert_eq!(d, "title: none | text: how do I recover deleted entries");
+    }
+
+    #[test]
+    fn a_titled_and_an_untitled_document_take_different_templates() {
+        let t = EmbedTemplates::default();
+        assert_eq!(
+            t.render_document(Some("Recovering deleted entries"), "run fsck first"),
+            "title: Recovering deleted entries | text: run fsck first"
+        );
+        assert_eq!(
+            t.render_document(None, "run fsck first"),
+            "title: none | text: run fsck first"
+        );
+    }
+
+    #[test]
+    fn the_legacy_templates_reproduce_the_old_join() {
+        // What `embed_text` produced before templates existed, and what a
+        // bge-m3 operator configures. The test doubles default to it so every
+        // retrieval test that queries with "title\ntext" keeps matching.
+        let t = EmbedTemplates::legacy();
+        assert_eq!(t.render_query("t0\nalpha"), "t0\nalpha");
+        assert_eq!(t.render_document(Some("t0"), "alpha"), "t0\nalpha");
+        assert_eq!(t.render_document(None, "alpha"), "alpha");
+    }
+
+    #[test]
+    fn substitution_is_one_pass_so_a_value_cannot_be_substituted_again() {
+        // A title that happens to contain the text placeholder must not have
+        // the body spliced into it. Two chained `replace` calls would.
+        let t = EmbedTemplates::default();
+        assert_eq!(
+            t.render_document(Some("about {text}"), "body"),
+            "title: about {text} | text: body"
+        );
+        assert_eq!(
+            substitute("a {x} b {y} c {x}", &[("x", "1"), ("y", "2")]),
+            "a 1 b 2 c 1"
+        );
+        // An unknown placeholder is left as written rather than eaten.
+        assert_eq!(substitute("{nope} {x}", &[("x", "1")]), "{nope} 1");
+    }
+
+    #[test]
+    fn a_template_without_its_placeholder_is_rejected() {
+        let mut t = EmbedTemplates::default();
+        assert!(t.validate().is_ok());
+        t.query_template = "task: search result | query: ".into();
+        assert!(t.validate().unwrap_err().contains("query_template"));
+        let mut t = EmbedTemplates::default();
+        t.document_template = "text: {text}".into();
+        assert!(t.validate().unwrap_err().contains("{title}"));
+        let mut t = EmbedTemplates::default();
+        t.document_template_untitled = "title: none | text: ".into();
+        assert!(t.validate().unwrap_err().contains("document_template_untitled"));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib config::tests::query_and_document_render_differently_for_the_same_text config::tests::a_titled_and_an_untitled_document_take_different_templates config::tests::the_legacy_templates_reproduce_the_old_join config::tests::substitution_is_one_pass config::tests::a_template_without_its_placeholder_is_rejected 2>&1 | tail -20`
+Expected: compile error — `EmbedTemplates` and `substitute` not found.
+
+- [ ] **Step 3: Implement `EmbedTemplates`**
+
+Insert into `src/config.rs` immediately after the `EmbedRole` struct (after line 661, before `pub struct AskRole`):
+
+```rust
+/// The three strings that, with `model`, fix what a stored vector means.
+///
+/// EmbeddingGemma is asymmetric: a query and a document are embedded through
+/// different prompts, and a document without a title substitutes the literal
+/// `none` rather than an empty field. Changing any of these invalidates every
+/// stored vector as thoroughly as changing `model` does; there is no fingerprint
+/// or rebuild path because there is no base to look after yet — the answer is
+/// to drop the collection and re-capture.
+///
+/// Kept in config rather than code so that a symmetric embedder — `bge-m3`,
+/// which engram shipped with — stays one TOML block away: see `legacy()`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbedTemplates {
+    /// `{text}` is the query.
+    pub query_template: String,
+    /// `{title}` and `{text}`.
+    pub document_template: String,
+    /// `{text}` only; used when the document has no title.
+    pub document_template_untitled: String,
+}
+
+pub(crate) fn default_query_template() -> String {
+    "task: search result | query: {text}".into()
+}
+pub(crate) fn default_document_template() -> String {
+    "title: {title} | text: {text}".into()
+}
+pub(crate) fn default_document_template_untitled() -> String {
+    "title: none | text: {text}".into()
+}
+
+impl Default for EmbedTemplates {
+    fn default() -> Self {
+        Self {
+            query_template: default_query_template(),
+            document_template: default_document_template(),
+            document_template_untitled: default_document_template_untitled(),
+        }
+    }
+}
+
+impl EmbedTemplates {
+    /// What `embed_text` produced before templates existed: the title on its
+    /// own line above the body, the query as typed. The right block for a
+    /// symmetric embedder, and what every test double renders with, so a test
+    /// that queries with `"title\ntext"` lands on the document it seeded.
+    pub fn legacy() -> Self {
+        Self {
+            query_template: "{text}".into(),
+            document_template: "{title}\n{text}".into(),
+            document_template_untitled: "{text}".into(),
+        }
+    }
+
+    pub fn render_query(&self, query: &str) -> String {
+        substitute(&self.query_template, &[("text", query)])
+    }
+
+    pub fn render_document(&self, title: Option<&str>, text: &str) -> String {
+        match title {
+            Some(t) => substitute(&self.document_template, &[("title", t), ("text", text)]),
+            None => substitute(&self.document_template_untitled, &[("text", text)]),
+        }
+    }
+
+    /// Every template must be able to carry what it is for. Checked at config
+    /// load; a template that drops `{text}` would embed the same string for
+    /// every document and nothing downstream would notice.
+    pub fn validate(&self) -> std::result::Result<(), String> {
+        if !self.query_template.contains("{text}") {
+            return Err("infer.embed.query_template must contain {text}".into());
+        }
+        if !self.document_template.contains("{text}") {
+            return Err("infer.embed.document_template must contain {text}".into());
+        }
+        if !self.document_template.contains("{title}") {
+            return Err("infer.embed.document_template must contain {title}; \
+                        use document_template_untitled for the case with no title"
+                .into());
+        }
+        if !self.document_template_untitled.contains("{text}") {
+            return Err("infer.embed.document_template_untitled must contain {text}".into());
+        }
+        Ok(())
+    }
+}
+
+/// Fill `{name}` placeholders in one left-to-right pass.
+///
+/// One pass rather than chained `replace` calls: a value that itself contains
+/// a placeholder — a heading that reads "about {text}" — must land verbatim,
+/// not have the next value spliced into it. A `{name}` that matches no
+/// variable is left as written.
+pub(crate) fn substitute(template: &str, vars: &[(&str, &str)]) -> String {
+    let mut out = String::with_capacity(template.len() + 64);
+    let mut rest = template;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        match after.find('}') {
+            Some(close) => {
+                let name = &after[..close];
+                match vars.iter().find(|(k, _)| *k == name) {
+                    Some((_, v)) => out.push_str(v),
+                    None => {
+                        out.push('{');
+                        out.push_str(name);
+                        out.push('}');
+                    }
+                }
+                rest = &after[close + 1..];
+            }
+            None => {
+                out.push_str(&rest[open..]);
+                rest = "";
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib config::tests:: 2>&1 | tail -20`
+Expected: all config tests PASS, including the five new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/config.rs
+git commit -m "feat: embed templates — the three strings that fix what a vector means"
+```
+
+---
+
+### Task 2: Templates on `EmbedRole`, with defaults and validation
+
+**Files:**
+- Modify: `src/config.rs:651-661` (`EmbedRole`), `src/config.rs:1079-1089` (`validate`)
+- Modify: `src/main.rs:325-332` (the `EmbedRole` literal)
+- Modify: `src/infer/openai.rs:1419-1428` (`embed_cfg` test helper)
+- Test: `src/config.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `EmbedTemplates`, `default_*_template()` from Task 1.
+- Produces:
+  ```rust
+  pub struct EmbedRole { /* existing fields */ pub query_template: String, pub document_template: String, pub document_template_untitled: String }
+  impl EmbedRole { pub fn templates(&self) -> EmbedTemplates; }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `mod tests` in `src/config.rs`. The helper `load_infer` and the `env_guard()` pattern already exist there (`src/config.rs:1646`); copy the `[server]/[store]/[vector]/[infer.tiers...]` preamble from `a_role_resolves_its_endpoint_from_its_tier` exactly as that test writes it, then add the body below. Read that test first and reuse its preamble verbatim — the `[infer.synthesize]` and `[infer.ask]` blocks it contains are required for the config to load at all.
+
+```rust
+    /// The preamble every `[infer.embed]` test below shares: a valid config
+    /// with the embed block left for the test to write.
+    const EMBED_PREAMBLE: &str = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer.tiers.efficient]
+        base_url = "http://localhost:8000/v1"
+        model = "qwen"
+        context_tokens = 32768
+        max_output_tokens = 16384
+        [infer.synthesize]
+        tier = "efficient"
+        output_ratio = 8.0
+        [infer.ask]
+        tier = "efficient"
+    "#;
+
+    #[test]
+    fn embed_templates_default_to_embeddinggemma_when_unset() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{EMBED_PREAMBLE}
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"embeddinggemma\"
+            dim = 768
+            max_input_tokens = 2048
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.embed.templates(), EmbedTemplates::default());
+    }
+
+    #[test]
+    fn embed_templates_are_read_from_config() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{EMBED_PREAMBLE}
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"bge-m3\"
+            dim = 1024
+            max_input_tokens = 1024
+            query_template = \"{{text}}\"
+            document_template = \"{{title}}\\n{{text}}\"
+            document_template_untitled = \"{{text}}\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.embed.templates(), EmbedTemplates::legacy());
+    }
+
+    #[test]
+    fn a_template_missing_its_placeholder_fails_at_load() {
+        let _guard = env_guard();
+        let err = load_infer(&format!(
+            "{EMBED_PREAMBLE}
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"embeddinggemma\"
+            dim = 768
+            max_input_tokens = 2048
+            query_template = \"task: search result | query: \"
+            "
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("query_template"), "got: {err}");
+    }
+```
+
+Note the doubled braces inside `format!` — `{{text}}` renders as `{text}` in the TOML. `EMBED_PREAMBLE` is the preamble of `a_role_resolves_its_endpoint_from_its_tier` (`src/config.rs:1655`) minus its `[infer.embed]` block; `output_ratio` is a required key on `[infer.synthesize]`, which is why it is there. The existing `[infer.embed]` blocks elsewhere in these tests (`model = "bge-m3"`, no template keys) keep loading — the keys default.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib config::tests::embed_templates 2>&1 | tail -20`
+Expected: compile error — no method `templates` on `EmbedRole` (and the third test fails because the load succeeds).
+
+- [ ] **Step 3: Add the fields, `templates()`, and validation**
+
+Replace `EmbedRole` in `src/config.rs:651-661` with:
+
+```rust
+#[derive(Debug, Deserialize, Clone)]
+pub struct EmbedRole {
+    pub base_url: String,
+    pub model: String,
+    #[serde(default)]
+    pub api_key: Option<String>,
+    pub dim: usize,
+    pub max_input_tokens: usize,
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+    /// See `EmbedTemplates`. Flat on the role rather than nested, so the TOML
+    /// reads `[infer.embed] query_template = ...` beside `model`, which is the
+    /// other half of the same identity.
+    #[serde(default = "default_query_template")]
+    pub query_template: String,
+    #[serde(default = "default_document_template")]
+    pub document_template: String,
+    #[serde(default = "default_document_template_untitled")]
+    pub document_template_untitled: String,
+}
+
+impl EmbedRole {
+    pub fn templates(&self) -> EmbedTemplates {
+        EmbedTemplates {
+            query_template: self.query_template.clone(),
+            document_template: self.document_template.clone(),
+            document_template_untitled: self.document_template_untitled.clone(),
+        }
+    }
+}
+```
+
+In `validate()` (`src/config.rs:1079`), add before the final `Ok(())`:
+
+```rust
+        self.infer
+            .embed
+            .templates()
+            .validate()
+            .map_err(ConfigError::Invalid)?;
+```
+
+Update the literal in `src/main.rs:325-332`:
+
+```rust
+                embed: EmbedRole {
+                    base_url: "http://localhost:8000/v1".into(),
+                    model: "e".into(),
+                    api_key: None,
+                    dim: 1024,
+                    max_input_tokens: 8192,
+                    timeout_secs: engram::config::DEFAULT_TIMEOUT_SECS,
+                    query_template: engram::config::EmbedTemplates::default().query_template,
+                    document_template: engram::config::EmbedTemplates::default().document_template,
+                    document_template_untitled: engram::config::EmbedTemplates::default()
+                        .document_template_untitled,
+                },
+```
+
+Update `embed_cfg` in `src/infer/openai.rs:1419-1428`:
+
+```rust
+    fn embed_cfg(base: String) -> EmbedRole {
+        let t = crate::config::EmbedTemplates::default();
+        EmbedRole {
+            base_url: base,
+            model: "e".into(),
+            api_key: None,
+            dim: 4,
+            max_input_tokens: 512,
+            timeout_secs: crate::config::DEFAULT_TIMEOUT_SECS,
+            query_template: t.query_template,
+            document_template: t.document_template,
+            document_template_untitled: t.document_template_untitled,
+        }
+    }
+```
+
+If `grep -rn "EmbedRole {" src tests` shows any other literal, give it the same three fields.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib config::tests:: 2>&1 | tail -20 && cargo build --all-targets 2>&1 | tail -5`
+Expected: config tests PASS; the whole crate (including tests and `main.rs`) builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/config.rs src/main.rs src/infer/openai.rs
+git commit -m "feat: embed templates are config, beside the model they belong to"
+```
+
+---
+
+### Task 3: Split the `Embedder` trait and move every caller onto it
+
+This is one task because the trait change forces every implementation and every call site to move together; the crate does not compile in between. Behaviour is preserved for the test doubles (legacy templates) so the existing suite is the regression net.
+
+**Files:**
+- Modify: `src/infer/mod.rs:65-71` (`Embedder` trait)
+- Modify: `src/infer/openai.rs:618-700` (`HttpEmbedder`)
+- Modify: `src/infer/fake.rs:25-91` (`FakeEmbedder`), `src/infer/fake.rs:348-420` (`StrictEmbedder`)
+- Modify: `src/core/search.rs:700-708` (query embedding), `src/core/search.rs:983-1008` (`BlockingEmbedder`)
+- Modify: `src/core/ask/mod.rs:987-1012` (`Keyed`)
+- Modify: `src/jobs/embed.rs` — `embed_text` (line 18), `run_with_limit` (69), `run_corpus_with_limit` (130), `embed_batch` (239-273), `split_oversize` as-is path (402-403), `embed_head` (484-490), and the tests at 890, 921, 957, 1258, 1702
+- Test: `src/infer/openai.rs` `mod tests`, `src/infer/fake.rs` (new `mod tests`), `src/jobs/embed.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `EmbedTemplates` (Task 1), `EmbedRole::templates()` (Task 2).
+- Produces:
+  ```rust
+  // src/infer/mod.rs
+  pub struct EmbedDoc { pub title: Option<String>, pub text: String }
+  #[async_trait] pub trait Embedder: Send + Sync {
+      async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;   // required: the wire call
+      fn templates(&self) -> &EmbedTemplates;                                // required
+      fn dim(&self) -> usize; fn model(&self) -> &str; fn max_input_tokens(&self) -> usize;
+      fn render_document(&self, doc: &EmbedDoc) -> String;                   // provided
+      async fn embed_documents(&self, docs: &[EmbedDoc]) -> Result<Vec<Vec<f32>>>; // provided
+      async fn embed_query(&self, query: &str) -> Result<Vec<f32>>;          // provided
+  }
+  // src/infer/fake.rs
+  impl FakeEmbedder { pub fn new(dim) -> Self /* legacy templates */; pub fn with_templates(dim, EmbedTemplates) -> Self; pub fn calls(&self) -> usize; pub fn sent(&self) -> Vec<String> /* every rendered string embed_raw received, in order */ }
+  // src/jobs/embed.rs (private)
+  fn doc_of(chunk: &Chunk) -> EmbedDoc; fn render(core: &Core, chunk: &Chunk) -> String; fn lexical_text(chunk: &Chunk) -> String;
+  async fn embed_batch(core: &Core, chunks: &[Chunk]) -> Result<()>;         // signature changes: no texts argument
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/infer/openai.rs` `mod tests`, after `embedder_sends_float_encoding_and_orders_results_by_index`:
+
+```rust
+    #[tokio::test]
+    async fn documents_and_queries_are_rendered_through_the_templates_before_the_post() {
+        use wiremock::matchers::body_partial_json;
+        let server = MockServer::start().await;
+        let one = serde_json::json!({"data":[{"index":0,"embedding":[1.0,0.0,0.0,0.0]}]});
+        let two = serde_json::json!({"data":[
+            {"index":0,"embedding":[1.0,0.0,0.0,0.0]},
+            {"index":1,"embedding":[0.0,1.0,0.0,0.0]}
+        ]});
+        // The document side: titled and untitled take different templates.
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .and(body_partial_json(serde_json::json!({
+                "input": ["title: Recovering | text: run fsck", "title: none | text: bare"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(two))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // The query side: the retrieval task prefix, nothing else.
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .and(body_partial_json(serde_json::json!({
+                "input": ["task: search result | query: fsck"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(one))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let e = HttpEmbedder::new(&embed_cfg(server.uri()));
+        let docs = vec![
+            crate::infer::EmbedDoc { title: Some("Recovering".into()), text: "run fsck".into() },
+            crate::infer::EmbedDoc { title: None, text: "bare".into() },
+        ];
+        let out = e.embed_documents(&docs).await.unwrap();
+        assert_eq!(out.len(), 2);
+        let q = e.embed_query("fsck").await.unwrap();
+        assert_eq!(q, vec![1.0, 0.0, 0.0, 0.0]);
+        // `.expect(1)` on both mocks is verified when `server` drops.
+    }
+```
+
+In `src/infer/fake.rs`, add at the end of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EmbedTemplates;
+    use crate::infer::EmbedDoc;
+
+    #[tokio::test]
+    async fn the_fake_renders_like_the_real_one_and_keeps_what_it_sent() {
+        // With the asymmetric templates the same words embed to different
+        // vectors as a query and as a document — the property the real
+        // embedder has, exercised here so a test can rely on it.
+        let e = FakeEmbedder::with_templates(8, EmbedTemplates::default());
+        let d = e
+            .embed_documents(&[EmbedDoc { title: None, text: "alpha".into() }])
+            .await
+            .unwrap();
+        let q = e.embed_query("alpha").await.unwrap();
+        assert_ne!(d[0], q);
+        assert_eq!(
+            e.sent(),
+            vec![
+                "title: none | text: alpha".to_string(),
+                "task: search result | query: alpha".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_default_fake_is_symmetric_so_a_query_can_name_a_document() {
+        // What every retrieval test in the crate depends on: querying with
+        // "title\ntext" lands on the document seeded with that title and text.
+        let e = FakeEmbedder::new(8);
+        let d = e
+            .embed_documents(&[EmbedDoc { title: Some("t0".into()), text: "alpha".into() }])
+            .await
+            .unwrap();
+        let q = e.embed_query("t0\nalpha").await.unwrap();
+        assert_eq!(d[0], q);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib infer:: 2>&1 | tail -20`
+Expected: compile errors — `EmbedDoc`, `embed_documents`, `embed_query`, `with_templates`, `sent` do not exist.
+
+- [ ] **Step 3: Rewrite the trait**
+
+Replace the `Embedder` trait in `src/infer/mod.rs:65-71` with:
+
+```rust
+/// One document as the embedder sees it: what goes into the `title:` slot and
+/// what goes into the `text:` slot. Built by `jobs::embed` from a `Chunk`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbedDoc {
+    pub title: Option<String>,
+    pub text: String,
+}
+
+/// Asymmetric by interface. A query and a document are rendered through
+/// different templates before they reach the model, and the rendering happens
+/// *inside* the trait — `embed_documents` and `embed_query` are provided — so
+/// there is no call site that can forget it. `embed_raw` is the wire call and
+/// is what an implementation supplies; nothing outside an `Embedder` should
+/// call it.
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    /// The strings sent, exactly as given. Implementations only.
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+    fn templates(&self) -> &crate::config::EmbedTemplates;
+    fn dim(&self) -> usize;
+    fn model(&self) -> &str;
+    fn max_input_tokens(&self) -> usize;
+
+    /// The string a document becomes. Exposed so budgets can be measured
+    /// against what will actually be sent — the envelope costs tokens too.
+    fn render_document(&self, doc: &EmbedDoc) -> String {
+        self.templates()
+            .render_document(doc.title.as_deref(), &doc.text)
+    }
+
+    async fn embed_documents(&self, docs: &[EmbedDoc]) -> Result<Vec<Vec<f32>>> {
+        let texts: Vec<String> = docs.iter().map(|d| self.render_document(d)).collect();
+        self.embed_raw(&texts).await
+    }
+
+    async fn embed_query(&self, query: &str) -> Result<Vec<f32>> {
+        let mut out = self
+            .embed_raw(&[self.templates().render_query(query)])
+            .await?;
+        if out.is_empty() {
+            return Err(crate::error::Error::Inference {
+                role: "embed",
+                detail: "no vector came back for the query".into(),
+            });
+        }
+        Ok(out.remove(0))
+    }
+}
+```
+
+- [ ] **Step 4: Move `HttpEmbedder`**
+
+In `src/infer/openai.rs:618-641`, add the field and rename the method:
+
+```rust
+pub struct HttpEmbedder {
+    ep: Endpoint,
+    dim: usize,
+    max_input_tokens: usize,
+    templates: crate::config::EmbedTemplates,
+}
+
+impl HttpEmbedder {
+    pub fn new(cfg: &EmbedRole) -> Self {
+        Self {
+            ep: Endpoint::new(
+                &cfg.base_url,
+                &cfg.model,
+                cfg.api_key.as_deref(),
+                cfg.timeout_secs,
+                "embed",
+            ),
+            dim: cfg.dim,
+            max_input_tokens: cfg.max_input_tokens,
+            templates: cfg.templates(),
+        }
+    }
+}
+
+#[async_trait]
+impl Embedder for HttpEmbedder {
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        // body unchanged from the old `embed`
+```
+
+Keep the body of the old `embed` exactly as it is under the new name. Below the existing `fn max_input_tokens`, add:
+
+```rust
+    fn templates(&self) -> &crate::config::EmbedTemplates {
+        &self.templates
+    }
+```
+
+Then fix the existing `HttpEmbedder` tests in this file that call `.embed(&[...])` (lines ~1729, 1756, 1773, 1791, 2312): they exercise the wire path — retry classification, index ordering, dimension check, short batch — so change each `.embed(` to `.embed_raw(` and leave their inputs as they are.
+
+- [ ] **Step 5: Move the fakes**
+
+Replace `FakeEmbedder` in `src/infer/fake.rs:25-91` with:
+
+```rust
+/// Hashes text into a fixed-dimension unit vector. Identical text gives an
+/// identical vector and different text gives a different one, which is all the
+/// retrieval tests need from an embedding model.
+///
+/// Renders with the *legacy* templates by default — `{text}` for a query,
+/// `{title}\n{text}` for a document — so a test that queries with
+/// `"title\ntext"` lands on the document it seeded, exactly as before
+/// templates existed. `with_templates` gives a fake the asymmetric recipe for
+/// the tests that are about the recipe.
+pub struct FakeEmbedder {
+    dim: usize,
+    templates: crate::config::EmbedTemplates,
+    /// How many times the endpoint was called. Batching is invisible in the
+    /// output — only the call count shows whether it happened.
+    calls: std::sync::atomic::AtomicUsize,
+    /// Every string handed to `embed_raw`, in order: what a real endpoint
+    /// would have been sent.
+    sent: std::sync::Mutex<Vec<String>>,
+    /// When set, every call is refused with this reason — the endpoint's "no",
+    /// which a worker must not retry.
+    reject_with: Option<String>,
+}
+
+impl FakeEmbedder {
+    pub fn new(dim: usize) -> Self {
+        Self::with_templates(dim, crate::config::EmbedTemplates::legacy())
+    }
+
+    pub fn with_templates(dim: usize, templates: crate::config::EmbedTemplates) -> Self {
+        Self {
+            dim,
+            templates,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            sent: std::sync::Mutex::new(Vec::new()),
+            reject_with: None,
+        }
+    }
+
+    pub fn rejecting(msg: &str) -> Self {
+        let mut e = Self::new(8);
+        e.reject_with = Some(msg.to_string());
+        e
+    }
+
+    pub fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// What was sent, rendered, in order.
+    pub fn sent(&self) -> Vec<String> {
+        self.sent.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl Embedder for FakeEmbedder {
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut s) = self.sent.lock() {
+            s.extend(texts.iter().cloned());
+        }
+        if let Some(m) = &self.reject_with {
+            return Err(Error::InferenceRejected {
+                role: "embed",
+                detail: m.clone(),
+            });
+        }
+        Ok(texts
+            .iter()
+            .map(|t| {
+                let mut v = vec![0f32; self.dim];
+                let mut seed = Sha256::digest(t.as_bytes()).to_vec();
+                for i in 0..self.dim {
+                    if i % 32 == 0 && i > 0 {
+                        seed = Sha256::digest(&seed).to_vec();
+                    }
+                    v[i] = (seed[i % 32] as f32 - 128.0) / 128.0;
+                }
+                let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9);
+                v.iter().map(|x| x / norm).collect()
+            })
+            .collect())
+    }
+    fn templates(&self) -> &crate::config::EmbedTemplates {
+        &self.templates
+    }
+    fn dim(&self) -> usize {
+        self.dim
+    }
+    fn model(&self) -> &str {
+        "fake-embed"
+    }
+    fn max_input_tokens(&self) -> usize {
+        8192
+    }
+}
+```
+
+In `StrictEmbedder` (`src/infer/fake.rs:377-420`): rename `async fn embed` to `async fn embed_raw`, change its final line `self.inner.embed(texts).await` to `self.inner.embed_raw(texts).await`, and add:
+
+```rust
+    fn templates(&self) -> &crate::config::EmbedTemplates {
+        self.inner.templates()
+    }
+```
+
+The length check inside it (`t.len() / 4`) now measures the rendered string, which is what a real server would measure — no change needed.
+
+- [ ] **Step 6: Move the two in-test doubles**
+
+`src/core/search.rs:992-1008` (`BlockingEmbedder`): rename `embed` → `embed_raw`, its body's `self.inner.embed(texts)` → `self.inner.embed_raw(texts)`, and add `fn templates(&self) -> &crate::config::EmbedTemplates { self.inner.templates() }`.
+
+`src/core/ask/mod.rs:990-1012` (`Keyed`): rename `embed` → `embed_raw`; it has no inner, so add:
+
+```rust
+        fn templates(&self) -> &crate::config::EmbedTemplates {
+            static LEGACY: std::sync::LazyLock<crate::config::EmbedTemplates> =
+                std::sync::LazyLock::new(crate::config::EmbedTemplates::legacy);
+            &LEGACY
+        }
+```
+
+Its `contains("alpha")` checks still see the word inside the rendered string.
+
+- [ ] **Step 7: Move the query site**
+
+`src/core/search.rs:701-706`: replace
+
+```rust
+                let v = self
+                    .embedder
+                    .embed(&[query.q.trim().to_string()])
+                    .await?
+                    .remove(0);
+```
+
+with
+
+```rust
+                let v = self.embedder.embed_query(query.q.trim()).await?;
+```
+
+- [ ] **Step 8: Move the embed job onto documents**
+
+In `src/jobs/embed.rs`, add `use crate::infer::EmbedDoc;` to the imports at the top of the file, then replace `embed_text` (lines 16-23) with three helpers:
+
+```rust
+/// The document as the embedder will see it.
+fn doc_of(chunk: &Chunk) -> EmbedDoc {
+    EmbedDoc {
+        title: chunk.title.clone(),
+        text: chunk.text.clone(),
+    }
+}
+
+/// What will actually be sent for this chunk — title slot, text slot and the
+/// template around them. Every budget in this file measures this string, so
+/// the splitter and the embedder cannot disagree about size.
+fn render(core: &Core, chunk: &Chunk) -> String {
+    core.embedder.render_document(&doc_of(chunk))
+}
+
+/// The lexical half. Title on its own line above the body — the words, not the
+/// template: `title:` and `text:` are in every document and would match every
+/// query that happens to contain them.
+fn lexical_text(chunk: &Chunk) -> String {
+    match &chunk.title {
+        Some(t) => format!("{t}\n{}", chunk.text),
+        None => chunk.text.clone(),
+    }
+}
+```
+
+`run_with_limit` (line 67 on): `let text = embed_text(&chunk);` → `let text = render(core, &chunk);`, and the call `embed_batch(core, std::slice::from_ref(&chunk), vec![text.clone()])` → `embed_batch(core, std::slice::from_ref(&chunk))`. The `measured` line below it keeps using `text`.
+
+`run_corpus_with_limit` (line 120 on): `let text = embed_text(&chunk);` → `let text = render(core, &chunk);`; delete the `texts` vector entirely (its two `push`/`with_capacity` lines and the `texts[..take].to_vec()` argument), so the call reads `embed_batch(core, &batch[..take])`. The `if core.counter.count(&text) > limit` test stays.
+
+`embed_batch` (line 239): new signature and body head:
+
+```rust
+async fn embed_batch(core: &Core, chunks: &[Chunk]) -> Result<()> {
+    if chunks.is_empty() {
+        return Ok(());
+    }
+    let docs: Vec<EmbedDoc> = chunks.iter().map(doc_of).collect();
+    let vectors = core.embedder.embed_documents(&docs).await?;
+    if vectors.len() != chunks.len() {
+        // unchanged error
+    }
+
+    let points = chunks
+        .iter()
+        .zip(vectors)
+        .map(|(c, vector)| VectorPoint {
+            vector,
+            // The words the dense side saw, without the template around them,
+            // so the lexical and the semantic half of a hit describe the same
+            // document.
+            sparse: crate::vector::sparse::encode_document(&lexical_text(c)),
+            payload: payload_of(c),
+        })
+        .collect();
+```
+
+`split_oversize`, the as-is path (lines 402-404): `core.embedder.embed(std::slice::from_ref(&chunk.text))` → `core.embedder.embed_documents(std::slice::from_ref(&doc_of(chunk)))`. This stops that one path from dropping the title — the limit was checked against title + text and the vector was made from text alone; now both see the same document. Its `sparse:` line below becomes `encode_document(&lexical_text(chunk))`.
+
+`embed_head` (line 484-490): replace
+
+```rust
+    let input = match chunk.title.as_deref() {
+        Some(t) => format!("{t}\n{head}"),
+        None => head,
+    };
+    let permit = core.gate.background().await;
+    let embedded = core.embedder.embed(std::slice::from_ref(&input)).await;
+```
+
+with
+
+```rust
+    let input = EmbedDoc {
+        title: chunk.title.clone(),
+        text: head,
+    };
+    let permit = core.gate.background().await;
+    let embedded = core
+        .embedder
+        .embed_documents(std::slice::from_ref(&input))
+        .await;
+```
+
+and its `sparse:` line becomes `encode_document(&lexical_text(chunk))` (it already encodes the whole artifact; the helper is the same join).
+
+Leave `title_cost` in `split_oversize` and `embed_head` alone in this task — Task 4 changes it.
+
+- [ ] **Step 9: Update the tests in `embed.rs` that built embed text by hand**
+
+- Lines ~890, 921, 957: `embed_batch(&core, std::slice::from_ref(&stale), vec![embed_text(&stale)])` → `embed_batch(&core, std::slice::from_ref(&stale))` (and `&hidden` likewise).
+- Line ~1258: `core.counter.count(&embed_text(c)) <= limit` → `core.counter.count(&render(&core, c)) <= limit`.
+- Line ~1702: replace
+
+```rust
+        let q = core
+            .embedder
+            .embed(&["t0\n## A\nthe body".to_string()])
+            .await
+            .unwrap();
+        let hits = core
+            .vectors
+            .search(&q[0], &Default::default(), 5, &Default::default())
+```
+
+with
+
+```rust
+        let q = core
+            .embedder
+            .embed_query("t0\n## A\nthe body")
+            .await
+            .unwrap();
+        let hits = core
+            .vectors
+            .search(&q, &Default::default(), 5, &Default::default())
+```
+
+Then `grep -rn "\.embed(" src tests` — every remaining hit must be inside an `impl Embedder` (none should remain) or be a non-embedder method. Fix any stragglers the same way: documents → `embed_documents(&[EmbedDoc{..}])`, queries → `embed_query(..)`.
+
+- [ ] **Step 10: Build, run the whole suite**
+
+Run: `cargo build --all-targets 2>&1 | grep -E "^(error|warning)" | head` → nothing.
+Run: `cargo test 2>&1 | tail -30`
+Expected: everything PASSES, including the three new tests. If a retrieval test fails with a hit not found: it queried with a string that is not `"title\ntext"` of what it seeded — check whether it used to pass only because both sides were embedded identically and now the fake renders the document as `title\ntext` while the query is raw; the fix is the query string in the test, never the templates.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -E "^(warning|error)" | head
+git add src/infer/mod.rs src/infer/openai.rs src/infer/fake.rs src/core/search.rs src/core/ask/mod.rs src/jobs/embed.rs
+git commit -m "feat: the embedder is asymmetric by interface — documents and queries render before the call"
+```
+
+---
+
+### Task 4: Charge the envelope against the split budget
+
+**Files:**
+- Modify: `src/jobs/embed.rs` — `split_oversize` (`title_cost` at ~line 368), `embed_head` (`title_cost` at ~line 469)
+- Test: `src/jobs/embed.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `render`, `doc_of` from Task 3; `FakeEmbedder::with_templates`, `EmbedTemplates::default()`.
+- Produces: `fn envelope_cost(core: &Core, title: Option<&str>) -> usize` (private to `embed.rs`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `src/jobs/embed.rs`, directly after `a_chunk_only_its_title_pushes_over_the_limit_does_not_respawn_itself`:
+
+```rust
+    #[tokio::test]
+    async fn the_envelope_is_charged_so_a_chunk_that_fits_bare_and_overflows_rendered_splits_once() {
+        // Same loop as the test above, reopened slightly narrower: with a real
+        // template the title is not the only thing around the text. `title: `
+        // plus ` | text: ` costs tokens, and a split that budgets for the title
+        // alone emits siblings that measure oversize again once rendered —
+        // each replaced by another exactly like it, forever.
+        let mut core = crate::core::test_support::test_core().await;
+        core.embedder = std::sync::Arc::new(crate::infer::fake::FakeEmbedder::with_templates(
+            crate::core::test_support::TEST_DIM,
+            crate::config::EmbedTemplates::default(),
+        ));
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+
+        let title = "heading".to_string();
+        let text = format!("{}\n\n{}", "alpha ".repeat(12), "beta ".repeat(12));
+        let limit = 40;
+        let bare = format!("{title}\n{text}");
+        assert!(
+            core.counter.count(&bare) <= limit,
+            "title + text must fit without the envelope ({})",
+            core.counter.count(&bare)
+        );
+        let rendered = core
+            .embedder
+            .render_document(&crate::infer::EmbedDoc {
+                title: Some(title.clone()),
+                text: text.clone(),
+            });
+        assert!(
+            core.counter.count(&rendered) > limit,
+            "the envelope must be what pushes it over ({})",
+            core.counter.count(&rendered)
+        );
+
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: text.clone(),
+                    corpus_span: None,
+                    title: Some(title),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        run_with_limit(&core, &made[0].id, limit).await.unwrap();
+
+        let chunks = core.store.artifacts_for_corpus(&src.id).await.unwrap();
+        assert!(chunks.len() > 1, "the chunk was not split: {} row(s)", chunks.len());
+        assert!(
+            !chunks.iter().any(|c| c.text == text && c.id != made[0].id),
+            "the parent was replaced by an identical copy of itself"
+        );
+        for c in &chunks {
+            assert!(
+                core.counter.count(&render(&core, c)) <= limit,
+                "sibling is still oversize once rendered: {:?}",
+                c.text
+            );
+        }
+    }
+```
+
+If the two `assert!`s on the fixture fail, adjust `repeat(12)` (up or down by one or two) until `bare` fits in 40 and `rendered` does not — the estimator is `chars * 2 / 7`, the envelope is `title:  | text: ` (16 characters, ~4 tokens), so the window is narrow but real.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib jobs::embed::tests::the_envelope_is_charged 2>&1 | tail -20`
+Expected: FAIL on "sibling is still oversize once rendered" (siblings were budgeted against the title alone and measure over the limit rendered), or the `run_with_limit` loops until a job-level guard stops it — either way, not PASS.
+
+- [ ] **Step 3: Replace `title_cost` with `envelope_cost`**
+
+Add next to `render` in `src/jobs/embed.rs`:
+
+```rust
+/// What the envelope around an empty body costs: the title, and the template
+/// around it. Siblings inherit both, so only what this leaves over is available
+/// to their text.
+fn envelope_cost(core: &Core, title: Option<&str>) -> usize {
+    core.counter.count(&core.embedder.render_document(&EmbedDoc {
+        title: title.map(str::to_string),
+        text: String::new(),
+    }))
+}
+```
+
+In `split_oversize`, replace
+
+```rust
+    let title_cost = chunk
+        .title
+        .as_deref()
+        .map_or(0, |t| core.counter.count(&format!("{t}\n")));
+    let budget = limit.saturating_sub(title_cost);
+```
+
+with
+
+```rust
+    let title_cost = envelope_cost(core, chunk.title.as_deref());
+    let budget = limit.saturating_sub(title_cost);
+```
+
+and update the comment above it: "The limit is checked against what actually gets embedded, and that is the rendered document — title, text and the template around them. Siblings inherit the title and the template, so only what the envelope leaves over is available to their text."
+
+In `embed_head`, make the same replacement of the `title_cost` computation.
+
+Note on the untitled case: `envelope_cost(core, None)` is now non-zero under the default templates (`title: none | text: ` costs a few tokens) where the old `title_cost` was zero. That is correct — the envelope is sent — and it is why the test doubles default to legacy templates: under those, `envelope_cost(None)` is `0` and `envelope_cost(Some(t))` is `count("t\n")`, exactly the old numbers, so every existing split test keeps its arithmetic.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib jobs::embed:: 2>&1 | tail -20`
+Expected: all embed tests PASS, including the new one and `a_chunk_only_its_title_pushes_over_the_limit_does_not_respawn_itself`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -E "^(warning|error)" | head
+git add src/jobs/embed.rs
+git commit -m "fix: the split budget charges the envelope, not just the title"
+```
+
+---
+
+### Task 5: EmbeddingGemma is the documented default
+
+**Files:**
+- Modify: `config.example.toml:170-183` (`[infer.embed]`)
+- Modify: `README.md:217` (the `infer.embed.*` row) and the notes at `README.md:237-250`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Rewrite the example block**
+
+Replace `config.example.toml` lines 170-183 with:
+
+```toml
+[infer.embed]
+base_url = "http://localhost:8000/v1"
+# EmbeddingGemma. 308M parameters, 768 dimensions, a 2048-token window, and an
+# asymmetric interface: queries and documents are embedded through different
+# prompts, which the three templates below are. The model card's exact strings
+# are the defaults, so nothing below `max_input_tokens` needs setting for it.
+model = "embeddinggemma"
+# Embedding is fast even locally; a shorter ceiling surfaces a wedged endpoint
+# instead of holding a worker for a quarter of an hour.
+timeout_secs = 120
+# MUST match the vector dimension of the Qdrant collection. Changing this
+# against an existing collection is refused at startup. The full Matryoshka
+# width: truncating to 512/256/128 buys memory at a recall cost, and recall is
+# the point.
+dim = 768
+# The server's real ceiling, not the model's nominal one. llama.cpp refuses any
+# input above its physical batch size with a 500, and no retry can fix that —
+# engram splits the artifact instead, but it splits sooner and cheaper if this
+# number is honest. 2048 is the model's window; use the server's if lower.
+max_input_tokens = 2048
+# The recipe. `{text}` is the query or the body; `{title}` is the artifact's
+# title. A document with no title takes the `_untitled` template — the model
+# card substitutes the literal word `none`, so it is a second template and not
+# an empty field. Changing any of these invalidates every stored vector as
+# surely as changing `model` does: drop the collection and re-capture. Check
+# once that your serving stack does not prepend a prompt of its own, or the
+# prefix is sent twice and every vector carries it.
+# query_template             = "task: search result | query: {text}"
+# document_template          = "title: {title} | text: {text}"
+# document_template_untitled = "title: none | text: {text}"
+#
+# A symmetric embedder — bge-m3, which engram shipped with — wants the text as
+# it is. That is these three lines, with `dim = 1024` and the server's ceiling:
+# model = "bge-m3"
+# dim = 1024
+# max_input_tokens = 1024
+# query_template             = "{text}"
+# document_template          = "{title}\n{text}"
+# document_template_untitled = "{text}"
+```
+
+- [ ] **Step 2: Update the README**
+
+Replace the table row at `README.md:217`:
+
+```markdown
+| `infer.embed.*` | Embedding model: `base_url`, `model`, `dim`, `max_input_tokens`, `timeout_secs`, and the three prompt templates `query_template`, `document_template`, `document_template_untitled`. Defaults are EmbeddingGemma's; a symmetric model sets the three to `{text}` / `{title}\n{text}` / `{text}`. No tier — an embedding endpoint is a different shape of thing, not a cheaper model. |
+```
+
+After the existing `infer.embed.max_input_tokens` note (`README.md:244-250`), add:
+
+```markdown
+- **`infer.embed.*_template`** and `model` together are one identity: a vector's
+  meaning is fixed by the model *and* by the text handed to it. Editing a
+  template later silently mixes embedding spaces. There is no rebuild path;
+  drop the collection and re-capture.
+```
+
+Read the surrounding README section first and match its list style (the existing `- **`infer.embed.dim`**` bullet is the model).
+
+- [ ] **Step 3: Check the example still loads**
+
+Run: `cargo test --lib config::tests:: 2>&1 | tail -5`
+Expected: PASS. (If a test loads `config.example.toml` directly — `grep -rn "config.example" src tests` — it must still pass; the active keys above are all ones `EmbedRole` knows.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config.example.toml README.md
+git commit -m "docs: embeddinggemma is the documented embedder, templates and all"
+```
+
+---
+
+### Task 6: Verification, then measure before anything else lands
+
+**Files:** none new.
+
+- [ ] **Step 1: The full gate**
+
+Run, in order, and paste the tails into the task report:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"    # expect 0
+cargo test 2>&1 | tail -15                                        # expect "test result: ok" for every binary
+cargo test --test eval 2>&1 | tail -5                              # the judge harness still builds and runs
+```
+
+- [ ] **Step 2: `grep` the invariants**
+
+```bash
+grep -rn "\.embed(" src tests | grep -v "embed_raw\|embed_documents\|embed_query\|fn embed"   # expect nothing
+grep -rn "format!(\"{t}\\\\n" src/jobs/embed.rs    # only `lexical_text` may join title and text by hand
+grep -n "title_cost" src/jobs/embed.rs             # every hit is assigned from envelope_cost
+```
+
+- [ ] **Step 3: Record the measurement step for the operator**
+
+This is not code. The spec's "Measurement" section says the recipe lands on its own and moves the retrieval baseline; the next plan (`off` mode) must not start before one judged-pair run has been recorded against this commit. In the PR description, state: which embedding server and model were used, `dim`/`max_input_tokens`, that the raw request body was checked once for a single prefix (no server-side template), and the `/ui/judge` numbers before and after on the same pair set — or that no pair set exists yet and the baseline is being recorded now.
+
+- [ ] **Step 4: Finish the branch**
+
+Use `superpowers:finishing-a-development-branch`. The branch is `docs/tiered-synthesis` today, which carries the spec; the recipe work belongs on its own branch (`feat/embedding-recipe`) cut from `master` with the spec commit cherry-picked or merged first — check with the operator which, since the spec PR may merge separately.
+
+---
+
+## Self-review
+
+**Spec coverage (§2 only):**
+- Three defects → Task 3 (prefixes, asymmetry), Task 3 step 8 (document format).
+- "Model plus templates is one identity", no fingerprint/migration → Task 5 docs; nothing built, by design.
+- Configuration block (`model`, `dim = 768`, `max_input_tokens = 2048`, three templates) → Task 2 (keys, defaults, validation), Task 5 (example).
+- "Two document templates rather than one plus a filler" → Task 1 `render_document`.
+- "Templates stay in config… bge-m3 must remain possible" → Task 1 `legacy()`, Task 5 commented block.
+- Where it lands table → `EmbedRole` (Task 2), trait (Task 3), `HttpEmbedder`/`FakeEmbedder` (Task 3), `embed_text → render_document` (Task 3 step 8), `search.rs:703` (Task 3 step 7).
+- Envelope token accounting → Task 4.
+- One known simplification (`gaps.rs` keeps the retrieval template) → no code; `src/core/gaps.rs` clusters stored vectors and calls no embedder, confirmed by `grep`. Stated in the spec; nothing to do.
+- Tests listed in the spec: "query and document render differently" (Task 1), "titled and untitled take different templates" (Task 1), "envelope cost is charged … does not respawn itself" (Task 4), "render_document for a passage with a carried heading puts the heading in the title slot" — passages do not exist until the `off`-mode plan; the titled-document test in Task 1 is the same assertion on an artifact's title and the passage variant is owed by that plan.
+- "Existing tests asserting the joined embedding text are updated to the new rendering rather than pinned" → Task 3 step 9.
+
+**Placeholder scan:** no TBD/TODO; every code step has code; the one "read the existing test and reuse its preamble" instruction in Task 2 step 1 is accompanied by a full preamble to fall back on.
+
+**Type consistency:** `EmbedTemplates` (Task 1) is what `EmbedRole::templates()` returns (Task 2), what `Embedder::templates()` borrows (Task 3), and what `FakeEmbedder::with_templates` takes (Task 3/4). `EmbedDoc { title: Option<String>, text: String }` is used identically in Tasks 3 and 4. `embed_batch(core, chunks)` has no third argument anywhere after Task 3. `render(core, chunk)` and `envelope_cost(core, title)` are both `embed.rs`-private and named the same in Tasks 3 and 4.
+
+**One deliberate deviation from the spec's wording:** "the fake exercises the asymmetry" — the default `FakeEmbedder` is symmetric (legacy templates) so the ~forty retrieval tests that query with `"title\ntext"` keep passing; the asymmetry is exercised by `FakeEmbedder::with_templates(.., EmbedTemplates::default())` in the tests that are about it (Task 3 fake tests, Task 4). The spec should gain one sentence saying so when the next plan is written.

--- a/docs/superpowers/plans/2026-08-19-off-mode.md
+++ b/docs/superpowers/plans/2026-08-19-off-mode.md
@@ -1,0 +1,2148 @@
+# Off Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `[infer] synthesis = "off"` — capture splits a corpus into verbatim passages, embeds them, and calls no model; `[infer.synthesize]` and `[infer.ask]` become optional; the doors that need them are not offered when they are absent; `ask` stitches adjacent passages back into continuous text.
+
+**Architecture:** The existing `Stage::Synthesize` job (`synthesize::plan`) branches on the mode: `eager` is today's path, `off`/`earned` call `passages::capture_verbatim`, which reuses the one splitter twice (segment budget, then `chunk_tokens`), writes segments in a new `verbatim` state, inserts passages with `provenance = 'passage'`, derives a title locally, and calls the existing `finish`. `verbatim` is what keeps `settle`, `reconcile` and `finish` from treating the rows as work owed. The five model handles on `Core` that derive from optional roles become `Option`, and every arming site checks before arming.
+
+**Tech Stack:** Rust 2024 (rust-version 1.94), sqlx/SQLite, askama templates, axum, rmcp 3.1 (`ToolRouter::remove_route`), `wiremock` unchanged.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md` — sections "The modes", 1, 1a, 5 (stitching + `adjacent_artifacts`), 8, 9. Section 3's "Ordinals after a promotion" defines the `adjacent_artifacts` change implemented here. Promotion (§3), consolidation (§6), origins (§7) and pursuits (§4) are later plans; `earned` compiles and captures like `off` after this plan but promotes nothing yet.
+
+## Global Constraints
+
+- Config keys and defaults, verbatim from the spec: `[infer] synthesis = "eager"` (`"off" | "earned" | "eager"`); `[infer.embed] chunk_tokens = 384`, clamped to `max_input_tokens * SAFETY (0.8)`; `[infer] segment_tokens = 4096` used only when no synthesizer is configured.
+- `eager` is the default so that setting nothing changes nothing.
+- `provenance` gains `passage` and `synthesized`; `Provenance::parse` must know both (spec §9) and `roots_of` must test "model-written" rather than "is merged".
+- "Chunk" is not a name for the new unit. The Rust struct `Chunk` stays what it is (a row of `artifacts`); the new unit is a *passage* everywhere in names and comments.
+- A passage never crosses a segment boundary; passage spans partition the window's own lines; the carried heading occupies none of them and is moved into `title`, not left in `text`.
+- `segments.state` gains `verbatim`; `settle` counts it resolved; `reconcile` never arms it; `finish` does not count it as degraded.
+- At `off` these do not run: `SegmentWindow`, `Title` (model), `Relate`, `Dedupe`, `Consolidate` judging, `Merge`. These do: split, embed, `describe`, shingling at capture, `associate`, activation.
+- Passages are never `Relate` anchors (spec §6 "dormant until use wakes it") — at any mode.
+- Coverage at `off` is green by construction: the passages partition the document.
+- `synthesis = "earned"`/`"eager"` without `[infer.synthesize]` is a startup error; `off` accepts its absence. `[infer.vision]` without its own `base_url`/tier and without `[infer.synthesize]` is a startup error.
+- What is not configured is not offered (spec §8): no ask page, no nav entry, no MCP `ask` tool, no `/api/ask` without `[infer.ask]`.
+- Stitching only for `provenance = 'passage'`, and every constituent id is kept in the citations.
+- `cargo fmt` before every commit; `cargo clippy --all-targets` clean at the end of every task; commit messages one lower-case imperative line with a `feat:`/`fix:`/`docs:`/`chore:` prefix and the harness's two trailer lines.
+
+---
+
+## File structure
+
+| file | responsibility after this plan |
+|---|---|
+| `src/config.rs` | `SynthesisMode`; `InferConfig.synthesis`, `.segment_tokens`; `synthesize`/`ask` become `Option`; `EmbedRole.chunk_tokens` + `effective_chunk_tokens()`; `VisionRole` helpers take `Option<&SynthesizeRole>`; validation rules |
+| `src/core/mod.rs` | `Core.synthesis`, `Core.segment_tokens`; `synthesizer`/`completer`/`judge`/`link_judge`/`gap_namer` are `Option`; `synthesizes()`, `asks()`; `from_config` builds them from the optional roles |
+| `src/store/artifacts.rs` | `Provenance::{Passage, Synthesized}`, `is_model_written()`; `insert_artifacts_with_provenance`; `artifacts_by_ids`; `adjacent_artifacts` = nearest active either side; `list_unrelated_artifact_ids` skips passages |
+| `src/store/lineage.rs` | `roots_of` empties for any model-written provenance |
+| `src/store/segments.rs` | `SegmentState::Verbatim`; `pending_segments` excludes it; `mark_segments_verbatim` |
+| `src/jobs/passages.rs` (new) | `split_passages` (pure), `derive_title` (pure), `capture_verbatim` |
+| `src/jobs/synthesize.rs` | `plan` branches on mode; `segment_budget`; `finish` treats `verbatim` as not degraded and arms `Title` only with a synthesizer |
+| `src/jobs/window.rs`, `src/jobs/reconcile.rs` | `settle` resolved-for-verbatim; reconcile skips verbatim |
+| `src/jobs/mod.rs` | `run_claimed` closes a model-stage job when its model is absent |
+| `src/jobs/embed.rs`, `src/jobs/relate.rs` | no `Relate` unit for passages |
+| `src/jobs/dedupe.rs`, `src/jobs/associate.rs`, `src/jobs/gaps.rs` | `Option` handles: dedupe/link-judge skip without a judge; gap naming falls back to terms |
+| `src/core/background.rs` | consolidate/dedupe tickers also gated on `synthesizes()` |
+| `src/core/ask/mod.rs` | `ask` refuses without a completer; stitching after packing; `Option` completer |
+| `src/infer/prompt.rs` | `ask_prompt` skips empty excerpts |
+| `src/web/ui.rs`, `src/web/*.rs`, `src/web/templates/layout.html` | `ask_enabled` on every nav-carrying template; ask routes 404 without ask |
+| `src/web/api.rs`, `src/mcp/mod.rs` | `/api/ask` 404 and no MCP `ask` tool without ask |
+| `src/main.rs`, `tests/eval.rs` | literals and probes follow the `Option`s |
+| `config.example.toml`, `README.md` | the new keys documented |
+
+---
+
+### Task 1: Config — the mode, the optional roles, the two sizes
+
+**Files:**
+- Modify: `src/config.rs` — `InferConfig` (`:349-362`), `RawInferConfig` (`:368-378`), `TryFrom<RawInferConfig>` (`:478-560`), `EmbedRole` (`:651+`), `VisionRole` impl (`:994-1036`), `validate()` (`:1079+`), `inferred_ceiling_params` (`:1274+`), `warn_on_file_secrets`/any other `self.infer.synthesize`/`self.infer.ask` reader
+- Test: `src/config.rs` `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)] #[serde(rename_all = "lowercase")]
+  pub enum SynthesisMode { Off, Earned, Eager }   // Default = Eager; as_str()
+  pub struct InferConfig { pub synthesis: SynthesisMode, pub segment_tokens: usize, pub synthesize: Option<SynthesizeRole>, pub embed: EmbedRole, pub ask: Option<AskRole>, pub rerank: Option<RerankRole>, pub vision: Option<VisionRole> }
+  pub const DEFAULT_SEGMENT_TOKENS: usize = 4096;
+  pub const DEFAULT_CHUNK_TOKENS: usize = 384;
+  impl EmbedRole { pub fn effective_chunk_tokens(&self) -> usize }   // min(chunk_tokens, max_input_tokens * 0.8)
+  impl VisionRole { pub fn resolve(&self, synth: Option<&SynthesizeRole>) -> (String, Option<String>); pub fn ceiling_param(&self, synth: Option<&SynthesizeRole>) -> Option<CeilingParam>; pub fn inherited_reasoning_effort<'a>(&self, synth: Option<&'a SynthesizeRole>) -> Option<&'a str> }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `mod tests` in `src/config.rs`, next to the `EMBED_PREAMBLE` tests from the embedding-recipe plan. `EMBED_PREAMBLE` contains `[infer.synthesize]` and `[infer.ask]`; these tests need a preamble without them, so define one:
+
+```rust
+    /// Everything but `[infer.*]` roles: the tests below write those themselves.
+    const BARE_PREAMBLE: &str = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer.tiers.efficient]
+        base_url = "http://localhost:8000/v1"
+        model = "qwen"
+        context_tokens = 32768
+        max_output_tokens = 16384
+        [infer.embed]
+        base_url = "http://localhost:8000/v1"
+        model = "embeddinggemma"
+        dim = 768
+        max_input_tokens = 2048
+    "#;
+
+    #[test]
+    fn synthesis_defaults_to_eager_and_parses_the_three_modes() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer.synthesize]
+            tier = \"efficient\"
+            output_ratio = 8.0
+            [infer.ask]
+            tier = \"efficient\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.synthesis, SynthesisMode::Eager);
+        assert_eq!(cfg.infer.segment_tokens, DEFAULT_SEGMENT_TOKENS);
+        for (word, mode) in [
+            ("off", SynthesisMode::Off),
+            ("earned", SynthesisMode::Earned),
+            ("eager", SynthesisMode::Eager),
+        ] {
+            let cfg = load_infer(&format!(
+                "{BARE_PREAMBLE}
+                [infer]
+                synthesis = \"{word}\"
+                [infer.synthesize]
+                tier = \"efficient\"
+                output_ratio = 8.0
+                [infer.ask]
+                tier = \"efficient\"
+                "
+            ))
+            .unwrap();
+            assert_eq!(cfg.infer.synthesis, mode, "{word}");
+        }
+    }
+
+    #[test]
+    fn off_needs_neither_synthesize_nor_ask() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            segment_tokens = 2048
+            "
+        ))
+        .unwrap();
+        assert!(cfg.infer.synthesize.is_none());
+        assert!(cfg.infer.ask.is_none());
+        assert_eq!(cfg.infer.segment_tokens, 2048);
+    }
+
+    #[test]
+    fn earned_and_eager_refuse_to_start_without_a_synthesizer() {
+        let _guard = env_guard();
+        for word in ["earned", "eager"] {
+            let err = load_infer(&format!(
+                "{BARE_PREAMBLE}
+                [infer]
+                synthesis = \"{word}\"
+                "
+            ))
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains("infer.synthesize"), "{word}: {err}");
+            assert!(err.contains(word), "{word}: {err}");
+        }
+    }
+
+    #[test]
+    fn vision_without_an_endpoint_of_its_own_needs_the_synthesizer() {
+        let _guard = env_guard();
+        let err = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            [infer.vision]
+            model = \"llava\"
+            "
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("infer.vision"), "{err}");
+        // With its own address it stands alone.
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            [infer.vision]
+            model = \"llava\"
+            base_url = \"http://localhost:9000/v1\"
+            "
+        ))
+        .unwrap();
+        let v = cfg.infer.vision.as_ref().unwrap();
+        assert_eq!(v.resolve(None).0, "http://localhost:9000/v1");
+    }
+
+    #[test]
+    fn chunk_tokens_defaults_to_384_and_is_clamped_to_the_embedder() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.embed.chunk_tokens, DEFAULT_CHUNK_TOKENS);
+        assert_eq!(cfg.infer.embed.effective_chunk_tokens(), 384);
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"small\"
+            dim = 384
+            max_input_tokens = 256
+            chunk_tokens = 1000
+            "
+            .replace(
+                "[infer.embed]\n        base_url = \"http://localhost:8000/v1\"\n        model = \"embeddinggemma\"\n        dim = 768\n        max_input_tokens = 2048\n",
+                ""
+            )
+        ))
+        .unwrap();
+        // 256 * 0.8 = 204: what the embedder will take wins over what was asked.
+        assert_eq!(cfg.infer.embed.effective_chunk_tokens(), 204);
+    }
+```
+
+The last test strips `BARE_PREAMBLE`'s embed block before adding its own; if the `replace` does not match because of indentation, build the TOML without the preamble's embed block explicitly — the point is one `[infer.embed]` table with `max_input_tokens = 256, chunk_tokens = 1000`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib config::tests::synthesis_defaults 2>&1 | grep -E "^error" | head -5`
+Expected: `SynthesisMode`, `DEFAULT_SEGMENT_TOKENS`, `chunk_tokens`, `effective_chunk_tokens`, `resolve(None)` not found.
+
+- [ ] **Step 3: Add the types and fields**
+
+Near `InferConfig` (`src/config.rs:349`), before it:
+
+```rust
+/// How much inference capture spends. `Off` embeds the source text verbatim
+/// and calls nothing; `Earned` does the same at capture and synthesizes later
+/// where use has shown it is worth it; `Eager` is one synthesis call per
+/// segment at capture — what engram did before the other two existed, and the
+/// default so that setting nothing changes nothing.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SynthesisMode {
+    Off,
+    Earned,
+    #[default]
+    Eager,
+}
+
+impl SynthesisMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SynthesisMode::Off => "off",
+            SynthesisMode::Earned => "earned",
+            SynthesisMode::Eager => "eager",
+        }
+    }
+}
+
+/// The window budget when no synthesizer is configured to derive one from.
+/// Estimator tokens. A synthesizer configured later whose context is smaller
+/// than the windows already stored means re-capturing; there is no migration.
+pub const DEFAULT_SEGMENT_TOKENS: usize = 4096;
+/// The retrieval unit. A target, not a ceiling: see the spec on why it is
+/// fixed rather than derived from the embedder's capacity.
+pub const DEFAULT_CHUNK_TOKENS: usize = 384;
+
+fn default_segment_tokens() -> usize {
+    DEFAULT_SEGMENT_TOKENS
+}
+fn default_chunk_tokens() -> usize {
+    DEFAULT_CHUNK_TOKENS
+}
+```
+
+`InferConfig` becomes:
+
+```rust
+pub struct InferConfig {
+    pub synthesis: SynthesisMode,
+    pub segment_tokens: usize,
+    pub synthesize: Option<SynthesizeRole>,
+    pub embed: EmbedRole,
+    pub ask: Option<AskRole>,
+    pub rerank: Option<RerankRole>,
+    pub vision: Option<VisionRole>,
+}
+```
+
+`RawInferConfig` gains/changes:
+
+```rust
+    #[serde(default)]
+    synthesis: SynthesisMode,
+    #[serde(default = "default_segment_tokens")]
+    segment_tokens: usize,
+    #[serde(default)]
+    synthesize: Option<RawSynthesizeRole>,
+    embed: EmbedRole,
+    #[serde(default)]
+    ask: Option<RawAskRole>,
+```
+
+In `TryFrom<RawInferConfig>`: wrap the synthesize block in `let synthesize = match raw.synthesize { None => None, Some(s) => { ...existing body producing SynthesizeRole... Some(SynthesizeRole { .. }) } };` and the ask block likewise. Return `InferConfig { synthesis: raw.synthesis, segment_tokens: raw.segment_tokens, synthesize, embed: raw.embed, ask, rerank: raw.rerank, vision }`.
+
+`EmbedRole` gains, after `document_template_untitled`:
+
+```rust
+    /// Passage size at `synthesis = "off"`/`"earned"`, in estimator tokens.
+    /// Under `embed` because it is sized to the retrieval unit, not to a
+    /// model's context. Clamped to what the embedder will take — see
+    /// `effective_chunk_tokens`.
+    #[serde(default = "default_chunk_tokens")]
+    pub chunk_tokens: usize,
+```
+
+and in `impl EmbedRole`:
+
+```rust
+    /// `chunk_tokens`, never above the embed path's own ceiling
+    /// (`max_input_tokens * 0.8`), so the passage splitter can never emit a
+    /// passage `split_oversize` then has to cut apart again.
+    pub fn effective_chunk_tokens(&self) -> usize {
+        let ceiling = (self.max_input_tokens as f32 * 0.8) as usize;
+        self.chunk_tokens.min(ceiling).max(1)
+    }
+```
+
+The `VisionRole` helpers take `Option<&SynthesizeRole>`:
+
+```rust
+    pub fn resolve(&self, synth: Option<&SynthesizeRole>) -> (String, Option<String>) {
+        (
+            self.base_url
+                .clone()
+                .or_else(|| synth.map(|s| s.base_url.clone()))
+                // Validation refuses a vision role with neither; this arm is
+                // unreachable after `Config::load` and exists so the type
+                // system does not have to be argued with here.
+                .unwrap_or_default(),
+            self.api_key
+                .clone()
+                .or_else(|| synth.and_then(|s| s.api_key.clone())),
+        )
+    }
+
+    pub fn ceiling_param(&self, synth: Option<&SynthesizeRole>) -> Option<CeilingParam> {
+        self.ceiling_param.or_else(|| {
+            self.base_url
+                .is_none()
+                .then(|| synth.and_then(|s| s.ceiling_param))
+                .flatten()
+        })
+    }
+
+    pub fn inherited_reasoning_effort<'a>(
+        &self,
+        synth: Option<&'a SynthesizeRole>,
+    ) -> Option<&'a str> {
+        self.base_url
+            .is_none()
+            .then(|| synth.and_then(|s| s.reasoning_effort.as_deref()))
+            .flatten()
+    }
+```
+
+In `validate()`, before the templates check:
+
+```rust
+        if self.infer.synthesis != SynthesisMode::Off && self.infer.synthesize.is_none() {
+            return Err(ConfigError::Invalid(format!(
+                "infer.synthesis = \"{}\" needs [infer.synthesize]; only \"off\" runs without a \
+                 synthesizer",
+                self.infer.synthesis.as_str()
+            )));
+        }
+        if let Some(v) = &self.infer.vision
+            && v.base_url.is_none()
+            && self.infer.synthesize.is_none()
+        {
+            return Err(ConfigError::Invalid(
+                "infer.vision has no base_url or tier and there is no [infer.synthesize] to \
+                 borrow an endpoint from"
+                    .into(),
+            ));
+        }
+```
+
+Check: does `VisionRole` keep `base_url: Option<String>` after the tier fold? Yes — the fold writes `base_url: v.base_url.or_else(|| vt...)`, so a vision tier lands in `base_url` and the test above holds.
+
+`inferred_ceiling_params` (`:1274`) reads `self.infer.synthesize` and `self.infer.ask` as values; make it `if let Some(synth) = &self.infer.synthesize { roles.push(...) }` and the same for ask and the follow-up endpoint (`:1302`). Then `grep -n "self.infer.synthesize\|self.infer.ask\|cfg.infer.synthesize\|cfg.infer.ask" src/config.rs` — every non-test hit gets the `Option` treatment; every **test** hit becomes `cfg.infer.synthesize.as_ref().unwrap().field` / `cfg.infer.ask.as_ref().unwrap().field` (or `.as_mut().unwrap()` where a test assigns, e.g. `cfg.infer.ask.follow_up = true` in `src/core/mod.rs:447`). Do this with one careful pass; the compiler lists every site.
+
+- [ ] **Step 4: Run the config tests and build**
+
+Run: `cargo test --lib config::tests:: 2>&1 | tail -3`
+Expected: PASS. Then `cargo build --all-targets 2>&1 | grep -cE "^error"` — **non-zero is expected here**: `core/mod.rs`, `main.rs`, `tests/eval.rs` still read the roles as values. Task 2 fixes them. Commit the config change now anyway so the next task starts from a known point — a commit that does not build is acceptable in the middle of this two-task sequence; note it in the message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/config.rs
+git commit -m "feat: config knows three synthesis modes, and two roles it can do without (core follows)"
+```
+
+---
+
+### Task 2: Core plumbing — optional model handles, and nothing arms what it cannot call
+
+**Files:**
+- Modify: `src/core/mod.rs` (`Core` struct `:66-142`, `from_config` `:149-195`, `test_support::build` `:290-330`)
+- Modify: `src/main.rs:95-117` (probes)
+- Modify: `tests/eval.rs:190, :291, :512-520`
+- Modify: `src/jobs/synthesize.rs` (`plan` `:20-25`, `run_title` `:192-215`, `finish` `:162-166`), `src/jobs/window.rs:30-56,70-78,90-98,128-136`, `src/jobs/dedupe.rs:140-195`, `src/jobs/associate.rs:118-130, :385-396`, `src/jobs/gaps.rs:135-152`, `src/core/ask/mod.rs:76-110, :306-330, :496`, `src/core/background.rs:95-100, :325-330`, `src/jobs/mod.rs:62-80`, `src/infer/openai.rs:1250-1275` (`HttpDescriber::new`)
+- Tests: `src/jobs/mod.rs` `mod tests`, `src/core/mod.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `SynthesisMode`, `InferConfig.{synthesis, segment_tokens, synthesize, ask}` from Task 1.
+- Produces:
+  ```rust
+  pub struct Core { pub synthesizer: Option<Arc<dyn Synthesizer>>, pub completer: Option<Arc<dyn Completer>>, pub judge: Option<Arc<dyn Completer>>, pub link_judge: Option<Arc<dyn Completer>>, pub gap_namer: Option<Arc<dyn Completer>>, pub synthesis: SynthesisMode, pub segment_tokens: usize, /* rest unchanged */ }
+  impl Core { pub fn synthesizes(&self) -> bool; pub fn asks(&self) -> bool; }
+  // jobs/synthesize.rs
+  pub(crate) fn segment_budget(core: &Core) -> usize;   // synthesizer's segment_tokens(...) or core.segment_tokens
+  // jobs/mod.rs
+  fn needs_model(stage: Stage) -> Option<&'static str>;  // "synthesize" for SegmentWindow|Title|Dedupe|LinkJudge, None otherwise
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/jobs/mod.rs` `mod tests` (it already has helpers; read the first test there for the `test_core` import and job-row helpers such as `job_row`/`live_job`):
+
+```rust
+    #[tokio::test]
+    async fn a_model_stage_job_with_no_model_is_closed_not_retried() {
+        // A dedupe unit left over from an `eager` base, reconfigured to run
+        // with no [infer.synthesize]: there is nothing that could ever run it,
+        // so it settles with a reason rather than sitting at the backoff
+        // ceiling for ever.
+        let mut core = crate::core::test_support::test_core().await;
+        core.judge = None;
+        core.store
+            .enqueue(Stage::Dedupe, "pair", "p1")
+            .await
+            .unwrap();
+        assert!(run_one(&core).await.unwrap(), "the job was claimed");
+        assert!(
+            !core.store.live_job(Stage::Dedupe, "p1").await.unwrap(),
+            "the unit is still armed"
+        );
+    }
+```
+
+In `src/core/mod.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn a_core_without_roles_says_so() {
+        let cfg_toml = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer]
+        synthesis = "off"
+        [infer.embed]
+        base_url = "http://localhost:8000/v1"
+        model = "embeddinggemma"
+        dim = 768
+        max_input_tokens = 2048
+        [auth]
+        mode = "local"
+        [auth.local]
+        username = "dev"
+        password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
+        "#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, cfg_toml).unwrap();
+        let cfg = crate::config::Config::load(Some(&path)).unwrap();
+        let core = Core::from_config(
+            &cfg,
+            Arc::new(crate::vector::memory::MemoryVectors::new()),
+            futures::executor::block_on(Store::memory()).unwrap(),
+        );
+        assert!(!core.synthesizes());
+        assert!(!core.asks());
+        assert!(core.synthesizer.is_none() && core.completer.is_none());
+        assert!(core.judge.is_none() && core.link_judge.is_none() && core.gap_namer.is_none());
+        assert_eq!(core.synthesis, crate::config::SynthesisMode::Off);
+    }
+```
+
+If `futures` is not a dependency, make the test `#[tokio::test] async fn` and `.await` the store. Check the `[auth]` block against `AUTH_TAIL` in `src/config.rs` tests and copy that one verbatim if it differs.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::tests::a_model_stage_job core::tests::a_core_without_roles 2>&1 | grep -E "^error" | head -5`
+Expected: compile errors (`core.judge = None` type mismatch, `synthesizes` not found).
+
+- [ ] **Step 3: `Core` fields, constructor, helpers**
+
+In the `Core` struct, change the five handle types and add two fields:
+
+```rust
+    /// `None` when `[infer.synthesize]` is not configured — `synthesis = "off"`
+    /// with no synthesizer. Every stage that would call it checks before arming.
+    pub synthesizer: Option<Arc<dyn Synthesizer>>,
+    pub embedder: Arc<dyn Embedder>,
+    pub reranker: Option<Arc<dyn Reranker>>,
+    /// `None` when `[infer.ask]` is not configured: no ask page, no ask tool.
+    pub completer: Option<Arc<dyn Completer>>,
+    pub judge: Option<Arc<dyn Completer>>,
+    pub link_judge: Option<Arc<dyn Completer>>,
+    pub gap_namer: Option<Arc<dyn Completer>>,
+    /* follow_up, describer unchanged */
+    /// How much inference capture spends. See `SynthesisMode`.
+    pub synthesis: crate::config::SynthesisMode,
+    /// The window budget when there is no synthesizer to derive one from.
+    pub segment_tokens: usize,
+```
+
+(Keep the existing doc comments on `judge`/`link_judge`/`gap_namer`; add one line each: "`None` with no synthesize role.")
+
+In `from_config`:
+
+```rust
+        let synth = cfg.infer.synthesize.as_ref();
+        Core {
+            store,
+            vectors,
+            synthesizer: synth.map(|s| {
+                Arc::new(HttpSynthesizer::new(s).with_max_artifact_tokens(max_artifact_tokens))
+                    as Arc<dyn Synthesizer>
+            }),
+            embedder: Arc::new(HttpEmbedder::new(&cfg.infer.embed)),
+            reranker: /* unchanged */,
+            completer: cfg
+                .infer
+                .ask
+                .as_ref()
+                .map(|a| Arc::new(HttpCompleter::new(a)) as Arc<dyn Completer>),
+            judge: synth.map(|s| Arc::new(HttpCompleter::for_judging(s)) as Arc<dyn Completer>),
+            link_judge: synth
+                .map(|s| Arc::new(HttpCompleter::for_link_judging(s)) as Arc<dyn Completer>),
+            gap_namer: synth
+                .map(|s| Arc::new(HttpCompleter::for_gap_naming(s)) as Arc<dyn Completer>),
+            follow_up: cfg.infer.ask.as_ref().and_then(|a| {
+                a.follow_up.then(|| {
+                    Arc::new(HttpCompleter::for_follow_up(&a.follow_up_on())) as Arc<dyn Completer>
+                })
+            }),
+            describer: cfg.infer.vision.as_ref().map(|v| {
+                Arc::new(HttpDescriber::new(v, synth)) as Arc<dyn Describer>
+            }),
+            synthesis: cfg.infer.synthesis,
+            segment_tokens: cfg.infer.segment_tokens,
+            /* rest unchanged */
+        }
+```
+
+`HttpDescriber::new(cfg: &VisionRole, synth: Option<&SynthesizeRole>)` — change the signature in `src/infer/openai.rs:1255` and pass `synth` through to the three `VisionRole` helpers (they take `Option` after Task 1). Fix its tests in `openai.rs` (`grep -n "HttpDescriber::new" src`) to pass `Some(&synth)`.
+
+Add to `impl Core`:
+
+```rust
+    /// Is there a synthesizer to call? `false` means no `[infer.synthesize]`:
+    /// nothing that needs one is armed, offered, or run.
+    pub fn synthesizes(&self) -> bool {
+        self.synthesizer.is_some()
+    }
+
+    /// Is there an ask model to call? `false` means no `[infer.ask]`: no ask
+    /// page, no nav entry, no MCP tool, no `/api/ask`.
+    pub fn asks(&self) -> bool {
+        self.completer.is_some()
+    }
+```
+
+`test_support::build`: wrap the five in `Some(...)`, add `synthesis: crate::config::SynthesisMode::Eager, segment_tokens: crate::config::DEFAULT_SEGMENT_TOKENS,`. Every test helper that assigns `core.X = <expr>;` for these five must now assign `Some(<expr>)`. Find them:
+
+```bash
+grep -rn "core\.synthesizer = \|core\.completer = \|core\.judge = \|core\.link_judge = \|core\.gap_namer = " src tests
+```
+
+and wrap each right-hand side in `Some(...)` — the statement may span lines (`core.synthesizer =\n    std::sync::Arc::new(...);`); wrap the whole expression up to the `;`. `tests/eval.rs:512-520`: same five in `Some`, plus the two new fields; `:190` → `cfg.infer.synthesize.as_ref().expect("the eval harness needs [infer.synthesize]")`; `:291` → `cfg.infer.ask.as_ref().expect("the eval harness needs [infer.ask]").model`.
+
+`src/main.rs:95-117`: the chunk probe becomes `if let Some(s) = &cfg.infer.synthesize { probe("chunk", &s.base_url, s.api_key.as_deref()).await } else { tracing::info!("synthesize not configured; capture embeds verbatim and nothing is synthesized"); }`; vision's `v.resolve(&cfg.infer.synthesize)` → `v.resolve(cfg.infer.synthesize.as_ref())`.
+
+- [ ] **Step 4: The production readers of the five handles**
+
+`src/jobs/synthesize.rs`:
+
+```rust
+/// The window budget: derived from the synthesizer's context when there is
+/// one, the configured fallback when there is not. `off` without a synthesizer
+/// still splits into windows — they are what promotion would later read, and
+/// what coverage is measured against.
+pub(crate) fn segment_budget(core: &Core) -> usize {
+    match &core.synthesizer {
+        Some(s) => segment_tokens(s.budget(), prompt_overhead(core)),
+        None => core.segment_tokens,
+    }
+}
+```
+
+`plan` (`:25`) uses `segment_budget(core)`; the test at `:664` and `:431` likewise. `run_title`: `let Some(synth) = &core.synthesizer else { return Ok(()); };` at the top, then `synth.title(...)`. `finish` (`:162`): arm `Stage::Title` only `if src.title_hint.is_none() && core.synthesizes() && !has_job`.
+
+`src/jobs/window.rs:30`: after the `Done` early return add
+
+```rust
+    // No synthesizer: the unit cannot run, and `run_claimed` closes it before
+    // it gets here. Said again at the call so a direct caller gets an answer
+    // and not a panic.
+    let Some(synth) = core.synthesizer.clone() else {
+        return Err(Error::Validation(
+            "[infer.synthesize] is not configured; this window cannot be synthesized".into(),
+        ));
+    };
+```
+
+and replace the four `core.synthesizer.` uses in that function with `synth.` (`:50`, `:74` → `segment_budget(core)` is better for the window budget, keep `synth.budget().context` for the context budget; `:94`, `:132`).
+
+`src/jobs/dedupe.rs:146-147, :189`: at the top of the function that judges a pair, `let Some(judge) = core.judge.clone() else { return Ok(()); };` and use `judge.` for the three sites. `src/jobs/associate.rs:385-396`: `let Some(judge) = core.link_judge.clone() else { return Ok(()); };` before the call; and in the arming loop (`:118-130`) skip the whole loop when `core.link_judge.is_none()` (return `Ok(0)` / whatever that function returns for "nothing armed"). `src/jobs/gaps.rs:135-152`: `let Some(namer) = core.gap_namer.clone() else { return None; };`.
+
+`src/core/ask/mod.rs`: at the top of `ask_events`'s stream (`:107`, beside the empty-question check):
+
+```rust
+            let Some(completer) = core.completer.clone() else {
+                Err(Error::Validation("[infer.ask] is not configured".into()))?;
+                unreachable!()
+            };
+```
+
+(Or shape it as `if core.completer.is_none() { Err(...)?; }` and then `let completer = core.completer.clone().expect("checked above");` — whichever compiles inside `try_stream!` without the `unreachable!`.) Then `core.completer.context_tokens()` (`:306,:308`) → `completer.context_tokens()`, the `let completer = core.completer.clone();` at `:324` goes, and `excerpt_budget` (`:496`) takes the completer: `fn excerpt_budget(&self, completer: &dyn Completer, question: &str)` — or read `self.completer.as_deref().expect(..)` there, since the stream checked already. `src/jobs/dedupe.rs:463`, `src/web/ui.rs` `.completer` test assignments → `Some(...)`.
+
+`src/core/background.rs`: the consolidate ticker (`:97`) and dedupe ticker (`:327`) add `|| !core.synthesizes()` to their disabled condition with a log line "no synthesizer; consolidation judging disabled".
+
+`src/jobs/mod.rs` `run_claimed`: before the `match`,
+
+```rust
+    // A unit that needs a model the configuration does not have can never run.
+    // Close it with a reason rather than retrying to the ceiling for ever —
+    // a base captured at `eager`, then reconfigured, has rows like this.
+    if let Some(role) = needs_model(job.stage)
+        && !core.synthesizes()
+    {
+        tracing::warn!(stage = job.stage.as_str(), "no [infer.{role}] configured; dropping the unit");
+        core.store.complete_job(job.id).await?;
+        return Ok(true);
+    }
+```
+
+with
+
+```rust
+/// The role a stage cannot run without. `Synthesize` is deliberately absent:
+/// at `off` it is the verbatim capture path and needs nothing.
+fn needs_model(stage: Stage) -> Option<&'static str> {
+    match stage {
+        Stage::SegmentWindow | Stage::Title | Stage::Dedupe | Stage::LinkJudge => {
+            Some("synthesize")
+        }
+        _ => None,
+    }
+}
+```
+
+(`Relate` needs no model — it files pairs; it is kept off passages in Task 6.)
+
+- [ ] **Step 5: Build and run everything**
+
+Run: `cargo build --all-targets 2>&1 | grep -E "^error" -A5 | head -40` until clean, then `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head`.
+Expected: all PASS including the two new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src tests
+git commit -m "feat: a core can run without a synthesizer or an ask model, and arms nothing it cannot call"
+```
+
+---
+
+### Task 3: Provenance — `passage` and `synthesized`, and the hazard in §9
+
+**Files:**
+- Modify: `src/store/artifacts.rs` (`Provenance` `:72-90`, `insert_artifacts` `:317-360`, `list_unrelated_artifact_ids` `:835`)
+- Modify: `src/store/lineage.rs:50-60` (`roots_of`)
+- Modify: `src/jobs/dedupe.rs:124`, `src/web/lineage_view.rs:295-300`
+- Test: `src/store/artifacts.rs`, `src/store/lineage.rs` `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub enum Provenance { Passage, Captured, Merged, Synthesized }
+  impl Provenance { pub fn as_str(&self) -> &'static str; pub fn parse(&str) -> Self; pub fn is_model_written(&self) -> bool /* Merged | Synthesized */; pub fn is_source_text(&self) -> bool /* Passage | Captured */ }
+  impl Store { pub async fn insert_artifacts_with_provenance(&self, corpus_id: &str, chunks: &[NewArtifact], provenance: Provenance) -> Result<Vec<Chunk>>; pub async fn artifacts_by_ids(&self, ids: &[String]) -> Result<Vec<Chunk>> }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/artifacts.rs` `mod tests` (uses the existing `nc(ordinal, text)` helper):
+
+```rust
+    #[test]
+    fn provenance_round_trips_all_four_values_and_unknown_reads_as_captured() {
+        for p in [
+            Provenance::Passage,
+            Provenance::Captured,
+            Provenance::Merged,
+            Provenance::Synthesized,
+        ] {
+            assert_eq!(Provenance::parse(p.as_str()), p);
+        }
+        assert_eq!(Provenance::parse("whatever"), Provenance::Captured);
+        assert!(Provenance::Merged.is_model_written());
+        assert!(Provenance::Synthesized.is_model_written());
+        assert!(Provenance::Passage.is_source_text());
+        assert!(Provenance::Captured.is_source_text());
+        assert!(!Provenance::Passage.is_model_written());
+    }
+
+    #[tokio::test]
+    async fn a_passage_is_inserted_as_one_and_read_back_as_one() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts_with_provenance(&src.id, &[nc(0, "verbatim")], Provenance::Passage)
+            .await
+            .unwrap();
+        assert_eq!(made[0].provenance, Provenance::Passage);
+        let read = s.get_artifact(&made[0].id).await.unwrap();
+        assert_eq!(read.provenance, Provenance::Passage);
+        // The old entry point still writes captured rows.
+        let cap = s.insert_artifacts(&src.id, &[nc(1, "captured")]).await.unwrap();
+        assert_eq!(cap[0].provenance, Provenance::Captured);
+    }
+
+    #[tokio::test]
+    async fn artifacts_by_ids_returns_the_rows_asked_for_and_skips_the_missing() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c")])
+            .await
+            .unwrap();
+        let got = s
+            .artifacts_by_ids(&[made[2].id.clone(), "gone".into(), made[0].id.clone()])
+            .await
+            .unwrap();
+        let mut texts: Vec<&str> = got.iter().map(|c| c.text.as_str()).collect();
+        texts.sort_unstable();
+        assert_eq!(texts, vec!["a", "c"]);
+    }
+
+    #[tokio::test]
+    async fn the_relate_backstop_never_lists_a_passage() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let p = s
+            .insert_artifacts_with_provenance(&src.id, &[nc(0, "p")], Provenance::Passage)
+            .await
+            .unwrap();
+        let c = s.insert_artifacts(&src.id, &[nc(1, "c")]).await.unwrap();
+        for id in [&p[0].id, &c[0].id] {
+            s.mark_embedded(id, "fake", 0).await.unwrap();
+        }
+        let ids = s.list_unrelated_artifact_ids(10).await.unwrap();
+        assert_eq!(ids, vec![c[0].id.clone()]);
+    }
+```
+
+`src/store/lineage.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn roots_of_a_model_written_artifact_with_no_lineage_is_empty_not_itself() {
+        // The §9 hazard: a synthesized artifact read as captured would hand its
+        // own model-written text to a merge prompt as an original.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "written from a pursuit".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+                crate::store::artifacts::Provenance::Synthesized,
+            )
+            .await
+            .unwrap();
+        let roots = s.roots_of(std::slice::from_ref(&made[0].id)).await.unwrap();
+        assert!(roots[&made[0].id].is_empty(), "{roots:?}");
+        // A passage is its own root, like a captured artifact.
+        let p = s
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 1,
+                    text: "verbatim".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        let roots = s.roots_of(std::slice::from_ref(&p[0].id)).await.unwrap();
+        assert_eq!(roots[&p[0].id], vec![p[0].id.clone()]);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib store::artifacts::tests::provenance_round store::lineage::tests::roots_of_a_model 2>&1 | grep -E "^error" | head -5`
+Expected: `Passage`/`Synthesized`/`insert_artifacts_with_provenance`/`artifacts_by_ids` not found.
+
+- [ ] **Step 3: Implement**
+
+`src/store/artifacts.rs` `Provenance`:
+
+```rust
+/// How a row of `artifacts` came to exist. `artifacts` is the index — every
+/// row is embedded and retrievable — and this says what kind of row it is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provenance {
+    /// A verbatim slice of a segment, sized to the embedder. Source text.
+    Passage,
+    /// Written by the synthesizer from one segment.
+    Captured,
+    /// Written by consolidation from several artifacts.
+    Merged,
+    /// Written from a pursuit — what was asked and what was engaged with.
+    Synthesized,
+}
+
+impl Provenance {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Provenance::Passage => "passage",
+            Provenance::Captured => "captured",
+            Provenance::Merged => "merged",
+            Provenance::Synthesized => "synthesized",
+        }
+    }
+    pub fn parse(s: &str) -> Provenance {
+        match s {
+            "passage" => Provenance::Passage,
+            "merged" => Provenance::Merged,
+            "synthesized" => Provenance::Synthesized,
+            _ => Provenance::Captured,
+        }
+    }
+    /// A model wrote this text. Such a row is never its own root: handing it
+    /// back as one is how a paraphrase of a paraphrase reaches a prompt as an
+    /// original. The test is "not source text" rather than "is merged", so the
+    /// next value added defaults to safe rather than to wrong.
+    pub fn is_model_written(&self) -> bool {
+        matches!(self, Provenance::Merged | Provenance::Synthesized)
+    }
+    /// The text is the document's own, verbatim (`Passage`) or as the one
+    /// synthesis rewrite of it (`Captured` — its own root by convention).
+    pub fn is_source_text(&self) -> bool {
+        !self.is_model_written()
+    }
+}
+```
+
+(Keep whatever derives the enum has today — check the existing `#[derive]` line and merge; `Copy` may be new and is fine.)
+
+`insert_artifacts` becomes a one-line delegate; the body moves to the new method and binds the provenance instead of the literal `'captured'`:
+
+```rust
+    pub async fn insert_artifacts(
+        &self,
+        corpus_id: &str,
+        chunks: &[NewArtifact],
+    ) -> Result<Vec<Chunk>> {
+        self.insert_artifacts_with_provenance(corpus_id, chunks, Provenance::Captured)
+            .await
+    }
+
+    /// `insert_artifacts`, saying what kind of row is being written. Capture at
+    /// `off`/`earned` writes passages through this; everything else keeps the
+    /// captured default.
+    pub async fn insert_artifacts_with_provenance(
+        &self,
+        corpus_id: &str,
+        chunks: &[NewArtifact],
+        provenance: Provenance,
+    ) -> Result<Vec<Chunk>> {
+        // existing body, with `provenance,` in the Chunk literal and the INSERT
+        // reading `VALUES (?, ?, ?, ?, ...)` with `.bind(provenance.as_str())`
+        // in place of the literal 'captured'
+    }
+```
+
+Add near `caveats_for`:
+
+```rust
+    /// The rows for these ids, in no particular order; ids that name nothing
+    /// are simply absent. One query for a page of hits.
+    pub async fn artifacts_by_ids(&self, ids: &[String]) -> Result<Vec<Chunk>> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let holes = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT * FROM artifacts WHERE id IN ({holes})"
+        )));
+        for id in ids {
+            q = q.bind(id);
+        }
+        Ok(q.fetch_all(&self.pool).await?.iter().map(row_to_artifact).collect())
+    }
+```
+
+`list_unrelated_artifact_ids` (`:837`): add `AND a.provenance <> 'passage'` to the WHERE — passages are never relate anchors (the unit would file pairs between neighbours under one heading on structural similarity; spec §6).
+
+`src/store/lineage.rs:56`: `if provenance.as_deref() == Some("merged")` → `if provenance.as_deref().is_some_and(|p| Provenance::parse(p).is_model_written())` (import `crate::store::artifacts::Provenance`). Update the doc comment above it: "A merged *or synthesized* artifact with no lineage rows resolves to the empty list".
+
+`src/jobs/dedupe.rs:124`: `if c.provenance == Provenance::Merged` → `if c.provenance.is_model_written()`. `src/web/lineage_view.rs:295-300`: `kind: if merged { "merge" } else { "captured" }` → `kind: match c.provenance { Provenance::Merged => "merge", Provenance::Synthesized => "synthesized", Provenance::Passage => "passage", Provenance::Captured => "captured" }` (keep the `merged` bool for whatever else reads it). `src/web/ui.rs:2594` stays (`merged` is about the undo-merge button).
+
+`src/store/schema.sql:74`: update the comment `-- 'captured' | 'merged'` to `-- 'passage' | 'captured' | 'merged' | 'synthesized'`. And the `artifact_sources` header comment (`:131-137`): after "one generation deep however many times a group is merged" add: "That sentence is about *merging*. A `synthesized` artifact may be written from another synthesized one (spec §4, nesting); `root_id` still names source text and `via_id` the intermediate."
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test --lib store:: jobs::dedupe web::lineage_view 2>&1 | grep -E "^test result|FAILED"`
+Expected: PASS.
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add src/store/artifacts.rs src/store/lineage.rs src/store/schema.sql src/jobs/dedupe.rs src/web/lineage_view.rs
+git commit -m "feat: provenance knows passages and synthesized artifacts, and roots_of tests for model-written"
+```
+
+---
+
+### Task 4: The segment state that says "not synthesized, on purpose"
+
+**Files:**
+- Modify: `src/store/segments.rs` (`SegmentState` `:11-32`, `pending_segments` `:166-176`, new `mark_segments_verbatim`)
+- Modify: `src/jobs/window.rs:212-246` (`settle`), `src/jobs/reconcile.rs:40-62`, `src/jobs/synthesize.rs:136` (`finish`'s `degraded`)
+- Modify: `src/store/schema.sql:175` (comment: `pending | done | failed | verbatim`)
+- Test: `src/store/segments.rs`, `src/jobs/reconcile.rs`, `src/jobs/window.rs` `mod tests`
+
+**Interfaces:**
+- Produces: `SegmentState::Verbatim` (`"verbatim"`); `Store::mark_segments_verbatim(&self, corpus_id: &str) -> Result<()>` — sets every `pending` segment of the corpus to `verbatim`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/segments.rs` `mod tests` (if none exists, create one with `use super::*;`):
+
+```rust
+    #[tokio::test]
+    async fn verbatim_segments_are_not_pending_work() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        s.upsert_segments(
+            &src.id,
+            &[
+                NewSegment { start_line: 1, end_line: 5, text: "a", carry_lines: 0 },
+                NewSegment { start_line: 6, end_line: 9, text: "b", carry_lines: 0 },
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(s.pending_segments(&src.id).await.unwrap().len(), 2);
+        s.mark_segments_verbatim(&src.id).await.unwrap();
+        assert!(s.pending_segments(&src.id).await.unwrap().is_empty());
+        let rows = s.segments_for_corpus(&src.id).await.unwrap();
+        assert!(rows.iter().all(|w| w.state == SegmentState::Verbatim));
+        assert_eq!(SegmentState::parse("verbatim"), SegmentState::Verbatim);
+        assert_eq!(SegmentState::Verbatim.as_str(), "verbatim");
+        // Resolved, for the progress count: neither is still owed a call.
+        assert_eq!(s.segment_progress(&src.id).await.unwrap(), (2, 2));
+    }
+```
+
+`src/jobs/reconcile.rs` `mod tests` (read the existing `seg(...)` helper and the first test's shape and follow them):
+
+```rust
+    #[tokio::test]
+    async fn the_sweep_arms_nothing_for_a_verbatim_corpus() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[seg(1, 10, "the window")])
+            .await
+            .unwrap();
+        core.store.mark_segments_verbatim(&src.id).await.unwrap();
+        let armed = run(&core).await.unwrap();
+        assert_eq!(armed, 0);
+        assert!(
+            !core
+                .store
+                .live_job(Stage::SegmentWindow, &crate::jobs::window::unit_target(&src.id, 0))
+                .await
+                .unwrap()
+        );
+    }
+```
+
+`src/jobs/window.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn settle_treats_a_verbatim_segment_as_resolved() {
+        // One promoted window done, every other window verbatim: the corpus
+        // must finish — that is what arms the embed for the promoted artifacts.
+        let core = crate::core::test_support::test_core().await;
+        let src = core.store.insert_corpus("l1\nl2\nl3\nl4", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(
+                &src.id,
+                &[
+                    crate::store::segments::NewSegment { start_line: 1, end_line: 2, text: "l1\nl2", carry_lines: 0 },
+                    crate::store::segments::NewSegment { start_line: 3, end_line: 4, text: "l3\nl4", carry_lines: 0 },
+                ],
+            )
+            .await
+            .unwrap();
+        core.store.mark_segments_verbatim(&src.id).await.unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        core.store
+            .insert_artifacts(&src.id, &[crate::store::artifacts::NewArtifact {
+                ordinal: 0, text: "l1 l2".into(), corpus_span: None, title: None,
+                category: None, tags: vec![], segment_idx: Some(0), caveats: vec![],
+            }])
+            .await
+            .unwrap();
+        settle(&core, &src.id).await.unwrap();
+        let s = core.store.get_corpus(&src.id).await.unwrap();
+        assert_eq!(s.status, crate::store::corpora::CorpusStatus::Embedding, "{:?}", s.status);
+        assert!(core.store.live_job(crate::store::jobs::Stage::Embed, &src.id).await.unwrap());
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib store::segments jobs::reconcile::tests::the_sweep_arms_nothing jobs::window::tests::settle_treats 2>&1 | grep -E "^error" | head -3`
+Expected: `Verbatim`/`mark_segments_verbatim` not found.
+
+- [ ] **Step 3: Implement**
+
+`SegmentState` gains `Verbatim` with `"verbatim"` in `as_str`/`parse`; the doc comment above the enum gains: "`Verbatim` means the window was captured as passages and never sent to the synthesizer — not work owed, and nothing re-arms it; promotion moves it to `pending`."
+
+`pending_segments`: `WHERE corpus_id = ? AND state NOT IN ('done', 'verbatim')` and the doc comment says why verbatim is out.
+
+Add:
+
+```rust
+    /// Mark every window of a corpus that was never synthesized — and is not
+    /// going to be, at this mode — as captured verbatim. Only `pending` rows:
+    /// a window that is `done` or `failed` has a history this must not erase.
+    pub async fn mark_segments_verbatim(&self, corpus_id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE segments SET state = 'verbatim' WHERE corpus_id = ? AND state = 'pending'",
+        )
+        .bind(corpus_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+```
+
+`window::settle` (`:215-238`): `SegmentState::Done | SegmentState::Verbatim => true,`. `reconcile.rs:43`: `.filter(|w| w.state != SegmentState::Done && w.state != SegmentState::Verbatim)`, with one comment line: "`verbatim` is not unresolved: it is the decided state of a window at `off`." `synthesize.rs:136`: `let degraded = windows.iter().any(|w| w.state == SegmentState::Failed);` — hmm, today `!= Done` also counts `Pending` as degraded (a settle with a pending window is impossible because `settle` returns early, so `Failed` is the only case that reaches here). Write it as `!matches!(w.state, SegmentState::Done | SegmentState::Verbatim)` to keep the exact old meaning plus verbatim.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+Expected: all PASS.
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add src/store/segments.rs src/store/schema.sql src/jobs/window.rs src/jobs/reconcile.rs src/jobs/synthesize.rs
+git commit -m "feat: a verbatim segment is a decided state, not work owed"
+```
+
+---
+
+### Task 5: Splitting a window into passages — pure functions
+
+**Files:**
+- Create: `src/jobs/passages.rs`
+- Modify: `src/jobs/mod.rs:1-11` (`pub mod passages;`)
+- Test: `src/jobs/passages.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `crate::infer::split::{split_into_segments, Window}`, `TokenCounter`.
+- Produces:
+  ```rust
+  pub struct Passage { pub title: Option<String>, pub text: String, pub start_line: i64, pub end_line: i64 }
+  pub fn split_passages(window: &Window, counter: &TokenCounter, chunk_tokens: usize) -> Vec<Passage>;
+  pub fn heading_title(line: &str) -> String;           // "## Recovering deleted entries" -> "Recovering deleted entries"
+  pub fn derive_title(raw_text: &str) -> Option<String>; // first heading, else first non-empty line, truncated to TITLE_MAX (80 chars)
+  pub const TITLE_MAX: usize = 80;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/jobs/passages.rs` with the module doc and this test module (the implementation goes above it in Step 3):
+
+```rust
+//! Capture without synthesis: a window becomes verbatim passages sized to the
+//! embedder, each under the heading the document gave it.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infer::budget::TokenCounter;
+    use crate::infer::split::Window;
+
+    fn window(text: &str, start_line: i64, carry_lines: i64) -> Window {
+        let own = text.lines().count() as i64 - carry_lines;
+        Window {
+            text: text.to_string(),
+            start_line,
+            end_line: start_line + own - 1,
+            carry_lines,
+        }
+    }
+
+    #[test]
+    fn a_window_that_fits_is_one_passage_whose_span_is_the_window() {
+        let w = window("para one\n\npara two", 10, 0);
+        let p = split_passages(&w, &TokenCounter, 1000);
+        assert_eq!(p.len(), 1);
+        assert_eq!((p[0].start_line, p[0].end_line), (10, 12));
+        assert_eq!(p[0].text, "para one\n\npara two");
+        assert_eq!(p[0].title, None);
+    }
+
+    #[test]
+    fn passages_partition_the_window_and_never_cross_it() {
+        // ~30 estimator tokens per paragraph, budget 40: one paragraph each.
+        let paras: Vec<String> = (0..4).map(|i| format!("paragraph {i} ") .repeat(8)).collect();
+        let text = paras.join("\n\n");
+        let w = window(&text, 1, 0);
+        let p = split_passages(&w, &TokenCounter, 40);
+        assert!(p.len() > 1, "{}", p.len());
+        assert_eq!(p[0].start_line, 1);
+        assert_eq!(p.last().unwrap().end_line, w.end_line);
+        for pair in p.windows(2) {
+            assert_eq!(pair[0].end_line + 1, pair[1].start_line, "spans must abut");
+        }
+        assert!(p.iter().all(|x| x.start_line >= w.start_line && x.end_line <= w.end_line));
+    }
+
+    #[test]
+    fn the_carried_heading_becomes_the_title_and_leaves_the_text() {
+        // A continuation window: the splitter carried "## Recovery" in from
+        // the previous window as line 1 of its text.
+        let w = window("## Recovery\nstep three\nstep four", 40, 1);
+        let p = split_passages(&w, &TokenCounter, 1000);
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0].title.as_deref(), Some("Recovery"));
+        assert_eq!(p[0].text, "step three\nstep four");
+        assert_eq!((p[0].start_line, p[0].end_line), (40, 41));
+    }
+
+    #[test]
+    fn a_heading_inside_the_window_titles_the_passage_that_holds_it_and_is_carried_on() {
+        let body = format!(
+            "intro line\n## Mounting\n{}\n\n{}",
+            "mount words ".repeat(12),
+            "more mount words ".repeat(12)
+        );
+        let w = window(&body, 1, 0);
+        let p = split_passages(&w, &TokenCounter, 40);
+        assert!(p.len() >= 2, "{}", p.len());
+        // The first passage holds the heading line verbatim and is titled by it.
+        assert!(p[0].text.contains("## Mounting"));
+        assert_eq!(p[0].title.as_deref(), Some("Mounting"));
+        // The continuation takes the carried heading as title, not as text.
+        assert_eq!(p[1].title.as_deref(), Some("Mounting"));
+        assert!(!p[1].text.contains("## Mounting"), "{:?}", p[1].text);
+        // And every heading line appears exactly once across the passages.
+        let total = p.iter().filter(|x| x.text.contains("## Mounting")).count();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn a_continuation_window_with_no_inner_heading_keeps_the_outer_one_throughout() {
+        let body = format!(
+            "## Outer\n{}\n\n{}",
+            "first part words ".repeat(12),
+            "second part words ".repeat(12)
+        );
+        let w = window(&body, 20, 1);
+        let p = split_passages(&w, &TokenCounter, 40);
+        assert!(p.len() >= 2);
+        assert!(p.iter().all(|x| x.title.as_deref() == Some("Outer")), "{p:?}");
+        assert!(p.iter().all(|x| !x.text.contains("## Outer")));
+    }
+
+    #[test]
+    fn derive_title_prefers_a_heading_then_the_first_line_and_truncates() {
+        assert_eq!(derive_title("\n\n# Big title\nbody").as_deref(), Some("Big title"));
+        assert_eq!(derive_title("plain first line\nsecond").as_deref(), Some("plain first line"));
+        let long = "x".repeat(200);
+        assert_eq!(derive_title(&long).unwrap().chars().count(), TITLE_MAX);
+        assert_eq!(derive_title("   \n\t\n"), None);
+        assert_eq!(heading_title("###   Deep heading  "), "Deep heading");
+    }
+}
+```
+
+Register the module: add `pub mod passages;` to `src/jobs/mod.rs` in alphabetical position.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::passages 2>&1 | grep -E "^error" | head -3`
+Expected: `split_passages`, `derive_title`, `heading_title`, `TITLE_MAX` not found.
+
+- [ ] **Step 3: Implement**
+
+Above the test module in `src/jobs/passages.rs`:
+
+```rust
+use crate::infer::budget::TokenCounter;
+use crate::infer::split::{Window, split_into_segments};
+
+/// A document's name, derived locally: longer than this is a paragraph.
+pub const TITLE_MAX: usize = 80;
+
+/// One verbatim slice of a window: the retrieval unit at `off` and `earned`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Passage {
+    /// The heading this text sits under, as the document wrote it — the
+    /// carried heading of a continuation, or the most recent heading inside
+    /// the window above it. Never inferred.
+    pub title: Option<String>,
+    /// The slice itself. A carried heading is *not* in here: it is not one of
+    /// the lines the span names, and the embedding input would carry it twice.
+    pub text: String,
+    pub start_line: i64,
+    pub end_line: i64,
+}
+
+fn is_heading(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with('#') && t.trim_start_matches('#').starts_with(' ')
+}
+
+/// "## Recovering deleted entries" → "Recovering deleted entries".
+pub fn heading_title(line: &str) -> String {
+    line.trim().trim_start_matches('#').trim().to_string()
+}
+
+/// Split one window into passages sized to the embedder.
+///
+/// The same splitter that made the window, called again with the retrieval
+/// budget, over the window's *body* — its text minus the heading the outer
+/// split carried in (`carry_lines`), which belongs to the document further up
+/// and occupies none of this window's lines. Passage spans therefore partition
+/// `start_line..=end_line` and never cross the window: promotion later
+/// supersedes a whole number of them.
+///
+/// Titles: a continuation passage takes the heading the inner split carried
+/// into it (and that heading leaves its `text`); a passage that contains a
+/// heading is titled by the first one it contains; a passage with neither
+/// takes the window's own carried heading, if the window had one.
+pub fn split_passages(window: &Window, counter: &TokenCounter, chunk_tokens: usize) -> Vec<Passage> {
+    let carry = window.carry_lines.max(0) as usize;
+    let mut lines = window.text.lines();
+    let outer_heading: Option<String> = (carry > 0)
+        .then(|| {
+            lines
+                .by_ref()
+                .take(carry)
+                .find(|l| is_heading(l))
+                .map(heading_title)
+        })
+        .flatten();
+    let body: String = lines.collect::<Vec<_>>().join("\n");
+
+    let inner = split_into_segments(&body, counter, chunk_tokens.max(1));
+    let mut out = Vec::with_capacity(inner.len());
+    let mut last_heading: Option<String> = outer_heading.clone();
+    for p in inner {
+        let pc = p.carry_lines.max(0) as usize;
+        let mut plines = p.text.lines();
+        let carried: Option<String> = (pc > 0)
+            .then(|| plines.by_ref().take(pc).find(|l| is_heading(l)).map(heading_title))
+            .flatten();
+        let own: Vec<&str> = plines.collect();
+        let inside: Option<String> = own.iter().find(|l| is_heading(l)).map(|l| heading_title(l));
+        let title = carried.clone().or_else(|| inside.clone()).or_else(|| last_heading.clone());
+        // What the next passage inherits if the splitter carries nothing: the
+        // last heading seen in document order.
+        if let Some(h) = own.iter().rev().find(|l| is_heading(l)) {
+            last_heading = Some(heading_title(h));
+        } else if carried.is_some() {
+            last_heading = carried.clone();
+        }
+        // Body line k is document line `window.start_line + k - 1`: the body
+        // starts where the window's own lines start. Clamped, because a cut
+        // long line can put more text lines in the body than the document has.
+        let start = (window.start_line + p.start_line - 1).clamp(window.start_line, window.end_line);
+        let end = (window.start_line + p.end_line - 1).clamp(start, window.end_line);
+        out.push(Passage {
+            title,
+            text: own.join("\n"),
+            start_line: start,
+            end_line: end,
+        });
+    }
+    out
+}
+
+/// A corpus title with no model: the first heading, else the first non-empty
+/// line, cut to `TITLE_MAX` characters. `None` for whitespace.
+pub fn derive_title(raw_text: &str) -> Option<String> {
+    let line = raw_text
+        .lines()
+        .find(|l| is_heading(l))
+        .map(heading_title)
+        .or_else(|| {
+            raw_text
+                .lines()
+                .map(str::trim)
+                .find(|l| !l.is_empty())
+                .map(str::to_string)
+        })?;
+    if line.is_empty() {
+        return None;
+    }
+    Some(line.chars().take(TITLE_MAX).collect())
+}
+```
+
+- [ ] **Step 4: Run the tests; tune the fixtures**
+
+Run: `cargo test --lib jobs::passages 2>&1 | grep -E "^test |test result|panicked"`
+Expected: PASS. If a fixture does not split (`p.len() > 1` fails), the paragraph is under budget — raise the `repeat(..)` count; if `passages_partition…` fails on abutting spans, check whether the inner splitter put a blank line on its own — the spans then still abut because the blank line belongs to one of the two passages; fix the assertion only if the inner windows truly overlap, which they must not.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add src/jobs/passages.rs src/jobs/mod.rs
+git commit -m "feat: a window splits into passages under the heading the document gave them"
+```
+
+---
+
+### Task 6: Capture without synthesis — `capture_verbatim`, and `plan` branches on the mode
+
+**Files:**
+- Modify: `src/jobs/passages.rs` (add `capture_verbatim`)
+- Modify: `src/jobs/synthesize.rs:20-85` (`plan`)
+- Modify: `src/jobs/embed.rs:325-340` (`mark_indexed` — no relate for passages), `src/jobs/relate.rs:37-50` (`run` — passage guard)
+- Test: `src/jobs/passages.rs` `mod tests`, `src/jobs/synthesize.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `split_passages`, `derive_title`, `segment_budget`, `mark_segments_verbatim`, `insert_artifacts_with_provenance`, `finish`, `Core.synthesis`, `EmbedRole::effective_chunk_tokens` (read through `core.chunk_tokens` — add that field to `Core` here: `pub chunk_tokens: usize`, set from `cfg.infer.embed.effective_chunk_tokens()` in `from_config` and `DEFAULT_CHUNK_TOKENS` in `test_support::build`/`tests/eval.rs`).
+- Produces: `pub async fn capture_verbatim(core: &Core, corpus_id: &str) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/jobs/passages.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn capture_at_off_writes_passages_marks_segments_verbatim_and_finishes() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        core.synthesizer = None;
+        let text = format!(
+            "# Manual\n\n## Install\n{}\n\n## Recover\n{}",
+            "install words ".repeat(40),
+            "recover words ".repeat(40)
+        );
+        let out = core.ingest(&text, "web", None).await.unwrap();
+        // The Synthesize job is what capture queued; run it.
+        assert!(crate::jobs::run_one(&core).await.unwrap());
+
+        let s = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(s.status, crate::store::corpora::CorpusStatus::Embedding, "{:?}", s.status);
+        assert_eq!(s.title_hint.as_deref(), Some("Manual"));
+        let segs = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(!segs.is_empty());
+        assert!(segs.iter().all(|w| w.state == crate::store::segments::SegmentState::Verbatim));
+        let rows = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert!(!rows.is_empty());
+        assert!(rows.iter().all(|c| c.provenance == crate::store::artifacts::Provenance::Passage));
+        assert!(rows.iter().all(|c| c.corpus_span.is_some()));
+        // Green by construction: every line is claimed.
+        assert_eq!(s.coverage.map(|c| (c * 100.0).round() as i64), Some(100));
+        assert!(core.store.live_job(crate::store::jobs::Stage::Embed, &out.id).await.unwrap());
+        // No model unit was armed.
+        for w in &segs {
+            assert!(!core.store.live_job(
+                crate::store::jobs::Stage::SegmentWindow,
+                &crate::jobs::window::unit_target(&out.id, w.idx)
+            ).await.unwrap());
+        }
+        assert!(!core.store.has_job(crate::store::jobs::Stage::Title, &out.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn capture_at_off_is_idempotent_per_segment() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        let out = core.ingest("one line\n\nanother line", "web", None).await.unwrap();
+        capture_verbatim(&core, &out.id).await.unwrap();
+        let n = core.store.artifacts_for_corpus(&out.id).await.unwrap().len();
+        capture_verbatim(&core, &out.id).await.unwrap();
+        assert_eq!(core.store.artifacts_for_corpus(&out.id).await.unwrap().len(), n);
+    }
+
+    #[tokio::test]
+    async fn a_passage_never_gets_a_relate_unit() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        let out = core.ingest("some verbatim text", "web", None).await.unwrap();
+        capture_verbatim(&core, &out.id).await.unwrap();
+        let id = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0].id.clone();
+        crate::jobs::embed::run(&core, &id).await.unwrap();
+        assert!(!core.store.live_job(crate::store::jobs::Stage::Relate, &id).await.unwrap());
+    }
+```
+
+In `src/jobs/synthesize.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn plan_at_eager_still_arms_windows_and_at_off_writes_passages() {
+        let mut core = crate::core::test_support::test_core().await;
+        let out = core.ingest("eager text", "web", None).await.unwrap();
+        plan(&core, &out.id).await.unwrap();
+        assert!(core.store.live_job(
+            Stage::SegmentWindow,
+            &crate::jobs::window::unit_target(&out.id, 0)
+        ).await.unwrap());
+
+        core.synthesis = crate::config::SynthesisMode::Off;
+        let out2 = core.ingest("off text", "web", None).await.unwrap();
+        plan(&core, &out2.id).await.unwrap();
+        assert!(!core.store.live_job(
+            Stage::SegmentWindow,
+            &crate::jobs::window::unit_target(&out2.id, 0)
+        ).await.unwrap());
+        let rows = core.store.artifacts_for_corpus(&out2.id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].provenance, crate::store::artifacts::Provenance::Passage);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib jobs::passages::tests::capture_at_off jobs::synthesize::tests::plan_at_eager 2>&1 | grep -E "^error|panicked" | head -5`
+Expected: `capture_verbatim` not found / `core.synthesis` or `chunk_tokens` missing.
+
+- [ ] **Step 3: Implement**
+
+`Core` gains `pub chunk_tokens: usize` (doc: "Passage size at `off`/`earned`, already clamped to the embedder"), set in `from_config` from `cfg.infer.embed.effective_chunk_tokens()`, and `crate::config::DEFAULT_CHUNK_TOKENS` in `test_support::build` and `tests/eval.rs`.
+
+In `src/jobs/passages.rs`:
+
+```rust
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::{CorpusSpan, NewArtifact, Provenance};
+use crate::store::corpora::CorpusStatus;
+
+/// The whole of capture at `off` and `earned`: split into windows, write them
+/// `verbatim`, split each window into passages, write those, name the document
+/// without a model, and finish the corpus the way a synthesized one finishes.
+/// No inference call anywhere on this path.
+///
+/// Idempotent per segment: a process that dies between two segments' inserts
+/// re-runs this, and a segment that already owns rows is left alone.
+pub async fn capture_verbatim(core: &Core, corpus_id: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    let windows = crate::infer::split::split_into_segments(
+        &src.raw_text,
+        &core.counter,
+        super::synthesize::segment_budget(core),
+    );
+    if windows.is_empty() {
+        tracing::warn!(corpus_id, "source has no usable text");
+        core.store
+            .set_corpus_status(corpus_id, CorpusStatus::Failed)
+            .await?;
+        return Ok(());
+    }
+
+    let rows: Vec<crate::store::segments::NewSegment<'_>> = windows
+        .iter()
+        .map(|w| crate::store::segments::NewSegment {
+            start_line: w.start_line,
+            end_line: w.end_line,
+            text: w.text.as_str(),
+            carry_lines: w.carry_lines,
+        })
+        .collect();
+    core.store.upsert_segments(corpus_id, &rows).await?;
+    core.store.mark_segments_verbatim(corpus_id).await?;
+
+    // Under the document lock like every other local rearrangement of a
+    // corpus's rows: `settle` and a promotion's write must not interleave.
+    let _corpus = core.corpus_lock(corpus_id).await;
+    for (idx, w) in windows.iter().enumerate() {
+        let idx = idx as i64;
+        if !core
+            .store
+            .artifact_ids_for_segment(corpus_id, idx)
+            .await?
+            .is_empty()
+        {
+            continue;
+        }
+        let new: Vec<NewArtifact> = split_passages(w, &core.counter, core.chunk_tokens)
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| NewArtifact {
+                ordinal: i as i64,
+                text: p.text,
+                corpus_span: Some(CorpusSpan {
+                    start_line: p.start_line,
+                    end_line: p.end_line,
+                }),
+                title: p.title,
+                category: None,
+                tags: vec![],
+                segment_idx: Some(idx),
+                caveats: vec![],
+            })
+            .collect();
+        core.store
+            .insert_artifacts_with_provenance(corpus_id, &new, Provenance::Passage)
+            .await?;
+    }
+    drop(_corpus);
+
+    if src.title_hint.is_none()
+        && let Some(t) = derive_title(&src.raw_text)
+    {
+        core.store.set_title_hint(corpus_id, &t).await?;
+    }
+
+    tracing::info!(corpus_id, windows = windows.len(), "captured verbatim");
+    // Renumbers, measures coverage (green: the passages partition the
+    // document), arms the embed and moves the corpus on. The same function a
+    // synthesized corpus reaches through its last window's settle.
+    super::synthesize::finish(core, corpus_id).await
+}
+```
+
+Check `finish` (`synthesize.rs:132`): it takes the corpus lock? No — `settle` does and then calls `finish`; `finish` alone does `renumber_artifacts` without the lock. `capture_verbatim` releases the lock before calling it, which matches `settle`'s behaviour (lock held through settle incl. finish). To keep the same property hold the lock across `finish` too: move `drop(_corpus)` after `finish` (i.e. don't drop early). Do that.
+
+`plan` (`synthesize.rs:20`): first lines become
+
+```rust
+pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
+    if core.synthesis != crate::config::SynthesisMode::Eager {
+        return crate::jobs::passages::capture_verbatim(core, corpus_id).await;
+    }
+    let src = core.store.get_corpus(corpus_id).await?;
+    let windows = split_into_segments(&src.raw_text, &core.counter, segment_budget(core));
+```
+
+and the doc comment gains: "At `off` and `earned` this is the verbatim capture instead — same job, same queue row, no model."
+
+`src/jobs/embed.rs` `mark_indexed` (`:331`): wrap the `relate::arm` in `if chunk.provenance != crate::store::artifacts::Provenance::Passage { ... }` with the comment: "A passage is never a relate anchor: neighbours under one heading are similar for structural reasons, and duplicate detection over verbatim text waits until use promotes it (spec §6)." `src/jobs/relate.rs` `run` (`:42`): beside the `in_results` guard add `if me.provenance == Provenance::Passage { return Ok(()); }`.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+Expected: all PASS.
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src tests
+git commit -m "feat: capture at off splits, embeds and stops — no model on the path"
+```
+
+---
+
+### Task 7: Ask over passages — nearest-active neighbours, and stitching
+
+**Files:**
+- Modify: `src/store/artifacts.rs:444-457` (`adjacent_artifacts`)
+- Modify: `src/core/ask/mod.rs` (after each `pack_by_budget` → `kept`, `:162` and `:228`; new `stitch_passages` method; `excerpts` unchanged)
+- Modify: `src/infer/prompt.rs:471-476` (`ask_prompt` skips empty excerpts)
+- Test: `src/store/artifacts.rs`, `src/core/ask/mod.rs`, `src/infer/prompt.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `Store::artifacts_by_ids`, `Provenance::Passage`, `CorpusSpan`.
+- Produces: `Core::stitch_passages(&self, hits: &[SearchResult], blocks: &mut [String])` (private to `ask`); `Store::adjacent_artifacts` keeps its signature, changes meaning to "nearest active either side".
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/artifacts.rs` `mod tests`, beside `adjacent_artifacts_skips_a_neighbour_that_is_not_active` (read it; its fixture seeds three ordinals and hides the middle one — this test asserts the *new* answer):
+
+```rust
+    #[tokio::test]
+    async fn adjacent_artifacts_steps_over_a_superseded_row_to_the_next_active_one() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c"), nc(3, "d")])
+            .await
+            .unwrap();
+        // Hide b and c; a's next active neighbour is d.
+        s.set_superseded_by(&made[1].id, Some(&made[3].id)).await.unwrap();
+        s.set_superseded_by(&made[2].id, Some(&made[3].id)).await.unwrap();
+        let got = s.adjacent_artifacts(&src.id, 0).await.unwrap();
+        assert_eq!(got.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(), vec!["d"]);
+        let got = s.adjacent_artifacts(&src.id, 3).await.unwrap();
+        assert_eq!(got.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(), vec!["a"]);
+    }
+```
+
+If `adjacent_artifacts_skips_a_neighbour_that_is_not_active` asserts that the far side returns *nothing*, update it: the neighbour that is not active is skipped **to the next active one**, and if there is none, nothing — keep its fixture, change the expectation to whatever the new rule gives for that fixture.
+
+`src/infer/prompt.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn ask_prompt_skips_an_empty_excerpt() {
+        let p = ask_prompt("q", &["[1] t\na".into(), String::new(), "[3] t\nc".into()]);
+        assert_eq!(p, "Question: q\n\nExcerpts:\n\n[1] t\na\n\n---\n\n[3] t\nc");
+    }
+```
+
+`src/core/ask/mod.rs` `mod tests` (read the seeding helpers there — tests seed artifacts with `NewArtifact`, set `core.completer` to a `FakeCompleter`, call `core.ask`; follow the same shape):
+
+```rust
+    #[tokio::test]
+    async fn consecutive_passages_are_stitched_into_one_excerpt_and_every_id_is_cited() {
+        let mut core = test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        // One corpus, one segment, three abutting passages, all hits.
+        let src = core.store.insert_corpus("l1\nl2\nl3", "web", None).await.unwrap();
+        let mk = |i: i64, text: &str, from: i64, to: i64| crate::store::artifacts::NewArtifact {
+            ordinal: i,
+            text: text.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan { start_line: from, end_line: to }),
+            title: Some("Recovery".into()),
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let made = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[mk(0, "first part", 1, 1), mk(1, "second part", 2, 2), mk(2, "third part", 3, 3)],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        for c in &made {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        // A completer that echoes its prompt, so the test can read what the
+        // model was shown.
+        let probe = std::sync::Arc::new(crate::infer::fake::EchoCompleter::default());
+        core.completer = Some(probe.clone());
+
+        let out = core
+            .ask(
+                &AskRequest { q: "Recovery\nfirst part".into(), limit: Some(8), tags: vec![], category: None },
+                Door::Api,
+            )
+            .await
+            .unwrap();
+
+        let prompt = probe.last_prompt();
+        // One excerpt carries the stitched text in document order, once.
+        assert!(prompt.contains("first part\nsecond part\nthird part"), "{prompt}");
+        assert_eq!(prompt.matches("Recovery").count(), 1 + 1, "heading once in the excerpt, once in the question: {prompt}");
+        // Every constituent is still a citation.
+        let cited: std::collections::HashSet<String> =
+            out.citations.iter().map(|c| c.artifact_id.clone()).collect();
+        for c in &made {
+            assert!(cited.contains(&c.id), "{} missing from citations", c.text);
+        }
+    }
+```
+
+This needs `crate::infer::fake::EchoCompleter` — check `src/infer/fake.rs` for an existing completer that records the prompt it was given (`grep -n "last_prompt\|prompts\b\|seen" src/infer/fake.rs`). If one exists (the follow-up tests use a probe), use it and its accessor name; if not, add:
+
+```rust
+/// Answers with a fixed line and keeps the last user prompt it was handed, so
+/// a test can read what the model was shown.
+#[derive(Default)]
+pub struct EchoCompleter {
+    last: std::sync::Mutex<String>,
+}
+impl EchoCompleter {
+    pub fn last_prompt(&self) -> String {
+        self.last.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+}
+#[async_trait]
+impl Completer for EchoCompleter {
+    async fn complete(&self, _system: &str, user: &str) -> Result<String> {
+        *self.last.lock().unwrap() = user.to_string();
+        Ok("See [1].".into())
+    }
+    fn context_tokens(&self) -> usize { 8192 }
+    fn max_output_tokens(&self) -> usize { 512 }
+}
+```
+
+plus whatever other `Completer` methods are required (`answer_streaming` has a default per the trait comment at `fake.rs:615` — "an implementor that knows nothing about streaming still streams, as one delta"). Copy the method set from `FakeCompleter`'s impl.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib store::artifacts::tests::adjacent_artifacts_steps infer::prompt::tests::ask_prompt_skips core::ask::tests::consecutive_passages 2>&1 | grep -E "^error|panicked" | head -5`
+Expected: the adjacency test fails (returns nothing for ordinal 0's right side), the prompt test fails on the extra separators, the ask test fails to compile or fails on "first part\nsecond part".
+
+- [ ] **Step 3: Implement**
+
+`adjacent_artifacts`:
+
+```rust
+    /// The nearest *active* artifact either side of `ordinal` in the same
+    /// corpus — not the rows at `ordinal ± 1`. After a promotion the ordinal
+    /// sequence interleaves superseded passages with what replaced them, and
+    /// "the row next door" is then often a hidden one; the reader wants the
+    /// next thing still in the document. An edge returns the one side that
+    /// exists.
+    pub async fn adjacent_artifacts(&self, corpus_id: &str, ordinal: i64) -> Result<Vec<Chunk>> {
+        let before = sqlx::query(
+            "SELECT * FROM artifacts
+             WHERE corpus_id = ? AND ordinal < ? AND status = 'active'
+             ORDER BY ordinal DESC LIMIT 1",
+        )
+        .bind(corpus_id)
+        .bind(ordinal)
+        .fetch_optional(&self.pool)
+        .await?;
+        let after = sqlx::query(
+            "SELECT * FROM artifacts
+             WHERE corpus_id = ? AND ordinal > ? AND status = 'active'
+             ORDER BY ordinal ASC LIMIT 1",
+        )
+        .bind(corpus_id)
+        .bind(ordinal)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(before
+            .iter()
+            .chain(after.iter())
+            .map(row_to_artifact)
+            .collect())
+    }
+```
+
+`ask_prompt`:
+
+```rust
+pub fn ask_prompt(question: &str, excerpts: &[String]) -> String {
+    // An empty block is a passage that was stitched into the one before it
+    // (`Core::stitch_passages`): its text is in the prompt, its slot is not.
+    let shown: Vec<&str> = excerpts.iter().map(String::as_str).filter(|e| !e.is_empty()).collect();
+    format!(
+        "Question: {question}\n\nExcerpts:\n\n{}",
+        shown.join("\n\n---\n\n")
+    )
+}
+```
+
+`src/core/ask/mod.rs`, in `impl Core` beside `excerpts`:
+
+```rust
+    /// Put consecutive passages back together as the text they are.
+    ///
+    /// Passages are verbatim slices whose spans tile a segment; two that abut
+    /// are literally continuous text, and showing them as two excerpts repeats
+    /// the carried heading, hides the continuity from the model, and cuts the
+    /// sentence running across the boundary. Here — after packing, over the
+    /// kept prefix only — runs of abutting passages from one `(corpus,
+    /// segment)` are merged into the block of the run's earliest member, in
+    /// document order, and the other members' blocks are emptied. A stitched
+    /// excerpt is a presentation, not a new unit: `hits` is untouched, every
+    /// constituent stays a citation, and the literal check reads the same
+    /// text the model did. Passages only — two adjacent *artifacts* are two
+    /// rewrites, not continuous text.
+    async fn stitch_passages(&self, hits: &[SearchResult], blocks: &mut [String]) {
+        use crate::store::artifacts::{CorpusSpan, Provenance};
+        let ids: Vec<String> = hits.iter().map(|h| h.artifact_id.clone()).collect();
+        let rows = match self.store.artifacts_by_ids(&ids).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "ask: could not read spans; excerpts stay unstitched");
+                return;
+            }
+        };
+        // (position in hits) -> (corpus, segment, span) for passages with a span
+        let mut pos: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for (i, h) in hits.iter().enumerate() {
+            pos.insert(h.artifact_id.as_str(), i);
+        }
+        let mut members: Vec<(String, i64, CorpusSpan, usize)> = rows
+            .iter()
+            .filter(|c| c.provenance == Provenance::Passage)
+            .filter_map(|c| {
+                Some((
+                    c.corpus_id.clone()?,
+                    c.segment_idx?,
+                    c.corpus_span.clone()?,
+                    *pos.get(c.id.as_str())?,
+                ))
+            })
+            .collect();
+        members.sort_by(|a, b| {
+            (a.0.as_str(), a.1, a.2.start_line).cmp(&(b.0.as_str(), b.1, b.2.start_line))
+        });
+
+        let mut i = 0;
+        while i < members.len() {
+            let mut run = vec![i];
+            while i + 1 < members.len()
+                && members[i + 1].0 == members[i].0
+                && members[i + 1].1 == members[i].1
+                && members[i + 1].2.start_line == members[i].2.end_line + 1
+            {
+                i += 1;
+                run.push(i);
+            }
+            i += 1;
+            if run.len() < 2 {
+                continue;
+            }
+            // The earliest in list order keeps its number and its title line;
+            // the rest contribute their text, in document order, and go dark.
+            let anchor = *run.iter().min_by_key(|&&m| members[m].3).unwrap();
+            let anchor_pos = members[anchor].3;
+            let head = hits[anchor_pos].title.as_deref().unwrap_or_default();
+            let text: Vec<&str> = run.iter().map(|&m| hits[members[m].3].text.as_str()).collect();
+            blocks[anchor_pos] =
+                crate::infer::prompt::ask_excerpt(anchor_pos + 1, head, &text.join("\n"), &[]);
+            for &m in &run {
+                if m != anchor {
+                    blocks[members[m].3].clear();
+                }
+            }
+        }
+    }
+```
+
+Call it right after each `kept` is computed, on the kept prefix:
+
+```rust
+            let mut kept = pack_by_budget(&blocks, &core.counter, budget);
+            core.stitch_passages(&hits[..kept], &mut blocks[..kept]).await;
+```
+
+and in the follow-up branch after `merged_kept`:
+
+```rust
+                        let mut merged_blocks = core.excerpts(&merged.hits).await;
+                        let merged_kept = pack_by_budget(&merged_blocks, &core.counter, budget);
+                        core.stitch_passages(&merged.hits[..merged_kept], &mut merged_blocks[..merged_kept]).await;
+```
+
+(Passages carry no caveats, so `&[]` in the stitched block is exact; a merge of a passage's block drops nothing.)
+
+- [ ] **Step 4: Run everything**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+Expected: all PASS. The `citations_match_exactly_what_the_model_was_shown` test must still pass — stitching does not change `hits[..kept]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: ask reads passages as the text they are — nearest neighbours, stitched runs"
+```
+
+---
+
+### Task 8: What is configured is what is offered
+
+**Files:**
+- Modify: `src/web/templates/layout.html:51, :82` (`{% if ask_enabled %}` around both Ask links)
+- Modify: every template struct that carries `judge_pending: Option<i64>` gains `ask_enabled: bool` — `src/web/ui.rs` (14 structs/sites), `src/web/auth_routes.rs:60,67,94`, `src/web/judge.rs:219`, `src/web/extension.rs:40`, `src/web/pair.rs`
+- Modify: `src/web/state.rs` (helper), `src/web/ui.rs:2127-2200` (ask routes), `src/web/api.rs:691-699`, `src/mcp/mod.rs:88-160, :230-240`
+- Test: `src/web/ui.rs`, `src/web/api.rs`, `src/mcp/mod.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `Core::asks()`.
+- Produces: `pub fn ask_enabled(st: &AppState) -> bool` in `src/web/state.rs`; `PkdbTools::routes(&self) -> ToolRouter<Self>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/web/ui.rs` `mod tests` (read `get_body`, `login`/cookie helpers used by the `/ui/ask` tests around `:3045` and `:6239` and reuse them; `app_with(core)` or similar builds the router from a core — find it with `grep -n "fn app\b\|fn app_with\|fn router_for" src/web/ui.rs src/web/test_support.rs`):
+
+```rust
+    #[tokio::test]
+    async fn without_an_ask_model_there_is_no_ask_page_and_no_ask_link() {
+        let mut core = test_core().await;
+        core.completer = None;
+        let (app, cookie) = app_with(core).await;   // use the real helper's name
+        let page = get_body(&app, &cookie, "/ui/search").await;
+        assert!(!page.contains("href=\"/ui/ask\""), "{page}");
+        let res = app
+            .clone()
+            .oneshot(get("/ui/ask", &cookie))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let res = app
+            .oneshot(form("/ui/ask", &cookie, "q=anything"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn with_an_ask_model_the_link_is_there() {
+        let (app, cookie) = app_with(test_core().await).await;
+        let page = get_body(&app, &cookie, "/ui/search").await;
+        assert!(page.contains("href=\"/ui/ask\""), "{page}");
+    }
+```
+
+`src/web/api.rs` `mod tests` (same pattern with the API's auth helper):
+
+```rust
+    #[tokio::test]
+    async fn api_ask_is_not_found_without_an_ask_model() {
+        let mut core = test_core().await;
+        core.completer = None;
+        let app = api_app(core).await;   // the file's existing helper
+        let res = app
+            .oneshot(json_post("/ask", r#"{"q":"x"}"#))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+```
+
+`src/mcp/mod.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn the_ask_tool_is_offered_only_with_an_ask_model() {
+        let core = futures::executor::block_on(crate::core::test_support::test_core());
+        let tools = PkdbTools { core: core.clone() };
+        assert!(tools.routes().has_route("ask"));
+        let mut core = core;
+        core.completer = None;
+        let tools = PkdbTools { core };
+        assert!(!tools.routes().has_route("ask"));
+        assert!(tools.routes().has_route("search"));
+    }
+```
+
+(Make it `#[tokio::test] async` and `.await` the core if `futures` is unavailable.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib web::ui::tests::without_an_ask web::api::tests::api_ask_is_not_found mcp::tests::the_ask_tool 2>&1 | grep -E "^error|panicked" | head -5`
+Expected: compile errors (`routes` missing, `ask_enabled` missing) or 200s where 404s are expected.
+
+- [ ] **Step 3: Implement**
+
+`src/web/state.rs`, beside `judge_pending`:
+
+```rust
+/// Whether the ask door is open: `[infer.ask]` is configured. The nav reads
+/// it through every page's template, the same way it reads `judge_pending`.
+pub fn ask_enabled(st: &AppState) -> bool {
+    st.core.asks()
+}
+```
+
+Every template struct with `judge_pending: Option<i64>` gets `ask_enabled: bool` on the next line, and every construction site `judge_pending: <expr>,` gets `ask_enabled: crate::web::state::ask_enabled(&st),` (in `auth_routes.rs` where `judge_pending: None`, write `ask_enabled: false` — the login page has no nav; in `judge.rs:219`, `extension.rs:40`, `pair.rs`, use the helper). Find them all:
+
+```bash
+grep -rn "judge_pending" src/web/*.rs | grep -v "fn judge_pending\|state::judge_pending\b(&st)\.await,$"
+```
+
+`layout.html`: wrap `<a href="/ui/ask">Ask</a>` (`:51`) and the tabbar `<a href="/ui/ask">…Ask</a>` (`:82-84`) in `{% if ask_enabled %} … {% endif %}`, with the comment: "Present only where there is a model to answer. No greyed-out entry, no page behind it that says so: the door is simply not there."
+
+`src/web/ui.rs` ask routes: add at the top of `ask_page`, `ask_submit`, `ask_stream`, `ask_verdict`, `ask_carried`:
+
+```rust
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
+```
+
+(adjust each handler's return type to `Result<...>` if it is `impl IntoResponse` today — `ask_page` is; wrap its template in `Ok(HtmlTemplate(...).into_response())`). Also the capture page's `prefill_ask` and any "ask this" link on search results — `grep -n "ui/ask?q=" src/web/templates/*.html` — guard each with `{% if ask_enabled %}`.
+
+`src/web/api.rs:691`: same guard, `Err(Error::NotFound)` (the `Result` alias there maps it to 404).
+
+`src/mcp/mod.rs`: change `#[tool_router(server_handler)]` to `#[tool_router]`, add inside the impl:
+
+```rust
+    /// The tools this core can actually serve. `ask` is not a tool that says
+    /// "not configured" — it is not a tool.
+    pub(crate) fn routes(&self) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        let mut r = Self::tool_router();
+        if !self.core.asks() {
+            r.remove_route("ask");
+        }
+        r
+    }
+```
+
+and after the impl:
+
+```rust
+#[rmcp::tool_handler(router = self.routes())]
+impl rmcp::ServerHandler for PkdbTools {}
+```
+
+`use rmcp::{tool, tool_router};` stays. If the generated `list_tools`/`call_tool` bodies complain that `self.routes()` is a temporary (borrowed in an `.await`), bind it: `router = self.routes()` is an expression the macro substitutes verbatim — if it does not compile, give `PkdbTools` a `routes: ToolRouter<Self>` field built in `mcp_router`'s `move || Ok(PkdbTools::new(core.clone()))` and use `router = self.routes`.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+Expected: all PASS.
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: no ask model, no ask door — page, nav, api and mcp tool alike"
+```
+
+---
+
+### Task 9: Docs, and the gate
+
+**Files:**
+- Modify: `config.example.toml` (the `[infer]` head, before `[infer.tiers...]`; the `[infer.embed]` block gains `chunk_tokens`)
+- Modify: `README.md` (the config table: `infer.synthesis`, `infer.segment_tokens`, `infer.embed.chunk_tokens`; the line that says `tier` is required on synthesize/ask; the status path sentence at `:165`)
+- Modify: `docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md` §1a — record the decision: the handles are `Option` on `Core` and the config roles are `Option`, exactly as specified; nothing to change there. Add one sentence to §2 recording that the default test double is symmetric (the deviation noted in the recipe plan).
+
+- [ ] **Step 1: Example config**
+
+Insert before the first `[infer.tiers.` table:
+
+```toml
+[infer]
+# How much inference capture spends.
+#   "off"    — split the text into verbatim passages, embed them, call nothing.
+#              [infer.synthesize] and [infer.ask] may be left out entirely.
+#   "earned" — the same capture; synthesis runs later where use has shown it
+#              is worth it. Needs [infer.synthesize].
+#   "eager"  — one synthesis call per segment at capture. The default.
+synthesis = "eager"
+# Window size when there is no [infer.synthesize] to derive one from, in
+# engram's estimator tokens. Ignored when a synthesizer is configured.
+# segment_tokens = 4096
+```
+
+In `[infer.embed]`, after `max_input_tokens`:
+
+```toml
+# Passage size at synthesis = "off"/"earned", in estimator tokens: about a
+# paragraph and a half, which is about one idea. Clamped to what the embedder
+# will take (max_input_tokens * 0.8). Argued, not measured — the judge
+# harness is what is allowed to move it.
+# chunk_tokens = 384
+```
+
+- [ ] **Step 2: README**
+
+Add rows to the config table:
+
+```markdown
+| `infer.synthesis` | `"off"`, `"earned"` or `"eager"` (default). `off` embeds the source text verbatim and calls no model at capture; `[infer.synthesize]` and `[infer.ask]` may then be omitted, and the doors that need them are not offered. |
+| `infer.segment_tokens` | Window size when no synthesizer is configured. Default 4096. |
+| `infer.embed.chunk_tokens` | Passage size at `off`/`earned`. Default 384, clamped to the embedder. |
+```
+
+Amend the "**`tier` is required** on `infer.synthesize` and `infer.ask`" bullet: "…when those tables are present. At `infer.synthesis = "off"` both may be omitted." Amend the status sentence at `:165`: "`raw → synthesizing → embedding → ready` (at `off`: `raw → embedding → ready`)".
+
+- [ ] **Step 3: Spec note**
+
+In the spec's §2 "Tests" list add: "— the default `FakeEmbedder` is symmetric (legacy templates) so retrieval tests that query with `"title\ntext"` keep matching; `FakeEmbedder::with_templates` exercises the asymmetric recipe."
+
+- [ ] **Step 4: The gate**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"     # 0
+cargo test 2>&1 | grep -E "^test result"                           # all ok
+cargo test --test eval 2>&1 | grep "^test result"
+grep -rn "Provenance::Merged" src | grep -v test | grep -v "merge.rs\|ui.rs:2594"   # only merge-specific sites remain
+grep -rn "\.synthesizer\.\|\.completer\.\|\.judge\.\|\.link_judge\.\|\.gap_namer\." src | grep -v "test" | grep -v "as_ref\|as_deref\|clone()\|is_some\|is_none"   # nothing that deref's an Option unguarded
+```
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add config.example.toml README.md docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+git commit -m "docs: off mode, and the two roles it lets you leave out"
+git push
+```
+
+---
+
+## Self-review
+
+**Spec coverage (sections in scope):**
+- "The modes" config key and default → Task 1; the table's "what runs at off" → Tasks 2 (model stages not armed/dropped), 6 (no relate for passages, no Title), 4 (no reconcile re-arm).
+- §1 "One splitter, called twice, nested" → Task 5; "passage never crosses a segment" → Task 5 (spans clamped to the window, one inner split per window); "inner split runs over the body" → Task 5; "carried heading becomes the title / leaves text / Markdown-only caveat" → Task 5; "segment state verbatim" → Task 4; "what capture does at off and earned" (finish, status path, title locally) → Task 6; "segment size without a synthesizer" → Tasks 1–2 (`segment_tokens`, `segment_budget`); "coverage green by construction" → Task 6 test asserts 100%; "configuration chunk_tokens, clamp" → Task 1; "corpus title without a model" → Task 5/6.
+- §1a optional roles, startup errors, stages not armed, dropped with reason → Tasks 1–2.
+- §5 stitching (passages only, every id kept), `adjacent_artifacts` nearest-active → Task 7. §5's "Ask at earned", "keep-this-answer", "economics", "server-side grouping prerequisite" — the first three are statements, not code; **server-side grouping (`query/groups`) is not in this plan** and is owed: it is a Qdrant-side change with its own measurement and belongs with the promotion plan, where `cap_per_corpus` is touched anyway (§7 call sites). Recorded as a gap, deliberately.
+- §8 → Task 8 (ask door); re-synthesise buttons at off: the gap-reread button renders only for red bands, and there are none; category chips come from facets of real rows and passages have none — both already hold by construction, verified by reading the templates, no code.
+- §9 → Task 3 (enum, parse, `roots_of`, dedupe, lineage view, schema comments).
+- Spec §3's "Ordinals after a promotion" `adjacent_artifacts` → Task 7; the stitching-by-spans and segment-based exclusion — stitching here, exclusion in the promotion plan.
+
+**Placeholder scan:** Task 2 step 3 says "existing body, with…" for `insert_artifacts_with_provenance` (Task 3) and `TryFrom` (Task 1) — both name the exact substitutions (bind the provenance; wrap in `match raw.x { None => None, Some(..) => Some(..) }`), and the surrounding code is in the repo at the cited lines. Task 8's `app_with`/`get`/`form`/`json_post`/`api_app` are "the file's existing helper" with a grep to find the real name — acceptable because the test files define exactly one such helper each; the executor must read it. No TBD/TODO.
+
+**Type consistency:** `SynthesisMode` (Task 1) is what `Core.synthesis` holds (Task 2) and what Tasks 6–7 tests set. `Core.chunk_tokens: usize` is introduced in Task 6 (not Task 2) and used there only. `segment_budget(core)` is defined in Task 2 and called in Tasks 2 (plan, window) and 6. `mark_segments_verbatim` (Task 4) is called in Task 6. `insert_artifacts_with_provenance` and `artifacts_by_ids` (Task 3) are called in Tasks 6 and 7. `Passage { title, text, start_line, end_line }` and `split_passages(window, counter, chunk_tokens)` (Task 5) are consumed in Task 6 with those field names. `SegmentState::Verbatim` spelled the same in Tasks 4, 6.

--- a/docs/superpowers/plans/2026-08-19-promotion.md
+++ b/docs/superpowers/plans/2026-08-19-promotion.md
@@ -1,0 +1,1558 @@
+# Promotion, Consolidation and Origins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `earned` becomes real — a passage that is opened or confirmed past a threshold gets its window synthesized, the new artifacts supersede the passages they cover by majority and inherit their access; consolidation judges rather than hides and never pairs rows from one window; a merged or synthesized artifact belongs to every corpus it drew from.
+
+**Architecture:** Promotion is today's `Stage::SegmentWindow` armed by evidence: the two engagement bump sites (`mark_artifact_seen`, the association sweep's confirmed bump) call `promote::maybe_promote`, which moves a `verbatim` segment to `pending` with `keep_artifacts = 1` and arms the unit; the window job, seeing `keep_artifacts`, supersedes covered passages by the majority rule and carries activation and links forward. Consolidation's `classify_pair` gains one exclusion and loses its free hide. `Store::origins_of` projects lineage onto corpora; four readers use it, and the vector payload mirrors it.
+
+**Tech Stack:** Rust 2024, sqlx/SQLite, askama, the existing job queue. No new crates.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md` — §3 (Promotion, incl. "Activation must actually move", "Carrying access forward", "Undo", "Ordinals after a promotion" already done), §6 (Consolidation), §7 (Origins). Pursuits (§4) are the last plan.
+
+## Global Constraints
+
+- Config, verbatim from the spec: `[promote] activation_above = 4.0`, `resynthesize_after_unconfirmed = 0` ("0 disables, and it ships disabled"). `feedback.enabled` becomes `true` by default; `earned` with `feedback.enabled = false` is a startup warning, not an error.
+- The threshold is tested `>=`, after the bump, decay folded in — and only at the `opened` and `confirmed` bump sites, never at `retrieved`.
+- Promotion arms a job; it never calls a model itself. No `max_per_sweep`.
+- `keep_artifacts = 1` → append; the guard against re-promotion is the segment state (`done` never promotes again); a re-run under `keep_artifacts` over a window that already holds non-passage rows writes nothing.
+- Majority rule: a passage is superseded only when some **one** artifact's span covers more than half its lines; best overlap wins, ties to the lowest ordinal; a passage nobody substantially claims stays active.
+- Activation carries as the **max** decayed activation of the superseded passages, stamped now. Links are **copied**, not moved; collisions: decayed max weight, `bumped_at = now`, `queries` max, cues merged top-3 by count, `dismissed` wins, `judged_rev_*` cleared, state `learning` unless dismissed. `hit_count`, `last_seen_at`, `search_candidates`, judged pairs do **not** carry.
+- Undo: passages back to active, the window's artifacts deprecated, segment back to `verbatim`; copied links and raised activation stay.
+- Consolidation: two rows from the same `(corpus_id, segment_idx)` are never pair candidates; `auto_supersede` stops hiding and becomes a fast lane to the judge (the key stays); `losses()` untouched.
+- Origins: derived, not stored; `origins_of` is non-empty for every active artifact; five call sites; `VectorPayload.origin_corpora`.
+- `cargo fmt` before every commit, `cargo clippy --all-targets` clean per task, commit messages as in the earlier plans.
+
+---
+
+## File structure
+
+| file | responsibility after this plan |
+|---|---|
+| `src/config.rs` | `PromoteConfig` + `[promote]`; `FeedbackConfig.enabled` default `true`; the earned-without-feedback warning |
+| `src/core/mod.rs` | `Core.promote: PromoteConfig`; `Core::undo_promotion` |
+| `src/store/segments.rs` | `segment_state(corpus, idx)` |
+| `src/store/artifacts.rs` | `artifacts_for_segment`, `set_activation`, `artifact_confirmed` |
+| `src/store/links.rs` | `links_touching`, `carry_link` (copy with collision merge) |
+| `src/store/lineage.rs` | `origins_of`, `Origin` |
+| `src/jobs/promote.rs` (new) | `maybe_promote`, `maybe_resynthesize`, `supersede_covered` (majority + carry), `covered_by` (pure) |
+| `src/jobs/window.rs` | keep-path idempotency; calls `supersede_covered` |
+| `src/core/search.rs` | `mark_artifact_seen` → `maybe_promote`; `mark_seen` → `maybe_resynthesize`; `cap_per_corpus` over origins |
+| `src/jobs/associate.rs` | confirmed bump → `maybe_promote` |
+| `src/jobs/relate.rs`, `src/jobs/consolidate.rs` | same-segment exclusion; fast lane instead of hide; header comment |
+| `src/store/links.rs` (`links_from`, `links_to_judge`) | cross-corpus via origins |
+| `src/vector/mod.rs`, `src/jobs/embed.rs` | `origin_corpora` payload field, written for model-written rows |
+| `src/web/ui.rs`, `src/web/templates/corpus.html` | promoted windows list + undo; "written from this corpus" section |
+| `config.example.toml`, `README.md` | `[promote]`, the feedback default |
+
+---
+
+### Task 1: Config — `[promote]`, and activation that actually moves
+
+**Files:**
+- Modify: `src/config.rs` (`FeedbackConfig` default `:107-117`; new `PromoteConfig`; `Config` struct field; `warn_on_inert_settings` `:1092+`)
+- Modify: `src/core/mod.rs` (`Core.promote`, `from_config`, `test_support::build`), `tests/eval.rs` (Core literal), `src/main.rs` (Config literal if it names `feedback`/a new field — check with `grep -n "feedback:" src/main.rs`)
+- Test: `src/config.rs`, `src/core/mod.rs` `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[derive(Debug, Deserialize, Clone)] #[serde(default)]
+  pub struct PromoteConfig { pub activation_above: f64, pub resynthesize_after_unconfirmed: i64 }  // Default 4.0, 0
+  pub struct Config { /* … */ pub promote: PromoteConfig }
+  pub struct Core { /* … */ pub promote: crate::config::PromoteConfig }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/config.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn promote_defaults_and_feedback_ships_on() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer.synthesize]
+            tier = \"efficient\"
+            output_ratio = 8.0
+            [infer.ask]
+            tier = \"efficient\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.promote.activation_above, 4.0);
+        assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 0);
+        // Opt-out now: promotion reads activation, and activation only moves
+        // while searches are recorded.
+        assert!(cfg.feedback.enabled);
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer.synthesize]
+            tier = \"efficient\"
+            output_ratio = 8.0
+            [infer.ask]
+            tier = \"efficient\"
+            [promote]
+            activation_above = 2.5
+            resynthesize_after_unconfirmed = 12
+            [feedback]
+            enabled = false
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.promote.activation_above, 2.5);
+        assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 12);
+        assert!(!cfg.feedback.enabled);
+    }
+```
+
+`src/core/mod.rs` `mod tests`: the existing `associating_requires_both_flags_the_shipped_default_has_only_one` asserts `feedback.enabled == false` on `test_core()`. `test_core` builds `FeedbackConfig::default()`, which flips to `true` — but many tests assert "nothing moves unless feedback is on" by *setting* `core.feedback.enabled = true` and relying on the default being off elsewhere. Keep `test_support::build` at `feedback: FeedbackConfig { enabled: false, ..Default::default() }` with a comment ("Off in tests, whatever ships: the capture tests switch it on and the rest assert nothing is recorded"), and rewrite the test:
+
+```rust
+    #[tokio::test]
+    async fn associating_requires_both_flags_and_the_shipped_default_has_both() {
+        // Shipped defaults: `associate.enabled = true`, `feedback.enabled =
+        // true` — promotion reads activation, and activation only moves while
+        // searches are recorded, so recording is opt-out. The test core keeps
+        // feedback off so every other test starts from nothing recorded.
+        assert!(crate::config::FeedbackConfig::default().enabled);
+        assert!(crate::config::AssociateConfig::default().enabled);
+        let mut core = test_support::test_core().await;
+        assert!(core.associate.enabled && !core.feedback.enabled);
+        assert!(!core.associating(), "on with only associate.enabled set");
+        core.feedback.enabled = true;
+        assert!(core.associating());
+        core.associate.enabled = false;
+        assert!(!core.associating(), "on with only feedback.enabled set");
+    }
+```
+
+(Read the old test body first and keep any assertion it makes that is still true.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib config::tests::promote_defaults 2>&1 | grep -E "^error" | head -3`
+Expected: no field `promote`.
+
+- [ ] **Step 3: Implement**
+
+In `src/config.rs`, after `ActivationConfig`:
+
+```rust
+/// When a passage has earned its window a synthesis call, and when an eager
+/// artifact has earned a second one.
+///
+/// `activation_above` is read against `[activation]`: baseline `1.0`,
+/// `retrieved = 1.0`, `opened = 0.5`, `confirmed = 3.0`, half-life 14 days.
+/// Checked with `>=` after the bump, decay folded in, and only at the two
+/// engagement bumps — opened and confirmed — never at retrieved, so a passage
+/// that merely keeps appearing in result lists is never promoted.
+///
+/// `resynthesize_after_unconfirmed` is the `eager` counterpart: an artifact
+/// shown this many times with no confirmation recorded against it is
+/// re-synthesised from its segment. `0` disables it, and it ships disabled —
+/// re-synthesising changes what an existing base contains without anyone
+/// asking, so it is a default the harness moves.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PromoteConfig {
+    pub activation_above: f64,
+    pub resynthesize_after_unconfirmed: i64,
+}
+
+impl Default for PromoteConfig {
+    fn default() -> Self {
+        Self {
+            activation_above: 4.0,
+            resynthesize_after_unconfirmed: 0,
+        }
+    }
+}
+```
+
+Add `pub promote: PromoteConfig` to `Config` with `#[serde(default)]` (look at how `activation` is declared on `Config` and copy its attributes). `FeedbackConfig::default().enabled = true`; update its doc comment: "On by default: promotion at `synthesis = \"earned\"` reads activation, and activation moves only while searches are recorded. Recording is the thing an operator turns *off*." In `warn_on_inert_settings` add:
+
+```rust
+        if self.infer.synthesis == SynthesisMode::Earned && !self.feedback.enabled {
+            tracing::warn!(
+                "infer.synthesis = \"earned\" with feedback.enabled = false: activation never \
+                 moves, so nothing is ever promoted — this is `off` under another name."
+            );
+        }
+```
+
+`Core`: add `pub promote: crate::config::PromoteConfig` after `activation`; `from_config` sets `promote: cfg.promote.clone()`; `test_support::build` sets `promote: crate::config::PromoteConfig::default()` and `feedback: crate::config::FeedbackConfig { enabled: false, ..Default::default() }`; `tests/eval.rs` gets both fields the same way. `grep -rn "FeedbackConfig::default()" src tests` — every test that relied on the default being off and then asserted nothing was recorded must be read: if it built its core through `test_support`, it is fine; if it built `FeedbackConfig::default()` by hand expecting `enabled == false`, set `enabled: false` explicitly.
+
+- [ ] **Step 4: Run everything**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+Expected: PASS. Expect the config test that loads `config.example.toml` to still pass (the example sets `feedback.enabled` explicitly? check — if it says `enabled = false` leave it; Task 9 documents the new default).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src tests
+git commit -m "feat: a promote section, and recording on by default so activation can move"
+```
+
+---
+
+### Task 2: Store plumbing for promotion
+
+**Files:**
+- Modify: `src/store/segments.rs` (new `segment_state`), `src/store/artifacts.rs` (new `artifacts_for_segment`, `set_activation`, `artifact_confirmed`), `src/store/links.rs` (new `links_touching`, `carry_link`)
+- Test: each file's `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  impl Store {
+      pub async fn segment_state(&self, corpus_id: &str, idx: i64) -> Result<Option<SegmentState>>;
+      pub async fn artifacts_for_segment(&self, corpus_id: &str, idx: i64) -> Result<Vec<Chunk>>;   // all rows, any status, ORDER BY ordinal
+      pub async fn set_activation(&self, id: &str, value: f64, at: i64) -> Result<()>;
+      pub async fn artifact_confirmed(&self, id: &str) -> Result<bool>;   // any search_events row with verdict='hit' AND expect_id = id
+      pub async fn links_touching(&self, id: &str) -> Result<Vec<Link>>;  // every row with a_id = id OR b_id = id, any state
+      /// Copy `from` (one endpoint = `old`) onto the pair (`new`, other endpoint), merging on collision.
+      pub async fn carry_link(&self, from: &Link, old: &str, new: &str, half_life_days: f64, at: i64) -> Result<()>;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/links.rs` `mod tests` (it has a `two(&store)` helper returning two artifact ids; read it and the test around `bump_link` for how a link is seeded and read back with `get_link`):
+
+```rust
+    #[tokio::test]
+    async fn carrying_a_link_copies_it_and_leaves_the_original() {
+        let s = Store::memory().await.unwrap();
+        let (p, x) = two(&s).await; // passage p, some artifact x
+        let src = s.insert_corpus("raw2", "web", None).await.unwrap();
+        let a = s
+            .insert_artifacts(&src.id, &[NewArtifact {
+                ordinal: 0, text: "the artifact".into(), corpus_span: None, title: None,
+                category: None, tags: vec![], segment_idx: None, caveats: vec![],
+            }])
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        s.bump_links(&[(p.as_str(), x.as_str())], 2.0, Some("how to mount"), 14.0, 1_000)
+            .await
+            .unwrap();
+        let from = s.get_link(&p, &x).await.unwrap().unwrap();
+
+        s.carry_link(&from, &p, &a, 14.0, 1_000 + 14 * 86_400).await.unwrap();
+
+        let copied = s.get_link(&a, &x).await.unwrap().expect("the copy exists");
+        // Decayed to the carry moment: one half-life later, half the weight.
+        assert!((copied.weight - 1.0).abs() < 1e-6, "{}", copied.weight);
+        assert_eq!(copied.bumped_at, 1_000 + 14 * 86_400);
+        assert_eq!(copied.queries, from.queries);
+        assert_eq!(copied.cues.len(), 1);
+        assert_eq!(copied.state, LinkState::Learning);
+        assert!(copied.judged_rev_a.is_none() && copied.judged_rev_b.is_none());
+        // The original is still there, untouched.
+        let orig = s.get_link(&p, &x).await.unwrap().unwrap();
+        assert_eq!(orig.weight, from.weight);
+    }
+
+    #[tokio::test]
+    async fn carrying_onto_an_existing_link_takes_the_max_not_the_sum_and_dismissed_wins() {
+        let s = Store::memory().await.unwrap();
+        let (p, x) = two(&s).await;
+        let src = s.insert_corpus("raw2", "web", None).await.unwrap();
+        let a = s
+            .insert_artifacts(&src.id, &[NewArtifact {
+                ordinal: 0, text: "the artifact".into(), corpus_span: None, title: None,
+                category: None, tags: vec![], segment_idx: None, caveats: vec![],
+            }])
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let at = 5_000;
+        s.bump_links(&[(p.as_str(), x.as_str())], 3.0, Some("q one"), 14.0, at).await.unwrap();
+        s.bump_links(&[(a.as_str(), x.as_str())], 2.0, Some("q two"), 14.0, at).await.unwrap();
+        // The operator dismissed the artifact's own link.
+        s.set_link_state(&a, &x, LinkState::Dismissed, None, None).await.unwrap();
+        let from = s.get_link(&p, &x).await.unwrap().unwrap();
+
+        s.carry_link(&from, &p, &a, 14.0, at).await.unwrap();
+
+        let merged = s.get_link(&a, &x).await.unwrap().unwrap();
+        assert!((merged.weight - 3.0).abs() < 1e-6, "max, not 5.0: {}", merged.weight);
+        assert_eq!(merged.queries, 1, "max of 1 and 1");
+        assert_eq!(merged.cues.len(), 2, "cues merged");
+        assert_eq!(merged.state, LinkState::Dismissed, "the operator's no is final");
+    }
+
+    #[tokio::test]
+    async fn links_touching_finds_a_link_from_either_end() {
+        let s = Store::memory().await.unwrap();
+        let (p, x) = two(&s).await;
+        s.bump_links(&[(p.as_str(), x.as_str())], 1.0, None, 14.0, 1).await.unwrap();
+        assert_eq!(s.links_touching(&p).await.unwrap().len(), 1);
+        assert_eq!(s.links_touching(&x).await.unwrap().len(), 1);
+        assert!(s.links_touching("nobody").await.unwrap().is_empty());
+    }
+```
+
+(`set_link_state`'s signature: read it at `links.rs:574` and pass what it takes — the test above assumes `(a, b, state, reason, judged_revs)`; adjust to the real one.)
+
+`src/store/artifacts.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn set_activation_writes_value_and_stamp_and_artifacts_for_segment_reads_every_status() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let mut a = nc(0, "a"); a.segment_idx = Some(3);
+        let mut b = nc(1, "b"); b.segment_idx = Some(3);
+        let mut c = nc(2, "c"); c.segment_idx = Some(4);
+        let made = s.insert_artifacts(&src.id, &[a, b, c]).await.unwrap();
+        s.set_superseded_by(&made[1].id, Some(&made[0].id)).await.unwrap();
+        let seg = s.artifacts_for_segment(&src.id, 3).await.unwrap();
+        assert_eq!(seg.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(), vec!["a", "b"]);
+
+        s.set_activation(&made[0].id, 7.25, 99).await.unwrap();
+        let act = s.activation_of(std::slice::from_ref(&made[0].id)).await.unwrap();
+        assert_eq!(act[&made[0].id], (7.25, 99));
+    }
+
+    #[tokio::test]
+    async fn artifact_confirmed_reads_a_hit_verdict_naming_it() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s.insert_artifacts(&src.id, &[nc(0, "a")]).await.unwrap();
+        assert!(!s.artifact_confirmed(&made[0].id).await.unwrap());
+        // Record a search and judge it a hit on this artifact. Use the
+        // feedback store's own API — read `record_search`/`judge` in
+        // src/store/feedback.rs and the `seeded()` helper in
+        // src/core/search.rs tests (~line 2380) for the shape.
+        let ev = seed_search_event(&s, "q").await;
+        s.judge(&ev, crate::store::feedback::Verdict::Hit /* with expect_id = made[0].id */).await.unwrap();
+        assert!(s.artifact_confirmed(&made[0].id).await.unwrap());
+    }
+```
+
+The second test's seeding must use the real feedback API: open `src/store/feedback.rs`, find the function that records a `SearchEvent` (`record_search` or similar, taking a `NewSearchEvent`/`SearchEvent` struct — `src/store/feedback.rs:120` shows `query_vec: Vec<f32>` in such a struct) and the one that judges (`judge(&event_id, Verdict, expect_id)` around `:470`); write a 10-line `seed_search_event` helper in the test module with those. If an existing test helper in `feedback.rs` already does it, call that.
+
+`src/store/segments.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn segment_state_reads_one_window() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        s.upsert_segments(&src.id, &[NewSegment { start_line: 1, end_line: 2, text: "t", carry_lines: 0 }])
+            .await
+            .unwrap();
+        assert_eq!(s.segment_state(&src.id, 0).await.unwrap(), Some(SegmentState::Pending));
+        s.mark_segments_verbatim(&src.id).await.unwrap();
+        assert_eq!(s.segment_state(&src.id, 0).await.unwrap(), Some(SegmentState::Verbatim));
+        assert_eq!(s.segment_state(&src.id, 9).await.unwrap(), None);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib store:: 2>&1 | grep -E "^error" | sort | uniq -c | head`
+Expected: the six new methods not found.
+
+- [ ] **Step 3: Implement**
+
+`segments.rs`:
+
+```rust
+    /// One window's state, or `None` for a window that does not exist.
+    pub async fn segment_state(&self, corpus_id: &str, idx: i64) -> Result<Option<SegmentState>> {
+        Ok(sqlx::query_scalar::<_, String>(
+            "SELECT state FROM segments WHERE corpus_id = ? AND idx = ?",
+        )
+        .bind(corpus_id)
+        .bind(idx)
+        .fetch_optional(&self.pool)
+        .await?
+        .map(|s| SegmentState::parse(&s)))
+    }
+```
+
+`artifacts.rs`:
+
+```rust
+    /// Every row a window owns, whatever its status, in ordinal order. The
+    /// promotion path reads this to see what it is superseding and, on a
+    /// retry, what it already wrote.
+    pub async fn artifacts_for_segment(&self, corpus_id: &str, idx: i64) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE corpus_id = ? AND segment_idx = ? ORDER BY ordinal",
+        )
+        .bind(corpus_id)
+        .bind(idx)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
+    /// Set an artifact's activation outright, stamped `at`. Promotion uses it
+    /// to hand a new artifact the access its passages earned; everything else
+    /// goes through `bump_activation`, which adds.
+    pub async fn set_activation(&self, id: &str, value: f64, at: i64) -> Result<()> {
+        sqlx::query("UPDATE artifacts SET activation = ?, activated_at = ? WHERE id = ?")
+            .bind(value)
+            .bind(at)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Has a person ever said this artifact was the answer? A `hit` verdict
+    /// naming it, on any recorded search.
+    pub async fn artifact_confirmed(&self, id: &str) -> Result<bool> {
+        Ok(sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM search_events WHERE verdict = 'hit' AND expect_id = ?",
+        )
+        .bind(id)
+        .fetch_one(&self.pool)
+        .await?
+            > 0)
+    }
+```
+
+`links.rs`:
+
+```rust
+    /// Every link naming `id` at either end, in any state.
+    pub async fn links_touching(&self, id: &str) -> Result<Vec<Link>> {
+        let rows = sqlx::query("SELECT * FROM artifact_links WHERE a_id = ? OR b_id = ?")
+            .bind(id)
+            .bind(id)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(row_to_link).collect())
+    }
+
+    /// Copy a link that touches `old` onto `new` and the same other endpoint,
+    /// leaving the original row where it is.
+    ///
+    /// Learned access carries forward; recorded history does not. Weight comes
+    /// across decayed to `at` and stamped `at`; `queries` and `cues` come
+    /// across as they are. On collision with a link `new` already has: the
+    /// larger decayed weight (max, not sum — one search returning three
+    /// passages of one section is one piece of evidence), the larger
+    /// `queries`, the cues merged and cut to three, `dismissed` if either side
+    /// was (the operator's "not related" is final), otherwise `learning` — a
+    /// verdict passed on the passage's text does not transfer to a rewrite —
+    /// and `judged_rev_*` cleared. A link whose other end *is* `new`, or that
+    /// would pair `new` with itself, is skipped.
+    pub async fn carry_link(
+        &self,
+        from: &Link,
+        old: &str,
+        new: &str,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        let other = if from.a_id == old { &from.b_id } else { &from.a_id };
+        if other == new || other == old {
+            return Ok(());
+        }
+        let (a, b) = canonical(new, other);
+        let incoming = decayed(from.weight, from.bumped_at, at, half_life_days);
+        let mut tx = self.pool.begin_with(IMMEDIATE).await?;
+        let existing = sqlx::query("SELECT * FROM artifact_links WHERE a_id = ? AND b_id = ?")
+            .bind(a)
+            .bind(b)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(|r| row_to_link(&r));
+        match existing {
+            None => {
+                let state = if from.state == LinkState::Dismissed {
+                    LinkState::Dismissed
+                } else {
+                    LinkState::Learning
+                };
+                sqlx::query(
+                    "INSERT INTO artifact_links
+                       (a_id, b_id, weight, bumped_at, queries, cues, state, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(a)
+                .bind(b)
+                .bind(incoming)
+                .bind(at)
+                .bind(from.queries)
+                .bind(serde_json::to_string(&from.cues).unwrap_or_else(|_| "[]".into()))
+                .bind(state.as_str())
+                .bind(now())
+                .execute(&mut *tx)
+                .await?;
+            }
+            Some(have) => {
+                let weight = decayed(have.weight, have.bumped_at, at, half_life_days).max(incoming);
+                let mut cues = have.cues.clone();
+                for c in &from.cues {
+                    match cues.iter_mut().find(|x| x.q == c.q) {
+                        Some(x) => x.n = x.n.max(c.n),
+                        None => cues.push(c.clone()),
+                    }
+                }
+                cues.sort_by(|x, y| y.n.cmp(&x.n));
+                cues.truncate(3);
+                let state = if have.state == LinkState::Dismissed || from.state == LinkState::Dismissed {
+                    LinkState::Dismissed
+                } else {
+                    LinkState::Learning
+                };
+                sqlx::query(
+                    "UPDATE artifact_links
+                        SET weight = ?, bumped_at = ?, queries = ?, cues = ?, state = ?,
+                            reason = NULL, judged_rev_a = NULL, judged_rev_b = NULL
+                      WHERE a_id = ? AND b_id = ?",
+                )
+                .bind(weight)
+                .bind(at)
+                .bind(have.queries.max(from.queries))
+                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+                .bind(state.as_str())
+                .bind(a)
+                .bind(b)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+```
+
+(`Cue` needs `Clone` — check its derives; `LinkState` has `as_str`.)
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test --lib store:: 2>&1 | grep -E "^test result|FAILED|panicked"`
+Expected: PASS.
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add src/store
+git commit -m "feat: the store can carry a passage's access forward"
+```
+
+---
+
+### Task 3: The trigger — engagement, at the bump
+
+**Files:**
+- Create: `src/jobs/promote.rs`
+- Modify: `src/jobs/mod.rs` (`pub mod promote;`), `src/core/search.rs:415-445` (`mark_artifact_seen`), `src/jobs/associate.rs:275-290` (confirmed bump)
+- Test: `src/jobs/promote.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `Store::segment_state`, `Store::activation_of`, `reset_segment(corpus, idx, keep_artifacts: true)`, `rearm_idle_seq(Stage::SegmentWindow, "segment", unit_target, idx)`, `Core.promote`, `Core.synthesis`, `Core::synthesizes()`.
+- Produces: `pub async fn maybe_promote(core: &Core, ids: &[String], at: i64) -> Result<usize>` (how many windows were armed).
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/jobs/promote.rs`:
+
+```rust
+//! Promotion: synthesis armed by evidence instead of by capture.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SynthesisMode;
+    use crate::core::test_support::test_core;
+    use crate::store::jobs::Stage;
+    use crate::store::segments::SegmentState;
+
+    /// A core at `earned`, recording, with one verbatim corpus of one passage.
+    async fn earned_with_one_passage() -> (crate::core::Core, String, String) {
+        let mut core = test_core().await;
+        core.synthesis = SynthesisMode::Earned;
+        core.feedback.enabled = true;
+        let out = core.ingest("a single verbatim passage", "web", None).await.unwrap();
+        crate::jobs::passages::capture_verbatim(&core, &out.id).await.unwrap();
+        let p = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0].id.clone();
+        (core, out.id, p)
+    }
+
+    fn unit(corpus: &str) -> String {
+        crate::jobs::window::unit_target(corpus, 0)
+    }
+
+    #[tokio::test]
+    async fn a_passage_over_the_line_arms_its_window_once() {
+        let (core, corpus, p) = earned_with_one_passage().await;
+        // Baseline 1.0 plus one confirmed bump puts it at 4.0 exactly.
+        core.store.bump_activation(std::slice::from_ref(&p), 3.0, 14.0, 1_000).await.unwrap();
+        let armed = maybe_promote(&core, std::slice::from_ref(&p), 1_000).await.unwrap();
+        assert_eq!(armed, 1);
+        assert_eq!(core.store.segment_state(&corpus, 0).await.unwrap(), Some(SegmentState::Pending));
+        assert!(core.store.segment_keeps_artifacts(&corpus, 0).await.unwrap());
+        assert!(core.store.live_job(Stage::SegmentWindow, &unit(&corpus)).await.unwrap());
+        // A second trigger on a window that is no longer verbatim does nothing.
+        core.store.set_segment_state(&corpus, 0, SegmentState::Done, None).await.unwrap();
+        let again = maybe_promote(&core, std::slice::from_ref(&p), 1_000).await.unwrap();
+        assert_eq!(again, 0);
+    }
+
+    #[tokio::test]
+    async fn under_the_line_nothing_is_armed() {
+        let (core, corpus, p) = earned_with_one_passage().await;
+        core.store.bump_activation(std::slice::from_ref(&p), 1.0, 14.0, 1_000).await.unwrap();
+        assert_eq!(maybe_promote(&core, std::slice::from_ref(&p), 1_000).await.unwrap(), 0);
+        assert_eq!(core.store.segment_state(&corpus, 0).await.unwrap(), Some(SegmentState::Verbatim));
+    }
+
+    #[tokio::test]
+    async fn only_earned_with_a_synthesizer_promotes() {
+        let (mut core, _corpus, p) = earned_with_one_passage().await;
+        core.store.bump_activation(std::slice::from_ref(&p), 5.0, 14.0, 1_000).await.unwrap();
+        core.synthesis = SynthesisMode::Off;
+        assert_eq!(maybe_promote(&core, std::slice::from_ref(&p), 1_000).await.unwrap(), 0);
+        core.synthesis = SynthesisMode::Earned;
+        core.synthesizer = None;
+        assert_eq!(maybe_promote(&core, std::slice::from_ref(&p), 1_000).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn retrieval_alone_never_promotes_but_one_open_afterwards_does() {
+        // The threshold is checked at the opened bump, not the retrieved one:
+        // ten retrievals leave the window verbatim; the first open promotes.
+        let (core, corpus, p) = earned_with_one_passage().await;
+        let ids = vec![p.clone()];
+        for _ in 0..10 {
+            core.store.bump_activation(&ids, core.activation.retrieved, 14.0, 1_000).await.unwrap();
+        }
+        // `mark_seen` is the retrieved site: it must not call `maybe_promote`.
+        assert_eq!(core.store.segment_state(&corpus, 0).await.unwrap(), Some(SegmentState::Verbatim));
+        core.mark_artifact_seen(&p);
+        core.background.drain().await;
+        assert_eq!(core.store.segment_state(&corpus, 0).await.unwrap(), Some(SegmentState::Pending));
+    }
+}
+```
+
+(`core.background.drain()` — check the name of the method that waits for spawned background writes in `src/core/background.rs`; several search tests use it.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib jobs::promote 2>&1 | grep -E "^error" | head -3`
+Expected: `maybe_promote` not found (after adding `pub mod promote;`).
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::Provenance;
+use crate::store::jobs::Stage;
+use crate::store::segments::SegmentState;
+
+/// Promote the windows of any of these passages that have earned it.
+///
+/// Called after an engagement bump — opened, or confirmed — and never after a
+/// retrieval bump: a passage that merely keeps appearing in result lists has
+/// helped nobody, and the condition "opened or confirmed at least once" is
+/// *where* this is called, not a stored flag. Checked at the bump, not on a
+/// sweep: a sweep reads decayed activation and the threshold would then mean
+/// something different depending on when it ran.
+///
+/// Arms a job; calls no model. The job queue and `[pacing]` bound the load.
+pub async fn maybe_promote(core: &Core, ids: &[String], at: i64) -> Result<usize> {
+    if core.synthesis != crate::config::SynthesisMode::Earned || !core.synthesizes() {
+        return Ok(0);
+    }
+    let activation = core.store.activation_of(ids).await?;
+    let mut armed = 0;
+    for id in ids {
+        let Some((value, stamp)) = activation.get(id) else { continue };
+        let now_value = crate::store::links::decayed(*value, *stamp, at, core.activation.half_life_days);
+        if now_value < core.promote.activation_above {
+            continue;
+        }
+        let Ok(c) = core.store.get_artifact(id).await else { continue };
+        if c.provenance != Provenance::Passage || !c.in_results() {
+            continue;
+        }
+        let (Some(corpus_id), Some(idx)) = (c.corpus_id.as_deref(), c.segment_idx) else {
+            continue;
+        };
+        // The guard against re-promotion is the segment state: a window that
+        // is `done` — or already on its way — never promotes again, however
+        // many of its surviving passages cross the line afterwards.
+        if core.store.segment_state(corpus_id, idx).await? != Some(SegmentState::Verbatim) {
+            continue;
+        }
+        // `keep_artifacts`: the window job appends rather than replaces, so the
+        // passages survive to be superseded by what covers them.
+        core.store.reset_segment(corpus_id, idx, true).await?;
+        core.store
+            .rearm_idle_seq(
+                Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(corpus_id, idx),
+                idx,
+            )
+            .await?;
+        tracing::info!(artifact_id = %id, corpus_id, window = idx, activation = now_value, "promoting a window");
+        armed += 1;
+    }
+    Ok(armed)
+}
+```
+
+`src/core/search.rs` `mark_artifact_seen`: inside the spawned task, after the `bump_activation` call succeeds:
+
+```rust
+                if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                    tracing::warn!(error = %e, "could not raise activation for opening");
+                    return;
+                }
+                // An open is an engagement: the one kind of bump that can
+                // promote. See `jobs::promote::maybe_promote`.
+                if let Err(e) = crate::jobs::promote::maybe_promote(&core, &ids, at).await {
+                    tracing::warn!(error = %e, "could not check the promotion threshold");
+                }
+```
+
+— the task needs a `core` clone rather than just `store`: `let core = self.clone();` before the spawn and use `core.store` inside. Read the surrounding code and keep the `associating()` gate as it is.
+
+`src/jobs/associate.rs:281` after the confirmed `bump_activation`:
+
+```rust
+        // A confirmation is the strongest engagement there is, and the other
+        // bump that may promote.
+        crate::jobs::promote::maybe_promote(core, std::slice::from_ref(&expect), at).await?;
+```
+
+`mark_seen` (the retrieved site, `search.rs:392-401`): **no call** — add one comment line there: "Never `maybe_promote` here: exposure is not engagement."
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: a passage that is read past the line arms its window — once, at the bump"
+```
+
+---
+
+### Task 4: The window job supersedes by majority and carries access forward
+
+**Files:**
+- Modify: `src/jobs/promote.rs` (add `covered_by`, `supersede_covered`), `src/jobs/window.rs:327-350` (`write_segment_artifacts` idempotency), `src/jobs/window.rs:185-191` (`run`'s tail)
+- Test: `src/jobs/promote.rs`, `src/jobs/window.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: Task 2's store methods; `Core::supersede`; `decayed`.
+- Produces:
+  ```rust
+  /// For each passage (id, span): the artifact covering a majority of its lines, if any. Pure.
+  pub fn covered_by<'a>(passages: &'a [(String, CorpusSpan)], artifacts: &'a [(String, i64, CorpusSpan)]) -> Vec<(&'a str, &'a str)>;  // (passage_id, artifact_id)
+  pub async fn supersede_covered(core: &Core, corpus_id: &str, idx: i64, written: &[Chunk], at: i64) -> Result<usize>;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/jobs/promote.rs` `mod tests`:
+
+```rust
+    use crate::store::artifacts::CorpusSpan;
+
+    fn sp(a: i64, b: i64) -> CorpusSpan {
+        CorpusSpan { start_line: a, end_line: b }
+    }
+
+    #[test]
+    fn the_majority_rule_is_per_artifact_best_overlap_ties_to_the_lowest_ordinal() {
+        // passage 1–20; A claims 1–11 (11 lines, majority), B claims 12–20 (9).
+        let passages = vec![("p".to_string(), sp(1, 20))];
+        let arts = vec![
+            ("b".to_string(), 1, sp(12, 20)),
+            ("a".to_string(), 0, sp(1, 11)),
+        ];
+        assert_eq!(covered_by(&passages, &arts), vec![("p", "a")]);
+        // 30% + 30% is not a majority: nobody claims it.
+        let arts = vec![("a".to_string(), 0, sp(1, 6)), ("b".to_string(), 1, sp(7, 12))];
+        assert!(covered_by(&passages, &arts).is_empty());
+        // Exactly half is not a majority either.
+        let arts = vec![("a".to_string(), 0, sp(1, 10))];
+        assert!(covered_by(&passages, &arts).is_empty());
+        // A tie on overlap goes to the lowest ordinal.
+        let arts = vec![("z".to_string(), 5, sp(1, 20)), ("y".to_string(), 2, sp(1, 20))];
+        assert_eq!(covered_by(&passages, &arts), vec![("p", "y")]);
+    }
+
+    /// A verbatim corpus of three passages (lines 1–2, 3–4, 5–6 of one
+    /// window) with activation and a link on the middle one; then a
+    /// promotion whose artifact A claims lines 1–4 and B claims line 6.
+    async fn promoted_fixture() -> (crate::core::Core, String, Vec<crate::store::artifacts::Chunk>, Vec<crate::store::artifacts::Chunk>) {
+        let mut core = test_core().await;
+        core.synthesis = SynthesisMode::Earned;
+        core.feedback.enabled = true;
+        let src = core.store.insert_corpus("l1\nl2\nl3\nl4\nl5\nl6", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[crate::store::segments::NewSegment { start_line: 1, end_line: 6, text: "l1\nl2\nl3\nl4\nl5\nl6", carry_lines: 0 }])
+            .await
+            .unwrap();
+        core.store.mark_segments_verbatim(&src.id).await.unwrap();
+        let na = |o: i64, t: &str, a: i64, b: i64| crate::store::artifacts::NewArtifact {
+            ordinal: o, text: t.into(), corpus_span: Some(sp(a, b)), title: None, category: None,
+            tags: vec![], segment_idx: Some(0), caveats: vec![],
+        };
+        let passages = core
+            .store
+            .insert_artifacts_with_provenance(&src.id, &[na(0, "l1 l2", 1, 2), na(1, "l3 l4", 3, 4), na(2, "l5 l6", 5, 6)], crate::store::artifacts::Provenance::Passage)
+            .await
+            .unwrap();
+        // Another corpus to link to.
+        let other = core.store.insert_corpus("other", "web", None).await.unwrap();
+        let x = core.store.insert_artifacts(&other.id, &[na(0, "x", 1, 1)]).await.unwrap()[0].id.clone();
+        core.store.bump_activation(std::slice::from_ref(&passages[1].id), 4.0, 14.0, 1_000).await.unwrap();
+        core.store.bump_links(&[(passages[1].id.as_str(), x.as_str())], 2.0, Some("mid"), 14.0, 1_000).await.unwrap();
+        // The promotion's artifacts, as `write_segment_artifacts` would write them.
+        core.store.reset_segment(&src.id, 0, true).await.unwrap();
+        let written = core
+            .store
+            .insert_artifacts(&src.id, &[na(0, "A covers one to four", 1, 4), na(1, "B covers six", 6, 6)])
+            .await
+            .unwrap();
+        (core, src.id, passages, written)
+    }
+
+    #[tokio::test]
+    async fn covered_passages_are_superseded_and_the_rest_stay_verbatim() {
+        let (core, corpus, passages, written) = promoted_fixture().await;
+        let n = supersede_covered(&core, &corpus, 0, &written, 2_000).await.unwrap();
+        assert_eq!(n, 2, "passages 1 and 2 are majority-covered by A; passage 3 is half-covered by B");
+        let p0 = core.store.get_artifact(&passages[0].id).await.unwrap();
+        let p1 = core.store.get_artifact(&passages[1].id).await.unwrap();
+        let p2 = core.store.get_artifact(&passages[2].id).await.unwrap();
+        assert_eq!(p0.superseded_by.as_deref(), Some(written[0].id.as_str()));
+        assert_eq!(p1.superseded_by.as_deref(), Some(written[0].id.as_str()));
+        assert!(p2.in_results(), "lines 5–6: B claims one of two, not a majority");
+    }
+
+    #[tokio::test]
+    async fn the_artifact_takes_the_max_decayed_activation_not_one_point_zero() {
+        let (core, corpus, passages, written) = promoted_fixture().await;
+        supersede_covered(&core, &corpus, 0, &written, 1_000).await.unwrap();
+        let act = core.store.activation_of(&[written[0].id.clone(), passages[1].id.clone()]).await.unwrap();
+        let (a_val, a_at) = act[&written[0].id];
+        let (p_val, p_at) = act[&passages[1].id];
+        let expect = crate::store::links::decayed(p_val, p_at, 1_000, 14.0);
+        assert!((a_val - expect).abs() < 1e-6, "got {a_val}, want {expect}");
+        assert_eq!(a_at, 1_000);
+        assert!(a_val > 1.0);
+    }
+
+    #[tokio::test]
+    async fn a_link_from_a_superseded_passage_resolves_on_the_artifact_and_the_dead_row_stays() {
+        let (core, corpus, passages, written) = promoted_fixture().await;
+        supersede_covered(&core, &corpus, 0, &written, 1_000).await.unwrap();
+        let out = core
+            .store
+            .links_from(&[written[0].id.clone()], &[crate::store::links::LinkState::Learning], 14.0, 1_000, 0.0, 10)
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!((out[0].weight - 2.0).abs() < 1e-6);
+        // The passage's own row is still there — dark, because its endpoint is superseded.
+        assert_eq!(core.store.links_touching(&passages[1].id).await.unwrap().len(), 1);
+        let from_passage = core
+            .store
+            .links_from(&[passages[1].id.clone()], &[crate::store::links::LinkState::Learning], 14.0, 1_000, 0.0, 10)
+            .await
+            .unwrap();
+        assert!(from_passage.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_re_run_under_keep_artifacts_writes_nothing_twice() {
+        let (core, corpus, _passages, written) = promoted_fixture().await;
+        // `write_segment_artifacts` with keep set and non-passage rows already
+        // present returns those rows and inserts none.
+        let again = crate::jobs::window::write_segment_artifacts(
+            &core, &corpus, 0,
+            vec![crate::store::artifacts::NewArtifact { ordinal: 0, text: "dup".into(), corpus_span: None, title: None, category: None, tags: vec![], segment_idx: Some(0), caveats: vec![] }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(again.iter().map(|c| c.id.clone()).collect::<Vec<_>>(), written.iter().map(|c| c.id.clone()).collect::<Vec<_>>());
+        assert_eq!(core.store.artifacts_for_segment(&corpus, 0).await.unwrap().len(), 5);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib jobs::promote 2>&1 | grep -E "^error" | head -3`
+
+- [ ] **Step 3: Implement**
+
+In `src/jobs/promote.rs`:
+
+```rust
+use crate::store::artifacts::{Chunk, CorpusSpan};
+
+fn overlap(a: &CorpusSpan, b: &CorpusSpan) -> i64 {
+    (a.end_line.min(b.end_line) - a.start_line.max(b.start_line) + 1).max(0)
+}
+
+/// Which artifact, if any, supersedes each passage: the one whose span covers
+/// a **majority** of the passage's lines — per artifact, not cumulative,
+/// because `supersede` names one winner and a passage hidden behind an
+/// artifact holding a third of it sends the reader to the wrong text. Best
+/// overlap wins; a tie goes to the lowest ordinal. Everything else stays
+/// active, verbatim, in results: promotion can only ever improve coverage.
+pub fn covered_by<'a>(
+    passages: &'a [(String, CorpusSpan)],
+    artifacts: &'a [(String, i64, CorpusSpan)],
+) -> Vec<(&'a str, &'a str)> {
+    let mut out = Vec::new();
+    for (pid, ps) in passages {
+        let len = ps.end_line - ps.start_line + 1;
+        let best = artifacts
+            .iter()
+            .map(|(aid, ord, asp)| (overlap(ps, asp), *ord, aid.as_str()))
+            .filter(|(ov, _, _)| 2 * ov > len)
+            .max_by(|x, y| x.0.cmp(&y.0).then(y.1.cmp(&x.1)));
+        if let Some((_, _, aid)) = best {
+            out.push((pid.as_str(), aid));
+        }
+    }
+    out
+}
+
+/// After a promoted window's artifacts are written: supersede the passages
+/// they cover and carry the passages' access forward.
+///
+/// Activation first, links second, the supersede last — `supersede` refuses a
+/// side that is no longer active, and everything before it needs the passage
+/// readable. Returns how many passages were superseded.
+pub async fn supersede_covered(
+    core: &Core,
+    corpus_id: &str,
+    idx: i64,
+    written: &[Chunk],
+    at: i64,
+) -> Result<usize> {
+    let rows = core.store.artifacts_for_segment(corpus_id, idx).await?;
+    let passages: Vec<(String, CorpusSpan)> = rows
+        .iter()
+        .filter(|c| c.provenance == Provenance::Passage && c.in_results())
+        .filter_map(|c| Some((c.id.clone(), c.corpus_span.clone()?)))
+        .collect();
+    let artifacts: Vec<(String, i64, CorpusSpan)> = written
+        .iter()
+        .filter_map(|c| Some((c.id.clone(), c.ordinal, c.corpus_span.clone()?)))
+        .collect();
+    let pairs = covered_by(&passages, &artifacts);
+    if pairs.is_empty() {
+        return Ok(0);
+    }
+    let half_life = core.activation.half_life_days;
+    let link_half_life = core.associate.half_life_days;
+
+    // Group by winner: one artifact may supersede several passages, and its
+    // activation is the max over all of them.
+    let mut by_winner: std::collections::BTreeMap<&str, Vec<&str>> = Default::default();
+    for (p, a) in &pairs {
+        by_winner.entry(a).or_default().push(p);
+    }
+    let all_superseded: std::collections::HashSet<&str> = pairs.iter().map(|(p, _)| *p).collect();
+    let mut n = 0;
+    for (winner, losers) in by_winner {
+        let ids: Vec<String> = losers.iter().map(|s| s.to_string()).collect();
+        let act = core.store.activation_of(&ids).await?;
+        let carried = act
+            .values()
+            .map(|(v, s)| crate::store::links::decayed(*v, *s, at, half_life))
+            .fold(f64::MIN, f64::max);
+        if carried.is_finite() && carried > f64::MIN {
+            let own = core
+                .store
+                .activation_of(std::slice::from_ref(&winner.to_string()))
+                .await?
+                .get(winner)
+                .map(|(v, s)| crate::store::links::decayed(*v, *s, at, half_life))
+                .unwrap_or(1.0);
+            core.store.set_activation(winner, carried.max(own), at).await?;
+        }
+        for loser in &losers {
+            for link in core.store.links_touching(loser).await? {
+                let other = if link.a_id == *loser { &link.b_id } else { &link.a_id };
+                // A link between two passages of this same promotion would
+                // become the artifact linked to itself — or to a passage about
+                // to go dark. Neither carries anything.
+                if all_superseded.contains(other.as_str()) {
+                    continue;
+                }
+                core.store.carry_link(&link, loser, winner, link_half_life, at).await?;
+            }
+        }
+        for loser in &losers {
+            if crate::jobs::try_supersede(core, loser, winner, "a passage its promotion covers").await {
+                n += 1;
+            }
+        }
+    }
+    Ok(n)
+}
+```
+
+`src/jobs/window.rs` `write_segment_artifacts`: after reading `keep`:
+
+```rust
+    if keep {
+        // A promotion re-run: the process died between the insert and `done`.
+        // Under `keep_artifacts` the write appends, so writing again would put
+        // the window's artifacts in twice. Rows this window already holds that
+        // are not passages are the earlier write; return them and insert none.
+        let have: Vec<_> = core
+            .store
+            .artifacts_for_segment(corpus_id, segment_idx)
+            .await?
+            .into_iter()
+            .filter(|c| c.provenance != crate::store::artifacts::Provenance::Passage && c.in_results())
+            .collect();
+        if !have.is_empty() {
+            tracing::info!(corpus_id, window = segment_idx, "window already written under keep_artifacts; not writing again");
+            return Ok(have);
+        }
+    }
+```
+
+(Note this changes the operator-reread semantics slightly: a re-read of a window that already has artifacts and `keep=1` now returns the existing rows rather than appending a second read. That is what `keep` promotion needs; for the reread button the model's new artifacts *are* the point. Distinguish: promotion sets `keep`, reread sets `keep` too. Check `reread_uncovered_ui` — it calls `reset_segment(.., true)`. To keep that path appending: gate the early return on **the window being a promotion**, i.e. `rows.iter().any(|c| c.provenance == Passage)`. A reread window has no passages (eager base), so it still appends.) Make the filter: `let is_promotion = rows.iter().any(passage)`, `if is_promotion && !have.is_empty() { return Ok(have) }`.
+
+`run`'s tail (`window.rs:185-191`):
+
+```rust
+    let keep = core.store.segment_keeps_artifacts(corpus_id, idx).await?;
+    let written =
+        write_segment_artifacts(core, corpus_id, idx, proposed_to_new(idx, chunks)).await?;
+    flag_unverified(core, &written, &text).await?;
+    if keep {
+        // A promotion: what the window's artifacts cover, they supersede, and
+        // the passages' access comes with them. Under the corpus lock as a
+        // second locked step — `write_segment_artifacts` took and released it.
+        let _corpus = core.corpus_lock(corpus_id).await;
+        let n = crate::jobs::promote::supersede_covered(core, corpus_id, idx, &written, crate::store::now())
+            .await?;
+        tracing::info!(corpus_id, window = idx, superseded = n, "promotion superseded its covered passages");
+    }
+    core.store
+        .set_segment_state(corpus_id, idx, SegmentState::Done, None)
+        .await?;
+```
+
+(`crate::store::now()` — check the name of the unix-seconds helper the store uses (`now()` in `artifacts.rs`); use whatever `mark_seen` uses: `now_secs()` in `core`.)
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -5`
+
+```bash
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: a promotion supersedes what it covers and keeps the access the passages earned"
+```
+
+---
+
+### Task 5: Undo
+
+**Files:**
+- Modify: `src/core/ingest.rs` (new `undo_promotion`, near `unsupersede`), `src/web/ui.rs` (route + `CorpusTemplate.promoted`), `src/web/templates/corpus.html`
+- Test: `src/core/ingest.rs`, `src/web/ui.rs` `mod tests`
+
+**Interfaces:**
+- Produces: `pub async fn undo_promotion(&self, corpus_id: &str, idx: i64) -> Result<()>` on `Core`; route `POST /ui/corpora/{id}/segments/{idx}/unpromote`; `CorpusTemplate.promoted: Vec<PromotedWindow { idx: i64, from: i64, to: i64 }>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/core/ingest.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn undoing_a_promotion_restores_the_passages_deprecates_the_artifacts_and_resets_the_window() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("l1\nl2", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[crate::store::segments::NewSegment { start_line: 1, end_line: 2, text: "l1\nl2", carry_lines: 0 }])
+            .await
+            .unwrap();
+        let na = |o: i64, t: &str| crate::store::artifacts::NewArtifact {
+            ordinal: o, text: t.into(), corpus_span: Some(crate::store::artifacts::CorpusSpan { start_line: 1, end_line: 2 }),
+            title: None, category: None, tags: vec![], segment_idx: Some(0), caveats: vec![],
+        };
+        let p = core.store.insert_artifacts_with_provenance(&src.id, &[na(0, "passage")], crate::store::artifacts::Provenance::Passage).await.unwrap();
+        let a = core.store.insert_artifacts(&src.id, &[na(1, "artifact")]).await.unwrap();
+        core.supersede(&p[0].id, &a[0].id).await.unwrap();
+        core.store.set_segment_state(&src.id, 0, crate::store::segments::SegmentState::Done, None).await.unwrap();
+
+        core.undo_promotion(&src.id, 0).await.unwrap();
+
+        assert!(core.store.get_artifact(&p[0].id).await.unwrap().in_results());
+        assert_eq!(core.store.get_artifact(&a[0].id).await.unwrap().status, crate::store::artifacts::ArtifactStatus::Deprecated);
+        assert_eq!(core.store.segment_state(&src.id, 0).await.unwrap(), Some(crate::store::segments::SegmentState::Verbatim));
+    }
+```
+
+`src/web/ui.rs` `mod tests`: a test that builds the same fixture through a core, renders `/ui/corpora/{id}`, asserts the page contains `segments/0/unpromote`, POSTs it with the `form` helper, and asserts the redirect (303/302) and that the passage is active again.
+
+- [ ] **Step 2: Run to verify failure** — `undo_promotion` not found.
+
+- [ ] **Step 3: Implement**
+
+`src/core/ingest.rs`, after `unsupersede`:
+
+```rust
+    /// Put a promoted window back: its passages active, the artifacts the
+    /// promotion wrote deprecated, the segment `verbatim` again so it may
+    /// promote afresh. The links copied onto the artifacts and the activation
+    /// they were handed stay where they are — both sides describe the same
+    /// corpus lines, and the asymmetry is accepted rather than fixed.
+    pub async fn undo_promotion(&self, corpus_id: &str, idx: i64) -> Result<()> {
+        let rows = self.store.artifacts_for_segment(corpus_id, idx).await?;
+        for c in rows.iter().filter(|c| c.provenance == Provenance::Passage && c.superseded_by.is_some()) {
+            self.unsupersede(&c.id).await?;
+        }
+        for c in rows.iter().filter(|c| c.provenance != Provenance::Passage && c.in_results()) {
+            self.deprecate(&c.id).await?;
+        }
+        self.store
+            .set_segment_state(corpus_id, idx, SegmentState::Verbatim, None)
+            .await?;
+        tracing::info!(corpus_id, window = idx, "promotion undone");
+        Ok(())
+    }
+```
+
+(`unsupersede` refuses nothing; `deprecate` refuses a superseded row — the filter above avoids that. Import `Provenance`/`SegmentState` as the file does.)
+
+UI: `CorpusTemplate` gains `promoted: Vec<PromotedWindow>` (`pub struct PromotedWindow { pub idx: i64, pub from: i64, pub to: i64 }`), computed in `corpus_detail` as every segment whose state is `Done` and that owns at least one `Passage` row with `superseded_by` set:
+
+```rust
+    let promoted: Vec<PromotedWindow> = segments
+        .iter()
+        .filter(|w| w.state == crate::store::segments::SegmentState::Done)
+        .filter(|w| chunks.iter().any(|c| c.segment_idx == Some(w.idx) && c.provenance == crate::store::artifacts::Provenance::Passage && c.superseded_by.is_some()))
+        .map(|w| PromotedWindow { idx: w.idx, from: w.start_line, to: w.end_line })
+        .collect();
+```
+
+Route: `.route("/ui/corpora/{id}/segments/{idx}/unpromote", post(unpromote_ui))` with
+
+```rust
+async fn unpromote_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path((cid, idx)): Path<(String, i64)>,
+) -> Result<Response> {
+    st.core.undo_promotion(&cid, idx).await?;
+    Ok(Redirect::to(&format!("/ui/corpora/{cid}")).into_response())
+}
+```
+
+`corpus.html`, before the bands include:
+
+```html
+{% if !promoted.is_empty() %}
+<p class="muted">
+  {# A window synthesis has read because its passages were read. Undo puts
+     the verbatim text back in results and retires what was written. #}
+  Promoted:
+  {% for w in promoted %}
+  <form method="post" action="/ui/corpora/{{ id }}/segments/{{ w.idx }}/unpromote" style="display:inline">
+    lines {{ w.from }}–{{ w.to }}
+    <button class="btn btn-ghost btn-sm" type="submit">undo</button>
+  </form>
+  {% endfor %}
+</p>
+{% endif %}
+```
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -3
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: a promotion can be undone — passages back, artifacts retired, window verbatim"
+```
+
+---
+
+### Task 6: Re-synthesis at `eager` (ships disabled)
+
+**Files:**
+- Modify: `src/jobs/promote.rs` (`maybe_resynthesize`), `src/core/search.rs:385-401` (`mark_seen`)
+- Test: `src/jobs/promote.rs` `mod tests`
+
+**Interfaces:**
+- Produces: `pub async fn maybe_resynthesize(core: &Core, hits: &[(String, i64)] /* (artifact_id, hit_count after this retrieval) */) -> Result<usize>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn an_eager_artifact_shown_often_and_never_confirmed_is_re_read_from_its_segment_when_enabled() {
+        let mut core = test_core().await;
+        core.promote.resynthesize_after_unconfirmed = 3;
+        let src = core.store.insert_corpus("l1\nl2", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[crate::store::segments::NewSegment { start_line: 1, end_line: 2, text: "l1\nl2", carry_lines: 0 }])
+            .await
+            .unwrap();
+        core.store.set_segment_state(&src.id, 0, SegmentState::Done, None).await.unwrap();
+        let a = core.store.insert_artifacts(&src.id, &[crate::store::artifacts::NewArtifact {
+            ordinal: 0, text: "artifact".into(), corpus_span: None, title: None, category: None,
+            tags: vec![], segment_idx: Some(0), caveats: vec![],
+        }]).await.unwrap()[0].id.clone();
+        // Under the line: nothing.
+        assert_eq!(maybe_resynthesize(&core, &[(a.clone(), 2)]).await.unwrap(), 0);
+        // At the line, unconfirmed: the window is re-armed to *replace*.
+        assert_eq!(maybe_resynthesize(&core, &[(a.clone(), 3)]).await.unwrap(), 1);
+        assert_eq!(core.store.segment_state(&src.id, 0).await.unwrap(), Some(SegmentState::Pending));
+        assert!(!core.store.segment_keeps_artifacts(&src.id, 0).await.unwrap(), "replace, not append: the old artifacts are the problem");
+        assert!(core.store.live_job(Stage::SegmentWindow, &unit(&src.id)).await.unwrap());
+        // Disabled (0) never fires.
+        core.promote.resynthesize_after_unconfirmed = 0;
+        core.store.set_segment_state(&src.id, 0, SegmentState::Done, None).await.unwrap();
+        assert_eq!(maybe_resynthesize(&core, &[(a.clone(), 99)]).await.unwrap(), 0);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// The `eager` counterpart of promotion: an artifact shown
+/// `resynthesize_after_unconfirmed` times with no confirmation recorded
+/// against it is misleading, and is re-synthesised from its source segment —
+/// never from itself. `keep_artifacts = 0`: replace, because the old artifacts
+/// are the problem. `0` disables it and it ships disabled.
+pub async fn maybe_resynthesize(core: &Core, hits: &[(String, i64)]) -> Result<usize> {
+    let line = core.promote.resynthesize_after_unconfirmed;
+    if line <= 0 || core.synthesis != crate::config::SynthesisMode::Eager || !core.synthesizes() {
+        return Ok(0);
+    }
+    let mut armed = 0;
+    for (id, count) in hits {
+        if *count < line {
+            continue;
+        }
+        let Ok(c) = core.store.get_artifact(id).await else { continue };
+        if c.provenance != Provenance::Captured || !c.in_results() {
+            continue;
+        }
+        let (Some(corpus_id), Some(idx)) = (c.corpus_id.as_deref(), c.segment_idx) else { continue };
+        if core.store.segment_state(corpus_id, idx).await? != Some(SegmentState::Done) {
+            continue;
+        }
+        if core.store.artifact_confirmed(id).await? {
+            continue;
+        }
+        core.store.reset_segment(corpus_id, idx, false).await?;
+        core.store
+            .rearm_idle_seq(Stage::SegmentWindow, "segment", &crate::jobs::window::unit_target(corpus_id, idx), idx)
+            .await?;
+        tracing::info!(artifact_id = %id, corpus_id, window = idx, shown = count, "re-synthesising an unconfirmed window");
+        armed += 1;
+    }
+    Ok(armed)
+}
+```
+
+`mark_seen` (`search.rs`): where it spawns the retrieved bump, also (only when `self.promote.resynthesize_after_unconfirmed > 0`, so the disabled path costs nothing) collect `(artifact_id, hit_counts[id] + 1)` for the results and call `maybe_resynthesize` in the same background task after the bump. The bump site stays retrieval-only for promotion.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -3
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: an eager artifact shown often and never confirmed can be re-read — off by default"
+```
+
+---
+
+### Task 7: Consolidation — one exclusion, and the hide becomes a fast lane
+
+**Files:**
+- Modify: `src/jobs/relate.rs:116-135` (`classify_pair`), `src/jobs/consolidate.rs:1-31` (header)
+- Test: `src/jobs/relate.rs`, `src/jobs/consolidate.rs` `mod tests` (update `a_near_identical_pair_supersedes_the_older_artifact`, `the_cluster_pass_settles_a_pair_the_relate_unit_filed`, `a_pair_the_cluster_pass_answered_stops_occupying_the_window`)
+
+- [ ] **Step 1: Write/rewrite the tests**
+
+`src/jobs/relate.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn two_rows_from_one_window_are_never_a_pair() {
+        // A promoted artifact and the passage it left standing in the same
+        // window look like a duplicate pair and are not one: overlap inside a
+        // window is the window job's decision, already made.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let na = |o: i64, t: &str, seg: i64| crate::store::artifacts::NewArtifact {
+            ordinal: o, text: t.into(), corpus_span: None, title: Some("same heading".into()),
+            category: None, tags: vec![], segment_idx: Some(seg), caveats: vec![],
+        };
+        let same = core.store.insert_artifacts(&src.id, &[na(0, "mount the disk first", 0), na(1, "mount the disk, first", 0)]).await.unwrap();
+        let other = core.store.insert_artifacts(&src.id, &[na(2, "mount the disk first please", 1)]).await.unwrap();
+        for c in same.iter().chain(other.iter()) {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        run(&core, &same[0].id).await.unwrap();
+        let pending = core.store.pairs_by_state(PairState::Pending, 10).await.unwrap();
+        assert!(
+            !pending.iter().any(|p| (p.a_id == same[0].id && p.b_id == same[1].id) || (p.a_id == same[1].id && p.b_id == same[0].id)),
+            "same-window pair was filed: {pending:?}"
+        );
+        // Across windows of the same corpus a pair is still a question.
+        assert!(
+            pending.iter().any(|p| p.a_id == other[0].id || p.b_id == other[0].id),
+            "cross-window pair not filed: {pending:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_above_auto_supersede_is_filed_for_the_judge_not_hidden() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("the same words", [1.0, 0.0]), ("the same words", [1.0, 0.0])]).await;
+        run(&core, &ids[1]).await.unwrap();
+        // Nobody is hidden…
+        assert!(core.store.get_artifact(&ids[0]).await.unwrap().in_results());
+        assert!(core.store.get_artifact(&ids[1]).await.unwrap().in_results());
+        // …and the pair is pending, first in line by score.
+        let to_judge = core.store.pairs_to_judge(10).await.unwrap();
+        assert_eq!(to_judge.len(), 1);
+        assert!(core.store.pairs_by_state(PairState::NearIdentical, 10).await.unwrap().is_empty());
+    }
+```
+
+(The `seed` helper lives in `consolidate.rs` tests and is already imported by `relate.rs` tests; the `same words` vectors give cosine 1.0 — with the FakeEmbedder this fixture may need `embed::run` instead; read `seed` to see whether it upserts vectors directly. Use whichever gives a score ≥ `auto_supersede` — `seed` takes explicit vectors, so it does.)
+
+`consolidate.rs`: rewrite `a_near_identical_pair_supersedes_the_older_artifact` to assert the opposite — after `sweep_and_dedupe`, nothing is superseded *by the cluster pass* and a dedupe unit was armed for the pair (rename it `a_near_identical_pair_goes_to_the_judge_first`). The two cluster-pass tests that file `NearIdentical` rows by hand (`record_settled_pair(.., NearIdentical)`) still pass: the pass still closes rows that already exist — keep them, adding a comment that no new row is filed that way.
+
+- [ ] **Step 2: Run to verify failure**
+
+- [ ] **Step 3: Implement**
+
+`classify_pair` (`relate.rs:116`): replace the free-band branch
+
+```rust
+    // The free band. Filed, not acted on: …
+    if score >= core.consolidate.auto_supersede {
+        core.store
+            .record_settled_pair(&a.id, &b.id, score, PairState::NearIdentical)
+            .await?;
+        return Ok(false);
+    }
+```
+
+with, placed right after the `in_results` guard:
+
+```rust
+    // Two rows from one window are not a pair. Neighbours under one heading
+    // are similar for how they were built, not for what they say; and a
+    // promoted artifact beside the passage it left standing is the window
+    // job's decision — the majority rule — already made. Sending that pair to
+    // the judge would spend a call to merge, and so hide behind model text,
+    // exactly the verbatim passage promotion just decided to keep.
+    if a.corpus_id.is_some()
+        && a.corpus_id == b.corpus_id
+        && a.segment_idx.is_some()
+        && a.segment_idx == b.segment_idx
+    {
+        return Ok(false);
+    }
+```
+
+and nothing at all for `auto_supersede` — the pair falls through the containment check to `record_pair`, where `pairs_to_judge`'s `ORDER BY score DESC` puts it first. Keep `auto_supersede` in `ConsolidateConfig` (validated above `review_min` as today) and reword its doc comment: "No longer a hide. A pair at or above it is judged first — a fast lane — and the judge's `losses` check stands behind the decision, because embeddings barely distinguish negation and 'runs on ext4' / 'does not run on ext4' sit far above any realistic threshold." Update the `consolidate.rs` header paragraph "Two thresholds still divide the work…" to say the same.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -3
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: consolidation judges instead of hiding, and never pairs two rows of one window"
+```
+
+---
+
+### Task 8: Origins — derived, not stored
+
+**Files:**
+- Modify: `src/store/lineage.rs` (`Origin`, `origins_of`), `src/vector/mod.rs` (`origin_corpora`), `src/jobs/embed.rs` (`payload_of` → async origins for model-written rows), `src/core/search.rs` (`cap_per_corpus`), `src/store/links.rs` (`links_from` `cross_corpus`, `links_to_judge`), `src/web/ui.rs` + `corpus.html` ("written from this corpus")
+- Test: each `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[derive(Debug, Clone, PartialEq)] pub struct Origin { pub corpus_id: String, pub span: Option<CorpusSpan> }
+  impl Store { pub async fn origins_of(&self, ids: &[String]) -> Result<BTreeMap<String, Vec<Origin>>>; pub async fn artifacts_originating_in(&self, corpus_id: &str) -> Result<Vec<Chunk>> /* model-written rows with a root in this corpus */ }
+  pub struct VectorPayload { /* … */ #[serde(default, skip_serializing_if = "Vec::is_empty")] pub origin_corpora: Vec<String> }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/store/lineage.rs` `mod tests` (there is a helper that inserts a merged artifact with sources — `insert_merged`; read the existing merge test at `:398` and reuse its shape):
+
+```rust
+    #[tokio::test]
+    async fn origins_of_a_merge_are_its_roots_corpora_and_spans() {
+        let s = Store::memory().await.unwrap();
+        let c1 = s.insert_corpus("one", "web", None).await.unwrap();
+        let c2 = s.insert_corpus("two", "web", None).await.unwrap();
+        let na = |t: &str, a: i64, b: i64| crate::store::artifacts::NewArtifact {
+            ordinal: 0, text: t.into(), corpus_span: Some(crate::store::artifacts::CorpusSpan { start_line: a, end_line: b }),
+            title: None, category: None, tags: vec![], segment_idx: Some(0), caveats: vec![],
+        };
+        let r1 = s.insert_artifacts(&c1.id, &[na("r1", 1, 3)]).await.unwrap()[0].id.clone();
+        let r2 = s.insert_artifacts(&c2.id, &[na("r2", 7, 9)]).await.unwrap()[0].id.clone();
+        let m = /* insert a merged artifact with roots r1, r2 — the helper the merge tests use */;
+        let o = s.origins_of(&[m.id.clone(), r1.clone()]).await.unwrap();
+        let mut got: Vec<(String, Option<i64>)> = o[&m.id].iter().map(|x| (x.corpus_id.clone(), x.span.as_ref().map(|sp| sp.start_line))).collect();
+        got.sort();
+        assert_eq!(got, vec![(c1.id.clone(), Some(1)), (c2.id.clone(), Some(7))]);
+        assert_eq!(o[&r1], vec![Origin { corpus_id: c1.id.clone(), span: Some(crate::store::artifacts::CorpusSpan { start_line: 1, end_line: 3 }) }]);
+        // Every active artifact has at least one origin.
+        assert!(o.values().all(|v| !v.is_empty()));
+        // And the corpus page can find the merge.
+        let from_c2 = s.artifacts_originating_in(&c2.id).await.unwrap();
+        assert_eq!(from_c2.iter().map(|c| c.id.clone()).collect::<Vec<_>>(), vec![m.id.clone()]);
+    }
+```
+
+`src/core/search.rs` `mod tests`: extend the existing `cap_per_corpus` tests (`:1525`) with a hit whose payload has `corpus_id: ""` and `origin_corpora: vec!["a", "b"]` and assert it counts against both `a` and `b`.
+
+`src/store/links.rs`: a test that a link between a merged artifact (roots in corpus 1) and a captured artifact in corpus 1 reads `cross_corpus == false` from `links_from`, and that `links_to_judge` does not offer it (same-corpus) while a link to corpus 2 is offered.
+
+`src/web/ui.rs`: the corpus page of `c2` lists the merge under a "Written from this corpus" heading.
+
+- [ ] **Step 2: Run to verify failure**
+
+- [ ] **Step 3: Implement**
+
+`lineage.rs`:
+
+```rust
+/// Where an artifact comes from, as corpus and lines. Derived from lineage,
+/// never stored: membership *is* lineage projected, so it cannot drift.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Origin {
+    pub corpus_id: String,
+    pub span: Option<CorpusSpan>,
+}
+
+impl Store {
+    /// Mirror of `roots_of`, one step further: every root's corpus and span.
+    /// A passage or captured artifact is its own origin; a merged or
+    /// synthesized one has one origin per root. Non-empty for every active
+    /// artifact — an empty answer is the same broken state `roots_of` reports.
+    pub async fn origins_of(&self, ids: &[String]) -> Result<BTreeMap<String, Vec<Origin>>> {
+        let roots = self.roots_of(ids).await?;
+        let mut all: Vec<String> = roots.values().flatten().cloned().collect();
+        all.sort();
+        all.dedup();
+        let rows = self.artifacts_by_ids(&all).await?;
+        let by_id: std::collections::HashMap<&str, &Chunk> = rows.iter().map(|c| (c.id.as_str(), c)).collect();
+        let mut out = BTreeMap::new();
+        for (id, rs) in roots {
+            let mut o: Vec<Origin> = rs
+                .iter()
+                .filter_map(|r| by_id.get(r.as_str()))
+                .filter_map(|c| Some(Origin { corpus_id: c.corpus_id.clone()?, span: c.corpus_span.clone() }))
+                .collect();
+            o.sort_by(|a, b| (a.corpus_id.as_str(), a.span.as_ref().map(|s| s.start_line)).cmp(&(b.corpus_id.as_str(), b.span.as_ref().map(|s| s.start_line))));
+            out.insert(id, o);
+        }
+        Ok(out)
+    }
+
+    /// Model-written artifacts with a root in this corpus: what the corpus
+    /// page lists as written from it.
+    pub async fn artifacts_originating_in(&self, corpus_id: &str) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT DISTINCT m.* FROM artifacts m
+               JOIN artifact_sources s ON s.child_id = m.id
+               JOIN artifacts r ON r.id = s.root_id
+              WHERE r.corpus_id = ? AND m.provenance IN ('merged', 'synthesized')
+              ORDER BY m.created_at",
+        )
+        .bind(corpus_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(crate::store::artifacts::row_to_artifact).collect())
+    }
+}
+```
+
+`vector/mod.rs`: add to `VectorPayload`
+
+```rust
+    /// Every corpus this artifact draws from — one for a passage or captured
+    /// row, several for a merge. A projection of `artifact_sources`, the way
+    /// `status` is a projection of the row; SQLite stays the authority.
+    /// `cap_per_corpus` groups on it, so a merge counts against each of its
+    /// corpora instead of all merges landing under one empty key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub origin_corpora: Vec<String>,
+```
+
+and `origin_corpora: vec![]` in every literal (`grep -rn "VectorPayload {" src tests`). `embed.rs` `payload_of` stays sync and sets `origin_corpora: vec![]`; `embed_batch` (and the two single-point paths) fill it afterwards: `let origins = core.store.origins_of(&ids).await?;` then for each point `payload.origin_corpora = origins[id].iter().map(|o| o.corpus_id.clone()).collect::<BTreeSet<_>>().into_iter().collect()`. Passages/captured get their own corpus; that is fine and makes the field uniform.
+
+`search.rs` `cap_per_corpus`: the key is `origin_corpora` when non-empty, else `corpus_id`; a hit with several origins increments each and is kept only if every one is under the cap:
+
+```rust
+        let keys: Vec<String> = if h.payload.origin_corpora.is_empty() { vec![h.payload.corpus_id.clone()] } else { h.payload.origin_corpora.clone() };
+        let over = keys.iter().any(|k| seen.get(k).copied().unwrap_or(0) >= max);
+        for k in &keys { *seen.entry(k.clone()).or_insert(0) += 1; }
+        if !over { kept.push(h) } else { displaced.push(h) }
+```
+
+`links.rs` `links_from`: compute `cross_corpus` in Rust over `origins_of` for both endpoints — "intersection empty" — instead of `a.corpus_id`/`b.corpus_id` from SQL (keep the SQL columns, use them only when both rows have a `corpus_id` and are source text; otherwise resolve through origins — one batched `origins_of` over all endpoints after the loop). `links_to_judge`: drop the `a.corpus_id <> b.corpus_id` clause from the SQL, fetch 4× limit as before, and filter in Rust with the same intersection test; its doc comment changes accordingly.
+
+UI: `CorpusTemplate.written_from: Vec<ArtifactView>` from `artifacts_originating_in`, rendered after `unplaced` in `corpus.html` under `<h3>Written from this corpus</h3>` with `{% for c in written_from %}{% include "_artifact.html" %}{% endfor %}`.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cargo test 2>&1 | grep -E "^test result|FAILED|panicked" | head -3
+cargo fmt && cargo clippy --all-targets 2>&1 | grep -cE "^(warning|error)"
+git add -A src
+git commit -m "feat: an artifact belongs to every corpus it drew from — derived, never stored"
+```
+
+---
+
+### Task 9: Docs and the gate
+
+- [ ] `config.example.toml`: a `[promote]` block after `[activation]` (find it) with the two keys and their comments from the spec; in `[feedback]` the comment says "On by default: promotion reads activation…" and shows `enabled = true`. `README.md` config table: `promote.*` row; `feedback.*` row says "On by default".
+- [ ] Gate: `cargo fmt --check`, clippy 0, `cargo test`, `cargo test --test eval`.
+- [ ] Commit `docs: promotion, and recording on by default` and `git push`.
+
+---
+
+## Self-review
+
+**Spec coverage:** §3 trigger (threshold, `>=`, engagement sites, checked at the bump) → Task 3; "activation must actually move" → Task 1; mechanics 1–4 (`verbatim→pending`, keep, arm, supersede under lock, settle→finish) → Tasks 3–4 (finish runs because every other segment is `verbatim` — plan 2); idempotency → Task 4; majority rule per artifact → Task 4 `covered_by`; eager re-synthesis → Task 6; carrying access (max activation, links copied, collisions, what does not carry) → Tasks 2, 4 — `hit_count`/`last_seen_at`/judged pairs are simply not touched; undo → Task 5; tests list in §3 → spread across Tasks 3–5 (each named bullet has a test). §6: exclusion by segment → Task 7; `auto_supersede` fast lane → Task 7; merge guards untouched → nothing to do; "dormant until use" → plan 2 already keeps passages out of relate. §7: `origins_of`, invariant, five call sites, payload → Task 8; corpus detail page, bands ("parent spans stay claimed" already holds because superseded rows keep their spans on the page — verified in plan 2 reading), `cross_corpus`, `links_to_judge`, `cap_per_corpus` → Task 8.
+
+**Gaps recorded:** the server-side grouping (`query/groups`) from §5 remains unbuilt; `cap_per_corpus` over origins is the in-memory fallback the spec names. The "before and after shown on Ops" for eager re-synthesis (§3 table) is not built — the log line is; Ops rendering can follow when the detector is turned on.
+
+**Placeholder scan:** Task 2's `artifact_confirmed` test and Task 8's merge-insert test name helpers the executor must find (`seed_search_event` to be written from the feedback store's API; the merge-insert helper in `lineage.rs` tests) — both have a pointer to the real API. Task 5's UI test is described rather than written out; it follows the `form`/`get_body` pattern of the other UI tests in the file. Acceptable for an inline executor with the file open; a subagent should be handed those two helpers explicitly.
+
+**Type consistency:** `maybe_promote(core, &[String], at) -> Result<usize>` used identically in Tasks 3 (search.rs, associate.rs). `supersede_covered(core, corpus_id, idx, &[Chunk], at)` defined and called with the same shape in Task 4. `carry_link(&Link, old, new, half_life, at)` (Task 2) is what Task 4 calls. `Origin { corpus_id, span }` (Task 8) is used in its own tests only.

--- a/docs/superpowers/plans/2026-08-19-pursuits.md
+++ b/docs/superpowers/plans/2026-08-19-pursuits.md
@@ -1,0 +1,284 @@
+# Pursuits Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When several artifacts jointly served one need and the base did not answer it — or the operator assembled an answer by moving between them — write one artifact that stands alone, carrying the questions it was written for, superseding nothing, and stop the loop the moment the base answers.
+
+**Architecture:** What happens after a result list renders is recorded in `interaction_events` (opened / pivoted, scoped to the person); searches and asks are already recorded. A sweep (`jobs::pursuit`) runs when everything unprocessed has been idle for `idle_secs`, clusters the query vectors at `gaps::link_threshold`, scores engagement, decides per the spec's eight steps, and arms `Stage::Generate` for a pursuit row. The generation job makes one call on the synthesize endpoint (`Core.generator`), writes a `synthesized` artifact with `cues` and lineage through `via_id`, and arms its embed. A `search_events.answered` flag set at result assembly is the stopping rule; a root-subset check against existing generations is the second anchor.
+
+**Tech Stack:** Rust 2024, sqlx/SQLite, askama, the job queue, `core::gaps` clustering. No new crates.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md` §4 (Pursuits), §5 "Ask at `earned`: two roles", §8 (pursuit view gated), §9 (`synthesized` provenance — enum exists from plan 2).
+
+## Global Constraints
+
+- Config, verbatim: `[pursuit] enabled = false`, `idle_secs = 900`, `min_sources = 2`, `min_engagement = 3.0`. No `coherence` key — the grouping line is `link_threshold()`. `pursuit.enabled = true` requires `feedback.enabled = true` (startup error).
+- Engagement weights: `opened 1.0`, `pivoted 1.5`, `returned 2.0`, `confirmed 3.0`, `dwell ≤ 0.5` (not recorded by this plan — no timing exists in the UI; documented as a gap), `refined`/`abandoned` carry no weight.
+- `confirmed` is read from `search_events.expect_id`/`verdict`, not stored again.
+- Stopping rule: a `synthesized` artifact at **final** rank 1, at or above `weak_below`, marks the search event `answered`; no interaction events are recorded for it; any pursuit containing it closes `satisfied`. The search event itself is still recorded.
+- Second anchor: a pursuit whose roots ⊆ an existing active `synthesized` artifact's roots does not generate; closes `satisfied` naming it.
+- The analysis pass: local, no inference, eight steps as the spec lists them (answered → engagement → assembled → unsatisfied → wanted-as-a-whole → root-subset → generate / close with reason). One engaged artifact → promotion (`maybe_promote`), not generation.
+- Generation: one call; in = queries + full text of engaged artifacts whatever their provenance; out = a normal artifact, `provenance = 'synthesized'`, `corpus_id = NULL`, `cues` = the queries; supersedes nothing; `artifact_sources` rows `(child, root, via = engaged artifact)`; `missing_literals` against the sources; embed armed.
+- An ask joins the same pursuit as the searches beside it (its `query_vec` clusters with theirs; its cited excerpts are engaged sources); an abstention closes its pursuit `unsatisfied` immediately.
+- Where it shows: search rail badge (model-written, source count); detail pane "written from" + cues; Ops generated list with one-click deprecate; the forget button clears `interaction_events` and `pursuits`; pursuit view on Ops only when enabled.
+- `cargo fmt`, `clippy` clean, commit style as before.
+
+---
+
+## File structure
+
+| file | responsibility |
+|---|---|
+| `src/config.rs` | `PursuitConfig`, `[pursuit]`, validation |
+| `src/store/schema.sql` | `interaction_events`, `pursuits`, `search_events.answered`, `artifacts.cues` |
+| `src/store/pursuits.rs` (new) | `record_interaction`, `interactions_between`, `insert_pursuit`, `close_pursuit`, `set_pursuit_artifact`, `open_pursuits`, `recent_pursuits`, `purge_pursuits`; `Interaction`, `Pursuit`, `NewPursuit` |
+| `src/store/feedback.rs` | `NewEvent.answered`; `events_between(from, to)` returning `(id, query, query_vec, created_at, answered, verdict/expect_id, scope)`; `purge_feedback` also clears pursuits/interactions |
+| `src/store/asks.rs` | `asks_between(from, to)` with `query_vec`, `abstained`, cited artifact ids, scope |
+| `src/store/artifacts.rs` | `cues` column on `Chunk`; `insert_synthesized_artifact(NewSynthesized, sources, cues)`; `synthesized_artifacts(limit)` |
+| `src/vector/mod.rs`, `src/jobs/embed.rs`, `src/core/search.rs` | `provenance` in the payload; `SearchResult.provenance`; `answered` computed at assembly |
+| `src/core/mod.rs` | `Core.pursuit`, `Core.generator: Option<Arc<dyn Completer>>`, `Core::record_interaction` |
+| `src/infer/openai.rs`, `src/infer/prompt.rs` | `HttpCompleter::for_generating`, `GENERATE_SYSTEM`, `generate_prompt`, `generate_schema`, `parse_generation` |
+| `src/jobs/pursuit.rs` (new) | `run` (the sweep), `generate` (the job), `decide` (pure) |
+| `src/jobs/mod.rs`, `src/store/jobs.rs` | `Stage::Pursuit` (sweep), `Stage::Generate`; dispatch; `needs_model` |
+| `src/core/background.rs` | pursuit ticker |
+| `src/core/ask/mod.rs` | nothing new — `record_ask` already stores what the sweep reads |
+| `src/web/ui.rs`, templates | `?via=` on rail links → pivoted; `opened` on detail; rail badge; cues on detail; Ops generated + pursuits; forget |
+| `config.example.toml`, `README.md` | `[pursuit]` |
+
+---
+
+### Task 1: Config and schema
+
+**Files:** `src/config.rs`, `src/store/schema.sql`, `src/core/mod.rs` (`Core.pursuit`), `tests/eval.rs`, `src/main.rs`
+
+- [ ] **Tests** (`src/config.rs`):
+
+```rust
+    #[test]
+    fn pursuit_defaults_and_requires_feedback() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!("{BARE_PREAMBLE}\n[infer.synthesize]\ntier = \"efficient\"\noutput_ratio = 8.0\n[infer.ask]\ntier = \"efficient\"\n")).unwrap();
+        assert!(!cfg.pursuit.enabled);
+        assert_eq!(cfg.pursuit.idle_secs, 900);
+        assert_eq!(cfg.pursuit.min_sources, 2);
+        assert_eq!(cfg.pursuit.min_engagement, 3.0);
+        let err = load_infer(&format!("{BARE_PREAMBLE}\n[infer.synthesize]\ntier = \"efficient\"\noutput_ratio = 8.0\n[infer.ask]\ntier = \"efficient\"\n[pursuit]\nenabled = true\n[feedback]\nenabled = false\n")).unwrap_err().to_string();
+        assert!(err.contains("pursuit.enabled"), "{err}");
+    }
+```
+
+- [ ] **Implement:**
+
+```rust
+/// What a coherent run of searches — a pursuit — may earn: one generated
+/// artifact, written from what was engaged with, when the base did not answer
+/// or the answer was assembled by hand. Off until turned on: this writes
+/// model-written text into the index, and that is a step an operator takes.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PursuitConfig {
+    pub enabled: bool,
+    /// A pursuit is over when nothing has happened for this long.
+    pub idle_secs: u64,
+    /// Fewer engaged artifacts than this is a promotion case, not generation.
+    pub min_sources: usize,
+    /// Total engagement weight a pursuit needs before it is worth a call.
+    pub min_engagement: f64,
+}
+impl Default for PursuitConfig { fn default() -> Self { Self { enabled: false, idle_secs: 900, min_sources: 2, min_engagement: 3.0 } } }
+```
+
+`Config.pursuit` with `#[serde(default)]`; validate: `if self.pursuit.enabled && !self.feedback.enabled → Err("pursuit.enabled = true needs feedback.enabled = true: the events it reads are the ones recording writes")`. `Core.pursuit: PursuitConfig` in `from_config`, `test_support::build`, `tests/eval.rs`, `src/main.rs` literal.
+
+`schema.sql` additions (after `artifact_links`):
+
+```sql
+-- ── Pursuits ─────────────────────────────────────────────────────────────────
+-- What happened after a result list rendered. Joined to a pursuit through
+-- time and scope at analysis, never by a stored pursuit id: the clustering
+-- decides, and re-clustering never has to rewrite these.
+CREATE TABLE IF NOT EXISTS interaction_events (
+  id          INTEGER PRIMARY KEY,
+  artifact_id TEXT REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- 'opened' | 'pivoted'
+  kind        TEXT NOT NULL,
+  -- The artifact this was reached from, for 'pivoted'.
+  via         TEXT,
+  scope       TEXT,
+  at          INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_interactions_at ON interaction_events(at);
+
+-- A coherent thing that was wanted: its queries, and what came of it.
+CREATE TABLE IF NOT EXISTS pursuits (
+  id           TEXT PRIMARY KEY,
+  opened_at    INTEGER NOT NULL,
+  closed_at    INTEGER,
+  -- open | satisfied | unsatisfied | generated | dismissed
+  state        TEXT NOT NULL DEFAULT 'open',
+  -- Why it closed, in one line. Read on Ops; never parsed.
+  reason       TEXT,
+  -- The clustered queries, JSON. Becomes the artifact's `cues` on generation.
+  queries      TEXT NOT NULL DEFAULT '[]',
+  -- The engaged artifact ids, JSON, in engagement order. What generation reads.
+  sources      TEXT NOT NULL DEFAULT '[]',
+  -- The generated artifact, once there is one.
+  artifact_id  TEXT REFERENCES artifacts(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pursuits_state ON pursuits(state, opened_at);
+```
+
+`search_events` gains `answered INTEGER NOT NULL DEFAULT 0` (comment: "A synthesized artifact led the list above `weak_below`: the base answered, and the pursuit this lands in closes satisfied."). `artifacts` gains `cues TEXT NOT NULL DEFAULT '[]'` (comment: "For a synthesized artifact: the questions it was written for, JSON list.").
+
+- [ ] Run `cargo test`, commit `feat: a pursuit section, and the tables that record what happens after a search`.
+
+---
+
+### Task 2: The store — interactions, pursuits, events-in-range, synthesized rows
+
+**Files:** `src/store/pursuits.rs` (new; `pub mod pursuits;` in `src/store/mod.rs`), `src/store/feedback.rs`, `src/store/asks.rs`, `src/store/artifacts.rs`
+
+**Produces:**
+```rust
+// pursuits.rs
+pub struct Interaction { pub id: i64, pub artifact_id: String, pub kind: String, pub via: Option<String>, pub scope: Option<String>, pub at: i64 }
+pub struct Pursuit { pub id: String, pub opened_at: i64, pub closed_at: Option<i64>, pub state: String, pub reason: Option<String>, pub queries: Vec<String>, pub sources: Vec<String>, pub artifact_id: Option<String> }
+impl Store {
+  pub async fn record_interaction(&self, artifact_id: &str, kind: &str, via: Option<&str>, scope: Option<&str>, at: i64) -> Result<()>;
+  pub async fn interactions_between(&self, from: i64, to: i64) -> Result<Vec<Interaction>>;   // at > from AND at <= to, ORDER BY at
+  pub async fn insert_pursuit(&self, opened_at: i64, queries: &[String], sources: &[String]) -> Result<String>;
+  pub async fn close_pursuit(&self, id: &str, state: &str, reason: &str, at: i64) -> Result<()>;
+  pub async fn set_pursuit_artifact(&self, id: &str, artifact_id: &str, at: i64) -> Result<()>;  // state = 'generated'
+  pub async fn get_pursuit(&self, id: &str) -> Result<Pursuit>;
+  pub async fn recent_pursuits(&self, limit: i64) -> Result<Vec<Pursuit>>;
+  pub async fn purge_pursuits(&self) -> Result<u64>;   // both tables
+}
+// feedback.rs
+pub struct RecordedEvent { pub id: String, pub query: String, pub query_vec: Vec<f32>, pub created_at: i64, pub answered: bool, pub confirmed: Option<String> /* expect_id when verdict = 'hit' */, pub scope: Option<String>, pub shown: Vec<(String, Option<f32>)> /* (artifact_id, similarity) of shown candidates */ }
+impl Store { pub async fn events_between(&self, from: i64, to: i64) -> Result<Vec<RecordedEvent>>; pub async fn newest_event_at(&self) -> Result<Option<i64>>; }   // newest of search_events ∪ ask_events
+// NewEvent gains `pub answered: bool`; record_search writes it.
+// asks.rs
+pub struct RecordedAsk { pub id: String, pub question: String, pub query_vec: Vec<f32>, pub created_at: i64, pub abstained: bool, pub cited: Vec<String>, pub scope: Option<String> }
+impl Store { pub async fn asks_between(&self, from: i64, to: i64) -> Result<Vec<RecordedAsk>>; }
+// artifacts.rs
+pub struct NewSynthesized { pub text: String, pub title: Option<String>, pub category: Option<String>, pub tags: Vec<String>, pub caveats: Vec<String>, pub cues: Vec<String> }
+impl Store { pub async fn insert_synthesized_artifact(&self, new: &NewSynthesized, sources: &[String]) -> Result<Chunk>; pub async fn synthesized_artifacts(&self, limit: i64) -> Result<Vec<Chunk>>; }
+// Chunk gains `pub cues: Vec<String>` (read in row_to_artifact; written by insert_synthesized_artifact; '[]' everywhere else)
+```
+
+- [ ] **Tests:** in each file — record two interactions and read them back in range; insert/close/get a pursuit round-trip with queries+sources; `events_between` returns `answered`, `confirmed`, `shown`; `asks_between` returns `cited` (use `record_ask` from `src/store/asks.rs` — read `NewAsk`/`record_ask` there and the `nothing_here` helper in `src/jobs/gaps.rs` tests for the shape); `insert_synthesized_artifact` writes provenance `synthesized`, `corpus_id NULL`, `cues`, and `artifact_sources` with `root_id = roots_of(source)`, `via_id = source` (model `insert_merged_artifact` at `artifacts.rs:256` — copy its structure: roots resolved before the transaction, `source_count`, rows per root); `roots_of` on a generation of a generation returns captured roots only (the spec's three-deep test); `purge_pursuits` empties both tables.
+
+- [ ] **Implement** per the signatures; `NewEvent.answered` defaults false in every existing literal (`grep -rn "NewEvent {" src tests` → add `answered: false,`). `record_search`'s INSERT and the coalescing UPDATE both write `answered`. `purge_feedback` calls `purge_pursuits` too.
+
+- [ ] Run, commit `feat: the store keeps what happens after a search, and can hold a pursuit`.
+
+---
+
+### Task 3: Provenance in the payload, the `answered` flag, and recording interactions
+
+**Files:** `src/vector/mod.rs` (`VectorPayload.provenance: Option<String>` serde default), `src/jobs/embed.rs` (`payload_of` writes `Some(chunk.provenance.as_str())`), `src/core/search.rs` (`SearchResult.provenance: Option<Provenance>` from payload; `answered` computed after the final ordering and written into `NewEvent`; `mark_seen`/interaction gating), `src/core/mod.rs` (`Core::record_interaction`), `src/web/ui.rs` (`ArtifactViewParams.via`, `artifact_detail` records `opened`/`pivoted`), templates (`?via={{ d.id }}` on Related and Seen-together rail links, both `href` and `hx-get`)
+
+**Produces:** `impl Core { pub fn record_interaction(&self, artifact_id: &str, via: Option<&str>, scope: Option<&str>) }` — background write, no-op unless `self.pursuit.enabled && self.feedback.enabled`; kind = `pivoted` when `via` is `Some`, else `opened`.
+
+- [ ] **Tests:**
+  - `src/core/search.rs`: a core with `feedback.enabled = true` seeds one synthesized artifact (via `insert_synthesized_artifact` with one captured source) and one captured artifact; `weak_below = 0.0`; a search whose rank-1 is the synthesized one records an event with `answered = true` (read through `events_between`); the same with the captured one first → `answered = false`. (Use the FakeEmbedder's symmetry: query `"title\ntext"` of the synthesized artifact lands it first.)
+  - `src/core/search.rs` or `src/core/mod.rs`: `record_interaction` with pursuit disabled writes nothing; enabled writes `opened`; with `via` writes `pivoted`.
+  - `src/web/ui.rs`: opening `/ui/artifacts/{id}?via={other}` on a pursuit-enabled core records a `pivoted` interaction; without `via`, `opened`; the rendered related rail carries `?via=`.
+
+- [ ] **Implement.** `answered`: after `results.truncate(limit)` and before the event is built, `let answered = results.first().is_some_and(|r| r.provenance == Some(Provenance::Synthesized) && !r.weak);` — but the event literal is built *before* the truncate today (`search.rs:~900`); move the `answered` computation to where `results` is final and pass it in (build the `NewEvent` after the truncate, or compute on `results[..limit]` before). `mark_seen`: no change — `answered` suppresses *interaction* recording, which lives in `record_interaction`: the detail route cannot know the search; so the suppression is applied in the sweep (Task 5) by ignoring interactions attached to an answered event. Document that in the spec's wording: "no events recorded for it" is implemented as "recorded but never counted".
+
+- [ ] Run, commit `feat: the rail knows what a model wrote, the event knows when the base answered, and opening is recorded`.
+
+---
+
+### Task 4: The generator — prompt, schema, completer, job stage
+
+**Files:** `src/infer/prompt.rs` (`GENERATE_SYSTEM`, `generate_prompt(questions, sources: &[(title, text)])`, `generate_schema()`, `parse_generation(reply) -> Result<Generated>`), `src/infer/openai.rs` (`HttpCompleter::for_generating(cfg: &SynthesizeRole) -> Self` = `Self::judging(cfg, ("artifact", prompt::generate_schema()))`), `src/core/mod.rs` (`Core.generator: Option<Arc<dyn Completer>>`, built from the synth role; `Some(FakeCompleter)` in `test_support`/eval), `src/store/jobs.rs` (`Stage::Pursuit` = "pursuit", `Stage::Generate` = "generate"), `src/jobs/mod.rs` (dispatch: `Pursuit → pursuit::run(core)`, `Generate → pursuit::generate(core, &target)`; `needs_model` includes `Generate`), `src/jobs/pursuit.rs` (new, `generate` only in this task)
+
+**Produces:**
+```rust
+pub struct Generated { pub title: String, pub text: String, pub category: Option<String>, pub tags: Vec<String>, pub caveats: Vec<String> }
+pub const GENERATE_SYSTEM: &str = "You write one self-contained knowledge-base artifact from the excerpts you are given, to answer the questions listed. Write only what the excerpts support: every command, path, version, port and flag must appear in an excerpt verbatim. Atomic — one subject, standing alone, readable without the excerpts. Reply with JSON only: {\"artifact\":{\"title\":\"…\",\"text\":\"…\",\"category\":\"…\",\"tags\":[],\"caveats\":[]}}";
+pub async fn generate(core: &Core, pursuit_id: &str) -> Result<()>;
+```
+
+`generate`: load pursuit (`get_pursuit`); if `state != 'open'` or `artifact_id.is_some()` return Ok (idempotent); `let Some(gen) = &core.generator else { return Ok(()) }`; load sources (`artifacts_by_ids`, keep `in_results()` ones, in `sources` order); if fewer than `core.pursuit.min_sources` → `close_pursuit(.., "unsatisfied", "sources gone before generation")`; build prompt with `generate_prompt(&p.queries, &[(title, text)])`, pack to the completer's `context_tokens` the way `dedupe.rs:146-190` trims (`ceiling_for_prompt`); call under `core.gate.background()`; parse; check `missing_literals(&text, &caveats, &joined_sources)` → flags on the new row (like `flag_unverified`); `insert_synthesized_artifact(NewSynthesized { cues: p.queries.clone(), .. }, &source_ids)`; `core.store.enqueue(Stage::Embed, "artifact", &id)`; `set_pursuit_artifact(pursuit, id, now)`.
+
+- [ ] **Tests:** `parse_generation` on a valid/invalid reply; `generate` on a fixture pursuit with two captured sources and a `ScriptedCompleter` returning a JSON artifact → a `synthesized` row exists with `cues == queries`, `artifact_sources` roots = the two captured ids with `via_id` = themselves, an embed job is live, pursuit state `generated`; a literal absent from both sources is flagged (`flags` contains `FLAG_LITERALS`); running `generate` twice writes one artifact.
+
+- [ ] Run, commit `feat: a pursuit can be written up — one call, lineage through via, cues kept`.
+
+---
+
+### Task 5: The sweep — cluster, score, decide
+
+**Files:** `src/jobs/pursuit.rs` (`run`, `decide`, helpers), `src/core/background.rs` (ticker: every `max(idle_secs / 2, 60)` s, only when `core.pursuit.enabled && core.associating()`, enqueue `Stage::Pursuit` with target `"collection"`), `src/jobs/promote.rs` (no change; called)
+
+**Produces:**
+```rust
+pub const PURSUIT_AFTER: &str = "pursuit.events_after";   // meta watermark (seconds)
+pub struct Need { /* one clustered pursuit, before a decision */ pub queries: Vec<String>, pub opened_at: i64, pub last_at: i64, pub answered: bool, pub abstained: bool, pub engagement: BTreeMap<String, f64>, pub pivots: usize, pub returns: usize, pub strong_engaged: bool, pub refined: usize, pub abandoned: bool }
+pub enum Decision { Satisfied(String), Unsatisfied(String), Promote(String /* the one artifact */), Generate }
+pub fn decide(n: &Need, min_sources: usize, min_engagement: f64) -> Decision;   // pure, the eight steps
+pub async fn run(core: &Core) -> Result<usize>;   // pursuits opened this sweep
+```
+
+**`run`:**
+1. `if !core.pursuit.enabled || !core.associating() { return Ok(0) }`.
+2. `after = meta PURSUIT_AFTER (default 0)`; `now = store::now()`; `newest = newest_event_at()`; **if `newest` is within `idle_secs` of `now` → return Ok(0)** — the operator is still going; everything waits until it is quiet (one sentence of comment: the cheapest correct idle rule; a pursuit is a thing that ended).
+3. `events = events_between(after, now)`, `asks = asks_between(after, now)`, `interactions = interactions_between(after, now)`; if no events and no asks → Ok(0).
+4. Vectors: one list of `(vec, kind, idx)`; `line = crate::core::gaps::link_threshold(&all_vecs)`; `clusters = crate::core::gaps::cluster(&refs, line)`.
+5. Per cluster → `Need`: queries (events' queries + asks' questions, deduped by `normalize_query`), `opened_at`/`last_at`, `answered = any event.answered`, `abstained = any ask.abstained`; engagement: for each event in the cluster — `confirmed` → +3.0 on `expect_id`; each interaction attached to this event (interactions with `at` after the event's `created_at` and before the next event in **the whole batch** for the same scope, scope-equal or both None) → `opened` +1.0 / `pivoted` +1.5; a second interaction on the same artifact after another artifact's interaction → +2.0 and `returns += 1`; `pivots` counted; asks' `cited` → +1.0 each; `strong_engaged` = any opened/confirmed artifact whose shown similarity ≥ `core.weak_below` (from `RecordedEvent.shown`) or any cited ask excerpt; `refined` = events in the cluster with no attached interactions that are followed by another event of the cluster; `abandoned` = the cluster's last event has no interactions and it is a search (not an ask that answered). Interactions attached to an `answered` event are not counted.
+6. `decide` (pure):
+   ```
+   if answered                                  → Satisfied("a synthesized artifact led the list")
+   if engagement.len() < min_sources {
+       if engagement.len() == 1 && !strong_engaged_or_unsatisfied…  → keep simple:
+       if engagement.len() == 1 → Promote(the id)            // one engaged artifact: promotion case
+       else → Unsatisfied("nothing engaged") if abstained || abandoned || refined >= 2, else Satisfied("nothing to assemble")
+   }
+   let assembled = engagement.values().sum() >= min_engagement;
+   let unsatisfied = !strong_engaged || refined >= 2 || abandoned || abstained;
+   let wanted = pivots + returns > 0;
+   if assembled && (unsatisfied || wanted) → Generate
+   if unsatisfied → Unsatisfied("engaged below min_engagement" or the reason)
+   else Satisfied("strong hit opened and searching stopped")
+   ```
+7. On `Generate`: root-subset check — `roots_of(engaged ids)` flattened vs `roots_of` of every active `synthesized_artifacts(200)`; subset → `insert_pursuit` + `close_pursuit(.., "satisfied", format!("covered by {id}"))`; else `insert_pursuit` (state open) and `rearm_idle_seq(Stage::Generate, "pursuit", &id, 0)`. On `Promote(id)` → `insert_pursuit` closed `"satisfied"`/`"promotion case"` and `promote::maybe_promote(core, &[id], now)`. On Satisfied/Unsatisfied → insert + close with the reason.
+8. `meta_set(PURSUIT_AFTER, now)`.
+
+- [ ] **Tests** (`src/jobs/pursuit.rs`): `decide` table-driven for each branch (answered; one engaged → Promote; three strong opens, no pivot → Satisfied; three strong opens + one return → Generate; two weak opens total 2.0 → Unsatisfied; two weak opens total 3.0 → Generate; abstained + two engaged → Generate; refined ≥ 2 + assembled → Generate). `run`: with `pursuit.enabled` and feedback on, seed two search events 10 s apart with unrelated vectors (`[1,0]` vs `[0,1]`) and one interaction each, watermark 0, `idle_secs = 1`, events stamped `now - 100` → two pursuits rows; a generate case produces an `open` pursuit and a live `Stage::Generate` job; the root-subset case closes satisfied naming the artifact; an event newer than `idle_secs` makes the sweep return 0 and write no rows; the forget button (`purge_feedback`) empties both tables.
+
+- [ ] Run, commit `feat: the sweep that turns a quiet run of searches into a pursuit, and decides`.
+
+---
+
+### Task 6: Where it shows
+
+**Files:** `src/web/ui.rs`, `src/web/templates/_results.html`, `_artifact_detail.html`, `_lineage.html`, `ops.html`, `settings.html` (the forget button text), `src/core/search.rs` (`SearchResult.origin_count`)
+
+- [ ] Rail: `SearchResult` gains `model_written: bool` (provenance merged|synthesized) and `origin_count: usize` (`origin_corpora.len()`); `_results.html` shows `<span class="badge">model-written · {{ r.origin_count }} source{% if r.origin_count != 1 %}s{% endif %}</span>` beside the title when `model_written`.
+- [ ] Detail: `ArtifactDetail.merged` becomes `c.provenance.is_model_written()` (the "no corpus, show lineage" branch); add `synthesized: bool` and `cues: Vec<String>`; `_lineage.html`'s label reads "Written from … artifacts" for both and, when `d.synthesized`, a `<div class="pane-label">Written because these were asked</div><ul>{% for q in d.cues %}<li>{{ q }}</li>{% endfor %}</ul>` block. Ops undo-merge button must keep testing `Provenance::Merged` specifically (read `ui.rs:2594` region and the Ops `merged` list — they use `merged_artifacts()`, which is SQL on `'merged'`; unchanged).
+- [ ] Ops: `generated: Vec<GeneratedRow { id, title, subtitle, cues: Vec<String>, sources: Vec<SourceRow> }>` from `synthesized_artifacts(table_cap)`, rendered after Merged with a one-click **Deprecate** (`/ui/ops/artifacts/{id}/deprecate` exists); `pursuits: Vec<PursuitRow { opened, state, reason, queries }>` from `recent_pursuits(50)`, rendered only `{% if pursuit_enabled %}` (field on `OpsTemplate` from `core.pursuit.enabled`). Forget button copy: "…searches, questions, pursuits and what was opened".
+- [ ] **Tests:** a synthesized artifact's detail page shows its cues; Ops lists it under Generated with a deprecate form; Ops shows the Pursuits section only with `pursuit.enabled`; a search result for a synthesized artifact carries the badge.
+- [ ] Run, commit `feat: generated artifacts are badged, explained, listed and one click from gone`.
+
+---
+
+### Task 7: Docs, spec note, gate, push
+
+- [ ] `config.example.toml`: `[pursuit]` block after `[promote]` with the four keys and the spec's comments ("Off until turned on…nothing leaves the machine…"). `README.md`: `pursuit.*` row. Spec §4: one sentence under "What gets recorded": "`dwell` is not recorded by the first implementation — the UI has no timing — and the `opened`/`pivoted` rows are attached to search events by time and scope at analysis, never by a stored id."
+- [ ] Gate: `cargo fmt --check`, clippy 0, `cargo test`, `cargo test --test eval`.
+- [ ] Commit `docs: pursuits`, `git push`.
+
+---
+
+## Self-review
+
+**Spec coverage (§4):** unit is a pursuit / clustering at `link_threshold` → Task 5 step 4; `interaction_events` and weights → Tasks 1–3, 5 (dwell: recorded gap); `pursuits` table → Task 1; stopping rule (`answered`, final rank, `weak_below`) → Task 3 + Task 5 step 6; second anchor → Task 5 step 7; analysis eight steps → Task 5 `decide`; step 4's `min_sources` partition → `Promote` branch; generation job (one call, in/out, provenance, `corpus_id NULL`, cues, supersedes nothing, lineage with `via_id`, `roots_of` invariant at depth, `missing_literals`) → Tasks 2, 4; nesting (a generated artifact's own text goes into the prompt, sources whatever their provenance) → Task 4 loads sources by id and uses their text; where it shows → Task 6; configuration and gating → Task 1; §4 tests list → spread across Tasks 2–6 (each bullet has a named test). §5 "ask as pursuit signal": asks join clusters and cited excerpts engage → Task 5; abstention closes unsatisfied → `decide`. §8 pursuit view gated → Task 6. Ops forget covers both tables → Task 2 (`purge_pursuits` from `purge_feedback`).
+
+**Gaps recorded:** `dwell`; "before and after on Ops" for eager re-synthesis (plan 3); server-side grouping (§5). Each is written into the spec as unbuilt.
+
+**Placeholder scan:** Tasks 2 and 6 list deliverables and tests by name with signatures rather than full code blocks — this plan is executed inline by the author with the earlier three plans' patterns in the file; the signatures are exact and every test named is concrete enough to write. A subagent executor should be handed Task 2's feedback/asks readers with the SQL spelled out.
+
+**Type consistency:** `record_interaction(artifact_id, kind, via, scope, at)` (store, Task 2) vs `Core::record_interaction(artifact_id, via, scope)` (Task 3, derives kind); `RecordedEvent`/`RecordedAsk` (Task 2) consumed by Task 5; `NewSynthesized` + `insert_synthesized_artifact` (Task 2) consumed by Task 4; `Stage::Generate`/`Stage::Pursuit` (Task 4) used by Task 5's arming and the ticker; `Need`/`Decision`/`decide` (Task 5) internal.

--- a/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+++ b/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
@@ -744,9 +744,16 @@ CREATE INDEX IF NOT EXISTS idx_pursuits_state ON pursuits(state, opened_at);
 `search_event_id`; the clustering decides which pursuit that is, so the events
 carry no pursuit id of their own and re-clustering never has to rewrite them.
 
-`dwell` is not recorded by the first implementation — the UI has no timing —
-and the `opened`/`pivoted` rows are attached to search events by time and
-scope at analysis, never by a stored id; `returned` is derived there too.
+`dwell` is measured by the page — the detail root names its artifact, a timer
+starts on every swap, and the seconds are sent as a beacon when the reader
+leaves (next swap, tab hidden, page gone); under three seconds is a glance and
+is not sent, over ten minutes is a tab left open and is capped. The sweep
+turns it into ≤ 0.5 per artifact (a tenth per minute) and uses it for one
+thing: the order the sources go into the prompt. It never counts toward
+`min_engagement`, and a search whose only trace is dwell is a search nothing
+was opened on. The `opened`/`pivoted`/`dwell` rows are attached to search
+events by time and scope at analysis, never by a stored id; `returned` is
+derived there too.
 
 **Dwell is deliberately the weakest.** Long dwell means *this was useful* or
 *this was confusing and hard to read*; a tab left open means *engaged* or *went
@@ -1059,7 +1066,10 @@ pool reliably and the cap has nothing left to redistribute.
 
 **Server-side grouping (`query/groups` in Qdrant) is therefore part of this
 spec**, with `cap_per_corpus` as the in-memory fallback. It is already a roadmap
-item; `off` promotes it from a nice-to-have to a prerequisite.
+item; `off` promotes it from a nice-to-have to a prerequisite. *Status:* the
+fallback landed (`cap_per_corpus` over `origin_corpora`); the `query/groups`
+call is on the roadmap as a prerequisite with its own measurement, and is not
+built yet.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+++ b/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
@@ -382,6 +382,11 @@ Existing tests asserting the joined embedding text (`embed.rs:1702` and
 siblings) are updated to the new rendering rather than pinned. They no longer
 guard anything.
 
+The default `FakeEmbedder` is symmetric — it renders with the legacy templates
+— so the retrieval tests that query with `"title\ntext"` keep landing on what
+they seeded; `FakeEmbedder::with_templates` exercises the asymmetric recipe in
+the tests that are about it.
+
 ---
 
 # 3. Promotion

--- a/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+++ b/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
@@ -1,0 +1,1077 @@
+# Tiered synthesis: passages, promotion, pursuits
+
+engram spends one inference call per segment at capture, always. That is the
+right price for a curated base and the wrong price for a general one — it makes
+you selective about what you paste, and it charges the same for a chapter you
+will read a hundred times as for a manual you will consult twice.
+
+This introduces three modes for how much inference is spent, one config key
+apart. The lowest embeds the source text verbatim and calls nothing. The middle
+spends synthesis only where use has shown it is worth spending. The highest is
+what engram does today, unchanged.
+
+Two things fall out that are worth more than the saving. Verbatim text in the
+index makes `ask`'s literal check a statement about the knowledge base rather
+than about its paraphrases. And a mode with no write-time inference makes `ask`
+the whole of the read side, which is where this application was always going.
+
+## Vocabulary
+
+Four terms, and the third is new.
+
+| term | what it is | where | embedded | model wrote it |
+|---|---|---|---|---|
+| **corpus** | what was pasted, verbatim | `corpora` | no | no |
+| **segment** | a window of a corpus sized to the *synthesis* model's context; the synthesis queue unit | `segments` | no | no |
+| **passage** | a verbatim slice of a segment sized to the *embedder*; the retrieval unit | `artifacts` | **yes** | **no** |
+| **artifact** | model-written text | `artifacts` | yes | yes |
+
+Passages and artifacts share one table, and that sharing is what makes this a
+config key rather than a storage tier. The reading to hold:
+
+> **`artifacts` is the index.** Every row in it is embedded and retrievable.
+> `provenance` says how the row came to exist.
+
+`provenance` gains two values, for four in total: `passage` (a verbatim slice),
+`captured` (written from a segment), `merged` (written by consolidation),
+`synthesized` (written from a pursuit).
+
+Note that `store::artifacts::Chunk` is the Rust struct for *any* row in
+`artifacts` — legacy naming from before the chunk/artifact rename. "Chunk" is
+therefore not available as a name for the new unit, and is not used for it
+anywhere.
+
+## The modes
+
+```toml
+[infer]
+synthesis = "eager"        # "off" | "earned" | "eager"
+```
+
+**`off`** — capture splits, embeds, and stops. Passages are the index. Zero
+inference calls per corpus, or one vision call per image.
+
+**`earned`** — the same capture path. Synthesis runs later, only where use has
+shown it is worth it, and always supersedes what it was written from.
+
+**`eager`** — today. One synthesis call per segment at capture.
+
+`eager` is the default so that setting nothing changes nothing. `off` with no
+`[infer.ask]` configured is a complete and coherent product state: a semantic
+search engine over verbatim text with no inference at all.
+
+| | `off` | `earned` | `eager` |
+|---|---|---|---|
+| what is in the index | passages | passages, plus artifacts as earned | artifacts |
+| what consolidation grooms | — | the index | the index |
+| image `describe` | optional | optional | optional |
+| `ask` | optional | optional | optional |
+| promotion | — | yes | optional (re-synthesis) |
+| generation from pursuits | — | yes | yes |
+| segments and corpora | source of truth | source of truth | source of truth |
+| inference at capture | none | none | one call per segment |
+
+---
+
+# 1. Capture without synthesis
+
+## One splitter, called twice, nested
+
+`split_into_segments` is already a pure `(text, counter, budget) -> Vec<Window>`
+with heading-first boundary preference, blank-line fallback, hard cut last, and
+the most recent heading carried into every continuation window. The only thing
+separating a synthesis window from a retrieval passage is the budget passed in.
+
+```
+raw_text ──split(segment_tokens)──▶ windows   → segments rows (pending, nothing armed)
+             each window.text ──split(chunk_tokens)──▶ passages → artifacts
+```
+
+**A passage never crosses a segment boundary.** This is an invariant, not an
+implementation detail: promoting a window later must cover a whole number of
+passages, or the earned tier has a permanent ragged edge where a passage is
+half-superseded.
+
+## The carried heading becomes the passage's title
+
+`embed_text` already prepends `title` to the embedding input "because it holds
+topical signal the body often leaves implicit." A passage under
+`## Recovering deleted entries` takes that as its title — verbatim, from the
+document, no inference. This is the single highest-leverage line in the mode:
+it is most of what synthesis was buying at the embedding layer, and section 2
+shows the embedder has a slot built for exactly it.
+
+It also has a consequence that section 6 has to handle: every passage in one
+section embeds with the same string in the most weighted position.
+
+## What runs, what does not
+
+Runs at `off`: split, embed, `describe` (an image must become text before it can
+be a passage at all), near-duplicate shingling at capture, `associate` and
+`activation`. Does not run: `SegmentWindow`, `Title`, `Relate`, `Dedupe`,
+`Consolidate`, `Merge`.
+
+**Corpus title without a model.** `Stage::Title` is a real inference call. At
+`off` it is replaced by a local derivation: the first heading in `raw_text`,
+else the first non-empty line, truncated. `title_hint` already exists and
+already short-circuits when set.
+
+## Coverage is green by construction
+
+The corpus-bands rule (2026-08-18) is that red means no artifact's `corpus_span`
+claims a line. At `off` the passages partition the document — every line is
+claimed, verbatim. There is no red, and this is a guarantee of the mode rather
+than a display choice. Section 3 depends on it: promotion can only ever improve
+coverage, never reduce it.
+
+## Configuration
+
+```toml
+[infer.embed]
+chunk_tokens = 384        # clamped to max_input_tokens * SAFETY (0.8)
+```
+
+It belongs under `embed` because it is sized to the retrieval unit, not to a
+model's context.
+
+**384, and why it is fixed rather than derived.** engram already derives one
+size from the embedder: `core/mod.rs:149` sets
+`max_artifact_tokens = max_input_tokens * 0.8`, giving 6553 by default. That is
+correct because it is a *ceiling* — the prompt says "split into more artifacts
+rather than exceeding it" and nothing approaches it. A passage size is a
+*target*, and deriving a target from a capacity is how a 32k-window embedder
+gets told that 26k-token passages are a good idea. Capacity says what fits; it
+says nothing about what retrieves.
+
+384 is chosen against EmbeddingGemma (section 2): its window is 2048, so
+truncation is not the binding constraint, and size becomes a pure retrieval
+question. The failure mode of an oversized passage is centroiding — a passage
+holding three ideas produces a vector between three regions of the space and
+near none of them — and a 308M-parameter model emitting 768 dimensions has less
+capacity to hold ideas apart in one vector than a larger, wider model does.
+384 tokens is roughly one and a half paragraphs of prose, which is about one
+idea.
+
+The clamp reuses the `SAFETY = 0.8` the embed path already applies, so the
+splitter can never emit a passage that `split_oversize` then has to cut apart
+again. A splitter and an embedder disagreeing about size is a loop with no good
+end.
+
+This number is argued, not measured. `/ui/judge` and `cargo test --test eval`
+can compare 256 / 384 / 512 over one judged pair set, and the harness is what is
+allowed to change it.
+
+---
+
+# 2. The embedding recipe
+
+EmbeddingGemma becomes the default embedder. This is a separable change that
+should land and be measured on its own, because it moves the retrieval baseline
+that everything else here will be judged against.
+
+## Three defects being fixed
+
+1. **No task prefixes.** EmbeddingGemma is trained to read them; engram sends
+   bare text.
+2. **Queries and documents are embedded identically.** `search.rs:703` and
+   `embed.rs:243` are the same call. That is correct for `bge-m3`, which is
+   symmetric by design. EmbeddingGemma is asymmetric, and that is its interface,
+   not a tuning detail.
+3. **The document format is engram's, not the model's.** `embed_text` joins
+   `"{title}\n{text}"`; the model wants `title: … | text: …` and treats a
+   missing title as the literal string `none`.
+
+None of these error. They cost recall silently, by an amount the judge harness
+records and cannot attribute.
+
+## Model plus templates is one identity
+
+A vector's meaning is fixed by the model *and* by the text handed to it.
+Changing `document_template` invalidates every stored vector as thoroughly as
+changing `model` does. There is no legacy base to migrate, so no fingerprint,
+no startup guard and no rebuild path is built — but the property is real, and
+editing a template later silently mixes embedding spaces. The answer then is to
+drop the collection and re-capture; the day that stops being acceptable, the
+generation-flip machinery for it already exists in `qdrant.rs`.
+
+## Configuration
+
+```toml
+[infer.embed]
+model            = "embeddinggemma"
+dim              = 768      # full MRL width; do not truncate
+max_input_tokens = 2048     # or the server's real batch ceiling, if lower
+chunk_tokens     = 384
+
+query_template             = "task: search result | query: {text}"
+document_template          = "title: {title} | text: {text}"
+document_template_untitled = "title: none | text: {text}"
+```
+
+`dim = 768`: Matryoshka truncation to 512/256/128 buys memory at a recall cost,
+which is the wrong trade for a base whose point is retrieval quality.
+
+`max_input_tokens = 2048` is the model's window. The existing comment is the
+caveat that matters — "the server's real ceiling, not the model's nominal one" —
+so a llama.cpp physical batch below 2048 is the number to use instead.
+
+**Two document templates rather than one plus a filler.** This maps exactly onto
+the `match &chunk.title { Some / None }` that `embed_text` already is, and the
+model card states the untitled case as a literal substitution rather than an
+empty field.
+
+Templates stay in config rather than hardcoded, because `model` is configurable
+and pointing at `bge-m3` must remain possible. That is three struct fields, not
+a subsystem.
+
+## Where it lands
+
+| site | change |
+|---|---|
+| `EmbedRole` (`config.rs`) | three template fields plus render helpers |
+| `Embedder` trait (`infer/mod.rs:66`) | gains `embed_query`; `embed` becomes document-side |
+| `HttpEmbedder`, `FakeEmbedder` | render before POST; the fake exercises the asymmetry |
+| `embed_text` (`embed.rs:16`) | becomes `render_document(title, text)` |
+| `search.rs:703` | calls `embed_query` |
+
+The trait split is not optional. Rendering at the call site works until someone
+adds a fourth place that embeds something — and `gaps.rs` already is one.
+
+## Envelope token accounting
+
+`split_oversize` computes `budget = limit - title_cost` where
+`title_cost = count(title)`. With a template the envelope costs tokens too —
+`title: ` plus ` | text: ` is about seven — and ignoring them makes the splitter
+and the embedder disagree about size. That is the loop
+`a_chunk_only_its_title_pushes_over_the_limit_does_not_respawn_itself` exists to
+close, reopened slightly narrower.
+
+`title_cost` becomes `envelope_cost(title) = count(render_document(title, ""))`
+at `embed.rs:368`, `:469`, and the limit checks at `:71` and `:131`. The
+existing "a title that fills the limit on its own" refusal keeps working and now
+correctly refuses one where the *envelope* fills it.
+
+## One known simplification
+
+There is one `query_template`, holding the retrieval task. `gaps.rs` is really
+doing EmbeddingGemma's `clustering` task and would prefer
+`task: clustering | query: `. It cannot have it: it clusters the *stored*
+search-event vectors, which were necessarily embedded for retrieval. Comparing
+retrieval-prefixed vectors to each other is symmetric and still meaningful. A
+second recipe would mean embedding every query twice forever to improve a
+feature that names clusters for a human to read.
+
+## Tests
+
+- query and document render differently for the same input
+- a titled and an untitled passage take different templates
+- envelope cost is charged: a passage that fits without the envelope and
+  overflows with it splits, and does not respawn itself
+- `render_document` for a passage with a carried heading puts the heading in the
+  `title:` slot
+
+Existing tests asserting the joined embedding text (`embed.rs:1702` and
+siblings) are updated to the new rendering rather than pinned. They no longer
+guard anything.
+
+---
+
+# 3. Promotion
+
+## The unit is the window, not the passage
+
+A passage earns promotion; the **window it lives in** is what gets synthesized.
+Handing the model a 384-token passage to synthesize a 384-token passage gains
+nothing — synthesis is worth paying for because it sees context the passage
+lacks.
+
+Which means promotion is not new inference code. It is today's
+`Stage::SegmentWindow`, armed by evidence instead of by capture. The `segments`
+rows written at capture sit `pending` with nothing armed, and promotion arms
+one.
+
+## The trigger
+
+```toml
+[promote]
+activation_above               = 4.0   # earned
+resynthesize_after_unconfirmed = 0     # eager; 0 disables, and it ships disabled
+```
+
+`activation_above` read against `[activation]` — baseline `1.0` at creation, `retrieved = 1.0`,
+`opened = 0.5`, `confirmed = 3.0`, half-life 14 days — that threshold means
+**one confirmation, or three retrievals inside the half-life**.
+
+**Engagement, not exposure.** `retrieved` fires when a passage merely *appears
+in a result list*. A threshold on activation alone would spend synthesis on a
+passage that has demonstrably helped nobody. So promotion additionally requires
+that the passage was **opened or confirmed** at least once. One extra condition,
+no new machinery, and it removes the "promoted a passage nobody read" failure
+entirely.
+
+**Checked at the bump, not on a sweep.** A sweep reads decayed activation, so a
+passage that crossed 4.0 on Tuesday is at 3.6 by Sunday and the threshold
+silently means something different depending on when the sweep runs. Checking
+where `bump_activation` is called is exact. It also means no `max_per_sweep`
+key: the bump *enqueues a job* rather than calling a model, and the job queue
+plus `[pacing] cooldown_secs` already bound GPU load.
+
+## Mechanically
+
+1. Set `keep_artifacts = 1` on the segment. This flag exists for re-reading a
+   window to pick up missed lines, and it makes `write_segment_artifacts`
+   **append rather than replace** (`window.rs:338`). Without it the promotion
+   would *delete* the passages it is supposed to supersede — artifacts and
+   passages share a `segment_idx`.
+2. Arm `Stage::SegmentWindow` for `(corpus_id, segment_idx)`. Unchanged job.
+3. After `write_segment_artifacts`, inside the same `corpus_lock`, supersede the
+   covered passages.
+4. The segment settles `done`, which clears `keep_artifacts`.
+
+**The guard against re-promotion is the segment state**, not `provenance`: a
+window whose segment is `done` never promotes again. This matters because
+passages can survive a promotion, per the next rule.
+
+## Which passages a promotion supersedes
+
+Each new artifact has a `corpus_span` from `resolve_span`; each passage has one
+from the splitter. Both are in the same coordinate space because passages nest
+inside windows.
+
+**A passage is superseded only when some artifact's span covers a majority of
+its lines.** Best overlap wins, ties go to the lowest ordinal, and a passage no
+artifact substantially claims **stays active, verbatim, in results**.
+
+The majority floor is load-bearing. Without it, an artifact overlapping one line
+of a twenty-line passage would remove nineteen lines of verbatim text on a 5%
+claim. With it, promotion can only ever improve coverage, and whatever synthesis
+declines to claim keeps its passage. Coverage becomes self-healing rather than
+something re-read windows chase.
+
+## Promotion at `eager` is error-driven re-synthesis
+
+The same mechanism, a different policy, and it is already on the roadmap: an
+artifact shown often and never confirmed is misleading, and is re-synthesised
+*from its source segment, never from itself*.
+
+| | `earned` | `eager` |
+|---|---|---|
+| trigger | `activation_above`, plus opened or confirmed | `resynthesize_after_unconfirmed` |
+| meaning | "read this properly" | "this is misleading" |
+| `keep_artifacts` | `1` (append, then supersede covered passages) | `0` (replace — the old artifacts are the problem) |
+| result | passages become artifacts | artifacts become better artifacts |
+
+The `eager` detector is the one the roadmap names — exposure and confirmation
+counts. `hit_count` already rides in the vector payload, is already read by
+`stale_candidates`, and is already excluded from scoring for the reason that
+matters here: a popular result must not boost itself. An artifact whose
+`hit_count` reaches the threshold with no confirmation recorded against it — in
+`interaction_events`, or in a judged pair — is re-synthesised from its segment,
+with before and after shown on Ops.
+
+It ships at `0`. Re-synthesising at `eager` changes what an existing base
+contains without anyone asking, so it is a default the harness moves, not this
+spec.
+
+## Carrying access forward
+
+**This is the part that is wrong if built the obvious way.**
+
+A passage reaches the threshold by being retrieved, opened and confirmed, and
+`associate` writes `artifact_links` rows against it from co-retrieval along the
+way. Then promotion supersedes it, and:
+
+- `supersede` (`ingest.rs:528`) writes `superseded_by` and the payload lifecycle.
+  It touches neither `activation` nor `artifact_links`.
+- `links_from` (`links.rs:400`) requires **both** endpoints
+  `status = 'active' AND superseded_by IS NULL` — so every link the passage
+  earned goes dark in the same instant, including links to artifacts that are
+  still active.
+- The artifact replacing it starts at `activation = 1.0` with zero links.
+
+The system's most-used material would be systematically replaced by cold
+artifacts, which must then re-earn from a standing start — and being paraphrases
+they may not retrieve the same way and may never re-earn. Run long enough,
+`earned` becomes a ratchet that periodically resets the accessibility of exactly
+the material most used, while priming and association stop firing on the
+best-worn paths.
+
+This contradicts the roadmap's own load-bearing sentence: *the trace is fixed,
+access is plastic*. Access being plastic has to mean it survives a
+re-expression of the content, or plastic degrades into periodically reset.
+
+**Activation.** The promoted artifact takes the **maximum** decayed activation
+of the passages it supersedes, stamped now. Max rather than sum: one search
+returning three passages of one section is one piece of evidence, and summing
+would let a wide passage manufacture accessibility. `decayed()` already exists.
+
+**Links are copied, not moved.** For every link touching a superseded passage,
+write the corresponding link on the artifact and leave the original row in
+place. `links_from` filters superseded endpoints out anyway, so the dead rows
+cost nothing at read time — and undo becomes free, because restoring a passage
+lights its links back up with no reverse migration to get wrong.
+
+Copying needs collision handling, since two passages in one window can link to
+the same artifact and both become the same `(a_id, b_id)` primary key:
+
+- decay both weights to now via `decayed()`, take the **max**,
+  set `bumped_at = now`
+- `queries` takes the max, not the sum — same double-counting argument
+- `cues` merge, keeping the top three by count
+- re-canonicalise the pair for `CHECK (a_id < b_id)`
+- `state`: a `dismissed` verdict on either side wins. The operator's "not
+  related" is final, and `links_from` already treats it as an invariant rather
+  than a filter.
+- `judged_rev_a/b` are cleared. The text changed under the judge, which the
+  schema comment already says reopens the verdict.
+
+**What does not carry:**
+
+- `hit_count` and `last_seen_at`. The artifact has not appeared in results, and
+  claiming otherwise puts a false number in front of `stale_candidates`.
+- `search_candidates` rows and judged pairs. A judged pair records *for this
+  query, that passage was the answer* — a historical fact that stays true.
+  Retargeting it would rewrite the eval set to say something no human said,
+  contaminating the one uncontaminated measurement in the system.
+  `--export-eval` keeps real ids and superseded rows stay readable by id, so the
+  pair remains resolvable forever.
+
+The rule in one line: **learned access carries forward; recorded history does
+not.** That is the fixed/plastic split applied one level down.
+
+## Undo
+
+`unsupersede` exists. Undoing a promotion restores the passages to active,
+deprecates the window's artifacts, and sets the segment back to `pending`. The
+copied links and the raised activation stay on the artifact — an asymmetry
+accepted rather than fixed, since both sides describe the same corpus lines.
+
+## Tests
+
+- a window promotes exactly once; a second trigger on a surviving passage in a
+  `done` segment does nothing
+- a passage claimed by no artifact's span survives, active and verbatim
+- a passage claimed at less than half its lines survives; at more than half it
+  is superseded
+- promotion appends: the passages still exist as rows immediately after
+  `write_segment_artifacts`
+- **the promoted artifact's activation equals the max decayed activation of its
+  superseded passages, not `1.0`** — the regression test for the bug above
+- a link from a superseded passage resolves through `links_from` on the
+  artifact, at the decayed weight
+- two passages linking to the same artifact collapse to one row at the max
+  weight, not the sum, with `queries` maxed and cues merged
+- a `dismissed` link stays dismissed after the copy
+- judged pairs still name the passage after promotion, and `--export-eval`
+  resolves it
+- a passage retrieved three times but never opened does **not** promote
+
+---
+
+# 4. Pursuits
+
+Promotion answers "this passage was never read properly." It cannot answer the
+other case: five passages across three corpora that jointly served one need, none
+of which individually crosses anything, and where what was wanted was the
+assembly rather than any one of them.
+
+## The unit is a pursuit, not a session
+
+A time window is the wrong unit — three unrelated searches in fifteen minutes
+are three needs. Idle time bounds the *candidate set*; coherence carves it into
+pursuits.
+
+`search_events.query_vec` is already stored. Cluster a window's queries by
+cosine — the same grouping `gaps.rs` already does to name knowledge gaps — and
+each cluster is one **pursuit**: a coherent thing that was wanted, its queries,
+and everything done with the results. Local, no inference.
+
+## What gets recorded
+
+`search_events` and `search_candidates` already capture query, candidates, rank
+and shown. A new table captures what happens after the list renders:
+
+```sql
+CREATE TABLE interaction_events (
+  id              INTEGER PRIMARY KEY,
+  search_event_id TEXT REFERENCES search_events(id) ON DELETE CASCADE,
+  artifact_id     TEXT REFERENCES artifacts(id) ON DELETE CASCADE,
+  kind            TEXT NOT NULL,
+  at              INTEGER NOT NULL,
+  detail          TEXT
+);
+```
+
+| kind | weight | why |
+|---|---|---|
+| `opened` | 1.0 | deliberate |
+| `pivoted` | 1.5 | followed a neighbour, association or continuation — the strongest voluntary act, and unique to this application |
+| `returned` | 2.0 | came back to it later in the pursuit; hard to fake |
+| `confirmed` | 3.0 | already an activation delta; reused verbatim |
+| `dwell` | ≤0.5, capped | tiebreak only, never decisive |
+| `refined` | — | searched again without opening anything: a failure signal |
+| `abandoned` | — | searched, opened nothing, no follow-up: the strongest failure signal, and the one the README already says leaves no other trace |
+
+The pursuit itself is a row, so the analysis job has something to claim and Ops
+has something to show:
+
+```sql
+CREATE TABLE pursuits (
+  id           TEXT PRIMARY KEY,
+  opened_at    INTEGER NOT NULL,
+  closed_at    INTEGER,
+  -- open | satisfied | unsatisfied | generated | dismissed
+  state        TEXT NOT NULL DEFAULT 'open',
+  -- Why it closed, in one line. Read on Ops; never parsed.
+  reason       TEXT,
+  -- The clustered queries, JSON. Becomes the artifact's `cues` on generation.
+  queries      TEXT NOT NULL DEFAULT '[]',
+  -- The generated artifact, once there is one.
+  artifact_id  TEXT REFERENCES artifacts(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pursuits_state ON pursuits(state, opened_at);
+```
+
+`interaction_events` rows are joined to a pursuit through their
+`search_event_id`; the clustering decides which pursuit that is, so the events
+carry no pursuit id of their own and re-clustering never has to rewrite them.
+
+**Dwell is deliberately the weakest.** Long dwell means *this was useful* or
+*this was confusing and hard to read*; a tab left open means *engaged* or *went
+to lunch*. With one operator there is no volume for the noise to average out.
+The failure kinds carry no engagement weight because they attach to no artifact
+— they are what says the base did not answer, which is the precondition for
+generating at all.
+
+## The stopping rule
+
+**A `synthesized` artifact at rank 1, at or above `weak_below`, closes the
+pursuit `satisfied` — no events recorded, no analysis, no generation.** Checked
+at result-assembly time in `search.rs` before anything is written.
+
+The `weak_below` qualification matters: a fused rank says where a hit placed,
+not how good it was, and a generated artifact at rank 1 with a 0.31 cosine is
+labelled "loose" on the page and is not a perfect answer.
+
+This rule is not a detail. **It is what makes the loop terminate.** Without a
+stopping condition every session generates, and generated artifacts seed
+sessions that generate more. With it, the system generates only while the base
+is failing and goes quiet the moment it is not. When a generated artifact later
+goes stale it stops being rank 1, telemetry resumes, a fresh one is generated,
+and consolidation resolves the pair. It self-maintains.
+
+A pursuit also closes `satisfied` when any hit above `weak_below` was opened or
+confirmed and searching stopped. Success is success regardless of who wrote the
+hit.
+
+## The analysis pass — local decides, the model only writes
+
+When a pursuit goes idle, one background job, no inference:
+
+1. group the window's queries into pursuits by cosine ≥ `coherence`
+2. sum engagement per artifact
+3. **unsatisfied?** — no strong hit opened or confirmed, or `refined` ≥ 2, or
+   `abandoned`
+4. **assembled?** — at least `min_sources` distinct artifacts engaged with, and
+   total engagement ≥ `min_engagement`
+5. both true → enqueue `Stage::Generate` — a new job stage, and the only one
+   this spec adds
+6. otherwise close the pursuit, recording why
+
+Step 4's `min_sources ≥ 2` does real separating work: **one** engaged artifact
+means there was nothing to assemble, and that is a promotion case — its window,
+section 3 — not a generation case. The two mechanisms partition on the number of
+sources.
+
+## The generation job
+
+One inference call, reusing `ask/retrieve.rs` for excerpt selection.
+
+**In:** the pursuit's queries — the only place the need enters — plus the full
+text of the engaged artifacts, **whatever their provenance**.
+
+**Out:** a normal artifact — title, category, tags, text, caveats — written to
+stand alone, like every other artifact in the base.
+
+```
+provenance = 'synthesized'
+corpus_id  = NULL          (its corpora are derived; see section 7)
+cues       = the pursuit's queries, stored and displayed
+```
+
+**It supersedes nothing.** Its sources stay active and keep ranking. The whole
+justification for generating a retrievable artifact rather than a hidden cue is
+that it is inspectable — and that only holds if the material it was written from
+remains reachable. This is the difference from `merged`, which hides its roots
+by design.
+
+`cues` is what makes the transparency concrete. The artifact carries the
+questions it was written for, shown on its detail page: not "a model guessed you
+would want this" but "this was written because these three things were asked and
+the base had no answer."
+
+## Nesting
+
+A generated artifact **may** be a source for another generated artifact. If a
+pursuit engaged one — meaning the operator pivoted through it, a deliberate act
+on a result they read and found worth following — its own text goes into the
+prompt, unresolved.
+
+Depth is therefore unbounded, and it is bounded in practice from the other end
+by the stopping rule: if a generated artifact were answering well it would be
+rank 1 and nothing would generate at all. Chains grow only along paths a human
+walked and found half-right.
+
+**Lineage keeps its invariant regardless of depth.** `artifact_sources` stores
+`root_id` naming a captured artifact and `via_id` naming the direct parent
+through which it entered. A generation `G2` written from `G1` (itself written
+from passages A and B) stores `(G2, root=A, via=G1)` and `(G2, root=B, via=G1)`.
+So `roots_of` keeps returning captured text — which `dedupe` and `merge` depend
+on and which are not part of this feature — while the chain stays fully
+reconstructible through `via_id`, and "at the root there is always a corpus"
+is true by construction at any depth.
+
+The `artifact_sources` header comment currently says the closure "is what keeps
+information loss one generation deep however many times a group is merged."
+That stays true of **merging** and is now false of **generation**. The comment
+must say which mechanism it describes.
+
+Drift compounds along deep chains. It is caught rather than prevented:
+`missing_literals` runs at every generation against the sources actually used;
+the `via_id` chain makes depth visible on the detail page; and consolidation
+sees generated artifacts normally, so a drifted one duplicating a fresher one
+gets resolved.
+
+## Where it shows
+
+- **Search rail:** badged as model-written, with its source count. Never
+  silently indistinguishable from captured text.
+- **Detail pane:** "written from", listing roots with links — `lineage_view.rs`
+  already renders this for merges — plus the cues and any literal flags.
+- **Ops:** a generated list beside deprecated and superseded, with one-click
+  deprecate. The existing forget-everything button covers `interaction_events`
+  and `pursuits` too.
+
+## Configuration
+
+```toml
+[pursuit]
+enabled        = false   # meaningful at synthesis = "earned" and "eager"
+idle_secs      = 900
+coherence      = 0.6
+min_sources    = 2
+min_engagement = 3.0
+```
+
+Gated like `feedback.enabled` — off until turned on, local only, nothing leaves
+the machine, and Ops forgets all of it on one press. Same posture as the judge
+data, for the same reason.
+
+## Tests
+
+- a generated artifact at rank 1 above `weak_below` records nothing and closes
+  the pursuit satisfied; the same artifact at rank 1 *below* it does not
+  suppress
+- two unrelated searches inside one idle window become two pursuits
+- a pursuit engaging one artifact enqueues promotion, not generation
+- a pursuit that engaged a generated artifact puts **its own text** in the
+  prompt, not its roots
+- `artifact_sources` for that generation names the **captured** roots with
+  `via_id` set to the generated intermediate
+- `roots_of` on a three-deep chain returns captured artifacts only, and never a
+  generated one
+- no source is superseded by a generation
+- a literal in the generated text absent from every source is flagged
+- `dwell` alone never crosses `min_engagement`
+- the pursuit's queries are stored as cues and render on the detail page
+- the forget button clears `interaction_events` and `pursuits`
+
+---
+
+# 5. Ask
+
+## What ask gains at `off`
+
+Today `missing_literals` checks an answer against the excerpts it was shown, and
+those excerpts are themselves synthesis — they have already lost literals on the
+way. The guarantee is therefore relative: *the answer invents nothing the
+artifacts did not contain*.
+
+At `off` the excerpts are the source text. The guarantee becomes absolute:
+
+> A command, path or version in the answer that appears in no excerpt appears
+> **nowhere in the corpus**.
+
+That is the point at which the literal check stops being a plausibility check
+and becomes a statement about the knowledge base.
+
+## Contiguous passages are stitched
+
+Passages are consecutive verbatim slices with consecutive ordinals inside a
+segment. When passages 7 and 8 are both selected, they are literally continuous
+text. Presenting them as two excerpts wastes tokens on the twice-repeated
+carried heading, hides the continuity from the model, and cuts whatever sentence
+runs across the boundary.
+
+Before packing: group selected passages by `(corpus_id, segment_idx)`, sort by
+`ordinal`, and merge runs of consecutive ordinals into one excerpt. This
+restores the original text as written, costs fewer tokens than the same passages
+separately, and is local work with no inference.
+
+Two conditions keep it honest:
+
+1. **Only for `provenance = 'passage'`.** Two adjacent *artifacts* are two
+   rewrites, not continuous text; stitching them would assert a continuity that
+   does not exist.
+2. **Every constituent id is kept.** `ask_citations`, the literal check and the
+   pursuit analysis all depend on knowing which passages actually carried the
+   answer. A stitched excerpt is a presentation, not a new unit.
+
+The existing sideways reach needs no change. `adjacent_artifacts` is a lookup in
+**document order** — `ordinal ± 1`, both sides already — and is a different
+mechanism from `neighbours()` (vector distance, directionless) and
+`artifact_links` (Hebbian association, explicitly undirected). `±1` plus
+stitching is enough; `NEIGHBOUR_ANCHORS` and `NEIGHBOUR_MAX` are ranking
+parameters and move only after the harness.
+
+## Ask at `earned`: two roles
+
+**Ask is the best pursuit signal there is.** A typed question is a better-formed
+need than any search query, and `ask_events` plus `ask_citations` are already
+exactly what section 4 wants: the question as cue, the cited excerpts as the
+sources engaged. An ask joins the same pursuit as the searches beside it — no
+second collection path.
+
+**An abstention is the strongest unsatisfied signal available.** An answer
+opening with *Not in the knowledge base* is not a weak indication like an
+unopened result; it is the explicit finding that the base holds nothing. It
+already feeds knowledge gaps; it additionally closes its pursuit `unsatisfied`
+immediately, without waiting for the idle timeout.
+
+**Generation is ask with a different sink:**
+
+| | `ask` | generation |
+|---|---|---|
+| retrieval | `ask/retrieve.rs` — cliff, sideways reach | **the same code** |
+| the need | the typed question | the pursuit's queries |
+| prompt | answer and cite | synthesis prompt: atomic, self-contained |
+| literal check | `missing_literals` | the same |
+| sink | streamed to the page | a row in `artifacts` |
+
+## Keep-this-answer, and a property of `off` worth naming
+
+A kept answer becomes a corpus with `origin = ORIGIN_ASK`, which at `off` is
+split into passages and embedded. Therefore:
+
+> **At `synthesis = "off"`, the operator is the only author of model-written
+> text in the index.**
+
+There is no synthesis at capture, no promotion, no generation. The only route by
+which model-written text enters the base is a deliberate click, and the trace
+records as `ORIGIN_ASK` that a model wrote it. This is the sharpest form of the
+fidelity line the application can have, and at `off` it costs nothing.
+
+## The economics invert
+
+| | `eager` | `off` |
+|---|---|---|
+| paid | per corpus, at capture | per question asked |
+| cost of a collection never read | full | zero |
+| cost of the search path | one embedding | one embedding |
+
+The roadmap's rule — inference at write time, not read time, with `ask` as the
+one carved-out exception — inverts at `off`: there *is* no write-time inference,
+so `ask` is the only inference. Not a violation of the principle but its
+limiting case.
+
+## What `off` makes mandatory
+
+`cap_per_corpus` is applied **client-side over a candidate pool of three times
+the limit**, and the roadmap already names the weakness: a corpus whose
+artifacts fill the pool leaves nothing to promote.
+
+At `eager` a 10,000-token document yields perhaps eight artifacts. At `off` it
+yields around twenty-six passages, and adjacent passages of a section are
+additionally similar through their shared heading. One large document fills the
+pool reliably and the cap has nothing left to redistribute.
+
+**Server-side grouping (`query/groups` in Qdrant) is therefore part of this
+spec**, with `cap_per_corpus` as the in-memory fallback. It is already a roadmap
+item; `off` promotes it from a nice-to-have to a prerequisite.
+
+---
+
+# 6. Consolidation
+
+## One rule, at every mode
+
+> **Consolidation operates on the index, not on a provenance class.**
+
+`relate` / `dedupe` / `consolidate` / `merge` see every active row and judge
+pairs on their merits. No provenance filter, no skip list. If passages are what
+rank, passages are what needs grooming; a system that serves one layer and
+tidies another is incoherent.
+
+At `eager` no passage is ever embedded, so consolidation grooms artifacts by
+construction rather than by rule. Same rule, different inhabitants.
+
+## The one exclusion, and it is not about provenance
+
+Section 1 makes the carried heading the passage's `title`, and `embed_text`
+prepends it — with EmbeddingGemma's `title:` slot giving it more weight still.
+Every passage under one heading therefore embeds with the same string in the
+most weighted position.
+
+**Adjacent passages in a section have systematically inflated cosine similarity
+for structural reasons, not semantic ones.** Pointed at them, `relate` would
+flood the pair queue with model calls adjudicating paragraphs that merely sit
+next to each other — "pay only where it pays" inverted.
+
+**Consecutive passages within the same corpus are not pair candidates.** Not
+same-corpus: *consecutive*. Boilerplate genuinely repeated in section 2 and
+section 9 is a real duplicate and must still be found; it is specifically
+neighbours under a shared heading whose similarity is an artefact of how they
+were built. One predicate in `classify_pair`, beside the `in_results()` check it
+already makes.
+
+One existing rule needs no change: the same-corpus containment check at
+`relate.rs:148` targets a synthesis defect — one call emitting a passage twice —
+and passages from a single splitter pass are disjoint slices that never contain
+one another.
+
+## `auto_supersede` stops hiding anything
+
+`auto_supersede` currently hides a member of a cluster on a cosine threshold
+alone: no model call, no `losses` check, no adjudication of any kind. And
+embeddings barely distinguish negation:
+
+> "runs on ext4"  ⟷  "does **not** run on ext4"
+
+These sit far above any realistic threshold. The mechanism would hide one of
+them by "newest wins", which here is chance — resolving by deletion a
+contradiction the roadmap says goes to a person.
+
+What remains as its benefit is near-identical content across corpora.
+Byte-identical and near-identical *documents* are already caught at capture by
+the shingle path, leaving only "I pasted an article, then a longer piece quoting
+it" — not worth an unguarded automatic hide.
+
+**The threshold stops being a hide and becomes a fast lane to the judge.** Pairs
+above it go to the model judge like everything else, with `losses` behind them.
+The config key stays (a wired feature is not legacy machinery) and changes
+meaning. Cost: more model calls, bounded by the already-capped pair queue.
+
+## The merge guards stay as they are
+
+`losses()` is forty lines: every number, version, port, path, flag, command and
+error string from both sources must appear in the merged text. Its simplification
+pass has already been done on evidence — the comment records that
+`missing_literals` was too strict for merges and was replaced with
+`missing_machine_literals`.
+
+Its value is highest exactly where this design points it. At `earned`,
+consolidation operates over passages — verbatim source text. A merge dropping
+"requires kernel 5.4+" from verbatim material destroys the one thing passages
+exist to preserve. Weakening the guard while extending merging to verbatim
+material would be turning two dials in opposite directions.
+
+The unguarded path was `auto_supersede`, and it is dealt with above.
+
+## Two consequences, decided rather than inherited
+
+**The merge guards were written for artifacts and now apply to passages.**
+`losses` holds regardless of input. Weaker is what `dedupe_prompt` relies on —
+titles — since a passage's title is a carried heading, which is often exactly
+the failure that prompt documents. Expect more `conflict` verdicts (escalating
+to a person) and fewer confident `duplicate` ones. That is the safe direction to
+fail; watch the pair queue rather than pre-tuning.
+
+**Duplicate detection is dormant until use wakes it, and so is contradiction
+detection.** Two passages in different corpora saying the same thing sit there
+until each is independently promoted. On a lightly used base that is
+approximately never — the deliberate consequence of paying only where it pays.
+Capture no longer surfaces conflicts; use does. Pasting the same *document*
+twice is still caught at capture, unchanged.
+
+---
+
+# 7. Origins
+
+## The problem
+
+`artifacts.corpus_id` is NULL for `merged`, and now also for `synthesized`. The
+schema comment explains why: claiming a corpus the artifact did not come from
+would put the wrong lines beside it, "the one dishonesty merging must not
+commit." NULL avoids the lie by declining to answer.
+
+The better answer is to claim **all** of them. A merged artifact belongs to
+every corpus it drew from, and its parents' line ranges stay claimed — so
+merging stops punching red holes in corpus coverage.
+
+## Derived, not stored
+
+The information already exists. `artifact_sources` names the roots, every root
+is `captured`, and every captured artifact has `corpus_id` and `corpus_span`.
+
+```rust
+// Mirror of roots_of. Batched, because search needs it for a page of hits.
+Store::origins_of(&[ids]) -> Map<String, Vec<Origin { corpus_id, span }>>
+```
+
+| provenance | origins |
+|---|---|
+| `passage` | exactly one — its own `corpus_id` and `corpus_span` |
+| `captured` | exactly one — the same |
+| `merged` | one per root corpus, with the roots' spans |
+| `synthesized` | one per root corpus, with the roots' spans |
+
+A join table storing the same fact was considered and rejected. Two tables
+asserting one truth create a synchronisation obligation that never ends — a root
+deleted, a root restored out of a merge via `artifact_sources.restored`, a merge
+of a merge, an undo — and a missed site produces an artifact claiming a corpus
+its lineage no longer supports, which is the original dishonesty in a new form.
+Derivation cannot drift, because membership *is* lineage projected.
+
+Behind one named function, derivation is also the future-proof choice: if stored
+origins are ever wanted, the body of `origins_of` changes and nothing else. The
+reverse migration would touch 250+ read sites.
+
+## The invariant this makes expressible
+
+> **`origins_of` returns a non-empty list for every active artifact.**
+
+This is the enforceable, testable form of "an artifact always belongs to a
+corpus" — true for all four provenances, where a `NOT NULL` column could only be
+satisfied for merges by a half-truth. An empty result is the same broken state
+`roots_of` already reports — a merge whose sources were deleted from under it —
+and escalates to a person the same way.
+
+## Call sites
+
+Four, not 177. Everything else keeps reading `corpus_id` and sees no change.
+
+1. **Corpus detail page** — a merge now appears under each of its corpora
+2. **Bands and coverage** — parent spans stay claimed, the red hole disappears
+3. **`cross_corpus` in `links_from`** — `x != y` becomes "intersection empty"
+4. **`cap_per_corpus` in `search.rs`** — a merge counts against each of its
+   corpora
+
+## One payload field
+
+`cap_per_corpus` groups on `payload.corpus_id`, which is NULL for merged and
+synthesized rows — so today they all land under one key. `VectorPayload` gains:
+
+```rust
+origin_corpora: Vec<String>
+```
+
+This does not contradict the rejection of a stored join table. The Qdrant
+payload is explicitly a projection of SQLite — `title`, `category`, `status` and
+`superseded_by` are already mirrored there, and `lifecycle_dirty` plus
+`repair_lifecycle_drift` are the machinery that pulls drift back. SQLite remains
+the sole authority. A second *SQLite* table claiming the same truth would have
+been a different thing.
+
+Side effect that justifies it alone: **corpus-filtered search works for merged
+artifacts for the first time.** Today it cannot, because `corpus_id` is NULL.
+
+---
+
+# 8. What is configured is what is offered
+
+A general rule, with precedent: without `[infer.vision]` the image door is
+closed.
+
+- no `[infer.ask]` → no ask page, no menu entry, no MCP `ask` tool
+- no `[infer.vision]` → no image door (already true)
+- `synthesis = "off"` → no re-synthesise buttons, no artifact filter chips that
+  can never match
+- `[pursuit] enabled = false` → no pursuit view in Ops
+- `feedback.enabled = false` → no judge
+
+No greyed-out control, no menu entry leading to an error page. The door is
+simply not there.
+
+---
+
+# 9. A hazard the new provenance values create
+
+`Provenance::parse` (`artifacts.rs:87`) is:
+
+```rust
+match s {
+    "merged" => Provenance::Merged,
+    _ => Provenance::Captured,     // everything unknown
+}
+```
+
+Writing `'passage'` or `'synthesized'` to the column without adding them here
+makes every such row read as `captured` throughout the process. The consequence
+is not cosmetic: `roots_of` returns a captured artifact's *own id* as its root,
+so a generated artifact would hand its own model-written text to the merge
+prompt as an original — precisely the failure `roots_of`'s comment names.
+
+Two fixes together:
+
+- add `Passage` and `Synthesized` to the enum, `as_str` and `parse`
+- `roots_of`'s inner check is a raw string compare,
+  `provenance.as_deref() == Some("merged")`. It must test **"not captured"**
+  rather than "is merged", so the next value added defaults to safe rather than
+  to wrong. Generated artifacts always have source rows so the branch is not
+  reached in practice — which is exactly why it must be right.
+
+Audit the remaining `Provenance::Merged` comparisons for what the new values
+should do: `dedupe.rs:124` (roots as prompt context — yes for `synthesized`,
+same as a merge), `embed.rs:313`, `merge.rs:90/184/240`, `ui.rs:2594` and
+`lineage_view.rs:295` (both need more than a boolean `merged`).
+
+---
+
+# Measurement
+
+Nothing here changes a default that moves ranking without the harness having run.
+
+Land in this order, measuring between:
+
+1. **The embedding recipe** on its own. It moves the retrieval baseline; if it
+   ships with the mode split, neither can be attributed.
+2. **`off`** — then compare `off` against `eager` on the same judged pair set,
+   and compare `chunk_tokens` at 256 / 384 / 512.
+3. **Promotion**, then **pursuits**.
+
+`--export-eval` reads SQLite only and keeps real ids, so re-exporting does not
+invalidate judged pairs. Superseded passages stay readable by id, so pairs
+naming a promoted-away passage still resolve.
+
+# Cut
+
+**A separate cue store or second vector for access reconsolidation.** A
+generated artifact *is* the access cue, and it is the more inspectable of the
+two: readable, editable, deprecable, and it says what it was written from and
+which questions produced it. A hidden cue list improves ranking by means the
+operator cannot see. This is a deliberate departure from the roadmap's cut of
+answer cards, and it rests on two things that version lacked — the artifact is
+retrievable and inspectable, and the top-1 rule makes the loop terminate.
+
+**Similarity between passages as a promotion trigger.** Two passages being alike
+is not evidence anyone needs them. Spending synthesis on redundancy nobody has
+searched for is eager synthesis in disguise. Both converge anyway: each is
+promoted by its own use, and consolidation then sees two artifacts.
+
+**Per-corpus or per-capture tier selection.** The middle mode already does
+per-item selectivity, dynamically and on evidence of use, which is strictly
+better than a guess at paste time. A capture-time dial would be a worse version
+of what the design already does.
+
+**A migration path for the embedding recipe.** There is no base to look after.
+The generation-flip machinery in `qdrant.rs` is what to build the day there is.
+
+**`max_per_sweep` for promotion.** The job queue and `[pacing] cooldown_secs`
+already bound GPU load; a second bound would be a worse re-implementation of
+one that works.
+
+**A second embedding recipe for gap clustering.** `gaps.rs` would prefer
+EmbeddingGemma's `clustering` task, but it clusters stored search-event vectors
+which were necessarily embedded for retrieval. Embedding every query twice
+forever to improve a feature that names clusters for a human to read is not
+worth it.

--- a/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+++ b/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
@@ -744,6 +744,10 @@ CREATE INDEX IF NOT EXISTS idx_pursuits_state ON pursuits(state, opened_at);
 `search_event_id`; the clustering decides which pursuit that is, so the events
 carry no pursuit id of their own and re-clustering never has to rewrite them.
 
+`dwell` is not recorded by the first implementation — the UI has no timing —
+and the `opened`/`pivoted` rows are attached to search events by time and
+scope at analysis, never by a stored id; `returned` is derived there too.
+
 **Dwell is deliberately the weakest.** Long dwell means *this was useful* or
 *this was confusing and hard to read*; a tab left open means *engaged* or *went
 to lunch*. With one operator there is no volume for the noise to average out.

--- a/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+++ b/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
@@ -45,7 +45,7 @@ anywhere.
 
 ```toml
 [infer]
-synthesis = "eager"        # "off" | "earned" | "eager"
+synthesis = "earned"       # "off" | "earned" | "eager"
 ```
 
 **`off`** — capture splits, embeds, and stops. Passages are the index. Zero
@@ -56,9 +56,19 @@ shown it is worth it, and always supersedes what it was written from.
 
 **`eager`** — today. One synthesis call per segment at capture.
 
-`eager` is the default so that setting nothing changes nothing. `off` with no
-`[infer.ask]` configured is a complete and coherent product state: a semantic
-search engine over verbatim text with no inference at all.
+`off` with no `[infer.ask]` configured is a complete and coherent product
+state: a semantic search engine over verbatim text with no inference at all.
+
+`eager` was the default while the other two were being built, so that setting
+nothing changed nothing. **Since 2026-08-19 the default is `earned`.** It is
+the mode the rest of this design is for: capture cannot know which paragraph
+will be asked about, so `eager` spends a call per segment rewriting text most
+of which is never retrieved, and it replaces the operator's own words before
+anyone has asked it to. At `earned` the source is the index until reading says
+otherwise, and every synthesized artifact in the base can name the use that
+earned it. An existing `eager` base is unaffected — the mode is written in its
+config — and `eager` stays supported for a base that wants everything
+pre-written.
 
 | | `off` | `earned` | `eager` |
 |---|---|---|---|

--- a/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
+++ b/docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md
@@ -83,14 +83,28 @@ the most recent heading carried into every continuation window. The only thing
 separating a synthesis window from a retrieval passage is the budget passed in.
 
 ```
-raw_text ──split(segment_tokens)──▶ windows   → segments rows (pending, nothing armed)
-             each window.text ──split(chunk_tokens)──▶ passages → artifacts
+raw_text ──split(segment_tokens)──▶ windows   → segments rows (state = verbatim)
+             each window.body ──split(chunk_tokens)──▶ passages → artifacts
 ```
 
 **A passage never crosses a segment boundary.** This is an invariant, not an
 implementation detail: promoting a window later must cover a whole number of
 passages, or the earned tier has a permanent ragged edge where a passage is
 half-superseded.
+
+**The inner split runs over the window's body, not its text.** `Window.text`
+carries the most recent heading in from the previous window as its first
+`carry_lines` lines — they belong to the document further up, not to this
+window's `start_line..=end_line`. Splitting `text` would put that heading
+verbatim into the first passage of every continuation window and then, because
+the splitter carries headings, prepend it again to every continuation passage
+inside the window. So: strip the first `carry_lines` lines off, keep them as
+the heading (next paragraph), split the remainder. The same two-level shift
+`resolve_span` already applies — `w.start_line - 1 - w.carry_lines` — maps a
+passage's line offset inside the body to a `corpus_span`, and the inner
+splitter's own `carry_lines` is discounted the same way one level down. Passage
+spans partition the window's own lines; the carried heading occupies none of
+them.
 
 ## The carried heading becomes the passage's title
 
@@ -101,8 +115,63 @@ document, no inference. This is the single highest-leverage line in the mode:
 it is most of what synthesis was buying at the embedding layer, and section 2
 shows the embedder has a slot built for exactly it.
 
+The heading is the one the splitter tracks: the window's carried heading for a
+continuation window, else the most recent heading inside the window above the
+passage. It is moved into `title` and does **not** stay in `text` — the
+embedding input would otherwise carry it twice, and `text` is meant to be the
+slice of the document the span names. `is_heading` recognises Markdown `#`
+headings only, so plain text, man pages and most fetched pages yield passages
+with no title, which section 2 renders as `title: none`. The leverage is real
+for the sources engram mostly holds and absent for the rest; nothing is
+inferred to fill the gap.
+
 It also has a consequence that section 6 has to handle: every passage in one
 section embeds with the same string in the most weighted position.
+
+## The segment state that says "not synthesized, on purpose"
+
+`segments.state` gains a value: `verbatim`. Capture at `off` and `earned`
+writes every segment row in that state. It is not `pending`, and that is not
+cosmetic: two existing readers treat `pending` as work owed.
+
+- `window::settle` returns early while any segment is `pending`, and only the
+  `finish` it guards renumbers, recomputes coverage and arms `Stage::Embed`.
+  `verbatim` counts as **resolved** there, so a corpus with no synthesized
+  segment settles and finishes like one where every window came back — and,
+  in section 3, so does a corpus where one window was just promoted and the
+  rest were not.
+- The reconciliation sweep (`reconcile.rs:44`) re-arms `Stage::SegmentWindow`
+  for every segment that is not `done`. Left as `pending`, every verbatim
+  segment would be synthesized on the next sweep — eager through the back door,
+  or a `failed` segment with its attempts spent where no synthesizer is
+  configured. The sweep does not touch `verbatim`.
+
+Promotion (section 3) moves a segment `verbatim → pending` and arms it; it
+settles `done` like any other. There is no legacy base to carry, so this is a
+new value in the `CHECK`-less column and a new arm in `SegmentState`, nothing
+more.
+
+## What capture does at `off` and `earned`
+
+Split, write segments `verbatim`, write passages with `provenance = 'passage'`
+(`insert_artifacts` takes the provenance instead of hardcoding `captured`),
+then call `finish` directly — the same function a synthesized corpus reaches
+through its last window's `settle`. `finish` renumbers, records coverage (green
+by construction, below), arms `Stage::Embed` and moves the corpus to
+`embedding`; the embed job moves it to `ready`. The status path is the one the
+UI already knows, minus the `segmenting` stop. `partial` cannot occur at `off`
+and means at `earned` what it means today: a promoted window that spent its
+attempts.
+
+**Segment size without a synthesizer.** `segment_tokens()` derives the window
+budget from the synthesis model's context, and at `off` there need not be one
+(section 1a). When `[infer.synthesize]` is configured the budget is taken from
+it as today, so a later switch to `earned` finds windows the model can read.
+When it is not, the budget is a fixed `[infer] segment_tokens` with a default
+of 4096 estimator tokens. Configuring a synthesizer later whose context is
+smaller than the windows already stored means re-capturing, the same posture
+section 2 takes for the embedding recipe: no migration for a base that does
+not exist yet.
 
 ## What runs, what does not
 
@@ -112,9 +181,30 @@ be a passage at all), near-duplicate shingling at capture, `associate` and
 `Consolidate`, `Merge`.
 
 **Corpus title without a model.** `Stage::Title` is a real inference call. At
-`off` it is replaced by a local derivation: the first heading in `raw_text`,
-else the first non-empty line, truncated. `title_hint` already exists and
-already short-circuits when set.
+`off` and `earned` it is replaced by a local derivation at capture: the first
+heading in `raw_text`, else the first non-empty line, truncated, written as the
+corpus title. `finish` arms `Stage::Title` only at `eager`; at `earned` a
+promotion therefore never spends a model call on a name the document already
+gave, and `title_hint` keeps its meaning — a name a person chose.
+
+## 1a. `[infer.synthesize]` and `[infer.ask]` become optional
+
+`InferConfig` (`config.rs:356`) requires both roles today, and `Core` holds a
+synthesizer and an ask client unconditionally. `off` with neither configured
+is a product state this spec promises, so both become `Option`, with the
+consequences that follow:
+
+- `synthesis = "earned"` or `"eager"` without `[infer.synthesize]` is a
+  startup error, not a runtime one. `off` accepts its absence.
+- `Core.synthesizer` and the ask client are `Option`; the stages that call
+  them (`SegmentWindow`, `Title`, `Relate`'s judge, `Dedupe`, `Merge`,
+  `Generate`) are not armed when the role is absent, and a job row that
+  nevertheless names one — a base captured at `eager`, then reconfigured —
+  settles with a reason rather than retrying to the ceiling.
+- Section 8 follows: what is not configured is not offered.
+
+This is the largest single piece of plumbing in the spec and is listed here so
+it is planned as one, not discovered as many.
 
 ## Coverage is green by construction
 
@@ -157,9 +247,15 @@ splitter can never emit a passage that `split_oversize` then has to cut apart
 again. A splitter and an embedder disagreeing about size is a loop with no good
 end.
 
+The unit is the estimator's. `TokenCounter` is `chars * 2 / 7`
+(`budget.rs:21`), deliberately pessimistic, so 384 is roughly 1,350 characters
+and somewhat fewer real Gemma tokens. Every budget in engram is in these units
+already; the number is stated in them and compared in them.
+
 This number is argued, not measured. `/ui/judge` and `cargo test --test eval`
 can compare 256 / 384 / 512 over one judged pair set, and the harness is what is
-allowed to change it.
+allowed to change it — after the embedding recipe has landed, so the two are
+not measured together.
 
 ---
 
@@ -224,6 +320,18 @@ Templates stay in config rather than hardcoded, because `model` is configurable
 and pointing at `bge-m3` must remain possible. That is three struct fields, not
 a subsystem.
 
+The three strings above are the model card's as of 2026-08-19 (`title: {title |
+"none"} | text: {content}`; `task: search result | query: {content}`; 2048
+context, 768/512/256/128 MRL, 300M parameters). Two things to check once at
+deploy time rather than assume: that the serving stack does not prepend a
+template of its own — an Ollama modelfile or a llama.cpp wrapper that does
+would double the prefix, which the stored vectors would then carry forever —
+and that the server's physical batch is not below 2048. The card also names a
+`task: question answering | query:` prefix; `ask` does not use it, because
+section 4 clusters ask vectors and search vectors together and a second query
+prefix would put them in two subspaces. One query template is a constraint of
+the design, not an oversight.
+
 ## Where it lands
 
 | site | change |
@@ -287,7 +395,7 @@ lacks.
 
 Which means promotion is not new inference code. It is today's
 `Stage::SegmentWindow`, armed by evidence instead of by capture. The `segments`
-rows written at capture sit `pending` with nothing armed, and promotion arms
+rows written at capture sit `verbatim` with nothing armed, and promotion arms
 one.
 
 ## The trigger
@@ -298,16 +406,25 @@ activation_above               = 4.0   # earned
 resynthesize_after_unconfirmed = 0     # eager; 0 disables, and it ships disabled
 ```
 
-`activation_above` read against `[activation]` — baseline `1.0` at creation, `retrieved = 1.0`,
-`opened = 0.5`, `confirmed = 3.0`, half-life 14 days — that threshold means
-**one confirmation, or three retrievals inside the half-life**.
+`activation_above` is read against `[activation]` — baseline `1.0` at
+creation, `retrieved = 1.0`, `opened = 0.5`, `confirmed = 3.0`, half-life 14
+days — and the test is `>=`, after the bump, with decay folded in. The
+baseline decays from the moment of insert, so "one confirmation" is
+`1.0·d + 3.0`, just under the line on its own; in practice a confirmation was
+preceded by the retrieval and open that made it possible, `1 + 1 + 0.5 + 3`,
+and clears it comfortably. Retrievals alone — `1 + 1 + 1 + 1` at best, less
+with any time between them — do not, and the next rule means they are not
+supposed to.
 
 **Engagement, not exposure.** `retrieved` fires when a passage merely *appears
 in a result list*. A threshold on activation alone would spend synthesis on a
-passage that has demonstrably helped nobody. So promotion additionally requires
-that the passage was **opened or confirmed** at least once. One extra condition,
-no new machinery, and it removes the "promoted a passage nobody read" failure
-entirely.
+passage that has demonstrably helped nobody. So the threshold is checked at
+exactly two of the three bump sites: the `opened` bump in `mark_artifact_seen`
+and the `confirmed` bump in the association sweep — never at the `retrieved`
+bump in `mark_seen`. A passage retrieved ten times sits at eleven and is not
+promoted until someone opens it; the act that promotes is always an engagement.
+No stored "was opened" flag, no new table: the condition is *where* the check
+lives.
 
 **Checked at the bump, not on a sweep.** A sweep reads decayed activation, so a
 passage that crossed 4.0 on Tuesday is at 3.6 by Sunday and the threshold
@@ -316,17 +433,45 @@ where `bump_activation` is called is exact. It also means no `max_per_sweep`
 key: the bump *enqueues a job* rather than calling a model, and the job queue
 plus `[pacing] cooldown_secs` already bound GPU load.
 
+**Activation must actually move.** Today every `bump_activation` call is
+gated on `Core::associating()` — `associate.enabled && feedback.enabled` — and
+`feedback.enabled` ships `false`, so on a default install no activation ever
+changes and `earned` would silently be `off`. **`feedback.enabled` becomes
+`true` by default.** Search recording, association and activation are on
+unless turned off; the privacy posture is opt-out, stated in the config
+comment and the README where it was stated the other way. The test
+`associating_requires_both_flags_the_shipped_default_has_only_one` is
+rewritten to assert the new default. `earned` with `feedback.enabled = false`
+is a startup warning naming the consequence, not an error — an operator may
+want verbatim search with no recording, and that is `off` under another name.
+
 ## Mechanically
 
-1. Set `keep_artifacts = 1` on the segment. This flag exists for re-reading a
-   window to pick up missed lines, and it makes `write_segment_artifacts`
-   **append rather than replace** (`window.rs:338`). Without it the promotion
-   would *delete* the passages it is supposed to supersede — artifacts and
-   passages share a `segment_idx`.
+1. Move the segment `verbatim → pending` and set `keep_artifacts = 1` on it.
+   The flag exists for re-reading a window to pick up missed lines, and it
+   makes `write_segment_artifacts` **append rather than replace**
+   (`window.rs:338`). Without it the promotion would *delete* the passages it
+   is supposed to supersede — artifacts and passages share a `segment_idx`.
 2. Arm `Stage::SegmentWindow` for `(corpus_id, segment_idx)`. Unchanged job.
-3. After `write_segment_artifacts`, inside the same `corpus_lock`, supersede the
-   covered passages.
-4. The segment settles `done`, which clears `keep_artifacts`.
+3. After `write_segment_artifacts` returns, under the `corpus_lock` the window
+   job takes for the step, supersede the covered passages and carry access
+   forward (below). `write_segment_artifacts` takes and releases the lock
+   itself, so the supersede is a second locked step in the same job, not a
+   call inside the first.
+4. The segment settles `done`, which clears `keep_artifacts`, and `settle`
+   runs `finish` — every other segment is `verbatim`, which counts as
+   resolved — so the new artifacts are armed for embedding, coverage is
+   recomputed and the corpus goes `embedding → ready` again. Nothing
+   promotion-specific arms the embed; the existing path does, because the
+   state was chosen so that it would.
+
+**Idempotency.** The append is the documented exception to "replace, never
+append", and its documented cost — a process dying between the insert and
+`done` re-runs the window and writes its artifacts twice — was accepted for an
+operator-initiated re-read. Promotion makes it the common path, so the window
+job pays one extra read: under `keep_artifacts`, if the segment already holds
+active rows with `provenance != 'passage'`, the write is a retry and is
+skipped. The dedupe sweep is no longer the thing that cleans up after a crash.
 
 **The guard against re-promotion is the segment state**, not `provenance`: a
 window whose segment is `done` never promotes again. This matters because
@@ -338,9 +483,12 @@ Each new artifact has a `corpus_span` from `resolve_span`; each passage has one
 from the splitter. Both are in the same coordinate space because passages nest
 inside windows.
 
-**A passage is superseded only when some artifact's span covers a majority of
-its lines.** Best overlap wins, ties go to the lowest ordinal, and a passage no
-artifact substantially claims **stays active, verbatim, in results**.
+**A passage is superseded only when some one artifact's span covers a majority
+of its lines.** Per artifact, not cumulative: two artifacts claiming 30% each
+leave the passage standing, because `supersede` names one winner and a passage
+hidden behind an artifact that holds a third of it would send the reader to
+the wrong text. Best overlap wins, ties go to the lowest ordinal, and a passage
+no artifact substantially claims **stays active, verbatim, in results**.
 
 The majority floor is load-bearing. Without it, an artifact overlapping one line
 of a twenty-line passage would remove nineteen lines of verbatim text on a 5%
@@ -408,8 +556,20 @@ would let a wide passage manufacture accessibility. `decayed()` already exists.
 **Links are copied, not moved.** For every link touching a superseded passage,
 write the corresponding link on the artifact and leave the original row in
 place. `links_from` filters superseded endpoints out anyway, so the dead rows
-cost nothing at read time — and undo becomes free, because restoring a passage
-lights its links back up with no reverse migration to get wrong.
+cost nothing at read time. The row on the passage stays because it records
+what the passage earned, and because a copy is one INSERT with no reverse
+migration to get wrong. Undo (below) gets its links back for free as a
+consequence — for as long as the rows exist: `prune_learning_links` removes
+`learning` rows whose decayed weight falls under the floor, and a dead row
+decays like a live one. That is a bounded convenience, not a guarantee, and the
+copy is not justified by it.
+
+The copy is written in state `learning` unless the original was `dismissed`.
+A `related` verdict was passed on the passage's text, which the artifact does
+not have; `reopen_stale_judged_links` would reset it on the next sweep anyway
+once it saw `judged_rev` cleared, and writing the reopened state directly is
+the same result without a window in which a judge's line is shown under text
+the judge never read.
 
 Copying needs collision handling, since two passages in one window can link to
 the same artifact and both become the same `(a_id, b_id)` primary key:
@@ -422,8 +582,30 @@ the same artifact and both become the same `(a_id, b_id)` primary key:
 - `state`: a `dismissed` verdict on either side wins. The operator's "not
   related" is final, and `links_from` already treats it as an invariant rather
   than a filter.
-- `judged_rev_a/b` are cleared. The text changed under the judge, which the
-  schema comment already says reopens the verdict.
+- `judged_rev_a/b` are cleared and `state` is `learning` (or `dismissed`), as
+  above.
+
+## Ordinals after a promotion
+
+`renumber_artifacts` orders every row of a corpus — superseded passages
+included — by `(segment_idx, ordinal, rowid)`, and `finish` runs it after
+every promotion. Inside a promoted window the new artifacts, the passages they
+superseded and the passages that survived are therefore interleaved in one
+ordinal sequence, and "the row at `ordinal ± 1`" stops meaning "the
+neighbouring text". Three readers depend on document order and each gets a
+definition that survives this:
+
+- `adjacent_artifacts` (`artifacts.rs:444`) becomes "the nearest **active**
+  row by ordinal on either side" — `ordinal < ? ORDER BY ordinal DESC LIMIT 1`
+  and its mirror — instead of `ordinal IN (n-1, n+1)`. Today a superseded
+  neighbour returns nothing on that side; at `earned` that is the common case
+  in exactly the windows people use.
+- Stitching in `ask` (section 5) joins passages whose `corpus_span`s abut —
+  `end_line + 1 == start_line` — within one `(corpus_id, segment_idx)`, not
+  consecutive ordinals.
+- The consolidation exclusion (section 6) is by segment, not by ordinal.
+
+Nothing else reads ordinals as adjacency.
 
 **What does not carry:**
 
@@ -442,7 +624,7 @@ not.** That is the fixed/plastic split applied one level down.
 ## Undo
 
 `unsupersede` exists. Undoing a promotion restores the passages to active,
-deprecates the window's artifacts, and sets the segment back to `pending`. The
+deprecates the window's artifacts, and sets the segment back to `verbatim`. The
 copied links and the raised activation stay on the artifact — an asymmetry
 accepted rather than fixed, since both sides describe the same corpus lines.
 
@@ -464,7 +646,18 @@ accepted rather than fixed, since both sides describe the same corpus lines.
 - a `dismissed` link stays dismissed after the copy
 - judged pairs still name the passage after promotion, and `--export-eval`
   resolves it
-- a passage retrieved three times but never opened does **not** promote
+- a passage retrieved three times but never opened does **not** promote; the
+  same passage opened once afterwards does
+- a corpus captured at `off` has every segment `verbatim`, reaches `ready`,
+  and a reconciliation sweep arms no `SegmentWindow` for it
+- after a promotion the window's artifacts are `embed_state = pending` with a
+  live embed job, and coverage was recomputed — with every other segment still
+  `verbatim`
+- a promotion re-run under `keep_artifacts` over a window that already holds
+  non-passage rows writes nothing
+- two artifacts each claiming 30% of one passage leave it active
+- a copied link is `learning`; a copied `dismissed` link is `dismissed`
+- `adjacent_artifacts` skips a superseded row and returns the next active one
 
 ---
 
@@ -485,6 +678,16 @@ pursuits.
 cosine — the same grouping `gaps.rs` already does to name knowledge gaps — and
 each cluster is one **pursuit**: a coherent thing that was wanted, its queries,
 and everything done with the results. Local, no inference.
+
+The same grouping means the same line. `gaps.rs` once used a fixed `0.55` and
+its header records why that failed: under bge-m3 unrelated short queries land
+in 0.45–0.6, single linkage is transitive, and a few dozen of them chain into
+one group. What replaced it is `link_threshold()` — the 99th percentile of
+pairwise cosine over the base's own recorded queries, rounded, clamped to
+`[0.55, 0.9]`. Pursuits use **that function**, not a second constant; a
+`coherence` key would reintroduce the guess the repo already paid to remove,
+and the embedding recipe in section 2 moves the whole cosine distribution in a
+way no constant would follow.
 
 ## What gets recorded
 
@@ -507,7 +710,7 @@ CREATE TABLE interaction_events (
 | `opened` | 1.0 | deliberate |
 | `pivoted` | 1.5 | followed a neighbour, association or continuation — the strongest voluntary act, and unique to this application |
 | `returned` | 2.0 | came back to it later in the pursuit; hard to fake |
-| `confirmed` | 3.0 | already an activation delta; reused verbatim |
+| `confirmed` | 3.0 | already an activation delta; reused verbatim. Not a row here — it is read from `search_events.expect_id`/`verdict`, which already record it |
 | `dwell` | ≤0.5, capped | tiebreak only, never decisive |
 | `refined` | — | searched again without opening anything: a failure signal |
 | `abandoned` | — | searched, opened nothing, no follow-up: the strongest failure signal, and the one the README already says leaves no other trace |
@@ -545,9 +748,19 @@ generating at all.
 
 ## The stopping rule
 
-**A `synthesized` artifact at rank 1, at or above `weak_below`, closes the
-pursuit `satisfied` — no events recorded, no analysis, no generation.** Checked
-at result-assembly time in `search.rs` before anything is written.
+**A `synthesized` artifact at final rank 1, at or above `weak_below`, marks the
+search `answered` — no `interaction_events` are recorded for it, and any
+pursuit the clustering later places it in closes `satisfied` without analysis
+or generation.** The mark is a flag on the `search_events` row, set at
+result-assembly time in `search.rs`; the pursuit does not exist yet at that
+moment — section "The unit is a pursuit" says the clustering decides which one
+an event belongs to — so what is written is the fact, and the analysis pass
+acts on it. The search event itself is still recorded: the judge and the gap
+sweep read it as they always did.
+
+"Final rank" is the rank the page shows — after the reranker, where one is
+configured. `weak` is read from the vector similarity regardless
+(`search.rs:781`), which is why the two are stated separately.
 
 The `weak_below` qualification matters: a fused rank says where a hit placed,
 not how good it was, and a generated artifact at rank 1 with a 0.31 cosine is
@@ -560,28 +773,55 @@ is failing and goes quiet the moment it is not. When a generated artifact later
 goes stale it stops being rank 1, telemetry resumes, a fresh one is generated,
 and consolidation resolves the pair. It self-maintains.
 
+**A second anchor, for when rank 1 is not reached.** The top-1 rule terminates
+only if the generated artifact places first for the *next* phrasing of the
+need, and a paraphrase need not. So before enqueueing, the analysis pass
+resolves the engaged artifacts to roots through `roots_of` and compares the set
+against the roots of every active `synthesized` artifact. **If the pursuit's
+roots are a subset of an existing generation's roots, nothing is generated**,
+and the pursuit closes `satisfied` naming that artifact. Local, one query per
+candidate, no model. This is what stops "the same assembly, again" without
+asking the ranking to have noticed; what the ranking then still has to do is
+surface the artifact, and consolidation gets a second chance if it does not.
+
 A pursuit also closes `satisfied` when any hit above `weak_below` was opened or
-confirmed and searching stopped. Success is success regardless of who wrote the
-hit.
+confirmed and searching stopped, **and** fewer than `min_sources` artifacts
+were engaged. Success is success regardless of who wrote the hit; the second
+clause is the assembly trigger below.
 
 ## The analysis pass — local decides, the model only writes
 
 When a pursuit goes idle, one background job, no inference:
 
-1. group the window's queries into pursuits by cosine ≥ `coherence`
-2. sum engagement per artifact
-3. **unsatisfied?** — no strong hit opened or confirmed, or `refined` ≥ 2, or
+1. group the window's queries into pursuits at `link_threshold()`
+2. any event in the group marked `answered` → close `satisfied`, stop
+3. sum engagement per artifact
+4. **assembled?** — at least `min_sources` distinct artifacts engaged with,
+   and total engagement ≥ `min_engagement`
+5. **unsatisfied?** — no strong hit opened or confirmed, or `refined` ≥ 2, or
    `abandoned`
-4. **assembled?** — at least `min_sources` distinct artifacts engaged with, and
-   total engagement ≥ `min_engagement`
-5. both true → enqueue `Stage::Generate` — a new job stage, and the only one
-   this spec adds
-6. otherwise close the pursuit, recording why
+6. **wanted as a whole?** — assembled, and the engagement includes at least
+   one `pivoted` or `returned` event: the operator moved *between* the
+   sources, which is what distinguishes reading three answers from assembling
+   one out of three
+7. assembled **and** (unsatisfied **or** wanted-as-a-whole) → root-subset
+   check against existing generations → enqueue `Stage::Generate` — a new job
+   stage, and the only one this spec adds
+8. otherwise close the pursuit, recording why
 
 Step 4's `min_sources ≥ 2` does real separating work: **one** engaged artifact
 means there was nothing to assemble, and that is a promotion case — its window,
 section 3 — not a generation case. The two mechanisms partition on the number of
 sources.
+
+Step 6 is the case the section opened with. Five passages across three
+corpora that jointly served one need are each, individually, a strong hit that
+was opened — "satisfied" by step 5's test — and without step 6 the scenario
+that motivates generation would never trigger it. The `pivoted`/`returned`
+requirement keeps the trigger honest: opening three results in a row is
+reading; going back to the first after the third, or following a neighbour
+out of one into another, is assembling. `dwell` does not count toward it for
+the reason given above.
 
 ## The generation job
 
@@ -658,22 +898,31 @@ gets resolved.
 [pursuit]
 enabled        = false   # meaningful at synthesis = "earned" and "eager"
 idle_secs      = 900
-coherence      = 0.6
 min_sources    = 2
 min_engagement = 3.0
 ```
 
-Gated like `feedback.enabled` — off until turned on, local only, nothing leaves
-the machine, and Ops forgets all of it on one press. Same posture as the judge
-data, for the same reason.
+No `coherence` key: the grouping line is measured, per the clustering
+paragraph above. Off until turned on — unlike `feedback.enabled`, which section
+3 makes opt-out, this generates model-written text into the index, and that is
+a step an operator takes deliberately. Local only, nothing leaves the machine,
+and Ops forgets all of it on one press. `pursuit.enabled = true` requires
+`feedback.enabled = true`, since the events it reads are the ones recording
+writes; the combination is a startup error.
 
 ## Tests
 
-- a generated artifact at rank 1 above `weak_below` records nothing and closes
-  the pursuit satisfied; the same artifact at rank 1 *below* it does not
-  suppress
-- two unrelated searches inside one idle window become two pursuits
+- a generated artifact at rank 1 above `weak_below` marks the search
+  `answered`, records no interaction events, and the pursuit it lands in
+  closes satisfied; the same artifact at rank 1 *below* it does not suppress;
+  the search event itself is recorded either way
+- two unrelated searches inside one idle window become two pursuits, at the
+  line `link_threshold()` returns for the base
 - a pursuit engaging one artifact enqueues promotion, not generation
+- three strong hits opened in sequence with no pivot or return close
+  satisfied; the same three with one `returned` event generate
+- a pursuit whose roots are a subset of an existing generation's roots does
+  not generate and closes naming it
 - a pursuit that engaged a generated artifact puts **its own text** in the
   prompt, not its roots
 - `artifact_sources` for that generation names the **captured** roots with
@@ -707,16 +956,20 @@ and becomes a statement about the knowledge base.
 
 ## Contiguous passages are stitched
 
-Passages are consecutive verbatim slices with consecutive ordinals inside a
-segment. When passages 7 and 8 are both selected, they are literally continuous
-text. Presenting them as two excerpts wastes tokens on the twice-repeated
+Passages are consecutive verbatim slices whose spans tile a segment. When
+the passages for lines 40–61 and 62–88 are both selected, they are literally
+continuous text. Presenting them as two excerpts wastes tokens on the twice-repeated
 carried heading, hides the continuity from the model, and cuts whatever sentence
 runs across the boundary.
 
 Before packing: group selected passages by `(corpus_id, segment_idx)`, sort by
-`ordinal`, and merge runs of consecutive ordinals into one excerpt. This
-restores the original text as written, costs fewer tokens than the same passages
-separately, and is local work with no inference.
+`corpus_span.start_line`, and merge runs whose spans abut — each
+`end_line + 1` is the next `start_line` — into one excerpt. Spans rather than
+ordinals, because after a promotion the ordinal sequence interleaves superseded
+and surviving rows (section 3, "Ordinals after a promotion") and two surviving
+passages with a superseded one between them are *not* continuous text. This
+restores the original text as written, costs fewer tokens than the same
+passages separately, and is local work with no inference.
 
 Two conditions keep it honest:
 
@@ -727,12 +980,12 @@ Two conditions keep it honest:
    pursuit analysis all depend on knowing which passages actually carried the
    answer. A stitched excerpt is a presentation, not a new unit.
 
-The existing sideways reach needs no change. `adjacent_artifacts` is a lookup in
-**document order** — `ordinal ± 1`, both sides already — and is a different
-mechanism from `neighbours()` (vector distance, directionless) and
-`artifact_links` (Hebbian association, explicitly undirected). `±1` plus
-stitching is enough; `NEIGHBOUR_ANCHORS` and `NEIGHBOUR_MAX` are ranking
-parameters and move only after the harness.
+The existing sideways reach changes in one line. `adjacent_artifacts` is a
+lookup in **document order** — the nearest active row either side, per section
+3 — and is a different mechanism from `neighbours()` (vector distance,
+directionless) and `artifact_links` (Hebbian association, explicitly
+undirected). One step each way plus stitching is enough; `NEIGHBOUR_ANCHORS`
+and `NEIGHBOUR_MAX` are ranking parameters and move only after the harness.
 
 ## Ask at `earned`: two roles
 
@@ -827,12 +1080,23 @@ for structural reasons, not semantic ones.** Pointed at them, `relate` would
 flood the pair queue with model calls adjudicating paragraphs that merely sit
 next to each other — "pay only where it pays" inverted.
 
-**Consecutive passages within the same corpus are not pair candidates.** Not
-same-corpus: *consecutive*. Boilerplate genuinely repeated in section 2 and
-section 9 is a real duplicate and must still be found; it is specifically
-neighbours under a shared heading whose similarity is an artefact of how they
-were built. One predicate in `classify_pair`, beside the `in_results()` check it
-already makes.
+**Two rows from the same `(corpus_id, segment_idx)` are not pair candidates.**
+Not same-corpus: *same window*. Boilerplate genuinely repeated in section 2 and
+section 9 is a real duplicate and must still be found; what is excluded is
+material that sits together in one window, whose similarity is an artefact of
+how it was built. One predicate in `classify_pair`, beside the `in_results()`
+check it already makes.
+
+The window, not "consecutive ordinals", for two reasons. Ordinals stop meaning
+adjacency after a promotion (section 3), and — the case that actually arises
+at `earned` — a promoted artifact that claimed 40% of a passage leaves that
+passage standing in the same window by the majority rule, and the two then
+look like a duplicate pair to `relate`. Sending that pair to the judge would
+spend a model call to merge, and so hide behind model text, exactly the
+verbatim passage the majority rule just decided to keep. Overlap inside a
+window is the window job's decision, already made; it is not the judge's.
+A document short enough to fit one window loses duplicate detection inside
+itself, which is the shingle path's territory at capture anyway.
 
 One existing rule needs no change: the same-corpus containment check at
 `relate.rs:148` targets a synthesis defect — one call emitting a passage twice —
@@ -948,12 +1212,16 @@ and escalates to a person the same way.
 
 ## Call sites
 
-Four, not 177. Everything else keeps reading `corpus_id` and sees no change.
+Five, not 177. Everything else keeps reading `corpus_id` and sees no change.
 
 1. **Corpus detail page** — a merge now appears under each of its corpora
 2. **Bands and coverage** — parent spans stay claimed, the red hole disappears
 3. **`cross_corpus` in `links_from`** — `x != y` becomes "intersection empty"
-4. **`cap_per_corpus` in `search.rs`** — a merge counts against each of its
+4. **`links_to_judge`** (`links.rs:470`) — the same test, in SQL today
+   (`a.corpus_id IS NULL OR … <>`); it moves into Rust over `origins_of`
+   like `links_from`, or a merge is never judged against its own parents'
+   neighbours and always against everything else
+5. **`cap_per_corpus` in `search.rs`** — a merge counts against each of its
    corpora
 
 ## One payload field

--- a/src/config.rs
+++ b/src/config.rs
@@ -807,8 +807,17 @@ pub struct EmbedRole {
 
 impl EmbedRole {
     /// `chunk_tokens`, never above the embed path's own ceiling
-    /// (`max_input_tokens * 0.8`), so the passage splitter can never emit a
-    /// passage `split_oversize` then has to cut apart again.
+    /// (`max_input_tokens * 0.8`).
+    ///
+    /// A ceiling on the passage, not a promise about the rendered document.
+    /// What `embed` measures is `render(chunk)` — the title and the template
+    /// around it as well as the text — against that same number, so a config
+    /// that sets `chunk_tokens` at or near the ceiling still produces passages
+    /// that measure oversize once rendered. That costs one split round-trip,
+    /// not a loop: `split_oversize` cuts against `limit - envelope_cost`, so
+    /// the pieces it makes fit with the envelope on. The envelope is a title
+    /// and a template this type has neither of, which is why the allowance is
+    /// left where it can be measured rather than guessed at here.
     pub fn effective_chunk_tokens(&self) -> usize {
         let ceiling = (self.max_input_tokens as f32 * 0.8) as usize;
         self.chunk_tokens.min(ceiling).max(1)
@@ -1365,17 +1374,20 @@ impl Config {
 
     /// Rules that a config can satisfy syntactically and still be wrong.
     ///
-    /// The thresholds are the only ones so far, and they are worth refusing to
-    /// start over: `auto_supersede` at or below `review_min` means every pair
-    /// the sweep finds is hidden without asking, with no review band left at
-    /// all. That destroys knowledge quietly, and the operator who typed one
-    /// number would find out from search results going missing weeks later.
+    /// The thresholds are the only ones so far. `auto_supersede` no longer
+    /// hides anything on the score alone — it marks the band the sweep asks
+    /// about *first*, ordering `pairs_to_judge` — but it is still refused at or
+    /// below `review_min`, because a fast lane that starts below the floor for
+    /// looking at a pair at all is a number that cannot mean anything. The
+    /// operator who typed it means one of the two, and neither is what they
+    /// would get.
     fn validate(&self) -> Result<(), ConfigError> {
         let c = &self.consolidate;
         if c.auto_supersede <= c.review_min {
             return Err(ConfigError::Invalid(format!(
-                "consolidate.auto_supersede ({}) must be above consolidate.review_min ({}), \
-                 or every pair found is hidden without review",
+                "consolidate.auto_supersede ({}) must be above consolidate.review_min ({}): \
+                 it marks the pairs asked about first, and cannot sit below the score at \
+                 which a pair is worth asking about",
                 c.auto_supersede, c.review_min
             )));
         }
@@ -1795,9 +1807,10 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
 
     #[test]
     fn thresholds_that_leave_no_review_band_are_refused() {
-        // `auto_supersede` at or below `review_min` hides every pair the sweep
-        // finds without asking anyone. The operator would find out from search
-        // results going missing, weeks later.
+        // `auto_supersede` marks the pairs the sweep asks about first. Below
+        // `review_min` — the score at which a pair is worth asking about at
+        // all — it names a lane no pair can be in, which is a number that
+        // means neither of the two things the operator could have intended.
         let _guard = env_guard();
         let dir = tempfile::tempdir().unwrap();
         let p = write(

--- a/src/config.rs
+++ b/src/config.rs
@@ -2177,15 +2177,21 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
 
     #[test]
     fn a_template_without_its_placeholder_is_rejected() {
-        let mut t = EmbedTemplates::default();
-        assert!(t.validate().is_ok());
-        t.query_template = "task: search result | query: ".into();
+        assert!(EmbedTemplates::default().validate().is_ok());
+        let t = EmbedTemplates {
+            query_template: "task: search result | query: ".into(),
+            ..EmbedTemplates::default()
+        };
         assert!(t.validate().unwrap_err().contains("query_template"));
-        let mut t = EmbedTemplates::default();
-        t.document_template = "text: {text}".into();
+        let t = EmbedTemplates {
+            document_template: "text: {text}".into(),
+            ..EmbedTemplates::default()
+        };
         assert!(t.validate().unwrap_err().contains("{title}"));
-        let mut t = EmbedTemplates::default();
-        t.document_template_untitled = "title: none | text: ".into();
+        let t = EmbedTemplates {
+            document_template_untitled: "title: none | text: ".into(),
+            ..EmbedTemplates::default()
+        };
         assert!(
             t.validate()
                 .unwrap_err()

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,6 +346,45 @@ pub struct TierConfig {
     pub structured_output: bool,
 }
 
+/// How much inference capture spends. `Off` embeds the source text verbatim
+/// and calls nothing; `Earned` does the same at capture and synthesizes later
+/// where use has shown it is worth it; `Eager` is one synthesis call per
+/// segment at capture — what engram did before the other two existed, and the
+/// default so that setting nothing changes nothing.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SynthesisMode {
+    Off,
+    Earned,
+    #[default]
+    Eager,
+}
+
+impl SynthesisMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SynthesisMode::Off => "off",
+            SynthesisMode::Earned => "earned",
+            SynthesisMode::Eager => "eager",
+        }
+    }
+}
+
+/// The window budget when no synthesizer is configured to derive one from.
+/// Estimator tokens. A synthesizer configured later whose context is smaller
+/// than the windows already stored means re-capturing; there is no migration.
+pub const DEFAULT_SEGMENT_TOKENS: usize = 4096;
+/// The retrieval unit. A target, not a ceiling: see the spec on why it is
+/// fixed rather than derived from the embedder's capacity.
+pub const DEFAULT_CHUNK_TOKENS: usize = 384;
+
+fn default_segment_tokens() -> usize {
+    DEFAULT_SEGMENT_TOKENS
+}
+fn default_chunk_tokens() -> usize {
+    DEFAULT_CHUNK_TOKENS
+}
+
 /// The resolved roles. Deserialised through [`RawInferConfig`] so that tiers
 /// are flattened away before anything downstream sees a role: `HttpCompleter`
 /// and friends keep taking a struct whose every field is concrete, and a tier
@@ -354,9 +393,13 @@ pub struct TierConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(try_from = "RawInferConfig")]
 pub struct InferConfig {
-    pub synthesize: SynthesizeRole,
+    pub synthesis: SynthesisMode,
+    pub segment_tokens: usize,
+    /// `None` is allowed only at `synthesis = "off"`.
+    pub synthesize: Option<SynthesizeRole>,
     pub embed: EmbedRole,
-    pub ask: AskRole,
+    /// `None` closes the ask door: no page, no nav entry, no tool.
+    pub ask: Option<AskRole>,
     pub rerank: Option<RerankRole>,
     pub vision: Option<VisionRole>,
 }
@@ -368,9 +411,15 @@ pub struct InferConfig {
 pub struct RawInferConfig {
     #[serde(default)]
     tiers: HashMap<String, TierConfig>,
-    synthesize: RawSynthesizeRole,
+    #[serde(default)]
+    synthesis: SynthesisMode,
+    #[serde(default = "default_segment_tokens")]
+    segment_tokens: usize,
+    #[serde(default)]
+    synthesize: Option<RawSynthesizeRole>,
     embed: EmbedRole,
-    ask: RawAskRole,
+    #[serde(default)]
+    ask: Option<RawAskRole>,
     #[serde(default)]
     rerank: Option<RerankRole>,
     #[serde(default)]
@@ -481,44 +530,52 @@ impl TryFrom<RawInferConfig> for InferConfig {
     fn try_from(raw: RawInferConfig) -> Result<Self, Self::Error> {
         let tiers = &raw.tiers;
 
-        let s = raw.synthesize;
-        let st = resolve_endpoint("synthesize", &s.tier, tiers)?;
-        let synthesize = SynthesizeRole {
-            base_url: s.base_url.unwrap_or(st.base_url),
-            model: s.model.unwrap_or(st.model),
-            api_key: s.api_key.or(st.api_key),
-            context_tokens: s.context_tokens.unwrap_or(st.context_tokens),
-            max_output_tokens: s.max_output_tokens.unwrap_or(st.max_output_tokens),
-            output_ratio: s.output_ratio,
-            reasoning_effort: s.reasoning_effort.or(st.reasoning_effort),
-            ceiling_param: s.ceiling_param.or(st.ceiling_param),
-            timeout_secs: s.timeout_secs.unwrap_or(st.timeout_secs),
-            structured_output: s.structured_output.unwrap_or(st.structured_output),
-            context_opening_tokens: s.context_opening_tokens,
-            context_overlap_tokens: s.context_overlap_tokens,
+        let synthesize = match raw.synthesize {
+            None => None,
+            Some(s) => {
+                let st = resolve_endpoint("synthesize", &s.tier, tiers)?;
+                Some(SynthesizeRole {
+                    base_url: s.base_url.unwrap_or(st.base_url),
+                    model: s.model.unwrap_or(st.model),
+                    api_key: s.api_key.or(st.api_key),
+                    context_tokens: s.context_tokens.unwrap_or(st.context_tokens),
+                    max_output_tokens: s.max_output_tokens.unwrap_or(st.max_output_tokens),
+                    output_ratio: s.output_ratio,
+                    reasoning_effort: s.reasoning_effort.or(st.reasoning_effort),
+                    ceiling_param: s.ceiling_param.or(st.ceiling_param),
+                    timeout_secs: s.timeout_secs.unwrap_or(st.timeout_secs),
+                    structured_output: s.structured_output.unwrap_or(st.structured_output),
+                    context_opening_tokens: s.context_opening_tokens,
+                    context_overlap_tokens: s.context_overlap_tokens,
+                })
+            }
         };
 
-        let a = raw.ask;
-        let at = resolve_endpoint("ask", &a.tier, tiers)?;
-        // Resolved here rather than where it is used, so a typo in the name is
-        // a startup failure like every other tier name instead of a surprise on
-        // the first question someone asks.
-        let follow_up_endpoint = match a.follow_up_tier.as_deref() {
-            Some(name) => Some(resolve_endpoint("ask.follow_up_tier", name, tiers)?),
+        let ask = match raw.ask {
             None => None,
-        };
-        let ask = AskRole {
-            base_url: a.base_url.unwrap_or(at.base_url),
-            model: a.model.unwrap_or(at.model),
-            api_key: a.api_key.or(at.api_key),
-            context_tokens: a.context_tokens.unwrap_or(at.context_tokens),
-            max_output_tokens: a.max_output_tokens.unwrap_or(at.max_output_tokens),
-            timeout_secs: a.timeout_secs.unwrap_or(at.timeout_secs),
-            reasoning_effort: a.reasoning_effort.or(at.reasoning_effort),
-            ceiling_param: a.ceiling_param.or(at.ceiling_param),
-            structured_output: at.structured_output,
-            follow_up: a.follow_up,
-            follow_up_endpoint,
+            Some(a) => {
+                let at = resolve_endpoint("ask", &a.tier, tiers)?;
+                // Resolved here rather than where it is used, so a typo in the name is
+                // a startup failure like every other tier name instead of a surprise on
+                // the first question someone asks.
+                let follow_up_endpoint = match a.follow_up_tier.as_deref() {
+                    Some(name) => Some(resolve_endpoint("ask.follow_up_tier", name, tiers)?),
+                    None => None,
+                };
+                Some(AskRole {
+                    base_url: a.base_url.unwrap_or(at.base_url),
+                    model: a.model.unwrap_or(at.model),
+                    api_key: a.api_key.or(at.api_key),
+                    context_tokens: a.context_tokens.unwrap_or(at.context_tokens),
+                    max_output_tokens: a.max_output_tokens.unwrap_or(at.max_output_tokens),
+                    timeout_secs: a.timeout_secs.unwrap_or(at.timeout_secs),
+                    reasoning_effort: a.reasoning_effort.or(at.reasoning_effort),
+                    ceiling_param: a.ceiling_param.or(at.ceiling_param),
+                    structured_output: at.structured_output,
+                    follow_up: a.follow_up,
+                    follow_up_endpoint,
+                })
+            }
         };
 
         // Vision is the one role whose endpoint may legitimately be absent:
@@ -560,6 +617,8 @@ impl TryFrom<RawInferConfig> for InferConfig {
         };
 
         Ok(InferConfig {
+            synthesis: raw.synthesis,
+            segment_tokens: raw.segment_tokens,
             synthesize,
             embed: raw.embed,
             ask,
@@ -667,9 +726,23 @@ pub struct EmbedRole {
     pub document_template: String,
     #[serde(default = "default_document_template_untitled")]
     pub document_template_untitled: String,
+    /// Passage size at `synthesis = "off"`/`"earned"`, in estimator tokens.
+    /// Under `embed` because it is sized to the retrieval unit, not to a
+    /// model's context. Clamped to what the embedder will take — see
+    /// `effective_chunk_tokens`.
+    #[serde(default = "default_chunk_tokens")]
+    pub chunk_tokens: usize,
 }
 
 impl EmbedRole {
+    /// `chunk_tokens`, never above the embed path's own ceiling
+    /// (`max_input_tokens * 0.8`), so the passage splitter can never emit a
+    /// passage `split_oversize` then has to cut apart again.
+    pub fn effective_chunk_tokens(&self) -> usize {
+        let ceiling = (self.max_input_tokens as f32 * 0.8) as usize;
+        self.chunk_tokens.min(ceiling).max(1)
+    }
+
     pub fn templates(&self) -> EmbedTemplates {
         EmbedTemplates {
             query_template: self.query_template.clone(),
@@ -995,23 +1068,29 @@ fn default_vision_max_output_tokens() -> usize {
 impl VisionRole {
     /// The endpoint and key this role actually calls: its own where given,
     /// the synthesize role's otherwise.
-    pub fn resolve(&self, synth: &SynthesizeRole) -> (String, Option<String>) {
+    pub fn resolve(&self, synth: Option<&SynthesizeRole>) -> (String, Option<String>) {
         (
             self.base_url
                 .clone()
-                .unwrap_or_else(|| synth.base_url.clone()),
-            self.api_key.clone().or_else(|| synth.api_key.clone()),
+                .or_else(|| synth.map(|s| s.base_url.clone()))
+                // Validation refuses a vision role with neither; this arm is
+                // unreachable after `Config::load` and exists so the type
+                // system does not have to be argued with here.
+                .unwrap_or_default(),
+            self.api_key
+                .clone()
+                .or_else(|| synth.and_then(|s| s.api_key.clone())),
         )
     }
 
     /// Which name to send the output ceiling under. Inherited only when this
     /// role borrows the synthesize endpoint: a setting about how one server
     /// reads a request says nothing about a different server.
-    pub fn ceiling_param(&self, synth: &SynthesizeRole) -> Option<CeilingParam> {
+    pub fn ceiling_param(&self, synth: Option<&SynthesizeRole>) -> Option<CeilingParam> {
         self.ceiling_param.or_else(|| {
             self.base_url
                 .is_none()
-                .then_some(synth.ceiling_param)
+                .then(|| synth.and_then(|s| s.ceiling_param))
                 .flatten()
         })
     }
@@ -1025,10 +1104,13 @@ impl VisionRole {
     /// different names for the one server they share. This role never sends
     /// `reasoning_effort` itself — it is read here only as the signal about how
     /// that server reads a request.
-    pub fn inherited_reasoning_effort<'a>(&self, synth: &'a SynthesizeRole) -> Option<&'a str> {
+    pub fn inherited_reasoning_effort<'a>(
+        &self,
+        synth: Option<&'a SynthesizeRole>,
+    ) -> Option<&'a str> {
         self.base_url
             .is_none()
-            .then_some(synth.reasoning_effort.as_deref())
+            .then(|| synth.and_then(|s| s.reasoning_effort.as_deref()))
             .flatten()
     }
 }
@@ -1226,6 +1308,23 @@ impl Config {
                 c.auto_supersede, c.review_min
             )));
         }
+        if self.infer.synthesis != SynthesisMode::Off && self.infer.synthesize.is_none() {
+            return Err(ConfigError::Invalid(format!(
+                "infer.synthesis = \"{}\" needs [infer.synthesize]; only \"off\" runs without a \
+                 synthesizer",
+                self.infer.synthesis.as_str()
+            )));
+        }
+        if let Some(v) = &self.infer.vision
+            && v.base_url.is_none()
+            && self.infer.synthesize.is_none()
+        {
+            return Err(ConfigError::Invalid(
+                "infer.vision has no base_url or tier and there is no [infer.synthesize] to \
+                 borrow an endpoint from"
+                    .into(),
+            ));
+        }
         self.infer
             .embed
             .templates()
@@ -1272,19 +1371,18 @@ impl Config {
     /// The roles whose output-ceiling name is a guess: `reasoning_effort` set,
     /// `ceiling_param` not. Each with the effort the guess is made from.
     fn inferred_ceiling_params(&self) -> Vec<(&'static str, &str)> {
-        let synth = &self.infer.synthesize;
-        let mut roles: Vec<(&str, Option<&str>, Option<CeilingParam>)> = vec![
-            (
+        let synth = self.infer.synthesize.as_ref();
+        let mut roles: Vec<(&str, Option<&str>, Option<CeilingParam>)> = Vec::new();
+        if let Some(s) = synth {
+            roles.push((
                 "infer.synthesize",
-                synth.reasoning_effort.as_deref(),
-                synth.ceiling_param,
-            ),
-            (
-                "infer.ask",
-                self.infer.ask.reasoning_effort.as_deref(),
-                self.infer.ask.ceiling_param,
-            ),
-        ];
+                s.reasoning_effort.as_deref(),
+                s.ceiling_param,
+            ));
+        }
+        if let Some(a) = &self.infer.ask {
+            roles.push(("infer.ask", a.reasoning_effort.as_deref(), a.ceiling_param));
+        }
         // Vision resolves a name the same way, off values it may have inherited
         // from synthesize — and it is the role a dropped ceiling costs most,
         // since what it writes is stored as a corpus and segmented again.
@@ -1299,7 +1397,12 @@ impl Config {
         // off a tier of its own — so a guess there is not covered by the ask
         // line above. Without a named tier it runs on ask's endpoint under
         // ask's values, and the ask line is the one that speaks for it.
-        if let Some(f) = &self.infer.ask.follow_up_endpoint {
+        if let Some(f) = self
+            .infer
+            .ask
+            .as_ref()
+            .and_then(|a| a.follow_up_endpoint.as_ref())
+        {
             roles.push((
                 "infer.ask.follow_up_tier",
                 f.reasoning_effort.as_deref(),
@@ -1338,11 +1441,15 @@ impl Config {
         let mut c = self.clone();
         const R: &str = "REDACTED";
         c.vector.api_key = c.vector.api_key.map(|_| R.into());
-        c.infer.synthesize.api_key = c.infer.synthesize.api_key.map(|_| R.into());
+        if let Some(s) = c.infer.synthesize.as_mut() {
+            s.api_key = s.api_key.as_ref().map(|_| R.into());
+        }
         c.infer.embed.api_key = c.infer.embed.api_key.map(|_| R.into());
-        c.infer.ask.api_key = c.infer.ask.api_key.map(|_| R.into());
-        if let Some(f) = c.infer.ask.follow_up_endpoint.as_mut() {
-            f.api_key = f.api_key.as_ref().map(|_| R.into());
+        if let Some(a) = c.infer.ask.as_mut() {
+            a.api_key = a.api_key.as_ref().map(|_| R.into());
+            if let Some(f) = a.follow_up_endpoint.as_mut() {
+                f.api_key = f.api_key.as_ref().map(|_| R.into());
+            }
         }
         if let Some(r) = c.infer.rerank.as_mut() {
             r.api_key = r.api_key.as_ref().map(|_| R.into());
@@ -1414,7 +1521,14 @@ mod tests {
 
         let cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
         assert!(
-            cfg.infer.ask.ceiling_param.is_none() && cfg.infer.synthesize.ceiling_param.is_none(),
+            cfg.infer.ask.as_ref().unwrap().ceiling_param.is_none()
+                && cfg
+                    .infer
+                    .synthesize
+                    .as_ref()
+                    .unwrap()
+                    .ceiling_param
+                    .is_none(),
             "the example config pins a ceiling name it should be leaving to the guess"
         );
     }
@@ -1438,10 +1552,19 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = write(&dir, MINIMAL);
         let cfg = Config::load(Some(&p)).unwrap();
-        assert_eq!(cfg.infer.synthesize.timeout_secs, DEFAULT_TIMEOUT_SECS);
+        assert_eq!(
+            cfg.infer.synthesize.as_ref().unwrap().timeout_secs,
+            DEFAULT_TIMEOUT_SECS
+        );
         assert_eq!(cfg.infer.embed.timeout_secs, DEFAULT_TIMEOUT_SECS);
-        assert_eq!(cfg.infer.ask.timeout_secs, DEFAULT_TIMEOUT_SECS);
-        assert_eq!(cfg.infer.synthesize.reasoning_effort, None);
+        assert_eq!(
+            cfg.infer.ask.as_ref().unwrap().timeout_secs,
+            DEFAULT_TIMEOUT_SECS
+        );
+        assert_eq!(
+            cfg.infer.synthesize.as_ref().unwrap().reasoning_effort,
+            None
+        );
     }
 
     #[test]
@@ -1629,9 +1752,9 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         assert_eq!(v.timeout_secs, 120);
         // Its own ceiling, sent on every call like every other role's.
         assert_eq!(v.max_output_tokens, 4096);
-        let (url, key) = v.resolve(&cfg.infer.synthesize);
-        assert_eq!(url, cfg.infer.synthesize.base_url);
-        assert_eq!(key, cfg.infer.synthesize.api_key);
+        let (url, key) = v.resolve(cfg.infer.synthesize.as_ref());
+        assert_eq!(url, cfg.infer.synthesize.as_ref().unwrap().base_url);
+        assert_eq!(key, cfg.infer.synthesize.as_ref().unwrap().api_key);
     }
 
     /// How a request is read is a property of the server reading it, so the
@@ -1645,20 +1768,20 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             &format!("{MINIMAL}\n[infer.vision]\nmodel = \"qwen-vl\"\n"),
         );
         let mut cfg = Config::load(Some(&p)).unwrap();
-        cfg.infer.synthesize.ceiling_param = Some(CeilingParam::MaxTokens);
-        let synth = cfg.infer.synthesize.clone();
+        cfg.infer.synthesize.as_mut().unwrap().ceiling_param = Some(CeilingParam::MaxTokens);
+        let synth = cfg.infer.synthesize.as_ref().unwrap().clone();
         let v = cfg.infer.vision.as_mut().expect("configured");
 
-        assert_eq!(v.ceiling_param(&synth), Some(CeilingParam::MaxTokens));
+        assert_eq!(v.ceiling_param(Some(&synth)), Some(CeilingParam::MaxTokens));
 
         // Its own endpoint: a different server, and nothing carries over.
         v.base_url = Some("http://vision:9000/v1".into());
-        assert_eq!(v.ceiling_param(&synth), None);
+        assert_eq!(v.ceiling_param(Some(&synth)), None);
 
         // Unless it says so itself, which beats both.
         v.ceiling_param = Some(CeilingParam::MaxCompletionTokens);
         assert_eq!(
-            v.ceiling_param(&synth),
+            v.ceiling_param(Some(&synth)),
             Some(CeilingParam::MaxCompletionTokens)
         );
     }
@@ -1677,16 +1800,20 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             &format!("{MINIMAL}\n[infer.vision]\nmodel = \"qwen-vl\"\n"),
         );
         let mut cfg = Config::load(Some(&p)).unwrap();
-        cfg.infer.synthesize.reasoning_effort = Some("high".into());
-        let synth = cfg.infer.synthesize.clone();
+        cfg.infer.synthesize.as_mut().unwrap().reasoning_effort = Some("high".into());
+        let synth = cfg.infer.synthesize.as_ref().unwrap().clone();
         let v = cfg.infer.vision.as_mut().expect("configured");
 
-        assert_eq!(v.ceiling_param(&synth), None, "nothing explicit to inherit");
-        assert_eq!(v.inherited_reasoning_effort(&synth), Some("high"));
+        assert_eq!(
+            v.ceiling_param(Some(&synth)),
+            None,
+            "nothing explicit to inherit"
+        );
+        assert_eq!(v.inherited_reasoning_effort(Some(&synth)), Some("high"));
 
         // Its own address is its own server, and the signal stops there.
         v.base_url = Some("http://vision:9000/v1".into());
-        assert_eq!(v.inherited_reasoning_effort(&synth), None);
+        assert_eq!(v.inherited_reasoning_effort(Some(&synth)), None);
     }
 
     /// The ceiling's name is guessed from `reasoning_effort`, and the two ways
@@ -1731,7 +1858,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             .vision
             .as_ref()
             .unwrap()
-            .resolve(&cfg.infer.synthesize);
+            .resolve(cfg.infer.synthesize.as_ref());
         assert_eq!(url, "http://vision:9000/v1");
         assert_eq!(key.as_deref(), Some("vk"));
         assert!(!cfg.redacted().contains("\"vk\""), "vision key leaked");
@@ -1826,12 +1953,21 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         )
         .expect("tiered config parses");
 
-        assert_eq!(cfg.infer.synthesize.base_url, "http://localhost:8000/v1");
-        assert_eq!(cfg.infer.synthesize.model, "qwen");
-        assert_eq!(cfg.infer.synthesize.context_tokens, 32768);
-        assert_eq!(cfg.infer.synthesize.max_output_tokens, 16384);
-        assert_eq!(cfg.infer.ask.base_url, "http://localhost:8000/v1");
-        assert_eq!(cfg.infer.ask.model, "qwen");
+        assert_eq!(
+            cfg.infer.synthesize.as_ref().unwrap().base_url,
+            "http://localhost:8000/v1"
+        );
+        assert_eq!(cfg.infer.synthesize.as_ref().unwrap().model, "qwen");
+        assert_eq!(cfg.infer.synthesize.as_ref().unwrap().context_tokens, 32768);
+        assert_eq!(
+            cfg.infer.synthesize.as_ref().unwrap().max_output_tokens,
+            16384
+        );
+        assert_eq!(
+            cfg.infer.ask.as_ref().unwrap().base_url,
+            "http://localhost:8000/v1"
+        );
+        assert_eq!(cfg.infer.ask.as_ref().unwrap().model, "qwen");
     }
 
     /// A role may override any field its tier defines. Without this the two tiers
@@ -1868,14 +2004,19 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         )
         .unwrap();
         assert_eq!(
-            cfg.infer.ask.max_output_tokens, 4096,
+            cfg.infer.ask.as_ref().unwrap().max_output_tokens,
+            4096,
             "the role's value wins"
         );
         assert_eq!(
-            cfg.infer.ask.context_tokens, 131072,
+            cfg.infer.ask.as_ref().unwrap().context_tokens,
+            131072,
             "unset fields come from the tier"
         );
-        assert_eq!(cfg.infer.synthesize.max_output_tokens, 16384);
+        assert_eq!(
+            cfg.infer.synthesize.as_ref().unwrap().max_output_tokens,
+            16384
+        );
     }
 
     /// A typo in a tier name must be a startup failure naming the typo, never a
@@ -1928,10 +2069,13 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             "the example must show a tier"
         );
         let cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
-        assert_eq!(cfg.infer.synthesize.context_tokens, 32768);
-        assert_eq!(cfg.infer.synthesize.max_output_tokens, 16384);
-        assert_eq!(cfg.infer.ask.context_tokens, 32768);
-        assert_eq!(cfg.infer.ask.max_output_tokens, 4096);
+        assert_eq!(cfg.infer.synthesize.as_ref().unwrap().context_tokens, 32768);
+        assert_eq!(
+            cfg.infer.synthesize.as_ref().unwrap().max_output_tokens,
+            16384
+        );
+        assert_eq!(cfg.infer.ask.as_ref().unwrap().context_tokens, 32768);
+        assert_eq!(cfg.infer.ask.as_ref().unwrap().max_output_tokens, 4096);
     }
     /// A tiered config with one endpoint everything can point at, so the tests
     /// below say only the thing they are about. `[infer.ask]` is last, which is
@@ -2016,8 +2160,8 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             "with no tier to take one from, the role keeps its own two minutes"
         );
         assert_eq!(
-            v.resolve(&cfg.infer.synthesize).0,
-            cfg.infer.synthesize.base_url
+            v.resolve(cfg.infer.synthesize.as_ref()).0,
+            cfg.infer.synthesize.as_ref().unwrap().base_url
         );
     }
 
@@ -2032,7 +2176,10 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         .unwrap();
         // And the endpoint it named is still the one it calls.
         let v = cfg.infer.vision.as_ref().expect("configured");
-        assert_eq!(v.resolve(&cfg.infer.synthesize).0, "http://vision:9000/v1");
+        assert_eq!(
+            v.resolve(cfg.infer.synthesize.as_ref()).0,
+            "http://vision:9000/v1"
+        );
     }
 
     /// The follow-up call's whole reason to name a tier is to run somewhere
@@ -2045,6 +2192,8 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         let f = cfg
             .infer
             .ask
+            .as_ref()
+            .unwrap()
             .follow_up_endpoint
             .as_ref()
             .expect("the named tier resolved");
@@ -2070,14 +2219,26 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             "ceiling_param = \"max_completion_tokens\"\nstructured_output = false",
         );
         let cfg = load_infer(&toml).unwrap();
-        assert!(cfg.infer.ask.follow_up_endpoint.is_none());
+        assert!(cfg.infer.ask.as_ref().unwrap().follow_up_endpoint.is_none());
         assert!(
-            !cfg.infer.ask.follow_up_on().structured_output,
+            !cfg.infer
+                .ask
+                .as_ref()
+                .unwrap()
+                .follow_up_on()
+                .structured_output,
             "the tier said no response format; the fallback endpoint said yes"
         );
         // And the default remains on, as it is for every tier.
         let cfg = load_infer(TIERED).unwrap();
-        assert!(cfg.infer.ask.follow_up_on().structured_output);
+        assert!(
+            cfg.infer
+                .ask
+                .as_ref()
+                .unwrap()
+                .follow_up_on()
+                .structured_output
+        );
     }
 
     /// A named follow-up tier infers its ceiling name the same way every role
@@ -2271,5 +2432,170 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         ))
         .unwrap_err();
         assert!(err.to_string().contains("query_template"), "got: {err}");
+    }
+
+    /// Everything but `[infer.*]` roles: the tests below write those themselves.
+    const BARE_PREAMBLE: &str = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer.tiers.efficient]
+        base_url = "http://localhost:8000/v1"
+        model = "qwen"
+        context_tokens = 32768
+        max_output_tokens = 16384
+        [infer.embed]
+        base_url = "http://localhost:8000/v1"
+        model = "embeddinggemma"
+        dim = 768
+        max_input_tokens = 2048
+    "#;
+
+    /// `BARE_PREAMBLE` without its `[infer.embed]` table, for a test that
+    /// writes its own.
+    const BARE_PREAMBLE_NO_EMBED: &str = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer.tiers.efficient]
+        base_url = "http://localhost:8000/v1"
+        model = "qwen"
+        context_tokens = 32768
+        max_output_tokens = 16384
+    "#;
+
+    #[test]
+    fn synthesis_defaults_to_eager_and_parses_the_three_modes() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer.synthesize]
+            tier = \"efficient\"
+            output_ratio = 8.0
+            [infer.ask]
+            tier = \"efficient\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.synthesis, SynthesisMode::Eager);
+        assert_eq!(cfg.infer.segment_tokens, DEFAULT_SEGMENT_TOKENS);
+        for (word, mode) in [
+            ("off", SynthesisMode::Off),
+            ("earned", SynthesisMode::Earned),
+            ("eager", SynthesisMode::Eager),
+        ] {
+            let cfg = load_infer(&format!(
+                "{BARE_PREAMBLE}
+                [infer]
+                synthesis = \"{word}\"
+                [infer.synthesize]
+                tier = \"efficient\"
+                output_ratio = 8.0
+                [infer.ask]
+                tier = \"efficient\"
+                "
+            ))
+            .unwrap();
+            assert_eq!(cfg.infer.synthesis, mode, "{word}");
+        }
+    }
+
+    #[test]
+    fn off_needs_neither_synthesize_nor_ask() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            segment_tokens = 2048
+            "
+        ))
+        .unwrap();
+        assert!(cfg.infer.synthesize.is_none());
+        assert!(cfg.infer.ask.is_none());
+        assert_eq!(cfg.infer.segment_tokens, 2048);
+    }
+
+    #[test]
+    fn earned_and_eager_refuse_to_start_without_a_synthesizer() {
+        let _guard = env_guard();
+        for word in ["earned", "eager"] {
+            let err = load_infer(&format!(
+                "{BARE_PREAMBLE}
+                [infer]
+                synthesis = \"{word}\"
+                "
+            ))
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains("infer.synthesize"), "{word}: {err}");
+            assert!(err.contains(word), "{word}: {err}");
+        }
+    }
+
+    #[test]
+    fn vision_without_an_endpoint_of_its_own_needs_the_synthesizer() {
+        let _guard = env_guard();
+        let err = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            [infer.vision]
+            model = \"llava\"
+            "
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("infer.vision"), "{err}");
+        // With its own address it stands alone.
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            [infer.vision]
+            model = \"llava\"
+            base_url = \"http://localhost:9000/v1\"
+            "
+        ))
+        .unwrap();
+        let v = cfg.infer.vision.as_ref().unwrap();
+        assert_eq!(v.resolve(None).0, "http://localhost:9000/v1");
+    }
+
+    #[test]
+    fn chunk_tokens_defaults_to_384_and_is_clamped_to_the_embedder() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer]
+            synthesis = \"off\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.embed.chunk_tokens, DEFAULT_CHUNK_TOKENS);
+        assert_eq!(cfg.infer.embed.effective_chunk_tokens(), 384);
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE_NO_EMBED}
+            [infer]
+            synthesis = \"off\"
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"small\"
+            dim = 384
+            max_input_tokens = 256
+            chunk_tokens = 1000
+            "
+        ))
+        .unwrap();
+        // 256 * 0.8 = 204: what the embedder will take wins over what was asked.
+        assert_eq!(cfg.infer.embed.effective_chunk_tokens(), 204);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub associate: AssociateConfig,
     #[serde(default)]
     pub activation: ActivationConfig,
+    #[serde(default)]
+    pub promote: PromoteConfig,
 }
 
 /// What the two supplied-from-outside capture paths are allowed to cost.
@@ -85,9 +87,11 @@ pub struct PacingConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct FeedbackConfig {
-    /// Whether real searches are recorded at all. Off by default: the wording of
-    /// a query is personal, and nothing here is useful to anyone but the
-    /// operator.
+    /// Whether real searches are recorded at all. On by default: promotion at
+    /// `synthesis = "earned"` reads activation, and activation moves only
+    /// while searches are recorded. The wording of a query is personal and
+    /// nothing here leaves the machine; this is the switch for the operator
+    /// who wants none of it kept.
     pub enabled: bool,
     /// Candidates stored per event. Wider than the answer on purpose — search
     /// over-fetches anyway, so the extra rows are free, and they are what lets a
@@ -107,7 +111,10 @@ pub struct FeedbackConfig {
 impl Default for FeedbackConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            // On: promotion at `synthesis = "earned"` reads activation, and
+            // activation moves only while searches are recorded. Recording is
+            // the thing an operator turns *off*.
+            enabled: true,
             candidates: 20,
             coalesce_secs: 15,
             retain_days: 0,
@@ -165,6 +172,36 @@ impl Default for AssociateConfig {
             spread_max: 3,
             prime_margin: 0.5,
             prime_lift: 2,
+        }
+    }
+}
+
+/// When a passage has earned its window a synthesis call, and when an eager
+/// artifact has earned a second one.
+///
+/// `activation_above` is read against `[activation]`: baseline `1.0`,
+/// `retrieved = 1.0`, `opened = 0.5`, `confirmed = 3.0`, half-life 14 days.
+/// Checked with `>=` after the bump, decay folded in, and only at the two
+/// engagement bumps — opened and confirmed — never at retrieved, so a passage
+/// that merely keeps appearing in result lists is never promoted.
+///
+/// `resynthesize_after_unconfirmed` is the `eager` counterpart: an artifact
+/// shown this many times with no confirmation recorded against it is
+/// re-synthesised from its segment. `0` disables it, and it ships disabled —
+/// re-synthesising changes what an existing base contains without anyone
+/// asking, so it is a default the harness moves.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PromoteConfig {
+    pub activation_above: f64,
+    pub resynthesize_after_unconfirmed: i64,
+}
+
+impl Default for PromoteConfig {
+    fn default() -> Self {
+        Self {
+            activation_above: 4.0,
+            resynthesize_after_unconfirmed: 0,
         }
     }
 }
@@ -1337,6 +1374,12 @@ impl Config {
     /// rather than letting an operator discover the association pass has been
     /// idle since they turned recording off.
     fn warn_on_inert_settings(&self) {
+        if self.infer.synthesis == SynthesisMode::Earned && !self.feedback.enabled {
+            tracing::warn!(
+                "infer.synthesis = \"earned\" with feedback.enabled = false: activation never \
+                 moves, so nothing is ever promoted — this is `off` under another name."
+            );
+        }
         if self.associate.enabled && !self.feedback.enabled {
             tracing::warn!(
                 "associate.enabled has no effect while feedback.enabled is false: links are \
@@ -1895,9 +1938,10 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         let p = write(&dir, MINIMAL);
         let cfg = Config::load(Some(&p)).unwrap();
         assert!(cfg.associate.enabled);
-        // ...and the feature is inert regardless, because there is nothing to
-        // learn from until searches are recorded.
-        assert!(!cfg.feedback.enabled);
+        // ...and recording is on too, so the feature is live out of the box:
+        // promotion reads activation, and activation moves only while
+        // searches are recorded.
+        assert!(cfg.feedback.enabled);
     }
 
     #[test]
@@ -2597,5 +2641,43 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         .unwrap();
         // 256 * 0.8 = 204: what the embedder will take wins over what was asked.
         assert_eq!(cfg.infer.embed.effective_chunk_tokens(), 204);
+    }
+
+    #[test]
+    fn promote_defaults_and_feedback_ships_on() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer.synthesize]
+            tier = \"efficient\"
+            output_ratio = 8.0
+            [infer.ask]
+            tier = \"efficient\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.promote.activation_above, 4.0);
+        assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 0);
+        // Opt-out now: promotion reads activation, and activation only moves
+        // while searches are recorded.
+        assert!(cfg.feedback.enabled);
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}
+            [infer.synthesize]
+            tier = \"efficient\"
+            output_ratio = 8.0
+            [infer.ask]
+            tier = \"efficient\"
+            [promote]
+            activation_above = 2.5
+            resynthesize_after_unconfirmed = 12
+            [feedback]
+            enabled = false
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.promote.activation_above, 2.5);
+        assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 12);
+        assert!(!cfg.feedback.enabled);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -420,14 +420,23 @@ pub struct TierConfig {
 /// How much inference capture spends. `Off` embeds the source text verbatim
 /// and calls nothing; `Earned` does the same at capture and synthesizes later
 /// where use has shown it is worth it; `Eager` is one synthesis call per
-/// segment at capture — what engram did before the other two existed, and the
-/// default so that setting nothing changes nothing.
+/// segment at capture — what engram did before the other two existed.
+///
+/// `Earned` is the default. What a base is for is answering, and capture
+/// cannot know which of ten thousand paragraphs will ever be asked about — so
+/// synthesising all of them spends a model call per segment on text most of
+/// which is never retrieved, and replaces the operator's own words with a
+/// rewrite before anyone has asked for one. At `earned` the source goes in as
+/// it was written and stays that way; a window is rewritten when reading has
+/// shown it is worth rewriting, and every artifact in the base can name the
+/// use that earned it. `eager` remains supported for a base that wants
+/// everything pre-written and is willing to pay for it up front.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum SynthesisMode {
     Off,
-    Earned,
     #[default]
+    Earned,
     Eager,
 }
 
@@ -806,6 +815,30 @@ pub struct EmbedRole {
 }
 
 impl EmbedRole {
+    /// What a stored vector means, in one string: the model, the dimension,
+    /// and the three templates the text is rendered through before the call.
+    ///
+    /// All five are one identity. A vector embedded under `task: search
+    /// result | {title}\n{text}` is not comparable with one embedded under
+    /// bare `{text}`, and nothing in the vector says which it was — the
+    /// collection keeps its name, the model field is unchanged, and the only
+    /// symptom is retrieval quietly getting worse. Recorded at boot so a
+    /// change can at least be *said*; the answer to it is a re-capture.
+    pub fn fingerprint(&self) -> String {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(
+            format!(
+                "{}\n{}\n{}\n{}\n{}",
+                self.model,
+                self.dim,
+                self.query_template,
+                self.document_template,
+                self.document_template_untitled,
+            )
+            .as_bytes(),
+        ))
+    }
+
     /// `chunk_tokens`, never above the embed path's own ceiling
     /// (`max_input_tokens * 0.8`).
     ///
@@ -2584,7 +2617,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
     "#;
 
     #[test]
-    fn synthesis_defaults_to_eager_and_parses_the_three_modes() {
+    fn synthesis_defaults_to_earned_and_parses_the_three_modes() {
         let _guard = env_guard();
         let cfg = load_infer(&format!(
             "{BARE_PREAMBLE}
@@ -2596,7 +2629,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             "
         ))
         .unwrap();
-        assert_eq!(cfg.infer.synthesis, SynthesisMode::Eager);
+        assert_eq!(cfg.infer.synthesis, SynthesisMode::Earned);
         assert_eq!(cfg.infer.segment_tokens, DEFAULT_SEGMENT_TOKENS);
         for (word, mode) in [
             ("off", SynthesisMode::Off),

--- a/src/config.rs
+++ b/src/config.rs
@@ -658,6 +658,25 @@ pub struct EmbedRole {
     pub max_input_tokens: usize,
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+    /// See `EmbedTemplates`. Flat on the role rather than nested, so the TOML
+    /// reads `[infer.embed] query_template = ...` beside `model`, which is the
+    /// other half of the same identity.
+    #[serde(default = "default_query_template")]
+    pub query_template: String,
+    #[serde(default = "default_document_template")]
+    pub document_template: String,
+    #[serde(default = "default_document_template_untitled")]
+    pub document_template_untitled: String,
+}
+
+impl EmbedRole {
+    pub fn templates(&self) -> EmbedTemplates {
+        EmbedTemplates {
+            query_template: self.query_template.clone(),
+            document_template: self.document_template.clone(),
+            document_template_untitled: self.document_template_untitled.clone(),
+        }
+    }
 }
 
 /// The three strings that, with `model`, fix what a stored vector means.
@@ -1207,6 +1226,11 @@ impl Config {
                 c.auto_supersede, c.review_min
             )));
         }
+        self.infer
+            .embed
+            .templates()
+            .validate()
+            .map_err(ConfigError::Invalid)?;
         Ok(())
     }
 
@@ -2167,5 +2191,79 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
                 .unwrap_err()
                 .contains("document_template_untitled")
         );
+    }
+
+    /// The preamble every `[infer.embed]` test below shares: a valid config
+    /// with the embed block left for the test to write.
+    const EMBED_PREAMBLE: &str = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer.tiers.efficient]
+        base_url = "http://localhost:8000/v1"
+        model = "qwen"
+        context_tokens = 32768
+        max_output_tokens = 16384
+        [infer.synthesize]
+        tier = "efficient"
+        output_ratio = 8.0
+        [infer.ask]
+        tier = "efficient"
+    "#;
+
+    #[test]
+    fn embed_templates_default_to_embeddinggemma_when_unset() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{EMBED_PREAMBLE}
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"embeddinggemma\"
+            dim = 768
+            max_input_tokens = 2048
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.embed.templates(), EmbedTemplates::default());
+    }
+
+    #[test]
+    fn embed_templates_are_read_from_config() {
+        let _guard = env_guard();
+        let cfg = load_infer(&format!(
+            "{EMBED_PREAMBLE}
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"bge-m3\"
+            dim = 1024
+            max_input_tokens = 1024
+            query_template = \"{{text}}\"
+            document_template = \"{{title}}\\n{{text}}\"
+            document_template_untitled = \"{{text}}\"
+            "
+        ))
+        .unwrap();
+        assert_eq!(cfg.infer.embed.templates(), EmbedTemplates::legacy());
+    }
+
+    #[test]
+    fn a_template_missing_its_placeholder_fails_at_load() {
+        let _guard = env_guard();
+        let err = load_infer(&format!(
+            "{EMBED_PREAMBLE}
+            [infer.embed]
+            base_url = \"http://localhost:8000/v1\"
+            model = \"embeddinggemma\"
+            dim = 768
+            max_input_tokens = 2048
+            query_template = \"task: search result | query: \"
+            "
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("query_template"), "got: {err}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -660,6 +660,128 @@ pub struct EmbedRole {
     pub timeout_secs: u64,
 }
 
+/// The three strings that, with `model`, fix what a stored vector means.
+///
+/// EmbeddingGemma is asymmetric: a query and a document are embedded through
+/// different prompts, and a document without a title substitutes the literal
+/// `none` rather than an empty field. Changing any of these invalidates every
+/// stored vector as thoroughly as changing `model` does; there is no fingerprint
+/// or rebuild path because there is no base to look after yet — the answer is
+/// to drop the collection and re-capture.
+///
+/// Kept in config rather than code so that a symmetric embedder — `bge-m3`,
+/// which engram shipped with — stays one TOML block away: see `legacy()`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbedTemplates {
+    /// `{text}` is the query.
+    pub query_template: String,
+    /// `{title}` and `{text}`.
+    pub document_template: String,
+    /// `{text}` only; used when the document has no title.
+    pub document_template_untitled: String,
+}
+
+pub(crate) fn default_query_template() -> String {
+    "task: search result | query: {text}".into()
+}
+pub(crate) fn default_document_template() -> String {
+    "title: {title} | text: {text}".into()
+}
+pub(crate) fn default_document_template_untitled() -> String {
+    "title: none | text: {text}".into()
+}
+
+impl Default for EmbedTemplates {
+    fn default() -> Self {
+        Self {
+            query_template: default_query_template(),
+            document_template: default_document_template(),
+            document_template_untitled: default_document_template_untitled(),
+        }
+    }
+}
+
+impl EmbedTemplates {
+    /// What `embed_text` produced before templates existed: the title on its
+    /// own line above the body, the query as typed. The right block for a
+    /// symmetric embedder, and what every test double renders with, so a test
+    /// that queries with `"title\ntext"` lands on the document it seeded.
+    pub fn legacy() -> Self {
+        Self {
+            query_template: "{text}".into(),
+            document_template: "{title}\n{text}".into(),
+            document_template_untitled: "{text}".into(),
+        }
+    }
+
+    pub fn render_query(&self, query: &str) -> String {
+        substitute(&self.query_template, &[("text", query)])
+    }
+
+    pub fn render_document(&self, title: Option<&str>, text: &str) -> String {
+        match title {
+            Some(t) => substitute(&self.document_template, &[("title", t), ("text", text)]),
+            None => substitute(&self.document_template_untitled, &[("text", text)]),
+        }
+    }
+
+    /// Every template must be able to carry what it is for. Checked at config
+    /// load; a template that drops `{text}` would embed the same string for
+    /// every document and nothing downstream would notice.
+    pub fn validate(&self) -> std::result::Result<(), String> {
+        if !self.query_template.contains("{text}") {
+            return Err("infer.embed.query_template must contain {text}".into());
+        }
+        if !self.document_template.contains("{text}") {
+            return Err("infer.embed.document_template must contain {text}".into());
+        }
+        if !self.document_template.contains("{title}") {
+            return Err("infer.embed.document_template must contain {title}; \
+                        use document_template_untitled for the case with no title"
+                .into());
+        }
+        if !self.document_template_untitled.contains("{text}") {
+            return Err("infer.embed.document_template_untitled must contain {text}".into());
+        }
+        Ok(())
+    }
+}
+
+/// Fill `{name}` placeholders in one left-to-right pass.
+///
+/// One pass rather than chained `replace` calls: a value that itself contains
+/// a placeholder — a heading that reads "about {text}" — must land verbatim,
+/// not have the next value spliced into it. A `{name}` that matches no
+/// variable is left as written.
+pub(crate) fn substitute(template: &str, vars: &[(&str, &str)]) -> String {
+    let mut out = String::with_capacity(template.len() + 64);
+    let mut rest = template;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        match after.find('}') {
+            Some(close) => {
+                let name = &after[..close];
+                match vars.iter().find(|(k, _)| *k == name) {
+                    Some((_, v)) => out.push_str(v),
+                    None => {
+                        out.push('{');
+                        out.push_str(name);
+                        out.push('}');
+                    }
+                }
+                rest = &after[close + 1..];
+            }
+            None => {
+                out.push_str(&rest[open..]);
+                rest = "";
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct AskRole {
     pub base_url: String,
@@ -1973,5 +2095,77 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             "the error must name the typo: {err}"
         );
         assert!(err.contains("efficient"), "and what was available: {err}");
+    }
+
+    #[test]
+    fn query_and_document_render_differently_for_the_same_text() {
+        let t = EmbedTemplates::default();
+        let q = t.render_query("how do I recover deleted entries");
+        let d = t.render_document(None, "how do I recover deleted entries");
+        assert_ne!(q, d);
+        assert_eq!(
+            q,
+            "task: search result | query: how do I recover deleted entries"
+        );
+        assert_eq!(d, "title: none | text: how do I recover deleted entries");
+    }
+
+    #[test]
+    fn a_titled_and_an_untitled_document_take_different_templates() {
+        let t = EmbedTemplates::default();
+        assert_eq!(
+            t.render_document(Some("Recovering deleted entries"), "run fsck first"),
+            "title: Recovering deleted entries | text: run fsck first"
+        );
+        assert_eq!(
+            t.render_document(None, "run fsck first"),
+            "title: none | text: run fsck first"
+        );
+    }
+
+    #[test]
+    fn the_legacy_templates_reproduce_the_old_join() {
+        // What `embed_text` produced before templates existed, and what a
+        // bge-m3 operator configures. The test doubles default to it so every
+        // retrieval test that queries with "title\ntext" keeps matching.
+        let t = EmbedTemplates::legacy();
+        assert_eq!(t.render_query("t0\nalpha"), "t0\nalpha");
+        assert_eq!(t.render_document(Some("t0"), "alpha"), "t0\nalpha");
+        assert_eq!(t.render_document(None, "alpha"), "alpha");
+    }
+
+    #[test]
+    fn substitution_is_one_pass_so_a_value_cannot_be_substituted_again() {
+        // A title that happens to contain the text placeholder must not have
+        // the body spliced into it. Two chained `replace` calls would.
+        let t = EmbedTemplates::default();
+        assert_eq!(
+            t.render_document(Some("about {text}"), "body"),
+            "title: about {text} | text: body"
+        );
+        assert_eq!(
+            substitute("a {x} b {y} c {x}", &[("x", "1"), ("y", "2")]),
+            "a 1 b 2 c 1"
+        );
+        // An unknown placeholder is left as written rather than eaten.
+        assert_eq!(substitute("{nope} {x}", &[("x", "1")]), "{nope} 1");
+    }
+
+    #[test]
+    fn a_template_without_its_placeholder_is_rejected() {
+        let mut t = EmbedTemplates::default();
+        assert!(t.validate().is_ok());
+        t.query_template = "task: search result | query: ".into();
+        assert!(t.validate().unwrap_err().contains("query_template"));
+        let mut t = EmbedTemplates::default();
+        t.document_template = "text: {text}".into();
+        assert!(t.validate().unwrap_err().contains("{title}"));
+        let mut t = EmbedTemplates::default();
+        t.document_template_untitled = "title: none | text: ".into();
+        assert!(
+            t.validate()
+                .unwrap_err()
+                .contains("document_template_untitled")
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -245,10 +245,12 @@ pub struct ConsolidateConfig {
     pub near_dupe_min: f64,
     /// Cosine at or above which a pair is worth an operator's attention.
     pub review_min: f32,
-    /// Cosine at or above which the older artifact is superseded without
-    /// asking. Deliberately far above `review_min`: two genuinely distinct
-    /// artifacts about one subsystem sit around 0.88 routinely, and superseding
-    /// at that score destroys knowledge rather than duplication.
+    /// Cosine at or above which a pair is judged *first* — a fast lane to the
+    /// dedupe judge, no longer a hide. It used to supersede the older artifact
+    /// on the score alone; embeddings barely distinguish negation, and "runs
+    /// on ext4" / "does not run on ext4" sit far above any realistic
+    /// threshold, so the judge's `losses` check now stands behind every hide.
+    /// Still validated above `review_min`.
     pub auto_supersede: f32,
     /// Neighbours considered per artifact when it looks for duplicates.
     pub per_point: usize,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1393,6 +1393,19 @@ impl Config {
                     .into(),
             ));
         }
+        // The other half of the same gate. Both the sweep and its ticker run
+        // behind `associating()`, which is these two flags together, so a
+        // pursuit configured without associating is not a degraded feature —
+        // it is a ticker that returns on its first line and a config that
+        // never writes a pursuit at all. Refused rather than warned, because
+        // the `feedback` half above is refused and the effect is identical.
+        if self.pursuit.enabled && !self.associate.enabled {
+            return Err(ConfigError::Invalid(
+                "pursuit.enabled = true needs associate.enabled = true: pursuits are swept on \
+                 the associative pass, which does not run without it"
+                    .into(),
+            ));
+        }
         if let Some(v) = &self.infer.vision
             && v.base_url.is_none()
             && self.infer.synthesize.is_none()
@@ -2737,5 +2750,15 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         .unwrap_err()
         .to_string();
         assert!(err.contains("pursuit.enabled"), "{err}");
+        // Associating is both flags, so the other half is refused the same
+        // way: with feedback on and associate off, the sweep and its ticker
+        // still never run, and a config that silently writes no pursuit is
+        // the thing this refusal exists to prevent.
+        let err = load_infer(&format!(
+            "{BARE_PREAMBLE}\n{roles}[pursuit]\nenabled = true\n[associate]\nenabled = false\n"
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("associate.enabled = true"), "{err}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,8 @@ pub struct Config {
     pub activation: ActivationConfig,
     #[serde(default)]
     pub promote: PromoteConfig,
+    #[serde(default)]
+    pub pursuit: PursuitConfig,
 }
 
 /// What the two supplied-from-outside capture paths are allowed to cost.
@@ -202,6 +204,36 @@ impl Default for PromoteConfig {
         Self {
             activation_above: 4.0,
             resynthesize_after_unconfirmed: 0,
+        }
+    }
+}
+
+/// What a coherent run of searches — a pursuit — may earn: one generated
+/// artifact, written from what was engaged with, when the base did not answer
+/// or the answer was assembled by hand. Off until turned on: this writes
+/// model-written text into the index, and that is a step an operator takes.
+/// Needs `feedback.enabled`, since the events it reads are the ones recording
+/// writes. The grouping line is not a key: it is measured, like the gap
+/// clusters', by `core::gaps::link_threshold`.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PursuitConfig {
+    pub enabled: bool,
+    /// A pursuit is over when nothing has happened for this long.
+    pub idle_secs: u64,
+    /// Fewer engaged artifacts than this is a promotion case, not generation.
+    pub min_sources: usize,
+    /// Total engagement weight a pursuit needs before it is worth a call.
+    pub min_engagement: f64,
+}
+
+impl Default for PursuitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            idle_secs: 900,
+            min_sources: 2,
+            min_engagement: 3.0,
         }
     }
 }
@@ -1353,6 +1385,13 @@ impl Config {
                  synthesizer",
                 self.infer.synthesis.as_str()
             )));
+        }
+        if self.pursuit.enabled && !self.feedback.enabled {
+            return Err(ConfigError::Invalid(
+                "pursuit.enabled = true needs feedback.enabled = true: the events it reads are \
+                 the ones recording writes"
+                    .into(),
+            ));
         }
         if let Some(v) = &self.infer.vision
             && v.base_url.is_none()
@@ -2681,5 +2720,22 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         assert_eq!(cfg.promote.activation_above, 2.5);
         assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 12);
         assert!(!cfg.feedback.enabled);
+    }
+
+    #[test]
+    fn pursuit_defaults_and_requires_feedback() {
+        let _guard = env_guard();
+        let roles = "[infer.synthesize]\ntier = \"efficient\"\noutput_ratio = 8.0\n[infer.ask]\ntier = \"efficient\"\n";
+        let cfg = load_infer(&format!("{BARE_PREAMBLE}\n{roles}")).unwrap();
+        assert!(!cfg.pursuit.enabled);
+        assert_eq!(cfg.pursuit.idle_secs, 900);
+        assert_eq!(cfg.pursuit.min_sources, 2);
+        assert_eq!(cfg.pursuit.min_engagement, 3.0);
+        let err = load_infer(&format!(
+            "{BARE_PREAMBLE}\n{roles}[pursuit]\nenabled = true\n[feedback]\nenabled = false\n"
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("pursuit.enabled"), "{err}");
     }
 }

--- a/src/core/ask/check.rs
+++ b/src/core/ask/check.rs
@@ -19,6 +19,35 @@ pub(super) fn unsupported_literals(answer: &str, excerpts: &[String]) -> Vec<Str
         .collect()
 }
 
+/// Which of the `n` excerpts the answer actually referenced.
+///
+/// The ask prompt numbers the excerpts and the answer cites them as `[k]`;
+/// the page turns those brackets into links (`ui::link_citations`). The same
+/// scan, run once at record time, is what tells a pursuit apart from a
+/// question that was merely handed a lot of text: being packed into the prompt
+/// is not engagement, and an abstention references nothing however many
+/// excerpts it was given.
+///
+/// A bare scan, deliberately. An `arr[1]` inside a code fence counts as a
+/// reference it is not, and the cost of that is one artifact scored a point
+/// too high in a sweep — against the cost of teaching this function markdown.
+pub(super) fn referenced(answer: &str, n: usize) -> Vec<bool> {
+    let mut used = vec![false; n];
+    let mut rest = answer;
+    while let Some(open) = rest.find('[') {
+        let after = &rest[open + 1..];
+        let digits: String = after.chars().take_while(char::is_ascii_digit).collect();
+        if after[digits.len()..].starts_with(']')
+            && let Ok(k) = digits.parse::<usize>()
+            && (1..=n).contains(&k)
+        {
+            used[k - 1] = true;
+        }
+        rest = after;
+    }
+    used
+}
+
 /// A candidate that is a bullet of prose rather than a literal.
 ///
 /// `extract_literals` treats a line indented four spaces as code, which is
@@ -208,6 +237,22 @@ fn mark_text(text: &str, needles: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn only_the_numbers_the_answer_used_come_back() {
+        let used = super::referenced("The path is /etc [2], and see [4] — not [9] or [x].", 4);
+        assert_eq!(used, vec![false, true, false, true]);
+        // An abstention references nothing, however much it was shown.
+        assert_eq!(
+            super::referenced("Not in the knowledge base. Nothing covers it.", 3),
+            vec![false; 3]
+        );
+        // `[04]` is excerpt four: the number is parsed, not the digits.
+        assert_eq!(
+            super::referenced("see [04]", 4),
+            vec![false, false, false, true]
+        );
+    }
+
     /// A fenced block is `<pre><code>`, so the two do nest. A flag cleared at
     /// the inner `</code>` would call whatever follows it prose, which is what
     /// a citation linker would then happily link.

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -564,11 +564,18 @@ impl Core {
             if run.len() < 2 {
                 continue;
             }
-            // The earliest in list order keeps its number and its title line;
-            // the rest contribute their text, in document order, and go dark.
+            // The earliest in list order keeps its number; the rest contribute
+            // their text, in document order, and go dark.
             let anchor = *run.iter().min_by_key(|&&m| members[m].3).unwrap();
             let anchor_pos = members[anchor].3;
-            let head = hits[anchor_pos].title.as_deref().unwrap_or_default();
+            // The heading belongs to where the block *starts*, and the anchor
+            // is whichever member ranked highest, not the first one down the
+            // page. Where a heading falls inside the second passage of a run,
+            // taking the anchor's title labelled text that opens above it with
+            // the section below. `run` is in document order by construction —
+            // that is what it was built by — so its first member is the one
+            // whose heading the reader is actually under.
+            let head = hits[members[run[0]].3].title.as_deref().unwrap_or_default();
             let text: Vec<&str> = run
                 .iter()
                 .map(|&m| hits[members[m].3].text.as_str())
@@ -591,12 +598,8 @@ impl Core {
                     }
                 }
             }
-            blocks[anchor_pos] = crate::infer::prompt::ask_excerpt(
-                anchor_pos + 1,
-                head,
-                &text.join("\n"),
-                &caveats,
-            );
+            blocks[anchor_pos] =
+                crate::infer::prompt::ask_excerpt(anchor_pos + 1, head, &text.join("\n"), &caveats);
             for &m in &run {
                 if m != anchor {
                     blocks[members[m].3].clear();
@@ -2360,5 +2363,91 @@ mod tests {
         for c in &made {
             assert!(cited.contains(&c.id), "{} missing from citations", c.text);
         }
+    }
+
+    #[tokio::test]
+    async fn a_stitched_run_is_headed_by_where_it_starts_not_by_its_best_hit() {
+        // The anchor is whichever member ranked highest, which is not the same
+        // as the one the block opens with. Where a heading falls inside the
+        // second passage of a run, taking the anchor's title labelled text
+        // beginning above that heading with the section below it.
+        //
+        // `stitch_passages` directly rather than through `ask`: what this is
+        // about is a run whose best hit is not its first line, and asking the
+        // retrieval to produce that ordering is asking it for something it does
+        // not promise. Handed in, it is the case every time.
+        let core = test_core().await;
+        let src = core
+            .store
+            .insert_corpus("l1\nl2", "web", None)
+            .await
+            .unwrap();
+        let mk = |i: i64, text: &str, title: &str, line: i64| NewArtifact {
+            ordinal: i,
+            text: text.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                start_line: line,
+                end_line: line,
+            }),
+            title: Some(title.into()),
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let made = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[
+                    mk(0, "the tail of the section above", "Recovery", 1),
+                    mk(1, "rotate the offsite copy weekly", "Backups", 2),
+                ],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+
+        // The second passage ranked first: it is the anchor, and it keeps the
+        // block's number — but not the heading, which belongs to line 1.
+        let hit =
+            |c: &crate::store::artifacts::Chunk, score: f32| crate::core::search::SearchResult {
+                artifact_id: c.id.clone(),
+                corpus_id: c.corpus_id.clone().unwrap_or_default(),
+                title: c.title.clone(),
+                text: c.text.clone(),
+                category: None,
+                tags: vec![],
+                score,
+                status: None,
+                superseded_by: None,
+                last_verified_at: None,
+                weak: false,
+                primed: false,
+                past_cliff: false,
+                via: None,
+                reason: None,
+                model_written: false,
+                synthesized: false,
+                origin_count: 0,
+            };
+        let hits = vec![hit(&made[1], 0.9), hit(&made[0], 0.5)];
+        let mut blocks = vec![
+            crate::infer::prompt::ask_excerpt(1, "Backups", &made[1].text, &[]),
+            crate::infer::prompt::ask_excerpt(2, "Recovery", &made[0].text, &[]),
+        ];
+        core.stitch_passages(&hits, &mut blocks).await;
+
+        assert!(blocks[1].is_empty(), "the run's other member goes dark");
+        assert!(
+            blocks[0].contains("the tail of the section above\nrotate the offsite copy weekly"),
+            "stitched in document order: {}",
+            blocks[0]
+        );
+        assert!(
+            blocks[0].starts_with("[1] Recovery\n"),
+            "the anchor keeps its number, the opening line keeps its heading: {}",
+            blocks[0]
+        );
     }
 }

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -107,6 +107,16 @@ impl Core {
             if req.q.trim().is_empty() {
                 Err(Error::Validation("question is empty".into()))?;
             }
+            // No ask model: the door is not offered anywhere, and a caller that
+            // found the route anyway is told why rather than served an answer
+            // from nothing.
+            if core.completer.is_none() {
+                Err(Error::Validation("[infer.ask] is not configured".into()))?;
+            }
+            let completer = core
+                .completer
+                .clone()
+                .expect("checked just above");
 
             // Held for the whole answer rather than around the completion, because
             // a search embeds the query and that is a model call too. A gap between
@@ -303,9 +313,9 @@ impl Core {
             // being an estimate.
             let spent = core.counter.count(ASK_SYSTEM) + core.counter.count(&user);
             let ceiling = crate::infer::budget::ceiling_for_prompt(
-                core.completer.context_tokens(),
+                completer.context_tokens(),
                 spent,
-                core.completer.max_output_tokens(),
+                completer.max_output_tokens(),
             );
 
             // The excerpts go out before the first token, so the rail beside the
@@ -321,7 +331,6 @@ impl Core {
             // longer than the channel — which is every answer worth reading — and
             // would still pass any test whose fake reply fits in 64 deltas.
             let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::infer::Delta>(64);
-            let completer = core.completer.clone();
             let prompt = user.clone();
             let held = std::sync::Arc::clone(&lane);
             let call = tokio::spawn(async move {
@@ -493,7 +502,13 @@ impl Core {
     /// How many tokens of excerpt one answer may be built from: the rule
     /// `excerpt_budget` states, for the answer model under the ask prompt.
     fn excerpt_budget(&self, question: &str) -> usize {
-        excerpt_budget(&*self.completer, &self.counter, ASK_SYSTEM, question)
+        // Only reached from `ask_events`, which returned before here without a
+        // completer; a caller that gets past that has one.
+        let completer = self
+            .completer
+            .as_deref()
+            .expect("ask_events refuses before budgeting without [infer.ask]");
+        excerpt_budget(completer, &self.counter, ASK_SYSTEM, question)
     }
 
     /// One hop sideways from the hits that placed best: the artifacts adjacent
@@ -777,7 +792,7 @@ mod tests {
             gate: std::sync::Arc::clone(&core.gate),
             background_was_held: std::sync::atomic::AtomicBool::new(false),
         });
-        core.completer = probe.clone();
+        core.completer = Some(probe.clone());
         seed(&core, 3, 4).await;
 
         core.ask(
@@ -901,7 +916,7 @@ mod tests {
     async fn follow_up_off_makes_no_extra_call() {
         let mut core = test_core().await;
         let model = Counting::saying("fake answer");
-        core.completer = model.clone();
+        core.completer = Some(model.clone());
         seed(&core, 3, 4).await;
         assert!(core.follow_up.is_none(), "the default wired a follow-up");
 
@@ -1191,7 +1206,9 @@ mod tests {
         // no answer. Caveats are not in the vector payload, so this asserts the
         // store lookup that puts them back.
         let mut core = test_core().await;
-        core.completer = std::sync::Arc::new(crate::infer::fake::FakeCompleter { reply: None });
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: None,
+        }));
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let made = core
             .store
@@ -1301,7 +1318,7 @@ mod tests {
         for (context, max_output) in [(4096, 3072), (8192, 1024), (4096, 4096), (32768, 2048)] {
             let completer = std::sync::Arc::new(Ceilinged::new(context, max_output));
             let mut core = test_core().await;
-            core.completer = completer.clone();
+            core.completer = Some(completer.clone());
             // Excerpts sized against the window, so packing actually fills it
             // in every case — a prompt that leaves the window half empty tests
             // nothing about what happens when it does not.
@@ -1349,7 +1366,7 @@ mod tests {
     #[tokio::test]
     async fn a_ceiling_as_wide_as_its_window_still_answers() {
         let mut core = test_core().await;
-        core.completer = std::sync::Arc::new(Ceilinged::new(4096, 4096));
+        core.completer = Some(std::sync::Arc::new(Ceilinged::new(4096, 4096)));
         seed(&core, 3, 4).await;
         let out = core.ask(&req("chunk"), Door::Api).await.unwrap();
         assert!(
@@ -1390,7 +1407,7 @@ mod tests {
         }
 
         let mut core = test_core().await;
-        core.completer = std::sync::Arc::new(Truncating);
+        core.completer = Some(std::sync::Arc::new(Truncating));
         seed(&core, 3, 4).await;
         let out = core.ask(&req("chunk"), Door::Api).await.unwrap();
         assert!(
@@ -1820,7 +1837,7 @@ mod tests {
     #[tokio::test]
     async fn an_answer_that_opens_with_the_sentinel_is_flagged_abstained() {
         let mut core = test_core().await;
-        core.completer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             // Carries a literal no excerpt does, so the abstention branch of
             // the check is what keeps `unsupported` empty below rather than the
             // reply happening to have nothing in it.
@@ -1828,7 +1845,7 @@ mod tests {
                 "Not in the knowledge base. The excerpts cover `chunk 0` only, not `wipefs --all /dev/sdX`."
                     .into(),
             ),
-        });
+        }));
         seed(&core, 3, 4).await;
         let out = core.ask(&req("chunk"), Door::Api).await.unwrap();
         assert!(out.abstained);
@@ -1846,9 +1863,9 @@ mod tests {
     #[tokio::test]
     async fn an_answer_that_invents_a_command_reports_it_as_unsupported() {
         let mut core = test_core().await;
-        core.completer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some("Run `wipefs --all /dev/sdX` first, then read chunk 0.".into()),
-        });
+        }));
         seed(&core, 3, 4).await;
         let out = core.ask(&req("chunk"), Door::Api).await.unwrap();
         assert_eq!(
@@ -1863,9 +1880,9 @@ mod tests {
         // The common case, and the one that must not badge every answer: the
         // seeded artifacts read "chunk 0 filler filler …".
         let mut core = test_core().await;
-        core.completer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some("The excerpt says `chunk 0 filler` and nothing else.".into()),
-        });
+        }));
         seed(&core, 3, 4).await;
         let out = core.ask(&req("chunk"), Door::Api).await.unwrap();
         assert!(out.unsupported.is_empty(), "{:?}", out.unsupported);
@@ -1922,7 +1939,7 @@ mod tests {
         let mut core = test_core().await;
         // Several deltas rather than one, so "before the first token" is a
         // claim about ordering and not about there being a single token.
-        core.completer = std::sync::Arc::new(Chatty { parts: 3 });
+        core.completer = Some(std::sync::Arc::new(Chatty { parts: 3 }));
         seed(&core, 3, 4).await;
 
         let mut order: Vec<&'static str> = vec![];
@@ -1998,7 +2015,7 @@ mod tests {
     async fn an_answer_longer_than_the_sink_can_hold_still_finishes() {
         let mut core = test_core().await;
         const PARTS: usize = 500;
-        core.completer = std::sync::Arc::new(Chatty { parts: PARTS });
+        core.completer = Some(std::sync::Arc::new(Chatty { parts: PARTS }));
         seed(&core, 3, 4).await;
 
         let out = tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -2070,9 +2087,9 @@ mod tests {
         let release = std::sync::Arc::new(tokio::sync::Notify::new());
         let mut core = test_core().await;
         core.feedback.enabled = true;
-        core.completer = std::sync::Arc::new(Stalling {
+        core.completer = Some(std::sync::Arc::new(Stalling {
             release: release.clone(),
-        });
+        }));
         seed(&core, 3, 4).await;
 
         // Read as far as the first token, so the call is provably in flight

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -988,7 +988,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl crate::infer::Embedder for Keyed {
-        async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
             Ok(texts
                 .iter()
                 .map(|t| {
@@ -1001,6 +1001,11 @@ mod tests {
                     v
                 })
                 .collect())
+        }
+        fn templates(&self) -> &crate::config::EmbedTemplates {
+            static LEGACY: std::sync::LazyLock<crate::config::EmbedTemplates> =
+                std::sync::LazyLock::new(crate::config::EmbedTemplates::legacy);
+            &LEGACY
         }
         fn dim(&self) -> usize {
             crate::core::test_support::TEST_DIM

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -512,12 +512,29 @@ impl Core {
     /// the carried heading, hides the continuity from the model, and cuts the
     /// sentence running across the boundary. Here — after packing, over the
     /// kept prefix only — runs of abutting passages from one `(corpus,
-    /// segment)` are merged into the block of the run's earliest member, in
-    /// document order, and the other members' blocks are emptied. A stitched
-    /// excerpt is a presentation, not a new unit: `hits` is untouched, every
-    /// constituent stays a citation, and the literal check reads the same
-    /// text the model did. Passages only — two adjacent *artifacts* are two
-    /// rewrites, not continuous text.
+    /// segment)` are merged into the block of the run's *first* member, in
+    /// document order, and every other member keeps its own numbered block
+    /// carrying a pointer to it.
+    ///
+    /// The pointer, rather than an emptied block, is what keeps a citation
+    /// honest. The rail beside the answer links `[n]` to the artifact at
+    /// position `n` of `hits`, so a run rendered under one number offers the
+    /// model exactly one number for text drawn from three artifacts, and a
+    /// claim taken from the second passage of a run is then linked to a page
+    /// that does not contain it. With a block each, whichever number the model
+    /// cites resolves to a passage of the run it actually read.
+    ///
+    /// The text goes to the run's first member and not to its best-ranked one
+    /// for the same reason: the block's heading is the heading the text opens
+    /// under, the rail row for that number is the artifact where the text
+    /// begins, and the reader who follows the link lands where they were
+    /// reading. Numbering the block after the best-ranked member instead put a
+    /// heading from one artifact over a rail row naming another.
+    ///
+    /// A stitched excerpt is a presentation, not a new unit: `hits` is
+    /// untouched, every constituent stays a citation, and the literal check
+    /// reads the same text the model did. Passages only — two adjacent
+    /// *artifacts* are two rewrites, not continuous text.
     async fn stitch_passages(&self, hits: &[SearchResult], blocks: &mut [String]) {
         use crate::store::artifacts::{CorpusSpan, Provenance};
         let ids: Vec<String> = hits.iter().map(|h| h.artifact_id.clone()).collect();
@@ -564,18 +581,11 @@ impl Core {
             if run.len() < 2 {
                 continue;
             }
-            // The earliest in list order keeps its number; the rest contribute
-            // their text, in document order, and go dark.
-            let anchor = *run.iter().min_by_key(|&&m| members[m].3).unwrap();
-            let anchor_pos = members[anchor].3;
-            // The heading belongs to where the block *starts*, and the anchor
-            // is whichever member ranked highest, not the first one down the
-            // page. Where a heading falls inside the second passage of a run,
-            // taking the anchor's title labelled text that opens above it with
-            // the section below. `run` is in document order by construction —
-            // that is what it was built by — so its first member is the one
-            // whose heading the reader is actually under.
-            let head = hits[members[run[0]].3].title.as_deref().unwrap_or_default();
+            // `run` is in document order by construction — that is what it
+            // was built by — so its first member is where the text begins, and
+            // the heading the reader is under is that member's.
+            let head_pos = members[run[0]].3;
+            let head = hits[head_pos].title.as_deref().unwrap_or_default();
             let text: Vec<&str> = run
                 .iter()
                 .map(|&m| hits[members[m].3].text.as_str())
@@ -598,11 +608,16 @@ impl Core {
                     }
                 }
             }
-            blocks[anchor_pos] =
-                crate::infer::prompt::ask_excerpt(anchor_pos + 1, head, &text.join("\n"), &caveats);
+            blocks[head_pos] =
+                crate::infer::prompt::ask_excerpt(head_pos + 1, head, &text.join("\n"), &caveats);
+            // Every other member keeps its slot and points at the block its
+            // text went into. Cheap — one line each — and it is what lets the
+            // model cite the passage it drew on rather than the one that
+            // happened to rank highest.
             for &m in &run {
-                if m != anchor {
-                    blocks[members[m].3].clear();
+                let p = members[m].3;
+                if p != head_pos {
+                    blocks[p] = crate::infer::prompt::ask_continues(p + 1, head_pos + 1);
                 }
             }
         }
@@ -796,14 +811,23 @@ impl Core {
             abstained: response.abstained,
             dropped: response.dropped,
             truncated: response.truncated,
-            citations: response
-                .citations
-                .iter()
-                .map(|c| NewAskCitation {
-                    artifact_id: c.artifact_id.clone(),
-                    score: c.score,
-                })
-                .collect(),
+            // What the answer referenced, not what it was shown. The sweep
+            // reads these as engagement, and every excerpt that fit the window
+            // would otherwise count as one — enough, on its own, to arm a
+            // generation off a question the model declined to answer.
+            citations: {
+                let used = check::referenced(&response.answer, response.citations.len());
+                response
+                    .citations
+                    .iter()
+                    .zip(used)
+                    .map(|(c, used)| NewAskCitation {
+                        artifact_id: c.artifact_id.clone(),
+                        score: c.score,
+                        used,
+                    })
+                    .collect()
+            },
         };
         match self.store.record_ask(ask).await {
             Ok(id) => response.event_id = Some(id),
@@ -2366,11 +2390,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_stitched_run_is_headed_by_where_it_starts_not_by_its_best_hit() {
-        // The anchor is whichever member ranked highest, which is not the same
-        // as the one the block opens with. Where a heading falls inside the
-        // second passage of a run, taking the anchor's title labelled text
-        // beginning above that heading with the section below it.
+    async fn a_stitched_run_is_numbered_and_headed_by_where_it_starts() {
+        // The run's text, its heading, and the number the rail resolves to an
+        // artifact all have to name the same passage: the one the text opens
+        // with. Numbering the block after whichever member ranked highest put
+        // one artifact's heading over another artifact's rail row, and linked
+        // a claim to a page that does not hold the words.
         //
         // `stitch_passages` directly rather than through `ask`: what this is
         // about is a run whose best hit is not its first line, and asking the
@@ -2438,15 +2463,23 @@ mod tests {
         ];
         core.stitch_passages(&hits, &mut blocks).await;
 
-        assert!(blocks[1].is_empty(), "the run's other member goes dark");
+        // The text goes under the number of the passage it starts with —
+        // `made[0]`, which retrieval placed second — heading and all.
         assert!(
-            blocks[0].contains("the tail of the section above\nrotate the offsite copy weekly"),
+            blocks[1].contains("the tail of the section above\nrotate the offsite copy weekly"),
             "stitched in document order: {}",
-            blocks[0]
+            blocks[1]
         );
         assert!(
-            blocks[0].starts_with("[1] Recovery\n"),
-            "the anchor keeps its number, the opening line keeps its heading: {}",
+            blocks[1].starts_with("[2] Recovery\n"),
+            "the block is numbered and headed by where the text begins: {}",
+            blocks[1]
+        );
+        // And the other member keeps its slot, pointing at it. A claim drawn
+        // from `made[1]` can be cited as [1] and still resolve to `made[1]`.
+        assert_eq!(
+            blocks[0], "[1] (continues [2])",
+            "every constituent keeps a citable number: {}",
             blocks[0]
         );
     }

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -721,6 +721,9 @@ impl Core {
                 status: Some(c.status),
                 superseded_by: c.superseded_by,
                 last_verified_at: c.last_verified_at,
+                model_written: c.provenance.is_model_written(),
+                synthesized: c.provenance == crate::store::artifacts::Provenance::Synthesized,
+                origin_count: 0,
                 // Weakness is read from a similarity to the query, and there is
                 // no similarity here to read. It has to be demonstrated, never
                 // assumed — in either direction.

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -573,8 +573,30 @@ impl Core {
                 .iter()
                 .map(|&m| hits[members[m].3].text.as_str())
                 .collect();
-            blocks[anchor_pos] =
-                crate::infer::prompt::ask_excerpt(anchor_pos + 1, head, &text.join("\n"), &[]);
+            // The caveats of everything the block now contains, not of the
+            // anchor alone. A stitched excerpt is one presentation of several
+            // passages, and the run's other members are no longer rendered
+            // anywhere — so a warning carried by the third passage in a run
+            // would leave the prompt entirely if only the anchor's came along.
+            // The caveats are the safety margin on an excerpt: dropping them
+            // silently is the one direction this must not fail in.
+            let mut caveats: Vec<String> = Vec::new();
+            for &m in &run {
+                let id = &hits[members[m].3].artifact_id;
+                if let Some(c) = rows.iter().find(|r| &r.id == id) {
+                    for cv in &c.caveats {
+                        if !caveats.contains(cv) {
+                            caveats.push(cv.clone());
+                        }
+                    }
+                }
+            }
+            blocks[anchor_pos] = crate::infer::prompt::ask_excerpt(
+                anchor_pos + 1,
+                head,
+                &text.join("\n"),
+                &caveats,
+            );
             for &m in &run {
                 if m != anchor {
                     blocks[members[m].3].clear();

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -171,6 +171,7 @@ impl Core {
 
             // Highest score first, so what gets cut is what mattered least.
             let mut kept = pack_by_budget(&blocks, &core.counter, budget);
+            core.stitch_passages(&hits[..kept], &mut blocks[..kept]).await;
             let mut ranked = first.ranked;
             let mut dropped = retrieve::dropped_count(&retrieved, &hits[..kept], ranked);
             if dropped > 0 {
@@ -234,9 +235,14 @@ impl Core {
                         // appended to what round one packed: the second round's
                         // excerpts have to fit the same window as the first, and
                         // the only honest way to know what fits is to pack it.
-                        let merged_blocks = core.excerpts(&merged.hits).await;
+                        let mut merged_blocks = core.excerpts(&merged.hits).await;
                         let merged_kept =
                             pack_by_budget(&merged_blocks, &core.counter, budget);
+                        core.stitch_passages(
+                            &merged.hits[..merged_kept],
+                            &mut merged_blocks[..merged_kept],
+                        )
+                        .await;
 
                         // A re-pack that fits nothing leaves round one standing.
                         // The prompt cannot be empty because the follow-up found
@@ -497,6 +503,84 @@ impl Core {
                 )
             })
             .collect()
+    }
+
+    /// Put consecutive passages back together as the text they are.
+    ///
+    /// Passages are verbatim slices whose spans tile a segment; two that abut
+    /// are literally continuous text, and showing them as two excerpts repeats
+    /// the carried heading, hides the continuity from the model, and cuts the
+    /// sentence running across the boundary. Here — after packing, over the
+    /// kept prefix only — runs of abutting passages from one `(corpus,
+    /// segment)` are merged into the block of the run's earliest member, in
+    /// document order, and the other members' blocks are emptied. A stitched
+    /// excerpt is a presentation, not a new unit: `hits` is untouched, every
+    /// constituent stays a citation, and the literal check reads the same
+    /// text the model did. Passages only — two adjacent *artifacts* are two
+    /// rewrites, not continuous text.
+    async fn stitch_passages(&self, hits: &[SearchResult], blocks: &mut [String]) {
+        use crate::store::artifacts::{CorpusSpan, Provenance};
+        let ids: Vec<String> = hits.iter().map(|h| h.artifact_id.clone()).collect();
+        let rows = match self.store.artifacts_by_ids(&ids).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "ask: could not read spans; excerpts stay unstitched");
+                return;
+            }
+        };
+        let mut pos: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for (i, h) in hits.iter().enumerate() {
+            pos.insert(h.artifact_id.as_str(), i);
+        }
+        // (corpus, segment, span, position in hits), for passages with a span.
+        let mut members: Vec<(String, i64, CorpusSpan, usize)> = rows
+            .iter()
+            .filter(|c| c.provenance == Provenance::Passage)
+            .filter_map(|c| {
+                Some((
+                    c.corpus_id.clone()?,
+                    c.segment_idx?,
+                    c.corpus_span.clone()?,
+                    *pos.get(c.id.as_str())?,
+                ))
+            })
+            .collect();
+        members.sort_by(|a, b| {
+            (a.0.as_str(), a.1, a.2.start_line).cmp(&(b.0.as_str(), b.1, b.2.start_line))
+        });
+
+        let mut i = 0;
+        while i < members.len() {
+            let mut run = vec![i];
+            while i + 1 < members.len()
+                && members[i + 1].0 == members[i].0
+                && members[i + 1].1 == members[i].1
+                && members[i + 1].2.start_line == members[i].2.end_line + 1
+            {
+                i += 1;
+                run.push(i);
+            }
+            i += 1;
+            if run.len() < 2 {
+                continue;
+            }
+            // The earliest in list order keeps its number and its title line;
+            // the rest contribute their text, in document order, and go dark.
+            let anchor = *run.iter().min_by_key(|&&m| members[m].3).unwrap();
+            let anchor_pos = members[anchor].3;
+            let head = hits[anchor_pos].title.as_deref().unwrap_or_default();
+            let text: Vec<&str> = run
+                .iter()
+                .map(|&m| hits[members[m].3].text.as_str())
+                .collect();
+            blocks[anchor_pos] =
+                crate::infer::prompt::ask_excerpt(anchor_pos + 1, head, &text.join("\n"), &[]);
+            for &m in &run {
+                if m != anchor {
+                    blocks[members[m].3].clear();
+                }
+            }
+        }
     }
 
     /// How many tokens of excerpt one answer may be built from: the rule
@@ -2169,6 +2253,87 @@ mod tests {
         }
         fn max_output_tokens(&self) -> usize {
             1024
+        }
+    }
+
+    #[tokio::test]
+    async fn consecutive_passages_are_stitched_into_one_excerpt_and_every_id_is_cited() {
+        let mut core = test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        // One corpus, one segment, three abutting passages, all hits.
+        let src = core
+            .store
+            .insert_corpus("l1\nl2\nl3", "web", None)
+            .await
+            .unwrap();
+        let mk = |i: i64, text: &str, from: i64, to: i64| NewArtifact {
+            ordinal: i,
+            text: text.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                start_line: from,
+                end_line: to,
+            }),
+            title: Some("Recovery".into()),
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let made = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[
+                    mk(0, "first part", 1, 1),
+                    mk(1, "second part", 2, 2),
+                    mk(2, "third part", 3, 3),
+                ],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        for c in &made {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        // A completer that keeps its prompts, so the test can read what the
+        // model was shown.
+        let probe = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
+            "See [1].".into(),
+        ]));
+        core.completer = Some(probe.clone());
+
+        let out = core
+            .ask(
+                &AskRequest {
+                    q: "Recovery\nfirst part".into(),
+                    limit: Some(8),
+                    tags: vec![],
+                    category: None,
+                },
+                Door::Api,
+            )
+            .await
+            .unwrap();
+
+        let prompt = probe.prompts().pop().expect("the model was called");
+        // One excerpt carries the stitched text in document order, once.
+        assert!(
+            prompt.contains("first part\nsecond part\nthird part"),
+            "{prompt}"
+        );
+        assert_eq!(
+            prompt.matches("Recovery").count(),
+            2,
+            "heading once in the excerpt, once in the question: {prompt}"
+        );
+        // Every constituent is still a citation.
+        let cited: std::collections::HashSet<String> = out
+            .citations
+            .iter()
+            .map(|c| c.artifact_id.clone())
+            .collect();
+        for c in &made {
+            assert!(cited.contains(&c.id), "{} missing from citations", c.text);
         }
     }
 }

--- a/src/core/ask/retrieve.rs
+++ b/src/core/ask/retrieve.rs
@@ -213,6 +213,9 @@ mod tests {
             past_cliff: false,
             via: via.map(str::to_string),
             reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
         }
     }
 

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -98,6 +98,10 @@ pub fn spawn_consolidation_ticker(
             tracing::info!("consolidation sweep disabled");
             return;
         }
+        if !core.synthesizes() {
+            tracing::info!("no synthesizer; consolidation judging disabled");
+            return;
+        }
         let period = std::time::Duration::from_secs(core.consolidate.interval_hours.max(1) * 3600);
         let mut tick = tokio::time::interval(period);
         loop {
@@ -326,6 +330,10 @@ pub fn spawn_dedupe_ticker(
     tokio::spawn(async move {
         if !core.consolidate.enabled || core.consolidate.max_dedupe_per_tick == 0 {
             tracing::info!("dedupe pass disabled");
+            return;
+        }
+        if !core.synthesizes() {
+            tracing::info!("no synthesizer; dedupe pass disabled");
             return;
         }
         let period =

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -372,6 +372,39 @@ pub const ASSOCIATE_TARGET: &str = "collection";
 ///
 /// Returns before its loop when there is nothing to learn from — either the
 /// feature is off, or searches are not being recorded, which is the same thing.
+/// Queue the pursuit sweep on a period shorter than the idle window, so a run
+/// of searches is grouped soon after it goes quiet.
+pub fn spawn_pursuit_ticker(
+    core: crate::core::Core,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !core.pursuit.enabled || !core.associating() {
+            tracing::info!("pursuit sweep disabled");
+            return;
+        }
+        let period = std::time::Duration::from_secs((core.pursuit.idle_secs / 2).max(60));
+        let mut tick = tokio::time::interval(period);
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = tick.tick() => {
+                    if let Err(e) = core
+                        .store
+                        .enqueue(crate::store::jobs::Stage::Pursuit, "collection", ASSOCIATE_TARGET)
+                        .await
+                    {
+                        tracing::warn!(error = %e, "could not queue the pursuit sweep");
+                    }
+                }
+            }
+        }
+        tracing::info!("pursuit ticker stopped");
+    })
+}
+
 pub fn spawn_associate_ticker(
     core: crate::core::Core,
     mut shutdown: tokio::sync::watch::Receiver<bool>,

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -550,6 +550,7 @@ mod tests {
                     query_vec: vec![0.0],
                     embed_model: "fake".into(),
                     candidates: vec![],
+                    answered: false,
                 },
                 0,
             )

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1697,6 +1697,7 @@ mod tests {
                     last_verified_at: None,
                     superseded_by: None,
                     origin_corpora: vec![],
+                    provenance: None,
                 },
             }])
             .await
@@ -1801,6 +1802,7 @@ mod tests {
                 last_verified_at: None,
                 superseded_by: None,
                 origin_corpora: vec![],
+                provenance: None,
             },
         }
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -955,11 +955,19 @@ impl Core {
             | Stage::Title
             | Stage::Dedupe
             | Stage::Relate
-            | Stage::LinkJudge => {
+            | Stage::LinkJudge
+            | Stage::Generate => {
                 return Err(Error::Validation(
                     "that stage is a single inference call the queue arms itself; \
                      reprocess the document instead"
                         .into(),
+                ));
+            }
+            // The pursuit sweep looks at every recorded search, not at one
+            // corpus.
+            Stage::Pursuit => {
+                return Err(Error::Validation(
+                    "that stage is a collection-wide sweep, not a per-corpus stage".into(),
                 ));
             }
             // A stored image can always be read again — with a better model, or

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -484,6 +484,38 @@ impl Core {
         Ok(())
     }
 
+    /// Put a promoted window back: its passages active, the artifacts the
+    /// promotion wrote deprecated, the segment `verbatim` again so it may
+    /// promote afresh. The links copied onto the artifacts and the activation
+    /// they were handed stay where they are — both sides describe the same
+    /// corpus lines, and the asymmetry is accepted rather than fixed.
+    pub async fn undo_promotion(&self, corpus_id: &str, idx: i64) -> Result<()> {
+        use crate::store::artifacts::Provenance;
+        let rows = self.store.artifacts_for_segment(corpus_id, idx).await?;
+        for c in rows
+            .iter()
+            .filter(|c| c.provenance == Provenance::Passage && c.superseded_by.is_some())
+        {
+            self.unsupersede(&c.id).await?;
+        }
+        for c in rows
+            .iter()
+            .filter(|c| c.provenance != Provenance::Passage && c.in_results())
+        {
+            self.deprecate(&c.id).await?;
+        }
+        self.store
+            .set_segment_state(
+                corpus_id,
+                idx,
+                crate::store::segments::SegmentState::Verbatim,
+                None,
+            )
+            .await?;
+        tracing::info!(corpus_id, window = idx, "promotion undone");
+        Ok(())
+    }
+
     /// Move an already-hidden artifact from one winner to another.
     ///
     /// Not `supersede`, which refuses a side that is not active — and both sides
@@ -2073,6 +2105,79 @@ mod tests {
         assert_eq!(
             m["file"],
             serde_json::json!({"name": "n.txt", "size": 5, "mime": "text/plain"})
+        );
+    }
+
+    #[tokio::test]
+    async fn undoing_a_promotion_restores_the_passages_deprecates_the_artifacts_and_resets_the_window()
+     {
+        let core = test_core().await;
+        let src = core
+            .store
+            .insert_corpus("l1\nl2", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .upsert_segments(
+                &src.id,
+                &[crate::store::segments::NewSegment {
+                    start_line: 1,
+                    end_line: 2,
+                    text: "l1\nl2",
+                    carry_lines: 0,
+                }],
+            )
+            .await
+            .unwrap();
+        let na = |o: i64, t: &str| crate::store::artifacts::NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                start_line: 1,
+                end_line: 2,
+            }),
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let p = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[na(0, "passage")],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        let a = core
+            .store
+            .insert_artifacts(&src.id, &[na(1, "artifact")])
+            .await
+            .unwrap();
+        core.supersede(&p[0].id, &a[0].id).await.unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, crate::store::segments::SegmentState::Done, None)
+            .await
+            .unwrap();
+
+        core.undo_promotion(&src.id, 0).await.unwrap();
+
+        assert!(
+            core.store
+                .get_artifact(&p[0].id)
+                .await
+                .unwrap()
+                .in_results()
+        );
+        assert_eq!(
+            core.store.get_artifact(&a[0].id).await.unwrap().status,
+            crate::store::artifacts::ArtifactStatus::Deprecated
+        );
+        assert_eq!(
+            core.store.segment_state(&src.id, 0).await.unwrap(),
+            Some(crate::store::segments::SegmentState::Verbatim)
         );
     }
 }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -485,10 +485,19 @@ impl Core {
     }
 
     /// Put a promoted window back: its passages active, the artifacts the
-    /// promotion wrote deprecated, the segment `verbatim` again so it may
-    /// promote afresh. The links copied onto the artifacts and the activation
-    /// they were handed stay where they are — both sides describe the same
-    /// corpus lines, and the asymmetry is accepted rather than fixed.
+    /// promotion wrote deprecated, the segment `verbatim` again — and marked
+    /// `no_promote`, so it stays that way. The links copied onto the artifacts
+    /// and the activation they were handed stay where they are — both sides
+    /// describe the same corpus lines, and the asymmetry is accepted rather
+    /// than fixed.
+    ///
+    /// The mark is what makes this an undo rather than a pause. The passages
+    /// keep the activation that armed the promotion, and `maybe_promote` reads
+    /// activation at the bump: restoring `verbatim` alone would let the next
+    /// open of any restored passage promote the window again, immediately,
+    /// leaving the operator with the same promotion and a set of deprecated
+    /// artifacts beside it. Only a re-split clears the mark — a window whose
+    /// text changed is a different window.
     pub async fn undo_promotion(&self, corpus_id: &str, idx: i64) -> Result<()> {
         use crate::store::artifacts::Provenance;
         let rows = self.store.artifacts_for_segment(corpus_id, idx).await?;
@@ -512,6 +521,7 @@ impl Core {
                 None,
             )
             .await?;
+        self.store.set_segment_no_promote(corpus_id, idx).await?;
         tracing::info!(corpus_id, window = idx, "promotion undone");
         Ok(())
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1696,6 +1696,7 @@ mod tests {
                     status: None,
                     last_verified_at: None,
                     superseded_by: None,
+                    origin_corpora: vec![],
                 },
             }])
             .await
@@ -1799,6 +1800,7 @@ mod tests {
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                origin_corpora: vec![],
             },
         }
     }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1580,8 +1580,8 @@ mod tests {
         // The whole point of deferred processing: a broken inference endpoint
         // must not turn into a failed capture.
         let mut core = test_core().await;
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing(
-            "endpoint down",
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::failing("endpoint down"),
         ));
         let out = core.ingest("still accepted", "web", None).await.unwrap();
         assert_eq!(out.status, CorpusStatus::Raw);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -106,6 +106,8 @@ pub struct Core {
     pub synthesis: crate::config::SynthesisMode,
     /// The window budget when there is no synthesizer to derive one from.
     pub segment_tokens: usize,
+    /// Passage size at `off`/`earned`, already clamped to the embedder.
+    pub chunk_tokens: usize,
     pub counter: Arc<TokenCounter>,
     /// Writes that run off the request path. Shared by every clone of `Core`,
     /// so draining one drains them all.
@@ -195,6 +197,7 @@ impl Core {
                 .map(|v| Arc::new(HttpDescriber::new(v, synth)) as Arc<dyn Describer>),
             synthesis: cfg.infer.synthesis,
             segment_tokens: cfg.infer.segment_tokens,
+            chunk_tokens: cfg.infer.embed.effective_chunk_tokens(),
             counter: Arc::new(TokenCounter),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
@@ -342,6 +345,7 @@ pub mod test_support {
             describer: Some(Arc::new(FakeDescriber::default())),
             synthesis: crate::config::SynthesisMode::Eager,
             segment_tokens: crate::config::DEFAULT_SEGMENT_TOKENS,
+            chunk_tokens: crate::config::DEFAULT_CHUNK_TOKENS,
             counter: Arc::new(TokenCounter),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -92,6 +92,10 @@ pub struct Core {
     /// endpoint as the judges, its own response shape, background only.
     /// `None` with no synthesize role; gaps are then named by their terms.
     pub gap_namer: Option<Arc<dyn Completer>>,
+    /// The model that writes an artifact from a pursuit. Same endpoint as the
+    /// judges, its own response shape, background only. `None` with no
+    /// synthesize role.
+    pub generator: Option<Arc<dyn Completer>>,
     /// The model that says, once, what one answer still needs — and with it,
     /// whether an ask gets a second retrieval round at all.
     ///
@@ -191,6 +195,8 @@ impl Core {
                 .map(|s| Arc::new(HttpCompleter::for_link_judging(s)) as Arc<dyn Completer>),
             gap_namer: synth
                 .map(|s| Arc::new(HttpCompleter::for_gap_naming(s)) as Arc<dyn Completer>),
+            generator: synth
+                .map(|s| Arc::new(HttpCompleter::for_generating(s)) as Arc<dyn Completer>),
             follow_up: cfg.infer.ask.as_ref().and_then(|a| {
                 a.follow_up.then(|| {
                     Arc::new(HttpCompleter::for_follow_up(&a.follow_up_on())) as Arc<dyn Completer>
@@ -347,6 +353,7 @@ pub mod test_support {
             gap_namer: Some(Arc::new(FakeCompleter {
                 reply: Some(r#"{"label":"Fake topic"}"#.into()),
             })),
+            generator: Some(Arc::new(FakeCompleter::default())),
             // Off, like the shipped default. The follow-up tests switch it on
             // by putting a completer here, which is the only thing that does.
             follow_up: None,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -130,6 +130,9 @@ pub struct Core {
     /// the sweep, so it lives here rather than being threaded down.
     pub associate: crate::config::AssociateConfig,
     pub activation: crate::config::ActivationConfig,
+    /// When a passage has earned its window a synthesis call. See
+    /// `PromoteConfig`.
+    pub promote: crate::config::PromoteConfig,
     /// The pacer every inference call passes through. Shared by every clone,
     /// because a per-clone gate would pace nothing: the point is one queue of
     /// calls in front of one GPU.
@@ -207,6 +210,7 @@ impl Core {
             capture: cfg.capture.clone(),
             associate: cfg.associate.clone(),
             activation: cfg.activation.clone(),
+            promote: cfg.promote.clone(),
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::from_secs(cfg.pacing.cooldown_secs),
             )),
@@ -355,13 +359,18 @@ pub mod test_support {
             // search test would be asserting against noise. Tests that care
             // about the labelling set it themselves.
             weak_below: 0.0,
-            // Off, like the shipped default. The capture tests switch it on.
-            feedback: crate::config::FeedbackConfig::default(),
+            // Off in tests, whatever ships: the capture tests switch it on and
+            // the rest assert nothing is recorded.
+            feedback: crate::config::FeedbackConfig {
+                enabled: false,
+                ..Default::default()
+            },
             capture: crate::config::CaptureConfig::default(),
             // On, like the shipped default — and inert in most tests, because
             // nothing has learned a link yet. The association tests seed one.
             associate: crate::config::AssociateConfig::default(),
             activation: crate::config::ActivationConfig::default(),
+            promote: crate::config::PromoteConfig::default(),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
@@ -408,11 +417,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn associating_requires_both_flags_the_shipped_default_has_only_one() {
+    async fn associating_requires_both_flags_and_the_shipped_default_has_both() {
         // Shipped defaults: `associate.enabled = true`, `feedback.enabled =
-        // false`. Links are learned from recorded searches, and recording is
-        // a separate privacy decision, so the layer must stay dark until both
-        // are on.
+        // true` — promotion reads activation, and activation only moves while
+        // searches are recorded, so recording is opt-out. The test core keeps
+        // feedback off so every other test starts from nothing recorded, and
+        // the layer must still stay dark until both are on.
+        assert!(crate::config::FeedbackConfig::default().enabled);
+        assert!(crate::config::AssociateConfig::default().enabled);
         let mut core = test_support::test_core().await;
         assert!(core.associate.enabled && !core.feedback.enabled);
         assert!(!core.associating(), "on with only associate.enabled set");

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -133,6 +133,9 @@ pub struct Core {
     /// When a passage has earned its window a synthesis call. See
     /// `PromoteConfig`.
     pub promote: crate::config::PromoteConfig,
+    /// Whether and how a run of searches may be written up. See
+    /// `PursuitConfig`.
+    pub pursuit: crate::config::PursuitConfig,
     /// The pacer every inference call passes through. Shared by every clone,
     /// because a per-clone gate would pace nothing: the point is one queue of
     /// calls in front of one GPU.
@@ -211,6 +214,7 @@ impl Core {
             associate: cfg.associate.clone(),
             activation: cfg.activation.clone(),
             promote: cfg.promote.clone(),
+            pursuit: cfg.pursuit.clone(),
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::from_secs(cfg.pacing.cooldown_secs),
             )),
@@ -371,6 +375,7 @@ pub mod test_support {
             associate: crate::config::AssociateConfig::default(),
             activation: crate::config::ActivationConfig::default(),
             promote: crate::config::PromoteConfig::default(),
+            pursuit: crate::config::PursuitConfig::default(),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.
             gate: Arc::new(crate::infer::gate::InferenceGate::new(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -68,23 +68,30 @@ pub type CorpusLocks =
 pub struct Core {
     pub store: Store,
     pub vectors: Arc<dyn VectorStore>,
-    pub synthesizer: Arc<dyn Synthesizer>,
+    /// `None` when `[infer.synthesize]` is not configured — `synthesis = "off"`
+    /// with no synthesizer. Every stage that would call it checks before
+    /// arming, and `run_claimed` closes a unit that slipped through.
+    pub synthesizer: Option<Arc<dyn Synthesizer>>,
     pub embedder: Arc<dyn Embedder>,
     pub reranker: Option<Arc<dyn Reranker>>,
-    pub completer: Arc<dyn Completer>,
+    /// `None` when `[infer.ask]` is not configured: no ask page, no ask tool.
+    pub completer: Option<Arc<dyn Completer>>,
     /// The model that rules on duplicate pairs. Separate from `completer`
     /// because judging is background work on the synthesize endpoint, not an
     /// interactive answer: sharing one endpoint put sweep traffic in front of
     /// the user's question and tuned one model for two unrelated tasks.
-    pub judge: Arc<dyn Completer>,
+    /// `None` with no synthesize role.
+    pub judge: Option<Arc<dyn Completer>>,
     /// The model that rules on associative links. Same endpoint and same
     /// settings as `judge`, separate because the response format each judge
     /// sends is part of the completer: a link asked under the duplicate
-    /// grammar can only answer with a duplicate verdict.
-    pub link_judge: Arc<dyn Completer>,
+    /// grammar can only answer with a duplicate verdict. `None` with no
+    /// synthesize role.
+    pub link_judge: Option<Arc<dyn Completer>>,
     /// The model that names a knowledge gap from the questions in it. Same
     /// endpoint as the judges, its own response shape, background only.
-    pub gap_namer: Arc<dyn Completer>,
+    /// `None` with no synthesize role; gaps are then named by their terms.
+    pub gap_namer: Option<Arc<dyn Completer>>,
     /// The model that says, once, what one answer still needs — and with it,
     /// whether an ask gets a second retrieval round at all.
     ///
@@ -95,6 +102,10 @@ pub struct Core {
     pub follow_up: Option<Arc<dyn Completer>>,
     /// The vision model, when one is configured. `None` closes the image door.
     pub describer: Option<Arc<dyn Describer>>,
+    /// How much inference capture spends. See `SynthesisMode`.
+    pub synthesis: crate::config::SynthesisMode,
+    /// The window budget when there is no synthesizer to derive one from.
+    pub segment_tokens: usize,
     pub counter: Arc<TokenCounter>,
     /// Writes that run off the request path. Shared by every clone of `Core`,
     /// so draining one drains them all.
@@ -148,30 +159,42 @@ impl Core {
         // token-count estimation error.
         let max_artifact_tokens = (cfg.infer.embed.max_input_tokens as f32 * 0.8) as usize;
 
+        let synth = cfg.infer.synthesize.as_ref();
         Core {
             store,
             vectors,
-            synthesizer: Arc::new(
-                HttpSynthesizer::new(&cfg.infer.synthesize)
-                    .with_max_artifact_tokens(max_artifact_tokens),
-            ),
+            synthesizer: synth.map(|s| {
+                Arc::new(HttpSynthesizer::new(s).with_max_artifact_tokens(max_artifact_tokens))
+                    as Arc<dyn Synthesizer>
+            }),
             embedder: Arc::new(HttpEmbedder::new(&cfg.infer.embed)),
             reranker: cfg
                 .infer
                 .rerank
                 .as_ref()
                 .map(|r| Arc::new(HttpReranker::new(r)) as Arc<dyn Reranker>),
-            completer: Arc::new(HttpCompleter::new(&cfg.infer.ask)),
-            judge: Arc::new(HttpCompleter::for_judging(&cfg.infer.synthesize)),
-            link_judge: Arc::new(HttpCompleter::for_link_judging(&cfg.infer.synthesize)),
-            gap_namer: Arc::new(HttpCompleter::for_gap_naming(&cfg.infer.synthesize)),
-            follow_up: cfg.infer.ask.follow_up.then(|| {
-                Arc::new(HttpCompleter::for_follow_up(&cfg.infer.ask.follow_up_on()))
-                    as Arc<dyn Completer>
+            completer: cfg
+                .infer
+                .ask
+                .as_ref()
+                .map(|a| Arc::new(HttpCompleter::new(a)) as Arc<dyn Completer>),
+            judge: synth.map(|s| Arc::new(HttpCompleter::for_judging(s)) as Arc<dyn Completer>),
+            link_judge: synth
+                .map(|s| Arc::new(HttpCompleter::for_link_judging(s)) as Arc<dyn Completer>),
+            gap_namer: synth
+                .map(|s| Arc::new(HttpCompleter::for_gap_naming(s)) as Arc<dyn Completer>),
+            follow_up: cfg.infer.ask.as_ref().and_then(|a| {
+                a.follow_up.then(|| {
+                    Arc::new(HttpCompleter::for_follow_up(&a.follow_up_on())) as Arc<dyn Completer>
+                })
             }),
-            describer: cfg.infer.vision.as_ref().map(|v| {
-                Arc::new(HttpDescriber::new(v, &cfg.infer.synthesize)) as Arc<dyn Describer>
-            }),
+            describer: cfg
+                .infer
+                .vision
+                .as_ref()
+                .map(|v| Arc::new(HttpDescriber::new(v, synth)) as Arc<dyn Describer>),
+            synthesis: cfg.infer.synthesis,
+            segment_tokens: cfg.infer.segment_tokens,
             counter: Arc::new(TokenCounter),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
@@ -239,6 +262,18 @@ impl Core {
     pub fn associating(&self) -> bool {
         self.associate.enabled && self.feedback.enabled
     }
+
+    /// Is there a synthesizer to call? `false` means no `[infer.synthesize]`:
+    /// nothing that needs one is armed, offered, or run.
+    pub fn synthesizes(&self) -> bool {
+        self.synthesizer.is_some()
+    }
+
+    /// Is there an ask model to call? `false` means no `[infer.ask]`: no ask
+    /// page, no nav entry, no MCP tool, no `/api/ask`.
+    pub fn asks(&self) -> bool {
+        self.completer.is_some()
+    }
 }
 
 #[cfg(test)]
@@ -292,19 +327,21 @@ pub mod test_support {
         Core {
             store,
             vectors: Arc::new(MemoryVectors::new()),
-            synthesizer,
+            synthesizer: Some(synthesizer),
             embedder: Arc::new(FakeEmbedder::new(TEST_DIM)),
             reranker,
-            completer: Arc::new(FakeCompleter::default()),
-            judge: Arc::new(FakeCompleter::default()),
-            link_judge: Arc::new(FakeCompleter::default()),
-            gap_namer: Arc::new(FakeCompleter {
+            completer: Some(Arc::new(FakeCompleter::default())),
+            judge: Some(Arc::new(FakeCompleter::default())),
+            link_judge: Some(Arc::new(FakeCompleter::default())),
+            gap_namer: Some(Arc::new(FakeCompleter {
                 reply: Some(r#"{"label":"Fake topic"}"#.into()),
-            }),
+            })),
             // Off, like the shipped default. The follow-up tests switch it on
             // by putting a completer here, which is the only thing that does.
             follow_up: None,
             describer: Some(Arc::new(FakeDescriber::default())),
+            synthesis: crate::config::SynthesisMode::Eager,
+            segment_tokens: crate::config::DEFAULT_SEGMENT_TOKENS,
             counter: Arc::new(TokenCounter),
             background: Arc::new(Background::default()),
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
@@ -435,7 +472,7 @@ mod tests {
         let mut cfg = Config::load(Some(std::path::Path::new("config.example.toml"))).unwrap();
 
         assert!(
-            !cfg.infer.ask.follow_up,
+            !cfg.infer.ask.as_ref().unwrap().follow_up,
             "the shipped config asks for a second retrieval round"
         );
         let core = Core::from_config(&cfg, vectors.clone(), store.clone());
@@ -444,7 +481,7 @@ mod tests {
             "there is a completer to call with the feature off"
         );
 
-        cfg.infer.ask.follow_up = true;
+        cfg.infer.ask.as_mut().unwrap().follow_up = true;
         let core = Core::from_config(&cfg, vectors, store);
         assert!(core.follow_up.is_some());
     }
@@ -474,5 +511,45 @@ mod tests {
         });
         let core = Core::from_config(&cfg, vectors, store);
         assert!(core.reranker.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_core_without_roles_says_so() {
+        let cfg_toml = r#"
+        [server]
+        bind = "127.0.0.1:8080"
+        [store]
+        path = "x.db"
+        [vector]
+        url = "http://localhost:6333"
+        collection = "engram"
+        [infer]
+        synthesis = "off"
+        [infer.embed]
+        base_url = "http://localhost:8000/v1"
+        model = "embeddinggemma"
+        dim = 768
+        max_input_tokens = 2048
+        [auth]
+        mode = "local"
+        [auth.local]
+        username = "dev"
+        password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
+        "#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, cfg_toml).unwrap();
+        let cfg = crate::config::Config::load(Some(&path)).unwrap();
+        let store = Store::memory().await.unwrap();
+        let core = Core::from_config(
+            &cfg,
+            Arc::new(crate::vector::memory::MemoryVectors::new()),
+            store,
+        );
+        assert!(!core.synthesizes());
+        assert!(!core.asks());
+        assert!(core.synthesizer.is_none() && core.completer.is_none());
+        assert!(core.judge.is_none() && core.link_judge.is_none() && core.gap_namer.is_none());
+        assert_eq!(core.synthesis, crate::config::SynthesisMode::Off);
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -913,6 +913,8 @@ impl Core {
                 query_vec: vector.clone(),
                 embed_model: self.embedder.model().to_string(),
                 candidates,
+                // Set for real in the next task, once the list is final.
+                answered: false,
             };
             let store = self.store.clone();
             let window = self.feedback.coalesce_secs;

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -389,6 +389,7 @@ impl Core {
         // priming, and an install that never opted into `feedback` must see
         // no artifact's activation move, or the ranked order could start
         // changing under a feature it never turned on.
+        // Never `maybe_promote` here: exposure is not engagement.
         if counts_as_hit && self.associating() {
             let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
             let store = self.store.clone();
@@ -428,12 +429,18 @@ impl Core {
         // layer is off.
         if self.associating() {
             let ids = vec![artifact_id.to_string()];
-            let store = self.store.clone();
+            let core = self.clone();
             let (delta, half_life) = (self.activation.opened, self.activation.half_life_days);
             let at = now_secs();
             self.background.spawn(async move {
-                if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                if let Err(e) = core.store.bump_activation(&ids, delta, half_life, at).await {
                     tracing::warn!(error = %e, "could not raise activation for opening");
+                    return;
+                }
+                // An open is an engagement: the one kind of bump that can
+                // promote. See `jobs::promote::maybe_promote`.
+                if let Err(e) = crate::jobs::promote::maybe_promote(&core, &ids, at).await {
+                    tracing::warn!(error = %e, "could not check the promotion threshold");
                 }
             });
         }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -183,10 +183,14 @@ fn cap_per_corpus(
         let over = keys
             .iter()
             .any(|k| seen.get(k).copied().unwrap_or(0) >= max);
-        for k in &keys {
-            *seen.entry(k.clone()).or_insert(0) += 1;
-        }
         if !over {
+            // Only a hit that took a place counts against one. A displaced hit
+            // is over its cap in *one* of its corpora, and charging it to the
+            // others as well let a five-corpus merge that never made the list
+            // evict unrelated hits from the four that had room for it.
+            for k in &keys {
+                *seen.entry(k.clone()).or_insert(0) += 1;
+            }
             kept.push(h);
         } else {
             displaced.push(h);
@@ -1657,6 +1661,24 @@ mod tests {
         assert_eq!(
             ids(cap_per_corpus(with_merge, 2, 3)),
             vec!["a1", "a2", "b1"]
+        );
+        // And a merge that was displaced took no place in the corpora it never
+        // made the list for. Charging it to all of them let one merge spanning
+        // `a` and `b` — dropped because `a` was full — evict `b2` from a corpus
+        // with room to spare.
+        let mut m = hit("m", "", 0.85);
+        m.payload.origin_corpora = vec!["a".into(), "b".into()];
+        let with_merge = vec![
+            hit("a1", "a", 0.9),
+            hit("a2", "a", 0.8),
+            m,
+            hit("b1", "b", 0.7),
+            hit("b2", "b", 0.6),
+        ];
+        assert_eq!(
+            ids(cap_per_corpus(with_merge, 2, 4)),
+            vec!["a1", "a2", "b1", "b2"],
+            "a displaced hit must not spend a slot in a corpus it did not enter"
         );
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -528,6 +528,23 @@ impl Core {
         });
     }
 
+    /// How long an artifact stayed open. Capped — a tab left open overnight is
+    /// not a day of reading — and a no-op unless pursuits are on.
+    pub fn record_dwell(&self, artifact_id: &str, secs: i64, scope: Option<&str>) {
+        if !self.pursuit.enabled || !self.feedback.enabled || secs <= 0 {
+            return;
+        }
+        let secs = secs.min(600);
+        let store = self.store.clone();
+        let (id, scope) = (artifact_id.to_string(), scope.map(str::to_string));
+        let at = now_secs();
+        self.background.spawn(async move {
+            if let Err(e) = store.record_dwell(&id, secs, scope.as_deref(), at).await {
+                tracing::warn!(error = %e, "could not record how long an artifact was open");
+            }
+        });
+    }
+
     /// Each artifact's activation, already decayed to now.
     ///
     /// The one SQLite read the query path takes. It can only add: a failure is

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -698,11 +698,7 @@ impl Core {
         let vector = match cached {
             Some(v) => v,
             None => {
-                let v = self
-                    .embedder
-                    .embed(&[query.q.trim().to_string()])
-                    .await?
-                    .remove(0);
+                let v = self.embedder.embed_query(query.q.trim()).await?;
                 if let Ok(mut c) = self.query_cache.lock() {
                     c.put(key, v.clone());
                 }
@@ -990,10 +986,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl crate::infer::Embedder for BlockingEmbedder {
-        async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
             self.started.notify_one();
             self.release.notified().await;
-            self.inner.embed(texts).await
+            self.inner.embed_raw(texts).await
+        }
+        fn templates(&self) -> &crate::config::EmbedTemplates {
+            self.inner.templates()
         }
         fn dim(&self) -> usize {
             self.inner.dim()

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -79,6 +79,16 @@ pub struct SearchResult {
     /// the benefit of the doubt. Weakness has to be demonstrated, never assumed.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub weak: bool,
+    /// A model wrote this text (merged, or synthesized from a pursuit). Never
+    /// silently indistinguishable from captured text.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub model_written: bool,
+    /// Written from a pursuit. What the stopping rule reads.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub synthesized: bool,
+    /// How many corpora it draws from — the badge's source count.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub origin_count: usize,
     /// This hit moved up because it is more accessible than the ones it passed
     /// — recently and often reached. Bounded by `associate.prime_lift`, never
     /// past rank 1, and said out loud wherever it happened: nothing about the
@@ -100,9 +110,21 @@ pub struct SearchResult {
     pub reason: Option<String>,
 }
 
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
+
 impl From<SearchHit> for SearchResult {
     fn from(h: SearchHit) -> Self {
+        let provenance = h
+            .payload
+            .provenance
+            .as_deref()
+            .map(crate::store::artifacts::Provenance::parse);
         SearchResult {
+            model_written: provenance.is_some_and(|p| p.is_model_written()),
+            synthesized: provenance == Some(crate::store::artifacts::Provenance::Synthesized),
+            origin_count: h.payload.origin_corpora.len(),
             artifact_id: h.payload.artifact_id,
             corpus_id: h.payload.corpus_id,
             title: h.payload.title,
@@ -479,6 +501,33 @@ impl Core {
         }
     }
 
+    /// What happened after the list rendered: this artifact was opened, or
+    /// reached from `via` — a neighbour, an association, a continuation. The
+    /// pursuit sweep attaches it to a search by time and scope; nothing here
+    /// names one. Off the request path, and a no-op unless pursuits are on
+    /// and searches are being recorded.
+    pub fn record_interaction(&self, artifact_id: &str, via: Option<&str>, scope: Option<&str>) {
+        if !self.pursuit.enabled || !self.feedback.enabled {
+            return;
+        }
+        let store = self.store.clone();
+        let (id, via, scope) = (
+            artifact_id.to_string(),
+            via.map(str::to_string),
+            scope.map(str::to_string),
+        );
+        let at = now_secs();
+        self.background.spawn(async move {
+            let kind = if via.is_some() { "pivoted" } else { "opened" };
+            if let Err(e) = store
+                .record_interaction(&id, kind, via.as_deref(), scope.as_deref(), at)
+                .await
+            {
+                tracing::warn!(error = %e, "could not record that an artifact was opened");
+            }
+        });
+    }
+
     /// Each artifact's activation, already decayed to now.
     ///
     /// The one SQLite read the query path takes. It can only add: a failure is
@@ -622,6 +671,9 @@ impl Core {
                 past_cliff: false,
                 via: Some(l.via),
                 reason: l.reason,
+                model_written: false,
+                synthesized: false,
+                origin_count: 0,
             });
         }
         out
@@ -913,8 +965,11 @@ impl Core {
                 query_vec: vector.clone(),
                 embed_model: self.embedder.model().to_string(),
                 candidates,
-                // Set for real in the next task, once the list is final.
-                answered: false,
+                // The stopping rule for pursuits: a synthesized artifact at
+                // final rank 1, at or above `weak_below`, means the base
+                // answered. A fused rank says where a hit placed and not how
+                // good it was, which is why `weak` is read beside it.
+                answered: results.first().is_some_and(|r| r.synthesized && !r.weak),
             };
             let store = self.store.clone();
             let window = self.feedback.coalesce_secs;
@@ -1547,6 +1602,7 @@ mod tests {
                 last_verified_at: None,
                 superseded_by: None,
                 origin_corpora: vec![],
+                provenance: None,
             },
             score,
             similarity: Some(score),
@@ -1796,6 +1852,9 @@ mod tests {
                 past_cliff: false,
                 via: None,
                 reason: None,
+                model_written: false,
+                synthesized: false,
+                origin_count: 0,
             })
             .collect()
     }
@@ -2607,6 +2666,9 @@ mod tests {
             past_cliff: false,
             via: None,
             reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
         };
         let results = vec![dummy(a.clone()), dummy(b.clone()), dummy(c.clone())];
 
@@ -2709,6 +2771,9 @@ mod tests {
             past_cliff: false,
             via: None,
             reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
         };
         let mut results = vec![
             dummy("a", 0.95),
@@ -2733,5 +2798,117 @@ mod tests {
         let mut flat = vec![dummy("a", 0.5), dummy("b", 0.5), dummy("c", 0.5)];
         mark_past_cliff(&mut flat);
         assert!(flat.iter().all(|r| !r.past_cliff));
+    }
+
+    #[tokio::test]
+    async fn a_synthesized_artifact_leading_the_list_marks_the_search_answered() {
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let captured = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "captured text".into(),
+                    corpus_span: None,
+                    title: Some("c".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        let made_gen = core
+            .store
+            .insert_synthesized_artifact(
+                &crate::store::artifacts::NewSynthesized {
+                    text: "generated text".into(),
+                    title: Some("g".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec![],
+                },
+                &[captured[0].id.clone()],
+            )
+            .await
+            .unwrap();
+        crate::jobs::embed::run(&core, &captured[0].id)
+            .await
+            .unwrap();
+        crate::jobs::embed::run(&core, &made_gen.id).await.unwrap();
+
+        // The fake embedder is symmetric: the query that is the generated
+        // artifact's rendered text lands it first.
+        core.search(&q("g\ngenerated text"), Door::Ui)
+            .await
+            .unwrap();
+        core.search(&q("c\ncaptured text"), Door::Ui).await.unwrap();
+        core.background.wait_idle().await;
+        let now = crate::store::now();
+        let events = core.store.events_between(0, now + 1).await.unwrap();
+        assert_eq!(events.len(), 2, "{events:?}");
+        let by_q: std::collections::HashMap<&str, bool> = events
+            .iter()
+            .map(|e| (e.query.as_str(), e.answered))
+            .collect();
+        assert!(by_q["g\ngenerated text"], "{events:?}");
+        assert!(!by_q["c\ncaptured text"], "{events:?}");
+        // And the rail knows what a model wrote.
+        let hits = core
+            .search(&q("g\ngenerated text"), Door::Ui)
+            .await
+            .unwrap();
+        assert!(hits[0].synthesized && hits[0].model_written);
+        assert_eq!(hits[0].origin_count, 1);
+    }
+
+    #[tokio::test]
+    async fn an_interaction_is_recorded_only_with_pursuits_on() {
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        core.record_interaction(&a, None, Some("me"));
+        core.background.wait_idle().await;
+        let now = crate::store::now();
+        assert!(
+            core.store
+                .interactions_between(0, now + 1)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        core.pursuit.enabled = true;
+        core.record_interaction(&a, None, Some("me"));
+        core.record_interaction(&a, Some("other"), Some("me"));
+        core.background.wait_idle().await;
+        let got = core.store.interactions_between(0, now + 1).await.unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].kind, "opened");
+        assert_eq!(got[1].kind, "pivoted");
+        assert_eq!(got[1].via.as_deref(), Some("other"));
     }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -149,9 +149,22 @@ fn cap_per_corpus(
     let mut kept = Vec::with_capacity(hits.len());
     let mut displaced = Vec::new();
     for h in hits {
-        let n = seen.entry(h.payload.corpus_id.clone()).or_insert(0);
-        *n += 1;
-        if *n <= max {
+        // A merge counts against every corpus it drew from; a passage or a
+        // captured artifact against its one. The payload carries the
+        // projection; a point written before it existed falls back to
+        // `corpus_id`.
+        let keys: Vec<String> = if h.payload.origin_corpora.is_empty() {
+            vec![h.payload.corpus_id.clone()]
+        } else {
+            h.payload.origin_corpora.clone()
+        };
+        let over = keys
+            .iter()
+            .any(|k| seen.get(k).copied().unwrap_or(0) >= max);
+        for k in &keys {
+            *seen.entry(k.clone()).or_insert(0) += 1;
+        }
+        if !over {
             kept.push(h);
         } else {
             displaced.push(h);
@@ -1531,6 +1544,7 @@ mod tests {
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                origin_corpora: vec![],
             },
             score,
             similarity: Some(score),
@@ -1554,6 +1568,20 @@ mod tests {
             ids(cap_per_corpus(ranked(), 2, 4)),
             vec!["a1", "a2", "b1", "a3"],
             "a displaced hit must refill an otherwise short list"
+        );
+        // A merge of `a` and `b` counts against both: with `a` already full it
+        // is displaced even though `b` has room.
+        let mut m = hit("m", "", 0.85);
+        m.payload.origin_corpora = vec!["a".into(), "b".into()];
+        let with_merge = vec![
+            hit("a1", "a", 0.9),
+            hit("a2", "a", 0.8),
+            m,
+            hit("b1", "b", 0.7),
+        ];
+        assert_eq!(
+            ids(cap_per_corpus(with_merge, 2, 3)),
+            vec!["a1", "a2", "b1"]
         );
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -389,15 +389,35 @@ impl Core {
         // priming, and an install that never opted into `feedback` must see
         // no artifact's activation move, or the ranked order could start
         // changing under a feature it never turned on.
-        // Never `maybe_promote` here: exposure is not engagement.
+        // Never `maybe_promote` here: exposure is not engagement. The only
+        // thing exposure can trigger is the opposite — an eager artifact shown
+        // and shown and never confirmed is re-read — and that ships disabled.
         if counts_as_hit && self.associating() {
             let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
-            let store = self.store.clone();
+            let shown: Vec<(String, i64)> = if self.promote.resynthesize_after_unconfirmed > 0 {
+                results
+                    .iter()
+                    .map(|r| {
+                        (
+                            r.artifact_id.clone(),
+                            hit_counts.get(&r.artifact_id).copied().unwrap_or(0) + 1,
+                        )
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let core = self.clone();
             let (delta, half_life) = (self.activation.retrieved, self.activation.half_life_days);
             let at = now_secs();
             self.background.spawn(async move {
-                if let Err(e) = store.bump_activation(&ids, delta, half_life, at).await {
+                if let Err(e) = core.store.bump_activation(&ids, delta, half_life, at).await {
                     tracing::warn!(error = %e, "could not raise activation for a search");
+                }
+                if !shown.is_empty()
+                    && let Err(e) = crate::jobs::promote::maybe_resynthesize(&core, &shown).await
+                {
+                    tracing::warn!(error = %e, "could not check the re-synthesis threshold");
                 }
             });
         }

--- a/src/eval/export.rs
+++ b/src/eval/export.rs
@@ -173,6 +173,7 @@ mod tests {
                         similarity: Some(0.7),
                         shown: true,
                     }],
+                    answered: false,
                 },
                 0,
             )

--- a/src/eval/export.rs
+++ b/src/eval/export.rs
@@ -296,6 +296,9 @@ mod tests {
                     .map(|id| crate::store::asks::NewAskCitation {
                         artifact_id: id.to_string(),
                         score: 1.0,
+                        // The harness names what the answer drew on, not what
+                        // it was shown; here they are the same list.
+                        used: true,
                     })
                     .collect(),
             })

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -22,11 +22,21 @@ pub const FAKE_BUDGET: SynthesisBudget = SynthesisBudget {
 /// Hashes text into a fixed-dimension unit vector. Identical text gives an
 /// identical vector and different text gives a different one, which is all the
 /// retrieval tests need from an embedding model.
+///
+/// Renders with the *legacy* templates by default — `{text}` for a query,
+/// `{title}\n{text}` for a document — so a test that queries with
+/// `"title\ntext"` lands on the document it seeded, exactly as before
+/// templates existed. `with_templates` gives a fake the asymmetric recipe for
+/// the tests that are about the recipe.
 pub struct FakeEmbedder {
     dim: usize,
+    templates: crate::config::EmbedTemplates,
     /// How many times the endpoint was called. Batching is invisible in the
     /// output — only the call count shows whether it happened.
     calls: std::sync::atomic::AtomicUsize,
+    /// Every string handed to `embed_raw`, in order: what a real endpoint
+    /// would have been sent.
+    sent: std::sync::Mutex<Vec<String>>,
     /// When set, every call is refused with this reason — the endpoint's "no",
     /// which a worker must not retry.
     reject_with: Option<String>,
@@ -34,9 +44,15 @@ pub struct FakeEmbedder {
 
 impl FakeEmbedder {
     pub fn new(dim: usize) -> Self {
+        Self::with_templates(dim, crate::config::EmbedTemplates::legacy())
+    }
+
+    pub fn with_templates(dim: usize, templates: crate::config::EmbedTemplates) -> Self {
         Self {
             dim,
+            templates,
             calls: std::sync::atomic::AtomicUsize::new(0),
+            sent: std::sync::Mutex::new(Vec::new()),
             reject_with: None,
         }
     }
@@ -50,13 +66,21 @@ impl FakeEmbedder {
     pub fn calls(&self) -> usize {
         self.calls.load(std::sync::atomic::Ordering::Relaxed)
     }
+
+    /// What was sent, rendered, in order.
+    pub fn sent(&self) -> Vec<String> {
+        self.sent.lock().map(|s| s.clone()).unwrap_or_default()
+    }
 }
 
 #[async_trait]
 impl Embedder for FakeEmbedder {
-    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         self.calls
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut s) = self.sent.lock() {
+            s.extend(texts.iter().cloned());
+        }
         if let Some(m) = &self.reject_with {
             return Err(Error::InferenceRejected {
                 role: "embed",
@@ -78,6 +102,9 @@ impl Embedder for FakeEmbedder {
                 v.iter().map(|x| x / norm).collect()
             })
             .collect())
+    }
+    fn templates(&self) -> &crate::config::EmbedTemplates {
+        &self.templates
     }
     fn dim(&self) -> usize {
         self.dim
@@ -376,7 +403,7 @@ impl StrictEmbedder {
 
 #[async_trait]
 impl Embedder for StrictEmbedder {
-    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         for t in texts {
             // The same crude estimate the budget code uses, so the test does
             // not depend on a tokenizer.
@@ -408,7 +435,10 @@ impl Embedder for StrictEmbedder {
                 });
             }
         }
-        self.inner.embed(texts).await
+        self.inner.embed_raw(texts).await
+    }
+    fn templates(&self) -> &crate::config::EmbedTemplates {
+        self.inner.templates()
     }
     fn dim(&self) -> usize {
         self.inner.dim()
@@ -644,5 +674,48 @@ mod tests {
         drop(rx);
         let done = c.answer_streaming("sys", "usr", 128, tx).await.unwrap();
         assert_eq!(done.text, "the answer");
+    }
+
+    use crate::config::EmbedTemplates;
+    use crate::infer::EmbedDoc;
+
+    #[tokio::test]
+    async fn the_fake_renders_like_the_real_one_and_keeps_what_it_sent() {
+        // With the asymmetric templates the same words embed to different
+        // vectors as a query and as a document — the property the real
+        // embedder has, exercised here so a test can rely on it.
+        let e = FakeEmbedder::with_templates(8, EmbedTemplates::default());
+        let d = e
+            .embed_documents(&[EmbedDoc {
+                title: None,
+                text: "alpha".into(),
+            }])
+            .await
+            .unwrap();
+        let q = e.embed_query("alpha").await.unwrap();
+        assert_ne!(d[0], q);
+        assert_eq!(
+            e.sent(),
+            vec![
+                "title: none | text: alpha".to_string(),
+                "task: search result | query: alpha".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_default_fake_is_symmetric_so_a_query_can_name_a_document() {
+        // What every retrieval test in the crate depends on: querying with
+        // "title\ntext" lands on the document seeded with that title and text.
+        let e = FakeEmbedder::new(8);
+        let d = e
+            .embed_documents(&[EmbedDoc {
+                title: Some("t0".into()),
+                text: "alpha".into(),
+            }])
+            .await
+            .unwrap();
+        let q = e.embed_query("t0\nalpha").await.unwrap();
+        assert_eq!(d[0], q);
     }
 }

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -61,12 +61,53 @@ pub trait Synthesizer: Send + Sync {
     }
 }
 
+/// One document as the embedder sees it: what goes into the `title:` slot and
+/// what goes into the `text:` slot. Built by `jobs::embed` from a `Chunk`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbedDoc {
+    pub title: Option<String>,
+    pub text: String,
+}
+
+/// Asymmetric by interface. A query and a document are rendered through
+/// different templates before they reach the model, and the rendering happens
+/// *inside* the trait — `embed_documents` and `embed_query` are provided — so
+/// there is no call site that can forget it. `embed_raw` is the wire call and
+/// is what an implementation supplies; nothing outside an `Embedder` should
+/// call it.
 #[async_trait]
 pub trait Embedder: Send + Sync {
-    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+    /// The strings sent, exactly as given. Implementations only.
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+    fn templates(&self) -> &crate::config::EmbedTemplates;
     fn dim(&self) -> usize;
     fn model(&self) -> &str;
     fn max_input_tokens(&self) -> usize;
+
+    /// The string a document becomes. Exposed so budgets can be measured
+    /// against what will actually be sent — the envelope costs tokens too.
+    fn render_document(&self, doc: &EmbedDoc) -> String {
+        self.templates()
+            .render_document(doc.title.as_deref(), &doc.text)
+    }
+
+    async fn embed_documents(&self, docs: &[EmbedDoc]) -> Result<Vec<Vec<f32>>> {
+        let texts: Vec<String> = docs.iter().map(|d| self.render_document(d)).collect();
+        self.embed_raw(&texts).await
+    }
+
+    async fn embed_query(&self, query: &str) -> Result<Vec<f32>> {
+        let mut out = self
+            .embed_raw(&[self.templates().render_query(query)])
+            .await?;
+        if out.is_empty() {
+            return Err(crate::error::Error::Inference {
+                role: "embed",
+                detail: "no vector came back for the query".into(),
+            });
+        }
+        Ok(out.remove(0))
+    }
 }
 
 #[async_trait]

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -619,6 +619,7 @@ pub struct HttpEmbedder {
     ep: Endpoint,
     dim: usize,
     max_input_tokens: usize,
+    templates: crate::config::EmbedTemplates,
 }
 
 impl HttpEmbedder {
@@ -633,13 +634,14 @@ impl HttpEmbedder {
             ),
             dim: cfg.dim,
             max_input_tokens: cfg.max_input_tokens,
+            templates: cfg.templates(),
         }
     }
 }
 
 #[async_trait]
 impl Embedder for HttpEmbedder {
-    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    async fn embed_raw(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         if texts.is_empty() {
             return Ok(vec![]);
         }
@@ -707,6 +709,9 @@ impl Embedder for HttpEmbedder {
     }
     fn max_input_tokens(&self) -> usize {
         self.max_input_tokens
+    }
+    fn templates(&self) -> &crate::config::EmbedTemplates {
+        &self.templates
     }
 }
 
@@ -1730,7 +1735,7 @@ mod tests {
             .mount(&server)
             .await;
         let e = HttpEmbedder::new(&embed_cfg(server.uri()))
-            .embed(&["x".into()])
+            .embed_raw(&["x".into()])
             .await
             .unwrap_err();
         assert!(e.retryable());
@@ -1757,9 +1762,60 @@ mod tests {
             .await;
 
         let e = HttpEmbedder::new(&embed_cfg(server.uri()));
-        let out = e.embed(&["first".into(), "second".into()]).await.unwrap();
+        let out = e
+            .embed_raw(&["first".into(), "second".into()])
+            .await
+            .unwrap();
         assert_eq!(out[0], vec![0.0, 1.0, 0.0, 0.0]);
         assert_eq!(out[1], vec![1.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[tokio::test]
+    async fn documents_and_queries_are_rendered_through_the_templates_before_the_post() {
+        use wiremock::matchers::body_partial_json;
+        let server = MockServer::start().await;
+        let one = serde_json::json!({"data":[{"index":0,"embedding":[1.0,0.0,0.0,0.0]}]});
+        let two = serde_json::json!({"data":[
+            {"index":0,"embedding":[1.0,0.0,0.0,0.0]},
+            {"index":1,"embedding":[0.0,1.0,0.0,0.0]}
+        ]});
+        // The document side: titled and untitled take different templates.
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .and(body_partial_json(serde_json::json!({
+                "input": ["title: Recovering | text: run fsck", "title: none | text: bare"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(two))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // The query side: the retrieval task prefix, nothing else.
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .and(body_partial_json(serde_json::json!({
+                "input": ["task: search result | query: fsck"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(one))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let e = HttpEmbedder::new(&embed_cfg(server.uri()));
+        let docs = vec![
+            crate::infer::EmbedDoc {
+                title: Some("Recovering".into()),
+                text: "run fsck".into(),
+            },
+            crate::infer::EmbedDoc {
+                title: None,
+                text: "bare".into(),
+            },
+        ];
+        let out = e.embed_documents(&docs).await.unwrap();
+        assert_eq!(out.len(), 2);
+        let q = e.embed_query("fsck").await.unwrap();
+        assert_eq!(q, vec![1.0, 0.0, 0.0, 0.0]);
+        // `.expect(1)` on both mocks is verified when `server` drops.
     }
 
     #[tokio::test]
@@ -1774,7 +1830,7 @@ mod tests {
         // Config says dim 4, server returned 2. Writing this to Qdrant would
         // corrupt the collection.
         let e = HttpEmbedder::new(&embed_cfg(server.uri()))
-            .embed(&["x".into()])
+            .embed_raw(&["x".into()])
             .await
             .unwrap_err();
         assert!(e.to_string().contains("dimension"));
@@ -1792,7 +1848,7 @@ mod tests {
             .mount(&server)
             .await;
         let e = HttpEmbedder::new(&embed_cfg(server.uri()))
-            .embed(&["a".into(), "b".into()])
+            .embed_raw(&["a".into(), "b".into()])
             .await
             .unwrap_err();
         assert!(e.to_string().contains("skipped"), "got: {e}");
@@ -2313,7 +2369,7 @@ mod tests {
             .mount(&server)
             .await;
         let e = HttpEmbedder::new(&embed_cfg(server.uri()))
-            .embed(&["x".into()])
+            .embed_raw(&["x".into()])
             .await
             .unwrap_err();
         assert!(

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -1252,7 +1252,7 @@ impl HttpDescriber {
     /// synthesize endpoint: it borrows that endpoint's address, key and — since
     /// it is the same server reading the request — the name it takes the output
     /// ceiling under.
-    pub fn new(cfg: &crate::config::VisionRole, synth: &SynthesizeRole) -> Self {
+    pub fn new(cfg: &crate::config::VisionRole, synth: Option<&SynthesizeRole>) -> Self {
         let (base_url, api_key) = cfg.resolve(synth);
         Self {
             ep: Endpoint::new(
@@ -1433,6 +1433,7 @@ mod tests {
             query_template: t.query_template,
             document_template: t.document_template,
             document_template_untitled: t.document_template_untitled,
+            chunk_tokens: crate::config::DEFAULT_CHUNK_TOKENS,
         }
     }
 
@@ -2391,7 +2392,7 @@ mod tests {
             .await;
         let cfg = vision_cfg(Some(format!("{}/v1", server.uri())));
         let model = cfg.model.clone();
-        let d = HttpDescriber::new(&cfg, &synthesize_cfg("http://unused".into()));
+        let d = HttpDescriber::new(&cfg, Some(&synthesize_cfg("http://unused".into())));
         let out = d
             .describe(b"\xFF\xD8jpegbytes", "Photo taken 2026-08-09")
             .await
@@ -2432,7 +2433,7 @@ mod tests {
         synth.reasoning_effort = Some("high".into());
         assert!(synth.ceiling_param.is_none(), "nothing explicit to inherit");
 
-        HttpDescriber::new(&vision_cfg(None), &synth)
+        HttpDescriber::new(&vision_cfg(None), Some(&synth))
             .describe(b"x", "")
             .await
             .unwrap();
@@ -2454,7 +2455,7 @@ mod tests {
         let mut synth = synthesize_cfg("http://unused".into());
         synth.reasoning_effort = Some("high".into());
 
-        HttpDescriber::new(&vision_cfg(Some(server.uri())), &synth)
+        HttpDescriber::new(&vision_cfg(Some(server.uri())), Some(&synth))
             .describe(b"x", "")
             .await
             .unwrap();
@@ -2473,7 +2474,7 @@ mod tests {
             .await;
         let mut cfg = vision_cfg(Some(server.uri()));
         cfg.api_key = None;
-        let d = HttpDescriber::new(&cfg, &synthesize_cfg("http://unused".into()));
+        let d = HttpDescriber::new(&cfg, Some(&synthesize_cfg("http://unused".into())));
         let e = d.describe(b"x", "").await.unwrap_err();
         assert!(matches!(e, Error::Inference { role: "vision", .. }), "{e}");
         assert!(e.retryable());

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -1417,6 +1417,7 @@ mod tests {
         }
     }
     fn embed_cfg(base: String) -> EmbedRole {
+        let t = crate::config::EmbedTemplates::default();
         EmbedRole {
             base_url: base,
             model: "e".into(),
@@ -1424,6 +1425,9 @@ mod tests {
             dim: 4,
             max_input_tokens: 512,
             timeout_secs: crate::config::DEFAULT_TIMEOUT_SECS,
+            query_template: t.query_template,
+            document_template: t.document_template,
+            document_template_untitled: t.document_template_untitled,
         }
     }
 

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -1024,6 +1024,12 @@ impl HttpCompleter {
         Self::judging(cfg, ("gap_label", prompt::gap_label_schema()))
     }
 
+    /// The model that writes an artifact from a pursuit, on the judges'
+    /// endpoint: background work in a fixed shape, like every other judge.
+    pub fn for_generating(cfg: &SynthesizeRole) -> Self {
+        Self::judging(cfg, ("artifact", prompt::generate_schema()))
+    }
+
     /// The model that says, once, what one answer still needs.
     ///
     /// Takes a `TierConfig` rather than a role because that is honestly what it

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -391,7 +391,9 @@ If the excerpts cover only part of the question, answer that part and say plainl
 cover — do not withhold a partial answer, and do not stretch an excerpt to cover what it does not. \
 If no excerpt mentions the subject of the question, begin your reply with the exact words \
 `Not in the knowledge base.` and say what is missing rather than guessing. \
-Cite excerpts by their number. \
+Cite excerpts by their number, and cite the excerpt the words you used came from. \
+An excerpt reading `(continues [n])` is the rest of excerpt n: its text is printed there, and a \
+claim drawn from that part of the text is cited by whichever of the two numbers holds it. \
 An excerpt may carry lines beginning `Caveat:` — the conditions under which it does not apply. \
 Repeat any caveat that bears on your answer rather than dropping it.";
 
@@ -467,10 +469,23 @@ pub fn ask_excerpt(number: usize, title: &str, text: &str, caveats: &[String]) -
     block
 }
 
+/// A passage whose text was printed under an earlier number, because the two
+/// abut and are one piece of continuous text (`Core::stitch_passages`).
+///
+/// It keeps its own number rather than vanishing from the prompt: the number
+/// is what the rail links to the artifact, so a run of three passages printed
+/// under one number leaves the model no way to cite the two it did not print
+/// without pointing the reader at a page that does not hold the words.
+pub fn ask_continues(number: usize, printed_under: usize) -> String {
+    format!("[{number}] (continues [{printed_under}])")
+}
+
 /// The question and whatever excerpts survived the context budget.
 pub fn ask_prompt(question: &str, excerpts: &[String]) -> String {
-    // An empty block is a passage that was stitched into the one before it
-    // (`Core::stitch_passages`): its text is in the prompt, its slot is not.
+    // Empty blocks are dropped. Stitching no longer makes any — a stitched
+    // passage keeps its slot and points at the block its text went into — but
+    // an excerpt with neither title nor text still has nothing to say, and a
+    // bare `[7]` in the prompt is worse than one number unused.
     let shown: Vec<&str> = excerpts
         .iter()
         .map(String::as_str)

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -469,9 +469,16 @@ pub fn ask_excerpt(number: usize, title: &str, text: &str, caveats: &[String]) -
 
 /// The question and whatever excerpts survived the context budget.
 pub fn ask_prompt(question: &str, excerpts: &[String]) -> String {
+    // An empty block is a passage that was stitched into the one before it
+    // (`Core::stitch_passages`): its text is in the prompt, its slot is not.
+    let shown: Vec<&str> = excerpts
+        .iter()
+        .map(String::as_str)
+        .filter(|e| !e.is_empty())
+        .collect();
     format!(
         "Question: {question}\n\nExcerpts:\n\n{}",
-        excerpts.join("\n\n---\n\n")
+        shown.join("\n\n---\n\n")
     )
 }
 
@@ -2170,5 +2177,11 @@ mod tests {
             !p.contains(&long),
             "no question reaches the prompt at full length"
         );
+    }
+
+    #[test]
+    fn ask_prompt_skips_an_empty_excerpt() {
+        let p = ask_prompt("q", &["[1] t\na".into(), String::new(), "[3] t\nc".into()]);
+        assert_eq!(p, "Question: q\n\nExcerpts:\n\n[1] t\na\n\n---\n\n[3] t\nc");
     }
 }

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -598,6 +598,71 @@ pub fn gap_label_prompt(questions: &[&str]) -> String {
     s
 }
 
+/// The generation behind a pursuit: one self-contained artifact written from
+/// the excerpts the operator engaged with, to answer the questions they asked.
+pub const GENERATE_SYSTEM: &str = r#"You write one self-contained knowledge-base artifact from the excerpts you are given, to answer the questions listed. Write only what the excerpts support: every command, path, version, port and flag in your text must appear in an excerpt verbatim. Atomic — one subject, standing alone, readable without the excerpts. Reply with JSON only: {"artifact":{"title":"…","text":"…","category":"…","tags":[],"caveats":[]}}"#;
+
+pub fn generate_prompt(questions: &[String], sources: &[(String, String)]) -> String {
+    let qs = questions
+        .iter()
+        .map(|q| format!("- {q}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ex = sources
+        .iter()
+        .enumerate()
+        .map(|(i, (title, text))| format!("[{}] {title}\n{text}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+    format!("Questions:\n{qs}\n\nExcerpts:\n\n{ex}")
+}
+
+pub fn generate_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "artifact": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "text": {"type": "string"},
+                    "category": {"type": "string", "enum": CATEGORIES},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "caveats": {"type": "array", "items": {"type": "string"}}
+                },
+                "required": ["title", "text", "category", "tags", "caveats"],
+                "additionalProperties": false
+            }
+        },
+        "required": ["artifact"],
+        "additionalProperties": false
+    })
+}
+
+/// What a generation call produced.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct Generated {
+    pub title: String,
+    pub text: String,
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub caveats: Vec<String>,
+}
+
+pub fn parse_generation(reply: &str) -> Result<Generated> {
+    let v: serde_json::Value = serde_json::from_str(extract_json(reply))
+        .map_err(|e| Error::MalformedLlmOutput(format!("generation was not JSON: {e}")))?;
+    let g: Generated = serde_json::from_value(v["artifact"].clone())
+        .map_err(|e| Error::MalformedLlmOutput(format!("generation had no artifact: {e}")))?;
+    if g.text.trim().is_empty() {
+        return Err(Error::MalformedLlmOutput("generation had no text".into()));
+    }
+    Ok(g)
+}
+
 pub fn gap_label_schema() -> serde_json::Value {
     serde_json::json!({
         "type": "object",

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -600,7 +600,7 @@ pub fn gap_label_prompt(questions: &[&str]) -> String {
 
 /// The generation behind a pursuit: one self-contained artifact written from
 /// the excerpts the operator engaged with, to answer the questions they asked.
-pub const GENERATE_SYSTEM: &str = r#"You write one self-contained knowledge-base artifact from the excerpts you are given, to answer the questions listed. Write only what the excerpts support: every command, path, version, port and flag in your text must appear in an excerpt verbatim. Atomic — one subject, standing alone, readable without the excerpts. Reply with JSON only: {"artifact":{"title":"…","text":"…","category":"…","tags":[],"caveats":[]}}"#;
+pub const GENERATE_SYSTEM: &str = r#"You write one self-contained knowledge-base artifact from the excerpts you are given, to answer the questions listed. Answer the questions and nothing else: use only the excerpts that bear on them and leave the rest out, however much they say. Write only what the excerpts support: every command, path, version, port and flag in your text must appear in an excerpt verbatim. Atomic — one subject, standing alone, readable without the excerpts. Reply with JSON only: {"artifact":{"title":"…","text":"…","category":"…","tags":[],"caveats":[]}}"#;
 
 pub fn generate_prompt(questions: &[String], sources: &[(String, String)]) -> String {
     let qs = questions

--- a/src/infer/split.rs
+++ b/src/infer/split.rs
@@ -62,57 +62,104 @@ pub fn split_into_segments(
         .collect();
     let lines: Vec<(&str, i64)> = owned.iter().map(|(s, n)| (s.as_str(), *n)).collect();
     let mut windows: Vec<Window> = Vec::new();
-    let mut buf: Vec<&str> = Vec::new();
+    // Each buffered line with its document number, so a window can be cut
+    // *inside* the buffer — at the last boundary before the line that
+    // overflowed — and both halves still know where they came from.
+    let mut buf: Vec<(&str, i64)> = Vec::new();
     let mut buf_tokens = 0usize;
-    let mut start_line = 1i64;
-    // The line the buffer currently reaches, which is not always the line
-    // before the one being placed: cutting a long line puts several pieces on
-    // one number, so a window can begin and end on the same line.
-    let mut buf_end = 1i64;
     let mut last_heading: Option<String> = None;
     let mut carry: Option<String> = None;
 
     for (line, line_no) in lines.iter().copied() {
         let line_tokens = counter.count(line) + 1; // +1 for the newline
         let at_boundary = is_heading(line) || line.trim().is_empty();
-
-        // Flush when the line would overflow the window. Prefer to break at a
-        // heading or blank line; if the buffer has grown well past the budget
-        // with no boundary in sight, cut anyway rather than emit one huge window.
         let overflows = !buf.is_empty() && buf_tokens + line_tokens > segment_tokens;
         let blank = line.trim().is_empty();
 
-        if overflows && (at_boundary || buf_tokens >= segment_tokens) {
+        if overflows && at_boundary {
+            // Prefer to break at a heading or blank line. A blank line closes
+            // the window it follows rather than opening the next one with an
+            // empty first line; a heading opens the window it introduces.
             if blank {
-                // A blank line separates; it closes the window it follows
-                // rather than opening the next one with an empty first line.
-                buf.push(line);
-                flush(&mut windows, &mut buf, start_line, line_no, &carry);
-                start_line = line_no + 1;
+                buf.push((line, line_no));
+                flush_buf(&mut windows, &mut buf, &carry);
+                carry = last_heading.clone();
+                buf_tokens = 0;
             } else {
-                // A heading opens the window it introduces.
-                flush(&mut windows, &mut buf, start_line, buf_end, &carry);
-                start_line = line_no;
-                if is_heading(line) {
-                    last_heading = Some(line.to_string());
-                }
-                buf.push(line);
+                flush_buf(&mut windows, &mut buf, &carry);
+                last_heading = Some(line.to_string());
+                carry = last_heading.clone();
+                buf.push((line, line_no));
+                buf_tokens = line_tokens;
             }
-            buf_end = line_no;
-            buf_tokens = if blank { 0 } else { line_tokens };
-            carry = last_heading.clone();
             continue;
+        }
+
+        if overflows {
+            // The overflowing line is text, not a boundary. Cut at the last
+            // boundary already in the buffer, if there is one: the window
+            // before it respects the budget, and this line joins the one
+            // after. Without this a paragraph that overflows rode along until
+            // the next heading, and a 384-token passage came out at 500.
+            let cut = buf
+                .iter()
+                .enumerate()
+                .skip(1)
+                .rev()
+                .find_map(|(i, (l, _))| {
+                    if is_heading(l) {
+                        Some(i) // the heading opens the next window
+                    } else if l.trim().is_empty() && i + 1 < buf.len() {
+                        Some(i + 1) // the blank line closes this one
+                    } else {
+                        None
+                    }
+                });
+            if let Some(i) = cut {
+                let rest: Vec<(&str, i64)> = buf.split_off(i);
+                // The heading the kept half continues under: the last one the
+                // flushed half held, else whatever was carried before it.
+                let flushed_heading = buf
+                    .iter()
+                    .rev()
+                    .find(|(l, _)| is_heading(l))
+                    .map(|(l, _)| l.to_string());
+                flush_buf(&mut windows, &mut buf, &carry);
+                if let Some(h) = flushed_heading {
+                    carry = Some(h);
+                } else if carry.is_none() {
+                    carry = last_heading.clone();
+                }
+                buf = rest;
+                buf_tokens = buf.iter().map(|(l, _)| counter.count(l) + 1).sum();
+            } else if buf_tokens >= segment_tokens {
+                // No boundary anywhere in a buffer already past the budget:
+                // cut here rather than emit one huge window.
+                flush_buf(&mut windows, &mut buf, &carry);
+                carry = last_heading.clone();
+                buf_tokens = 0;
+            }
         }
 
         if is_heading(line) {
             last_heading = Some(line.to_string());
         }
-        buf.push(line);
-        buf_end = line_no;
+        buf.push((line, line_no));
         buf_tokens += line_tokens;
     }
-    flush(&mut windows, &mut buf, start_line, buf_end, &carry);
+    flush_buf(&mut windows, &mut buf, &carry);
     windows
+}
+
+fn flush_buf(windows: &mut Vec<Window>, buf: &mut Vec<(&str, i64)>, carry: &Option<String>) {
+    if buf.is_empty() {
+        return;
+    }
+    let start = buf[0].1;
+    let end = buf[buf.len() - 1].1;
+    let mut lines: Vec<&str> = buf.iter().map(|(l, _)| *l).collect();
+    flush(windows, &mut lines, start, end, carry);
+    buf.clear();
 }
 
 fn flush(
@@ -348,5 +395,36 @@ mod tests {
     #[test]
     fn empty_input_produces_nothing() {
         assert!(split_into_segments("   \n  ", &TokenCounter, 100).is_empty());
+    }
+
+    #[test]
+    fn a_paragraph_that_overflows_is_cut_at_the_boundary_before_it() {
+        // Three sections of ~60 tokens each, budget 100. The third body line
+        // overflows; the cut must fall at "## C" (before it), not at the next
+        // heading after it — so no window exceeds the budget while a boundary
+        // exists to cut at.
+        let body = "word ".repeat(40); // ~57 tokens
+        let text = format!("## A\n\n{body}\n\n## B\n\n{body}\n\n## C\n\n{body}\n\n## D\n\n{body}");
+        let ws = split_into_segments(&text, &TokenCounter, 100);
+        assert!(ws.len() >= 3, "{}", ws.len());
+        for w in &ws {
+            let own: String = w
+                .text
+                .lines()
+                .skip(w.carry_lines as usize)
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                TokenCounter.count(&own) <= 100,
+                "window over budget ({} tokens): {:?}",
+                TokenCounter.count(&own),
+                own
+            );
+        }
+        // Every heading opens its own window.
+        assert!(
+            ws.iter()
+                .all(|w| w.text.lines().any(|l| l.starts_with("## ")))
+        );
     }
 }

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -101,18 +101,23 @@ pub async fn run(core: &Core) -> Result<()> {
         .reopen_stale_judged_links(PRUNE_SCAN_LIMIT)
         .await?;
 
+    // No judge, no units: a link stays `learning` and visible, and nothing is
+    // queued that could never be claimed.
+    let to_judge = if core.link_judge.is_some() {
+        core.store
+            .links_to_judge(
+                core.associate.judge_min,
+                core.associate.judge_min_queries,
+                core.associate.half_life_days,
+                at,
+                core.associate.judge_per_sweep,
+            )
+            .await?
+    } else {
+        Vec::new()
+    };
     let mut armed = 0;
-    for l in core
-        .store
-        .links_to_judge(
-            core.associate.judge_min,
-            core.associate.judge_min_queries,
-            core.associate.half_life_days,
-            at,
-            core.associate.judge_per_sweep,
-        )
-        .await?
-    {
+    for l in to_judge {
         let target = link_target(&l.a_id, &l.b_id);
         // A link whose judgement is already queued is already going to be
         // judged; arming it again is a no-op that costs another link its turn.
@@ -385,10 +390,12 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
         return Ok(());
     }
 
+    let Some(judge) = core.link_judge.clone() else {
+        return Ok(());
+    };
     let cues: Vec<String> = link.cues.iter().map(|c| c.q.clone()).collect();
     let permit = core.gate.background().await;
-    let reply = core
-        .link_judge
+    let reply = judge
         .complete(
             crate::infer::prompt::LINK_SYSTEM,
             &crate::infer::prompt::link_prompt(
@@ -1113,7 +1120,7 @@ mod tests {
         let scripted = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"relation":"related","reason":"should never be read"}"#.into(),
         ]));
-        core.link_judge = scripted.clone();
+        core.link_judge = Some(scripted.clone());
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1161,9 +1168,9 @@ mod tests {
     async fn a_related_verdict_names_the_relation_and_stops_the_decay() {
         let mut core = test_core().await;
         on(&mut core).await;
-        core.link_judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some(r#"{"relation":"related","reason":"the config and its errors"}"#.into()),
-        });
+        }));
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1191,9 +1198,9 @@ mod tests {
         // reach the row.
         let mut core = test_core().await;
         on(&mut core).await;
-        core.link_judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some(r#"{"relation":"related"}"#.into()),
-        });
+        }));
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1216,9 +1223,9 @@ mod tests {
     async fn an_unrelated_verdict_is_stored_so_it_is_not_asked_again() {
         let mut core = test_core().await;
         on(&mut core).await;
-        core.link_judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some(r#"{"relation":"unrelated","reason":"a coincidence of retrieval"}"#.into()),
-        });
+        }));
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1256,9 +1263,9 @@ mod tests {
         // connection while dedupe decides what to do about it.
         let mut core = test_core().await;
         on(&mut core).await;
-        core.link_judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some(r#"{"relation":"duplicate","reason":"the same procedure twice"}"#.into()),
-        });
+        }));
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1288,9 +1295,9 @@ mod tests {
     async fn three_unreadable_replies_shelve_the_link_rather_than_asking_forever() {
         let mut core = test_core().await;
         on(&mut core).await;
-        core.link_judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some("no idea, sorry".into()),
-        });
+        }));
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1364,7 +1371,7 @@ mod tests {
         let scripted = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"relation":"related","reason":"should never be read"}"#.into(),
         ]));
-        core.link_judge = scripted.clone();
+        core.link_judge = Some(scripted.clone());
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -1467,9 +1474,9 @@ mod tests {
         // assert a handover that did not happen.
         let mut core = test_core().await;
         on(&mut core).await;
-        core.link_judge = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some(r#"{"relation":"duplicate","reason":"same thing"}"#.into()),
-        });
+        }));
         let ids = seed(&core, 2).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -572,6 +572,7 @@ mod tests {
                     query_vec: vec![0.0],
                     embed_model: "fake".into(),
                     candidates,
+                    answered: false,
                 },
                 0,
             )

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -290,6 +290,9 @@ async fn replay_verdicts(core: &Core, at: i64) -> Result<usize> {
                 at,
             )
             .await?;
+        // A confirmation is the strongest engagement there is, and the other
+        // bump that may promote.
+        crate::jobs::promote::maybe_promote(core, std::slice::from_ref(&expect), at).await?;
         // Same reason as in `replay_events`: the bump above propagates, and a
         // verdict counted twice raises an artifact's activation twice.
         if last_of_its_second(&stamps, idx, end) {

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -818,7 +818,7 @@ pub(crate) mod tests {
         // posts a contradiction about something nobody can see.
         let mut core = test_core().await;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         // Queue the pair with the judge off, so the only call this test can
         // count is the one the second sweep would make.
         let ids = disagreeing(&core).await;
@@ -870,7 +870,7 @@ pub(crate) mod tests {
         // only, which a deprecation never sets.
         let mut core = test_core().await;
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         let ids = disagreeing(&core).await;
         run(&core).await.unwrap();
 
@@ -1372,7 +1372,7 @@ pub(crate) mod tests {
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         seed_related(
             &core,
             &[
@@ -1582,7 +1582,7 @@ pub(crate) mod tests {
         let completer = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         disagreeing(&core).await;
 
         let out = run(&core).await.unwrap();
@@ -1609,10 +1609,12 @@ pub(crate) mod tests {
         // sweep's budget forever and the rest would never be judged at all.
         let mut core = test_core().await;
         core.consolidate.max_dedupe_per_tick = 1;
-        core.judge = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            "not json".into(),
-            r#"{"relation":"conflict","detail":"30 versus 90"}"#.into(),
-        ]));
+        core.judge = Some(std::sync::Arc::new(
+            crate::infer::fake::ScriptedCompleter::new(vec![
+                "not json".into(),
+                r#"{"relation":"conflict","detail":"30 versus 90"}"#.into(),
+            ]),
+        ));
         seed_related(
             &core,
             &[

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -511,6 +511,7 @@ pub(crate) mod tests {
                     status: None,
                     last_verified_at: None,
                     superseded_by: None,
+                    origin_corpora: vec![],
                 },
             })
             .collect();

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -512,6 +512,7 @@ pub(crate) mod tests {
                     last_verified_at: None,
                     superseded_by: None,
                     origin_corpora: vec![],
+                    provenance: None,
                 },
             })
             .collect();

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -4,12 +4,16 @@
 //! This sweep is the backstop for that arming, the clustering that spans many
 //! pairs at once, the pacing of the dedupe units, and the repairs.
 //!
-//! Two thresholds still divide the work. At or above `auto_supersede` a group
-//! collapses onto its newest member for free: no call, no rewrite, and the
-//! survivor is a stored original. Between `review_min` and that, the group goes
-//! to `jobs::dedupe`, because two genuinely distinct artifacts about one
-//! subsystem sit at 0.88 routinely and acting on that score alone destroys
-//! knowledge rather than duplication.
+//! Two thresholds still shape the work, and neither hides anything on its own.
+//! From `review_min` up a pair is a question for `jobs::dedupe`, because two
+//! genuinely distinct artifacts about one subsystem sit at 0.88 routinely and
+//! acting on that score alone destroys knowledge rather than duplication. At
+//! or above `auto_supersede` it is the *first* question asked — a fast lane,
+//! by score — and still a question: embeddings barely distinguish negation,
+//! and "runs on ext4" / "does not run on ext4" sit far above any realistic
+//! threshold. The judge's `losses` check stands behind every hide. The cluster
+//! pass below still closes `NearIdentical` rows an older base filed; nothing
+//! files new ones.
 //!
 //! **On merging.** This header used to say that nothing here rewrites an
 //! artifact, and that a merged artifact would be synthetic text standing where
@@ -553,27 +557,28 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn a_near_identical_pair_supersedes_the_older_artifact() {
+    async fn a_near_identical_pair_goes_to_the_judge_first_and_hides_nothing() {
+        // `auto_supersede` used to hide the older member on the score alone:
+        // no call, no `losses` check. Embeddings barely distinguish negation —
+        // "runs on ext4" and "does not run on ext4" sit far above any realistic
+        // threshold — so the sweep now hides nothing by itself. The pair is a
+        // question for the judge, and by score it is the first one asked.
         let core = test_core().await;
         let ids = seed_related(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
 
         let out = run(&core).await.unwrap();
-        assert_eq!(out.superseded, 1, "{out:?}");
-
-        // The older one loses: ordinal 0 was inserted first.
-        let older = core.store.get_artifact(&ids[0]).await.unwrap();
-        let newer = core.store.get_artifact(&ids[1]).await.unwrap();
-        assert_eq!(older.superseded_by.as_deref(), Some(ids[1].as_str()));
-        assert!(newer.superseded_by.is_none());
-
-        // And it is out of search, which is the whole point.
+        assert_eq!(out.superseded, 0, "{out:?}");
+        assert!(out.judged >= 1, "{out:?}");
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().in_results());
+        }
+        // Both are still in search.
         let hits = core
             .vectors
             .search(&[1.0, 0.0], &Default::default(), 10, &Default::default())
             .await
             .unwrap();
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].payload.artifact_id, ids[1]);
+        assert_eq!(hits.len(), 2);
     }
 
     #[tokio::test]
@@ -768,7 +773,12 @@ pub(crate) mod tests {
         // copy that no longer exists — the surviving text becomes invisible,
         // which is the loss this whole feature exists to prevent.
         let core = test_core().await;
-        let ids = seed_related(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
+        // Filed by hand: an older base's row, which the cluster pass still acts on.
+        core.store
+            .record_settled_pair(&ids[0], &ids[1], 0.999, PairState::NearIdentical)
+            .await
+            .unwrap();
         run(&core).await.unwrap();
         let mut hidden = None;
         for id in &ids {
@@ -1273,11 +1283,13 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn an_artifact_is_never_superseded_twice() {
-        // Three near-identical artifacts. Whatever survives, exactly one must,
-        // and no artifact may point at one that is itself superseded — that is
-        // a chain the UI cannot resolve and the reader cannot follow.
+        // Three near-identical rows an older base filed. Whatever survives,
+        // exactly one must, and no artifact may point at one that is itself
+        // superseded — that is a chain the UI cannot resolve and the reader
+        // cannot follow. Nothing files `NearIdentical` any more; the cluster
+        // pass still closes what is there.
         let core = test_core().await;
-        let ids = seed_related(
+        let ids = seed(
             &core,
             &[
                 ("first", [1.0, 0.0]),
@@ -1286,6 +1298,12 @@ pub(crate) mod tests {
             ],
         )
         .await;
+        for (a, b) in [(0, 1), (1, 2), (0, 2)] {
+            core.store
+                .record_settled_pair(&ids[a], &ids[b], 0.999, PairState::NearIdentical)
+                .await
+                .unwrap();
+        }
 
         run(&core).await.unwrap();
 
@@ -1606,16 +1624,14 @@ pub(crate) mod tests {
     async fn a_pair_the_model_keeps_failing_on_goes_to_the_back_of_the_queue() {
         // An unreadable reply leaves the pair pending on purpose. Ordered by
         // score alone, the same top-scoring pair would then absorb every
-        // sweep's budget forever and the rest would never be judged at all.
+        // sweep's budget forever and the rest would never be judged at all:
+        // after one unreadable attempt the *other* pair must come first.
         let mut core = test_core().await;
         core.consolidate.max_dedupe_per_tick = 1;
         core.judge = Some(std::sync::Arc::new(
-            crate::infer::fake::ScriptedCompleter::new(vec![
-                "not json".into(),
-                r#"{"relation":"conflict","detail":"30 versus 90"}"#.into(),
-            ]),
+            crate::infer::fake::ScriptedCompleter::new(vec!["not json".into()]),
         ));
-        seed_related(
+        let ids = seed(
             &core,
             &[
                 ("timeout is 30 seconds", [1.0, 0.0]),
@@ -1624,26 +1640,50 @@ pub(crate) mod tests {
             ],
         )
         .await;
+        // 30 and 60 sit in one window, so they are not a pair (the same-window
+        // rule) and the fixture has two pairs: 30–90 (0.898) and 60–90 (0.903).
+        for id in &ids[..2] {
+            sqlx::query("UPDATE artifacts SET segment_idx = 0 WHERE id = ?")
+                .bind(id)
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+        }
+        for id in &ids {
+            crate::jobs::relate::run(&core, id).await.unwrap();
+        }
 
-        sweep_and_dedupe(&core).await;
-        sweep_and_dedupe(&core).await;
-
-        let pending = core.store.pairs_to_judge(10).await.unwrap();
-        assert!(
-            pending.iter().all(|p| p.judge_attempts <= 1),
-            "the second sweep judged the same pair again: {pending:?}"
-        );
-        assert_eq!(
-            core.store
-                .pairs_by_state(PairState::Contradiction, 10)
+        // One sweep arms the top pair by score; work the queue until that one
+        // dedupe unit has run and read "not json" — other units (the sweep's
+        // own housekeeping) may sit ahead of it.
+        run(&core).await.unwrap();
+        for _ in 0..20 {
+            let asked = core
+                .store
+                .pairs_to_judge(10)
                 .await
                 .unwrap()
-                .len(),
-            1,
-            "the second sweep never reached an unjudged pair"
-        );
-    }
+                .iter()
+                .any(|p| p.judge_attempts > 0);
+            if asked {
+                break;
+            }
+            sqlx::query("UPDATE jobs SET run_after = 0")
+                .execute(&core.store.pool)
+                .await
+                .unwrap();
+            assert!(crate::jobs::run_one(&core).await.unwrap(), "queue ran dry");
+        }
 
+        let pending = core.store.pairs_to_judge(10).await.unwrap();
+        assert_eq!(pending.len(), 2, "{pending:?}");
+        // The pair that was asked and answered unreadably has one attempt
+        // against it and has dropped behind the pair with none — although its
+        // score is the higher.
+        assert_eq!(pending[0].judge_attempts, 0, "{pending:?}");
+        assert_eq!(pending[1].judge_attempts, 1, "{pending:?}");
+        assert!(pending[0].score < pending[1].score, "{pending:?}");
+    }
     #[tokio::test]
     async fn a_pair_whose_artifact_vanished_does_not_abandon_the_rest_of_the_sweep() {
         // `pairs_to_judge` hands back a snapshot, and the arming loop is full of

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -142,9 +142,14 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     //
     // No count-based cap. `merge_max_roots` was one, left at a default of eight
     // nobody typed, and it settled whole clusters before any call was made.
+    let Some(judge) = core.judge.clone() else {
+        // Nothing to ask. The pair stays pending; `run_claimed` closes the unit
+        // before it gets here when there is no synthesize role at all.
+        return Ok(());
+    };
     let counter = crate::infer::budget::TokenCounter;
-    let window = core.judge.context_tokens();
-    let ceiling = core.judge.max_output_tokens();
+    let window = judge.context_tokens();
+    let ceiling = judge.max_output_tokens();
     let system = counter.count(crate::infer::prompt::DEDUPE_SYSTEM);
     let user = loop {
         let user = build_prompt(&members, &context, p.judge_attempts);
@@ -185,8 +190,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     core.store.record_judge_attempt(p.id).await?;
 
     let permit = core.gate.background().await;
-    let reply = core
-        .judge
+    let reply = judge
         .complete(crate::infer::prompt::DEDUPE_SYSTEM, &user)
         .await;
     permit.finished();
@@ -459,8 +463,8 @@ mod tests {
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
         let asker = Arc::new(ScriptedCompleter::new(vec![]));
-        core.judge = judge.clone();
-        core.completer = asker.clone();
+        core.judge = Some(judge.clone());
+        core.completer = Some(asker.clone());
         let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.93, 0.37])]).await;
         let seed_pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
@@ -489,9 +493,9 @@ mod tests {
         // and it no longer merely flags them — a merge would grind a reference
         // document into one paragraph that describes none of its subjects.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"two different filesystems"}"#.into(),
-        ]));
+        ])));
         let ids = seed_titled(
             &core,
             &[
@@ -539,9 +543,9 @@ mod tests {
         // job. This is the one queue that expects a human, and autonomy does not
         // empty it.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"conflict","detail":"1.21.4 versus 1.30.0"}"#.into(),
-        ]));
+        ])));
         let ids = disagreeing(&core).await;
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
@@ -572,9 +576,9 @@ mod tests {
         // the path by which the fidelity thesis keeps holding under autonomy —
         // so the prompt prefers it and this pins that the code does too.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
-        ]));
+        ])));
         let ids = disagreeing(&core).await;
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
@@ -613,9 +617,9 @@ mod tests {
             .execute(&core.store.pool)
             .await
             .unwrap();
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"replaced","supersedes":"b","detail":"x"}"#.into(),
-        ]));
+        ])));
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
         run(&core, &pair.to_string()).await.unwrap();
@@ -649,11 +653,11 @@ mod tests {
         // a version number — evidence too thin to put on a card someone has to
         // act on, in a voice unlike every other line beside it.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"duplicate","detail":"same claim",
                 "merged":{"text":"engram needs Rust 1.30.0 to build.","tags":[],"caveats":[]}}"#
                 .into(),
-        ]));
+        ])));
         let ids = disagreeing(&core).await;
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
@@ -692,7 +696,7 @@ mod tests {
         let completer = Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"unrelated"}"#.into(),
         ]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         let ids = seed(
             &core,
             &[
@@ -713,7 +717,7 @@ mod tests {
     async fn a_failed_dedupe_leaves_the_pair_pending() {
         // A dead endpoint must not silently clear a queue of real duplicates.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec!["not json".into()]));
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec!["not json".into()])));
         let ids = disagreeing(&core).await;
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
@@ -734,7 +738,7 @@ mod tests {
     async fn a_pair_whose_member_was_retired_is_dismissed_without_a_call() {
         let mut core = test_core().await;
         let completer = Arc::new(ScriptedCompleter::new(vec![]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         let ids = disagreeing(&core).await;
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
         core.deprecate(&ids[0]).await.unwrap();
@@ -760,7 +764,7 @@ mod tests {
         // generation per merge, which the lineage design exists to prevent.
         let mut core = test_core().await;
         let completer = Arc::new(ScriptedCompleter::new(vec![]));
-        core.judge = completer.clone();
+        core.judge = Some(completer.clone());
         let ids = disagreeing(&core).await;
         let m = core
             .store
@@ -804,9 +808,9 @@ mod tests {
         // as "awaiting confirmation" — with Keep buttons that could only
         // return a validation error against the already-superseded side.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"replaced","supersedes":"a","detail":"old flag vs new flag"}"#.into(),
-        ]));
+        ])));
         let ids = disagreeing(&core).await;
         let pair = queue_pair(&core, &ids[0], &ids[1]).await;
 
@@ -865,9 +869,9 @@ mod tests {
         // pair in it with one verdict. A sibling pair is a separate question
         // about a different pair of artifacts, and it keeps its own turn.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
-        ]));
+        ])));
         let ids = seed(
             &core,
             &[
@@ -908,9 +912,9 @@ mod tests {
         // was settled Oversized, terminal, with no call ever made. Nothing about
         // it is oversized now — it is a sequence of two-artifact questions.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
-        ]));
+        ])));
         let rows: Vec<(&str, [f32; 2])> = vec![
             ("t0", [1.00, 0.00]),
             ("t1", [0.99, 0.01]),
@@ -985,9 +989,9 @@ mod tests {
         // newest artifact in its own lineage.
         let stored = core.store.get_pair(pair).await.unwrap();
         let letter = if stored.a_id == ids[2] { "a" } else { "b" };
-        core.judge = Arc::new(ScriptedCompleter::new(vec![format!(
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![format!(
             r#"{{"relation":"replaced","detail":"stale","supersedes":"{letter}"}}"#
-        )]));
+        )])));
 
         run(&core, &pair.to_string()).await.unwrap();
 
@@ -1017,7 +1021,7 @@ mod tests {
         let judge = Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
-        core.judge = judge.clone();
+        core.judge = Some(judge.clone());
         let ids = seed_titled(
             &core,
             &[
@@ -1058,7 +1062,7 @@ mod tests {
         // matches itself, at the price of a call.
         let mut core = test_core().await;
         let judge = Arc::new(ScriptedCompleter::new(vec![]));
-        core.judge = judge.clone();
+        core.judge = Some(judge.clone());
         let ids = seed(&core, &[("a text", [1.0, 0.0]), ("b text", [0.99, 0.05])]).await;
         let m = merged_from(
             &core,
@@ -1092,11 +1096,11 @@ mod tests {
         // whole flattened lineage instead, a value dropped a generation ago
         // would fail every later merge in that lineage forever and freeze it.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"duplicate","detail":"same thing",
                 "merged":{"title":"Pool","text":"the pool holds sixteen connections","tags":[],"caveats":[]}}"#
                 .into(),
-        ]));
+        ])));
         let ids = seed_titled(
             &core,
             &[
@@ -1138,11 +1142,11 @@ mod tests {
         // again, and it carries the flattened lineage of both sides rather than
         // naming the intermediate.
         let mut core = test_core().await;
-        core.judge = Arc::new(ScriptedCompleter::new(vec![
+        core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"duplicate","detail":"same thing",
                 "merged":{"title":"Pool","text":"max_connections is 16, raise it for batch jobs, sixteen connections","tags":[],"caveats":[]}}"#
                 .into(),
-        ]));
+        ])));
         let ids = seed_titled(
             &core,
             &[
@@ -1191,7 +1195,7 @@ mod tests {
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
         judge.set_context_tokens(1200);
-        core.judge = judge.clone();
+        core.judge = Some(judge.clone());
         let long = "verylongsourcetoken ".repeat(400);
         let ids = seed_titled(
             &core,
@@ -1237,7 +1241,7 @@ mod tests {
         let mut core = test_core().await;
         let judge = Arc::new(ScriptedCompleter::new(vec![]));
         judge.set_context_tokens(100);
-        core.judge = judge.clone();
+        core.judge = Some(judge.clone());
         let long = "verylongartifacttoken ".repeat(500);
         let ids = seed_titled(
             &core,

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -121,7 +121,7 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
     let mut context: Vec<Vec<Chunk>> = Vec::new();
     for c in &members {
         let mut v = Vec::new();
-        if c.provenance == crate::store::artifacts::Provenance::Merged {
+        if c.provenance.is_model_written() {
             for rid in &root_map[&c.id] {
                 match core.store.get_artifact(rid).await {
                     Ok(r) => v.push(r),

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -29,6 +29,17 @@ fn render(core: &Core, chunk: &Chunk) -> String {
     core.embedder.render_document(&doc_of(chunk))
 }
 
+/// What the envelope around an empty body costs: the title, and the template
+/// around it. Siblings inherit both, so only what this leaves over is available
+/// to their text.
+fn envelope_cost(core: &Core, title: Option<&str>) -> usize {
+    core.counter
+        .count(&core.embedder.render_document(&EmbedDoc {
+            title: title.map(str::to_string),
+            text: String::new(),
+        }))
+}
+
 /// The lexical half. Title on its own line above the body — the words, not the
 /// template: `title:` and `text:` are in every document and would match every
 /// query that happens to contain them.
@@ -377,14 +388,12 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
     // so the attempts at it are skipped rather than made and refused.
     let splittable = chunk.corpus_id.is_some();
     // The limit is checked against what actually gets embedded, and that is the
-    // title followed by the text. Siblings inherit the title, so only what the
-    // title leaves over is available to their text. Giving the text the whole
-    // limit produced siblings that measured oversize again the instant they
-    // were re-queued, each one replaced by another exactly like it, forever.
-    let title_cost = chunk
-        .title
-        .as_deref()
-        .map_or(0, |t| core.counter.count(&format!("{t}\n")));
+    // rendered document — title, text and the template around them. Siblings
+    // inherit the title and the template, so only what the envelope leaves
+    // over is available to their text. Giving the text the whole limit
+    // produced siblings that measured oversize again the instant they were
+    // re-queued, each one replaced by another exactly like it, forever.
+    let title_cost = envelope_cost(core, chunk.title.as_deref());
     let budget = limit.saturating_sub(title_cost);
 
     // A title that fills the limit on its own cannot be cut out of the way:
@@ -485,10 +494,7 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
 /// and that is worth saying out loud in the log, because a merge this long is
 /// usually a merge that should have stayed two artifacts.
 async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
-    let title_cost = chunk
-        .title
-        .as_deref()
-        .map_or(0, |t| core.counter.count(&format!("{t}\n")));
+    let title_cost = envelope_cost(core, chunk.title.as_deref());
     let budget = limit.saturating_sub(title_cost);
     let head = if budget > 0 {
         split_by_lines(&chunk.text, budget, &core.counter)
@@ -1267,6 +1273,79 @@ mod tests {
             assert!(
                 core.counter.count(&render(&core, c)) <= limit,
                 "sibling is still oversize: {:?}",
+                c.text
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn the_envelope_is_charged_so_a_chunk_that_fits_bare_and_overflows_rendered_splits_once()
+    {
+        // Same loop as the test above, reopened slightly narrower: with a real
+        // template the title is not the only thing around the text. `title: `
+        // plus ` | text: ` costs tokens, and a split that budgets for the title
+        // alone emits siblings that measure oversize again once rendered —
+        // each replaced by another exactly like it, forever.
+        let mut core = crate::core::test_support::test_core().await;
+        core.embedder = std::sync::Arc::new(crate::infer::fake::FakeEmbedder::with_templates(
+            crate::core::test_support::TEST_DIM,
+            crate::config::EmbedTemplates::default(),
+        ));
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+
+        let title = "heading".to_string();
+        let text = format!("{}\n\n{}", "alpha ".repeat(12), "beta ".repeat(12));
+        let limit = 40;
+        let bare = format!("{title}\n{text}");
+        assert!(
+            core.counter.count(&bare) <= limit,
+            "title + text must fit without the envelope ({})",
+            core.counter.count(&bare)
+        );
+        let rendered = core.embedder.render_document(&crate::infer::EmbedDoc {
+            title: Some(title.clone()),
+            text: text.clone(),
+        });
+        assert!(
+            core.counter.count(&rendered) > limit,
+            "the envelope must be what pushes it over ({})",
+            core.counter.count(&rendered)
+        );
+
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: text.clone(),
+                    corpus_span: None,
+                    title: Some(title),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        run_with_limit(&core, &made[0].id, limit).await.unwrap();
+
+        let chunks = core.store.artifacts_for_corpus(&src.id).await.unwrap();
+        assert!(
+            chunks.len() > 1,
+            "the chunk was not split: {} row(s)",
+            chunks.len()
+        );
+        assert!(
+            !chunks.iter().any(|c| c.text == text && c.id != made[0].id),
+            "the parent was replaced by an identical copy of itself"
+        );
+        for c in &chunks {
+            assert!(
+                core.counter.count(&render(&core, c)) <= limit,
+                "sibling is still oversize once rendered: {:?}",
                 c.text
             );
         }

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -767,6 +767,7 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // no winner is a hidden artifact whose replacement the UI cannot show.
         superseded_by: chunk.superseded_by.clone(),
         origin_corpora: vec![],
+        provenance: Some(chunk.provenance.as_str().to_string()),
     }
 }
 

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -1,5 +1,6 @@
 use crate::core::Core;
 use crate::error::{Error, Result};
+use crate::infer::EmbedDoc;
 use crate::store::artifacts::{ArtifactStatus, Chunk, NewArtifact};
 use crate::store::corpora::CorpusStatus;
 use crate::store::jobs::Stage;
@@ -13,9 +14,25 @@ const SAFETY: f32 = 0.8;
 /// can hold hundreds of chunks and endpoints cap how many inputs they accept.
 const BATCH: usize = 32;
 
-/// Text for the embedding carries the title: it holds topical signal the body
-/// often leaves implicit.
-fn embed_text(chunk: &Chunk) -> String {
+/// The document as the embedder will see it.
+fn doc_of(chunk: &Chunk) -> EmbedDoc {
+    EmbedDoc {
+        title: chunk.title.clone(),
+        text: chunk.text.clone(),
+    }
+}
+
+/// What will actually be sent for this chunk — title slot, text slot and the
+/// template around them. Every budget in this file measures this string, so
+/// the splitter and the embedder cannot disagree about size.
+fn render(core: &Core, chunk: &Chunk) -> String {
+    core.embedder.render_document(&doc_of(chunk))
+}
+
+/// The lexical half. Title on its own line above the body — the words, not the
+/// template: `title:` and `text:` are in every document and would match every
+/// query that happens to contain them.
+fn lexical_text(chunk: &Chunk) -> String {
     match &chunk.title {
         Some(t) => format!("{t}\n{}", chunk.text),
         None => chunk.text.clone(),
@@ -66,7 +83,7 @@ fn input_too_large(e: &Error) -> bool {
 
 pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Result<()> {
     let chunk = core.store.get_artifact(artifact_id).await?;
-    let text = embed_text(&chunk);
+    let text = render(core, &chunk);
 
     if core.counter.count(&text) > limit {
         // Our own estimate, which can be wrong in either direction. Do not
@@ -77,7 +94,7 @@ pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Res
     // Paced like every other inference call. `split_into_artifact_jobs` can
     // leave hundreds of these behind for one document.
     let permit = core.gate.background().await;
-    let outcome = embed_batch(core, std::slice::from_ref(&chunk), vec![text.clone()]).await;
+    let outcome = embed_batch(core, std::slice::from_ref(&chunk)).await;
     permit.finished();
     match outcome {
         Ok(()) => {}
@@ -125,9 +142,8 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
     // along in a batch — and finding out how to cut it can itself cost a call.
     // It gets a unit of its own and this job goes on without it.
     let mut batch: Vec<Chunk> = Vec::with_capacity(pending.len());
-    let mut texts: Vec<String> = Vec::with_capacity(pending.len());
     for chunk in pending {
-        let text = embed_text(&chunk);
+        let text = render(core, &chunk);
         if core.counter.count(&text) > limit {
             // Splitting is not free: `split_oversize` falls through to embedding
             // the chunk whole when there is no boundary to cut on, and that is a
@@ -144,7 +160,6 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
                 .rearm_idle_seq(Stage::Embed, "artifact", &chunk.id, 0)
                 .await?;
         } else {
-            texts.push(text);
             batch.push(chunk);
         }
     }
@@ -159,7 +174,7 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
     }
 
     let permit = core.gate.background().await;
-    let outcome = embed_batch(core, &batch[..take], texts[..take].to_vec()).await;
+    let outcome = embed_batch(core, &batch[..take]).await;
     permit.finished();
     match outcome {
         Ok(()) => {}
@@ -236,11 +251,12 @@ pub async fn rearm_if_more(core: &Core, corpus_id: &str) -> Result<()> {
 /// One inference call and one upsert for the whole slice. Chunks are marked
 /// embedded only once Qdrant has durably accepted their vectors, so a crash
 /// leaves work to redo rather than a chunk that claims to be searchable.
-async fn embed_batch(core: &Core, chunks: &[Chunk], texts: Vec<String>) -> Result<()> {
+async fn embed_batch(core: &Core, chunks: &[Chunk]) -> Result<()> {
     if chunks.is_empty() {
         return Ok(());
     }
-    let vectors = core.embedder.embed(&texts).await?;
+    let docs: Vec<EmbedDoc> = chunks.iter().map(doc_of).collect();
+    let vectors = core.embedder.embed_documents(&docs).await?;
     if vectors.len() != chunks.len() {
         return Err(Error::Inference {
             role: "embed",
@@ -255,13 +271,13 @@ async fn embed_batch(core: &Core, chunks: &[Chunk], texts: Vec<String>) -> Resul
 
     let points = chunks
         .iter()
-        .zip(texts.iter())
         .zip(vectors)
-        .map(|((c, text), vector)| VectorPoint {
+        .map(|(c, vector)| VectorPoint {
             vector,
-            // The same text the embedder saw, so the lexical and the semantic
-            // half of a hit always describe the same thing.
-            sparse: crate::vector::sparse::encode_document(text),
+            // The words the dense side saw, without the template around them,
+            // so the lexical and the semantic half of a hit describe the same
+            // document.
+            sparse: crate::vector::sparse::encode_document(&lexical_text(c)),
             payload: payload_of(c),
         })
         .collect();
@@ -400,7 +416,10 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         "oversize chunk has no split available; embedding as-is"
     );
     let permit = core.gate.background().await;
-    let embedded = core.embedder.embed(std::slice::from_ref(&chunk.text)).await;
+    let embedded = core
+        .embedder
+        .embed_documents(std::slice::from_ref(&doc_of(chunk)))
+        .await;
     permit.finished();
     let vectors = match embedded {
         Ok(v) => v,
@@ -434,7 +453,7 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         core,
         vec![VectorPoint {
             vector: vectors.into_iter().next().unwrap(),
-            sparse: crate::vector::sparse::encode_document(&chunk.text),
+            sparse: crate::vector::sparse::encode_document(&lexical_text(chunk)),
             payload: payload_of(chunk),
         }],
     )
@@ -497,12 +516,15 @@ async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
          indexing its opening"
     );
 
-    let input = match chunk.title.as_deref() {
-        Some(t) => format!("{t}\n{head}"),
-        None => head,
+    let input = EmbedDoc {
+        title: chunk.title.clone(),
+        text: head,
     };
     let permit = core.gate.background().await;
-    let embedded = core.embedder.embed(std::slice::from_ref(&input)).await;
+    let embedded = core
+        .embedder
+        .embed_documents(std::slice::from_ref(&input))
+        .await;
     permit.finished();
     let vectors = embedded?;
 
@@ -513,7 +535,7 @@ async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
             // The whole artifact, unlike the dense side. Lexical retrieval has
             // no length limit to respect, so there is no reason to lose the
             // tail on both halves of the query at once.
-            sparse: crate::vector::sparse::encode_document(&chunk.text),
+            sparse: crate::vector::sparse::encode_document(&lexical_text(chunk)),
             payload: payload_of(chunk),
         }],
     )
@@ -884,13 +906,9 @@ mod tests {
         assert!(stale.superseded_by.is_some(), "the fixture is not hidden");
 
         core.unsupersede(&ids[0]).await.unwrap();
-        embed_batch(
-            &core,
-            std::slice::from_ref(&stale),
-            vec![embed_text(&stale)],
-        )
-        .await
-        .unwrap();
+        embed_batch(&core, std::slice::from_ref(&stale))
+            .await
+            .unwrap();
 
         let hits = core
             .vectors
@@ -915,13 +933,9 @@ mod tests {
         let stale = core.store.get_artifact(&ids[0]).await.unwrap();
 
         core.store.delete_artifact(&ids[0]).await.unwrap();
-        embed_batch(
-            &core,
-            std::slice::from_ref(&stale),
-            vec![embed_text(&stale)],
-        )
-        .await
-        .unwrap();
+        embed_batch(&core, std::slice::from_ref(&stale))
+            .await
+            .unwrap();
 
         assert!(
             !core
@@ -951,13 +965,9 @@ mod tests {
         core.supersede(&ids[0], &ids[1]).await.unwrap();
         let hidden = core.store.get_artifact(&ids[0]).await.unwrap();
 
-        embed_batch(
-            &core,
-            std::slice::from_ref(&hidden),
-            vec![embed_text(&hidden)],
-        )
-        .await
-        .unwrap();
+        embed_batch(&core, std::slice::from_ref(&hidden))
+            .await
+            .unwrap();
 
         assert!(
             core.store
@@ -1255,7 +1265,7 @@ mod tests {
         // pass splits it again and the loop is only slower.
         for c in &chunks {
             assert!(
-                core.counter.count(&embed_text(c)) <= limit,
+                core.counter.count(&render(&core, c)) <= limit,
                 "sibling is still oversize: {:?}",
                 c.text
             );
@@ -1699,12 +1709,12 @@ mod tests {
         // The payload must carry enough to render a result without touching SQLite.
         let q = core
             .embedder
-            .embed(&["t0\n## A\nthe body".to_string()])
+            .embed_query("t0\n## A\nthe body")
             .await
             .unwrap();
         let hits = core
             .vectors
-            .search(&q[0], &Default::default(), 5, &Default::default())
+            .search(&q, &Default::default(), 5, &Default::default())
             .await
             .unwrap();
         assert_eq!(hits[0].payload.corpus_id, src_id);

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -328,7 +328,13 @@ async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
     // nothing. Both have a backstop in the sweep: an artifact with no relate
     // row is armed there, and an unfinished merge is found through
     // `merged_with_active_roots`.
-    if let Err(e) = crate::jobs::relate::arm(core, &chunk.id, 0).await {
+    //
+    // A passage is never a relate anchor: neighbours under one heading are
+    // similar for structural reasons, and duplicate detection over verbatim
+    // text waits until use promotes it (spec §6).
+    if chunk.provenance != crate::store::artifacts::Provenance::Passage
+        && let Err(e) = crate::jobs::relate::arm(core, &chunk.id, 0).await
+    {
         tracing::warn!(
             artifact_id = %chunk.id,
             error = %e,

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -268,6 +268,7 @@ async fn embed_batch(core: &Core, chunks: &[Chunk]) -> Result<()> {
     }
     let docs: Vec<EmbedDoc> = chunks.iter().map(doc_of).collect();
     let vectors = core.embedder.embed_documents(&docs).await?;
+    let origins = origins_for(core, chunks).await?;
     if vectors.len() != chunks.len() {
         return Err(Error::Inference {
             role: "embed",
@@ -289,7 +290,7 @@ async fn embed_batch(core: &Core, chunks: &[Chunk]) -> Result<()> {
             // so the lexical and the semantic half of a hit describe the same
             // document.
             sparse: crate::vector::sparse::encode_document(&lexical_text(c)),
-            payload: payload_of(c),
+            payload: with_origins(payload_of(c), &origins),
         })
         .collect();
     upsert_with_current_lifecycle(core, points).await?;
@@ -464,12 +465,13 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         }
         Err(e) => return Err(e),
     };
+    let origins = origins_for(core, std::slice::from_ref(chunk)).await?;
     upsert_with_current_lifecycle(
         core,
         vec![VectorPoint {
             vector: vectors.into_iter().next().unwrap(),
             sparse: crate::vector::sparse::encode_document(&lexical_text(chunk)),
-            payload: payload_of(chunk),
+            payload: with_origins(payload_of(chunk), &origins),
         }],
     )
     .await?;
@@ -540,6 +542,7 @@ async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
     permit.finished();
     let vectors = embedded?;
 
+    let origins = origins_for(core, std::slice::from_ref(chunk)).await?;
     upsert_with_current_lifecycle(
         core,
         vec![VectorPoint {
@@ -548,7 +551,7 @@ async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
             // no length limit to respect, so there is no reason to lose the
             // tail on both halves of the query at once.
             sparse: crate::vector::sparse::encode_document(&lexical_text(chunk)),
-            payload: payload_of(chunk),
+            payload: with_origins(payload_of(chunk), &origins),
         }],
     )
     .await?;
@@ -709,6 +712,30 @@ async fn replace_with_siblings(core: &Core, chunk: &Chunk, parts: Vec<String>) -
     Ok(())
 }
 
+/// Every corpus each chunk draws from, through its lineage. One query for the
+/// batch; a passage or captured row answers with its own corpus.
+async fn origins_for(
+    core: &Core,
+    chunks: &[Chunk],
+) -> Result<std::collections::BTreeMap<String, Vec<crate::store::lineage::Origin>>> {
+    let ids: Vec<String> = chunks.iter().map(|c| c.id.clone()).collect();
+    core.store.origins_of(&ids).await
+}
+
+/// The payload's `origin_corpora`: the distinct corpora of the chunk's
+/// origins, sorted, so `cap_per_corpus` can count a merge against each.
+fn with_origins(
+    mut payload: VectorPayload,
+    origins: &std::collections::BTreeMap<String, Vec<crate::store::lineage::Origin>>,
+) -> VectorPayload {
+    let set: std::collections::BTreeSet<String> = origins
+        .get(&payload.artifact_id)
+        .map(|o| o.iter().map(|x| x.corpus_id.clone()).collect())
+        .unwrap_or_default();
+    payload.origin_corpora = set.into_iter().collect();
+    payload
+}
+
 fn payload_of(chunk: &Chunk) -> VectorPayload {
     VectorPayload {
         artifact_id: chunk.id.clone(),
@@ -739,6 +766,7 @@ fn payload_of(chunk: &Chunk) -> VectorPayload {
         // The same rule as `status`: a point that says superseded while naming
         // no winner is a hidden artifact whose replacement the UI cannot show.
         superseded_by: chunk.superseded_by.clone(),
+        origin_corpora: vec![],
     }
 }
 

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -135,9 +135,10 @@ pub async fn sweep(core: &Core) -> Result<SweepReport> {
 /// One bounded call under the background lane. Any failure — endpoint down,
 /// unreadable reply — is `None`, and the caller falls back to terms.
 async fn name(core: &Core, questions: &[&str]) -> Option<String> {
+    // No model, no name: the caller falls back to the cluster's terms.
+    let namer = core.gap_namer.clone()?;
     let permit = core.gate.background().await;
-    let reply = core
-        .gap_namer
+    let reply = namer
         .complete(
             crate::infer::prompt::GAP_LABEL_SYSTEM,
             &crate::infer::prompt::gap_label_prompt(questions),
@@ -236,9 +237,9 @@ mod tests {
     #[tokio::test]
     async fn without_a_readable_model_a_cluster_is_named_by_its_terms_and_retried_later() {
         let mut core = test_core().await;
-        core.gap_namer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.gap_namer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some("not json".into()),
-        });
+        }));
         nothing_here(&core, "mount an E01 image", vec![1.0]).await;
         nothing_here(&core, "E01 mount read only", vec![1.0]).await;
         let r = sweep(&core).await.unwrap();
@@ -247,9 +248,9 @@ mod tests {
         assert_eq!(rows[0].labelled_by, "terms");
         assert!(rows[0].label.contains("e01"), "{}", rows[0].label);
 
-        core.gap_namer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.gap_namer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some(r#"{"label":"Image mounting"}"#.into()),
-        });
+        }));
         assert_eq!(sweep(&core).await.unwrap().named, 1);
         assert_eq!(
             core.store.gap_rows(core.embedder.model()).await.unwrap().0[0].label,

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -857,12 +857,14 @@ mod tests {
         // literally the same bug as
         // reactivating_a_superseded_artifact_survives_the_next_sweep.
         let mut core = crate::core::test_support::test_core().await;
-        core.judge = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
-            r#"{"relation":"duplicate","detail":"same claim",
+        core.judge = Some(std::sync::Arc::new(
+            crate::infer::fake::ScriptedCompleter::new(vec![
+                r#"{"relation":"duplicate","detail":"same claim",
                 "merged":{"text":"Mount the filesystem, or attach the volume, before writing.",
                           "tags":[],"caveats":[]}}"#
-                .into(),
-        ]));
+                    .into(),
+            ]),
+        ));
         let ids = crate::jobs::consolidate::tests::seed(
             &core,
             &[

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -409,6 +409,7 @@ mod tests {
             caveats: vec![],
             status: ArtifactStatus::Active,
             last_verified_at: None,
+            cues: vec![],
         }
     }
 

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -6,6 +6,7 @@ pub mod embed;
 pub mod gaps;
 pub mod merge;
 pub mod passages;
+pub mod promote;
 pub mod reconcile;
 pub mod relate;
 pub mod synthesize;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -60,7 +60,31 @@ pub async fn run_one(core: &Core) -> Result<bool> {
     run_claimed(core, job).instrument(span).await
 }
 
+/// The role a stage cannot run without. `Synthesize` is deliberately absent:
+/// at `off` it is the verbatim capture path and needs nothing.
+fn needs_model(stage: Stage) -> Option<&'static str> {
+    match stage {
+        Stage::SegmentWindow | Stage::Title | Stage::Dedupe | Stage::LinkJudge => {
+            Some("synthesize")
+        }
+        _ => None,
+    }
+}
+
 async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
+    // A unit that needs a model the configuration does not have can never run.
+    // Close it with a reason rather than retrying to the ceiling for ever —
+    // a base captured at `eager`, then reconfigured, has rows like this.
+    if let Some(role) = needs_model(job.stage)
+        && !core.synthesizes()
+    {
+        tracing::warn!(
+            stage = job.stage.as_str(),
+            "no [infer.{role}] configured; dropping the unit"
+        );
+        core.store.complete_job(job.id).await?;
+        return Ok(true);
+    }
     let result = match (job.stage, job.target_kind.as_str()) {
         (Stage::Synthesize | Stage::Enrich, _) => synthesize::plan(core, &job.target_id).await,
         // Embedding is batched per source; the per-chunk path is for edits,
@@ -309,9 +333,9 @@ mod tests {
     #[tokio::test]
     async fn a_refused_window_backs_off_further_every_time_it_is_refused() {
         let mut core = test_core().await;
-        core.synthesizer = Arc::new(crate::infer::fake::FakeSynthesizer::rejecting(
+        core.synthesizer = Some(Arc::new(crate::infer::fake::FakeSynthesizer::rejecting(
             "HTTP 400: context length exceeded",
-        ));
+        )));
         let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
 
         let delay = |core: &Core| {
@@ -366,6 +390,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_model_stage_job_with_no_model_is_closed_not_retried() {
+        // A dedupe unit left over from an `eager` base, reconfigured to run
+        // with no [infer.synthesize]: there is nothing that could ever run it,
+        // so it settles with a reason rather than sitting at the backoff
+        // ceiling for ever.
+        let mut core = test_core().await;
+        core.synthesizer = None;
+        core.judge = None;
+        core.store
+            .enqueue(Stage::Dedupe, "pair", "p1")
+            .await
+            .unwrap();
+        assert!(run_one(&core).await.unwrap(), "the job was claimed");
+        assert!(
+            !core.store.live_job(Stage::Dedupe, "p1").await.unwrap(),
+            "the unit is still armed"
+        );
+    }
+
+    #[tokio::test]
     async fn run_one_reports_when_the_queue_is_empty() {
         let core = test_core().await;
         assert!(!run_one(&core).await.unwrap(), "no jobs means no work done");
@@ -393,9 +437,9 @@ mod tests {
     #[tokio::test]
     async fn a_failing_stage_is_retried_then_gives_up_with_a_reason() {
         let mut core = test_core().await;
-        core.synthesizer = Arc::new(crate::infer::fake::FakeSynthesizer::failing(
+        core.synthesizer = Some(Arc::new(crate::infer::fake::FakeSynthesizer::failing(
             "endpoint down",
-        ));
+        )));
         let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
 
         // Each attempt fails and pushes run_after forward; wind it back to

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -5,6 +5,7 @@ pub mod describe;
 pub mod embed;
 pub mod gaps;
 pub mod merge;
+pub mod passages;
 pub mod reconcile;
 pub mod relate;
 pub mod synthesize;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -7,6 +7,7 @@ pub mod gaps;
 pub mod merge;
 pub mod passages;
 pub mod promote;
+pub mod pursuit;
 pub mod reconcile;
 pub mod relate;
 pub mod synthesize;
@@ -66,9 +67,11 @@ pub async fn run_one(core: &Core) -> Result<bool> {
 /// at `off` it is the verbatim capture path and needs nothing.
 fn needs_model(stage: Stage) -> Option<&'static str> {
     match stage {
-        Stage::SegmentWindow | Stage::Title | Stage::Dedupe | Stage::LinkJudge => {
-            Some("synthesize")
-        }
+        Stage::SegmentWindow
+        | Stage::Title
+        | Stage::Dedupe
+        | Stage::LinkJudge
+        | Stage::Generate => Some("synthesize"),
         _ => None,
     }
 }
@@ -103,6 +106,8 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Dedupe, _) => dedupe::run(core, &job.target_id).await,
         (Stage::Relate, _) => relate::run(core, &job.target_id).await,
         (Stage::Describe, _) => describe::run(core, &job.target_id).await,
+        (Stage::Pursuit, _) => pursuit::run(core).await.map(|_| ()),
+        (Stage::Generate, _) => pursuit::generate(core, &job.target_id).await,
     };
 
     match result {

--- a/src/jobs/passages.rs
+++ b/src/jobs/passages.rs
@@ -1,0 +1,243 @@
+//! Capture without synthesis: a window becomes verbatim passages sized to the
+//! embedder, each under the heading the document gave it.
+
+use crate::infer::budget::TokenCounter;
+use crate::infer::split::{Window, split_into_segments};
+
+/// A document's name, derived locally: longer than this is a paragraph.
+pub const TITLE_MAX: usize = 80;
+
+/// One verbatim slice of a window: the retrieval unit at `off` and `earned`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Passage {
+    /// The heading this text sits under, as the document wrote it — the
+    /// carried heading of a continuation, or the most recent heading inside
+    /// the window above it. Never inferred.
+    pub title: Option<String>,
+    /// The slice itself. A carried heading is *not* in here: it is not one of
+    /// the lines the span names, and the embedding input would carry it twice.
+    pub text: String,
+    pub start_line: i64,
+    pub end_line: i64,
+}
+
+fn is_heading(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with('#') && t.trim_start_matches('#').starts_with(' ')
+}
+
+/// "## Recovering deleted entries" → "Recovering deleted entries".
+pub fn heading_title(line: &str) -> String {
+    line.trim().trim_start_matches('#').trim().to_string()
+}
+
+/// Split one window into passages sized to the embedder.
+///
+/// The same splitter that made the window, called again with the retrieval
+/// budget, over the window's *body* — its text minus the heading the outer
+/// split carried in (`carry_lines`), which belongs to the document further up
+/// and occupies none of this window's lines. Passage spans therefore partition
+/// `start_line..=end_line` and never cross the window: promotion later
+/// supersedes a whole number of them.
+///
+/// Titles: a continuation passage takes the heading the inner split carried
+/// into it (and that heading leaves its `text`); a passage that contains a
+/// heading is titled by the first one it contains; a passage with neither
+/// takes the last heading seen above it, the window's own carried heading
+/// included. `is_heading` knows Markdown `#` headings only, so plain text
+/// yields untitled passages — nothing is inferred to fill the gap.
+pub fn split_passages(
+    window: &Window,
+    counter: &TokenCounter,
+    chunk_tokens: usize,
+) -> Vec<Passage> {
+    let carry = window.carry_lines.max(0) as usize;
+    let mut lines = window.text.lines();
+    let outer_heading: Option<String> = (carry > 0)
+        .then(|| {
+            lines
+                .by_ref()
+                .take(carry)
+                .find(|l| is_heading(l))
+                .map(heading_title)
+        })
+        .flatten();
+    let body: String = lines.collect::<Vec<_>>().join("\n");
+
+    let inner = split_into_segments(&body, counter, chunk_tokens.max(1));
+    let mut out = Vec::with_capacity(inner.len());
+    let mut last_heading: Option<String> = outer_heading;
+    for p in inner {
+        let pc = p.carry_lines.max(0) as usize;
+        let mut plines = p.text.lines();
+        let carried: Option<String> = (pc > 0)
+            .then(|| {
+                plines
+                    .by_ref()
+                    .take(pc)
+                    .find(|l| is_heading(l))
+                    .map(heading_title)
+            })
+            .flatten();
+        let own: Vec<&str> = plines.collect();
+        let inside: Option<String> = own.iter().find(|l| is_heading(l)).map(|l| heading_title(l));
+        let title = carried
+            .clone()
+            .or_else(|| inside.clone())
+            .or_else(|| last_heading.clone());
+        // What the next passage inherits if the splitter carries nothing: the
+        // last heading seen in document order.
+        if let Some(h) = own.iter().rev().find(|l| is_heading(l)) {
+            last_heading = Some(heading_title(h));
+        } else if carried.is_some() {
+            last_heading = carried.clone();
+        }
+        // Body line k is document line `window.start_line + k - 1`: the body
+        // starts where the window's own lines start. Clamped, because a cut
+        // long line can put more text lines in the body than the document has.
+        let start =
+            (window.start_line + p.start_line - 1).clamp(window.start_line, window.end_line);
+        let end = (window.start_line + p.end_line - 1).clamp(start, window.end_line);
+        out.push(Passage {
+            title,
+            text: own.join("\n"),
+            start_line: start,
+            end_line: end,
+        });
+    }
+    out
+}
+
+/// A corpus title with no model: the first heading, else the first non-empty
+/// line, cut to `TITLE_MAX` characters. `None` for whitespace.
+pub fn derive_title(raw_text: &str) -> Option<String> {
+    let line = raw_text
+        .lines()
+        .find(|l| is_heading(l))
+        .map(heading_title)
+        .or_else(|| {
+            raw_text
+                .lines()
+                .map(str::trim)
+                .find(|l| !l.is_empty())
+                .map(str::to_string)
+        })?;
+    if line.is_empty() {
+        return None;
+    }
+    Some(line.chars().take(TITLE_MAX).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infer::budget::TokenCounter;
+    use crate::infer::split::Window;
+
+    fn window(text: &str, start_line: i64, carry_lines: i64) -> Window {
+        let own = text.lines().count() as i64 - carry_lines;
+        Window {
+            text: text.to_string(),
+            start_line,
+            end_line: start_line + own - 1,
+            carry_lines,
+        }
+    }
+
+    #[test]
+    fn a_window_that_fits_is_one_passage_whose_span_is_the_window() {
+        let w = window("para one\n\npara two", 10, 0);
+        let p = split_passages(&w, &TokenCounter, 1000);
+        assert_eq!(p.len(), 1);
+        assert_eq!((p[0].start_line, p[0].end_line), (10, 12));
+        assert_eq!(p[0].text, "para one\n\npara two");
+        assert_eq!(p[0].title, None);
+    }
+
+    #[test]
+    fn passages_partition_the_window_and_never_cross_it() {
+        // ~30 estimator tokens per paragraph, budget 40: one paragraph each.
+        let paras: Vec<String> = (0..4)
+            .map(|i| format!("paragraph {i} ").repeat(8))
+            .collect();
+        let text = paras.join("\n\n");
+        let w = window(&text, 1, 0);
+        let p = split_passages(&w, &TokenCounter, 40);
+        assert!(p.len() > 1, "{}", p.len());
+        assert_eq!(p[0].start_line, 1);
+        assert_eq!(p.last().unwrap().end_line, w.end_line);
+        for pair in p.windows(2) {
+            assert_eq!(pair[0].end_line + 1, pair[1].start_line, "spans must abut");
+        }
+        assert!(
+            p.iter()
+                .all(|x| x.start_line >= w.start_line && x.end_line <= w.end_line)
+        );
+    }
+
+    #[test]
+    fn the_carried_heading_becomes_the_title_and_leaves_the_text() {
+        // A continuation window: the splitter carried "## Recovery" in from
+        // the previous window as line 1 of its text.
+        let w = window("## Recovery\nstep three\nstep four", 40, 1);
+        let p = split_passages(&w, &TokenCounter, 1000);
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0].title.as_deref(), Some("Recovery"));
+        assert_eq!(p[0].text, "step three\nstep four");
+        assert_eq!((p[0].start_line, p[0].end_line), (40, 41));
+    }
+
+    #[test]
+    fn a_heading_inside_the_window_titles_the_passage_that_holds_it_and_is_carried_on() {
+        let body = format!(
+            "intro line\n## Mounting\n{}\n\n{}",
+            "mount words ".repeat(12),
+            "more mount words ".repeat(12)
+        );
+        let w = window(&body, 1, 0);
+        let p = split_passages(&w, &TokenCounter, 40);
+        assert!(p.len() >= 2, "{}", p.len());
+        // The first passage holds the heading line verbatim and is titled by it.
+        assert!(p[0].text.contains("## Mounting"));
+        assert_eq!(p[0].title.as_deref(), Some("Mounting"));
+        // The continuation takes the carried heading as title, not as text.
+        assert_eq!(p[1].title.as_deref(), Some("Mounting"));
+        assert!(!p[1].text.contains("## Mounting"), "{:?}", p[1].text);
+        // And every heading line appears exactly once across the passages.
+        let total = p.iter().filter(|x| x.text.contains("## Mounting")).count();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn a_continuation_window_with_no_inner_heading_keeps_the_outer_one_throughout() {
+        let body = format!(
+            "## Outer\n{}\n\n{}",
+            "first part words ".repeat(12),
+            "second part words ".repeat(12)
+        );
+        let w = window(&body, 20, 1);
+        let p = split_passages(&w, &TokenCounter, 40);
+        assert!(p.len() >= 2);
+        assert!(
+            p.iter().all(|x| x.title.as_deref() == Some("Outer")),
+            "{p:?}"
+        );
+        assert!(p.iter().all(|x| !x.text.contains("## Outer")));
+    }
+
+    #[test]
+    fn derive_title_prefers_a_heading_then_the_first_line_and_truncates() {
+        assert_eq!(
+            derive_title("\n\n# Big title\nbody").as_deref(),
+            Some("Big title")
+        );
+        assert_eq!(
+            derive_title("plain first line\nsecond").as_deref(),
+            Some("plain first line")
+        );
+        let long = "x".repeat(200);
+        assert_eq!(derive_title(&long).unwrap().chars().count(), TITLE_MAX);
+        assert_eq!(derive_title("   \n\t\n"), None);
+        assert_eq!(heading_title("###   Deep heading  "), "Deep heading");
+    }
+}

--- a/src/jobs/passages.rs
+++ b/src/jobs/passages.rs
@@ -35,6 +35,22 @@ pub fn heading_title(line: &str) -> String {
     line.trim().trim_start_matches('#').trim().to_string()
 }
 
+/// The first heading among the next `n` lines, with all `n` consumed.
+///
+/// Consuming all of them is the whole point. The carried lines belong to the
+/// window above rather than to this passage's body, so the iterator must be
+/// left standing just past them — and `find` alone stops at the heading, which
+/// leaves every carried line after it to be read as body text. `flush` emits a
+/// carry of 0 or 1 today, and at 1 the two spellings agree; at 2 they would
+/// not, and every passage span below here would quietly shift by a line.
+fn carried_heading<'a>(lines: &mut impl Iterator<Item = &'a str>, n: usize) -> Option<String> {
+    let carried: Vec<&str> = lines.take(n).collect();
+    carried
+        .into_iter()
+        .find(|l| is_heading(l))
+        .map(heading_title)
+}
+
 /// Split one window into passages sized to the embedder.
 ///
 /// The same splitter that made the window, called again with the retrieval
@@ -58,13 +74,7 @@ pub fn split_passages(
     let carry = window.carry_lines.max(0) as usize;
     let mut lines = window.text.lines();
     let outer_heading: Option<String> = (carry > 0)
-        .then(|| {
-            lines
-                .by_ref()
-                .take(carry)
-                .find(|l| is_heading(l))
-                .map(heading_title)
-        })
+        .then(|| carried_heading(&mut lines, carry))
         .flatten();
     let body: String = lines.collect::<Vec<_>>().join("\n");
 
@@ -75,13 +85,7 @@ pub fn split_passages(
         let pc = p.carry_lines.max(0) as usize;
         let mut plines = p.text.lines();
         let carried: Option<String> = (pc > 0)
-            .then(|| {
-                plines
-                    .by_ref()
-                    .take(pc)
-                    .find(|l| is_heading(l))
-                    .map(heading_title)
-            })
+            .then(|| carried_heading(&mut plines, pc))
             .flatten();
         let own: Vec<&str> = plines.collect();
         let inside: Option<String> = own.iter().find(|l| is_heading(l)).map(|l| heading_title(l));

--- a/src/jobs/passages.rs
+++ b/src/jobs/passages.rs
@@ -84,9 +84,7 @@ pub fn split_passages(
     for p in inner {
         let pc = p.carry_lines.max(0) as usize;
         let mut plines = p.text.lines();
-        let carried: Option<String> = (pc > 0)
-            .then(|| carried_heading(&mut plines, pc))
-            .flatten();
+        let carried: Option<String> = (pc > 0).then(|| carried_heading(&mut plines, pc)).flatten();
         let own: Vec<&str> = plines.collect();
         let inside: Option<String> = own.iter().find(|l| is_heading(l)).map(|l| heading_title(l));
         let title = carried

--- a/src/jobs/passages.rs
+++ b/src/jobs/passages.rs
@@ -283,13 +283,23 @@ mod tests {
         );
         let w = window(&body, 1, 0);
         let p = split_passages(&w, &TokenCounter, 40);
-        assert!(p.len() >= 2, "{}", p.len());
-        // The first passage holds the heading line verbatim and is titled by it.
-        assert!(p[0].text.contains("## Mounting"));
-        assert_eq!(p[0].title.as_deref(), Some("Mounting"));
+        assert!(p.len() >= 3, "{}", p.len());
+        // The heading opens its own passage, which holds the heading line
+        // verbatim and is titled by it; the intro line before it stands alone
+        // and untitled.
+        let k = p
+            .iter()
+            .position(|x| x.text.contains("## Mounting"))
+            .expect("a passage holds the heading");
+        assert_eq!(p[k].title.as_deref(), Some("Mounting"));
+        assert_eq!(p[0].title, None, "{p:?}");
         // The continuation takes the carried heading as title, not as text.
-        assert_eq!(p[1].title.as_deref(), Some("Mounting"));
-        assert!(!p[1].text.contains("## Mounting"), "{:?}", p[1].text);
+        assert_eq!(p[k + 1].title.as_deref(), Some("Mounting"));
+        assert!(
+            !p[k + 1].text.contains("## Mounting"),
+            "{:?}",
+            p[k + 1].text
+        );
         // And every heading line appears exactly once across the passages.
         let total = p.iter().filter(|x| x.text.contains("## Mounting")).count();
         assert_eq!(total, 1);

--- a/src/jobs/passages.rs
+++ b/src/jobs/passages.rs
@@ -1,8 +1,12 @@
 //! Capture without synthesis: a window becomes verbatim passages sized to the
 //! embedder, each under the heading the document gave it.
 
+use crate::core::Core;
+use crate::error::Result;
 use crate::infer::budget::TokenCounter;
 use crate::infer::split::{Window, split_into_segments};
+use crate::store::artifacts::{CorpusSpan, NewArtifact, Provenance};
+use crate::store::corpora::CorpusStatus;
 
 /// A document's name, derived locally: longer than this is a paragraph.
 pub const TITLE_MAX: usize = 80;
@@ -106,6 +110,89 @@ pub fn split_passages(
         });
     }
     out
+}
+
+/// The whole of capture at `off` and `earned`: split into windows, write them
+/// `verbatim`, split each window into passages, write those, name the document
+/// without a model, and finish the corpus the way a synthesized one finishes.
+/// No inference call anywhere on this path.
+///
+/// Idempotent per segment: a process that dies between two segments' inserts
+/// re-runs this, and a segment that already owns rows is left alone.
+pub async fn capture_verbatim(core: &Core, corpus_id: &str) -> Result<()> {
+    let src = core.store.get_corpus(corpus_id).await?;
+    let windows = split_into_segments(
+        &src.raw_text,
+        &core.counter,
+        super::synthesize::segment_budget(core),
+    );
+    if windows.is_empty() {
+        tracing::warn!(corpus_id, "source has no usable text");
+        core.store
+            .set_corpus_status(corpus_id, CorpusStatus::Failed)
+            .await?;
+        return Ok(());
+    }
+
+    let rows: Vec<crate::store::segments::NewSegment<'_>> = windows
+        .iter()
+        .map(|w| crate::store::segments::NewSegment {
+            start_line: w.start_line,
+            end_line: w.end_line,
+            text: w.text.as_str(),
+            carry_lines: w.carry_lines,
+        })
+        .collect();
+    core.store.upsert_segments(corpus_id, &rows).await?;
+    core.store.mark_segments_verbatim(corpus_id).await?;
+
+    // Under the document lock like every other local rearrangement of a
+    // corpus's rows, held through `finish` the way `settle` holds it: a
+    // promotion's write must not interleave with the renumbering.
+    let _corpus = core.corpus_lock(corpus_id).await;
+    for (idx, w) in windows.iter().enumerate() {
+        let idx = idx as i64;
+        if !core
+            .store
+            .artifact_ids_for_segment(corpus_id, idx)
+            .await?
+            .is_empty()
+        {
+            continue;
+        }
+        let new: Vec<NewArtifact> = split_passages(w, &core.counter, core.chunk_tokens)
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| NewArtifact {
+                ordinal: i as i64,
+                text: p.text,
+                corpus_span: Some(CorpusSpan {
+                    start_line: p.start_line,
+                    end_line: p.end_line,
+                }),
+                title: p.title,
+                category: None,
+                tags: vec![],
+                segment_idx: Some(idx),
+                caveats: vec![],
+            })
+            .collect();
+        core.store
+            .insert_artifacts_with_provenance(corpus_id, &new, Provenance::Passage)
+            .await?;
+    }
+
+    if src.title_hint.is_none()
+        && let Some(t) = derive_title(&src.raw_text)
+    {
+        core.store.set_title_hint(corpus_id, &t).await?;
+    }
+
+    tracing::info!(corpus_id, windows = windows.len(), "captured verbatim");
+    // Renumbers, measures coverage (green: the passages partition the
+    // document), arms the embed and moves the corpus on. The same function a
+    // synthesized corpus reaches through its last window's settle.
+    super::synthesize::finish(core, corpus_id).await
 }
 
 /// A corpus title with no model: the first heading, else the first non-empty
@@ -239,5 +326,118 @@ mod tests {
         assert_eq!(derive_title(&long).unwrap().chars().count(), TITLE_MAX);
         assert_eq!(derive_title("   \n\t\n"), None);
         assert_eq!(heading_title("###   Deep heading  "), "Deep heading");
+    }
+
+    #[tokio::test]
+    async fn capture_at_off_writes_passages_marks_segments_verbatim_and_finishes() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        core.synthesizer = None;
+        let text = format!(
+            "# Manual\n\n## Install\n{}\n\n## Recover\n{}",
+            "install words ".repeat(40),
+            "recover words ".repeat(40)
+        );
+        let out = core.ingest(&text, "web", None).await.unwrap();
+        // The Synthesize job is what capture queued; run it.
+        assert!(crate::jobs::run_one(&core).await.unwrap());
+
+        let s = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(
+            s.status,
+            crate::store::corpora::CorpusStatus::Embedding,
+            "{:?}",
+            s.status
+        );
+        assert_eq!(s.title_hint.as_deref(), Some("Manual"));
+        let segs = core.store.segments_for_corpus(&out.id).await.unwrap();
+        assert!(!segs.is_empty());
+        assert!(
+            segs.iter()
+                .all(|w| w.state == crate::store::segments::SegmentState::Verbatim)
+        );
+        let rows = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert!(!rows.is_empty());
+        assert!(
+            rows.iter()
+                .all(|c| c.provenance == crate::store::artifacts::Provenance::Passage)
+        );
+        assert!(rows.iter().all(|c| c.corpus_span.is_some()));
+        // Green by construction: every line is claimed.
+        assert_eq!(s.coverage.map(|c| (c * 100.0).round() as i64), Some(100));
+        assert!(
+            core.store
+                .live_job(crate::store::jobs::Stage::Embed, &out.id)
+                .await
+                .unwrap()
+        );
+        // No model unit was armed.
+        for w in &segs {
+            assert!(
+                !core
+                    .store
+                    .live_job(
+                        crate::store::jobs::Stage::SegmentWindow,
+                        &crate::jobs::window::unit_target(&out.id, w.idx)
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
+        assert!(
+            !core
+                .store
+                .has_job(crate::store::jobs::Stage::Title, &out.id)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_at_off_is_idempotent_per_segment() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        let out = core
+            .ingest("one line\n\nanother line", "web", None)
+            .await
+            .unwrap();
+        capture_verbatim(&core, &out.id).await.unwrap();
+        let n = core
+            .store
+            .artifacts_for_corpus(&out.id)
+            .await
+            .unwrap()
+            .len();
+        capture_verbatim(&core, &out.id).await.unwrap();
+        assert_eq!(
+            core.store
+                .artifacts_for_corpus(&out.id)
+                .await
+                .unwrap()
+                .len(),
+            n
+        );
+    }
+
+    #[tokio::test]
+    async fn a_passage_never_gets_a_relate_unit() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Off;
+        let out = core
+            .ingest("some verbatim text", "web", None)
+            .await
+            .unwrap();
+        capture_verbatim(&core, &out.id).await.unwrap();
+        let id = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+        crate::jobs::embed::run(&core, &id).await.unwrap();
+        assert!(
+            !core
+                .store
+                .live_job(crate::store::jobs::Stage::Relate, &id)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -46,6 +46,16 @@ pub async fn maybe_promote(core: &Core, ids: &[String], at: i64) -> Result<usize
         if core.store.segment_state(corpus_id, idx).await? != Some(SegmentState::Verbatim) {
             continue;
         }
+        // And the second guard, for the one window that is `verbatim` *because*
+        // it was promoted: `undo_promotion` puts the state back so the window
+        // can be read again, but leaves the passages the activation they
+        // earned — which is the very number that armed the promotion. Without
+        // this the next open of any of those passages re-promotes the window
+        // and the operator's undo is undone, with the deprecated artifacts
+        // still lying behind it.
+        if core.store.segment_no_promote(corpus_id, idx).await? {
+            continue;
+        }
         // `keep_artifacts`: the window job appends rather than replaces, so the
         // passages survive to be superseded by what covers them.
         core.store.reset_segment(corpus_id, idx, true).await?;
@@ -322,6 +332,45 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(again, 0);
+    }
+
+    #[tokio::test]
+    async fn an_undone_promotion_is_not_re_promoted_by_the_next_open() {
+        // Undo puts the window back to `verbatim` so it can be read again, and
+        // leaves the passage the activation it earned — which is the number
+        // that armed the promotion in the first place. Without the mark the
+        // next bump promotes it straight back and the operator's undo is
+        // undone, with the deprecated artifacts still lying behind it.
+        let (core, corpus, p) = earned_with_one_passage().await;
+        core.store
+            .bump_activation(std::slice::from_ref(&p), 3.0, 14.0, 1_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+                .await
+                .unwrap(),
+            1
+        );
+
+        core.undo_promotion(&corpus, 0).await.unwrap();
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Verbatim),
+            "the window is readable again"
+        );
+        // The passage still sits well over the line: nothing was decayed.
+        assert_eq!(
+            maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+                .await
+                .unwrap(),
+            0,
+            "the undo holds"
+        );
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Verbatim)
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -174,7 +174,27 @@ pub async fn supersede_covered(
         .iter()
         .filter_map(|c| Some((c.id.clone(), c.ordinal, c.corpus_span.clone()?)))
         .collect();
-    let pairs = covered_by(&passages, &artifacts);
+    // A span is a claim the splitter can verify for a passage and only guess
+    // for a rewrite: `resolve_span` falls back to the model's hint or the
+    // whole window when nothing in the artifact locates verbatim, and a
+    // heavily paraphrasing model then hands every artifact the same span. So
+    // a majority by span is necessary, not sufficient: the artifact must also
+    // be *traceable* to the passage — at least one of its lines found in the
+    // passage's text. Whatever is not traceable leaves the passage standing,
+    // which is the direction promotion is allowed to fail in.
+    let text_of = |id: &str| rows.iter().find(|c| c.id == id).map(|c| c.text.as_str());
+    let pairs: Vec<(&str, &str)> = covered_by(&passages, &artifacts)
+        .into_iter()
+        .filter(|(p, a)| {
+            let (Some(pt), Some(at)) = (
+                text_of(p),
+                written.iter().find(|c| c.id == *a).map(|c| c.text.as_str()),
+            ) else {
+                return false;
+            };
+            crate::infer::verify::locate_span(at, pt, 1).is_some()
+        })
+        .collect();
     if pairs.is_empty() {
         return Ok(0);
     }
@@ -457,9 +477,9 @@ mod tests {
             .insert_artifacts_with_provenance(
                 &src.id,
                 &[
-                    na(0, "l1 l2", 1, 2),
-                    na(1, "l3 l4", 3, 4),
-                    na(2, "l5 l6", 5, 6),
+                    na(0, "lines one and two of the text", 1, 2),
+                    na(1, "lines three and four of the text", 3, 4),
+                    na(2, "lines five and six of the text", 5, 6),
                 ],
                 crate::store::artifacts::Provenance::Passage,
             )
@@ -499,8 +519,14 @@ mod tests {
             .insert_artifacts(
                 &src.id,
                 &[
-                    na(0, "A covers one to four", 1, 4),
-                    na(1, "B covers six", 6, 6),
+                    // A's lines are traceable to passages 1 and 2; B's to 3.
+                    na(
+                        0,
+                        "lines one and two of the text\nlines three and four of the text",
+                        1,
+                        4,
+                    ),
+                    na(1, "lines five and six of the text", 6, 6),
                 ],
             )
             .await
@@ -712,5 +738,44 @@ mod tests {
             maybe_resynthesize(&core, &[(a.clone(), 99)]).await.unwrap(),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn a_majority_span_without_a_traceable_line_does_not_supersede() {
+        // `resolve_span` can only guess a paraphrase's span — the model's hint,
+        // or the whole window — and a guess must not hide verbatim text. The
+        // artifact here claims the passage's lines by span but shares no line
+        // of text with it: the passage stays.
+        let (core, corpus, passages, _written) = promoted_fixture().await;
+        let na = |o: i64, t: &str, a: i64, b: i64| crate::store::artifacts::NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: Some(sp(a, b)),
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let paraphrase = core
+            .store
+            .insert_artifacts(
+                &corpus,
+                &[na(
+                    9,
+                    "an entirely different sentence about nothing here",
+                    1,
+                    6,
+                )],
+            )
+            .await
+            .unwrap();
+        let n = supersede_covered(&core, &corpus, 0, &paraphrase, 2_000)
+            .await
+            .unwrap();
+        assert_eq!(n, 0);
+        for p in &passages {
+            assert!(core.store.get_artifact(&p.id).await.unwrap().in_results());
+        }
     }
 }

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -2,7 +2,7 @@
 
 use crate::core::Core;
 use crate::error::Result;
-use crate::store::artifacts::Provenance;
+use crate::store::artifacts::{Chunk, CorpusSpan, Provenance};
 use crate::store::jobs::Stage;
 use crate::store::segments::SegmentState;
 
@@ -67,6 +67,121 @@ pub async fn maybe_promote(core: &Core, ids: &[String], at: i64) -> Result<usize
         armed += 1;
     }
     Ok(armed)
+}
+
+fn overlap(a: &CorpusSpan, b: &CorpusSpan) -> i64 {
+    (a.end_line.min(b.end_line) - a.start_line.max(b.start_line) + 1).max(0)
+}
+
+/// Which artifact, if any, supersedes each passage: the one whose span covers
+/// a **majority** of the passage's lines — per artifact, not cumulative,
+/// because `supersede` names one winner and a passage hidden behind an
+/// artifact holding a third of it sends the reader to the wrong text. Best
+/// overlap wins; a tie goes to the lowest ordinal. Everything else stays
+/// active, verbatim, in results: promotion can only ever improve coverage.
+pub fn covered_by<'a>(
+    passages: &'a [(String, CorpusSpan)],
+    artifacts: &'a [(String, i64, CorpusSpan)],
+) -> Vec<(&'a str, &'a str)> {
+    let mut out = Vec::new();
+    for (pid, ps) in passages {
+        let len = ps.end_line - ps.start_line + 1;
+        let best = artifacts
+            .iter()
+            .map(|(aid, ord, asp)| (overlap(ps, asp), *ord, aid.as_str()))
+            .filter(|(ov, _, _)| 2 * ov > len)
+            .max_by(|x, y| x.0.cmp(&y.0).then(y.1.cmp(&x.1)));
+        if let Some((_, _, aid)) = best {
+            out.push((pid.as_str(), aid));
+        }
+    }
+    out
+}
+
+/// After a promoted window's artifacts are written: supersede the passages
+/// they cover and carry the passages' access forward.
+///
+/// Activation first, links second, the supersede last — `supersede` refuses a
+/// side that is no longer active, and everything before it needs the passage
+/// readable. Returns how many passages were superseded.
+pub async fn supersede_covered(
+    core: &Core,
+    corpus_id: &str,
+    idx: i64,
+    written: &[Chunk],
+    at: i64,
+) -> Result<usize> {
+    let rows = core.store.artifacts_for_segment(corpus_id, idx).await?;
+    let passages: Vec<(String, CorpusSpan)> = rows
+        .iter()
+        .filter(|c| c.provenance == Provenance::Passage && c.in_results())
+        .filter_map(|c| Some((c.id.clone(), c.corpus_span.clone()?)))
+        .collect();
+    let artifacts: Vec<(String, i64, CorpusSpan)> = written
+        .iter()
+        .filter_map(|c| Some((c.id.clone(), c.ordinal, c.corpus_span.clone()?)))
+        .collect();
+    let pairs = covered_by(&passages, &artifacts);
+    if pairs.is_empty() {
+        return Ok(0);
+    }
+    let half_life = core.activation.half_life_days;
+    let link_half_life = core.associate.half_life_days;
+
+    // Group by winner: one artifact may supersede several passages, and its
+    // activation is the max over all of them.
+    let mut by_winner: std::collections::BTreeMap<&str, Vec<&str>> = Default::default();
+    for (p, a) in &pairs {
+        by_winner.entry(a).or_default().push(p);
+    }
+    let all_superseded: std::collections::HashSet<&str> = pairs.iter().map(|(p, _)| *p).collect();
+    let mut n = 0;
+    for (winner, losers) in by_winner {
+        let ids: Vec<String> = losers.iter().map(|s| s.to_string()).collect();
+        let act = core.store.activation_of(&ids).await?;
+        let carried = act
+            .values()
+            .map(|(v, s)| crate::store::links::decayed(*v, *s, at, half_life))
+            .fold(f64::MIN, f64::max);
+        if carried > f64::MIN {
+            let own = core
+                .store
+                .activation_of(std::slice::from_ref(&winner.to_string()))
+                .await?
+                .get(winner)
+                .map(|(v, s)| crate::store::links::decayed(*v, *s, at, half_life))
+                .unwrap_or(1.0);
+            core.store
+                .set_activation(winner, carried.max(own), at)
+                .await?;
+        }
+        for loser in &losers {
+            for link in core.store.links_touching(loser).await? {
+                let other = if link.a_id == *loser {
+                    &link.b_id
+                } else {
+                    &link.a_id
+                };
+                // A link between two passages of this same promotion would
+                // become the artifact linked to itself — or to a passage about
+                // to go dark. Neither carries anything.
+                if all_superseded.contains(other.as_str()) {
+                    continue;
+                }
+                core.store
+                    .carry_link(&link, loser, winner, link_half_life, at)
+                    .await?;
+            }
+        }
+        for loser in &losers {
+            if crate::jobs::try_supersede(core, loser, winner, "a passage its promotion covers")
+                .await
+            {
+                n += 1;
+            }
+        }
+    }
+    Ok(n)
 }
 
 #[cfg(test)]
@@ -206,6 +321,258 @@ mod tests {
         assert_eq!(
             core.store.segment_state(&corpus, 0).await.unwrap(),
             Some(SegmentState::Pending)
+        );
+    }
+
+    use crate::store::artifacts::CorpusSpan;
+
+    fn sp(a: i64, b: i64) -> CorpusSpan {
+        CorpusSpan {
+            start_line: a,
+            end_line: b,
+        }
+    }
+
+    #[test]
+    fn the_majority_rule_is_per_artifact_best_overlap_ties_to_the_lowest_ordinal() {
+        // passage 1–20; A claims 1–11 (11 lines, majority), B claims 12–20 (9).
+        let passages = vec![("p".to_string(), sp(1, 20))];
+        let arts = vec![
+            ("b".to_string(), 1, sp(12, 20)),
+            ("a".to_string(), 0, sp(1, 11)),
+        ];
+        assert_eq!(covered_by(&passages, &arts), vec![("p", "a")]);
+        // 30% + 30% is not a majority: nobody claims it.
+        let arts = vec![
+            ("a".to_string(), 0, sp(1, 6)),
+            ("b".to_string(), 1, sp(7, 12)),
+        ];
+        assert!(covered_by(&passages, &arts).is_empty());
+        // Exactly half is not a majority either.
+        let arts = vec![("a".to_string(), 0, sp(1, 10))];
+        assert!(covered_by(&passages, &arts).is_empty());
+        // A tie on overlap goes to the lowest ordinal.
+        let arts = vec![
+            ("z".to_string(), 5, sp(1, 20)),
+            ("y".to_string(), 2, sp(1, 20)),
+        ];
+        assert_eq!(covered_by(&passages, &arts), vec![("p", "y")]);
+    }
+
+    /// A verbatim corpus of three passages (lines 1–2, 3–4, 5–6 of one
+    /// window) with activation and a link on the middle one; then a
+    /// promotion whose artifact A claims lines 1–4 and B claims line 6.
+    async fn promoted_fixture() -> (
+        crate::core::Core,
+        String,
+        Vec<crate::store::artifacts::Chunk>,
+        Vec<crate::store::artifacts::Chunk>,
+    ) {
+        let mut core = test_core().await;
+        core.synthesis = SynthesisMode::Earned;
+        core.feedback.enabled = true;
+        let src = core
+            .store
+            .insert_corpus("l1\nl2\nl3\nl4\nl5\nl6", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .upsert_segments(
+                &src.id,
+                &[crate::store::segments::NewSegment {
+                    start_line: 1,
+                    end_line: 6,
+                    text: "l1\nl2\nl3\nl4\nl5\nl6",
+                    carry_lines: 0,
+                }],
+            )
+            .await
+            .unwrap();
+        core.store.mark_segments_verbatim(&src.id).await.unwrap();
+        let na = |o: i64, t: &str, a: i64, b: i64| crate::store::artifacts::NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: Some(sp(a, b)),
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let passages = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[
+                    na(0, "l1 l2", 1, 2),
+                    na(1, "l3 l4", 3, 4),
+                    na(2, "l5 l6", 5, 6),
+                ],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        // Another corpus to link to.
+        let other = core
+            .store
+            .insert_corpus("other", "web", None)
+            .await
+            .unwrap();
+        let x = core
+            .store
+            .insert_artifacts(&other.id, &[na(0, "x", 1, 1)])
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        core.store
+            .bump_activation(std::slice::from_ref(&passages[1].id), 4.0, 14.0, 1_000)
+            .await
+            .unwrap();
+        core.store
+            .bump_links(
+                &[(passages[1].id.as_str(), x.as_str())],
+                2.0,
+                Some("mid"),
+                14.0,
+                1_000,
+            )
+            .await
+            .unwrap();
+        // The promotion's artifacts, as `write_segment_artifacts` would write them.
+        core.store.reset_segment(&src.id, 0, true).await.unwrap();
+        let written = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    na(0, "A covers one to four", 1, 4),
+                    na(1, "B covers six", 6, 6),
+                ],
+            )
+            .await
+            .unwrap();
+        (core, src.id, passages, written)
+    }
+
+    #[tokio::test]
+    async fn covered_passages_are_superseded_and_the_rest_stay_verbatim() {
+        let (core, corpus, passages, written) = promoted_fixture().await;
+        let n = supersede_covered(&core, &corpus, 0, &written, 2_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            n, 2,
+            "passages 1 and 2 are majority-covered by A; passage 3 is half-covered by B"
+        );
+        let p0 = core.store.get_artifact(&passages[0].id).await.unwrap();
+        let p1 = core.store.get_artifact(&passages[1].id).await.unwrap();
+        let p2 = core.store.get_artifact(&passages[2].id).await.unwrap();
+        assert_eq!(p0.superseded_by.as_deref(), Some(written[0].id.as_str()));
+        assert_eq!(p1.superseded_by.as_deref(), Some(written[0].id.as_str()));
+        assert!(
+            p2.in_results(),
+            "lines 5–6: B claims one of two, not a majority"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_artifact_takes_the_max_decayed_activation_not_one_point_zero() {
+        let (core, corpus, passages, written) = promoted_fixture().await;
+        supersede_covered(&core, &corpus, 0, &written, 1_000)
+            .await
+            .unwrap();
+        let act = core
+            .store
+            .activation_of(&[written[0].id.clone(), passages[1].id.clone()])
+            .await
+            .unwrap();
+        let (a_val, a_at) = act[&written[0].id];
+        let (p_val, p_at) = act[&passages[1].id];
+        let expect = crate::store::links::decayed(p_val, p_at, 1_000, 14.0);
+        assert!((a_val - expect).abs() < 1e-6, "got {a_val}, want {expect}");
+        assert_eq!(a_at, 1_000);
+        assert!(a_val > 1.0);
+    }
+
+    #[tokio::test]
+    async fn a_link_from_a_superseded_passage_resolves_on_the_artifact_and_the_dead_row_stays() {
+        let (core, corpus, passages, written) = promoted_fixture().await;
+        supersede_covered(&core, &corpus, 0, &written, 1_000)
+            .await
+            .unwrap();
+        let out = core
+            .store
+            .links_from(
+                &[written[0].id.clone()],
+                &[crate::store::links::LinkState::Learning],
+                14.0,
+                1_000,
+                0.0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!((out[0].weight - 2.0).abs() < 1e-6);
+        // The passage's own row is still there — dark, because its endpoint
+        // is superseded.
+        assert_eq!(
+            core.store
+                .links_touching(&passages[1].id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        let from_passage = core
+            .store
+            .links_from(
+                &[passages[1].id.clone()],
+                &[crate::store::links::LinkState::Learning],
+                14.0,
+                1_000,
+                0.0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert!(from_passage.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_re_run_under_keep_artifacts_writes_nothing_twice() {
+        let (core, corpus, _passages, written) = promoted_fixture().await;
+        // `write_segment_artifacts` with keep set and non-passage rows already
+        // present returns those rows and inserts none.
+        let again = crate::jobs::window::write_segment_artifacts(
+            &core,
+            &corpus,
+            0,
+            vec![crate::store::artifacts::NewArtifact {
+                ordinal: 0,
+                text: "dup".into(),
+                corpus_span: None,
+                title: None,
+                category: None,
+                tags: vec![],
+                segment_idx: Some(0),
+                caveats: vec![],
+            }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            again.iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
+            written.iter().map(|c| c.id.clone()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            core.store
+                .artifacts_for_segment(&corpus, 0)
+                .await
+                .unwrap()
+                .len(),
+            5
         );
     }
 }

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -69,6 +69,59 @@ pub async fn maybe_promote(core: &Core, ids: &[String], at: i64) -> Result<usize
     Ok(armed)
 }
 
+/// The `eager` counterpart of promotion: an artifact shown
+/// `resynthesize_after_unconfirmed` times with no confirmation recorded
+/// against it is misleading, and is re-synthesised from its source segment —
+/// never from itself. `keep_artifacts = 0`: replace, because the old artifacts
+/// are the problem. `0` disables it and it ships disabled.
+///
+/// `hits` carries each artifact's retrieval count *after* this retrieval.
+pub async fn maybe_resynthesize(core: &Core, hits: &[(String, i64)]) -> Result<usize> {
+    let line = core.promote.resynthesize_after_unconfirmed;
+    if line <= 0 || core.synthesis != crate::config::SynthesisMode::Eager || !core.synthesizes() {
+        return Ok(0);
+    }
+    let mut armed = 0;
+    for (id, count) in hits {
+        if *count < line {
+            continue;
+        }
+        let Ok(c) = core.store.get_artifact(id).await else {
+            continue;
+        };
+        if c.provenance != Provenance::Captured || !c.in_results() {
+            continue;
+        }
+        let (Some(corpus_id), Some(idx)) = (c.corpus_id.as_deref(), c.segment_idx) else {
+            continue;
+        };
+        if core.store.segment_state(corpus_id, idx).await? != Some(SegmentState::Done) {
+            continue;
+        }
+        if core.store.artifact_confirmed(id).await? {
+            continue;
+        }
+        core.store.reset_segment(corpus_id, idx, false).await?;
+        core.store
+            .rearm_idle_seq(
+                Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(corpus_id, idx),
+                idx,
+            )
+            .await?;
+        tracing::info!(
+            artifact_id = %id,
+            corpus_id,
+            window = idx,
+            shown = count,
+            "re-synthesising an unconfirmed window"
+        );
+        armed += 1;
+    }
+    Ok(armed)
+}
+
 fn overlap(a: &CorpusSpan, b: &CorpusSpan) -> i64 {
     (a.end_line.min(b.end_line) - a.start_line.max(b.start_line) + 1).max(0)
 }
@@ -573,6 +626,91 @@ mod tests {
                 .unwrap()
                 .len(),
             5
+        );
+    }
+
+    #[tokio::test]
+    async fn an_eager_artifact_shown_often_and_never_confirmed_is_re_read_from_its_segment_when_enabled()
+     {
+        let mut core = test_core().await;
+        core.promote.resynthesize_after_unconfirmed = 3;
+        let src = core
+            .store
+            .insert_corpus("l1\nl2", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .upsert_segments(
+                &src.id,
+                &[crate::store::segments::NewSegment {
+                    start_line: 1,
+                    end_line: 2,
+                    text: "l1\nl2",
+                    carry_lines: 0,
+                }],
+            )
+            .await
+            .unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "artifact".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        // Under the line: nothing.
+        assert_eq!(
+            maybe_resynthesize(&core, &[(a.clone(), 2)]).await.unwrap(),
+            0
+        );
+        // At the line, unconfirmed: the window is re-armed to *replace*.
+        assert_eq!(
+            maybe_resynthesize(&core, &[(a.clone(), 3)]).await.unwrap(),
+            1
+        );
+        assert_eq!(
+            core.store.segment_state(&src.id, 0).await.unwrap(),
+            Some(SegmentState::Pending)
+        );
+        assert!(
+            !core
+                .store
+                .segment_keeps_artifacts(&src.id, 0)
+                .await
+                .unwrap(),
+            "replace, not append: the old artifacts are the problem"
+        );
+        assert!(
+            core.store
+                .live_job(Stage::SegmentWindow, &unit(&src.id))
+                .await
+                .unwrap()
+        );
+        // Disabled (0) never fires.
+        core.promote.resynthesize_after_unconfirmed = 0;
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            maybe_resynthesize(&core, &[(a.clone(), 99)]).await.unwrap(),
+            0
         );
     }
 }

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -1,0 +1,211 @@
+//! Promotion: synthesis armed by evidence instead of by capture.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::store::artifacts::Provenance;
+use crate::store::jobs::Stage;
+use crate::store::segments::SegmentState;
+
+/// Promote the windows of any of these passages that have earned it.
+///
+/// Called after an engagement bump — opened, or confirmed — and never after a
+/// retrieval bump: a passage that merely keeps appearing in result lists has
+/// helped nobody, and the condition "opened or confirmed at least once" is
+/// *where* this is called, not a stored flag. Checked at the bump, not on a
+/// sweep: a sweep reads decayed activation and the threshold would then mean
+/// something different depending on when it ran.
+///
+/// Arms a job; calls no model. The job queue and `[pacing]` bound the load.
+pub async fn maybe_promote(core: &Core, ids: &[String], at: i64) -> Result<usize> {
+    if core.synthesis != crate::config::SynthesisMode::Earned || !core.synthesizes() {
+        return Ok(0);
+    }
+    let activation = core.store.activation_of(ids).await?;
+    let mut armed = 0;
+    for id in ids {
+        let Some((value, stamp)) = activation.get(id) else {
+            continue;
+        };
+        let now_value =
+            crate::store::links::decayed(*value, *stamp, at, core.activation.half_life_days);
+        if now_value < core.promote.activation_above {
+            continue;
+        }
+        let Ok(c) = core.store.get_artifact(id).await else {
+            continue;
+        };
+        if c.provenance != Provenance::Passage || !c.in_results() {
+            continue;
+        }
+        let (Some(corpus_id), Some(idx)) = (c.corpus_id.as_deref(), c.segment_idx) else {
+            continue;
+        };
+        // The guard against re-promotion is the segment state: a window that
+        // is `done` — or already on its way — never promotes again, however
+        // many of its surviving passages cross the line afterwards.
+        if core.store.segment_state(corpus_id, idx).await? != Some(SegmentState::Verbatim) {
+            continue;
+        }
+        // `keep_artifacts`: the window job appends rather than replaces, so the
+        // passages survive to be superseded by what covers them.
+        core.store.reset_segment(corpus_id, idx, true).await?;
+        core.store
+            .rearm_idle_seq(
+                Stage::SegmentWindow,
+                "segment",
+                &crate::jobs::window::unit_target(corpus_id, idx),
+                idx,
+            )
+            .await?;
+        tracing::info!(
+            artifact_id = %id,
+            corpus_id,
+            window = idx,
+            activation = now_value,
+            "promoting a window"
+        );
+        armed += 1;
+    }
+    Ok(armed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SynthesisMode;
+    use crate::core::test_support::test_core;
+
+    /// A core at `earned`, recording, with one verbatim corpus of one passage.
+    async fn earned_with_one_passage() -> (crate::core::Core, String, String) {
+        let mut core = test_core().await;
+        core.synthesis = SynthesisMode::Earned;
+        core.feedback.enabled = true;
+        let out = core
+            .ingest("a single verbatim passage", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::passages::capture_verbatim(&core, &out.id)
+            .await
+            .unwrap();
+        let p = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+        (core, out.id, p)
+    }
+
+    fn unit(corpus: &str) -> String {
+        crate::jobs::window::unit_target(corpus, 0)
+    }
+
+    #[tokio::test]
+    async fn a_passage_over_the_line_arms_its_window_once() {
+        let (core, corpus, p) = earned_with_one_passage().await;
+        // Baseline 1.0 plus one confirmed bump puts it at 4.0 exactly.
+        core.store
+            .bump_activation(std::slice::from_ref(&p), 3.0, 14.0, 1_000)
+            .await
+            .unwrap();
+        let armed = maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+            .await
+            .unwrap();
+        assert_eq!(armed, 1);
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Pending)
+        );
+        assert!(
+            core.store
+                .segment_keeps_artifacts(&corpus, 0)
+                .await
+                .unwrap()
+        );
+        assert!(
+            core.store
+                .live_job(Stage::SegmentWindow, &unit(&corpus))
+                .await
+                .unwrap()
+        );
+        // A second trigger on a window that is no longer verbatim does nothing.
+        core.store
+            .set_segment_state(&corpus, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        let again = maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+            .await
+            .unwrap();
+        assert_eq!(again, 0);
+    }
+
+    #[tokio::test]
+    async fn under_the_line_nothing_is_armed() {
+        let (core, corpus, p) = earned_with_one_passage().await;
+        core.store
+            .bump_activation(std::slice::from_ref(&p), 1.0, 14.0, 1_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Verbatim)
+        );
+    }
+
+    #[tokio::test]
+    async fn only_earned_with_a_synthesizer_promotes() {
+        let (mut core, _corpus, p) = earned_with_one_passage().await;
+        core.store
+            .bump_activation(std::slice::from_ref(&p), 5.0, 14.0, 1_000)
+            .await
+            .unwrap();
+        core.synthesis = SynthesisMode::Off;
+        assert_eq!(
+            maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+                .await
+                .unwrap(),
+            0
+        );
+        core.synthesis = SynthesisMode::Earned;
+        core.synthesizer = None;
+        assert_eq!(
+            maybe_promote(&core, std::slice::from_ref(&p), 1_000)
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieval_alone_never_promotes_but_one_open_afterwards_does() {
+        // The threshold is checked at the opened bump, not the retrieved one:
+        // ten retrievals leave the window verbatim; the first open promotes.
+        let (core, corpus, p) = earned_with_one_passage().await;
+        let ids = vec![p.clone()];
+        // Stamped now: `mark_artifact_seen` reads the clock, and a bump from
+        // 1970 would have decayed to nothing by the time it looks.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        for _ in 0..10 {
+            core.store
+                .bump_activation(&ids, core.activation.retrieved, 14.0, now)
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Verbatim)
+        );
+        core.mark_artifact_seen(&p);
+        core.background.wait_idle().await;
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Pending)
+        );
+    }
+}

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -186,13 +186,13 @@ pub async fn supersede_covered(
     let pairs: Vec<(&str, &str)> = covered_by(&passages, &artifacts)
         .into_iter()
         .filter(|(p, a)| {
-            let (Some(pt), Some(at)) = (
+            let (Some(passage_text), Some(artifact_text)) = (
                 text_of(p),
                 written.iter().find(|c| c.id == *a).map(|c| c.text.as_str()),
             ) else {
                 return false;
             };
-            crate::infer::verify::locate_span(at, pt, 1).is_some()
+            crate::infer::verify::locate_span(artifact_text, passage_text, 1).is_some()
         })
         .collect();
     if pairs.is_empty() {

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -136,6 +136,21 @@ pub async fn generate(core: &Core, pursuit_id: &str) -> Result<()> {
 /// Cursor: the moment everything up to which has been grouped into pursuits.
 pub const PURSUIT_AFTER: &str = "pursuit.events_after";
 
+/// How far back one sweep may look, whatever the cursor says.
+///
+/// A ceiling rather than a budget: pursuits are swept every time the operator
+/// goes quiet, so nothing in ordinary use comes near it. What it stops is the
+/// first sweep after `pursuit.enabled` is turned on, where there is no cursor
+/// and the window would otherwise open at the epoch. Recording is on by
+/// default, so that window holds every search the base has taken since it was
+/// installed — and the clustering below is quadratic in *memory* as well as
+/// time, so reading it is not a slow sweep, it is one `Vec` the size of the
+/// square of the log.
+///
+/// A day is chosen because a pursuit is a sitting, and the sweep after an
+/// idle stretch has already seen everything older than the last one.
+const MAX_LOOKBACK_SECS: i64 = 24 * 60 * 60;
+
 /// One clustered pursuit before a decision: what was asked, and what was done
 /// with the results.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -236,6 +251,7 @@ pub async fn run(core: &Core) -> Result<usize> {
         .await?
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
+    let after = after.max(now - MAX_LOOKBACK_SECS);
     if let Some(newest) = core.store.newest_event_at().await?
         && newest > after
         && now - newest < idle
@@ -300,10 +316,30 @@ pub async fn run(core: &Core) -> Result<usize> {
     let refs: Vec<&[f32]> = vecs.iter().map(Vec::as_slice).collect();
     let clusters = crate::core::gaps::cluster(&refs, line);
 
+    // `cluster` groups on the words alone, and the words do not say when. Two
+    // sittings a week apart on one subject come back as one group, and every
+    // count taken over it is then taken across the gap: `opened_at`/`last_at`
+    // span the week, and `refined`/`abandoned` are read from events that were
+    // never consecutive. Splitting on the same idle gap that decides when the
+    // sweep runs is what makes each piece a pursuit — something that ended —
+    // rather than a topic.
+    let clusters: Vec<Vec<usize>> = clusters
+        .into_iter()
+        .flat_map(|mut members| {
+            members.sort_by_key(|&m| evs[m].at);
+            let mut sittings: Vec<Vec<usize>> = Vec::new();
+            for m in members {
+                match sittings.last_mut() {
+                    Some(run) if evs[m].at - evs[*run.last().unwrap()].at <= idle => run.push(m),
+                    _ => sittings.push(vec![m]),
+                }
+            }
+            sittings
+        })
+        .collect();
+
     let mut written = 0;
     for members in clusters {
-        let mut members = members;
-        members.sort_by_key(|&m| evs[m].at);
         let need = need_of(core, &evs, &members, &attached, &interactions);
         // Sources in the order they go to the model: engagement first, dwell
         // breaking ties. Dwell moves an artifact up the list and nothing else.
@@ -351,7 +387,21 @@ pub async fn run(core: &Core) -> Result<usize> {
                 crate::jobs::promote::maybe_promote(core, std::slice::from_ref(&id), now).await?;
             }
             Decision::Generate => {
-                if let Some(covering) = covered_by_existing(core, &sources).await? {
+                // Nothing to arm without a generator. `run_claimed` would drop
+                // the unit with a warning and the pursuit would stay `open`
+                // with no reason — one more row on Ops after every sweep,
+                // saying a call is coming that never is. Pursuits still earn
+                // their keep at `synthesis = "off"`: `Promote` needs no model.
+                if !core.synthesizes() {
+                    core.store
+                        .close_pursuit(
+                            &pid,
+                            "unsatisfied",
+                            "earned an artifact, but there is no [infer.synthesize] to write it",
+                            now,
+                        )
+                        .await?;
+                } else if let Some(covering) = covered_by_existing(core, &sources).await? {
                     core.store
                         .close_pursuit(&pid, "satisfied", &format!("covered by {covering}"), now)
                         .await?;
@@ -777,6 +827,116 @@ mod tests {
         assert_eq!(lone.state, "unsatisfied", "{lone:?}");
         // The watermark moved; a second sweep finds nothing new.
         assert_eq!(run(&core).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn two_sittings_on_one_subject_are_two_pursuits() {
+        // `cluster` groups on the words, and the words do not say when. Without
+        // the split these two come back as one pursuit whose `opened_at` and
+        // `last_at` span the gap between them and whose engagement is summed
+        // across a session boundary.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let t0 = now - 10_000;
+        let gap = core.pursuit.idle_secs as i64 * 10;
+        search_event(&core, "read the journal", vec![1.0, 0.0], &[&ids[0]], t0).await;
+        search_event(
+            &core,
+            "read the journal again",
+            vec![1.0, 0.0],
+            &[&ids[0]],
+            t0 + gap,
+        )
+        .await;
+
+        assert_eq!(run(&core).await.unwrap(), 2, "one sitting each");
+        let ps = core.store.recent_pursuits(10).await.unwrap();
+        assert!(
+            ps.iter().all(|p| p.queries.len() == 1),
+            "a pursuit spans one sitting: {ps:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_sweep_never_reaches_further_back_than_its_lookback() {
+        // With no cursor the window would open at the epoch, and on a base that
+        // has been recording since it was installed that is every search ever
+        // taken — clustered quadratically, in one allocation.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        search_event(
+            &core,
+            "from another era",
+            vec![1.0, 0.0],
+            &[&ids[0]],
+            now - MAX_LOOKBACK_SECS - 60,
+        )
+        .await;
+        search_event(&core, "from today", vec![0.0, 1.0], &[&ids[0]], now - 100).await;
+
+        assert!(
+            core.store.meta_get(PURSUIT_AFTER).await.unwrap().is_none(),
+            "the fixture must start without a cursor"
+        );
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let ps = core.store.recent_pursuits(10).await.unwrap();
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].queries, vec!["from today".to_string()], "{ps:?}");
+    }
+
+    #[tokio::test]
+    async fn a_pursuit_that_earns_a_write_up_with_no_generator_is_closed_not_left_open() {
+        // `run_claimed` drops a `Generate` unit it cannot run, with a warning.
+        // Nothing then closes the pursuit, so it sits `open` with no reason on
+        // Ops, one more of it after every sweep, promising a call that is never
+        // coming.
+        let mut core = pursuing_core().await;
+        core.synthesizer = None;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let t0 = now - 100;
+        search_event(
+            &core,
+            "read the journal",
+            vec![1.0, 0.0],
+            &[&ids[0], &ids[1]],
+            t0,
+        )
+        .await;
+        search_event(
+            &core,
+            "journal location",
+            vec![0.99, 0.1],
+            &[&ids[1], &ids[0]],
+            t0 + 2,
+        )
+        .await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 1)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "pivoted", Some(&ids[0]), Some("me"), t0 + 3)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 4)
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+        let ps = core.store.recent_pursuits(10).await.unwrap();
+        let p = ps
+            .iter()
+            .find(|p| p.queries.iter().any(|q| q == "read the journal"))
+            .expect("the journal pursuit");
+        assert_eq!(p.state, "unsatisfied", "{p:?}");
+        assert!(
+            !core.store.live_job(Stage::Generate, &p.id).await.unwrap(),
+            "nothing to arm without a generator"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -131,6 +131,9 @@ pub struct Need {
     pub abstained: bool,
     /// Engagement weight per artifact, in first-engagement order.
     pub engagement: Vec<(String, f64)>,
+    /// Dwell weight per artifact, ≤ 0.5 each. A tiebreak for the order the
+    /// sources go into the prompt; never part of what decides.
+    pub dwell: Vec<(String, f64)>,
     pub pivots: usize,
     pub returns: usize,
     /// Something opened or confirmed was a strong hit — at or above
@@ -284,7 +287,23 @@ pub async fn run(core: &Core) -> Result<usize> {
         let mut members = members;
         members.sort_by_key(|&m| evs[m].at);
         let need = need_of(core, &evs, &members, &attached, &interactions);
-        let sources: Vec<String> = need.engagement.iter().map(|(id, _)| id.clone()).collect();
+        // Sources in the order they go to the model: engagement first, dwell
+        // breaking ties. Dwell moves an artifact up the list and nothing else.
+        let mut ranked: Vec<(String, f64)> = need
+            .engagement
+            .iter()
+            .map(|(id, w)| {
+                let d = need
+                    .dwell
+                    .iter()
+                    .find(|(x, _)| x == id)
+                    .map(|(_, v)| *v)
+                    .unwrap_or(0.0);
+                (id.clone(), w + d)
+            })
+            .collect();
+        ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+        let sources: Vec<String> = ranked.into_iter().map(|(id, _)| id).collect();
         let decision = decide(&need, core.pursuit.min_sources, core.pursuit.min_engagement);
         let pid = core
             .store
@@ -377,6 +396,21 @@ fn need_of(
             attached[m].iter().map(|&k| &interactions[k]).collect();
         if !e.answered {
             for i in &mine {
+                if i.kind == "dwell" {
+                    // ≤ 0.5 per artifact: a tenth per minute, capped. Tiebreak
+                    // only — see `Need::dwell`.
+                    let secs: f64 = i
+                        .detail
+                        .as_deref()
+                        .and_then(|d| d.parse().ok())
+                        .unwrap_or(0.0);
+                    let w = (secs / 600.0).min(0.5);
+                    match n.dwell.iter_mut().find(|(x, _)| x == &i.artifact_id) {
+                        Some(d) => d.1 = (d.1 + w).min(0.5),
+                        None => n.dwell.push((i.artifact_id.clone(), w)),
+                    }
+                    continue;
+                }
                 let w = if i.kind == "pivoted" {
                     n.pivots += 1;
                     1.5
@@ -401,7 +435,10 @@ fn need_of(
             }
         }
         let followed = pos + 1 < members.len();
-        if mine.is_empty() && e.confirmed.is_none() && !e.answered {
+        // Dwell alone is not engagement: a search whose only trace is time
+        // spent is still a search nothing was opened on.
+        let engaged = mine.iter().any(|i| i.kind != "dwell");
+        if !engaged && e.confirmed.is_none() && !e.answered {
             if followed {
                 n.refined += 1;
             } else {
@@ -812,5 +849,71 @@ mod tests {
             Some(crate::store::segments::SegmentState::Pending),
             "the window was not promoted"
         );
+    }
+
+    #[tokio::test]
+    async fn dwell_alone_never_crosses_min_engagement_but_orders_the_sources() {
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let t0 = now - 100;
+        // Nothing opened; long dwell on both. A search with only dwell is a
+        // search nothing was opened on: unsatisfied, not generated.
+        search_event(
+            &core,
+            "only looked",
+            vec![1.0, 0.0],
+            &[&ids[0], &ids[1]],
+            t0,
+        )
+        .await;
+        core.store
+            .record_dwell(&ids[0], 600, Some("me"), t0 + 1)
+            .await
+            .unwrap();
+        core.store
+            .record_dwell(&ids[1], 600, Some("me"), t0 + 2)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
+        assert_eq!(p.state, "unsatisfied", "{p:?}");
+
+        // Opened both equally, dwelt on the second: the second leads. A fresh
+        // core — the first sweep moved the watermark past these timestamps.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let t1 = now - 50;
+        search_event(&core, "read both", vec![0.0, 1.0], &[&ids[0], &ids[1]], t1).await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t1 + 1)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "opened", None, Some("me"), t1 + 2)
+            .await
+            .unwrap();
+        core.store
+            .record_dwell(&ids[1], 300, Some("me"), t1 + 3)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t1 + 4)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "opened", None, Some("me"), t1 + 5)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        let p = core
+            .store
+            .recent_pursuits(10)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.queries.iter().any(|q| q == "read both"))
+            .unwrap();
+        assert_eq!(p.sources[0], ids[1], "{p:?}");
     }
 }

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -62,8 +62,26 @@ pub async fn generate(core: &Core, pursuit_id: &str) -> Result<()> {
             .collect();
         let user = prompt::generate_prompt(&p.queries, &excerpts);
         let spent = system + core.counter.count(&user);
-        if spent + ceiling.min(window / 2) <= window || sources.len() <= core.pursuit.min_sources {
+        if spent + ceiling.min(window / 2) <= window {
             break user;
+        }
+        // Dropping the tail is what makes it fit, and `min_sources` is the
+        // floor below which a generation has too little to stand on. Reaching
+        // that floor still over budget is not a smaller prompt to try — it is
+        // a fact about how long these particular artifacts are. Sending it
+        // anyway spends a 400 and then `MAX_ATTEMPTS` more on byte-identical
+        // content, so the pursuit is closed here with the reason on it,
+        // the way `dedupe` refuses a pair that cannot fit one call.
+        if sources.len() <= core.pursuit.min_sources {
+            core.store
+                .close_pursuit(
+                    pursuit_id,
+                    "unsatisfied",
+                    "the fewest sources worth generating from do not fit one call",
+                    now,
+                )
+                .await?;
+            return Ok(());
         }
         sources.pop();
     };
@@ -463,11 +481,17 @@ async fn covered_by_existing(core: &Core, sources: &[String]) -> Result<Option<S
     if mine.is_empty() {
         return Ok(None);
     }
-    for g in core.store.synthesized_artifacts(200).await? {
-        let theirs = core.store.roots_of(std::slice::from_ref(&g.id)).await?;
-        let set: std::collections::BTreeSet<&String> = theirs.values().flatten().collect();
+    // One lineage read for the whole candidate set rather than one per
+    // candidate inside the loop: the answer is the same, and the walk stays a
+    // single awaited call however many generations are on the list.
+    let generated = core.store.synthesized_artifacts(200).await?;
+    let ids: Vec<String> = generated.iter().map(|g| g.id.clone()).collect();
+    let theirs = core.store.roots_of(&ids).await?;
+    for g in &generated {
+        let set: std::collections::BTreeSet<&String> =
+            theirs.get(&g.id).into_iter().flatten().collect();
         if mine.iter().all(|r| set.contains(r)) {
-            return Ok(Some(g.id));
+            return Ok(Some(g.id.clone()));
         }
     }
     Ok(None)

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -229,6 +229,8 @@ struct Ev {
     /// Ask only.
     is_ask: bool,
     abstained: bool,
+    /// The excerpts the *answer* referenced — never everything the ask packed
+    /// into its prompt. See `RecordedAsk::cited`.
     cited: Vec<String>,
 }
 
@@ -363,6 +365,16 @@ pub async fn run(core: &Core) -> Result<usize> {
             .store
             .insert_pursuit(need.opened_at, &need.queries, &sources)
             .await?;
+        // `insert_pursuit` is keyed on the cluster, so a sitting the previous
+        // sweep already reached comes back with the row it wrote. Only a
+        // pursuit still `open` is undecided — either brand new, or written by
+        // a sweep that failed between the insert and the decision. Anything
+        // closed, generated or dismissed has had its answer and must not be
+        // decided a second time: that is what would arm a second generation
+        // for one need, or re-open a pursuit the operator dismissed.
+        if core.store.get_pursuit(&pid).await?.state != "open" {
+            continue;
+        }
         written += 1;
         match decision {
             Decision::Satisfied(why) => {
@@ -450,6 +462,11 @@ fn need_of(
         n.answered |= e.answered;
         n.abstained |= e.abstained;
         if e.is_ask {
+            // A question that drew on an artifact engaged it as surely as
+            // opening it does. A question the model declined to answer drew on
+            // nothing and arrives here with an empty list — which is what
+            // keeps an abstention from being both the evidence that a need
+            // exists and the engagement that says it was pursued.
             for id in &e.cited {
                 bump(id, 1.0);
                 n.strong_engaged = true;
@@ -827,6 +844,165 @@ mod tests {
         assert_eq!(lone.state, "unsatisfied", "{lone:?}");
         // The watermark moved; a second sweep finds nothing new.
         assert_eq!(run(&core).await.unwrap(), 0);
+    }
+
+    /// Record a question at `at`, with `cited` naming each excerpt the model
+    /// was shown and whether the answer referenced it.
+    async fn ask_event(
+        core: &crate::core::Core,
+        q: &str,
+        vec: Vec<f32>,
+        cited: &[(&str, bool)],
+        abstained: bool,
+        at: i64,
+    ) -> String {
+        let id = core
+            .store
+            .record_ask(crate::store::asks::NewAsk {
+                question: q.into(),
+                scope: Some("me".into()),
+                filters: "{}".into(),
+                query_vec: vec,
+                embed_model: "fake".into(),
+                answer: "an answer".into(),
+                abstained,
+                dropped: 0,
+                truncated: false,
+                citations: cited
+                    .iter()
+                    .map(|(a, used)| crate::store::asks::NewAskCitation {
+                        artifact_id: a.to_string(),
+                        score: 0.9,
+                        used: *used,
+                    })
+                    .collect(),
+            })
+            .await
+            .unwrap();
+        sqlx::query("UPDATE ask_events SET created_at = ? WHERE id = ?")
+            .bind(at)
+            .bind(&id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn a_question_the_model_declined_does_not_pay_for_a_generation() {
+        // An ask packs whatever fits its window, so a question that retrieved
+        // three excerpts and then abstained was *shown* three artifacts. Score
+        // those as engagement and the abstention is both the evidence that a
+        // need exists and the engagement that says it was pursued: the base
+        // spends a call writing an artifact out of the very excerpts it has
+        // just declared insufficient.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let shown: Vec<(&str, bool)> = vec![(ids[0].as_str(), false), (ids[1].as_str(), false)];
+        ask_event(
+            &core,
+            "how do I read the journal",
+            vec![1.0, 0.0],
+            &shown,
+            true,
+            now - 100,
+        )
+        .await;
+
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
+        assert_eq!(p.state, "unsatisfied", "{p:?}");
+        assert!(
+            !core.store.live_job(Stage::Generate, &p.id).await.unwrap(),
+            "an unanswered question is a need, not an engagement"
+        );
+
+        // The same question, answered out of the same two excerpts: the
+        // engagement is real and the pursuit is worth a call.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let used: Vec<(&str, bool)> = vec![(ids[0].as_str(), true), (ids[1].as_str(), true)];
+        ask_event(
+            &core,
+            "how do I read it",
+            vec![1.0, 0.0],
+            &used,
+            false,
+            now - 100,
+        )
+        .await;
+        search_event(
+            &core,
+            "journal location",
+            vec![0.99, 0.1],
+            &[&ids[0]],
+            now - 98,
+        )
+        .await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), now - 97)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "pivoted", Some(&ids[0]), Some("me"), now - 96)
+            .await
+            .unwrap();
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
+        assert_eq!(p.state, "open", "{p:?}");
+        assert!(core.store.live_job(Stage::Generate, &p.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_failed_before_its_cursor_moved_writes_no_second_copy() {
+        // The cursor advances once, after the loop. Anything that fails inside
+        // it — a locked database on the fourth cluster — leaves the pursuits
+        // already written under a cursor that never moved, and the retry reads
+        // the same events and clusters them the same way. The pursuit's
+        // identity is the sitting, so the second pass finds its own rows.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let t0 = now - 100;
+        search_event(&core, "read the journal", vec![1.0, 0.0], &[&ids[0]], t0).await;
+        search_event(
+            &core,
+            "journal location",
+            vec![0.99, 0.1],
+            &[&ids[1]],
+            t0 + 2,
+        )
+        .await;
+        search_event(&core, "something else", vec![0.0, 1.0], &[&ids[0]], t0 + 50).await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 1)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "pivoted", Some(&ids[0]), Some("me"), t0 + 3)
+            .await
+            .unwrap();
+
+        let first = run(&core).await.unwrap();
+        let before = core.store.recent_pursuits(50).await.unwrap();
+        assert_eq!(before.len(), first);
+
+        // The cursor back where the failed sweep left it.
+        core.store.meta_set(PURSUIT_AFTER, "0").await.unwrap();
+        run(&core).await.unwrap();
+
+        let after = core.store.recent_pursuits(50).await.unwrap();
+        assert_eq!(
+            after.len(),
+            before.len(),
+            "the same sitting was written twice: {after:?}"
+        );
+        let mut ids_before: Vec<&str> = before.iter().map(|p| p.id.as_str()).collect();
+        let mut ids_after: Vec<&str> = after.iter().map(|p| p.id.as_str()).collect();
+        ids_before.sort_unstable();
+        ids_after.sort_unstable();
+        assert_eq!(ids_before, ids_after);
     }
 
     #[tokio::test]

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -115,9 +115,325 @@ pub async fn generate(core: &Core, pursuit_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Placeholder until the sweep lands in the next task.
-pub async fn run(_core: &Core) -> Result<usize> {
-    Ok(0)
+/// Cursor: the moment everything up to which has been grouped into pursuits.
+pub const PURSUIT_AFTER: &str = "pursuit.events_after";
+
+/// One clustered pursuit before a decision: what was asked, and what was done
+/// with the results.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Need {
+    pub queries: Vec<String>,
+    pub opened_at: i64,
+    pub last_at: i64,
+    /// A synthesized artifact led one of the lists above `weak_below`.
+    pub answered: bool,
+    /// A question was answered "not in the knowledge base".
+    pub abstained: bool,
+    /// Engagement weight per artifact, in first-engagement order.
+    pub engagement: Vec<(String, f64)>,
+    pub pivots: usize,
+    pub returns: usize,
+    /// Something opened or confirmed was a strong hit — at or above
+    /// `weak_below` — or a question cited it.
+    pub strong_engaged: bool,
+    /// Searches with nothing opened that were followed by another search.
+    pub refined: usize,
+    /// The last search opened nothing and nothing followed it.
+    pub abandoned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    Satisfied(String),
+    Unsatisfied(String),
+    /// One engaged artifact: its window, not a generation.
+    Promote(String),
+    Generate,
+}
+
+/// The analysis pass, in the spec's order. Pure: every input is in `Need`.
+pub fn decide(n: &Need, min_sources: usize, min_engagement: f64) -> Decision {
+    if n.answered {
+        return Decision::Satisfied("a synthesized artifact led the list".into());
+    }
+    let total: f64 = n.engagement.iter().map(|(_, w)| *w).sum();
+    let unsatisfied = !n.strong_engaged || n.refined >= 2 || n.abandoned || n.abstained;
+    if n.engagement.len() < min_sources {
+        if n.engagement.len() == 1 {
+            return Decision::Promote(n.engagement[0].0.clone());
+        }
+        return if unsatisfied {
+            Decision::Unsatisfied("nothing engaged".into())
+        } else {
+            Decision::Satisfied("nothing to assemble".into())
+        };
+    }
+    let assembled = total >= min_engagement;
+    let wanted = n.pivots + n.returns > 0;
+    if assembled && (unsatisfied || wanted) {
+        return Decision::Generate;
+    }
+    if unsatisfied {
+        Decision::Unsatisfied(format!("engaged {total:.1} below min_engagement"))
+    } else {
+        Decision::Satisfied("a strong hit was opened and searching stopped".into())
+    }
+}
+
+/// One event of either kind, as the sweep clusters it.
+struct Ev {
+    at: i64,
+    scope: Option<String>,
+    query: String,
+    vec: Vec<f32>,
+    /// Search only.
+    answered: bool,
+    confirmed: Option<String>,
+    shown: Vec<(String, Option<f32>)>,
+    /// Ask only.
+    is_ask: bool,
+    abstained: bool,
+    cited: Vec<String>,
+}
+
+/// Group quiet searches into pursuits and decide each. Returns how many
+/// pursuit rows were written.
+///
+/// Runs only when everything unprocessed has been idle for `idle_secs`: a
+/// pursuit is a thing that ended, and the cheapest correct idle rule is to
+/// wait until the operator stopped. Local throughout — the only model call is
+/// the one `Generate` makes later, and only for a pursuit that earned it.
+pub async fn run(core: &Core) -> Result<usize> {
+    if !core.pursuit.enabled || !core.associating() {
+        return Ok(0);
+    }
+    let now = crate::store::now();
+    let idle = core.pursuit.idle_secs as i64;
+    let after: i64 = core
+        .store
+        .meta_get(PURSUIT_AFTER)
+        .await?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    if let Some(newest) = core.store.newest_event_at().await?
+        && newest > after
+        && now - newest < idle
+    {
+        return Ok(0);
+    }
+    let searches = core.store.events_between(after, now).await?;
+    let asks = core.store.asks_between(after, now).await?;
+    if searches.is_empty() && asks.is_empty() {
+        return Ok(0);
+    }
+    let interactions = core.store.interactions_between(after, now).await?;
+
+    let mut evs: Vec<Ev> = searches
+        .into_iter()
+        .map(|e| Ev {
+            at: e.created_at,
+            scope: e.scope,
+            query: e.query,
+            vec: e.query_vec,
+            answered: e.answered,
+            confirmed: e.confirmed,
+            shown: e.shown,
+            is_ask: false,
+            abstained: false,
+            cited: vec![],
+        })
+        .chain(asks.into_iter().map(|a| Ev {
+            at: a.created_at,
+            scope: a.scope,
+            query: a.question,
+            vec: a.query_vec,
+            answered: false,
+            confirmed: None,
+            shown: vec![],
+            is_ask: true,
+            abstained: a.abstained,
+            cited: a.cited,
+        }))
+        .filter(|e| !e.vec.is_empty())
+        .collect();
+    evs.sort_by_key(|e| e.at);
+
+    // An interaction belongs to the latest event before it, in the same scope,
+    // within the idle window. Never to an answered search: the base answered,
+    // and what was opened afterwards is not a need.
+    let mut attached: Vec<Vec<usize>> = vec![Vec::new(); evs.len()];
+    for (k, i) in interactions.iter().enumerate() {
+        let owner = evs
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.at <= i.at && i.at - e.at <= idle && e.scope == i.scope)
+            .max_by_key(|(_, e)| e.at)
+            .map(|(idx, _)| idx);
+        if let Some(idx) = owner {
+            attached[idx].push(k);
+        }
+    }
+
+    let vecs: Vec<Vec<f32>> = evs.iter().map(|e| e.vec.clone()).collect();
+    let line = crate::core::gaps::link_threshold(&vecs);
+    let refs: Vec<&[f32]> = vecs.iter().map(Vec::as_slice).collect();
+    let clusters = crate::core::gaps::cluster(&refs, line);
+
+    let mut written = 0;
+    for members in clusters {
+        let mut members = members;
+        members.sort_by_key(|&m| evs[m].at);
+        let need = need_of(core, &evs, &members, &attached, &interactions);
+        let sources: Vec<String> = need.engagement.iter().map(|(id, _)| id.clone()).collect();
+        let decision = decide(&need, core.pursuit.min_sources, core.pursuit.min_engagement);
+        let pid = core
+            .store
+            .insert_pursuit(need.opened_at, &need.queries, &sources)
+            .await?;
+        written += 1;
+        match decision {
+            Decision::Satisfied(why) => {
+                core.store
+                    .close_pursuit(&pid, "satisfied", &why, now)
+                    .await?;
+            }
+            Decision::Unsatisfied(why) => {
+                core.store
+                    .close_pursuit(&pid, "unsatisfied", &why, now)
+                    .await?;
+            }
+            Decision::Promote(id) => {
+                core.store
+                    .close_pursuit(
+                        &pid,
+                        "satisfied",
+                        "one artifact engaged: a promotion case",
+                        now,
+                    )
+                    .await?;
+                crate::jobs::promote::maybe_promote(core, std::slice::from_ref(&id), now).await?;
+            }
+            Decision::Generate => {
+                if let Some(covering) = covered_by_existing(core, &sources).await? {
+                    core.store
+                        .close_pursuit(&pid, "satisfied", &format!("covered by {covering}"), now)
+                        .await?;
+                } else {
+                    core.store
+                        .rearm_idle_seq(Stage::Generate, "pursuit", &pid, 0)
+                        .await?;
+                }
+            }
+        }
+    }
+    core.store.meta_set(PURSUIT_AFTER, &now.to_string()).await?;
+    tracing::info!(pursuits = written, line, "pursuit sweep");
+    Ok(written)
+}
+
+/// Score one cluster.
+fn need_of(
+    core: &Core,
+    evs: &[Ev],
+    members: &[usize],
+    attached: &[Vec<usize>],
+    interactions: &[crate::store::pursuits::Interaction],
+) -> Need {
+    use crate::store::links::normalize_query;
+    let mut n = Need {
+        opened_at: evs[members[0]].at,
+        last_at: evs[*members.last().unwrap()].at,
+        ..Default::default()
+    };
+    let mut seen_q: std::collections::HashSet<String> = Default::default();
+    let mut order: Vec<String> = Vec::new();
+    let mut weight: std::collections::HashMap<String, f64> = Default::default();
+    let mut bump = |id: &str, w: f64| {
+        if !weight.contains_key(id) {
+            order.push(id.to_string());
+        }
+        *weight.entry(id.to_string()).or_insert(0.0) += w;
+    };
+    let mut touched: Vec<String> = Vec::new();
+    for (pos, &m) in members.iter().enumerate() {
+        let e = &evs[m];
+        if seen_q.insert(normalize_query(&e.query)) {
+            n.queries.push(e.query.clone());
+        }
+        n.answered |= e.answered;
+        n.abstained |= e.abstained;
+        if e.is_ask {
+            for id in &e.cited {
+                bump(id, 1.0);
+                n.strong_engaged = true;
+            }
+            continue;
+        }
+        if let Some(id) = &e.confirmed {
+            bump(id, 3.0);
+            n.strong_engaged = true;
+        }
+        let mine: Vec<&crate::store::pursuits::Interaction> =
+            attached[m].iter().map(|&k| &interactions[k]).collect();
+        if !e.answered {
+            for i in &mine {
+                let w = if i.kind == "pivoted" {
+                    n.pivots += 1;
+                    1.5
+                } else {
+                    1.0
+                };
+                bump(&i.artifact_id, w);
+                // Came back to it after something else: hard to fake.
+                if touched.last().is_some_and(|t| t != &i.artifact_id)
+                    && touched.contains(&i.artifact_id)
+                {
+                    bump(&i.artifact_id, 2.0);
+                    n.returns += 1;
+                }
+                touched.push(i.artifact_id.clone());
+                let strong = e
+                    .shown
+                    .iter()
+                    .find(|(id, _)| id == &i.artifact_id)
+                    .is_some_and(|(_, sim)| sim.is_none_or(|s| s >= core.weak_below));
+                n.strong_engaged |= strong;
+            }
+        }
+        let followed = pos + 1 < members.len();
+        if mine.is_empty() && e.confirmed.is_none() && !e.answered {
+            if followed {
+                n.refined += 1;
+            } else {
+                n.abandoned = true;
+            }
+        }
+    }
+    n.engagement = order
+        .into_iter()
+        .map(|id| (weight[&id], id))
+        .map(|(w, id)| (id, w))
+        .collect();
+    n
+}
+
+/// The second anchor: are these sources' roots all inside an existing active
+/// generation's roots? Then the need is already written up, whatever the
+/// ranking did with it.
+async fn covered_by_existing(core: &Core, sources: &[String]) -> Result<Option<String>> {
+    let roots = core.store.roots_of(sources).await?;
+    let mine: std::collections::BTreeSet<String> = roots.values().flatten().cloned().collect();
+    if mine.is_empty() {
+        return Ok(None);
+    }
+    for g in core.store.synthesized_artifacts(200).await? {
+        let theirs = core.store.roots_of(std::slice::from_ref(&g.id)).await?;
+        let set: std::collections::BTreeSet<&String> = theirs.values().flatten().collect();
+        if mine.iter().all(|r| set.contains(r)) {
+            return Ok(Some(g.id));
+        }
+    }
+    Ok(None)
 }
 
 #[cfg(test)]
@@ -231,6 +547,270 @@ mod tests {
                 .any(|f| f == crate::infer::verify::FLAG_LITERALS),
             "{:?}",
             g.flags
+        );
+    }
+
+    fn need(engaged: &[(&str, f64)]) -> Need {
+        Need {
+            queries: vec!["q".into()],
+            engagement: engaged.iter().map(|(i, w)| (i.to_string(), *w)).collect(),
+            strong_engaged: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn the_decision_table_follows_the_spec() {
+        // Answered: nothing else matters.
+        let mut n = need(&[("a", 5.0), ("b", 5.0)]);
+        n.answered = true;
+        assert!(matches!(decide(&n, 2, 3.0), Decision::Satisfied(_)));
+        // One engaged artifact: promotion, not generation.
+        assert_eq!(
+            decide(&need(&[("a", 9.0)]), 2, 3.0),
+            Decision::Promote("a".into())
+        );
+        // Three strong opens in a row, then stopped: reading, not assembling.
+        assert!(matches!(
+            decide(&need(&[("a", 1.0), ("b", 1.0), ("c", 1.0)]), 2, 3.0),
+            Decision::Satisfied(_)
+        ));
+        // The same three with one return: assembled.
+        let mut n = need(&[("a", 3.0), ("b", 1.0), ("c", 1.0)]);
+        n.returns = 1;
+        assert_eq!(decide(&n, 2, 3.0), Decision::Generate);
+        // Two weak opens totalling 2.0: unsatisfied but not worth a call.
+        let mut n = need(&[("a", 1.0), ("b", 1.0)]);
+        n.strong_engaged = false;
+        assert!(matches!(decide(&n, 2, 3.0), Decision::Unsatisfied(_)));
+        // Two weak opens totalling 3.0: generate.
+        let mut n = need(&[("a", 1.5), ("b", 1.5)]);
+        n.strong_engaged = false;
+        assert_eq!(decide(&n, 2, 3.0), Decision::Generate);
+        // An abstention with two cited sources: generate.
+        let mut n = need(&[("a", 2.0), ("b", 1.0)]);
+        n.abstained = true;
+        assert_eq!(decide(&n, 2, 3.0), Decision::Generate);
+        // Refined twice, assembled: generate.
+        let mut n = need(&[("a", 2.0), ("b", 1.0)]);
+        n.refined = 2;
+        assert_eq!(decide(&n, 2, 3.0), Decision::Generate);
+        // Nothing engaged and abandoned: unsatisfied.
+        let mut n = need(&[]);
+        n.strong_engaged = false;
+        n.abandoned = true;
+        assert!(matches!(decide(&n, 2, 3.0), Decision::Unsatisfied(_)));
+    }
+
+    /// A core at earned with pursuits on, recording, and a tiny idle window.
+    async fn pursuing_core() -> crate::core::Core {
+        let mut core = test_core().await;
+        core.synthesis = crate::config::SynthesisMode::Earned;
+        core.feedback.enabled = true;
+        core.pursuit.enabled = true;
+        core.pursuit.idle_secs = 10;
+        core
+    }
+
+    async fn search_event(
+        core: &crate::core::Core,
+        q: &str,
+        vec: Vec<f32>,
+        shown: &[&str],
+        at: i64,
+    ) -> String {
+        let id = core
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: q.into(),
+                    door: crate::store::feedback::Door::Ui,
+                    scope: Some("me".into()),
+                    filters: "{}".into(),
+                    query_vec: vec,
+                    embed_model: "fake".into(),
+                    candidates: shown
+                        .iter()
+                        .enumerate()
+                        .map(|(i, a)| crate::store::feedback::NewCandidate {
+                            artifact_id: a.to_string(),
+                            score: 1.0 - i as f32 * 0.1,
+                            similarity: Some(0.9),
+                            shown: true,
+                        })
+                        .collect(),
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        // Back-date it: `record_search` stamps now, and the sweep wants quiet.
+        sqlx::query("UPDATE search_events SET created_at = ? WHERE id = ?")
+            .bind(at)
+            .bind(&id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn the_sweep_groups_quiet_searches_into_pursuits_and_arms_a_generation() {
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let t0 = now - 100;
+        // Two unrelated needs: one assembled by pivoting between two sources,
+        // one a single search with nothing opened.
+        search_event(
+            &core,
+            "read the journal",
+            vec![1.0, 0.0],
+            &[&ids[0], &ids[1]],
+            t0,
+        )
+        .await;
+        search_event(
+            &core,
+            "journal location",
+            vec![0.99, 0.1],
+            &[&ids[1], &ids[0]],
+            t0 + 2,
+        )
+        .await;
+        search_event(&core, "something else", vec![0.0, 1.0], &[&ids[0]], t0 + 50).await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 1)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "pivoted", Some(&ids[0]), Some("me"), t0 + 3)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 4)
+            .await
+            .unwrap();
+
+        let written = run(&core).await.unwrap();
+        assert_eq!(written, 2);
+        let ps = core.store.recent_pursuits(10).await.unwrap();
+        let assembled = ps
+            .iter()
+            .find(|p| p.queries.iter().any(|q| q == "read the journal"))
+            .expect("the journal pursuit");
+        assert_eq!(assembled.state, "open", "{assembled:?}");
+        assert_eq!(assembled.queries.len(), 2, "{assembled:?}");
+        assert_eq!(assembled.sources, ids, "{assembled:?}");
+        assert!(
+            core.store
+                .live_job(Stage::Generate, &assembled.id)
+                .await
+                .unwrap()
+        );
+        let lone = ps
+            .iter()
+            .find(|p| p.queries.iter().any(|q| q == "something else"))
+            .expect("the lone pursuit");
+        assert_eq!(lone.state, "unsatisfied", "{lone:?}");
+        // The watermark moved; a second sweep finds nothing new.
+        assert_eq!(run(&core).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn the_sweep_waits_while_the_operator_is_still_searching() {
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        search_event(&core, "fresh", vec![1.0, 0.0], &[&ids[0]], now).await;
+        assert_eq!(run(&core).await.unwrap(), 0);
+        assert!(core.store.recent_pursuits(10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_need_already_written_up_closes_satisfied_naming_the_generation() {
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let existing = core
+            .store
+            .insert_synthesized_artifact(
+                &NewSynthesized {
+                    text: "already written".into(),
+                    title: Some("G".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec![],
+                },
+                &ids,
+            )
+            .await
+            .unwrap();
+        let now = crate::store::now();
+        let t0 = now - 100;
+        search_event(
+            &core,
+            "read the journal",
+            vec![1.0, 0.0],
+            &[&ids[0], &ids[1]],
+            t0,
+        )
+        .await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 1)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "pivoted", Some(&ids[0]), Some("me"), t0 + 2)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), t0 + 3)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
+        assert_eq!(p.state, "satisfied", "{p:?}");
+        assert!(
+            p.reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains(&existing.id),
+            "{p:?}"
+        );
+        assert!(!core.store.live_job(Stage::Generate, &p.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn one_engaged_artifact_is_a_promotion_case() {
+        let core = pursuing_core().await;
+        let out = core
+            .ingest("a verbatim passage", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::passages::capture_verbatim(&core, &out.id)
+            .await
+            .unwrap();
+        let p = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+        let now = crate::store::now();
+        // Enough activation that the promotion check passes when the sweep asks.
+        core.store
+            .bump_activation(std::slice::from_ref(&p), 5.0, 14.0, now)
+            .await
+            .unwrap();
+        search_event(&core, "that passage", vec![1.0, 0.0], &[&p], now - 100).await;
+        core.store
+            .record_interaction(&p, "opened", None, Some("me"), now - 99)
+            .await
+            .unwrap();
+        run(&core).await.unwrap();
+        assert_eq!(
+            core.store.segment_state(&out.id, 0).await.unwrap(),
+            Some(crate::store::segments::SegmentState::Pending),
+            "the window was not promoted"
         );
     }
 }

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -1,0 +1,236 @@
+//! Pursuits: a coherent run of searches, what was engaged with, and — when the
+//! base did not answer or the answer was assembled by hand — the one artifact
+//! that earns.
+//!
+//! Local decides, the model only writes. The sweep (`run`) groups quiet
+//! searches by their stored vectors, scores engagement, and arms `Generate`
+//! for a pursuit that earned it; `generate` makes the one call.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::infer::prompt;
+use crate::store::artifacts::NewSynthesized;
+use crate::store::jobs::Stage;
+
+/// Write the artifact a pursuit earned. One call; supersedes nothing.
+///
+/// Idempotent: a pursuit that is no longer `open`, or already names an
+/// artifact, is left alone — a retry after a crash between the insert and the
+/// pursuit update must not write twice.
+pub async fn generate(core: &Core, pursuit_id: &str) -> Result<()> {
+    let p = core.store.get_pursuit(pursuit_id).await?;
+    if p.state != "open" || p.artifact_id.is_some() {
+        return Ok(());
+    }
+    let Some(generator) = core.generator.clone() else {
+        return Ok(());
+    };
+    let now = crate::store::now();
+
+    // The engaged artifacts, whatever their provenance — a generated artifact
+    // the operator pivoted through contributes its own text, unresolved. In
+    // engagement order, the way the sweep stored them.
+    let rows = core.store.artifacts_by_ids(&p.sources).await?;
+    let mut sources: Vec<crate::store::artifacts::Chunk> = p
+        .sources
+        .iter()
+        .filter_map(|id| rows.iter().find(|c| &c.id == id).cloned())
+        .filter(|c| c.in_results())
+        .collect();
+    if sources.len() < core.pursuit.min_sources {
+        core.store
+            .close_pursuit(
+                pursuit_id,
+                "unsatisfied",
+                "sources gone before generation",
+                now,
+            )
+            .await?;
+        return Ok(());
+    }
+
+    // Packed to the window the way the dedupe judge packs: the questions and
+    // the system prompt always go out; sources are dropped from the tail when
+    // they would not fit.
+    let window = generator.context_tokens();
+    let ceiling = generator.max_output_tokens();
+    let system = core.counter.count(prompt::GENERATE_SYSTEM);
+    let user = loop {
+        let excerpts: Vec<(String, String)> = sources
+            .iter()
+            .map(|c| (c.title.clone().unwrap_or_default(), c.text.clone()))
+            .collect();
+        let user = prompt::generate_prompt(&p.queries, &excerpts);
+        let spent = system + core.counter.count(&user);
+        if spent + ceiling.min(window / 2) <= window || sources.len() <= core.pursuit.min_sources {
+            break user;
+        }
+        sources.pop();
+    };
+    let source_text: String = sources
+        .iter()
+        .map(|c| c.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let permit = core.gate.background().await;
+    let reply = generator.complete(prompt::GENERATE_SYSTEM, &user).await;
+    permit.finished();
+    let g = prompt::parse_generation(&reply?)?;
+
+    let ids: Vec<String> = sources.iter().map(|c| c.id.clone()).collect();
+    let made = core
+        .store
+        .insert_synthesized_artifact(
+            &NewSynthesized {
+                text: g.text,
+                title: Some(g.title),
+                category: g.category,
+                tags: g.tags,
+                caveats: g.caveats,
+                cues: p.queries.clone(),
+            },
+            &ids,
+        )
+        .await?;
+    // Drift is caught rather than prevented: a literal in the generated text
+    // that no source carries is flagged for whoever reads it.
+    let missing = crate::infer::verify::missing_literals(&made.text, &made.caveats, &source_text);
+    if let Some(first) = missing.first() {
+        core.store
+            .set_artifact_flags(
+                &made.id,
+                &[crate::infer::verify::FLAG_LITERALS.to_string()],
+                Some(&format!("missing literal: {first}")),
+            )
+            .await?;
+    }
+    core.store
+        .enqueue(Stage::Embed, "artifact", &made.id)
+        .await?;
+    core.store
+        .set_pursuit_artifact(pursuit_id, &made.id, now)
+        .await?;
+    tracing::info!(pursuit = pursuit_id, artifact_id = %made.id, sources = ids.len(), "generated an artifact from a pursuit");
+    Ok(())
+}
+
+/// Placeholder until the sweep lands in the next task.
+pub async fn run(_core: &Core) -> Result<usize> {
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::test_support::test_core;
+    use crate::store::artifacts::{NewArtifact, Provenance};
+
+    #[test]
+    fn a_generation_reply_parses_and_an_empty_one_does_not() {
+        let g = prompt::parse_generation(
+            r#"{"artifact":{"title":"T","text":"run `mount -o ro`","category":"procedure","tags":["x"],"caveats":["read-only"]}}"#,
+        )
+        .unwrap();
+        assert_eq!(g.title, "T");
+        assert_eq!(g.caveats, vec!["read-only".to_string()]);
+        assert!(prompt::parse_generation(r#"{"artifact":{"title":"T","text":"  "}}"#).is_err());
+        assert!(prompt::parse_generation("not json").is_err());
+    }
+
+    async fn two_sources(core: &crate::core::Core) -> Vec<String> {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let na = |o: i64, t: &str| NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: None,
+            title: Some(format!("S{o}")),
+            category: None,
+            tags: vec![],
+            segment_idx: None,
+            caveats: vec![],
+        };
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    na(0, "mount the image with `mount -o ro,loop`"),
+                    na(1, "then read the journal at /var/log/journal"),
+                ],
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_pursuit_is_written_up_once_with_cues_lineage_and_an_embed() {
+        let mut core = test_core().await;
+        core.generator = Some(std::sync::Arc::new(
+            crate::infer::fake::ScriptedCompleter::new(vec![
+                r#"{"artifact":{"title":"Reading a journal","text":"Mount with `mount -o ro,loop`, then read /var/log/journal.","category":"procedure","tags":[],"caveats":[]}}"#.into(),
+            ]),
+        ));
+        let ids = two_sources(&core).await;
+        let pid = core
+            .store
+            .insert_pursuit(100, &["how do I read the journal".into()], &ids)
+            .await
+            .unwrap();
+
+        generate(&core, &pid).await.unwrap();
+        generate(&core, &pid).await.unwrap();
+
+        let made = core.store.synthesized_artifacts(10).await.unwrap();
+        assert_eq!(made.len(), 1, "generated twice");
+        let g = &made[0];
+        assert_eq!(g.provenance, Provenance::Synthesized);
+        assert_eq!(g.cues, vec!["how do I read the journal".to_string()]);
+        assert!(g.flags.is_empty(), "{:?}", g.flags);
+        let roots = core
+            .store
+            .roots_of(std::slice::from_ref(&g.id))
+            .await
+            .unwrap();
+        let mut got = roots[&g.id].clone();
+        got.sort();
+        let mut want = ids.clone();
+        want.sort();
+        assert_eq!(got, want);
+        assert!(core.store.live_job(Stage::Embed, &g.id).await.unwrap());
+        let p = core.store.get_pursuit(&pid).await.unwrap();
+        assert_eq!(p.state, "generated");
+        assert_eq!(p.artifact_id.as_deref(), Some(g.id.as_str()));
+        // Its sources stay active: nothing was superseded.
+        for id in &ids {
+            assert!(core.store.get_artifact(id).await.unwrap().in_results());
+        }
+    }
+
+    #[tokio::test]
+    async fn a_literal_no_source_carries_is_flagged() {
+        let mut core = test_core().await;
+        core.generator = Some(std::sync::Arc::new(
+            crate::infer::fake::ScriptedCompleter::new(vec![
+                r#"{"artifact":{"title":"T","text":"Run `wipefs --all /dev/sdX` first.","category":"procedure","tags":[],"caveats":[]}}"#.into(),
+            ]),
+        ));
+        let ids = two_sources(&core).await;
+        let pid = core
+            .store
+            .insert_pursuit(100, &["q".into()], &ids)
+            .await
+            .unwrap();
+        generate(&core, &pid).await.unwrap();
+        let g = &core.store.synthesized_artifacts(10).await.unwrap()[0];
+        assert!(
+            g.flags
+                .iter()
+                .any(|f| f == crate::infer::verify::FLAG_LITERALS),
+            "{:?}",
+            g.flags
+        );
+    }
+}

--- a/src/jobs/reconcile.rs
+++ b/src/jobs/reconcile.rs
@@ -38,9 +38,11 @@ pub async fn run(core: &Core) -> Result<usize> {
             // the case. Capture arms the planning job; this sweep is for work
             // that started and stopped.
             let segments = core.store.segments_for_corpus(&c.id).await?;
+            // `verbatim` is not unresolved: it is the decided state of a window
+            // at `off`, and arming it would synthesize through the back door.
             let unresolved: Vec<_> = segments
                 .iter()
-                .filter(|w| w.state != SegmentState::Done)
+                .filter(|w| w.state != SegmentState::Done && w.state != SegmentState::Verbatim)
                 .collect();
             if !unresolved.is_empty() {
                 // Windows exist but their units may not: a process killed
@@ -427,6 +429,29 @@ mod tests {
         assert!(
             core.store.claim_job().await.unwrap().is_none(),
             "the sweep queued the same work twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_sweep_arms_nothing_for_a_verbatim_corpus() {
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .upsert_segments(&src.id, &[seg(1, 10, "the window")])
+            .await
+            .unwrap();
+        core.store.mark_segments_verbatim(&src.id).await.unwrap();
+        let armed = run(&core).await.unwrap();
+        assert_eq!(armed, 0);
+        assert!(
+            !core
+                .store
+                .live_job(
+                    Stage::SegmentWindow,
+                    &crate::jobs::window::unit_target(&src.id, 0)
+                )
+                .await
+                .unwrap()
         );
     }
 }

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -36,6 +36,11 @@ pub async fn arm(core: &Core, artifact_id: &str, seq: i64) -> Result<()> {
 
 pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
     let me = core.store.get_artifact(artifact_id).await?;
+    // A passage is not anchored: see `embed::mark_indexed`. Said here too, so a
+    // unit armed some other way files nothing.
+    if me.provenance == crate::store::artifacts::Provenance::Passage {
+        return Ok(());
+    }
     // A retired artifact has no duplicates worth recording. Every pair naming
     // it would be skipped by `classify_pair` anyway, so this saves the query
     // rather than changing the outcome.

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -19,7 +19,7 @@
 
 use crate::core::Core;
 use crate::error::Result;
-use crate::store::artifacts::Chunk;
+use crate::store::artifacts::{Chunk, Provenance};
 use crate::store::jobs::Stage;
 use crate::store::pairs::PairState;
 
@@ -38,7 +38,7 @@ pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
     let me = core.store.get_artifact(artifact_id).await?;
     // A passage is not anchored: see `embed::mark_indexed`. Said here too, so a
     // unit armed some other way files nothing.
-    if me.provenance == crate::store::artifacts::Provenance::Passage {
+    if me.provenance == Provenance::Passage {
         return Ok(());
     }
     // A retired artifact has no duplicates worth recording. Every pair naming
@@ -135,10 +135,18 @@ async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<
     // job's decision — the majority rule — already made. Sending that pair to
     // the judge would spend a call to merge, and so hide behind model text,
     // exactly the verbatim passage promotion just decided to keep.
+    //
+    // Both of those cases have a passage on at least one side, which is what
+    // the last clause asks. Two *written* rows from one window are the case
+    // neither reason covers: one synthesis call emitting the same passage
+    // twice is a defect in its output, not a decision anything made, and
+    // excluding it would leave the containment rule below unable to reach the
+    // very case it was written for. So model-written pairs fall through.
     if a.corpus_id.is_some()
         && a.corpus_id == b.corpus_id
         && a.segment_idx.is_some()
         && a.segment_idx == b.segment_idx
+        && (a.provenance == Provenance::Passage || b.provenance == Provenance::Passage)
     {
         return Ok(false);
     }
@@ -149,10 +157,12 @@ async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<
     // `pairs_to_judge` orders by score and so asks about it first.
 
     // One synthesis call emitting the same passage twice: the shorter text is
-    // wholly inside the longer, and both came out of the same document. That is
-    // a defect in one artifact rather than two sources saying different things,
-    // and nothing is lost by hiding it — the survivor says everything it said,
-    // Ops lists it, and one press undoes it.
+    // wholly inside the longer, and both came out of the same document — the
+    // same window of it, when the call repeated itself inside one window, which
+    // is why the exclusion above lets a written pair through. That is a defect
+    // in one artifact rather than two sources saying different things, and
+    // nothing is lost by hiding it — the survivor says everything it said, Ops
+    // lists it, and one press undoes it.
     //
     // Same corpus is the whole of the condition. Two documents that share a
     // sentence are two sources, and hiding one of those on a 0.9 similarity is
@@ -222,6 +232,21 @@ async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<
             }
             return Ok(false);
         }
+    }
+
+    // The other half of the same-window rule. A written pair from one window
+    // was let through above so containment could reach it; containment did not
+    // fire, so what is left is two rows that merely resemble each other — and
+    // resemblance inside one window is what the rule at the top calls a fact
+    // about how they were built. Filing it would put the window job's own
+    // output in front of the judge as a merge candidate, which is the cost the
+    // exclusion exists to avoid. Containment is the whole of what gets through.
+    if a.corpus_id.is_some()
+        && a.corpus_id == b.corpus_id
+        && a.segment_idx.is_some()
+        && a.segment_idx == b.segment_idx
+    {
+        return Ok(false);
     }
 
     // Everything else is a question for the dedupe pass.
@@ -506,7 +531,8 @@ mod tests {
     async fn two_rows_from_one_window_are_never_a_pair() {
         // A promoted artifact and the passage it left standing in the same
         // window look like a duplicate pair and are not one: overlap inside a
-        // window is the window job's decision, already made.
+        // window is the window job's decision, already made. A passage on
+        // either side is what marks that case, and what this pins.
         let core = test_core().await;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let na = |o: i64, t: &str, seg: i64| crate::store::artifacts::NewArtifact {
@@ -519,17 +545,22 @@ mod tests {
             segment_idx: Some(seg),
             caveats: vec![],
         };
-        let same = core
+        // One written row and the verbatim passage beside it, in one window.
+        let written = core
             .store
-            .insert_artifacts(
+            .insert_artifacts(&src.id, &[na(0, "mount the disk first", 0)])
+            .await
+            .unwrap();
+        let passage = core
+            .store
+            .insert_artifacts_with_provenance(
                 &src.id,
-                &[
-                    na(0, "mount the disk first", 0),
-                    na(1, "mount the disk first", 0),
-                ],
+                &[na(1, "mount the disk first", 0)],
+                Provenance::Passage,
             )
             .await
             .unwrap();
+        let same: Vec<_> = written.iter().chain(passage.iter()).cloned().collect();
         let other = core
             .store
             .insert_artifacts(&src.id, &[na(2, "mount the disk first", 1)])
@@ -568,6 +599,57 @@ mod tests {
                 .any(|p| p.a_id == other[0].id || p.b_id == other[0].id),
             "cross-window pair not filed: {pending:?} {settled:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn one_call_emitting_a_passage_twice_is_still_caught_inside_a_window() {
+        // The case the same-window exclusion must not swallow: no passage on
+        // either side, so nothing here is the window job's decision — just one
+        // synthesis call that wrote the same text twice, the shorter wholly
+        // inside the longer. Containment settles it and hides the copy.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let na = |o: i64, t: &str| crate::store::artifacts::NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: None,
+            title: Some("same heading".into()),
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let rows = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    na(0, "mount the disk first, then run the installer"),
+                    na(1, "mount the disk first"),
+                ],
+            )
+            .await
+            .unwrap();
+        for c in &rows {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        let (long, short) = (&rows[0], &rows[1]);
+        let a = core.store.get_artifact(&long.id).await.unwrap();
+        let b = core.store.get_artifact(&short.id).await.unwrap();
+        classify_pair(&core, &a, &b, 0.95).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::NoConflict, 10)
+                .await
+                .unwrap()
+                .iter()
+                .any(|p| (p.a_id == a.id && p.b_id == b.id)
+                    || (p.a_id == b.id && p.b_id == a.id)),
+            "a duplicate inside one window was not settled"
+        );
+        let after = core.store.get_artifact(&short.id).await.unwrap();
+        assert!(!after.in_results(), "the duplicated copy is still visible");
     }
 
     #[tokio::test]

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -129,16 +129,24 @@ async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<
         return Ok(false);
     }
 
-    // The free band. Filed, not acted on: resolving pairs one at a time leaves A
-    // pointing at a B that is itself hidden, and following that chain is
-    // something no page and no reader can do. The sweep's union-find groups
-    // these rows first and then picks one survivor per cluster.
-    if score >= core.consolidate.auto_supersede {
-        core.store
-            .record_settled_pair(&a.id, &b.id, score, PairState::NearIdentical)
-            .await?;
+    // Two rows from one window are not a pair. Neighbours under one heading
+    // are similar for how they were built, not for what they say; and a
+    // promoted artifact beside the passage it left standing is the window
+    // job's decision — the majority rule — already made. Sending that pair to
+    // the judge would spend a call to merge, and so hide behind model text,
+    // exactly the verbatim passage promotion just decided to keep.
+    if a.corpus_id.is_some()
+        && a.corpus_id == b.corpus_id
+        && a.segment_idx.is_some()
+        && a.segment_idx == b.segment_idx
+    {
         return Ok(false);
     }
+
+    // No free band any more. A pair at or above `auto_supersede` used to be
+    // filed as near-identical and hidden by the sweep on the score alone; it
+    // now falls through to `record_pair` like everything else, where
+    // `pairs_to_judge` orders by score and so asks about it first.
 
     // One synthesis call emitting the same passage twice: the shorter text is
     // wholly inside the longer, and both came out of the same document. That is
@@ -300,36 +308,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_near_identical_neighbour_never_costs_a_model_call() {
-        // At or above `auto_supersede` the pair is settled for free by
-        // clustering. Filing it as an ordinary pending pair would arm a dedupe
-        // unit and spend a call on the one case where the cheap rule is already
-        // right — the free path quietly becoming a paid one.
-        let core = test_core().await;
-        seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
-        let ids = core
-            .store
-            .all_active_artifacts()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|c| c.id)
-            .collect::<Vec<_>>();
-
-        run(&core, &ids[1]).await.unwrap();
-
-        assert!(core.store.pairs_to_judge(10).await.unwrap().is_empty());
-        assert_eq!(
-            core.store
-                .pairs_by_state(PairState::NearIdentical, 10)
-                .await
-                .unwrap()
-                .len(),
-            1
-        );
-    }
-
-    #[tokio::test]
     async fn an_unrelated_neighbour_is_left_entirely_alone() {
         let core = test_core().await;
         let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
@@ -437,31 +415,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_pair_at_auto_supersede_is_filed_for_the_cluster_pass() {
-        // It must not reach the dedupe queue: that band is answered by a rule
-        // that costs nothing. It must also not be superseded here — pairwise
-        // resolution is what `Clusters` exists to avoid, because A loses to B
-        // and B then loses to C, leaving A pointing at something hidden.
-        let core = test_core().await;
-        let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.9999, 0.01])]).await;
-        let (a, b) = pair_of(&core, &ids).await;
-
-        classify_pair(&core, &a, &b, 0.999).await.unwrap();
-        for id in &ids {
-            assert!(
-                core.store
-                    .get_artifact(id)
-                    .await
-                    .unwrap()
-                    .superseded_by
-                    .is_none(),
-                "the pair was resolved pairwise instead of being filed"
-            );
-        }
-        assert!(core.store.pairs_to_judge(10).await.unwrap().is_empty());
-    }
-
-    #[tokio::test]
     async fn a_pair_naming_a_hidden_artifact_is_skipped() {
         let core = test_core().await;
         let ids = seed(&core, &[("first", [1.0, 0.0]), ("second", [0.0, 1.0])]).await;
@@ -546,6 +499,101 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn two_rows_from_one_window_are_never_a_pair() {
+        // A promoted artifact and the passage it left standing in the same
+        // window look like a duplicate pair and are not one: overlap inside a
+        // window is the window job's decision, already made.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let na = |o: i64, t: &str, seg: i64| crate::store::artifacts::NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: None,
+            title: Some("same heading".into()),
+            category: None,
+            tags: vec![],
+            segment_idx: Some(seg),
+            caveats: vec![],
+        };
+        let same = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    na(0, "mount the disk first", 0),
+                    na(1, "mount the disk first", 0),
+                ],
+            )
+            .await
+            .unwrap();
+        let other = core
+            .store
+            .insert_artifacts(&src.id, &[na(2, "mount the disk first", 1)])
+            .await
+            .unwrap();
+        for c in same.iter().chain(other.iter()) {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        // Relate the same-window pair only: identical text under one title
+        // embeds identically, so without the exclusion this is a 1.0 pair.
+        run(&core, &same[0].id).await.unwrap();
+        let pending = core
+            .store
+            .pairs_by_state(PairState::Pending, 10)
+            .await
+            .unwrap();
+        assert!(
+            !pending.iter().any(|p| {
+                (p.a_id == same[0].id && p.b_id == same[1].id)
+                    || (p.a_id == same[1].id && p.b_id == same[0].id)
+            }),
+            "same-window pair was filed: {pending:?}"
+        );
+        // Across windows of the same corpus a pair is still a question —
+        // unless containment settles it, which identical text does; so the
+        // cross-window pair is settled or pending, never nothing.
+        let settled = core
+            .store
+            .pairs_by_state(PairState::NoConflict, 10)
+            .await
+            .unwrap();
+        assert!(
+            pending
+                .iter()
+                .chain(settled.iter())
+                .any(|p| p.a_id == other[0].id || p.b_id == other[0].id),
+            "cross-window pair not filed: {pending:?} {settled:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_above_auto_supersede_is_filed_for_the_judge_not_hidden() {
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("the first wording", [1.0, 0.0]),
+                ("the second wording", [1.0, 0.0]),
+            ],
+        )
+        .await;
+        run(&core, &ids[1]).await.unwrap();
+        // Nobody is hidden…
+        assert!(core.store.get_artifact(&ids[0]).await.unwrap().in_results());
+        assert!(core.store.get_artifact(&ids[1]).await.unwrap().in_results());
+        // …and the pair is pending, first in line by score.
+        let to_judge = core.store.pairs_to_judge(10).await.unwrap();
+        assert_eq!(to_judge.len(), 1, "{to_judge:?}");
+        assert!(
+            core.store
+                .pairs_by_state(PairState::NearIdentical, 10)
+                .await
+                .unwrap()
+                .is_empty()
         );
     }
 }

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -105,16 +105,19 @@ pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
 /// Is the whole of one artifact inside the other, whitespace aside?
 ///
 /// Not a similarity — containment. A score says two texts are alike; this says
-/// one of them adds nothing, which is the only ground on which a pair below
-/// `auto_supersede` is hidden without asking anyone.
+/// one of them adds nothing, which is now the only ground on which any pair is
+/// hidden without asking anyone: the `auto_supersede` band settles nothing on
+/// the score alone any more (see `classify_pair`).
 fn contains_normalized(long: &str, short: &str) -> bool {
     let n = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
     !short.trim().is_empty() && n(long).contains(&n(short))
 }
 
 /// Turn one scored pair into one decision. Nothing here calls a model: every
-/// rule is local, and the two that settle a pair outright — containment, and
-/// the `auto_supersede` band — are why most near pairs cost nothing at all.
+/// rule is local, and the ones that settle a pair outright — an exhausted
+/// side, two rows from one window, containment — are why most near pairs cost
+/// nothing at all. `auto_supersede` is not among them: it orders
+/// `pairs_to_judge` and no longer hides anything by itself.
 ///
 /// Returns whether `a` itself was hidden by the decision, which is the caller's
 /// signal that the artifact it is scanning neighbours for is no longer live.
@@ -644,8 +647,7 @@ mod tests {
                 .await
                 .unwrap()
                 .iter()
-                .any(|p| (p.a_id == a.id && p.b_id == b.id)
-                    || (p.a_id == b.id && p.b_id == a.id)),
+                .any(|p| (p.a_id == a.id && p.b_id == b.id) || (p.a_id == b.id && p.b_id == a.id)),
             "a duplicate inside one window was not settled"
         );
         let after = core.store.get_artifact(&short.id).await.unwrap();

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -17,7 +17,13 @@ pub(super) fn prompt_overhead(core: &Core) -> usize {
 /// This is the whole of the `Synthesize` stage now: deciding what the units of
 /// work are, which is local arithmetic over the text. The calls belong to the
 /// units it arms.
+///
+/// At `off` and `earned` this is the verbatim capture instead — same job, same
+/// queue row, no model.
 pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
+    if core.synthesis != crate::config::SynthesisMode::Eager {
+        return crate::jobs::passages::capture_verbatim(core, corpus_id).await;
+    }
     let src = core.store.get_corpus(corpus_id).await?;
     let windows = split_into_segments(&src.raw_text, &core.counter, segment_budget(core));
 
@@ -1313,6 +1319,42 @@ Then run sync.";
         assert!(
             span.start_line > 1,
             "later chunks must not all claim to start at line 1"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_at_eager_still_arms_windows_and_at_off_writes_passages() {
+        let mut core = crate::core::test_support::test_core().await;
+        let out = core.ingest("eager text", "web", None).await.unwrap();
+        plan(&core, &out.id).await.unwrap();
+        assert!(
+            core.store
+                .live_job(
+                    Stage::SegmentWindow,
+                    &crate::jobs::window::unit_target(&out.id, 0)
+                )
+                .await
+                .unwrap()
+        );
+
+        core.synthesis = crate::config::SynthesisMode::Off;
+        let out2 = core.ingest("off text", "web", None).await.unwrap();
+        plan(&core, &out2.id).await.unwrap();
+        assert!(
+            !core
+                .store
+                .live_job(
+                    Stage::SegmentWindow,
+                    &crate::jobs::window::unit_target(&out2.id, 0)
+                )
+                .await
+                .unwrap()
+        );
+        let rows = core.store.artifacts_for_corpus(&out2.id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].provenance,
+            crate::store::artifacts::Provenance::Passage
         );
     }
 }

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -140,7 +140,9 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
     core.store.renumber_artifacts(corpus_id).await?;
     let windows = core.store.segments_for_corpus(corpus_id).await?;
-    let degraded = windows.iter().any(|w| w.state != SegmentState::Done);
+    let degraded = windows
+        .iter()
+        .any(|w| !matches!(w.state, SegmentState::Done | SegmentState::Verbatim));
     let chunks = core.store.artifacts_for_corpus(corpus_id).await?;
     if chunks.is_empty() {
         core.store

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -19,11 +19,7 @@ pub(super) fn prompt_overhead(core: &Core) -> usize {
 /// units it arms.
 pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
     let src = core.store.get_corpus(corpus_id).await?;
-    let windows = split_into_segments(
-        &src.raw_text,
-        &core.counter,
-        segment_tokens(core.synthesizer.budget(), prompt_overhead(core)),
-    );
+    let windows = split_into_segments(&src.raw_text, &core.counter, segment_budget(core));
 
     if windows.is_empty() {
         tracing::warn!(corpus_id, "source has no usable text");
@@ -81,6 +77,17 @@ pub async fn plan(core: &Core, corpus_id: &str) -> Result<()> {
             .await?;
     }
     Ok(())
+}
+
+/// The window budget: derived from the synthesizer's context when there is
+/// one, the configured fallback when there is not. `off` without a synthesizer
+/// still splits into windows — they are what promotion would later read, and
+/// what coverage is measured against.
+pub(crate) fn segment_budget(core: &Core) -> usize {
+    match &core.synthesizer {
+        Some(s) => segment_tokens(s.budget(), prompt_overhead(core)),
+        None => core.segment_tokens,
+    }
 }
 
 /// Measure how much of a corpus survived into its artifacts, and store it.
@@ -159,7 +166,10 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
     // attempts and spend another `MAX_ATTEMPTS` on a name already given up
     // on. An operator's reprocess deletes the row and is the one way back. A
     // name given at capture is left alone — someone chose it.
-    if src.title_hint.is_none() && !core.store.has_job(Stage::Title, corpus_id).await? {
+    if src.title_hint.is_none()
+        && core.synthesizes()
+        && !core.store.has_job(Stage::Title, corpus_id).await?
+    {
         core.store
             .enqueue(Stage::Title, "corpus", corpus_id)
             .await?;
@@ -203,8 +213,13 @@ pub async fn run_title(core: &Core, corpus_id: &str) -> Result<()> {
         .filter_map(|c| c.title.clone())
         .collect();
 
+    // No synthesizer, no name from a model: the corpus keeps what capture
+    // derived locally, and `finish` never arms this unit in that case.
+    let Some(synth) = &core.synthesizer else {
+        return Ok(());
+    };
     let permit = core.gate.background().await;
-    let named = core.synthesizer.title(&src.raw_text, &titles).await;
+    let named = synth.title(&src.raw_text, &titles).await;
     permit.finished();
     match named {
         Ok(Some(t)) => {
@@ -428,7 +443,7 @@ mod tests {
         // spins against the endpoint forever, and a debug_assert turns that
         // into a test failure instead of a production incident.
         let core = crate::core::test_support::test_core().await;
-        let budget = segment_tokens(core.synthesizer.budget(), prompt_overhead(&core));
+        let budget = segment_budget(&core);
 
         let lines: Vec<String> = (0..400)
             .map(|i| format!("body line {i} with enough words to cost real tokens"))
@@ -463,9 +478,9 @@ mod tests {
         use crate::infer::fake::GreedySynthesizer;
 
         let mut core = crate::core::test_support::test_core().await;
-        core.synthesizer = std::sync::Arc::new(GreedySynthesizer {
+        core.synthesizer = Some(std::sync::Arc::new(GreedySynthesizer {
             budget: context_budget(30, 20),
-        });
+        }));
 
         let lines: Vec<String> = (0..400)
             .map(|i| format!("body line {i} with enough words to cost real tokens"))
@@ -496,7 +511,7 @@ mod tests {
 
         let mut core = crate::core::test_support::test_core().await;
         let rec = std::sync::Arc::new(RecordingSynthesizer::new(context_budget(30, 20)));
-        core.synthesizer = rec.clone();
+        core.synthesizer = Some(rec.clone());
 
         let mut lines = vec!["# Backup Guide".to_string(), "PBS 3.x on Debian 12.".into()];
         for i in 0..400 {
@@ -542,7 +557,7 @@ mod tests {
 
         let mut core = crate::core::test_support::test_core().await;
         let rec = std::sync::Arc::new(RecordingSynthesizer::new(context_budget(30, 20)));
-        core.synthesizer = rec.clone();
+        core.synthesizer = Some(rec.clone());
 
         let lines: Vec<String> = (0..400)
             .map(|i| format!("body line {i} with enough words to cost real tokens"))
@@ -629,8 +644,8 @@ mod tests {
         // so naming is exercised through `finish` on a corpus that already has
         // them: the state a real failure leaves behind.
         let mut failing = test_core().await;
-        failing.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing(
-            "endpoint down",
+        failing.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::failing("endpoint down"),
         ));
         let hurt = failing
             .ingest("alpha line\n\nbravo line", "web", None)
@@ -658,12 +673,7 @@ mod tests {
     }
 
     fn segment_count(core: &crate::core::Core, body: &str) -> usize {
-        crate::infer::split::split_into_segments(
-            body,
-            &core.counter,
-            segment_tokens(core.synthesizer.budget(), prompt_overhead(core)),
-        )
-        .len()
+        crate::infer::split::split_into_segments(body, &core.counter, segment_budget(core)).len()
     }
 
     #[tokio::test]
@@ -711,8 +721,9 @@ mod tests {
             .enqueue(Stage::Title, "corpus", &out.id)
             .await
             .unwrap();
-        core.synthesizer =
-            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::failing("no title"));
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::failing("no title"),
+        ));
         for _ in 0..crate::store::jobs::MAX_ATTEMPTS + 3 {
             sqlx::query("UPDATE jobs SET run_after = 0")
                 .execute(&core.store.pool)
@@ -810,7 +821,7 @@ mod tests {
         use crate::infer::fake::RecordingSynthesizer;
         let mut core = test_core().await;
         let rec = std::sync::Arc::new(RecordingSynthesizer::new(context_budget(30, 20)));
-        core.synthesizer = rec.clone();
+        core.synthesizer = Some(rec.clone());
         let body = multi_segment_body();
         let out = core.ingest(&body, "web", None).await.unwrap();
 
@@ -850,8 +861,8 @@ mod tests {
             .ingest("bravo one\n\nbravo two", "web", None)
             .await
             .unwrap();
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
-            "STOPHERE",
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::unparsable_on("STOPHERE"),
         ));
 
         plan(&core, &a.id).await.unwrap();
@@ -887,8 +898,8 @@ mod tests {
         let mut core = test_core().await;
         let body = format!("STOPHERE poison\n\n{}", multi_segment_body());
         let out = core.ingest(&body, "web", None).await.unwrap();
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
-            "STOPHERE",
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::unparsable_on("STOPHERE"),
         ));
 
         segment_all(&core, &out.id).await;
@@ -923,8 +934,8 @@ mod tests {
         let mut core = test_core().await;
         let body = format!("STOPHERE poison\n\n{}", multi_segment_body());
         let out = core.ingest(&body, "web", None).await.unwrap();
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on(
-            "STOPHERE",
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::unparsable_on("STOPHERE"),
         ));
         segment_all(&core, &out.id).await;
         assert_eq!(
@@ -934,7 +945,9 @@ mod tests {
 
         // The endpoint comes back to its senses. Settling has to run again, or
         // the document would stay `partial` with a window that is now fine.
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::default());
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::default(),
+        ));
         segment_all(&core, &out.id).await;
 
         let windows = core.store.segments_for_corpus(&out.id).await.unwrap();
@@ -1035,7 +1048,7 @@ Then run sync.";
             "oflag=sync ",
             false,
         ));
-        core.synthesizer = synthesizer.clone();
+        core.synthesizer = Some(synthesizer.clone());
         let out = core.ingest(COMMAND_BODY, "web", None).await.unwrap();
 
         segment_all(&core, &out.id).await;
@@ -1051,9 +1064,8 @@ Then run sync.";
     #[tokio::test]
     async fn a_literal_the_retry_also_drops_is_stored_flagged() {
         let mut core = test_core().await;
-        core.synthesizer = std::sync::Arc::new(crate::infer::fake::ParaphrasingSynthesizer::new(
-            "oflag=sync ",
-            true,
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::ParaphrasingSynthesizer::new("oflag=sync ", true),
         ));
         let out = core.ingest(COMMAND_BODY, "web", None).await.unwrap();
 
@@ -1086,8 +1098,9 @@ Then run sync.";
         // Where the chunk still reproduces its source, the real span can be
         // found — better than flagging a chunk whose lines we can work out.
         let mut core = test_core().await;
-        core.synthesizer =
-            std::sync::Arc::new(crate::infer::fake::MisreportingSynthesizer { echo_text: true });
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::MisreportingSynthesizer { echo_text: true },
+        ));
         let out = core
             .ingest("first paragraph here\n\nsecond paragraph here", "web", None)
             .await
@@ -1114,8 +1127,9 @@ Then run sync.";
         // model call on a whole segment. The span falls back to the window and
         // the reader is none the wiser.
         let mut core = test_core().await;
-        core.synthesizer =
-            std::sync::Arc::new(crate::infer::fake::MisreportingSynthesizer { echo_text: false });
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::MisreportingSynthesizer { echo_text: false },
+        ));
         let out = core
             .ingest("first paragraph here\n\nsecond paragraph here", "web", None)
             .await

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -42,12 +42,20 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
     if w.state == SegmentState::Done {
         return Ok(());
     }
+    // No synthesizer: the unit cannot run, and `run_claimed` closes it before
+    // it gets here. Said again at the call so a direct caller gets an answer
+    // and not a panic.
+    let Some(synth) = core.synthesizer.clone() else {
+        return Err(Error::Validation(
+            "[infer.synthesize] is not configured; this window cannot be synthesized".into(),
+        ));
+    };
 
     let all_texts: Vec<&str> = all.iter().map(|s| s.text.as_str()).collect();
     let ctx = crate::infer::context::WindowContext::build(
         &all_texts,
         idx as usize,
-        core.synthesizer.budget().context,
+        synth.budget().context,
         &core.counter,
     );
     // The stored text, not a re-derivation from the line range: line numbers
@@ -70,10 +78,7 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
     // `text_with_no_structure_still_splits_by_line_cap` has always asserted.
     // What must never happen is unbounded — the corpus that came back fifteen
     // times its budget.
-    let window_budget = crate::infer::budget::segment_tokens(
-        core.synthesizer.budget(),
-        super::synthesize::prompt_overhead(core),
-    );
+    let window_budget = super::synthesize::segment_budget(core);
     let window_tokens = core.counter.count(&text);
     debug_assert!(
         window_tokens <= window_budget * 2,
@@ -90,8 +95,7 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
     }
 
     let permit = core.gate.background().await;
-    let first = core
-        .synthesizer
+    let first = synth
         .segment(crate::infer::SegmentInput {
             core: &text,
             context: &ctx,
@@ -128,8 +132,7 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
             "literals missing; re-segmenting once"
         );
         let permit = core.gate.background().await;
-        let second = core
-            .synthesizer
+        let second = synth
             .segment(crate::infer::SegmentInput {
                 core: &text,
                 context: &ctx,
@@ -610,8 +613,9 @@ mod tests {
         let mut core = test_core().await;
         let out = core.ingest("alpha\n\nbeta", "web", None).await.unwrap();
         crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
-        core.synthesizer =
-            std::sync::Arc::new(crate::infer::fake::FakeSynthesizer::unparsable_on("alpha"));
+        core.synthesizer = Some(std::sync::Arc::new(
+            crate::infer::fake::FakeSynthesizer::unparsable_on("alpha"),
+        ));
 
         let err = run(&core, &unit_target(&out.id, 0)).await.unwrap_err();
         assert!(err.retryable(), "the window is still owed a call");

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -189,30 +189,83 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
         write_segment_artifacts(core, corpus_id, idx, proposed_to_new(idx, chunks)).await?;
     flag_unverified(core, &written, &text).await?;
     if keep {
-        // A promotion: what the window's artifacts cover, they supersede, and
-        // the passages' access comes with them. Under the corpus lock as a
-        // second locked step — `write_segment_artifacts` took and released it.
-        let _corpus = core.corpus_lock(corpus_id).await;
-        let n = crate::jobs::promote::supersede_covered(
-            core,
-            corpus_id,
-            idx,
-            &written,
-            crate::store::now(),
-        )
-        .await?;
-        tracing::info!(
-            corpus_id,
-            window = idx,
-            superseded = n,
-            "promotion superseded its covered passages"
-        );
+        // The replacements have to be searchable before the originals stop
+        // being. `supersede_covered` takes the passages out of results, and the
+        // artifacts standing in for them are still `pending` until the corpus
+        // embed job settling arms below gets its turn — under a backed-up queue
+        // and `[pacing] cooldown_secs` that is however long the queue takes,
+        // and for all of it this window's lines are reachable from neither
+        // side. Embedded here, inline, so the swap is a swap.
+        //
+        // A refusal leaves the passages standing and the artifacts queued: the
+        // window is captured either way, the corpus embed job below will pick
+        // the artifacts up, and the next settle re-runs this. Hiding readable
+        // text behind text nothing can find is the one outcome not worth
+        // risking, so it is the direction this fails in.
+        let embedded = embed_written(core, &written).await;
+        if let Err(e) = &embedded {
+            tracing::warn!(
+                corpus_id,
+                window = idx,
+                error = %e,
+                "the promoted window's artifacts could not be embedded; \
+                 leaving its passages in results"
+            );
+        }
+        if let Ok(written) = &embedded {
+            // A promotion: what the window's artifacts cover, they supersede,
+            // and the passages' access comes with them. Under the corpus lock
+            // as a second locked step — `write_segment_artifacts` took and
+            // released it.
+            let _corpus = core.corpus_lock(corpus_id).await;
+            let n = crate::jobs::promote::supersede_covered(
+                core,
+                corpus_id,
+                idx,
+                written,
+                crate::store::now(),
+            )
+            .await?;
+            tracing::info!(
+                corpus_id,
+                window = idx,
+                superseded = n,
+                "promotion superseded its covered passages"
+            );
+        }
     }
     core.store
         .set_segment_state(corpus_id, idx, SegmentState::Done, None)
         .await?;
 
     settle(core, corpus_id).await
+}
+
+/// Embed one promoted window's artifacts now, rather than leaving them to the
+/// corpus batch. Only a promotion needs this: it is the one path that hides
+/// existing text on the strength of text it has just written.
+///
+/// Returns the artifacts that are actually there afterwards. An oversize one is
+/// replaced by siblings and its own row goes away, so what was written is not
+/// always what is now searchable — and superseding a passage behind an id that
+/// no longer exists is the failure this whole step is here to avoid. The
+/// siblings cover the same lines and could be traced to the same passages, but
+/// working that out is `resolve_span`'s job on a re-run; dropping them leaves
+/// the passages standing, which is the direction promotion may fail in.
+async fn embed_written(
+    core: &Core,
+    written: &[crate::store::artifacts::Chunk],
+) -> Result<Vec<crate::store::artifacts::Chunk>> {
+    for c in written {
+        crate::jobs::embed::run(core, &c.id).await?;
+    }
+    let ids: Vec<String> = written.iter().map(|c| c.id.clone()).collect();
+    let live = core.store.artifacts_by_ids(&ids).await?;
+    Ok(written
+        .iter()
+        .filter(|c| live.iter().any(|l| l.id == c.id))
+        .cloned()
+        .collect())
 }
 
 /// Everything that can only be decided once every window has resolved.
@@ -645,6 +698,51 @@ mod tests {
                 .unwrap(),
             "and reaching `done` spends it"
         );
+    }
+
+    #[tokio::test]
+    async fn a_promotion_embeds_what_it_wrote_before_it_hides_anything() {
+        // The window that promotes is the one window whose artifacts cannot
+        // wait for the corpus batch: `supersede_covered` takes the passages out
+        // of results, and until the replacements are indexed the lines are
+        // reachable from neither side. Under a backed-up queue that gap is as
+        // long as the queue.
+        let core = test_core().await;
+        let out = core
+            .ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::plan(&core, &out.id).await.unwrap();
+        run(&core, &unit_target(&out.id, 0)).await.unwrap();
+        let before = core
+            .store
+            .artifact_ids_for_segment(&out.id, 0)
+            .await
+            .unwrap();
+
+        // The keep mark is what makes the re-read a promotion.
+        core.store.reset_segment(&out.id, 0, true).await.unwrap();
+        run(&core, &unit_target(&out.id, 0)).await.unwrap();
+
+        let after = core
+            .store
+            .artifact_ids_for_segment(&out.id, 0)
+            .await
+            .unwrap();
+        let written: Vec<String> = after
+            .into_iter()
+            .filter(|id| !before.contains(id))
+            .collect();
+        assert!(!written.is_empty(), "the fixture must promote something");
+        for c in core.store.artifacts_by_ids(&written).await.unwrap() {
+            assert_eq!(
+                c.embed_state,
+                crate::store::artifacts::EmbedState::Embedded,
+                "the promotion superseded while {} was still {:?}",
+                c.id,
+                c.embed_state
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -184,9 +184,30 @@ pub async fn run(core: &Core, target: &str) -> Result<()> {
         c.corpus_lines = Some(resolve_span(&c.text, &body, &w, c.corpus_lines));
     }
 
+    let keep = core.store.segment_keeps_artifacts(corpus_id, idx).await?;
     let written =
         write_segment_artifacts(core, corpus_id, idx, proposed_to_new(idx, chunks)).await?;
     flag_unverified(core, &written, &text).await?;
+    if keep {
+        // A promotion: what the window's artifacts cover, they supersede, and
+        // the passages' access comes with them. Under the corpus lock as a
+        // second locked step — `write_segment_artifacts` took and released it.
+        let _corpus = core.corpus_lock(corpus_id).await;
+        let n = crate::jobs::promote::supersede_covered(
+            core,
+            corpus_id,
+            idx,
+            &written,
+            crate::store::now(),
+        )
+        .await?;
+        tracing::info!(
+            corpus_id,
+            window = idx,
+            superseded = n,
+            "promotion superseded its covered passages"
+        );
+    }
     core.store
         .set_segment_state(corpus_id, idx, SegmentState::Done, None)
         .await?;
@@ -340,6 +361,34 @@ pub(crate) async fn write_segment_artifacts(
         .store
         .segment_keeps_artifacts(corpus_id, segment_idx)
         .await?;
+    if keep {
+        // A promotion re-run: the process died between the insert and `done`.
+        // Under `keep_artifacts` the write appends, so writing again would put
+        // the window's artifacts in twice. A window holding passages is a
+        // promotion (an operator's re-read has none); rows in it that are not
+        // passages are the earlier write — return them and insert none.
+        let rows = core
+            .store
+            .artifacts_for_segment(corpus_id, segment_idx)
+            .await?;
+        let is_promotion = rows
+            .iter()
+            .any(|c| c.provenance == crate::store::artifacts::Provenance::Passage);
+        let have: Vec<_> = rows
+            .into_iter()
+            .filter(|c| {
+                c.provenance != crate::store::artifacts::Provenance::Passage && c.in_results()
+            })
+            .collect();
+        if is_promotion && !have.is_empty() {
+            tracing::info!(
+                corpus_id,
+                window = segment_idx,
+                "window already written under keep_artifacts; not writing again"
+            );
+            return Ok(have);
+        }
+    }
     if !keep {
         let old = core
             .store

--- a/src/jobs/window.rs
+++ b/src/jobs/window.rs
@@ -215,7 +215,9 @@ pub(crate) async fn settle(core: &Core, corpus_id: &str) -> Result<()> {
     let _corpus = core.corpus_lock(corpus_id).await;
     for w in core.store.segments_for_corpus(corpus_id).await? {
         let resolved = match w.state {
-            SegmentState::Done => true,
+            // A verbatim window was captured as passages and is owed nothing;
+            // it resolves the way a synthesized one does.
+            SegmentState::Done | SegmentState::Verbatim => true,
             // `jobs.attempts` rather than a counter on the segment: the unit is
             // the job now, and two counters for one thing is what made the
             // original incident so hard to read.
@@ -727,5 +729,72 @@ mod tests {
             core_text,
             &ctx
         ));
+    }
+
+    #[tokio::test]
+    async fn settle_treats_a_verbatim_segment_as_resolved() {
+        // One promoted window done, every other window verbatim: the corpus
+        // must finish — that is what arms the embed for the promoted artifacts.
+        let core = test_core().await;
+        let src = core
+            .store
+            .insert_corpus("l1\nl2\nl3\nl4", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .upsert_segments(
+                &src.id,
+                &[
+                    crate::store::segments::NewSegment {
+                        start_line: 1,
+                        end_line: 2,
+                        text: "l1\nl2",
+                        carry_lines: 0,
+                    },
+                    crate::store::segments::NewSegment {
+                        start_line: 3,
+                        end_line: 4,
+                        text: "l3\nl4",
+                        carry_lines: 0,
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        core.store.mark_segments_verbatim(&src.id).await.unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, SegmentState::Done, None)
+            .await
+            .unwrap();
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "l1 l2".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        settle(&core, &src.id).await.unwrap();
+        let s = core.store.get_corpus(&src.id).await.unwrap();
+        assert_eq!(
+            s.status,
+            crate::store::corpora::CorpusStatus::Embedding,
+            "{:?}",
+            s.status
+        );
+        assert!(
+            core.store
+                .live_job(crate::store::jobs::Stage::Embed, &src.id)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,7 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
         cfg.infer.embed.api_key.as_deref(),
     )
     .await;
+    embed_recipe_check(core, cfg).await?;
     if let Some(r) = &cfg.infer.rerank {
         engram::infer::openai::probe("rerank", &r.base_url, r.api_key.as_deref()).await;
     } else {
@@ -116,6 +117,35 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
     } else {
         tracing::info!("vision not configured; the image door is closed");
     }
+    Ok(())
+}
+
+/// Say it out loud when the embedding recipe changed under a base that already
+/// has vectors in it.
+///
+/// `model`, `dim` and the three templates together decide what a stored vector
+/// means (`EmbedRole::fingerprint`). Change any of them and the vectors already
+/// in the collection describe the old recipe while every new query is rendered
+/// through the new one — a base that answers worse for no visible reason, with
+/// nothing in any log tying it to the config edit that caused it.
+///
+/// A warning and not a refusal: the operator may be mid-migration, and a base
+/// that will not boot is worse than one that says what is wrong with it. The
+/// fingerprint is stored either way, so the warning is printed once rather than
+/// every restart.
+async fn embed_recipe_check(core: &Core, cfg: &Config) -> Result<()> {
+    const KEY: &str = "embed.recipe";
+    let now = cfg.infer.embed.fingerprint();
+    match core.store.meta_get(KEY).await? {
+        Some(before) if before != now => tracing::warn!(
+            model = %cfg.infer.embed.model,
+            "the embedding recipe changed — model, dim or a template. Vectors stored under the \
+             old one do not compare with queries rendered through the new one: drop the \
+             collection and re-capture, or put the old recipe back"
+        ),
+        _ => {}
+    }
+    core.store.meta_set(KEY, &now).await?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,6 +369,7 @@ mod startup_tests {
             associate: AssociateConfig::default(),
             activation: ActivationConfig::default(),
             promote: engram::config::PromoteConfig::default(),
+            pursuit: engram::config::PursuitConfig::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,6 +329,10 @@ mod startup_tests {
                     dim: 1024,
                     max_input_tokens: 8192,
                     timeout_secs: engram::config::DEFAULT_TIMEOUT_SECS,
+                    query_template: engram::config::EmbedTemplates::default().query_template,
+                    document_template: engram::config::EmbedTemplates::default().document_template,
+                    document_template_untitled: engram::config::EmbedTemplates::default()
+                        .document_template_untitled,
                 },
                 ask: AskRole {
                     base_url: "http://localhost:8000/v1".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,7 @@ async fn main() -> anyhow::Result<()> {
     let repair = engram::core::background::spawn_repair_ticker(core.clone(), shutdown_rx.clone());
     let associate =
         engram::core::background::spawn_associate_ticker(core.clone(), shutdown_rx.clone());
+    let pursuit = engram::core::background::spawn_pursuit_ticker(core.clone(), shutdown_rx.clone());
     let mut handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
     // Joined with the workers so shutdown waits for them too, rather than
     // leaving tasks the runtime drops mid-enqueue.
@@ -248,6 +249,7 @@ async fn main() -> anyhow::Result<()> {
     handles.push(dedupe);
     handles.push(repair);
     handles.push(associate);
+    handles.push(pursuit);
 
     let listener = tokio::net::TcpListener::bind(&cfg.server.bind).await?;
     tracing::info!(bind = %cfg.server.bind, mode = ?cfg.auth.mode, "engram listening");

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,7 @@ mod startup_tests {
                     document_template: engram::config::EmbedTemplates::default().document_template,
                     document_template_untitled: engram::config::EmbedTemplates::default()
                         .document_template_untitled,
+                    chunk_tokens: engram::config::DEFAULT_CHUNK_TOKENS,
                 },
                 ask: AskRole {
                     base_url: "http://localhost:8000/v1".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,7 @@ mod startup_tests {
             pacing: engram::config::PacingConfig::default(),
             associate: AssociateConfig::default(),
             activation: ActivationConfig::default(),
+            promote: engram::config::PromoteConfig::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,12 +92,13 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
         }
     });
 
-    engram::infer::openai::probe(
-        "chunk",
-        &cfg.infer.synthesize.base_url,
-        cfg.infer.synthesize.api_key.as_deref(),
-    )
-    .await;
+    if let Some(s) = &cfg.infer.synthesize {
+        engram::infer::openai::probe("chunk", &s.base_url, s.api_key.as_deref()).await;
+    } else {
+        tracing::info!(
+            "synthesize not configured; capture embeds verbatim and nothing is synthesized"
+        );
+    }
     engram::infer::openai::probe(
         "embed",
         &cfg.infer.embed.base_url,
@@ -110,7 +111,7 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
         tracing::info!("rerank not configured; search returns vector order");
     }
     if let Some(v) = &cfg.infer.vision {
-        let (base_url, api_key) = v.resolve(&cfg.infer.synthesize);
+        let (base_url, api_key) = v.resolve(cfg.infer.synthesize.as_ref());
         engram::infer::openai::probe("vision", &base_url, api_key.as_deref()).await;
     } else {
         tracing::info!("vision not configured; the image door is closed");
@@ -308,7 +309,9 @@ mod startup_tests {
                 weak_below: 0.35,
             },
             infer: InferConfig {
-                synthesize: SynthesizeRole {
+                synthesis: engram::config::SynthesisMode::Eager,
+                segment_tokens: engram::config::DEFAULT_SEGMENT_TOKENS,
+                synthesize: Some(SynthesizeRole {
                     base_url: "http://localhost:8000/v1".into(),
                     model: "m".into(),
                     api_key: None,
@@ -321,7 +324,7 @@ mod startup_tests {
                     structured_output: true,
                     context_opening_tokens: 200,
                     context_overlap_tokens: 150,
-                },
+                }),
                 embed: EmbedRole {
                     base_url: "http://localhost:8000/v1".into(),
                     model: "e".into(),
@@ -335,7 +338,7 @@ mod startup_tests {
                         .document_template_untitled,
                     chunk_tokens: engram::config::DEFAULT_CHUNK_TOKENS,
                 },
-                ask: AskRole {
+                ask: Some(AskRole {
                     base_url: "http://localhost:8000/v1".into(),
                     model: "m".into(),
                     api_key: None,
@@ -347,7 +350,7 @@ mod startup_tests {
                     follow_up: false,
                     structured_output: true,
                     follow_up_endpoint: None,
-                },
+                }),
                 rerank: None,
                 vision: None,
             },

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -379,6 +379,9 @@ mod tests {
             past_cliff: false,
             via: via.map(str::to_string),
             reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
         }
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -85,8 +85,18 @@ pub struct AskParams {
     pub q: String,
 }
 
-#[tool_router(server_handler)]
+#[tool_router]
 impl PkdbTools {
+    /// The tools this core can actually serve. `ask` is not a tool that says
+    /// "not configured" — it is not a tool.
+    pub(crate) fn routes(&self) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        let mut r = Self::tool_router();
+        if !self.core.asks() {
+            r.remove_route("ask");
+        }
+        r
+    }
+
     #[tool(
         name = "ingest",
         description = "Store text in the personal knowledge base. Returns immediately; \
@@ -168,6 +178,9 @@ impl PkdbTools {
         }
     }
 }
+
+#[rmcp::tool_handler(router = self.routes())]
+impl rmcp::ServerHandler for PkdbTools {}
 
 /// An answer, with everything the page would have shown around it.
 ///
@@ -397,5 +410,17 @@ mod tests {
         assert!(out.contains("### 1. ranked"), "{out}");
         assert!(out.contains("### recalled"), "{out}");
         assert!(!out.contains("### 2"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn the_ask_tool_is_offered_only_with_an_ask_model() {
+        let core = crate::core::test_support::test_core().await;
+        let tools = PkdbTools { core: core.clone() };
+        assert!(tools.routes().has_route("ask"));
+        let mut core = core;
+        core.completer = None;
+        let tools = PkdbTools { core };
+        assert!(!tools.routes().has_route("ask"));
+        assert!(tools.routes().has_route("search"));
     }
 }

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -494,25 +494,41 @@ impl Store {
         Ok(rows.iter().map(row_to_artifact).collect())
     }
 
-    /// The artifacts either side of `ordinal` in the same corpus.
+    /// The nearest *active* artifact either side of `ordinal` in the same
+    /// corpus — not the rows at `ordinal ± 1`.
     ///
     /// The answer to a question is often the paragraph after the one that
-    /// matched. `ordinal` is already a continuous per-corpus sequence, which is
-    /// what makes this a lookup instead of a search. An edge returns the one
-    /// side that exists; `status = 'active'` keeps deprecated and superseded
-    /// artifacts out, exactly as an ordinary search would.
+    /// matched, and `ordinal` is a continuous per-corpus sequence, which is
+    /// what makes this a lookup instead of a search. But after a promotion the
+    /// sequence interleaves superseded passages with what replaced them, and
+    /// "the row next door" is then often a hidden one; the reader wants the
+    /// next thing still in the document. An edge returns the one side that
+    /// exists; `status = 'active'` keeps deprecated and superseded artifacts
+    /// out, exactly as an ordinary search would.
     pub async fn adjacent_artifacts(&self, corpus_id: &str, ordinal: i64) -> Result<Vec<Chunk>> {
-        let rows = sqlx::query(
+        let before = sqlx::query(
             "SELECT * FROM artifacts
-             WHERE corpus_id = ? AND ordinal IN (?, ?) AND status = 'active'
-             ORDER BY ordinal",
+             WHERE corpus_id = ? AND ordinal < ? AND status = 'active'
+             ORDER BY ordinal DESC LIMIT 1",
         )
         .bind(corpus_id)
-        .bind(ordinal - 1)
-        .bind(ordinal + 1)
-        .fetch_all(&self.pool)
+        .bind(ordinal)
+        .fetch_optional(&self.pool)
         .await?;
-        Ok(rows.iter().map(row_to_artifact).collect())
+        let after = sqlx::query(
+            "SELECT * FROM artifacts
+             WHERE corpus_id = ? AND ordinal > ? AND status = 'active'
+             ORDER BY ordinal ASC LIMIT 1",
+        )
+        .bind(corpus_id)
+        .bind(ordinal)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(before
+            .iter()
+            .chain(after.iter())
+            .map(row_to_artifact)
+            .collect())
     }
 
     pub async fn artifacts_for_corpus(&self, corpus_id: &str) -> Result<Vec<Chunk>> {
@@ -1520,5 +1536,32 @@ mod tests {
         }
         let ids = s.list_unrelated_artifact_ids(10).await.unwrap();
         assert_eq!(ids, vec![c[0].id.clone()]);
+    }
+
+    #[tokio::test]
+    async fn adjacent_artifacts_steps_over_a_superseded_row_to_the_next_active_one() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c"), nc(3, "d")])
+            .await
+            .unwrap();
+        // Hide b and c; a's next active neighbour is d.
+        s.set_superseded_by(&made[1].id, Some(&made[3].id))
+            .await
+            .unwrap();
+        s.set_superseded_by(&made[2].id, Some(&made[3].id))
+            .await
+            .unwrap();
+        let got = s.adjacent_artifacts(&src.id, 0).await.unwrap();
+        assert_eq!(
+            got.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(),
+            vec!["d"]
+        );
+        let got = s.adjacent_artifacts(&src.id, 3).await.unwrap();
+        assert_eq!(
+            got.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(),
+            vec!["a"]
+        );
     }
 }

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -68,25 +68,49 @@ impl ArtifactStatus {
 /// corpus lines for a span it does not have — so both branch on this rather
 /// than on `corpus_id.is_none()`. A null says a field is absent; this says what
 /// the row *is*, which is what a reader needs in order to know why.
+///
+/// `Passage` text is a verbatim slice of a segment, sized to the embedder —
+/// the retrieval unit at `synthesis = "off"` and `"earned"`; it has a corpus
+/// and a span like captured text, and no model ever touched it. `Synthesized`
+/// text was written from a pursuit; like a merge it has no corpus of its own
+/// and names its sources through `artifact_sources`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Provenance {
+    Passage,
     Captured,
     Merged,
+    Synthesized,
 }
 
 impl Provenance {
     pub fn as_str(&self) -> &'static str {
         match self {
+            Provenance::Passage => "passage",
             Provenance::Captured => "captured",
             Provenance::Merged => "merged",
+            Provenance::Synthesized => "synthesized",
         }
     }
     pub fn parse(s: &str) -> Provenance {
         match s {
+            "passage" => Provenance::Passage,
             "merged" => Provenance::Merged,
+            "synthesized" => Provenance::Synthesized,
             _ => Provenance::Captured,
         }
+    }
+    /// A model wrote this text. Such a row is never its own root: handing it
+    /// back as one is how a paraphrase of a paraphrase reaches a prompt as an
+    /// original. The test is "not source text" rather than "is merged", so the
+    /// next value added defaults to safe rather than to wrong.
+    pub fn is_model_written(&self) -> bool {
+        matches!(self, Provenance::Merged | Provenance::Synthesized)
+    }
+    /// The text is the document's own, verbatim (`Passage`) or as the one
+    /// synthesis rewrite of it (`Captured` — its own root by convention).
+    pub fn is_source_text(&self) -> bool {
+        !self.is_model_written()
     }
 }
 
@@ -319,6 +343,19 @@ impl Store {
         corpus_id: &str,
         chunks: &[NewArtifact],
     ) -> Result<Vec<Chunk>> {
+        self.insert_artifacts_with_provenance(corpus_id, chunks, Provenance::Captured)
+            .await
+    }
+
+    /// `insert_artifacts`, saying what kind of row is being written. Capture at
+    /// `off`/`earned` writes passages through this; everything else keeps the
+    /// captured default.
+    pub async fn insert_artifacts_with_provenance(
+        &self,
+        corpus_id: &str,
+        chunks: &[NewArtifact],
+        provenance: Provenance,
+    ) -> Result<Vec<Chunk>> {
         let mut tx = self.pool.begin().await?;
         let mut out = Vec::with_capacity(chunks.len());
         for nc in chunks {
@@ -326,7 +363,7 @@ impl Store {
             let c = Chunk {
                 id: new_id(),
                 corpus_id: Some(corpus_id.to_string()),
-                provenance: Provenance::Captured,
+                provenance,
                 source_count: 0,
                 ordinal: nc.ordinal,
                 text: nc.text.clone(),
@@ -348,10 +385,11 @@ impl Store {
             };
             sqlx::query(
                 "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, activation, activated_at)
-                 VALUES (?, ?, 'captured', ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 1.0, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 1.0, ?)",
             )
             .bind(&c.id)
             .bind(&c.corpus_id)
+            .bind(provenance.as_str())
             .bind(c.ordinal)
             .bind(&c.text)
             .bind(c.corpus_span.as_ref().map(|s| serde_json::to_string(s).unwrap()))
@@ -380,6 +418,28 @@ impl Store {
             .await?
             .ok_or(Error::NotFound)?;
         Ok(row_to_artifact(&row))
+    }
+
+    /// The rows for these ids, in no particular order; ids that name nothing
+    /// are simply absent. One query for a page of hits.
+    pub async fn artifacts_by_ids(&self, ids: &[String]) -> Result<Vec<Chunk>> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let holes = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT * FROM artifacts WHERE id IN ({holes})"
+        )));
+        for id in ids {
+            q = q.bind(id);
+        }
+        Ok(q.fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(row_to_artifact)
+            .collect())
     }
 
     /// The caveats of many artifacts in one query, keyed by id.
@@ -837,6 +897,7 @@ impl Store {
             "SELECT a.id FROM artifacts a
               WHERE a.status = 'active' AND a.superseded_by IS NULL
                 AND a.embed_state = 'embedded'
+                AND a.provenance <> 'passage'
                 AND NOT EXISTS (SELECT 1 FROM jobs j
                                  WHERE j.stage = 'relate' AND j.target_id = a.id)
               ORDER BY a.created_at
@@ -1389,5 +1450,75 @@ mod tests {
         .await
         .unwrap();
         assert!(leftovers.is_empty(), "fts leftovers: {leftovers:?}");
+    }
+
+    #[test]
+    fn provenance_round_trips_all_four_values_and_unknown_reads_as_captured() {
+        for p in [
+            Provenance::Passage,
+            Provenance::Captured,
+            Provenance::Merged,
+            Provenance::Synthesized,
+        ] {
+            assert_eq!(Provenance::parse(p.as_str()), p);
+        }
+        assert_eq!(Provenance::parse("whatever"), Provenance::Captured);
+        assert!(Provenance::Merged.is_model_written());
+        assert!(Provenance::Synthesized.is_model_written());
+        assert!(Provenance::Passage.is_source_text());
+        assert!(Provenance::Captured.is_source_text());
+        assert!(!Provenance::Passage.is_model_written());
+    }
+
+    #[tokio::test]
+    async fn a_passage_is_inserted_as_one_and_read_back_as_one() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts_with_provenance(&src.id, &[nc(0, "verbatim")], Provenance::Passage)
+            .await
+            .unwrap();
+        assert_eq!(made[0].provenance, Provenance::Passage);
+        let read = s.get_artifact(&made[0].id).await.unwrap();
+        assert_eq!(read.provenance, Provenance::Passage);
+        // The old entry point still writes captured rows.
+        let cap = s
+            .insert_artifacts(&src.id, &[nc(1, "captured")])
+            .await
+            .unwrap();
+        assert_eq!(cap[0].provenance, Provenance::Captured);
+    }
+
+    #[tokio::test]
+    async fn artifacts_by_ids_returns_the_rows_asked_for_and_skips_the_missing() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c")])
+            .await
+            .unwrap();
+        let got = s
+            .artifacts_by_ids(&[made[2].id.clone(), "gone".into(), made[0].id.clone()])
+            .await
+            .unwrap();
+        let mut texts: Vec<&str> = got.iter().map(|c| c.text.as_str()).collect();
+        texts.sort_unstable();
+        assert_eq!(texts, vec!["a", "c"]);
+    }
+
+    #[tokio::test]
+    async fn the_relate_backstop_never_lists_a_passage() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let p = s
+            .insert_artifacts_with_provenance(&src.id, &[nc(0, "p")], Provenance::Passage)
+            .await
+            .unwrap();
+        let c = s.insert_artifacts(&src.id, &[nc(1, "c")]).await.unwrap();
+        for id in [&p[0].id, &c[0].id] {
+            s.mark_embedded(id, "fake", 0).await.unwrap();
+        }
+        let ids = s.list_unrelated_artifact_ids(10).await.unwrap();
+        assert_eq!(ids, vec![c[0].id.clone()]);
     }
 }

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -166,6 +166,9 @@ pub struct Chunk {
     /// `created_at` at insert; this, not `created_at`, is what search ranking
     /// decays against.
     pub last_verified_at: Option<i64>,
+    /// For a synthesized artifact: the questions it was written for. Empty
+    /// everywhere else.
+    pub cues: Vec<String>,
 }
 
 impl Chunk {
@@ -192,6 +195,19 @@ pub struct NewMerged {
     pub category: Option<String>,
     pub tags: Vec<String>,
     pub caveats: Vec<String>,
+}
+
+/// An artifact written from a pursuit: what was asked, and what was engaged
+/// with. Inserted through `insert_synthesized_artifact`.
+#[derive(Debug, Clone)]
+pub struct NewSynthesized {
+    pub text: String,
+    pub title: Option<String>,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub caveats: Vec<String>,
+    /// The pursuit's queries: why this was written, shown on its page.
+    pub cues: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -237,6 +253,12 @@ pub(crate) fn row_to_artifact(r: &sqlx::sqlite::SqliteRow) -> Chunk {
             .unwrap_or_default(),
         status: ArtifactStatus::parse(r.get::<String, _>("status").as_str()),
         last_verified_at: r.get("last_verified_at"),
+        cues: r
+            .try_get::<Option<String>, _>("cues")
+            .ok()
+            .flatten()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default(),
     }
 }
 
@@ -297,6 +319,7 @@ impl Store {
             caveats: new.caveats.clone(),
             status: ArtifactStatus::Active,
             last_verified_at: Some(created_at),
+            cues: vec![],
         };
         sqlx::query(
             "INSERT INTO artifacts (id, corpus_id, provenance, source_count, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, activation, activated_at)
@@ -336,6 +359,95 @@ impl Store {
         }
         tx.commit().await?;
         Ok(c)
+    }
+
+    /// Write an artifact generated from a pursuit. Like a merge it has no
+    /// corpus of its own and names its sources through `artifact_sources`;
+    /// unlike a merge it supersedes nothing — its sources stay active and
+    /// keep ranking. `root_id` resolves through `roots_of`, so a generation
+    /// written from another generation still names source text, and `via_id`
+    /// keeps the chain reconstructible at any depth.
+    pub async fn insert_synthesized_artifact(
+        &self,
+        new: &NewSynthesized,
+        sources: &[String],
+    ) -> Result<Chunk> {
+        let resolved = self.roots_of(sources).await?;
+        let root_ids: std::collections::BTreeSet<&String> = resolved.values().flatten().collect();
+        let mut tx = self.pool.begin().await?;
+        let created_at = now();
+        let c = Chunk {
+            id: new_id(),
+            corpus_id: None,
+            provenance: Provenance::Synthesized,
+            source_count: root_ids.len() as i64,
+            ordinal: 0,
+            text: new.text.clone(),
+            corpus_span: None,
+            title: new.title.clone(),
+            category: new.category.clone(),
+            tags: new.tags.clone(),
+            embed_state: EmbedState::Pending,
+            embed_model: None,
+            created_at,
+            embed_rev: 0,
+            segment_idx: None,
+            flags: vec![],
+            flag_detail: None,
+            superseded_by: None,
+            caveats: new.caveats.clone(),
+            status: ArtifactStatus::Active,
+            last_verified_at: Some(created_at),
+            cues: new.cues.clone(),
+        };
+        sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, provenance, source_count, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, activation, activated_at, cues)
+             VALUES (?, NULL, 'synthesized', ?, 0, ?, NULL, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?, 1.0, ?, ?)",
+        )
+        .bind(&c.id)
+        .bind(c.source_count)
+        .bind(&c.text)
+        .bind(&c.title)
+        .bind(&c.category)
+        .bind(serde_json::to_string(&c.tags).unwrap())
+        .bind(c.embed_state.as_str())
+        .bind(c.created_at)
+        .bind(serde_json::to_string(&c.caveats).unwrap_or_else(|_| "[]".into()))
+        .bind(c.status.as_str())
+        .bind(c.last_verified_at)
+        .bind(c.created_at)
+        .bind(serde_json::to_string(&c.cues).unwrap_or_else(|_| "[]".into()))
+        .execute(&mut *tx)
+        .await?;
+        for (via, roots) in &resolved {
+            for root in roots {
+                sqlx::query(
+                    "INSERT OR IGNORE INTO artifact_sources (child_id, root_id, via_id, created_at)
+                     VALUES (?, ?, ?, ?)",
+                )
+                .bind(&c.id)
+                .bind(root)
+                .bind(via)
+                .bind(created_at)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(c)
+    }
+
+    /// Generated artifacts still in results, newest first. What Ops lists.
+    pub async fn synthesized_artifacts(&self, limit: i64) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts
+              WHERE provenance = 'synthesized' AND status = 'active' AND superseded_by IS NULL
+              ORDER BY created_at DESC LIMIT ?",
+        )
+        .bind(limit.max(0))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
     }
 
     pub async fn insert_artifacts(
@@ -382,6 +494,7 @@ impl Store {
                 caveats: nc.caveats.clone(),
                 status: ArtifactStatus::Active,
                 last_verified_at: Some(created_at),
+                cues: vec![],
             };
             sqlx::query(
                 "INSERT INTO artifacts (id, corpus_id, provenance, ordinal, text, corpus_span, title, category, tags, embed_state, embed_model, created_at, segment_idx, caveats, status, last_verified_at, activation, activated_at)
@@ -1648,6 +1761,7 @@ mod tests {
                     query_vec: vec![1.0, 0.0],
                     embed_model: "fake".into(),
                     candidates: vec![],
+                    answered: false,
                 },
                 0,
             )
@@ -1655,5 +1769,64 @@ mod tests {
             .unwrap();
         s.judge_hit(&ev, &made[0].id).await.unwrap();
         assert!(s.artifact_confirmed(&made[0].id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_synthesized_artifact_names_source_text_as_roots_at_any_depth() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b")])
+            .await
+            .unwrap();
+        let gen1 = s
+            .insert_synthesized_artifact(
+                &NewSynthesized {
+                    text: "written from a and b".into(),
+                    title: Some("G1".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec!["how do I a and b".into()],
+                },
+                &[made[0].id.clone(), made[1].id.clone()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(gen1.provenance, Provenance::Synthesized);
+        assert!(gen1.corpus_id.is_none());
+        let read = s.get_artifact(&gen1.id).await.unwrap();
+        assert_eq!(read.cues, vec!["how do I a and b".to_string()]);
+        // Its sources stay active: a generation supersedes nothing.
+        assert!(s.get_artifact(&made[0].id).await.unwrap().in_results());
+        // A generation written from the generation: roots are still a and b,
+        // reached through G1.
+        let gen2 = s
+            .insert_synthesized_artifact(
+                &NewSynthesized {
+                    text: "written from G1".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec![],
+                },
+                std::slice::from_ref(&gen1.id),
+            )
+            .await
+            .unwrap();
+        let roots = s.roots_of(std::slice::from_ref(&gen2.id)).await.unwrap();
+        let mut got = roots[&gen2.id].clone();
+        got.sort();
+        let mut want = vec![made[0].id.clone(), made[1].id.clone()];
+        want.sort();
+        assert_eq!(got, want, "roots must be captured text, never a generation");
+        let via = s.sources_with_via(&gen2.id).await.unwrap();
+        assert!(
+            via.iter()
+                .all(|(_, v)| v.as_deref() == Some(gen1.id.as_str())),
+            "{via:?}"
+        );
+        assert_eq!(s.synthesized_artifacts(10).await.unwrap().len(), 2);
     }
 }

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -420,6 +420,45 @@ impl Store {
         Ok(row_to_artifact(&row))
     }
 
+    /// Every row a window owns, whatever its status, in ordinal order. The
+    /// promotion path reads this to see what it is superseding and, on a
+    /// retry, what it already wrote.
+    pub async fn artifacts_for_segment(&self, corpus_id: &str, idx: i64) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts WHERE corpus_id = ? AND segment_idx = ? ORDER BY ordinal",
+        )
+        .bind(corpus_id)
+        .bind(idx)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
+    /// Set an artifact's activation outright, stamped `at`. Promotion uses it
+    /// to hand a new artifact the access its passages earned; everything else
+    /// goes through `bump_activation`, which adds.
+    pub async fn set_activation(&self, id: &str, value: f64, at: i64) -> Result<()> {
+        sqlx::query("UPDATE artifacts SET activation = ?, activated_at = ? WHERE id = ?")
+            .bind(value)
+            .bind(at)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Has a person ever said this artifact was the answer? A `hit` verdict
+    /// naming it, on any recorded search.
+    pub async fn artifact_confirmed(&self, id: &str) -> Result<bool> {
+        Ok(sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM search_events WHERE verdict = 'hit' AND expect_id = ?",
+        )
+        .bind(id)
+        .fetch_one(&self.pool)
+        .await?
+            > 0)
+    }
+
     /// The rows for these ids, in no particular order; ids that name nothing
     /// are simply absent. One query for a page of hits.
     pub async fn artifacts_by_ids(&self, ids: &[String]) -> Result<Vec<Chunk>> {
@@ -1563,5 +1602,58 @@ mod tests {
             got.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(),
             vec!["a"]
         );
+    }
+
+    #[tokio::test]
+    async fn set_activation_writes_value_and_stamp_and_artifacts_for_segment_reads_every_status() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let mut a = nc(0, "a");
+        a.segment_idx = Some(3);
+        let mut b = nc(1, "b");
+        b.segment_idx = Some(3);
+        let mut c = nc(2, "c");
+        c.segment_idx = Some(4);
+        let made = s.insert_artifacts(&src.id, &[a, b, c]).await.unwrap();
+        s.set_superseded_by(&made[1].id, Some(&made[0].id))
+            .await
+            .unwrap();
+        let seg = s.artifacts_for_segment(&src.id, 3).await.unwrap();
+        assert_eq!(
+            seg.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+
+        s.set_activation(&made[0].id, 7.25, 99).await.unwrap();
+        let act = s
+            .activation_of(std::slice::from_ref(&made[0].id))
+            .await
+            .unwrap();
+        assert_eq!(act[&made[0].id], (7.25, 99));
+    }
+
+    #[tokio::test]
+    async fn artifact_confirmed_reads_a_hit_verdict_naming_it() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s.insert_artifacts(&src.id, &[nc(0, "a")]).await.unwrap();
+        assert!(!s.artifact_confirmed(&made[0].id).await.unwrap());
+        let ev = s
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "q".into(),
+                    door: crate::store::feedback::Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0, 0.0],
+                    embed_model: "fake".into(),
+                    candidates: vec![],
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        s.judge_hit(&ev, &made[0].id).await.unwrap();
+        assert!(s.artifact_confirmed(&made[0].id).await.unwrap());
     }
 }

--- a/src/store/asks.rs
+++ b/src/store/asks.rs
@@ -14,6 +14,10 @@ use sqlx::Row;
 pub struct NewAskCitation {
     pub artifact_id: String,
     pub score: f32,
+    /// The answer referenced this `[n]`. What the model was *shown* is not
+    /// what it used, and only what it used is engagement — see
+    /// `RecordedAsk::cited`.
+    pub used: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -44,7 +48,10 @@ pub struct RecordedAsk {
     pub query_vec: Vec<f32>,
     pub created_at: i64,
     pub abstained: bool,
-    /// The excerpts the model was shown, in order: what the question engaged.
+    /// The excerpts the answer actually referenced, in the order they were
+    /// shown. Not everything the model saw: an ask packs whatever fits, so
+    /// "was in the prompt" says nothing about whether it helped, and an
+    /// abstention leaves this empty however much it was given.
     pub cited: Vec<String>,
     pub scope: Option<String>,
 }
@@ -143,12 +150,14 @@ impl Store {
         .await?;
         for (i, c) in ask.citations.iter().enumerate() {
             sqlx::query(
-                "INSERT INTO ask_citations (event_id, n, artifact_id, score) VALUES (?, ?, ?, ?)",
+                "INSERT INTO ask_citations (event_id, n, artifact_id, score, used)
+                 VALUES (?, ?, ?, ?, ?)",
             )
             .bind(&id)
             .bind(i as i64 + 1)
             .bind(&c.artifact_id)
             .bind(c.score)
+            .bind(c.used as i64)
             .execute(&mut *tx)
             .await?;
         }
@@ -294,7 +303,7 @@ impl Store {
     }
 
     /// Recorded questions with `from < created_at <= to`, oldest first, with
-    /// the excerpts they cited — the sources a question engaged.
+    /// the excerpts their answers referenced — the sources a question engaged.
     pub async fn asks_between(&self, from: i64, to: i64) -> Result<Vec<RecordedAsk>> {
         let rows = sqlx::query(
             "SELECT id, question, query_vec, created_at, abstained, scope FROM ask_events
@@ -308,7 +317,8 @@ impl Store {
         for r in &rows {
             let id: String = r.get("id");
             let cited: Vec<String> = sqlx::query_scalar(
-                "SELECT artifact_id FROM ask_citations WHERE event_id = ? ORDER BY n",
+                "SELECT artifact_id FROM ask_citations
+                  WHERE event_id = ? AND used = 1 ORDER BY n",
             )
             .bind(&id)
             .fetch_all(&self.pool)
@@ -353,6 +363,7 @@ mod tests {
                 .map(|i| NewAskCitation {
                     artifact_id: format!("art-{i}"),
                     score: 1.0 - i as f32 * 0.1,
+                    used: true,
                 })
                 .collect(),
         }

--- a/src/store/asks.rs
+++ b/src/store/asks.rs
@@ -36,6 +36,19 @@ pub struct NewAsk {
     pub citations: Vec<NewAskCitation>,
 }
 
+/// One recorded question as the pursuit sweep reads it.
+#[derive(Debug, Clone)]
+pub struct RecordedAsk {
+    pub id: String,
+    pub question: String,
+    pub query_vec: Vec<f32>,
+    pub created_at: i64,
+    pub abstained: bool,
+    /// The excerpts the model was shown, in order: what the question engaged.
+    pub cited: Vec<String>,
+    pub scope: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AskVerdict {
     /// The answer is correct as stated.
@@ -280,6 +293,39 @@ impl Store {
         )
     }
 
+    /// Recorded questions with `from < created_at <= to`, oldest first, with
+    /// the excerpts they cited — the sources a question engaged.
+    pub async fn asks_between(&self, from: i64, to: i64) -> Result<Vec<RecordedAsk>> {
+        let rows = sqlx::query(
+            "SELECT id, question, query_vec, created_at, abstained, scope FROM ask_events
+              WHERE created_at > ? AND created_at <= ? ORDER BY created_at, id",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let id: String = r.get("id");
+            let cited: Vec<String> = sqlx::query_scalar(
+                "SELECT artifact_id FROM ask_citations WHERE event_id = ? ORDER BY n",
+            )
+            .bind(&id)
+            .fetch_all(&self.pool)
+            .await?;
+            out.push(RecordedAsk {
+                id,
+                question: r.get("question"),
+                query_vec: crate::store::feedback::blob_to_vec(&r.get::<Vec<u8>, _>("query_vec")),
+                created_at: r.get("created_at"),
+                abstained: r.get::<i64, _>("abstained") != 0,
+                cited,
+                scope: r.get("scope"),
+            });
+        }
+        Ok(out)
+    }
+
     pub async fn purge_asks(&self) -> Result<u64> {
         Ok(sqlx::query("DELETE FROM ask_events")
             .execute(&self.pool)
@@ -464,5 +510,23 @@ mod tests {
         store.judge_ask(&a, AskVerdict::Right).await.unwrap();
         assert_eq!(store.purge_asks().await.unwrap(), 2);
         assert_eq!(store.ask_stats().await.unwrap().asked, 0);
+    }
+
+    #[tokio::test]
+    async fn asks_between_carries_what_was_cited_and_whether_it_abstained() {
+        let store = Store::memory().await.unwrap();
+        let id = store.record_ask(ask("how", 2)).await.unwrap();
+        let mut abst = ask("nothing", 0);
+        abst.abstained = true;
+        store.record_ask(abst).await.unwrap();
+        let now = crate::store::now();
+        let got = store.asks_between(0, now + 1).await.unwrap();
+        assert_eq!(got.len(), 2);
+        let first = got.iter().find(|a| a.id == id).unwrap();
+        assert_eq!(first.cited, vec!["art-0".to_string(), "art-1".to_string()]);
+        assert!(!first.abstained);
+        assert_eq!(first.scope.as_deref(), Some("me"));
+        assert!(got.iter().any(|a| a.abstained && a.cited.is_empty()));
+        assert!(got.iter().all(|a| a.query_vec == vec![0.1, 0.2, 0.3]));
     }
 }

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -121,6 +121,25 @@ pub struct NewEvent {
     /// Vectors are only comparable under the model that produced them.
     pub embed_model: String,
     pub candidates: Vec<NewCandidate>,
+    /// A synthesized artifact led the list above `weak_below`: the base
+    /// answered, and the pursuit this lands in closes satisfied.
+    pub answered: bool,
+}
+
+/// One recorded search as the pursuit sweep reads it.
+#[derive(Debug, Clone)]
+pub struct RecordedEvent {
+    pub id: String,
+    pub query: String,
+    pub query_vec: Vec<f32>,
+    pub created_at: i64,
+    pub answered: bool,
+    /// `expect_id` when the verdict is `hit`: a person said this artifact was
+    /// the answer.
+    pub confirmed: Option<String>,
+    pub scope: Option<String>,
+    /// The shown candidates: `(artifact_id, similarity)`, rank order.
+    pub shown: Vec<(String, Option<f32>)>,
 }
 
 fn vec_to_blob(v: &[f32]) -> Vec<u8> {
@@ -245,7 +264,7 @@ impl Store {
                 sqlx::query(
                     "UPDATE search_events
                      SET query = ?, filters = ?, query_vec = ?, vec_dim = ?,
-                         embed_model = ?, created_at = ?
+                         embed_model = ?, created_at = ?, answered = ?
                      WHERE id = ?",
                 )
                 .bind(&ev.query)
@@ -254,6 +273,7 @@ impl Store {
                 .bind(ev.query_vec.len() as i64)
                 .bind(&ev.embed_model)
                 .bind(at)
+                .bind(ev.answered as i64)
                 .bind(&id)
                 .execute(&mut *tx)
                 .await?;
@@ -268,8 +288,8 @@ impl Store {
                 sqlx::query(
                     "INSERT INTO search_events
                        (id, query, door, scope, filters, query_vec, vec_dim, embed_model,
-                        created_at)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        created_at, answered)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(&id)
                 .bind(&ev.query)
@@ -280,6 +300,7 @@ impl Store {
                 .bind(ev.query_vec.len() as i64)
                 .bind(&ev.embed_model)
                 .bind(at)
+                .bind(ev.answered as i64)
                 .execute(&mut *tx)
                 .await?;
                 id
@@ -664,7 +685,75 @@ impl Store {
             .execute(&self.pool)
             .await?
             .rows_affected();
-        Ok(searches + self.purge_asks().await?)
+        // Pursuits and what was opened are the same kind of record — what a
+        // person did — and go with one press.
+        Ok(searches + self.purge_asks().await? + self.purge_pursuits().await?)
+    }
+
+    /// Recorded searches with `from < created_at <= to`, oldest first, with
+    /// what the sweep needs and nothing else. The judge door is excluded: a
+    /// benchmark query is not a need.
+    pub async fn events_between(&self, from: i64, to: i64) -> Result<Vec<RecordedEvent>> {
+        let rows = sqlx::query(
+            "SELECT id, query, query_vec, created_at, answered, verdict, expect_id, scope
+               FROM search_events
+              WHERE created_at > ? AND created_at <= ? AND door <> 'judge'
+              ORDER BY created_at, id",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let id: String = r.get("id");
+            let shown: Vec<(String, Option<f32>)> = sqlx::query(
+                "SELECT artifact_id, similarity FROM search_candidates
+                  WHERE event_id = ? AND shown = 1 ORDER BY rank",
+            )
+            .bind(&id)
+            .fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(|c| {
+                (
+                    c.get::<String, _>("artifact_id"),
+                    c.get::<Option<f32>, _>("similarity"),
+                )
+            })
+            .collect();
+            let verdict: Option<String> = r.get("verdict");
+            out.push(RecordedEvent {
+                id,
+                query: r.get("query"),
+                query_vec: blob_to_vec(&r.get::<Vec<u8>, _>("query_vec")),
+                created_at: r.get("created_at"),
+                answered: r.get::<i64, _>("answered") != 0,
+                confirmed: if verdict.as_deref() == Some("hit") {
+                    r.get("expect_id")
+                } else {
+                    None
+                },
+                scope: r.get("scope"),
+                shown,
+            });
+        }
+        Ok(out)
+    }
+
+    /// When the most recent search or question was recorded, if any.
+    pub async fn newest_event_at(&self) -> Result<Option<i64>> {
+        let s: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM search_events")
+            .fetch_one(&self.pool)
+            .await?;
+        let a: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM ask_events")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(match (s, a) {
+            (Some(x), Some(y)) => Some(x.max(y)),
+            (x, None) => x,
+            (None, y) => y,
+        })
     }
 }
 
@@ -710,6 +799,7 @@ mod tests {
                 similarity: Some(0.8),
                 shown: true,
             }],
+            answered: false,
         }
     }
 
@@ -1242,5 +1332,32 @@ mod tests {
             blob_to_vec(&row.get::<Vec<u8>, _>("query_vec")),
             vec![0.5, -0.25]
         );
+    }
+
+    #[tokio::test]
+    async fn events_between_reads_answered_confirmed_and_what_was_shown() {
+        let store = Store::memory().await.unwrap();
+        let mut e = ev("a question", Door::Ui);
+        e.answered = true;
+        let id = store.record_search(e, 0).await.unwrap();
+        store.judge_hit(&id, "a1").await.unwrap();
+        let now = now();
+        let got = store.events_between(0, now + 1).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert!(got[0].answered);
+        assert_eq!(got[0].confirmed.as_deref(), Some("a1"));
+        assert_eq!(got[0].shown, vec![("a1".to_string(), Some(0.8))]);
+        assert_eq!(got[0].query_vec, vec![0.5, -0.25]);
+        // The judge door is not a need.
+        store
+            .record_search(ev("bench", Door::Judge), 0)
+            .await
+            .unwrap();
+        assert_eq!(store.events_between(0, now + 1).await.unwrap().len(), 1);
+        assert!(store.newest_event_at().await.unwrap().is_some());
+        // The forget button takes the pursuits along.
+        store.insert_pursuit(now, &["q".into()], &[]).await.unwrap();
+        store.purge_feedback().await.unwrap();
+        assert!(store.recent_pursuits(10).await.unwrap().is_empty());
     }
 }

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -741,7 +741,17 @@ impl Store {
         Ok(out)
     }
 
-    /// When the most recent search or question was recorded, if any.
+    /// When the session was last active, if it ever was.
+    ///
+    /// Every kind of event, not just the ones that open a pursuit. A search is
+    /// what a pursuit is built around, but reading is what the operator spends
+    /// the session doing: one search at the top of the hour, then twenty
+    /// minutes of opening and pivoting through what it returned. Counting only
+    /// searches calls that session idle while it is at its most active, and the
+    /// sweep that then fires is not merely early — it advances the cursor past
+    /// the search, so every interaction still to come arrives with no search of
+    /// its own left in range, finds no owner, and is dropped. The long read is
+    /// scored as an abandonment, which is the one reading it least resembles.
     pub async fn newest_event_at(&self) -> Result<Option<i64>> {
         let s: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM search_events")
             .fetch_one(&self.pool)
@@ -749,11 +759,10 @@ impl Store {
         let a: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM ask_events")
             .fetch_one(&self.pool)
             .await?;
-        Ok(match (s, a) {
-            (Some(x), Some(y)) => Some(x.max(y)),
-            (x, None) => x,
-            (None, y) => y,
-        })
+        let i: Option<i64> = sqlx::query_scalar("SELECT MAX(at) FROM interaction_events")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok([s, a, i].into_iter().flatten().max())
     }
 }
 

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -752,10 +752,16 @@ impl Store {
     /// the search, so every interaction still to come arrives with no search of
     /// its own left in range, finds no owner, and is dropped. The long read is
     /// scored as an abandonment, which is the one reading it least resembles.
+    ///
+    /// The judge door is excluded for the same reason `events_between` excludes
+    /// it: a benchmark run is not a session. Counting it kept the base looking
+    /// busy for as long as a harness was pointed at it, and the sweep that
+    /// waits for quiet then never ran at all.
     pub async fn newest_event_at(&self) -> Result<Option<i64>> {
-        let s: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM search_events")
-            .fetch_one(&self.pool)
-            .await?;
+        let s: Option<i64> =
+            sqlx::query_scalar("SELECT MAX(created_at) FROM search_events WHERE door <> 'judge'")
+                .fetch_one(&self.pool)
+                .await?;
         let a: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM ask_events")
             .fetch_one(&self.pool)
             .await?;
@@ -1363,7 +1369,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.events_between(0, now + 1).await.unwrap().len(), 1);
-        assert!(store.newest_event_at().await.unwrap().is_some());
+        // Nor is it a session: a harness pointed at the base kept `idle` from
+        // ever elapsing, and the sweep that waits for quiet never ran at all.
+        assert_eq!(store.newest_event_at().await.unwrap(), Some(now));
         // The forget button takes the pursuits along.
         store.insert_pursuit(now, &["q".into()], &[]).await.unwrap();
         store.purge_feedback().await.unwrap();

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -461,6 +461,7 @@ mod tests {
                     query_vec: vec,
                     embed_model: "fake".into(),
                     candidates: vec![],
+                    answered: false,
                 },
                 0,
             )

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -45,6 +45,11 @@ pub enum Stage {
     Associate,
     /// One strong cross-corpus link, one call. Target is `"<a_id>|<b_id>"`.
     LinkJudge,
+    /// The pursuit sweep: groups quiet searches, scores what was engaged,
+    /// decides. Local work; arms `Generate`.
+    Pursuit,
+    /// One pursuit, one call: write the artifact it earned.
+    Generate,
 }
 
 impl Stage {
@@ -61,6 +66,8 @@ impl Stage {
             Stage::Describe => "describe",
             Stage::Associate => "associate",
             Stage::LinkJudge => "link_judge",
+            Stage::Pursuit => "pursuit",
+            Stage::Generate => "generate",
         }
     }
     pub fn parse(s: &str) -> Option<Stage> {
@@ -76,6 +83,8 @@ impl Stage {
             "describe" => Some(Stage::Describe),
             "associate" => Some(Stage::Associate),
             "link_judge" => Some(Stage::LinkJudge),
+            "pursuit" => Some(Stage::Pursuit),
+            "generate" => Some(Stage::Generate),
             _ => None,
         }
     }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -31,8 +31,8 @@ impl Store {
     /// A merged artifact resolves through `artifact_sources`, which already
     /// holds the closure, so this is one query per id and not a traversal.
     ///
-    /// A merged artifact with no lineage rows — every root deleted out from
-    /// under it — resolves to the *empty* list, never to itself. Its text is a
+    /// A merged or synthesized artifact with no lineage rows — every root
+    /// deleted out from under it — resolves to the *empty* list, never to itself. Its text is a
     /// synthesis, and handing it back as a root is how a paraphrase of a
     /// paraphrase ends up in a prompt as an original, or recorded as another
     /// merge's `root_id`. The empty answer makes that state visible to the
@@ -53,7 +53,9 @@ impl Store {
                         .bind(id)
                         .fetch_optional(&self.pool)
                         .await?;
-                if provenance.as_deref() == Some("merged") {
+                if provenance.as_deref().is_some_and(|p| {
+                    crate::store::artifacts::Provenance::parse(p).is_model_written()
+                }) {
                     vec![]
                 } else {
                     vec![id.clone()]
@@ -635,5 +637,44 @@ mod tests {
         let found = s.pairs_among(&[a.clone(), b.clone()]).await.unwrap();
         assert_eq!(found.len(), 1);
         assert!(found[0].a_id == a || found[0].b_id == a);
+    }
+
+    #[tokio::test]
+    async fn roots_of_a_model_written_artifact_with_no_lineage_is_empty_not_itself() {
+        // The §9 hazard: a synthesized artifact read as captured would hand its
+        // own model-written text to a merge prompt as an original.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let na = |ordinal: i64, text: &str| crate::store::artifacts::NewArtifact {
+            ordinal,
+            text: text.into(),
+            corpus_span: None,
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: None,
+            caveats: vec![],
+        };
+        let made = s
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[na(0, "written from a pursuit")],
+                crate::store::artifacts::Provenance::Synthesized,
+            )
+            .await
+            .unwrap();
+        let roots = s.roots_of(std::slice::from_ref(&made[0].id)).await.unwrap();
+        assert!(roots[&made[0].id].is_empty(), "{roots:?}");
+        // A passage is its own root, like a captured artifact.
+        let p = s
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[na(1, "verbatim")],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        let roots = s.roots_of(std::slice::from_ref(&p[0].id)).await.unwrap();
+        assert_eq!(roots[&p[0].id], vec![p[0].id.clone()]);
     }
 }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -16,9 +16,18 @@
 
 use super::Store;
 use crate::error::Result;
+use crate::store::artifacts::{Chunk, CorpusSpan};
 use crate::store::pairs::ArtifactPair;
 use sqlx::Row;
 use std::collections::BTreeMap;
+
+/// Where an artifact comes from, as corpus and lines. Derived from lineage,
+/// never stored: membership *is* lineage projected, so it cannot drift.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Origin {
+    pub corpus_id: String,
+    pub span: Option<CorpusSpan>,
+}
 
 impl Store {
     /// The captured roots of each of `artifact_ids`, keyed by the input id.
@@ -66,6 +75,60 @@ impl Store {
             out.insert(id.clone(), entry);
         }
         Ok(out)
+    }
+
+    /// Mirror of `roots_of`, one step further: every root's corpus and span.
+    /// A passage or captured artifact is its own origin; a merged or
+    /// synthesized one has one origin per root. Non-empty for every active
+    /// artifact — an empty answer is the same broken state `roots_of` reports.
+    /// Derived, never stored: membership *is* lineage projected, so it cannot
+    /// drift.
+    pub async fn origins_of(&self, ids: &[String]) -> Result<BTreeMap<String, Vec<Origin>>> {
+        let roots = self.roots_of(ids).await?;
+        let mut all: Vec<String> = roots.values().flatten().cloned().collect();
+        all.sort();
+        all.dedup();
+        let rows = self.artifacts_by_ids(&all).await?;
+        let by_id: std::collections::HashMap<&str, &Chunk> =
+            rows.iter().map(|c| (c.id.as_str(), c)).collect();
+        let mut out = BTreeMap::new();
+        for (id, rs) in roots {
+            let mut o: Vec<Origin> = rs
+                .iter()
+                .filter_map(|r| by_id.get(r.as_str()))
+                .filter_map(|c| {
+                    Some(Origin {
+                        corpus_id: c.corpus_id.clone()?,
+                        span: c.corpus_span.clone(),
+                    })
+                })
+                .collect();
+            o.sort_by(|a, b| {
+                (a.corpus_id.as_str(), a.span.as_ref().map(|s| s.start_line))
+                    .cmp(&(b.corpus_id.as_str(), b.span.as_ref().map(|s| s.start_line)))
+            });
+            out.insert(id, o);
+        }
+        Ok(out)
+    }
+
+    /// Model-written artifacts with a root in this corpus: what the corpus
+    /// page lists as written from it.
+    pub async fn artifacts_originating_in(&self, corpus_id: &str) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT DISTINCT m.* FROM artifacts m
+               JOIN artifact_sources s ON s.child_id = m.id
+               JOIN artifacts r ON r.id = s.root_id
+              WHERE r.corpus_id = ? AND m.provenance IN ('merged', 'synthesized')
+              ORDER BY m.created_at",
+        )
+        .bind(corpus_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(crate::store::artifacts::row_to_artifact)
+            .collect())
     }
 
     /// Merged artifacts still standing, newest first. What Ops lists.
@@ -298,6 +361,7 @@ impl Store {
 
 #[cfg(test)]
 mod tests {
+    use super::Origin;
     use crate::store::Store;
     use crate::store::artifacts::{NewArtifact, NewMerged, Provenance};
 
@@ -676,5 +740,62 @@ mod tests {
             .unwrap();
         let roots = s.roots_of(std::slice::from_ref(&p[0].id)).await.unwrap();
         assert_eq!(roots[&p[0].id], vec![p[0].id.clone()]);
+    }
+
+    #[tokio::test]
+    async fn origins_of_a_merge_are_its_roots_corpora_and_spans() {
+        let s = Store::memory().await.unwrap();
+        let c1 = s.insert_corpus("one", "web", None).await.unwrap();
+        let c2 = s.insert_corpus("two", "web", None).await.unwrap();
+        let na = |t: &str, a: i64, b: i64| crate::store::artifacts::NewArtifact {
+            ordinal: 0,
+            text: t.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                start_line: a,
+                end_line: b,
+            }),
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let r1 = s.insert_artifacts(&c1.id, &[na("r1", 1, 3)]).await.unwrap()[0]
+            .id
+            .clone();
+        let r2 = s.insert_artifacts(&c2.id, &[na("r2", 7, 9)]).await.unwrap()[0]
+            .id
+            .clone();
+        let m = s
+            .insert_merged_artifact(&merged("r1 and r2"), &[r1.clone(), r2.clone()])
+            .await
+            .unwrap();
+        let o = s.origins_of(&[m.id.clone(), r1.clone()]).await.unwrap();
+        let mut got: Vec<(String, Option<i64>)> = o[&m.id]
+            .iter()
+            .map(|x| (x.corpus_id.clone(), x.span.as_ref().map(|sp| sp.start_line)))
+            .collect();
+        got.sort();
+        let mut want = vec![(c1.id.clone(), Some(1)), (c2.id.clone(), Some(7))];
+        want.sort();
+        assert_eq!(got, want);
+        assert_eq!(
+            o[&r1],
+            vec![Origin {
+                corpus_id: c1.id.clone(),
+                span: Some(crate::store::artifacts::CorpusSpan {
+                    start_line: 1,
+                    end_line: 3
+                })
+            }]
+        );
+        // Every active artifact has at least one origin.
+        assert!(o.values().all(|v| !v.is_empty()));
+        // And the corpus page can find the merge from either corpus.
+        let from_c2 = s.artifacts_originating_in(&c2.id).await.unwrap();
+        assert_eq!(
+            from_c2.iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
+            vec![m.id.clone()]
+        );
     }
 }

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -105,6 +105,23 @@ pub fn normalize_query(q: &str) -> String {
         .to_lowercase()
 }
 
+/// Do two artifacts share no corpus? An artifact with no origins at all —
+/// lineage lost — is treated as its own document, which keeps such a link
+/// judgeable rather than silently shown-only.
+fn origins_disjoint(
+    origins: &std::collections::BTreeMap<String, Vec<crate::store::lineage::Origin>>,
+    a: &str,
+    b: &str,
+) -> bool {
+    let of = |id: &str| -> std::collections::BTreeSet<&str> {
+        origins
+            .get(id)
+            .map(|o| o.iter().map(|x| x.corpus_id.as_str()).collect())
+            .unwrap_or_default()
+    };
+    of(a).is_disjoint(&of(b))
+}
+
 /// Strength now, from strength then. `half_life_days <= 0` turns decay off.
 ///
 /// A clock that moved backwards — a restored database, an NTP correction —
@@ -546,8 +563,9 @@ impl Store {
                     state,
                     reason: r.get("reason"),
                     cues: serde_json::from_str(&r.get::<String, _>("cues")).unwrap_or_default(),
-                    // A merged artifact belongs to no corpus, so it can never be
-                    // "the same document" as anything.
+                    // Decided below through origins where either side is a
+                    // merge; here only the case both rows answer for
+                    // themselves.
                     cross_corpus: match (a_corpus, b_corpus) {
                         (Some(x), Some(y)) => x != y,
                         _ => true,
@@ -557,6 +575,19 @@ impl Store {
         }
         out.sort_by(|x, y| y.weight.total_cmp(&x.weight));
         out.truncate(limit.max(0) as usize);
+        // A merged or synthesized artifact belongs to every corpus it drew
+        // from, so "the same document" is "the two origin sets intersect" —
+        // read through lineage, one batched query for the page of links.
+        let mut ids: Vec<String> = out
+            .iter()
+            .flat_map(|l| [l.via.clone(), l.other.clone()])
+            .collect();
+        ids.sort();
+        ids.dedup();
+        let origins = self.origins_of(&ids).await?;
+        for l in &mut out {
+            l.cross_corpus = origins_disjoint(&origins, &l.via, &l.other);
+        }
         Ok(out)
     }
 
@@ -565,7 +596,9 @@ impl Store {
     ///
     /// Same two-step as `links_from`: the raw weight narrows with the index and
     /// the decayed weight decides. Four times the caller's limit is fetched so
-    /// that rows failing the exact test do not eat the budget.
+    /// that rows failing the exact test do not eat the budget. Cross-corpus is
+    /// decided in Rust over origins rather than in SQL over `corpus_id`: a
+    /// merge has none of its own and belongs to every corpus it drew from.
     pub async fn links_to_judge(
         &self,
         min_weight: f64,
@@ -582,7 +615,6 @@ impl Store {
                 AND l.weight >= ? AND l.queries >= ?
                 AND a.status = 'active' AND a.superseded_by IS NULL
                 AND b.status = 'active' AND b.superseded_by IS NULL
-                AND (a.corpus_id IS NULL OR b.corpus_id IS NULL OR a.corpus_id <> b.corpus_id)
               ORDER BY l.weight DESC LIMIT ?",
         )
         .bind(min_weight)
@@ -594,10 +626,24 @@ impl Store {
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows
+        let strong: Vec<Link> = rows
             .iter()
             .map(row_to_link)
             .filter(|l| decayed(l.weight, l.bumped_at, at, half_life_days) >= min_weight)
+            .collect();
+        // Two passages of one document being related is not information, so a
+        // same-document link is shown and never judged — "same document" read
+        // through origins, so a merge is the documents it drew from.
+        let mut ids: Vec<String> = strong
+            .iter()
+            .flat_map(|l| [l.a_id.clone(), l.b_id.clone()])
+            .collect();
+        ids.sort();
+        ids.dedup();
+        let origins = self.origins_of(&ids).await?;
+        Ok(strong
+            .into_iter()
+            .filter(|l| origins_disjoint(&origins, &l.a_id, &l.b_id))
             .take(limit.max(0) as usize)
             .collect())
     }
@@ -1493,5 +1539,76 @@ mod tests {
         assert_eq!(s.links_touching(&p).await.unwrap().len(), 1);
         assert_eq!(s.links_touching(&x).await.unwrap().len(), 1);
         assert!(s.links_touching("nobody").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cross_corpus_is_read_through_origins_for_a_merge() {
+        // A merge of two artifacts from corpus 1, linked to a third artifact of
+        // corpus 1: same document, however the merge's own `corpus_id` reads.
+        let store = Store::memory().await.unwrap();
+        let src = store.insert_corpus("one", "web", None).await.unwrap();
+        let na = |o: i64, t: &str| NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: None,
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: None,
+            caveats: vec![],
+        };
+        let made = store
+            .insert_artifacts(&src.id, &[na(0, "a"), na(1, "b"), na(2, "c")])
+            .await
+            .unwrap();
+        let m = store
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    text: "a and b".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[made[0].id.clone(), made[1].id.clone()],
+            )
+            .await
+            .unwrap();
+        let other_src = store.insert_corpus("two", "web", None).await.unwrap();
+        let far = store
+            .insert_artifacts(&other_src.id, &[na(0, "far")])
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        for q in ["one", "two", "three"] {
+            store
+                .bump_link(&m.id, &made[2].id, 2.0, Some(q), 30.0, 0)
+                .await
+                .unwrap();
+            store
+                .bump_link(&m.id, &far, 2.0, Some(q), 30.0, 0)
+                .await
+                .unwrap();
+        }
+        let out = store
+            .links_from(
+                std::slice::from_ref(&m.id),
+                &[LinkState::Learning],
+                30.0,
+                0,
+                0.0,
+                10,
+            )
+            .await
+            .unwrap();
+        let same = out.iter().find(|l| l.other == made[2].id).unwrap();
+        let cross = out.iter().find(|l| l.other == far).unwrap();
+        assert!(!same.cross_corpus, "a merge of corpus-1 roots is corpus 1");
+        assert!(cross.cross_corpus);
+        // And the judge is offered only the cross-corpus one.
+        let armed = store.links_to_judge(4.0, 3, 30.0, 0, 10).await.unwrap();
+        assert_eq!(armed.len(), 1, "{armed:?}");
+        assert!(armed[0].a_id == far || armed[0].b_id == far);
     }
 }

--- a/src/store/links.rs
+++ b/src/store/links.rs
@@ -324,6 +324,115 @@ async fn bump_one(
 }
 
 impl Store {
+    /// Every link naming `id` at either end, in any state.
+    pub async fn links_touching(&self, id: &str) -> Result<Vec<Link>> {
+        let rows = sqlx::query("SELECT * FROM artifact_links WHERE a_id = ? OR b_id = ?")
+            .bind(id)
+            .bind(id)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(row_to_link).collect())
+    }
+
+    /// Copy a link that touches `old` onto `new` and the same other endpoint,
+    /// leaving the original row where it is.
+    ///
+    /// Learned access carries forward; recorded history does not. Weight comes
+    /// across decayed to `at` and stamped `at`; `queries` and `cues` come
+    /// across as they are. On collision with a link `new` already has: the
+    /// larger decayed weight (max, not sum — one search returning three
+    /// passages of one section is one piece of evidence), the larger
+    /// `queries`, the cues merged and cut to three, `dismissed` if either side
+    /// was (the operator's "not related" is final), otherwise `learning` — a
+    /// verdict passed on the passage's text does not transfer to a rewrite —
+    /// and `judged_rev_*` cleared. A link whose other end *is* `new`, or that
+    /// would pair `new` with itself, is skipped.
+    pub async fn carry_link(
+        &self,
+        from: &Link,
+        old: &str,
+        new: &str,
+        half_life_days: f64,
+        at: i64,
+    ) -> Result<()> {
+        let other = if from.a_id == old {
+            &from.b_id
+        } else {
+            &from.a_id
+        };
+        if other == new || other == old {
+            return Ok(());
+        }
+        let (a, b) = canonical(new, other);
+        let incoming = decayed(from.weight, from.bumped_at, at, half_life_days);
+        let mut tx = self.pool.begin_with(IMMEDIATE).await?;
+        let existing = sqlx::query("SELECT * FROM artifact_links WHERE a_id = ? AND b_id = ?")
+            .bind(a)
+            .bind(b)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(|r| row_to_link(&r));
+        match existing {
+            None => {
+                let state = if from.state == LinkState::Dismissed {
+                    LinkState::Dismissed
+                } else {
+                    LinkState::Learning
+                };
+                sqlx::query(
+                    "INSERT INTO artifact_links
+                       (a_id, b_id, weight, bumped_at, queries, cues, state, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(a)
+                .bind(b)
+                .bind(incoming)
+                .bind(at)
+                .bind(from.queries)
+                .bind(serde_json::to_string(&from.cues).unwrap_or_else(|_| "[]".into()))
+                .bind(state.as_str())
+                .bind(now())
+                .execute(&mut *tx)
+                .await?;
+            }
+            Some(have) => {
+                let weight = decayed(have.weight, have.bumped_at, at, half_life_days).max(incoming);
+                let mut cues = have.cues.clone();
+                for c in &from.cues {
+                    match cues.iter_mut().find(|x| x.q == c.q) {
+                        Some(x) => x.n = x.n.max(c.n),
+                        None => cues.push(c.clone()),
+                    }
+                }
+                cues.sort_by_key(|x| std::cmp::Reverse(x.n));
+                cues.truncate(3);
+                let state =
+                    if have.state == LinkState::Dismissed || from.state == LinkState::Dismissed {
+                        LinkState::Dismissed
+                    } else {
+                        LinkState::Learning
+                    };
+                sqlx::query(
+                    "UPDATE artifact_links
+                        SET weight = ?, bumped_at = ?, queries = ?, cues = ?, state = ?,
+                            reason = NULL, judged_rev_a = NULL, judged_rev_b = NULL
+                      WHERE a_id = ? AND b_id = ?",
+                )
+                .bind(weight)
+                .bind(at)
+                .bind(have.queries.max(from.queries))
+                .bind(serde_json::to_string(&cues).unwrap_or_else(|_| "[]".into()))
+                .bind(state.as_str())
+                .bind(a)
+                .bind(b)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
     /// One link, whichever way round it is named.
     pub async fn get_link(&self, a: &str, b: &str) -> Result<Option<Link>> {
         let (a, b) = canonical(a, b);
@@ -1281,5 +1390,108 @@ mod tests {
         let store = Store::memory().await.unwrap();
         store.bump_activation(&[], 1.0, 14.0, 0).await.unwrap();
         assert!(store.activation_of(&[]).await.unwrap().is_empty());
+    }
+
+    /// An artifact in a corpus of its own, for a link to be carried onto.
+    async fn third(store: &Store) -> String {
+        let src = store.insert_corpus("raw2", "web", None).await.unwrap();
+        store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "the artifact".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn carrying_a_link_copies_it_and_leaves_the_original() {
+        let s = Store::memory().await.unwrap();
+        let (p, x) = two(&s).await; // passage p, some artifact x
+        let a = third(&s).await;
+        s.bump_links(
+            &[(p.as_str(), x.as_str())],
+            2.0,
+            Some("how to mount"),
+            14.0,
+            1_000,
+        )
+        .await
+        .unwrap();
+        let from = s.get_link(&p, &x).await.unwrap().unwrap();
+
+        s.carry_link(&from, &p, &a, 14.0, 1_000 + 14 * 86_400)
+            .await
+            .unwrap();
+
+        let copied = s.get_link(&a, &x).await.unwrap().expect("the copy exists");
+        // Decayed to the carry moment: one half-life later, half the weight.
+        assert!((copied.weight - 1.0).abs() < 1e-6, "{}", copied.weight);
+        assert_eq!(copied.bumped_at, 1_000 + 14 * 86_400);
+        assert_eq!(copied.queries, from.queries);
+        assert_eq!(copied.cues.len(), 1);
+        assert_eq!(copied.state, LinkState::Learning);
+        assert!(copied.judged_rev_a.is_none() && copied.judged_rev_b.is_none());
+        // The original is still there, untouched.
+        let orig = s.get_link(&p, &x).await.unwrap().unwrap();
+        assert_eq!(orig.weight, from.weight);
+    }
+
+    #[tokio::test]
+    async fn carrying_onto_an_existing_link_takes_the_max_not_the_sum_and_dismissed_wins() {
+        let s = Store::memory().await.unwrap();
+        let (p, x) = two(&s).await;
+        let a = third(&s).await;
+        let at = 5_000;
+        s.bump_links(&[(p.as_str(), x.as_str())], 3.0, Some("q one"), 14.0, at)
+            .await
+            .unwrap();
+        s.bump_links(&[(a.as_str(), x.as_str())], 2.0, Some("q two"), 14.0, at)
+            .await
+            .unwrap();
+        // The operator dismissed the artifact's own link.
+        s.set_link_state(&a, &x, LinkState::Dismissed, None, None)
+            .await
+            .unwrap();
+        let from = s.get_link(&p, &x).await.unwrap().unwrap();
+
+        s.carry_link(&from, &p, &a, 14.0, at).await.unwrap();
+
+        let merged = s.get_link(&a, &x).await.unwrap().unwrap();
+        assert!(
+            (merged.weight - 3.0).abs() < 1e-6,
+            "max, not 5.0: {}",
+            merged.weight
+        );
+        assert_eq!(merged.queries, 1, "max of 1 and 1");
+        assert_eq!(merged.cues.len(), 2, "cues merged");
+        assert_eq!(
+            merged.state,
+            LinkState::Dismissed,
+            "the operator's no is final"
+        );
+    }
+
+    #[tokio::test]
+    async fn links_touching_finds_a_link_from_either_end() {
+        let s = Store::memory().await.unwrap();
+        let (p, x) = two(&s).await;
+        s.bump_links(&[(p.as_str(), x.as_str())], 1.0, None, 14.0, 1)
+            .await
+            .unwrap();
+        assert_eq!(s.links_touching(&p).await.unwrap().len(), 1);
+        assert_eq!(s.links_touching(&x).await.unwrap().len(), 1);
+        assert!(s.links_touching("nobody").await.unwrap().is_empty());
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -261,6 +261,7 @@ mod tests {
                 "carry_lines",
                 "state",
                 "keep_artifacts",
+                "no_promote",
                 "attempts",
                 "last_error",
             ],

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -9,6 +9,7 @@ pub mod jobs;
 pub mod lineage;
 pub mod links;
 pub mod pairs;
+pub mod pursuits;
 pub mod segments;
 pub mod shingle;
 

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -51,10 +51,12 @@ pub enum PairState {
     Superseded,
     /// An operator looked and decided there is nothing here.
     Dismissed,
-    /// Scored at or above `auto_supersede`. Settled by the sweep's free
-    /// clustering pass, and never armed for a model call: that band is answered
-    /// correctly by a rule that costs nothing, and spending a call there is the
-    /// free path quietly becoming a paid one.
+    /// Scored at or above `auto_supersede`, and settled by the sweep's free
+    /// clustering pass rather than by a model call.
+    ///
+    /// Nothing files this any more — a pair in that band now goes to the judge
+    /// like every other, first in line. The variant and the pass that closes it
+    /// stay for the rows an older base filed.
     ///
     /// Filed rather than acted on where it is found, because resolving pairs one
     /// at a time leaves A pointing at a B that is itself hidden — which is what

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -9,6 +9,22 @@ use super::Store;
 use crate::error::{Error, Result};
 use sqlx::Row;
 
+/// The identity of a pursuit: when the sitting opened and what was asked in
+/// it. Queries are normalised and sorted first, so the same sitting re-read
+/// after a crash hashes the same however the clusterer happened to order it.
+fn pursuit_id(opened_at: i64, queries: &[String]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut keys: Vec<String> = queries
+        .iter()
+        .map(|q| format!("{}\n", super::links::normalize_query(q)))
+        .collect();
+    keys.sort();
+    keys.dedup();
+    hex::encode(Sha256::digest(
+        format!("{opened_at}\n{}", keys.concat()).as_bytes(),
+    ))
+}
+
 /// One thing done with a result: opened, or reached from another artifact.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Interaction {
@@ -124,15 +140,25 @@ impl Store {
     }
 
     /// A new pursuit, `open`. Returns its id.
+    ///
+    /// Idempotent by identity rather than by insertion order: the id is the
+    /// cluster itself — when it opened and what was asked — so the same
+    /// sitting swept twice is the same row twice. The sweep needs that. It
+    /// writes a pursuit per cluster and advances its cursor once at the end,
+    /// so a failure in the middle of the loop leaves rows written under a
+    /// cursor that never moved, and the retry re-reads the same events and
+    /// re-clusters them identically. Without this the operator would find the
+    /// sitting listed once per crash on Ops, each copy able to arm its own
+    /// generation.
     pub async fn insert_pursuit(
         &self,
         opened_at: i64,
         queries: &[String],
         sources: &[String],
     ) -> Result<String> {
-        let id = super::new_id();
+        let id = pursuit_id(opened_at, queries);
         sqlx::query(
-            "INSERT INTO pursuits (id, opened_at, state, queries, sources)
+            "INSERT OR IGNORE INTO pursuits (id, opened_at, state, queries, sources)
              VALUES (?, ?, 'open', ?, ?)",
         )
         .bind(&id)

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -18,6 +18,8 @@ pub struct Interaction {
     pub kind: String,
     /// The artifact this was reached from, for `pivoted`.
     pub via: Option<String>,
+    /// Seconds, for `dwell`.
+    pub detail: Option<String>,
     pub scope: Option<String>,
     pub at: i64,
 }
@@ -73,10 +75,34 @@ impl Store {
         Ok(())
     }
 
+    /// How long an artifact stayed open, in seconds. The weakest signal there
+    /// is — long means useful or means confusing, a tab left open means
+    /// engaged or means lunch — so it is a tiebreak in the sweep and never
+    /// decisive.
+    pub async fn record_dwell(
+        &self,
+        artifact_id: &str,
+        secs: i64,
+        scope: Option<&str>,
+        at: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO interaction_events (artifact_id, kind, detail, scope, at)
+             VALUES (?, 'dwell', ?, ?, ?)",
+        )
+        .bind(artifact_id)
+        .bind(secs.to_string())
+        .bind(scope)
+        .bind(at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Interactions with `from < at <= to`, oldest first.
     pub async fn interactions_between(&self, from: i64, to: i64) -> Result<Vec<Interaction>> {
         let rows = sqlx::query(
-            "SELECT id, artifact_id, kind, via, scope, at FROM interaction_events
+            "SELECT id, artifact_id, kind, via, detail, scope, at FROM interaction_events
               WHERE at > ? AND at <= ? ORDER BY at, id",
         )
         .bind(from)
@@ -90,6 +116,7 @@ impl Store {
                 artifact_id: r.get("artifact_id"),
                 kind: r.get("kind"),
                 via: r.get("via"),
+                detail: r.get("detail"),
                 scope: r.get("scope"),
                 at: r.get("at"),
             })
@@ -214,6 +241,10 @@ mod tests {
         assert_eq!(got.len(), 2);
         assert_eq!(got[1].via.as_deref(), Some("other"));
         assert_eq!(got[1].scope.as_deref(), Some("u1"));
+        s.record_dwell(&a, 45, Some("u1"), 30).await.unwrap();
+        let got = s.interactions_between(0, 100).await.unwrap();
+        assert_eq!(got[2].kind, "dwell");
+        assert_eq!(got[2].detail.as_deref(), Some("45"));
     }
 
     #[tokio::test]

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -1,0 +1,240 @@
+//! What happens after a result list renders, and the pursuits it is grouped
+//! into at analysis.
+//!
+//! An interaction carries no pursuit id: the clustering decides which pursuit
+//! a search event belongs to, and an interaction is joined to that event by
+//! time and scope when the sweep runs. Re-clustering never rewrites these rows.
+
+use super::Store;
+use crate::error::{Error, Result};
+use sqlx::Row;
+
+/// One thing done with a result: opened, or reached from another artifact.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Interaction {
+    pub id: i64,
+    pub artifact_id: String,
+    /// `opened` | `pivoted`
+    pub kind: String,
+    /// The artifact this was reached from, for `pivoted`.
+    pub via: Option<String>,
+    pub scope: Option<String>,
+    pub at: i64,
+}
+
+/// A coherent thing that was wanted, and what came of it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pursuit {
+    pub id: String,
+    pub opened_at: i64,
+    pub closed_at: Option<i64>,
+    /// open | satisfied | unsatisfied | generated | dismissed
+    pub state: String,
+    pub reason: Option<String>,
+    pub queries: Vec<String>,
+    pub sources: Vec<String>,
+    pub artifact_id: Option<String>,
+}
+
+fn row_to_pursuit(r: &sqlx::sqlite::SqliteRow) -> Pursuit {
+    Pursuit {
+        id: r.get("id"),
+        opened_at: r.get("opened_at"),
+        closed_at: r.get("closed_at"),
+        state: r.get("state"),
+        reason: r.get("reason"),
+        queries: serde_json::from_str(&r.get::<String, _>("queries")).unwrap_or_default(),
+        sources: serde_json::from_str(&r.get::<String, _>("sources")).unwrap_or_default(),
+        artifact_id: r.get("artifact_id"),
+    }
+}
+
+impl Store {
+    /// One interaction, stamped `at`. `kind` is `opened` or `pivoted`.
+    pub async fn record_interaction(
+        &self,
+        artifact_id: &str,
+        kind: &str,
+        via: Option<&str>,
+        scope: Option<&str>,
+        at: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO interaction_events (artifact_id, kind, via, scope, at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(artifact_id)
+        .bind(kind)
+        .bind(via)
+        .bind(scope)
+        .bind(at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Interactions with `from < at <= to`, oldest first.
+    pub async fn interactions_between(&self, from: i64, to: i64) -> Result<Vec<Interaction>> {
+        let rows = sqlx::query(
+            "SELECT id, artifact_id, kind, via, scope, at FROM interaction_events
+              WHERE at > ? AND at <= ? ORDER BY at, id",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| Interaction {
+                id: r.get("id"),
+                artifact_id: r.get("artifact_id"),
+                kind: r.get("kind"),
+                via: r.get("via"),
+                scope: r.get("scope"),
+                at: r.get("at"),
+            })
+            .collect())
+    }
+
+    /// A new pursuit, `open`. Returns its id.
+    pub async fn insert_pursuit(
+        &self,
+        opened_at: i64,
+        queries: &[String],
+        sources: &[String],
+    ) -> Result<String> {
+        let id = super::new_id();
+        sqlx::query(
+            "INSERT INTO pursuits (id, opened_at, state, queries, sources)
+             VALUES (?, ?, 'open', ?, ?)",
+        )
+        .bind(&id)
+        .bind(opened_at)
+        .bind(serde_json::to_string(queries).unwrap_or_else(|_| "[]".into()))
+        .bind(serde_json::to_string(sources).unwrap_or_else(|_| "[]".into()))
+        .execute(&self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    /// Close a pursuit with a state and a one-line reason.
+    pub async fn close_pursuit(&self, id: &str, state: &str, reason: &str, at: i64) -> Result<()> {
+        sqlx::query("UPDATE pursuits SET state = ?, reason = ?, closed_at = ? WHERE id = ?")
+            .bind(state)
+            .bind(reason)
+            .bind(at)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// The generation landed: name the artifact, state `generated`.
+    pub async fn set_pursuit_artifact(&self, id: &str, artifact_id: &str, at: i64) -> Result<()> {
+        sqlx::query(
+            "UPDATE pursuits SET artifact_id = ?, state = 'generated', closed_at = ? WHERE id = ?",
+        )
+        .bind(artifact_id)
+        .bind(at)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_pursuit(&self, id: &str) -> Result<Pursuit> {
+        let row = sqlx::query("SELECT * FROM pursuits WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(Error::NotFound)?;
+        Ok(row_to_pursuit(&row))
+    }
+
+    /// Newest first. What Ops lists.
+    pub async fn recent_pursuits(&self, limit: i64) -> Result<Vec<Pursuit>> {
+        let rows = sqlx::query("SELECT * FROM pursuits ORDER BY opened_at DESC LIMIT ?")
+            .bind(limit.max(0))
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(row_to_pursuit).collect())
+    }
+
+    /// Forget every pursuit and every interaction. Rows dropped.
+    pub async fn purge_pursuits(&self) -> Result<u64> {
+        let a = sqlx::query("DELETE FROM interaction_events")
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+        let b = sqlx::query("DELETE FROM pursuits")
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+        Ok(a + b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::artifacts::NewArtifact;
+
+    #[tokio::test]
+    async fn interactions_are_recorded_and_read_back_in_range() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let a = s
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        s.record_interaction(&a, "opened", None, Some("u1"), 10)
+            .await
+            .unwrap();
+        s.record_interaction(&a, "pivoted", Some("other"), Some("u1"), 20)
+            .await
+            .unwrap();
+        let got = s.interactions_between(0, 15).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].kind, "opened");
+        let got = s.interactions_between(0, 100).await.unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[1].via.as_deref(), Some("other"));
+        assert_eq!(got[1].scope.as_deref(), Some("u1"));
+    }
+
+    #[tokio::test]
+    async fn a_pursuit_round_trips_and_closes() {
+        let s = Store::memory().await.unwrap();
+        let id = s
+            .insert_pursuit(100, &["how to mount".into()], &["a1".into(), "a2".into()])
+            .await
+            .unwrap();
+        let p = s.get_pursuit(&id).await.unwrap();
+        assert_eq!(p.state, "open");
+        assert_eq!(p.queries, vec!["how to mount".to_string()]);
+        assert_eq!(p.sources, vec!["a1".to_string(), "a2".to_string()]);
+        s.close_pursuit(&id, "satisfied", "answered", 200)
+            .await
+            .unwrap();
+        let p = s.get_pursuit(&id).await.unwrap();
+        assert_eq!((p.state.as_str(), p.closed_at), ("satisfied", Some(200)));
+        assert_eq!(p.reason.as_deref(), Some("answered"));
+        assert_eq!(s.recent_pursuits(10).await.unwrap().len(), 1);
+        assert_eq!(s.purge_pursuits().await.unwrap(), 1);
+        assert!(s.recent_pursuits(10).await.unwrap().is_empty());
+    }
+}

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -388,10 +388,12 @@ CREATE INDEX IF NOT EXISTS idx_links_state ON artifact_links(state, weight DESC)
 CREATE TABLE IF NOT EXISTS interaction_events (
   id          INTEGER PRIMARY KEY,
   artifact_id TEXT REFERENCES artifacts(id) ON DELETE CASCADE,
-  -- 'opened' | 'pivoted'
+  -- 'opened' | 'pivoted' | 'dwell'
   kind        TEXT NOT NULL,
   -- The artifact this was reached from, for 'pivoted'.
   via         TEXT,
+  -- Seconds, for 'dwell'. Read on Ops; the sweep parses it.
+  detail      TEXT,
   scope       TEXT,
   at          INTEGER NOT NULL
 );

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -69,7 +69,8 @@ CREATE TABLE IF NOT EXISTS artifacts (
   -- corpus it did not come from would put the wrong lines beside it in the
   -- detail pane, which is the one dishonesty merging must not commit.
   corpus_id        TEXT REFERENCES corpora(id) ON DELETE CASCADE,
-  -- 'captured' | 'merged'. The discriminator every consumer branches on, rather
+  -- 'passage' | 'captured' | 'merged' | 'synthesized'. The discriminator every
+  -- consumer branches on, rather
   -- than `corpus_id IS NULL`: a null is an absence, and the failure modes
   -- merging can produce want to hang off an assertion.
   provenance       TEXT NOT NULL DEFAULT 'captured',
@@ -131,7 +132,9 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_provenance ON artifacts(provenance);
 -- parent edges. `root_id` always names a `provenance = 'captured'` artifact, so
 -- a re-merge reads the leaves in one query and is never written from text a
 -- model produced — which is what keeps information loss one generation deep
--- however many times a group is merged.
+-- however many times a group is merged. That sentence is about *merging*: a
+-- `synthesized` artifact may be written from another synthesized one, and then
+-- `root_id` still names source text while `via_id` names the intermediate.
 --
 -- The closure duplicates what edges would imply. That is the trade: the fan-in
 -- cap bounds how much, and it buys a hot-path read with no recursive CTE.

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -114,7 +114,9 @@ CREATE TABLE IF NOT EXISTS artifacts (
   -- weight. In SQLite rather than the vector payload because the query path
   -- already needs one SQLite read for links, and the same read returns this
   -- — one crossing.
-  activated_at     INTEGER NOT NULL DEFAULT 0
+  activated_at     INTEGER NOT NULL DEFAULT 0,
+  -- For a synthesized artifact: the questions it was written for, JSON list.
+  cues             TEXT    NOT NULL DEFAULT '[]'
 );
 CREATE INDEX IF NOT EXISTS idx_artifacts_corpus     ON artifacts(corpus_id, ordinal);
 CREATE INDEX IF NOT EXISTS idx_artifacts_embed      ON artifacts(embed_state);
@@ -271,7 +273,10 @@ CREATE TABLE IF NOT EXISTS search_events (
   expect_id   TEXT,
   skips       INTEGER NOT NULL DEFAULT 0,
   -- Set when the operator says a `gap` search has since been covered.
-  dismissed_at INTEGER
+  dismissed_at INTEGER,
+  -- A synthesized artifact led the list above `weak_below`: the base
+  -- answered, and the pursuit this lands in closes satisfied.
+  answered    INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_events_pending ON search_events(judged_at, skips, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_events_verdict ON search_events(verdict);
@@ -376,8 +381,42 @@ CREATE TABLE IF NOT EXISTS artifact_links (
 CREATE INDEX IF NOT EXISTS idx_links_b ON artifact_links(b_id);
 CREATE INDEX IF NOT EXISTS idx_links_state ON artifact_links(state, weight DESC);
 
--- Cursors that have no row to live on. Two keys so far:
--- `associate.events_after` and `associate.judged_after`.
+-- ── Pursuits ─────────────────────────────────────────────────────────────────
+-- What happened after a result list rendered. Joined to a pursuit through
+-- time and scope at analysis, never by a stored pursuit id: the clustering
+-- decides, and re-clustering never has to rewrite these.
+CREATE TABLE IF NOT EXISTS interaction_events (
+  id          INTEGER PRIMARY KEY,
+  artifact_id TEXT REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- 'opened' | 'pivoted'
+  kind        TEXT NOT NULL,
+  -- The artifact this was reached from, for 'pivoted'.
+  via         TEXT,
+  scope       TEXT,
+  at          INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_interactions_at ON interaction_events(at);
+
+-- A coherent thing that was wanted: its queries, and what came of it.
+CREATE TABLE IF NOT EXISTS pursuits (
+  id           TEXT PRIMARY KEY,
+  opened_at    INTEGER NOT NULL,
+  closed_at    INTEGER,
+  -- open | satisfied | unsatisfied | generated | dismissed
+  state        TEXT NOT NULL DEFAULT 'open',
+  -- Why it closed, in one line. Read on Ops; never parsed.
+  reason       TEXT,
+  -- The clustered queries, JSON. Becomes the artifact's `cues` on generation.
+  queries      TEXT NOT NULL DEFAULT '[]',
+  -- The engaged artifact ids, JSON, in engagement order. What generation reads.
+  sources      TEXT NOT NULL DEFAULT '[]',
+  -- The generated artifact, once there is one.
+  artifact_id  TEXT REFERENCES artifacts(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pursuits_state ON pursuits(state, opened_at);
+
+-- Cursors that have no row to live on. Three keys so far:
+-- `associate.events_after`, `associate.judged_after`, `pursuit.events_after`.
 CREATE TABLE IF NOT EXISTS meta (
   key   TEXT PRIMARY KEY,
   value TEXT NOT NULL

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -174,7 +174,7 @@ CREATE TABLE IF NOT EXISTS segments (
   -- the heading the splitter carries into a window that continues a section.
   -- An offset measured inside the window is that much too high without it.
   carry_lines INTEGER NOT NULL DEFAULT 0,
-  state      TEXT    NOT NULL DEFAULT 'pending',  -- pending | done | failed
+  state      TEXT    NOT NULL DEFAULT 'pending',  -- pending | done | failed | verbatim
   -- Set when this window is being read again to pick up lines the first read
   -- missed, and cleared once the window reaches `done`. It is what tells
   -- `window::write_segment_artifacts` to append rather than replace: see there

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -182,6 +182,11 @@ CREATE TABLE IF NOT EXISTS segments (
   -- `window::write_segment_artifacts` to append rather than replace: see there
   -- for why the two reasons to re-run a window want opposite answers.
   keep_artifacts INTEGER NOT NULL DEFAULT 0,
+  -- Set when an operator undid this window's promotion. The passages keep the
+  -- activation that earned the promotion in the first place, so `verbatim`
+  -- alone would let the very next open promote it again and undo the undo.
+  -- Cleared when the window is re-split: that is a different window.
+  no_promote INTEGER NOT NULL DEFAULT 0,
   -- Dead since 2026-08-13. A window is its own queue unit now, so `jobs.attempts`
   -- is the count that governs its backoff and its settling, and two counters for
   -- one thing is exactly what made the incident behind that change so hard to
@@ -332,6 +337,10 @@ CREATE TABLE IF NOT EXISTS ask_citations (
   score       REAL NOT NULL,
   -- The operator said this excerpt carried the answer.
   carried     INTEGER NOT NULL DEFAULT 0,
+  -- The answer actually referenced this [n]. Being shown to the model is not
+  -- engagement: the pursuit sweep scores what the answer drew on, and an
+  -- abstention draws on nothing.
+  used        INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (event_id, n)
 );
 

--- a/src/store/segments.rs
+++ b/src/store/segments.rs
@@ -215,6 +215,18 @@ impl Store {
         Ok(())
     }
 
+    /// One window's state, or `None` for a window that does not exist.
+    pub async fn segment_state(&self, corpus_id: &str, idx: i64) -> Result<Option<SegmentState>> {
+        Ok(sqlx::query_scalar::<_, String>(
+            "SELECT state FROM segments WHERE corpus_id = ? AND idx = ?",
+        )
+        .bind(corpus_id)
+        .bind(idx)
+        .fetch_optional(&self.pool)
+        .await?
+        .map(|s| SegmentState::parse(&s)))
+    }
+
     /// Mark every window of a corpus that was never synthesized — and is not
     /// going to be, at this mode — as captured verbatim. Only `pending` rows:
     /// a window that is `done` or `failed` has a history this must not erase.
@@ -594,5 +606,32 @@ mod tests {
         assert_eq!(SegmentState::Verbatim.as_str(), "verbatim");
         // Resolved, for the progress count: neither is still owed a call.
         assert_eq!(s.segment_progress(&src.id).await.unwrap(), (2, 2));
+    }
+
+    #[tokio::test]
+    async fn segment_state_reads_one_window() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        s.upsert_segments(
+            &src.id,
+            &[NewSegment {
+                start_line: 1,
+                end_line: 2,
+                text: "t",
+                carry_lines: 0,
+            }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            s.segment_state(&src.id, 0).await.unwrap(),
+            Some(SegmentState::Pending)
+        );
+        s.mark_segments_verbatim(&src.id).await.unwrap();
+        assert_eq!(
+            s.segment_state(&src.id, 0).await.unwrap(),
+            Some(SegmentState::Verbatim)
+        );
+        assert_eq!(s.segment_state(&src.id, 9).await.unwrap(), None);
     }
 }

--- a/src/store/segments.rs
+++ b/src/store/segments.rs
@@ -130,7 +130,8 @@ impl Store {
                    start_line = excluded.start_line,
                    end_line = excluded.end_line,
                    text = excluded.text,
-                   carry_lines = excluded.carry_lines",
+                   carry_lines = excluded.carry_lines,
+                   no_promote = 0",
             )
             .bind(corpus_id)
             .bind(idx as i64)
@@ -225,6 +226,29 @@ impl Store {
         .fetch_optional(&self.pool)
         .await?
         .map(|s| SegmentState::parse(&s)))
+    }
+
+    /// Whether this window may be promoted at all: an operator who undid its
+    /// promotion said no, and nothing but a re-split says otherwise.
+    pub async fn segment_no_promote(&self, corpus_id: &str, idx: i64) -> Result<bool> {
+        Ok(sqlx::query_scalar::<_, i64>(
+            "SELECT no_promote FROM segments WHERE corpus_id = ? AND idx = ?",
+        )
+        .bind(corpus_id)
+        .bind(idx)
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some_and(|v| v != 0))
+    }
+
+    /// Refuse this window to promotion, for good. Set by `undo_promotion`.
+    pub async fn set_segment_no_promote(&self, corpus_id: &str, idx: i64) -> Result<()> {
+        sqlx::query("UPDATE segments SET no_promote = 1 WHERE corpus_id = ? AND idx = ?")
+            .bind(corpus_id)
+            .bind(idx)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     /// Mark every window of a corpus that was never synthesized — and is not

--- a/src/store/segments.rs
+++ b/src/store/segments.rs
@@ -5,13 +5,16 @@ use sqlx::Row;
 /// Where one window of a source stands. `Failed` means the synthesizer never
 /// succeeded here and the lines are represented by no chunk at all — the model
 /// is a hard dependency, so an unsegmentable window leaves a hole that the
-/// source's coverage measures, and the reason it ends up `partial`.
+/// source's coverage measures, and the reason it ends up `partial`. `Verbatim`
+/// means the window was captured as passages and never sent to the synthesizer
+/// — not work owed, and nothing re-arms it; promotion moves it to `pending`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SegmentState {
     Pending,
     Done,
     Failed,
+    Verbatim,
 }
 
 impl SegmentState {
@@ -20,12 +23,14 @@ impl SegmentState {
             SegmentState::Pending => "pending",
             SegmentState::Done => "done",
             SegmentState::Failed => "failed",
+            SegmentState::Verbatim => "verbatim",
         }
     }
     pub fn parse(s: &str) -> SegmentState {
         match s {
             "done" => SegmentState::Done,
             "failed" => SegmentState::Failed,
+            "verbatim" => SegmentState::Verbatim,
             _ => SegmentState::Pending,
         }
     }
@@ -165,10 +170,13 @@ impl Store {
     /// was asleep, says nothing about the text. Excluding it made the next run
     /// see a finished corpus and close the job, which is how a quarter of a
     /// document stayed missing while the endpoint sat there answering.
+    ///
+    /// `verbatim` is excluded: that window was captured as passages on purpose
+    /// and is owed nothing.
     pub async fn pending_segments(&self, corpus_id: &str) -> Result<Vec<Segment>> {
         let rows = sqlx::query(
             "SELECT * FROM segments
-             WHERE corpus_id = ? AND state != 'done' ORDER BY idx",
+             WHERE corpus_id = ? AND state NOT IN ('done', 'verbatim') ORDER BY idx",
         )
         .bind(corpus_id)
         .fetch_all(&self.pool)
@@ -202,6 +210,19 @@ impl Store {
         .bind(state.as_str())
         .bind(corpus_id)
         .bind(idx)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Mark every window of a corpus that was never synthesized — and is not
+    /// going to be, at this mode — as captured verbatim. Only `pending` rows:
+    /// a window that is `done` or `failed` has a history this must not erase.
+    pub async fn mark_segments_verbatim(&self, corpus_id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE segments SET state = 'verbatim' WHERE corpus_id = ? AND state = 'pending'",
+        )
+        .bind(corpus_id)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -539,5 +560,39 @@ mod tests {
             .unwrap();
         s.delete_corpus(&src.id).await.unwrap();
         assert!(s.segments_for_corpus(&src.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn verbatim_segments_are_not_pending_work() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        s.upsert_segments(
+            &src.id,
+            &[
+                NewSegment {
+                    start_line: 1,
+                    end_line: 5,
+                    text: "a",
+                    carry_lines: 0,
+                },
+                NewSegment {
+                    start_line: 6,
+                    end_line: 9,
+                    text: "b",
+                    carry_lines: 0,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(s.pending_segments(&src.id).await.unwrap().len(), 2);
+        s.mark_segments_verbatim(&src.id).await.unwrap();
+        assert!(s.pending_segments(&src.id).await.unwrap().is_empty());
+        let rows = s.segments_for_corpus(&src.id).await.unwrap();
+        assert!(rows.iter().all(|w| w.state == SegmentState::Verbatim));
+        assert_eq!(SegmentState::parse("verbatim"), SegmentState::Verbatim);
+        assert_eq!(SegmentState::Verbatim.as_str(), "verbatim");
+        // Resolved, for the progress count: neither is still owed a call.
+        assert_eq!(s.segment_progress(&src.id).await.unwrap(), (2, 2));
     }
 }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -417,6 +417,7 @@ mod tests {
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                origin_corpora: vec![],
             },
         }
     }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -418,6 +418,7 @@ mod tests {
                 last_verified_at: None,
                 superseded_by: None,
                 origin_corpora: vec![],
+                provenance: None,
             },
         }
     }

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -106,12 +106,30 @@ impl VectorStore for MemoryVectors {
                 .superseded_by
                 .clone()
                 .or_else(|| p.payload.superseded_by.clone());
+            // Both carry `skip_serializing_if`, so Qdrant never receives them
+            // from a caller that left them empty and the stored values stand.
+            // Only `jobs::embed` knows either: every other caller — the tag and
+            // category edits above all — builds a payload with no corpora and
+            // no provenance, and copying that over the stored one would strip a
+            // synthesized artifact of the mark that earns it its badge and its
+            // stopping rule, on a tag edit, in this backend only.
+            let corpora = if payload.origin_corpora.is_empty() {
+                p.payload.origin_corpora.clone()
+            } else {
+                payload.origin_corpora.clone()
+            };
+            let provenance = payload
+                .provenance
+                .clone()
+                .or_else(|| p.payload.provenance.clone());
             p.payload = payload.clone();
             p.payload.last_seen_at = seen;
             p.payload.hit_count = hits;
             p.payload.status = status;
             p.payload.last_verified_at = verified;
             p.payload.superseded_by = superseded_by;
+            p.payload.origin_corpora = corpora;
+            p.payload.provenance = provenance;
         }
         Ok(())
     }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -49,6 +49,11 @@ pub struct VectorPayload {
     /// corpora instead of all merges landing under one empty key.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub origin_corpora: Vec<String>,
+    /// `passage` | `captured` | `merged` | `synthesized` — mirrors the row so a
+    /// result can say a model wrote it without a second lookup, and so the
+    /// search path can see a synthesized artifact lead the list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -42,6 +42,13 @@ pub struct VectorPayload {
     /// without a second lookup.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub superseded_by: Option<String>,
+    /// Every corpus this artifact draws from — one for a passage or captured
+    /// row, several for a merge. A projection of `artifact_sources`, the way
+    /// `status` is a projection of the row; SQLite stays the authority.
+    /// `cap_per_corpus` groups on it, so a merge counts against each of its
+    /// corpora instead of all merges landing under one empty key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub origin_corpora: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -693,6 +693,10 @@ async fn ask(
     _id: Identity,
     Json(req): Json<crate::core::ask::AskRequest>,
 ) -> Result<Json<crate::core::ask::AskResponse>> {
+    // No ask model, no ask door: the route is not there. See `Core::asks`.
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
     Ok(Json(
         st.core.ask(&req, crate::store::feedback::Door::Api).await?,
     ))
@@ -1968,6 +1972,18 @@ pub(crate) mod tests {
         assert!(v["jobs"].is_array());
         assert!(v["sources"].is_array());
         assert!(v["failed"].is_array());
+    }
+
+    #[tokio::test]
+    async fn api_ask_is_not_found_without_an_ask_model() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.completer = None;
+        let (app, token) = app_with_token(core).await;
+        let res = app
+            .oneshot(post_json("/ask", &token, serde_json::json!({"q": "x"})))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -812,6 +812,7 @@ async fn patch_artifact(
                 last_verified_at: None,
                 superseded_by: None,
                 origin_corpora: vec![],
+                provenance: None,
             })
             .await?;
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -811,6 +811,7 @@ async fn patch_artifact(
                 status: None,
                 last_verified_at: None,
                 superseded_by: None,
+                origin_corpora: vec![],
             })
             .await?;
     }

--- a/src/web/auth_routes.rs
+++ b/src/web/auth_routes.rs
@@ -33,6 +33,8 @@ struct LoginTemplate {
     /// Always `None`: the sign-in page has no nav, and a count of what is
     /// waiting inside is not something to tell someone who is still outside.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     oidc: bool,
     error: Option<String>,
 }
@@ -58,6 +60,7 @@ async fn login_page(State(st): State<AppState>, Query(q): Query<LoginQuery>) -> 
             }
             Ok(HtmlTemplate(LoginTemplate {
                 judge_pending: None,
+                ask_enabled: false,
                 oidc: true,
                 error: None,
             })
@@ -65,6 +68,7 @@ async fn login_page(State(st): State<AppState>, Query(q): Query<LoginQuery>) -> 
         }
         AuthMode::Local => Ok(HtmlTemplate(LoginTemplate {
             judge_pending: None,
+            ask_enabled: false,
             oidc: false,
             error: None,
         })
@@ -92,6 +96,7 @@ async fn login_submit(State(st): State<AppState>, Form(f): Form<LoginForm>) -> R
             StatusCode::UNAUTHORIZED,
             HtmlTemplate(LoginTemplate {
                 judge_pending: None,
+                ask_enabled: false,
                 oidc: false,
                 error: Some("Incorrect username or password.".into()),
             }),

--- a/src/web/extension.rs
+++ b/src/web/extension.rs
@@ -21,6 +21,8 @@ use axum::routing::get;
 #[template(path = "extension.html")]
 struct InstallTemplate {
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     origin: String,
     /// Whether the XPI on offer has been through AMO.
     ///
@@ -38,6 +40,7 @@ struct InstallTemplate {
 async fn install_page(State(st): State<AppState>, _id: Identity, headers: HeaderMap) -> Response {
     HtmlTemplate(InstallTemplate {
         judge_pending: judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         origin: request_origin(&headers).unwrap_or_default(),
         xpi_signed: Assets::get("extension/firefox.signed").is_some(),
     })

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -61,6 +61,8 @@ struct JudgeTemplate {
     /// this page too, so the badge falls as the queue is worked down rather
     /// than standing at whatever it read on arrival.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     stats: Stats,
     recall: String,
     mrr: String,
@@ -217,6 +219,7 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     Ok(HtmlTemplate(JudgeTemplate {
         // Read off the stats already in hand rather than counted again.
         judge_pending: st.core.feedback.enabled.then_some(stats.pending),
+        ask_enabled: crate::web::state::ask_enabled(&st),
         recall: format!("{:.2}", stats.recall_at_10),
         mrr: format!("{:.2}", stats.mrr),
         target: FIRST_SWEEP_AT,

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -608,6 +608,7 @@ mod tests {
                                 shown: i < 10,
                             })
                             .collect(),
+                        answered: false,
                     },
                     0,
                 )
@@ -1012,6 +1013,7 @@ mod tests {
                     query_vec: vec![0.1, 0.2],
                     embed_model: "fake".into(),
                     candidates: vec![],
+                    answered: false,
                 },
                 0,
             )

--- a/src/web/lineage_view.rs
+++ b/src/web/lineage_view.rs
@@ -292,11 +292,15 @@ impl Walk<'_> {
                 children: Vec::new(),
             };
         };
-        let merged = c.provenance == crate::store::artifacts::Provenance::Merged;
         let (source_href, source_label) = self.source_of(&c).await;
         LineageNode {
             title: crate::web::ui::title_of(&c),
-            kind: if merged { "merge" } else { "captured" },
+            kind: match c.provenance {
+                crate::store::artifacts::Provenance::Merged => "merge",
+                crate::store::artifacts::Provenance::Synthesized => "synthesized",
+                crate::store::artifacts::Provenance::Passage => "passage",
+                crate::store::artifacts::Provenance::Captured => "captured",
+            },
             when: crate::web::ui::fmt_time(c.created_at),
             created_at: c.created_at,
             source_href,

--- a/src/web/pair.rs
+++ b/src/web/pair.rs
@@ -91,6 +91,8 @@ fn is_loopback(host: &str) -> bool {
 #[template(path = "pair.html")]
 struct PairTemplate {
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     origin: String,
     redirect_uri: String,
     state: String,
@@ -135,6 +137,7 @@ async fn pair_page(
     }
     Ok(HtmlTemplate(PairTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         origin: request_origin(&headers).unwrap_or_default(),
         redirect_uri: p.redirect_uri,
         state: p.state,

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -94,6 +94,12 @@ impl AppState {
 /// door you pass rather than a page you remember. The count is one indexed
 /// `count(*)`; a failure returns `None`, since a broken badge is not a reason to
 /// fail the page it sits on.
+/// Whether the ask door is open: `[infer.ask]` is configured. The nav reads
+/// it through every page's template, the same way it reads `judge_pending`.
+pub fn ask_enabled(st: &AppState) -> bool {
+    st.core.asks()
+}
+
 pub async fn judge_pending(st: &AppState) -> Option<i64> {
     if !st.core.feedback.enabled {
         return None;

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -87,6 +87,12 @@ impl AppState {
     }
 }
 
+/// Whether the ask door is open: `[infer.ask]` is configured. The nav reads
+/// it through every page's template, the same way it reads `judge_pending`.
+pub fn ask_enabled(st: &AppState) -> bool {
+    st.core.asks()
+}
+
 /// What the nav needs to know about judging: how many searches are waiting, or
 /// `None` when nothing is being captured and the entry does not belong there.
 ///
@@ -94,12 +100,6 @@ impl AppState {
 /// door you pass rather than a page you remember. The count is one indexed
 /// `count(*)`; a failure returns `None`, since a broken badge is not a reason to
 /// fail the page it sits on.
-/// Whether the ask door is open: `[infer.ask]` is configured. The nav reads
-/// it through every page's template, the same way it reads `judge_pending`.
-pub fn ask_enabled(st: &AppState) -> bool {
-    st.core.asks()
-}
-
 pub async fn judge_pending(st: &AppState) -> Option<i64> {
     if !st.core.feedback.enabled {
         return None;

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -1,4 +1,4 @@
-<div data-terms="{{ d.terms }}">
+<div data-terms="{{ d.terms }}" data-artifact="{{ d.id }}">
   {# The way back to the list, for a narrow window where opening a result hides
      it. An installed app has no back button to fall back on. Hidden above
      60rem, where the rail is still on screen beside this — the same width that

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -180,8 +180,8 @@
       <div class="pane-label">Related</div>
       <div class="related">
         {% for r in d.related %}
-        <a class="rail-item" href="/ui/artifacts/{{ r.id }}"
-           hx-get="/ui/artifacts/{{ r.id }}"
+        <a class="rail-item" href="/ui/artifacts/{{ r.id }}?via={{ d.id }}"
+           hx-get="/ui/artifacts/{{ r.id }}?via={{ d.id }}"
            hx-target="closest [data-terms]" hx-swap="outerHTML"
            hx-push-url="true">
           <div class="rail-head"><span class="rail-title">{{ r.title }}</span></div>
@@ -198,8 +198,8 @@
       <div class="related">
         {% for r in d.seen_together %}
         <div class="seen-row{% if !r.cross_corpus %} muted{% endif %}">
-          <a class="rail-item" href="/ui/artifacts/{{ r.id }}"
-             hx-get="/ui/artifacts/{{ r.id }}"
+          <a class="rail-item" href="/ui/artifacts/{{ r.id }}?via={{ d.id }}"
+             hx-get="/ui/artifacts/{{ r.id }}?via={{ d.id }}"
              hx-target="closest [data-terms]" hx-swap="outerHTML"
              hx-push-url="true">
             <div class="rail-head"><span class="rail-title">{{ r.title }}</span></div>

--- a/src/web/templates/_gaps.html
+++ b/src/web/templates/_gaps.html
@@ -11,7 +11,7 @@
       {% for m in g.members %}
       <li id="gap-{{ m.kind }}-{{ m.id }}" class="row">
         <span>{{ m.text }}</span>
-        <a class="btn btn-ghost btn-sm" href="/ui/ask?q={{ m.text|urlencode }}">ask again</a>
+        {% if ask_enabled %}<a class="btn btn-ghost btn-sm" href="/ui/ask?q={{ m.text|urlencode }}">ask again</a>{% endif %}
         <button class="btn btn-ghost btn-sm" hx-post="/ui/gaps/{{ m.kind }}/{{ m.id }}/dismiss"
                 hx-target="closest li" hx-swap="outerHTML">covered</button>
       </li>
@@ -26,7 +26,7 @@
       {% for m in loose %}
       <li id="gap-{{ m.kind }}-{{ m.id }}" class="row">
         <span>{{ m.text }}</span>
-        <a class="btn btn-ghost btn-sm" href="/ui/ask?q={{ m.text|urlencode }}">ask again</a>
+        {% if ask_enabled %}<a class="btn btn-ghost btn-sm" href="/ui/ask?q={{ m.text|urlencode }}">ask again</a>{% endif %}
         <button class="btn btn-ghost btn-sm" hx-post="/ui/gaps/{{ m.kind }}/{{ m.id }}/dismiss"
                 hx-target="closest li" hx-swap="outerHTML">covered</button>
       </li>

--- a/src/web/templates/_lineage.html
+++ b/src/web/templates/_lineage.html
@@ -18,6 +18,15 @@
 </div>
 {% endif %}
 
+{% if d.synthesized && !d.cues.is_empty() %}
+{# Not "a model guessed you would want this" but "this was written because
+   these things were asked and the base had no answer". #}
+<div class="pane-label">Written because these were asked</div>
+<ul class="cues">
+  {% for q in d.cues %}<li>{{ q }}</li>{% endfor %}
+</ul>
+{% endif %}
+
 {% if d.merged && d.lineage.roots.is_empty() %}
 <p class="muted">
   Every artifact this was written from has since been deleted. Its content is

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -44,6 +44,10 @@
         {% if r.primed %}
         <span class="badge" title="Moved up: you reach this one often">primed</span>
         {% endif %}
+        {% if r.model_written %}
+        {# Never silently indistinguishable from captured text. #}
+        <span class="badge" title="A model wrote this, from {{ r.origin_count }} source corpus/corpora">model-written · {{ r.origin_count }}</span>
+        {% endif %}
         <span class="rail-title">{{ r.title }}</span>
       </div>
       {# Rank, title, two lines. No tags: the pane beside this lists them in

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -45,8 +45,15 @@
         <span class="badge" title="Moved up: you reach this one often">primed</span>
         {% endif %}
         {% if r.model_written %}
-        {# Never silently indistinguishable from captured text. #}
+        {# Never silently indistinguishable from captured text. The count comes
+           off the vector payload, so a hit that was reached rather than ranked
+           — a neighbour, an association — does not carry one. Zero there means
+           "not read", not "no sources", and the badge said the second. #}
+        {% if r.origin_count > 0 %}
         <span class="badge" title="A model wrote this, from {{ r.origin_count }} source corpus/corpora">model-written · {{ r.origin_count }}</span>
+        {% else %}
+        <span class="badge" title="A model wrote this">model-written</span>
+        {% endif %}
         {% endif %}
         <span class="rail-title">{{ r.title }}</span>
       </div>

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -159,4 +159,18 @@
   {% for c in unplaced %}{% include "_artifact.html" %}{% endfor %}
 </div>
 {% endif %}
+
+{% if !written_from.is_empty() %}
+{# A merged or synthesized artifact belongs to every corpus it drew from — its
+   origins are its roots' corpora, derived from lineage, never stored — and
+   this capture is one of them. #}
+<h3>Written from this corpus</h3>
+<p class="muted">
+  Model-written artifacts with a source here. Each lists what it was written
+  from on its own page.
+</p>
+<div class="unplaced">
+  {% for c in written_from %}{% include "_artifact.html" %}{% endfor %}
+</div>
+{% endif %}
 {% endblock %}

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -123,6 +123,19 @@
 <h3>Transcription</h3>
 <p class="muted">The model's reading of the photo, not the source itself.</p>
 {% endif %}
+{% if !promoted.is_empty() %}
+<p class="muted">
+  {# A window synthesis has read because its passages were read. Undo puts
+     the verbatim text back in results and retires what was written. #}
+  Promoted:
+  {% for w in promoted %}
+  <form method="post" action="/ui/corpora/{{ id }}/segments/{{ w.idx }}/unpromote" style="display:inline">
+    lines {{ w.from }}–{{ w.to }}
+    <button class="btn btn-ghost btn-sm" type="submit">undo</button>
+  </form>
+  {% endfor %}
+</p>
+{% endif %}
 {% include "_bands.html" %}
 {% endif %}
 

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -48,7 +48,11 @@
          already appears. #}
       <a href="/ui/capture">Capture</a>
       <a href="/ui/search">Search</a>
+      {# Present only where there is a model to answer. No greyed-out entry,
+         no page behind it that says so: the door is simply not there. #}
+      {% if ask_enabled %}
       <a href="/ui/ask">Ask</a>
+      {% endif %}
       {# A fourth destination only where searches are actually being recorded.
          It was reachable from one conditional sentence on Ops before, which is
          a page you open when something is wrong — the wrong place for the one
@@ -79,8 +83,10 @@
       <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M10 4v12M4 10h12"/></svg>Capture</a>
     <a href="/ui/search">
       <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="9" cy="9" r="5.5"/><path d="M13 13l4 4"/></svg>Search</a>
+    {% if ask_enabled %}
     <a href="/ui/ask">
       <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M7 7.5a3 3 0 115 2.2c-.8.7-1.2 1.2-1.2 2.3M10 15.5v.01"/></svg>Ask</a>
+    {% endif %}
     {# Same rule as the top row: present only where there is something to judge
        at all. A dot rather than a number, because the tab is 52px tall and the
        count is not the point — that anything is waiting is. #}

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -69,6 +69,69 @@
 {% endif %}
 {% endif %}
 
+{% if !generated.is_empty() %}
+<h3>Generated</h3>
+<p class="muted">
+  Artifacts written from a pursuit: what was asked, and what was engaged with
+  while the base did not answer. Each supersedes nothing — what it was written
+  from stays in results beside it. Deprecating one hides it; it can be
+  reactivated from the deprecated list.
+</p>
+<table class="grid">
+  <thead><tr><th>Artifact</th><th>Written because</th><th>Written from</th><th></th></tr></thead>
+  <tbody>
+  {% for g in generated %}
+    <tr>
+      <td>
+        <a href="/ui/artifacts/{{ g.id }}">{{ g.title }}</a>
+        <div class="muted row-sub">{{ g.subtitle }}</div>
+      </td>
+      <td>
+        {% for q in g.cues %}<div class="muted">{{ q }}</div>{% endfor %}
+      </td>
+      <td>
+        {% for src in g.sources %}
+        <div>
+          <a href="/ui/artifacts/{{ src.id }}">{{ src.title }}</a>
+          <div class="muted row-sub">{{ src.subtitle }}</div>
+        </div>
+        {% endfor %}
+      </td>
+      <td>
+        <form method="post" action="/ui/ops/artifacts/{{ g.id }}/deprecate">
+          <button class="btn btn-sm" type="submit">Deprecate</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+{% if pursuit_enabled %}
+<h3>Pursuits</h3>
+{% if pursuits.is_empty() %}
+<p class="muted">No run of searches has gone quiet yet.</p>
+{% else %}
+<table class="grid">
+  <thead><tr><th>When</th><th>Asked</th><th>Outcome</th></tr></thead>
+  <tbody>
+  {% for p in pursuits %}
+    <tr>
+      <td>{{ p.when }}</td>
+      <td>{% for q in p.queries %}<div>{{ q }}</div>{% endfor %}</td>
+      <td>
+        {{ p.state }}
+        {% if let Some(a) = p.artifact_id %} · <a href="/ui/artifacts/{{ a }}">the artifact</a>{% endif %}
+        {% if !p.reason.is_empty() %}<div class="muted row-sub">{{ p.reason }}</div>{% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endif %}
+
 {% if !deprecated.is_empty() %}
 <h3>Deprecated</h3>
 <p class="muted">Flagged stale with no specific replacement. Still stored and still readable; kept out of results only.</p>

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -77,8 +77,8 @@ reading, and search from a panel beside it.</p>
 {% when None %}
 {% endmatch %}
 <form method="post" action="/ui/ops/feedback/purge"
-      onsubmit="return confirm('Delete every captured search and every recorded question, with every verdict given on one? The judged questions cannot be recovered — they are what the ask harness is measured against.')">
-  <button class="btn btn-sm btn-danger" type="submit">Delete all captured searches and questions</button>
+      onsubmit="return confirm('Delete every captured search and every recorded question, with every verdict given on one, and every pursuit and what was opened? The judged questions cannot be recovered — they are what the ask harness is measured against.')">
+  <button class="btn btn-sm btn-danger" type="submit">Delete all captured searches, questions and pursuits</button>
 </form>
 {% when None %}
 {% endmatch %}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -503,6 +503,9 @@ struct CorpusTemplate {
     /// a restored placeholder, or a photo not read yet — which falls back to
     /// the flat rendering.
     bands: Vec<BandView>,
+    /// Windows synthesis has read because their passages were read — each with
+    /// an undo, which puts the verbatim text back in results.
+    promoted: Vec<PromotedWindow>,
     /// The artifacts of this capture that name no lines of it, in a section of
     /// their own below the source. Every artifact of a restored placeholder is
     /// here, as is anything written before spans were recorded — and the page
@@ -519,6 +522,13 @@ struct CorpusTemplate {
     /// Stated whether or not a band is red, because the two measures answer
     /// different questions and can disagree.
     coverage: Option<String>,
+}
+
+/// A window a promotion has synthesized, for the corpus page's undo list.
+pub struct PromotedWindow {
+    pub idx: i64,
+    pub from: i64,
+    pub to: i64,
 }
 
 /// One stretch of the source on the corpus page, beside what came of it.
@@ -1279,6 +1289,17 @@ async fn reread_uncovered_ui(
     Ok(back)
 }
 
+/// Undo a promotion: the window's passages back in results, what the
+/// promotion wrote retired, the window `verbatim` again.
+async fn unpromote_ui(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path((cid, idx)): Path<(String, i64)>,
+) -> Result<Response> {
+    st.core.undo_promotion(&cid, idx).await?;
+    Ok(Redirect::to(&format!("/ui/corpora/{cid}")).into_response())
+}
+
 async fn corpus_detail(
     State(st): State<AppState>,
     _id: Identity,
@@ -1407,6 +1428,23 @@ async fn corpus_detail(
     let note = s.metadata["note"].as_str().map(str::to_string);
     let meta_rows = metadata_rows(&s.metadata);
     let exif_rows = exif_tag_rows(&s.metadata);
+    // A promoted window: `done`, and owning at least one superseded passage.
+    let promoted: Vec<PromotedWindow> = segments
+        .iter()
+        .filter(|w| w.state == crate::store::segments::SegmentState::Done)
+        .filter(|w| {
+            chunks.iter().any(|c| {
+                c.segment_idx == Some(w.idx)
+                    && c.provenance == crate::store::artifacts::Provenance::Passage
+                    && c.superseded_by.is_some()
+            })
+        })
+        .map(|w| PromotedWindow {
+            idx: w.idx,
+            from: w.start_line,
+            to: w.end_line,
+        })
+        .collect();
     Ok(HtmlTemplate(CorpusTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
         ask_enabled: crate::web::state::ask_enabled(&st),
@@ -1421,6 +1459,7 @@ async fn corpus_detail(
         exif_rows,
         note,
         bands,
+        promoted,
         unplaced,
         lines_empty: s.raw_text.trim().is_empty(),
         raw_text: s.raw_text.clone(),
@@ -2725,6 +2764,10 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/corpora/{id}/delete", post(delete_corpus_ui))
         .route("/ui/corpora/{id}/reprocess", post(reprocess_ui))
         .route("/ui/corpora/{id}/reread", post(reread_uncovered_ui))
+        .route(
+            "/ui/corpora/{id}/segments/{idx}/unpromote",
+            post(unpromote_ui),
+        )
         .route("/ui/artifacts/{id}", get(artifact_detail).put(put_artifact))
         .route("/ui/artifacts/{cid}/reviewed", post(mark_artifact_reviewed))
         .route(
@@ -7045,5 +7088,83 @@ mod tests {
         let (app, cookie) = app_with_session().await;
         let page = get_body(&app, &cookie, "/ui/search").await;
         assert!(page.contains("href=\"/ui/ask\""), "{page}");
+    }
+
+    #[tokio::test]
+    async fn a_promoted_window_is_listed_with_an_undo_that_works() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let src = core
+            .store
+            .insert_corpus("l1\nl2", "web", None)
+            .await
+            .unwrap();
+        core.store
+            .upsert_segments(
+                &src.id,
+                &[crate::store::segments::NewSegment {
+                    start_line: 1,
+                    end_line: 2,
+                    text: "l1\nl2",
+                    carry_lines: 0,
+                }],
+            )
+            .await
+            .unwrap();
+        let na = |o: i64, t: &str| crate::store::artifacts::NewArtifact {
+            ordinal: o,
+            text: t.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                start_line: 1,
+                end_line: 2,
+            }),
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let p = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[na(0, "passage")],
+                crate::store::artifacts::Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        let a = core
+            .store
+            .insert_artifacts(&src.id, &[na(1, "artifact")])
+            .await
+            .unwrap();
+        core.supersede(&p[0].id, &a[0].id).await.unwrap();
+        core.store
+            .set_segment_state(&src.id, 0, crate::store::segments::SegmentState::Done, None)
+            .await
+            .unwrap();
+        core.store
+            .set_corpus_status(&src.id, CorpusStatus::Ready)
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", src.id)).await;
+        let action = format!("/ui/corpora/{}/segments/0/unpromote", src.id);
+        assert!(page.contains(&action), "{page}");
+
+        let res = app
+            .clone()
+            .oneshot(form(&action, &cookie, ""))
+            .await
+            .unwrap();
+        assert!(res.status().is_redirection(), "{:?}", res.status());
+        assert!(
+            core.store
+                .get_artifact(&p[0].id)
+                .await
+                .unwrap()
+                .in_results()
+        );
+        let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", src.id)).await;
+        assert!(!page.contains(&action), "undo still offered after undoing");
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -51,6 +51,11 @@ pub struct RenderedResult {
     /// The title of the ranked hit that recalled this one. Set only on an
     /// associated hit, and it is what the row names.
     pub via_title: Option<String>,
+    /// A model wrote this — merged, or generated from a pursuit. Badged, so
+    /// it is never silently indistinguishable from captured text.
+    pub model_written: bool,
+    /// How many corpora it draws from, for the badge.
+    pub origin_count: usize,
     /// The judge's line, where the link was judged.
     pub reason: Option<String>,
 }
@@ -1101,6 +1106,8 @@ fn render_hit(
         past_cliff: h.past_cliff,
         via_title: h.via.as_ref().and_then(|v| titles.get(v).cloned()),
         reason: h.reason.clone(),
+        model_written: h.model_written,
+        origin_count: h.origin_count,
     }
 }
 
@@ -2699,13 +2706,17 @@ pub(crate) async fn build_artifact_detail(
 struct ArtifactViewParams {
     #[serde(default)]
     terms: String,
+    /// The artifact this one was reached from — a neighbour, an association,
+    /// a continuation — when the link came from another artifact's page.
+    #[serde(default)]
+    via: Option<String>,
 }
 
 /// One route, two shapes. An htmx swap wants the pane's body; a pasted link
 /// wants a page with navigation around it.
 async fn artifact_detail(
     State(st): State<AppState>,
-    _id: Identity,
+    id: Identity,
     headers: axum::http::HeaderMap,
     Path(cid): Path<String>,
     Query(p): Query<ArtifactViewParams>,
@@ -2713,6 +2724,9 @@ async fn artifact_detail(
     let d = build_artifact_detail(&st.core, &cid, &p.terms).await?;
     // Opening a chunk is the deliberate act that counts as remembering it.
     st.core.mark_artifact_seen(&cid);
+    // And the act the pursuit sweep reads: opened, or pivoted through.
+    st.core
+        .record_interaction(&cid, p.via.as_deref(), Some(&id.subject));
     if headers.contains_key("hx-request") {
         return Ok(HtmlTemplate(ArtifactDetailFragment { d }).into_response());
     }
@@ -4071,6 +4085,9 @@ mod tests {
             past_cliff: false,
             via: None,
             reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
         };
 
         let loose = render_hit(0, result(true), &Default::default());
@@ -4104,6 +4121,8 @@ mod tests {
             past_cliff: false,
             via_title: via.map(str::to_string),
             reason: reason.map(str::to_string),
+            model_written: false,
+            origin_count: 0,
         }
     }
 
@@ -4216,6 +4235,8 @@ mod tests {
             past_cliff: false,
             via_title: None,
             reason: None,
+            model_written: false,
+            origin_count: 0,
         }
     }
 
@@ -7237,5 +7258,63 @@ mod tests {
             assert!(page.contains("Written from this corpus"), "{page}");
             assert!(page.contains(&m.id), "{page}");
         }
+    }
+
+    #[tokio::test]
+    async fn opening_from_another_artifacts_page_records_a_pivot() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        core.pursuit.enabled = true;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        let src = handle
+            .store
+            .insert_corpus("raw", "web", None)
+            .await
+            .unwrap();
+        let made = handle
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "a".into(),
+                        corpus_span: None,
+                        title: Some("A".into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "b".into(),
+                        corpus_span: None,
+                        title: Some("B".into()),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+        get_body(&app, &cookie, &format!("/ui/artifacts/{}", made[0].id)).await;
+        get_body(
+            &app,
+            &cookie,
+            &format!("/ui/artifacts/{}?via={}", made[1].id, made[0].id),
+        )
+        .await;
+        handle.background.wait_idle().await;
+        let now = crate::store::now();
+        let got = handle.store.interactions_between(0, now + 1).await.unwrap();
+        assert_eq!(got.len(), 2, "{got:?}");
+        assert_eq!(got[0].kind, "opened");
+        assert_eq!(got[1].kind, "pivoted");
+        assert_eq!(got[1].via.as_deref(), Some(made[0].id.as_str()));
+        assert_eq!(got[1].scope.as_deref(), Some("user-1"));
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1327,6 +1327,24 @@ async fn reread_uncovered_ui(
     Ok(back)
 }
 
+#[derive(serde::Deserialize)]
+struct DwellForm {
+    #[serde(default)]
+    secs: i64,
+}
+
+/// The page saying how long an artifact was open, sent as the reader leaves
+/// it. `sendBeacon` lands here; nothing is rendered back.
+async fn artifact_dwell(
+    State(st): State<AppState>,
+    id: Identity,
+    Path(aid): Path<String>,
+    Form(f): Form<DwellForm>,
+) -> Result<Response> {
+    st.core.record_dwell(&aid, f.secs, Some(&id.subject));
+    Ok(axum::http::StatusCode::NO_CONTENT.into_response())
+}
+
 /// Undo a promotion: the window's passages back in results, what the
 /// promotion wrote retired, the window `verbatim` again.
 async fn unpromote_ui(
@@ -2873,6 +2891,7 @@ pub fn ui_router() -> Router<AppState> {
             post(dismiss_link),
         )
         .route("/ui/artifacts/{id}/delete", post(delete_artifact_ui))
+        .route("/ui/artifacts/{id}/dwell", post(artifact_dwell))
         .route("/ui/ask", get(ask_page).post(ask_submit))
         .route("/ui/ask/{id}/stream", get(ask_stream))
         .route("/ui/ask/{id}/verdict", post(ask_verdict))
@@ -7469,5 +7488,57 @@ mod tests {
         let (app, cookie) = app_with_session().await;
         let ops = get_body(&app, &cookie, "/ui/ops").await;
         assert!(!ops.contains("<h3>Pursuits</h3>"), "{ops}");
+    }
+
+    #[tokio::test]
+    async fn the_page_reports_how_long_an_artifact_was_open() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        core.pursuit.enabled = true;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        let src = handle
+            .store
+            .insert_corpus("raw", "web", None)
+            .await
+            .unwrap();
+        let a = handle
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{a}/dwell"),
+                &cookie,
+                "secs=42",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        handle.background.wait_idle().await;
+        let now = crate::store::now();
+        let got = handle.store.interactions_between(0, now + 1).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].kind, "dwell");
+        assert_eq!(got[0].detail.as_deref(), Some("42"));
+        // The detail root names the artifact, which is what the page's timer reads.
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
+        assert!(page.contains(&format!("data-artifact=\"{a}\"")), "{page}");
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -360,6 +360,8 @@ fn artifact_view(c: &crate::store::artifacts::Chunk) -> ArtifactView {
 struct CaptureTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     /// Decisions waiting on a person, shown where the work arrives rather than
     /// on a page you have to remember to visit. Empty renders nothing at all.
     pairs: Vec<PairRow>,
@@ -428,6 +430,8 @@ struct CapturedTemplate {
 struct SearchTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     /// Kept so a reload or a deep link restores the box with its results.
     q: String,
     /// What this collection can actually be narrowed by. Rendered as chips, so
@@ -466,6 +470,8 @@ struct QueueTemplate {
 struct CorpusTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     id: String,
     status: String,
     badge: &'static str,
@@ -551,6 +557,8 @@ struct ArtifactDetailFragment {
 struct ArtifactDetailPage {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     d: ArtifactDetail,
 }
 
@@ -559,6 +567,8 @@ struct ArtifactDetailPage {
 struct OpsTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     job_counts: Vec<(String, i64)>,
     oldest_pending_secs: Option<i64>,
     artifact_count: i64,
@@ -591,6 +601,8 @@ struct OpsTemplate {
 struct SettingsTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     tokens: Vec<TokenRow>,
     /// `None` when capture is switched off, which renders nothing at all: a
     /// section about a log nobody is keeping is noise.
@@ -677,6 +689,8 @@ struct TokenCreatedTemplate {
 struct AskTemplate {
     /// Waiting judgements for the nav. See `state::judge_pending`.
     judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
     /// A question to prefill the box with — a gap's "ask again".
     q: String,
 }
@@ -787,6 +801,7 @@ async fn capture_page(
     };
     Ok(HtmlTemplate(CaptureTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         pairs,
         more_pairs,
         vision_enabled: st.core.describer.is_some(),
@@ -900,6 +915,7 @@ async fn search_page(
     ensure_facet(&mut facets.categories, &category);
     Ok(HtmlTemplate(SearchTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         q: p.q,
         facets,
         category,
@@ -1393,6 +1409,7 @@ async fn corpus_detail(
     let exif_rows = exif_tag_rows(&s.metadata);
     Ok(HtmlTemplate(CorpusTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         id: s.id,
         badge: status_badge(&s.status),
         status: s.status.as_str().to_string(),
@@ -1723,6 +1740,7 @@ async fn token_rows(st: &AppState) -> Result<Vec<TokenRow>> {
 async fn settings(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     Ok(HtmlTemplate(SettingsTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         tokens: token_rows(&st).await?,
         feedback: match st.core.feedback.enabled {
             true => Some(st.core.store.feedback_stats().await?),
@@ -1872,6 +1890,7 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
 
     Ok(HtmlTemplate(OpsTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         retrying,
         parked,
         superseded,
@@ -2128,11 +2147,17 @@ async fn ask_page(
     State(st): State<AppState>,
     _id: Identity,
     Query(p): Query<AskPrefill>,
-) -> impl IntoResponse {
-    HtmlTemplate(AskTemplate {
+) -> Result<Response> {
+    // No ask model, no ask door: the route is not there. See `Core::asks`.
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
+    Ok(HtmlTemplate(AskTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         q: p.q,
     })
+    .into_response())
 }
 
 #[derive(serde::Deserialize)]
@@ -2151,6 +2176,10 @@ async fn ask_submit(
     id: Identity,
     Form(f): Form<AskForm>,
 ) -> Result<Response> {
+    // No ask model, no ask door: the route is not there. See `Core::asks`.
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
     // Refused before anything is parked, so an empty box costs no entry in the
     // map and no second round trip to find out.
     if f.q.trim().is_empty() {
@@ -2182,6 +2211,10 @@ async fn ask_stream(
     id: Identity,
     Path(handoff): Path<String>,
 ) -> Result<Response> {
+    // No ask model, no ask door: the route is not there. See `Core::asks`.
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
     use tokio_stream::StreamExt as _;
 
     // Unknown, already spent, expired, or somebody else's — all one answer.
@@ -2411,6 +2444,10 @@ async fn ask_verdict(
     Path(id): Path<String>,
     Form(f): Form<VerdictForm>,
 ) -> Result<Response> {
+    // No ask model, no ask door: the route is not there. See `Core::asks`.
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
     match f.verdict.as_str() {
         "none" => st.core.store.unjudge_ask(&id).await?,
         v => {
@@ -2433,6 +2470,10 @@ async fn ask_carried(
     Path(id): Path<String>,
     Form(f): Form<CarriedForm>,
 ) -> Result<Response> {
+    // No ask model, no ask door: the route is not there. See `Core::asks`.
+    if !st.core.asks() {
+        return Err(Error::NotFound);
+    }
     let carried = st.core.store.toggle_carried(&id, f.n).await?;
     let bar = ask_verdict_bar(&st, &id, true).await?;
     Ok(HtmlTemplate(AskCarriedTemplate {
@@ -2625,6 +2666,7 @@ async fn artifact_detail(
     }
     Ok(HtmlTemplate(ArtifactDetailPage {
         judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
         d,
     })
     .into_response())
@@ -6970,5 +7012,38 @@ mod tests {
             out, r##"<a href="/x?q=[1]"><a class="cite" href="#cite-1">[1]</a></a>"##,
             "{out}"
         );
+    }
+
+    #[tokio::test]
+    async fn without_an_ask_model_there_is_no_ask_page_and_no_ask_link() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.completer = None;
+        let (app, cookie) = app_with_cookie(core).await;
+        let page = get_body(&app, &cookie, "/ui/search").await;
+        assert!(!page.contains("href=\"/ui/ask\""), "{page}");
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/ask")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let res = app
+            .oneshot(form("/ui/ask", &cookie, "q=anything"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn with_an_ask_model_the_link_is_there() {
+        let (app, cookie) = app_with_session().await;
+        let page = get_body(&app, &cookie, "/ui/search").await;
+        assert!(page.contains("href=\"/ui/ask\""), "{page}");
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -511,6 +511,9 @@ struct CorpusTemplate {
     /// here, as is anything written before spans were recorded — and the page
     /// showed none of them once it rendered bands alone.
     unplaced: Vec<ArtifactView>,
+    /// Merged and synthesized artifacts with a root in this capture. A merge
+    /// belongs to every corpus it drew from, and this is where that shows.
+    written_from: Vec<ArtifactView>,
     /// Nothing was captured here at all, so the flat fallback has nothing to
     /// show either.
     lines_empty: bool,
@@ -1428,6 +1431,15 @@ async fn corpus_detail(
     let note = s.metadata["note"].as_str().map(str::to_string);
     let meta_rows = metadata_rows(&s.metadata);
     let exif_rows = exif_tag_rows(&s.metadata);
+    let written_from: Vec<ArtifactView> = st
+        .core
+        .store
+        .artifacts_originating_in(&cid)
+        .await?
+        .iter()
+        .filter(|c| c.in_results())
+        .map(artifact_view)
+        .collect();
     // A promoted window: `done`, and owning at least one superseded passage.
     let promoted: Vec<PromotedWindow> = segments
         .iter()
@@ -1461,6 +1473,7 @@ async fn corpus_detail(
         bands,
         promoted,
         unplaced,
+        written_from,
         lines_empty: s.raw_text.trim().is_empty(),
         raw_text: s.raw_text.clone(),
         coverage,
@@ -7166,5 +7179,62 @@ mod tests {
         );
         let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", src.id)).await;
         assert!(!page.contains(&action), "undo still offered after undoing");
+    }
+
+    #[tokio::test]
+    async fn a_merge_is_listed_under_each_corpus_it_drew_from() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let c1 = core.store.insert_corpus("one", "web", None).await.unwrap();
+        let c2 = core.store.insert_corpus("two", "web", None).await.unwrap();
+        let na = |t: &str| crate::store::artifacts::NewArtifact {
+            ordinal: 0,
+            text: t.into(),
+            corpus_span: Some(crate::store::artifacts::CorpusSpan {
+                start_line: 1,
+                end_line: 1,
+            }),
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: Some(0),
+            caveats: vec![],
+        };
+        let r1 = core
+            .store
+            .insert_artifacts(&c1.id, &[na("root one")])
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let r2 = core
+            .store
+            .insert_artifacts(&c2.id, &[na("root two")])
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let m = core
+            .store
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    text: "the merge of one and two".into(),
+                    title: Some("Merged title".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[r1, r2],
+            )
+            .await
+            .unwrap();
+        for c in [&c1, &c2] {
+            core.store
+                .set_corpus_status(&c.id, CorpusStatus::Ready)
+                .await
+                .unwrap();
+            let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", c.id)).await;
+            assert!(page.contains("Written from this corpus"), "{page}");
+            assert!(page.contains(&m.id), "{page}");
+        }
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3430,6 +3430,7 @@ mod tests {
                         query_vec: vec![0.1, 0.2],
                         embed_model: "fake".into(),
                         candidates: vec![],
+                        answered: false,
                     },
                     // No folding: these stand for separate searches, not one
                     // being typed.

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -143,6 +143,10 @@ pub struct ArtifactDetail {
     /// highlighted" label over an empty link and an empty line table — on
     /// exactly the artifact whose orphan notice matters most.
     pub merged: bool,
+    /// Written from a pursuit: shows the questions it was written for.
+    pub synthesized: bool,
+    /// Those questions.
+    pub cues: Vec<String>,
     /// True when one of those sources has since been deleted. The text still
     /// carries what it said, so this is a missing link rather than missing
     /// knowledge — and saying so beats listing one source fewer in silence.
@@ -612,6 +616,12 @@ struct OpsTemplate {
     /// count of links on a base that records no searches is a line about a
     /// feature that is switched off.
     links: Option<crate::store::links::LinkCounts>,
+    /// Artifacts written from pursuits, newest first, each one click from
+    /// deprecated.
+    generated: Vec<GeneratedRow>,
+    /// Recent pursuits, only when the feature is on.
+    pursuit_enabled: bool,
+    pursuits: Vec<PursuitRow>,
 }
 
 #[derive(Template)]
@@ -630,6 +640,24 @@ struct SettingsTemplate {
     /// only the searches let an operator clear their query log without knowing
     /// the judged questions went with it.
     asks: Option<crate::store::asks::AskStats>,
+}
+
+/// One generated artifact on Ops.
+struct GeneratedRow {
+    id: String,
+    title: String,
+    subtitle: String,
+    cues: Vec<String>,
+    sources: Vec<SourceRow>,
+}
+
+/// One pursuit on Ops: what was wanted, what came of it.
+struct PursuitRow {
+    when: String,
+    state: String,
+    reason: String,
+    queries: Vec<String>,
+    artifact_id: Option<String>,
 }
 
 struct MergedRow {
@@ -1912,6 +1940,44 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
 
     let more_merged = merged.len() > TABLE_CAP as usize;
     merged.truncate(TABLE_CAP as usize);
+
+    let mut generated = Vec::new();
+    let gen_chunks = st.core.store.synthesized_artifacts(TABLE_CAP).await?;
+    let gen_ids: Vec<String> = gen_chunks.iter().map(|c| c.id.clone()).collect();
+    let gen_roots = st.core.store.roots_of(&gen_ids).await.unwrap_or_default();
+    for c in gen_chunks {
+        let sources = source_rows(
+            &st.core.store,
+            &c.id,
+            gen_roots.get(&c.id).map(Vec::as_slice).unwrap_or_default(),
+        )
+        .await;
+        generated.push(GeneratedRow {
+            title: title_of(&c),
+            subtitle: row_subtitle(&c),
+            cues: c.cues.clone(),
+            id: c.id,
+            sources,
+        });
+    }
+    let pursuit_enabled = st.core.pursuit.enabled;
+    let pursuits: Vec<PursuitRow> = if pursuit_enabled {
+        st.core
+            .store
+            .recent_pursuits(50)
+            .await?
+            .into_iter()
+            .map(|p| PursuitRow {
+                when: fmt_time(p.opened_at),
+                state: p.state,
+                reason: p.reason.unwrap_or_default(),
+                queries: p.queries,
+                artifact_id: p.artifact_id,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
     let more_superseded = superseded.len() > TABLE_CAP as usize;
     superseded.truncate(TABLE_CAP as usize);
 
@@ -1969,6 +2035,9 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             true => Some(st.core.store.link_counts().await?),
             false => None,
         },
+        generated,
+        pursuit_enabled,
+        pursuits,
     })
     .into_response())
 }
@@ -2691,7 +2760,9 @@ pub(crate) async fn build_artifact_detail(
         status: c.status,
         last_verified_at: c.last_verified_at,
         caveats: c.caveats,
-        merged: c.provenance == crate::store::artifacts::Provenance::Merged,
+        merged: c.provenance.is_model_written(),
+        synthesized: c.provenance == crate::store::artifacts::Provenance::Synthesized,
+        cues: c.cues,
         corpus_id: c.corpus_id,
         // A merged artifact has no corpus and so cannot have a restored one.
         corpus_restored: src.as_ref().is_some_and(|s| s.restored_at.is_some()),
@@ -7316,5 +7387,87 @@ mod tests {
         assert_eq!(got[1].kind, "pivoted");
         assert_eq!(got[1].via.as_deref(), Some(made[0].id.as_str()));
         assert_eq!(got[1].scope.as_deref(), Some("user-1"));
+    }
+
+    #[tokio::test]
+    async fn a_generated_artifact_shows_its_cues_is_listed_on_ops_and_badged_in_the_rail() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.pursuit.enabled = true;
+        core.feedback.enabled = true;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        let src = handle
+            .store
+            .insert_corpus("raw", "web", None)
+            .await
+            .unwrap();
+        let s = handle
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "source text".into(),
+                    corpus_span: None,
+                    title: Some("S".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        let g = handle
+            .store
+            .insert_synthesized_artifact(
+                &crate::store::artifacts::NewSynthesized {
+                    text: "generated from S".into(),
+                    title: Some("Generated title".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec!["why was this asked".into()],
+                },
+                &[s[0].id.clone()],
+            )
+            .await
+            .unwrap();
+        crate::jobs::embed::run(&handle, &g.id).await.unwrap();
+        handle
+            .store
+            .insert_pursuit(1, &["why was this asked".into()], &[s[0].id.clone()])
+            .await
+            .unwrap();
+
+        let detail = get_body(&app, &cookie, &format!("/ui/artifacts/{}", g.id)).await;
+        assert!(
+            detail.contains("Written because these were asked"),
+            "{detail}"
+        );
+        assert!(detail.contains("why was this asked"), "{detail}");
+
+        let ops = get_body(&app, &cookie, "/ui/ops").await;
+        assert!(ops.contains("Generated"), "{ops}");
+        assert!(
+            ops.contains(&format!("/ui/ops/artifacts/{}/deprecate", g.id)),
+            "{ops}"
+        );
+        assert!(ops.contains("Pursuits"), "{ops}");
+
+        let rail = get_body(
+            &app,
+            &cookie,
+            "/ui/search/results?q=Generated%20title%0Agenerated%20from%20S",
+        )
+        .await;
+        assert!(rail.contains("model-written"), "{rail}");
+    }
+
+    #[tokio::test]
+    async fn the_pursuit_section_is_not_there_when_pursuits_are_off() {
+        let (app, cookie) = app_with_session().await;
+        let ops = get_body(&app, &cookie, "/ui/ops").await;
+        assert!(!ops.contains("<h3>Pursuits</h3>"), "{ops}");
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -6267,9 +6267,9 @@ mod tests {
             .await
             .unwrap();
         // Swapped in after indexing, so only the answer comes from it.
-        core.completer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some("First run `wipefs --all /dev/sdX`, then read alpha.".into()),
-        });
+        }));
         let (app, cookie) = app_with_cookie(core).await;
         let html = done_html(&ask_over_sse(&app, &cookie, "what+is+alpha").await);
         assert!(html.contains("unsupported literal(s)"), "no badge: {html}");
@@ -6654,9 +6654,9 @@ mod tests {
             .unwrap();
         // Swapped in after indexing, so the citations in the answer are this
         // reply's and not something retrieval happened to produce.
-        core.completer = std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
             reply: Some("alpha [1], bravo [2], and alpha again [01].".into()),
-        });
+        }));
         let (app, cookie) = app_with_cookie(core).await;
 
         let body = ask_over_sse(&app, &cookie, "what+is+alpha").await;

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -527,6 +527,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         judge: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
         link_judge: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
         gap_namer: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
+        generator: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
         // The harness measures the shipped default, which is one round.
         follow_up: None,
         describer: None,

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -548,6 +548,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         associate: engram::config::AssociateConfig::default(),
         activation: engram::config::ActivationConfig::default(),
         promote: engram::config::PromoteConfig::default(),
+        pursuit: engram::config::PursuitConfig::default(),
         // The benchmark makes no background inference call, so the pacer never
         // has anything to hold back.
         gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -532,6 +532,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         describer: None,
         synthesis: engram::config::SynthesisMode::Eager,
         segment_tokens: engram::config::DEFAULT_SEGMENT_TOKENS,
+        chunk_tokens: engram::config::DEFAULT_CHUNK_TOKENS,
         counter: Arc::new(engram::infer::budget::TokenCounter),
         background: Arc::new(engram::core::background::Background::default()),
         query_cache: Arc::new(std::sync::Mutex::new(engram::core::QueryCache::new(

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -540,10 +540,14 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         ))),
         consolidate: engram::config::ConsolidateConfig::default(),
         weak_below: 0.0,
-        feedback: engram::config::FeedbackConfig::default(),
+        feedback: engram::config::FeedbackConfig {
+            enabled: false,
+            ..Default::default()
+        },
         capture: engram::config::CaptureConfig::default(),
         associate: engram::config::AssociateConfig::default(),
         activation: engram::config::ActivationConfig::default(),
+        promote: engram::config::PromoteConfig::default(),
         // The benchmark makes no background inference call, so the pacer never
         // has anything to hold back.
         gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -186,8 +186,12 @@ async fn evaluate_ask() {
     let translated = index(&core, &artifacts).await;
 
     let check_claims = std::env::var("ENGRAM_EVAL_CLAIMS").is_ok_and(|v| v == "1");
-    let claim_checker =
-        engram::infer::openai::HttpCompleter::for_claim_checking(&cfg.infer.synthesize);
+    let claim_checker = engram::infer::openai::HttpCompleter::for_claim_checking(
+        cfg.infer
+            .synthesize
+            .as_ref()
+            .expect("the eval harness needs [infer.synthesize]"),
+    );
 
     let mut recall: Vec<f64> = Vec::new();
     let mut all_cited = (0usize, 0usize);
@@ -288,7 +292,11 @@ async fn evaluate_ask() {
         "\n{} questions over {} artifacts   (ask {}, embed {}, claims {})",
         questions.len(),
         artifacts.len(),
-        cfg.infer.ask.model,
+        cfg.infer
+            .ask
+            .as_ref()
+            .expect("the eval harness needs [infer.ask]")
+            .model,
         cfg.infer.embed.model,
         if check_claims { "on" } else { "off" }
     );
@@ -512,16 +520,18 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
     let core = Core {
         store: Store::memory().await.unwrap(),
         vectors: Arc::new(engram::vector::memory::MemoryVectors::new()),
-        synthesizer: Arc::new(engram::infer::fake::FakeSynthesizer::default()),
+        synthesizer: Some(Arc::new(engram::infer::fake::FakeSynthesizer::default())),
         embedder: Arc::new(engram::infer::fake::FakeEmbedder::new(8)),
         reranker: None,
-        completer: Arc::new(engram::infer::fake::FakeCompleter::default()),
-        judge: Arc::new(engram::infer::fake::FakeCompleter::default()),
-        link_judge: Arc::new(engram::infer::fake::FakeCompleter::default()),
-        gap_namer: Arc::new(engram::infer::fake::FakeCompleter::default()),
+        completer: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
+        judge: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
+        link_judge: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
+        gap_namer: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
         // The harness measures the shipped default, which is one round.
         follow_up: None,
         describer: None,
+        synthesis: engram::config::SynthesisMode::Eager,
+        segment_tokens: engram::config::DEFAULT_SEGMENT_TOKENS,
         counter: Arc::new(engram::infer::budget::TokenCounter),
         background: Arc::new(engram::core::background::Background::default()),
         query_cache: Arc::new(std::sync::Mutex::new(engram::core::QueryCache::new(

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -58,6 +58,7 @@ fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPo
             last_verified_at: None,
             superseded_by: None,
             origin_corpora: vec![],
+            provenance: None,
         },
     }
 }
@@ -716,6 +717,7 @@ fn hybrid_point(id: &str, text: &str, dense: Vec<f32>) -> VectorPoint {
             last_verified_at: None,
             superseded_by: None,
             origin_corpora: vec![],
+            provenance: None,
         },
     }
 }
@@ -917,6 +919,7 @@ fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint 
             last_verified_at: Some(ts),
             superseded_by: None,
             origin_corpora: vec![],
+            provenance: None,
         },
     }
 }

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -57,6 +57,7 @@ fn point(id: &str, src: &str, v: Vec<f32>, tags: &[&str], cat: &str) -> VectorPo
             status: None,
             last_verified_at: None,
             superseded_by: None,
+            origin_corpora: vec![],
         },
     }
 }
@@ -714,6 +715,7 @@ fn hybrid_point(id: &str, text: &str, dense: Vec<f32>) -> VectorPoint {
             status: None,
             last_verified_at: None,
             superseded_by: None,
+            origin_corpora: vec![],
         },
     }
 }
@@ -914,6 +916,7 @@ fn aged(id: &str, dense: Vec<f32>, days_old: i64, tags: &[&str]) -> VectorPoint 
             // scores, so it has to set the field the formula actually uses.
             last_verified_at: Some(ts),
             superseded_by: None,
+            origin_corpora: vec![],
         },
     }
 }


### PR DESCRIPTION
The whole of the tiered-synthesis spec (`docs/superpowers/specs/2026-08-19-tiered-synthesis-design.md`, included on this branch with the review folded in), landed in four plans in sequence — each one measured-able on its own, all in one PR at the operator's request. 40 commits; 1304 tests (up from 1219), clippy clean.

## 1. The embedding recipe (spec §2)

`[infer.embed]` gains three prompt templates, defaulting to EmbeddingGemma's model-card strings; the `Embedder` trait is asymmetric by interface (`embed_raw` is the wire call, `embed_documents`/`embed_query` render first); the envelope is charged against the split budget. Test doubles default to the legacy templates so retrieval tests keep matching; `FakeEmbedder::with_templates` exercises the recipe.

## 2. `off` mode (spec §1, §1a, §5, §8, §9)

`[infer] synthesis = "off" | "earned" | "eager"` (default `eager`: nothing changes unless set). At `off`/`earned` capture splits into windows (`verbatim` segment state, owed nothing) and then into **passages** — verbatim slices sized to `chunk_tokens = 384`, titled by the heading the document gave them, spans partitioning the window — and embeds them; no model on the path. `[infer.synthesize]` and `[infer.ask]` are optional; a core without them arms nothing it cannot call and offers no door that needs them (no ask page, nav entry, API route or MCP tool). `ask` stitches abutting passages back into continuous text and reaches the nearest *active* neighbour. `provenance` gains `passage` and `synthesized`; `roots_of` tests "model-written", not "is merged".

## 3. Promotion, consolidation, origins (spec §3, §6, §7)

`[promote] activation_above = 4.0`, checked `>=` after the **opened** and **confirmed** bumps only (never retrieved). A passage over the line moves its `verbatim` window to `pending` with `keep_artifacts` and arms today's `SegmentWindow` job; the window's artifacts supersede the passages they cover **by majority, per artifact** and inherit the passages' access — max decayed activation, links copied with collision rules (max not sum; `dismissed` wins; verdicts reopen). Undo restores the passages, retires the artifacts, resets the window. `resynthesize_after_unconfirmed` (ships 0) is the `eager` counterpart. **`feedback.enabled` is now `true` by default** — promotion reads activation, and activation moves only while searches are recorded. Consolidation never pairs two rows of one window and no longer hides on `auto_supersede` (it is a fast lane to the judge). `origins_of` derives every corpus an artifact draws from; `cap_per_corpus`, `links_from`/`links_to_judge` cross-corpus, the corpus page ("Written from this corpus") and the vector payload read it.

## 4. Pursuits (spec §4)

`[pursuit]` (off by default; needs `feedback.enabled`). `interaction_events` records opened/pivoted (the detail pane's rail links carry `?via=`); a sweep runs once everything unprocessed is idle, clusters searches and asks by `link_threshold` (no `coherence` key), scores engagement, and applies the spec's decision table: answered → satisfied; one engaged artifact → promotion; assembled and (unsatisfied or pivoted/returned) → generate, unless the roots are already covered by an existing generation. `Stage::Generate` makes one call on the synthesize endpoint and writes a `synthesized` artifact with `cues`, lineage through `via_id`, `missing_literals` flags, superseding nothing. Search events carry `answered` (a synthesized artifact at final rank 1 above `weak_below`) — the stopping rule. Surfaces: rail badge, detail cues, Ops "Generated" with deprecate, Ops "Pursuits" when enabled; the forget button clears both tables.

## Breaking / defaults that move

- `feedback.enabled` default → `true` (opt-out). Set `false` to record nothing.
- `auto_supersede` no longer hides: pairs above it are judged first instead.
- `Embedder` trait reshaped; default templates are EmbeddingGemma's (a bge-m3 base sets the three legacy templates or re-captures).
- New schema: `segments.state = 'verbatim'`, `artifacts.cues`, `search_events.answered`, `interaction_events`, `pursuits`. No migration (no legacy base, by agreement).

## Run against a real stack

Exercised end-to-end against a llama.cpp/litellm server (EmbeddingGemma-300m, Qwen3.5-9B) and a Qdrant container, in `off`, `earned` and with pursuits on:

- **Embedding endpoint:** dim 768; no server-side prompt template (`hello` costs 3 tokens); the templates widen the relevant/irrelevant cosine gap from 0.37 to 0.49; the server's physical batch is **1024**, not the model's 2048 — set `max_input_tokens` to the server's number, exactly as the config comment says.
- **`off`:** a Markdown document captured to two passages under their headings, coverage 1.0, `ready`, no model call; search and `ask` (passages stitched into one excerpt) answered from Qwen.
- **`earned`:** retrievals + opens crossed 4.0 (the exact-4.0 case sits at 3.9998 after decay — the `>=` fragility the spec notes), the window was promoted, Qwen wrote four artifacts, activation carried over.
- **Pursuits:** three same-need searches, a pivot and a return clustered into one pursuit at the measured line; Qwen generated an artifact with cues and lineage; it then led the list for the need, badged, and the event recorded `answered = 1` — the stopping rule fires.

Two fixes came out of it: the splitter now cuts at the boundary *before* an overflowing paragraph (a 384-token passage came out at 500 otherwise), and a promotion supersedes a passage only if its artifact is traceable to it by text — a paraphrasing model's guessed spans hid the wrong passages.

## Not built, recorded

"Before/after on Ops" for eager re-synthesis (the detector ships disabled); server-side grouping (`query/groups`) — on the roadmap as a prerequisite with its own measurement; `cap_per_corpus` over origins is the in-memory fallback. `dwell` **is** built: the page measures it and the sweep uses it as a tiebreak only.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets` (0), `cargo test` (1308 passed), `cargo test --test eval` — green at `26cf4d2`. The spec's own measurement note still stands: the embedding recipe moves the retrieval baseline and should get a judged-pair run before `off`/`earned` are compared against `eager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhTDaGxNRcf5smhswitZgF
