### PR TITLE
One system: the queue is the scheduler, the sitting is live, and one queue for what is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ engram --export-eval ~/engram-eval          # artifacts.json + pairs.json
 ENGRAM_EVAL_DIR=~/engram-eval cargo test --test eval -- --ignored --nocapture
 ```
 
+What the two harnesses measure, why both numbers are reported, which knob to
+sweep for which metric, and what they cannot measure at all:
+**[docs/evaluation.md](docs/evaluation.md)**.
+
 The export reads SQLite only: no inference, no Qdrant, and the artifacts keep
 their real ids, so running it again does not invalidate the pairs. Nothing
 leaves the machine, `enabled` is off until you turn it on, and Ops has a button

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,14 +57,15 @@ a layer crossing without a measured retrieval gain does not go in. The harness
 is the only figure comparable across months; a default that changes ranking
 moves only after it has been run.
 
-Most of what is left is not a mechanism but a seam. The mechanisms are mostly
-built and mostly work alone: six background tickers on six intervals with no
-order between them (`src/core/background.rs`), four front doors with nothing
-carried between them, and four separate ways of saying *the base did not
-answer*, each ending somewhere else. The list is grouped by subject, as it
-always was, but read end to end it is one project — and roughly in the order it
-would be built, because a seam that only joins two surfaces ships when it is
-written, while a seam that moves ranking waits for the harness.
+Most of what is left is not a mechanism but a seam. Three of them are now
+closed — the queue is the scheduler, the sitting is live, and the four ways of
+saying *the base did not answer* end on one list
+(`docs/superpowers/specs/2026-08-20-one-system-design.md`). What is left below
+is what those three make easier rather than what they replace. The list is
+grouped by subject, as it always was, but read end to end it is one project —
+and roughly in the order it would be built, because a seam that only joins two
+surfaces ships when it is written, while a seam that moves ranking waits for
+the harness.
 
 ## [Associative Memory]
 
@@ -74,28 +75,36 @@ bounded priming and one-hop association in the results, a sparse judge on
 strong cross-corpus links, switched on with `[associate]` and `[activation]`
 in config. The items below are the mechanisms that come after it, in order.
 
-- **Sleep as an explicit cycle.** The background work already exists — link
-  replay, activation decay, pruning, relate/dedupe, retention. It becomes phases
-  of one scheduled cycle with one Ops report: last sleep, what changed. Framing
-  over what exists, and the home every later mechanism slots into. The part
-  that is more than framing is the order, and the account. Each of those is its
-  own ticker with its own interval and its own gate
-  (`spawn_consolidation_ticker` and its five siblings), so what runs before
-  what is whichever interval elapsed first — `Relate` arms the pairs that
-  `Dedupe` and the consolidation sweep both read, and nothing sequences the
-  three. Inside one ticker the order is already right; it is the orderings that
-  cross a ticker boundary that were never written down. And each ticker's
-  account of itself is one `info` line in a log.
-- **Working memory.** Within a session, what you just opened primes its
-  neighbours and links for the next query. Session-scoped, expires with it,
-  never written to activation. The sitting this needs already exists — but only
-  afterwards, reconstructed from idle gaps in the search log by the pursuit
-  sweep (`jobs/pursuit.rs`), which is to say the base can name what you were
-  working on last week and not what you are working on now. Making it live is
-  also what joins the doors: the query carries from search into ask, the answer
-  into capture, and a sitting can say what it has touched.
-  `Core::record_interaction` already writes the events and nothing reads them
-  until the sweep.
+- **Sleep as an explicit cycle.** Built, and not as a cycle. The queue was
+  already three-quarters of a scheduler; it has a priority column now
+  (`jobs.class` — is somebody waiting on this?), ageing on the repair pass, and
+  five fewer tickers: a sweep arms itself one interval out when it finishes, so
+  `run_after` is the cursor saying when it last ran. Ordering is expressed the
+  way the tree already expressed dependencies, by arming — the association
+  sweep pulls the pursuit sweep forward, replay before pursue. The account is
+  `sweep_runs`, one row per run, shown on Ops as the last day with the history
+  under it.
+
+  What did not survive contact is the *cycle*. Units on their own periods do
+  not line up into one night, and grouping them by an invented cycle identity
+  would be inventing it — so there is no "last sleep", there is the last day.
+  Repair stays outside the schedule: it is what recovers an interrupted one.
+- **Working memory.** Built, carrying only. A live sitting keyed by web
+  session (`src/core/sitting.rs`), in memory, expiring at `pursuit.idle_secs` —
+  the same number the sweep uses, so the live definition and the reconstructed
+  one agree by construction. It joins the doors: the query carries from search
+  into ask, an answer kept from ask shows the question it answered, and both
+  pages carry a rail of what this sitting has been in. It never writes
+  activation, and there is a test saying so.
+
+  Priming from it is behind `[sitting] prime`, off, sharing the one budget
+  `associate.prime_lift` bounds. It is the one thing here that moves ranking,
+  so it waits for the harness — see below.
+- **`[sitting] prime` is unmeasured.** The one default here that would move
+  ranking, and the harness has not been run either way: it needs a live Qdrant,
+  a real embedding endpoint and a corpus that is not in this repository. Until
+  it has, the flag stays `false`. It moves in a commit of its own, carrying
+  both numbers in its message, or it does not move.
 - **Every door counts as engagement.** Retrieval is recorded at every door —
   `core.search` bumps activation whether the query came from the rail, the API
   or `/mcp`. Engagement is not: `mark_artifact_seen` and `record_interaction`
@@ -257,23 +266,29 @@ base already knows are currently spread across four pages in four vocabularies,
 and a mechanism the operator cannot see the effect of is one they cannot decide
 to trust.
 
-- **One queue for "the base did not answer".** There are four ways to say it
-  today and each ends somewhere else: a search judged `gap` becomes a knowledge
-  gap, an ask verdict of *nothing here* becomes a knowledge gap by a second
-  path, a quiet run of engaged searches becomes a pursuit on Ops, and a search
-  abandoned with nothing opened — the most telling of all, and the reason the
-  feedback log records it — becomes nothing at all. They are one statement
-  about one hole. One queue, closable three ways: by a paste, by a pursuit that
-  earned itself, or by dismissal. And the capture page saying *this closes two
-  open gaps* is the loop shutting where the operator can see it, which is the
-  part the app currently does all the work for and never shows.
+- **One queue for "the base did not answer".** Built. Four `GapKind`s on the
+  one list the capture page already had, each badged with what asked it:
+  *judged*, *asked*, *nothing near*, *pursued*. Closable three ways — a capture
+  that covers it, a pursuit that earns itself, or dismissal — and a capture
+  that answered something says so on its own queue row, which is the loop
+  shutting where the operator can see it.
+
+  The fourth source is distance, not behaviour: a search whose best candidate
+  fell under `vector.weak_below`. *Abandoned* was the first draft and it was
+  wrong twice — not clicking a result can mean the list was useless or that the
+  titles told you what you needed, and an open is only recorded when pursuits
+  *and* feedback are on, so with pursuits off every search looks abandoned.
+  Coverage is stored in `gap_coverage` rather than on the judged row, so
+  nothing an automatic score decided overwrites what a person judged, and
+  deleting the capture that closed a gap reopens it.
 - **Ops as the state of the memory, not the housekeeping table.** It lists
   merges, deprecations, hidden near-duplicates, retries. What it does not say
   is what the memory is *like*: how much is held and how densely, what is
   activated and what is fading, recall@10 and MRR over months rather than as
-  today's number on the judge page, when it last slept and what changed. Four
-  figures in four places, and the one page named for the answer has none of
-  them.
+  today's number on the judge page. Four figures in four places, and the one
+  page named for the answer has none of them. What the sweeps did is answered
+  now — the last day, and the history under it — which leaves the shape of the
+  base itself.
 - **Where an artifact came from, end to end.** Corpus lines, passage, the
   window whose reading earned a synthesis, the merge, the pursuit, the answer
   it was cited in. `store/lineage.rs` and `web/lineage_view.rs` hold the middle

--- a/assets/app.js
+++ b/assets/app.js
@@ -195,6 +195,9 @@
     if (!form) return;
     var live = document.getElementById('ask-live');
     var reasoning = document.getElementById('ask-reasoning');
+    // The disclosure around it: what is shown or hidden is the box, while the
+    // text still streams into the div inside it.
+    var reasoningBox = document.getElementById('ask-reasoning-box');
     var progress = document.getElementById('ask-progress');
     var rail = document.getElementById('ask-rail');
     var result = document.getElementById('ask-result');
@@ -225,7 +228,7 @@
       box.textContent = message;
       result.appendChild(box);
       live.hidden = true;
-      reasoning.hidden = true;
+      reasoningBox.hidden = true;
       progress.hidden = true;
     }
 
@@ -284,8 +287,11 @@
       });
       source.addEventListener('reasoning', function (e) {
         if (!current()) return;
-        reasoning.hidden = false;
+        reasoningBox.hidden = false;
         reasoning.appendChild(document.createTextNode(JSON.parse(e.data).text));
+        // Only while it is open. A closed box has no scroll position to keep,
+        // and asking for one fights the page for the reader's.
+        if (reasoningBox.open) reasoning.scrollTop = reasoning.scrollHeight;
       });
       source.addEventListener('token', function (e) {
         if (!current()) return;
@@ -306,7 +312,7 @@
         // the rendered answer. Hidden rather than emptied, so the next ask
         // reuses them.
         live.hidden = true;
-        reasoning.hidden = true;
+        reasoningBox.hidden = true;
         // `progress` deliberately stays: what the retrieval went looking for
         // still describes the rail underneath the answer, and it is the only
         // place on the page that says a fan-out happened at all.
@@ -347,7 +353,8 @@
       rail.textContent = '';
       result.textContent = '';
       live.hidden = true;
-      reasoning.hidden = true;
+      reasoningBox.hidden = true;
+      reasoningBox.open = false;
       form.classList.add('asking');
 
       fetch('/ui/ask', {

--- a/assets/app.js
+++ b/assets/app.js
@@ -202,7 +202,14 @@
     var rail = document.getElementById('ask-rail');
     var result = document.getElementById('ask-result');
     var status = document.getElementById('ask-status');
+    var spinner = document.getElementById('ask-spinner');
+    var stopBtn = document.getElementById('ask-stop');
     var source = null;
+    // The wait is fifty seconds on a fan-out and nothing on the page predicted
+    // it. Counted from the submit rather than from the first token, because
+    // the retrieval in front of the model is most of what is being waited on.
+    var started = 0;
+    var ticker = null;
     // Which ask the page belongs to. See the submit handler.
     var generation = 0;
 
@@ -214,8 +221,32 @@
     // here.
     function stop() {
       if (source) { source.close(); source = null; }
+      if (ticker) { clearInterval(ticker); ticker = null; }
+      stopBtn.hidden = true;
+      spinner.textContent = 'thinking…';
       form.classList.remove('asking');
     }
+
+    // Count up beside the spinner while the stream is open.
+    function startTicking() {
+      started = Date.now();
+      stopBtn.hidden = false;
+      if (ticker) clearInterval(ticker);
+      ticker = setInterval(function () {
+        var secs = Math.round((Date.now() - started) / 1000);
+        spinner.textContent = 'thinking… ' + secs + 's';
+      }, 1000);
+    }
+
+    stopBtn.addEventListener('click', function () {
+      if (!source) return;
+      var secs = Math.round((Date.now() - started) / 1000);
+      stop();
+      // What arrived stays. `live` holds the partial answer and the rail holds
+      // the excerpts it was being written from, and both are worth more than a
+      // cleared page — the reader stopped the wait, not the answer.
+      status.textContent = 'stopped after ' + secs + ' seconds';
+    });
 
     function fail(message) {
       stop();
@@ -356,6 +387,7 @@
       reasoningBox.hidden = true;
       reasoningBox.open = false;
       form.classList.add('asking');
+      startTicking();
 
       fetch('/ui/ask', {
         method: 'POST',

--- a/assets/app.js
+++ b/assets/app.js
@@ -633,7 +633,31 @@
       // A fresh list is the answer to a new query or chip, so a narrow screen
       // shows it again rather than leaving the result you opened on screen
       // over results that have since changed underneath it.
-      if (ws && e.target.id === 'rail') ws.classList.remove('has-selection');
+      //
+      // `#results` rather than `#rail`: the list is its own element inside the
+      // rail now, so that what a search replaces is the results and not the
+      // sitting beside them.
+      if (e.target.id === 'results') {
+        if (ws) ws.classList.remove('has-selection');
+        // Back to the top of the answer. Nothing moved the scroll on a swap,
+        // and the two layouts strand it in different places for the same
+        // reason: whatever you had scrolled to in the last list is kept, and
+        // the new list is drawn under it. On a phone the search box is the
+        // fixed bar at the *bottom*, so typing leaves the window scrolled to
+        // the end of the page — and the answer to what you just typed opened
+        // at its last result, with the best hits somewhere above the top of
+        // the screen.
+        var railEl = document.getElementById('rail');
+        if (railEl) {
+          // Wide: the rail is its own scroll box (see 40-search.css).
+          railEl.scrollTop = 0;
+          // Narrow: `max-height: none`, so the window is the scroller. Only
+          // ever scrolls up, and only as far as the list's own top — a page
+          // that jumped on every keystroke would be worse than the bug.
+          var top = railEl.getBoundingClientRect().top;
+          if (top < 0) window.scrollBy(0, top);
+        }
+      }
       // A clicked result was never marked as the open one. `aria-selected` was
       // set only by the arrow-key handler below, so the styling for an open
       // card — the accent border, and dropping the snippet the pane beside it

--- a/assets/css/20-layout.css
+++ b/assets/css/20-layout.css
@@ -125,6 +125,16 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
   .regions-rail-focus-source { grid-template-columns: [rail] 19rem [focus] minmax(0, 1fr); }
 }
 
+/* Until something is opened into it, the pane holds one line of placeholder
+   and the rail holds every result — so the rail takes the width the pane is
+   not using. `has-selection` is what the pane gains when an artifact is
+   swapped into it, so its absence is exactly "nothing open yet".
+   The pane is not filled on arrival instead: opening the top hit would spend
+   a read on every search, including the ones the rail already answers. */
+.regions-rail-focus-source:not(.has-selection) {
+  grid-template-columns: [rail] minmax(0, 40rem) [focus] minmax(0, 1fr);
+}
+
 /* One-up: one region, the rest a navigation away. This is the phone, and it is
    equally a half-width desktop window — which is the whole reason it is a
    container query and not a device breakpoint. */

--- a/assets/css/30-components.css
+++ b/assets/css/30-components.css
@@ -196,9 +196,15 @@ mark { background: var(--color-accent-dim); color: inherit; border-radius: 2px; 
   background: linear-gradient(to bottom, transparent, var(--color-bg-elevated));
 }
 
-.codewrap { position: relative; }
+/* Room above the block for the button, rather than the button on top of the
+   block. A fenced code sample is short and its first line usually is too, so
+   sitting over its top-right corner cost nothing — but a passage kept as the
+   document wrote it is one `<pre>` from end to end, and there the button
+   landed squarely on the first sentence of the artifact. Reserved space
+   overlaps nothing, whichever of the two it is. */
+.codewrap { position: relative; padding-top: 1.6rem; }
 .copy {
-  position: absolute; top: 6px; right: 6px;
+  position: absolute; top: 0; right: 0;
   font-family: var(--font-mono); font-size: 0.6875rem; cursor: pointer;
   padding: 3px 7px; border-radius: var(--radius-sm);
   background: var(--color-bg-elevated); color: var(--color-fg-secondary);

--- a/assets/css/40-search.css
+++ b/assets/css/40-search.css
@@ -88,22 +88,12 @@ body { overflow-x: hidden; }
 }
 .rail-item:hover { background: var(--color-bg-hover); }
 
-/* A result row is the link plus a delete control *beside* it, not inside it: a
-   <button> nested in an <a> is invalid HTML, and the anchor has to stay the
-   `.rail-item` because that is the element the arrow-key navigation focuses.
-   The control is held out of the way until the row is hovered or something
-   inside it takes focus, so the rail still reads as a list of results rather
-   than a list of delete buttons. Keyboard users reach it by tabbing, which
-   `:focus-within` reveals; a touch screen has no hover, so there it is simply
-   always visible. */
-.rail-row { position: relative; }
-.rail-row .rail-item { padding-right: 2.75rem; }
-.rail-del {
-  position: absolute; top: 0.5rem; right: 0.5rem;
-  opacity: 0; transition: opacity 120ms ease;
-}
-.rail-row:hover .rail-del, .rail-del:focus-within { opacity: 1; }
-@media (hover: none) { .rail-del { opacity: 1; } }
+/* A result row is the link and nothing else. It carried a delete control until
+   that control turned out to be the only irreversible act in the app that could
+   be fired on something nobody had opened; `.rail-row` stays as the row's own
+   element, and the shape the control needed — a sibling of the anchor, held out
+   of the way until hover or focus — lives on in `.seen-row` below, which still
+   has a dismiss button to place. */
 .rail-item[aria-selected="true"] { border-color: var(--color-accent); background: var(--color-accent-dim); }
 .rail-head { display: flex; gap: 0.5rem; align-items: baseline; }
 .rail-rank { font-size: 0.75rem; color: var(--color-fg-muted); }
@@ -367,8 +357,7 @@ body { overflow-x: hidden; }
   .regions.reading .rail-title,
   .regions.reading .rail-snippet,
   .regions.reading .rail-why,
-  .regions.reading .badge,
-  .regions.reading .rail-row > form { display: none; }
+  .regions.reading .badge { display: none; }
   .regions.reading .rail-item {
     padding: 0.5rem 0; text-align: center;
   }

--- a/assets/css/40-search.css
+++ b/assets/css/40-search.css
@@ -77,6 +77,10 @@ body { overflow-x: hidden; }
    under a container query. */
 
 .rail { display: flex; flex-direction: column; gap: 0.5rem; max-height: 40rem; overflow-y: auto; }
+/* The results are their own element inside the rail, so that a search replaces
+   them and not the sitting above them — and the rail's own column layout has to
+   carry through to it, or every card loses the gap between it and the next. */
+#results { display: flex; flex-direction: column; gap: 0.5rem; min-width: 0; }
 .rail-item {
   display: block; text-decoration: none; color: inherit;
   background: var(--color-bg-elevated); border: 1px solid var(--color-border);

--- a/assets/css/40-search.css
+++ b/assets/css/40-search.css
@@ -112,6 +112,14 @@ body { overflow-x: hidden; }
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
   min-height: 2.4em;
 }
+/* With the rail at its reading width there is room for the whole excerpt, and
+   the two-line clamp is what made a result unreadable without opening it.
+   The floor stays: an artifact whose excerpt came back empty still must not
+   collapse the card. */
+.regions-rail-focus-source:not(.has-selection) .rail-snippet {
+  -webkit-line-clamp: unset; display: block; overflow: visible;
+}
+
 .pane { min-width: 0; }
 
 /* Association is a second list on the same page, not a continuation of the

--- a/assets/css/40-search.css
+++ b/assets/css/40-search.css
@@ -524,3 +524,7 @@ body { overflow-x: hidden; }
     min-height: 12rem; overflow-y: auto;
   }
 }
+
+/* Said under the passage it belongs to, quietly: it is a way onward, not a
+   warning that something is wrong. */
+.continues { margin: 0.5rem 0 0; font-size: 0.8125rem; }

--- a/assets/css/40-search.css
+++ b/assets/css/40-search.css
@@ -252,6 +252,16 @@ body { overflow-x: hidden; }
   padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--color-border-subtle);
 }
+
+/* The name of what is being read stays while it is read. The pane scrolls a
+   long artifact past its own heading, and three screens down there was
+   nothing on the page saying which artifact this was. Its own background, or
+   the text scrolls through it. */
+.pane .card-head {
+  position: sticky; top: 0; z-index: 1;
+  background: var(--color-bg-elevated);
+  padding-top: 0.25rem;
+}
 .actions > form + form:last-of-type { margin-left: auto; }
 
 /* The open card keeps one line of itself. The pane beside it holds the text in

--- a/assets/css/41-capture.css
+++ b/assets/css/41-capture.css
@@ -97,3 +97,16 @@
 .decide-cluster {
   margin: 0.9rem 0 0.2rem; font-size: 0.8125rem; color: var(--color-fg-muted);
 }
+
+/* Two sides side by side, because the decision is a comparison. Stacked where
+   there is no room for two columns — one above the other still compares; two
+   columns 12rem wide do not. */
+.decide-read { margin: 0.5rem 0; }
+.decide-read summary { cursor: pointer; font-size: 0.8125rem; color: var(--color-fg-muted); }
+.decide-sides {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 0.5rem;
+}
+.decide-sides p { margin: 0.25rem 0 0; font-size: 0.8125rem; color: var(--color-fg-secondary); }
+@container shell (max-width: 60rem) {
+  .decide-sides { grid-template-columns: 1fr; }
+}

--- a/assets/css/41-capture.css
+++ b/assets/css/41-capture.css
@@ -91,3 +91,9 @@
    only where the title is shared with another row on the page — see
    `disambiguate_pair_titles`. */
 .decide-opening { color: var(--color-fg-muted); font-size: 0.8125rem; }
+
+/* What a run of cards is about, said once above them. A cluster of two needs
+   no such line — the two titles on the card are the whole of it. */
+.decide-cluster {
+  margin: 0.9rem 0 0.2rem; font-size: 0.8125rem; color: var(--color-fg-muted);
+}

--- a/assets/css/41-capture.css
+++ b/assets/css/41-capture.css
@@ -12,13 +12,24 @@
 }
 .qrow:last-child { border-bottom: none; }
 .qrow:hover { background: var(--color-bg-hover); }
+.qname { min-width: 0; text-decoration: none; display: block; }
 .qtitle {
+  display: block;
   font-size: 0.9375rem; text-decoration: none; color: var(--color-fg-primary);
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
+/* The label truncates; what tells this row from the one above it does not.
+   `disambiguate_labels` keeps the capture's opening words for a label shared
+   with another row, and a single `nowrap` line cut them off — so the repair
+   ran and six rows still read the same six words. Its own line, dimmer and
+   smaller, because it is a qualifier on the name rather than part of it. */
+.qtitle-opening {
+  display: block; white-space: normal; overflow: visible;
+  font-size: 0.8125rem; line-height: 1.35; color: var(--color-fg-muted);
+}
 .qrow:hover .qtitle { color: var(--color-accent); }
 /* A capture on its way to being named reads as a placeholder, because it is. */
-.qtitle.pending { color: var(--color-fg-muted); font-style: italic; }
+.qname.pending .qtitle { color: var(--color-fg-muted); font-style: italic; }
 /* A grid rather than a flex row, so the timestamp sits in a column of its own
    width and stops sliding left and right as the text beside it changes. */
 .qmeta {
@@ -75,3 +86,8 @@
 }
 .quiet-link:hover { color: var(--color-fg-primary); text-decoration: underline; }
 
+
+/* Which "LevelDB: Funktionsweise und forensische Analyse" this one is. Shown
+   only where the title is shared with another row on the page — see
+   `disambiguate_pair_titles`. */
+.decide-opening { color: var(--color-fg-muted); font-size: 0.8125rem; }

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -44,7 +44,17 @@
 .judge-peek > summary:hover { color: var(--color-fg-secondary); }
 .judge-full { max-height: 22rem; overflow-y: auto; margin-top: 0.25rem; }
 .judge-full .md { font-size: 0.875rem; }
-.judge-outs { margin-bottom: 1rem; }
+/* Sticky, because the three answers sat below every candidate: twenty-three
+   cards at `feedback.candidates` of twenty, and the way out of the question
+   was a scroll past all of them. The shortcuts always worked from anywhere;
+   the bar is what says so. Its own background, or the cards scroll through
+   it. */
+.judge-outs {
+  position: sticky; bottom: 0; z-index: 1;
+  margin-bottom: 0; padding: 0.6rem 0;
+  background: var(--color-bg-base);
+  border-top: 1px solid var(--color-border-subtle);
+}
 .judge-undo { margin-left: 0.5rem; }
 
 /* Read from the ranks the searches actually gave, so it moves on every

--- a/assets/css/45-ask.css
+++ b/assets/css/45-ask.css
@@ -53,3 +53,14 @@
   cursor: pointer; font-size: 0.8125rem; color: var(--color-fg-muted);
 }
 .reasoning-box > .reasoning { max-height: 14rem; overflow-y: auto; }
+
+/* The sitting rail had no rule at all: `_sitting.html` rendered `.sitting` and
+   the page fell back to a bare `<ul>`, bullets and browser indent included,
+   directly under the question. It is an aside — a way back to what you were
+   just reading — so it reads as one, and it must not grow into a second set of
+   results beside the real ones. */
+.sitting { margin: 0.5rem 0 0.25rem; }
+.sitting ul { list-style: none; margin: 0.25rem 0 0; padding: 0; }
+.sitting li { display: inline; }
+.sitting li:not(:last-child)::after { content: " · "; color: var(--color-fg-muted); }
+.sitting a { font-size: 0.8125rem; color: var(--color-fg-secondary); }

--- a/assets/css/45-ask.css
+++ b/assets/css/45-ask.css
@@ -44,3 +44,12 @@
    result carries, because it means the same thing — this is the row the page is
    pointing at. */
 .rail-active { border-color: var(--color-accent); background: var(--color-accent-dim); }
+
+/* Bounded once it is open: the reasoning runs to several times the length of
+   the answer it precedes, and an unbounded box pushes that answer off screen
+   for as long as the model is thinking. */
+.reasoning-box { margin-bottom: 0.75rem; }
+.reasoning-box > summary {
+  cursor: pointer; font-size: 0.8125rem; color: var(--color-fg-muted);
+}
+.reasoning-box > .reasoning { max-height: 14rem; overflow-y: auto; }

--- a/build-lowmem.sh
+++ b/build-lowmem.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Build on a 2 GB box with no swap.
+#
+# Two things blow the memory budget here, both at link time: dependencies
+# compiled with full debuginfo (the default `dev` profile), and GNU ld holding
+# the whole thing in memory at once. Dropping debuginfo and linking with the
+# lld that ships inside the toolchain fits the link into what is left after
+# the editor and the service.
+set -euo pipefail
+LLD="$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld"
+export RUSTFLAGS="-C link-arg=-B$LLD -C link-arg=-fuse-ld=lld"
+export CARGO_INCREMENTAL=0
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_PROFILE_TEST_DEBUG=0
+exec cargo "$@" -j 1

--- a/config.example.toml
+++ b/config.example.toml
@@ -492,6 +492,14 @@ min_engagement = 3.0
 # one long ingest keeps night work off the workers for as long as it lasts.
 # The default is a guess; the sweep history on Ops is how you check it — a
 # sweep whose runs thin out says the guess is wrong.
+#
+# `0` does not switch ageing off, it makes every waiting unit old enough at
+# once: the two classes stop dividing anything and the queue behaves as it did
+# before priority existed. There is no way to switch ageing off, because a base
+# under constant capture with no ageing never runs its night work at all.
+#
+# At most twenty units are promoted per repair pass, so a backlog that built up
+# behind a slow endpoint cannot put itself in front of a capture all at once.
 age_after_mins = 60
 
 # ── The sitting ──────────────────────────────────────────────────────────────

--- a/config.example.toml
+++ b/config.example.toml
@@ -494,6 +494,23 @@ min_engagement = 3.0
 # sweep whose runs thin out says the guess is wrong.
 age_after_mins = 60
 
+# ── The sitting ──────────────────────────────────────────────────────────────
+# What this session has touched, carried between search, ask and capture. In
+# memory only: it dies with the process, because a working memory that survives
+# a restart is a long-term memory and engram has one of those already. The web
+# door only — an access token is not a conversation.
+#
+# Carrying is always on and changes no order: a prefilled ask box, the question
+# an answer answered, a rail of what you have been in.
+[sitting]
+# Let what this sitting has touched lift a result.
+#
+# The only part of the sitting that moves an order, and the same query ranking
+# differently in two sittings is exactly what is disorienting about it — so it
+# is off, the lift shares the one budget `associate.prime_lift` bounds, rank 0
+# never moves, and a hit it lifted says so on the row.
+prime = false
+
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share
 # one GPU, so a per-role cooldown could not bound total load.

--- a/config.example.toml
+++ b/config.example.toml
@@ -481,6 +481,19 @@ min_sources = 2
 # pivoted 1.5, returned 2.0, confirmed 3.0.
 min_engagement = 3.0
 
+# ── Scheduling ───────────────────────────────────────────────────────────────
+# The queue is the scheduler. Whether somebody is waiting on a unit is a
+# constant per stage rather than a setting: a priority you can set wrong
+# presents as "the capture is hanging", with nothing anywhere saying why. What
+# is left to decide is the one number that keeps priority from becoming
+# starvation.
+[schedule]
+# A background unit waiting longer than this becomes foreground. Without it,
+# one long ingest keeps night work off the workers for as long as it lasts.
+# The default is a guess; the sweep history on Ops is how you check it — a
+# sweep whose runs thin out says the guess is wrong.
+age_after_mins = 60
+
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share
 # one GPU, so a per-role cooldown could not bound total load.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,202 @@
+# The evaluation harness
+
+Two benchmarks, over your own base, both `#[ignore]`d so an ordinary
+`cargo test` never touches them.
+
+They exist for one reason. Ranking has knobs — fusion, the per-source cap,
+recency weight, reranking, priming — and hand-testing cannot judge any of them,
+because the queries anyone thinks to type reuse words they remember from the
+passage they are looking for. A knob change either moves a number or it is a
+preference. Hence the rule this repository holds itself to:
+
+> A default that changes ranking moves only after the harness has been run.
+
+That rule is the whole of what the harness is *for*. It is not a test suite —
+it asserts almost nothing — and a bad score is not a failure. It is the one
+figure comparable across months.
+
+---
+
+## 1. What each one measures
+
+### `evaluate_retrieval` — did search put the answer on the page?
+
+Replays judged searches against a freshly indexed copy of your artifacts and
+scores where the expected artifact landed.
+
+| Metric | Question it answers | Read it when |
+|---|---|---|
+| **recall@10** | Was the answer in the first ten results at all? | Changing what is *retrieved*: embeddings, fusion, the candidate pool, the per-source cap. |
+| **MRR** | How far down was it? | Changing what is *ordered*: recency, pinning, reranking, priming. |
+
+Both, never one. A change can lift recall and hurt MRR — a wider candidate pool
+finds more and buries it deeper — and which of those matters is a judgement
+about what a search page is for, so the harness reports both rather than
+choosing for you. `mrr` counts a miss as zero rather than excluding it: a
+ranking that answers one query perfectly and fails nineteen must not be able to
+report a perfect score.
+
+**The miss list under the numbers is the part to read.** An aggregate says
+something moved; the list says *what* moved, which is what a knob change is
+actually judged on. Each miss is named by the first 48 characters of its own
+query — no artifact text is ever printed.
+
+### `evaluate_ask` — was the answer honest?
+
+Asks each judged question again and scores the answer against what a person
+said about the original.
+
+| Metric | Question it answers |
+|---|---|
+| **citation recall** | Of the excerpts the operator marked as carrying the answer, how many did the model actually cite? |
+| **abstention accuracy** | Did it say *not in the knowledge base* exactly when there was nothing there? Reported as two counts, because the two mistakes are not equal: answering when it should have abstained is confabulation, abstaining when it should have answered is timidity. |
+| **unsupported literals** | Commands, paths and flags in the answer that appear in no cited excerpt. Prose is left alone on purpose — a bare number inside a sentence of explanation is not the kind of claim this looks for, and a guard that fires on ordinary writing is one you learn to ignore. |
+| **claims supported** *(opt-in)* | With `ENGRAM_EVAL_CLAIMS=1`, the synthesize model traces every claim in the answer to an excerpt. One extra call per answered question. |
+
+---
+
+## 2. Where the data comes from
+
+Nothing here is fixtures. The corpus is whatever you actually want to search,
+and it is **not in this repository and must not be**.
+
+Pairs are made by judging, at `/ui/judge`: a recorded search comes back with its
+candidates shuffled and unlabelled, and you say which one you needed. The
+shuffling is not decoration — a label assigned while reading the answer
+contaminates the question, which is the same reason the query is recorded in the
+moment and the verdict is not.
+
+```bash
+engram --export-eval ~/engram-eval
+```
+
+writes three files. The export reads SQLite only: no inference, no Qdrant, and
+artifacts keep their real ids, so re-exporting does not invalidate pairs you
+already judged.
+
+| File | What it holds |
+|---|---|
+| `artifacts.json` | Every artifact, frozen, so a run costs no completions and two runs rank exactly the same text. |
+| `pairs.json` | `{query, expect}` — a query, and the artifact id that answered it. |
+| `questions.json` | `{question, verdict, expect[]}` — `right`, `wrong` or `nothing_here`, plus the excerpts marked as carrying the answer. |
+
+A pair naming an artifact that no longer exists is a hard error rather than a
+miss: it is a stale pair left by a deletion, and scored as a miss it would look
+like a ranking problem forever. Re-export.
+
+A grade is also satisfied by anything that **superseded** the artifact it names.
+Merging moves knowledge into a new artifact and search correctly returns that
+one; scoring only the original would report a retrieval regression that is
+really a bookkeeping change — exactly when it matters most.
+
+---
+
+## 3. Running it
+
+Needs a reachable Qdrant and a real embedding endpoint, both read from
+`config.toml`. The fake embedder produces meaningless vectors, so a benchmark
+built on it would measure nothing — which is why these are `#[ignore]`d.
+
+```bash
+# retrieval
+ENGRAM_EVAL_DIR=~/engram-eval cargo test --test eval -- --ignored --nocapture
+
+# ask
+ENGRAM_EVAL_DIR=~/engram-eval cargo test --test eval evaluate_ask -- --ignored --nocapture
+```
+
+Both use their own Qdrant collection, `engram_eval`, dropped before and after.
+**Your real index is never touched**, and a run is never polluted by the one
+before it.
+
+With no corpus at `ENGRAM_EVAL_DIR` both print what is missing and return
+without failing: most people running `cargo test` have no corpus, and a
+benchmark that cannot run has nothing to report either way.
+
+---
+
+## 4. Tuning
+
+Every ranking setting comes from configuration, so a sweep is a loop over
+environment variables rather than a rebuild. The prefix is `ENGRAM__` and the
+nesting separator is `__`:
+
+```bash
+for w in 0.0 0.05 0.15; do
+  ENGRAM__VECTOR__RECENCY_WEIGHT=$w \
+  ENGRAM_EVAL_DIR=~/engram-eval \
+    cargo test --test eval -- --ignored --nocapture | head -5
+done
+```
+
+The harness prints its settings line above the numbers on purpose: **a number
+recorded without the configuration that produced it cannot be compared against
+anything.** Keep the whole line when you write a result down.
+
+| Knob | Variable | What it moves | Watch |
+|---|---|---|---|
+| Recency weight | `ENGRAM__VECTOR__RECENCY_WEIGHT` | How much age counts against a hit. `0.0` turns it off. Fused ranks sit between ~0.1 and 1.0, so the default breaks near-ties without overturning a clear match. | MRR |
+| Recency half-life | `ENGRAM__VECTOR__RECENCY_HALF_LIFE_DAYS` | Age at which a hit has lost half that boost. | MRR |
+| Pinned boost | `ENGRAM__VECTOR__PINNED_BOOST` | Extra score for a `pinned` tag, so a decision you made beats the decay curve. | MRR |
+| Per-source cap | `ENGRAM_EVAL_CAP` (a number, or `none`) | Chunks one document may contribute. Default 3; `none` lets one document fill the list. Raising it usually lifts recall and costs diversity. | recall@10 |
+| Reranker | `[infer.rerank]` present or absent in `config.toml` | A cross-encoder over the candidate pool. The settings line reports `rerank on/off`. | MRR first, recall second |
+| Embedding model | `ENGRAM__INFER__EMBED__MODEL` (+ `DIM`) | The whole retrieval geometry. Needs `--reindex` against a real base; the harness reindexes its own collection anyway. | both |
+| Embed templates | `ENGRAM__INFER__EMBED__QUERY_TEMPLATE`, `..._DOCUMENT_TEMPLATE` | The envelope each side is embedded in. Asymmetric models care a great deal. | both |
+| Priming lift | `ENGRAM__ASSOCIATE__PRIME_LIFT` | How many places an accessible hit may climb. `0` turns priming off. | MRR |
+| Priming margin | `ENGRAM__ASSOCIATE__PRIME_MARGIN` | How much more accessible it has to be before it climbs. | MRR |
+| Weak threshold | `ENGRAM__VECTOR__WEAK_BELOW` | Similarity under which a hit is labelled *loose*. Changes no order — it changes what the page claims, and what becomes an `unmatched` knowledge gap. | neither; read the page |
+
+For the ask harness, the levers are the excerpt budget and the answering model
+(`[infer.tiers.deep]`, `max_output_tokens` — the ceiling comes out of the
+context window, so raising it buys longer answers by showing the model fewer
+excerpts, and `dropped` on the answer says how many).
+
+### A tuning session, in order
+
+1. Judge until you have enough pairs to move a number. **Twenty is a floor, not
+   a target**: with ten pairs, recall@10 moves in ten-point steps and every
+   result is noise.
+2. Record a baseline, settings line and all.
+3. Change **one** knob. Re-run. Compare both metrics and read the miss list.
+4. Keep the change only if the number moved and the misses got less bad. A knob
+   that moves nothing is a knob that should keep its default.
+5. Write the numbers into the commit message that moves the default. That is
+   what the rule at the top asks for, and a commit that changes ranking without
+   them is the thing this whole apparatus exists to prevent.
+
+---
+
+## 5. What it cannot measure
+
+Being clear about this matters more than the numbers, because the temptation is
+to run *something* and call the question answered.
+
+- **Anything about a sequence of queries.** The harness scores each pair
+  independently against a static index. Features about continuity within one
+  sitting — priming from the live sitting (`[sitting] prime`), working memory,
+  anything reading `Origin::session` — cannot move a number here, because the
+  harness searches through `Door::Ui` with no session attached. Measuring those
+  needs a harness that scores *runs* of queries, which does not exist yet. Until
+  it does, `[sitting] prime` stays off and unmeasured, and ROADMAP.md says so.
+- **Anything needing engagement.** Activation, pursuits and promotion are
+  driven by what a person opened and dwelt on. The harness opens nothing and
+  sets `mark: false` deliberately — resurfacing reads `last_seen_at`, and a
+  scored run is not someone reading their notes.
+- **Whether an artifact is any good.** It measures whether the right artifact
+  was *found*, never whether it was worth finding. Synthesis quality is what
+  the ask harness's faithfulness metrics get at, obliquely.
+- **A base too small to have an opinion.** Under twenty pairs the arithmetic
+  works and the result means nothing.
+
+---
+
+## 6. Where the pieces live
+
+| Path | What |
+|---|---|
+| `tests/eval.rs` | Both harnesses, the report formatting, and one non-ignored wiring test that runs without infrastructure. |
+| `src/eval/mod.rs` | The on-disk shapes: `FrozenArtifact`, `EvalPair`, `EvalQuestion`. |
+| `src/eval/metrics.rs` | `recall_at`, `mrr`, and the ask metrics. |
+| `src/eval/export.rs` | `--export-eval`. |
+| `src/eval/claims.rs` | Literal extraction and claim support. |
+| `/ui/judge` | Where pairs come from. Its counter is not a stand-in for the measurement — it *is* recall@10 and MRR over the positions those searches actually gave. |

--- a/docs/superpowers/plans/2026-08-20-one-system.md
+++ b/docs/superpowers/plans/2026-08-20-one-system.md
@@ -1,0 +1,427 @@
+# One System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three seams between mechanisms that already exist — give the job queue a priority and an account so the tickers become units that reschedule themselves; give a sitting a live existence instead of only a reconstructed one; and make the four ways the base can fail to answer end in one list.
+
+**Architecture:** Nothing new is built. One column on `jobs` (`class`), one table (`sweep_runs`), two more `GapKind`s, and one in-memory map on `Core`. Five ticker tasks are deleted and their periods become each unit's own `run_after`. `spawn_repair_ticker` stays outside the schedule and gains two duties: ageing background rows into the foreground, and re-arming a periodic unit that has gone missing.
+
+**Tech Stack:** Rust, sqlx/SQLite, tokio, axum, Askama, htmx. No new dependency, no new subsystem, and no model call that is not already made.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-one-system-design.md`
+
+---
+
+## Global Constraints
+
+- **The claim query stays one covering index walk.** `EXPLAIN QUERY PLAN` on `claim_job` must name the index and show no temp B-tree. Priority sorts *before* `attempts`; ageing is an `UPDATE`, never a term in the claim. Spec §3, §4.4.
+- **`seq` keeps doing its job.** Within one class the order stays `attempts, seq, id`. Assert it directly — `seq`'s anti-starvation property is the easiest thing to lose here.
+- **Repair does not join the schedule.** `a_crashed_capture_is_repaired_with_the_sweep_switched_off` is the pinned regression and must pass at the end of every task.
+- **Lazy decay stays lazy.** No unit added here writes a decayed value.
+- **No new model call.** Not for `Unmatched`, not for coverage, not for the sitting. The only inference in this area is the existing gap-cluster naming call, untouched.
+- **The state string is `'running'`, not `'claimed'`.** The spec says "claimed" in §4.1 prose; the tree says `state = 'running'` with a `claimed_at` timestamp. Follow the tree.
+- **Every existing test keeps passing.** Where a signature moves, update the assertion; never delete it.
+- **Commit after every task**, conventional-commit subject in the repo's voice. Three commits' worth of *behaviour* (§11), but tasks inside a phase may commit separately.
+
+---
+
+## Decisions the spec leaves open
+
+Four places where the spec's data-model summary does not survive contact with the tree. Each has a recommendation; settle them before Task 1, because three of them change the schema.
+
+### D1 — There is no `ALTER TABLE` path in this codebase
+
+`Store::migrate` applies `schema.sql` whole, every object `IF NOT EXISTS`, and then *checks* that every column the file declares exists — failing at boot, by name, when it does not. The doctrine is written into the file's own header: "Changing a column means changing it here and recreating the database."
+
+So spec §8's "one `ALTER TABLE`" is not how this base migrates. Two options:
+
+- **(recommended) Follow the existing doctrine.** Declare `class` in `schema.sql`. An existing base — including the live `engram.db` — fails at boot with `this database is older than the schema: jobs.class missing. Recreate it, or add the columns by hand.` The operator runs one `ALTER TABLE jobs ADD COLUMN class INTEGER NOT NULL DEFAULT 0;` and restarts. Nothing new is invented, and the failure is loud and already-explained.
+- Add a narrow, idempotent additive-migration step to `migrate()`, run before the column check. This is precedent-setting: the next column will use it too, and the "one statement of shape" doctrine ends there.
+
+**The backfill is not optional either way**: rows written before the column exists default to `0` (foreground), which §4.3 chose as the safe direction. The one `UPDATE` setting the sweeps to `1` runs in `migrate()` regardless, guarded so it is a no-op on a base that has it.
+
+### D2 — The index cannot be swapped by `IF NOT EXISTS`
+
+`CREATE INDEX IF NOT EXISTS idx_jobs_claim2` on a base that already has `idx_jobs_claim2` with the old columns is a silent no-op — the claim would then sort in a temp B-tree on exactly the installs this is meant to speed up. **Give the new index a new name** (`idx_jobs_claim3`) and add `DROP INDEX IF EXISTS idx_jobs_claim2;` beside it. `DROP ... IF EXISTS` is idempotent, so `schema.sql` stays applicable-on-every-connect.
+
+### D3 — `GapKind::Pursuit` has no stored query vector
+
+`pursuits.queries` is a JSON array of query *strings*. A gap is `(kind, id, text, query_vec)` — `open_gaps` reads `query_vec` straight off the source row, and the clustering and the calibration both need it. A pursuit row has no vector and no reference to the events it was built from, so there is nothing to read.
+
+Embedding the queries at read time is a call this spec forbids. **Recommendation: carry the vector forward at close.** The pursuit sweep already holds the `search_events` rows it clustered; write the leading event's `query_vec`, `vec_dim` and `embed_model` onto the pursuit row when it closes (three columns, all nullable, all `NULL` on existing rows). A pursuit closed before this lands has no vector and is therefore not a gap — correct, not a bug: an uncomparable vector is exactly what `open_gaps` already excludes with `vec_dim > 0`.
+
+This is a fourth schema change beyond §8. Say so in the commit message rather than pretending §8 was complete.
+
+### D4 — "Closed silently, source row untouched" needs somewhere to write
+
+§6.3 says a covered gap is closed, the capture page says which, and the operator can reopen it — while "the source row is untouched". Those cannot both hold with no third place to record the closure.
+
+**Recommendation: one small table.**
+
+```sql
+-- A gap the base has since answered: the capture that covered it, and how
+-- well. Kept off the source row on purpose — nothing an automatic score
+-- decides should overwrite what a person judged, and deleting the row here
+-- reopens the gap with the judgement intact.
+CREATE TABLE IF NOT EXISTS gap_coverage (
+  kind        TEXT NOT NULL,
+  gap_id      TEXT NOT NULL,
+  corpus_id   TEXT NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+  artifact_id TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  score       REAL NOT NULL,
+  covered_at  INTEGER NOT NULL,
+  PRIMARY KEY (kind, gap_id)
+);
+```
+
+`ON DELETE CASCADE` on both references is the reversibility the spec asks for, for free: delete the capture that closed a gap and the gap comes back.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+|---|---|
+| `src/core/sitting.rs` | The live sitting: the map, `CARRY`, expiry, the read the doors take |
+| `src/store/sweeps.rs` | `sweep_runs`: record one run, read the last day, read the history, trim |
+| `src/store/coverage.rs` | `gap_coverage`: close, reopen, read what closed a gap (may live in `store/gaps.rs` instead) |
+
+**Modified:**
+
+| File | Change |
+|---|---|
+| `src/store/schema.sql` | `jobs.class`; `idx_jobs_claim3` + drop of `claim2`; `sweep_runs`; `gap_coverage`; three nullable columns on `pursuits` (D3) |
+| `src/store/mod.rs` | The class backfill in `migrate()` |
+| `src/store/jobs.rs` | `Stage::{Retention, ArmDedupe}`, `Stage::class()`, `class` written on insert, claim order, `age_background()`, `arm_missing_periodic()` |
+| `src/core/background.rs` | Five tickers deleted; `repair_once` gains ageing and re-arming; `periodic_units()` |
+| `src/jobs/mod.rs` | Dispatch for the two new stages; the re-arm-on-completion step; `sweep_runs` written around every periodic unit |
+| `src/core/ingest.rs` | Queue-label arms for the two new stages (`~1045`) |
+| `src/main.rs` | Five `spawn_*_ticker` calls and their join handles removed (`266–273`) |
+| `src/config.rs` | `ScheduleConfig`, `SittingConfig`, both on `Config` |
+| `src/core/mod.rs` | The sitting map on `Core`; `schedule`/`sitting` settings carried through |
+| `src/core/search.rs` | Sitting writes on `mark_artifact_seen` / `record_interaction`; `Unmatched` recording; sitting priming behind its flag |
+| `src/store/gaps.rs` | `GapKind::{Unmatched, Pursuit}`, their two source queries, dismissal for both |
+| `src/jobs/gaps.rs` | Coverage check on a corpus reaching `ready` |
+| `src/jobs/pursuit.rs` | Carry the query vector onto the pursuit row at close (D3) |
+| `src/web/ui.rs` | Ops: the last day and the history, minus the pursuits table; capture: kind badges, coverage line; sitting rail on search and ask |
+| `src/web/templates/ops.html`, `_gaps.html`, `capture.html`, `search.html`, `ask.html` | The surface, §7 |
+| `config.example.toml`, `ROADMAP.md` | Two keys; the seams marked closed |
+
+---
+
+# Phase 1 — The scheduler (spec §4)
+
+One column, one index, one table, five tickers deleted. No behaviour the operator asked for changes.
+
+## Task 1: The schema, the column and the backfill
+
+**Files:** `src/store/schema.sql`, `src/store/mod.rs`, `src/store/jobs.rs`
+
+**Interfaces:** Produces a `jobs.class` column every later task reads. Consumes nothing.
+
+- [ ] **Step 1: Settle D1 and D2** — write the chosen answer into this plan before touching a file.
+
+- [ ] **Step 2: Declare the column, the index and the table**
+
+In `schema.sql`, inside `CREATE TABLE ... jobs`:
+
+```sql
+  -- Is someone waiting on this? 0 = foreground (the capture pipeline the
+  -- operator is watching move raw → ready), 1 = background (work nobody is
+  -- standing in front of). One distinction and not a scale: a priority the
+  -- operator can set wrong presents as "the capture is hanging" with nothing
+  -- anywhere saying why. Default 0 because a row written before this column
+  -- existed is foreground, which is the safe direction to be wrong in.
+  class       INTEGER NOT NULL DEFAULT 0,
+```
+
+Then, beside the existing index lines:
+
+```sql
+-- Superseded by idx_jobs_claim3 below: same walk, with class in front of
+-- attempts. Dropped by name because CREATE INDEX IF NOT EXISTS would leave
+-- the old columns in place on every existing base — silently, and on exactly
+-- the installs the new order exists to serve.
+DROP INDEX IF EXISTS idx_jobs_claim2;
+CREATE INDEX IF NOT EXISTS idx_jobs_claim3 ON jobs(state, class, attempts, seq, id, run_after);
+```
+
+Keep the existing comment explaining why `run_after` is last; extend it to say why `class` is first.
+
+Add `sweep_runs` exactly as §4.5 gives it.
+
+- [ ] **Step 3: Backfill in `migrate()`**
+
+After the schema applies and before the column check, one guarded statement setting the periodic and background stages to `1`, listing the stages by name. Idempotent by construction — it only ever moves rows that are still `0` *and* whose stage is background — so applying the schema twice still changes nothing, which `applying_the_schema_twice_changes_nothing` asserts.
+
+- [ ] **Step 4: `Stage::class()`**
+
+One `match` in `src/store/jobs.rs`, exhaustive, no wildcard arm — a stage added later must be made to choose:
+
+```rust
+/// Is someone waiting on this?
+///
+/// Foreground is the capture pipeline: the operator pasted something and is
+/// watching it move. Background is every sweep whose result nobody is
+/// standing in front of. Exhaustive on purpose: a stage added later has to
+/// answer this question rather than inherit an answer.
+pub fn class(self) -> i64 {
+    match self {
+        Stage::Synthesize | Stage::Enrich | Stage::SegmentWindow
+        | Stage::Title | Stage::Embed | Stage::Describe | Stage::Extract => 0,
+        Stage::Consolidate | Stage::Dedupe | Stage::Relate | Stage::Associate
+        | Stage::LinkJudge | Stage::Pursuit | Stage::Generate => 1,
+    }
+}
+```
+
+`Enrich` is not in the spec's table; it shares `synthesize::plan` with `Synthesize` and is foreground for the same reason.
+
+- [ ] **Step 5: Write it on insert, read it on claim**
+
+`upsert_job` sets `class = ?` from `Stage::class()`. `claim_job` becomes `ORDER BY class, attempts, seq, id`. Nothing else in the query moves.
+
+- [ ] **Step 6: Test**
+
+```bash
+cargo test --lib store::jobs 2>&1 | tail -20
+```
+
+New tests:
+- a background unit armed first is claimed after a foreground unit armed second;
+- within one class, `attempts, seq, id` order is unchanged (assert directly against a batch with mixed `seq`);
+- `EXPLAIN QUERY PLAN` on the claim's inner `SELECT` names `idx_jobs_claim3` and contains no `TEMP B-TREE`.
+
+## Task 2: Ageing
+
+**Files:** `src/store/jobs.rs`, `src/core/background.rs`, `src/config.rs`, `config.example.toml`
+
+- [ ] **Step 1: `[schedule] age_after_mins = 60`**
+
+New `ScheduleConfig` next to `PursuitConfig` in `config.rs`, `#[serde(default)]` on `Config`, carried onto `Core` the way `pursuit` is. Document in `config.example.toml` that the default is a guess and that `sweep_runs` on Ops is how the guess gets checked.
+
+- [ ] **Step 2: `Store::age_background(older_than: i64) -> Result<u64>`**
+
+```sql
+UPDATE jobs SET class = 0
+ WHERE state = 'pending' AND class = 1 AND created_at < ?;
+```
+
+The doc comment carries §4.4's reason: computing age at claim time would put an inequality into the ordering and cost the covering index. A unit that has aged stays aged; it has already waited.
+
+- [ ] **Step 3: Call it from `repair_once`**, warn-and-continue like every other step there.
+
+- [ ] **Step 4: Test** — a background unit older than `age_after_mins` is claimed ahead of a fresh foreground one, and re-reading the row shows `class = 0` (durable, not computed).
+
+## Task 3: Two stages for the two tickers that did their work inline
+
+**Files:** `src/store/jobs.rs`, `src/jobs/mod.rs`, `src/core/ingest.rs`
+
+The consolidation, association and pursuit tickers *enqueue* a unit; the retention and dedupe tickers **do their work in the ticker body**. There is no stage to reschedule, so two are added. This is a deviation from §4.3's table — record it in the commit message.
+
+- [ ] **Step 1: `Stage::Retention`** — expire feedback past `retain_days`, then run `jobs::gaps::sweep`, in that order, which is the order the retention ticker already uses and the ordering §1 credits it for. Class `1`.
+
+- [ ] **Step 2: `Stage::ArmDedupe`** — calls `jobs::consolidate::arm_dedupe`. Class `1`. Named for what it does: it arms `Dedupe` units, it is not one.
+
+- [ ] **Step 3: Dispatch arms in `run_claimed`**, `Stage::parse`/`as_str`, and the queue-label match at `src/core/ingest.rs:1045`.
+
+- [ ] **Step 4: Test** — each stage, claimed and run, does what its ticker did. Port the two ticker tests in `background.rs` rather than deleting them.
+
+## Task 4: The tickers become units that reschedule themselves
+
+**Files:** `src/core/background.rs`, `src/jobs/mod.rs`, `src/store/jobs.rs`, `src/main.rs`
+
+- [ ] **Step 1: `periodic_units(core) -> Vec<(Stage, &'static str, Duration)>`**
+
+One list, in `background.rs`, replacing five ticker preambles. It is where every gate that used to be an early `return` now lives — and getting this wrong re-creates the exact bug `spawn_repair_ticker`'s comment records, so each gate keeps its original condition verbatim:
+
+| Stage | Gate today | Period today |
+|---|---|---|
+| `Consolidate` | `consolidate.enabled && synthesizes()` | `consolidate.interval_hours` |
+| `ArmDedupe` | `consolidate.enabled && max_dedupe_per_tick > 0 && synthesizes()` | `consolidate.dedupe_interval_mins` |
+| `Retention` | `feedback.retain_days > 0 \|\| feedback.enabled` | `feedback.sweep_hours` |
+| `Associate` | `associating()` | `associate.interval_mins` |
+| `Pursuit` | `pursuit.enabled && associating()` | `(pursuit.idle_secs / 2).max(60)` |
+
+Keep the existing `.max(1)` and `saturating_mul` guards: an operator-typed interval that wraps turns a long period into a hammering one.
+
+- [ ] **Step 2: Re-arm on completion**
+
+In `run_claimed`, beside the existing `embed::rearm_if_more` step and for the same stated reason — *after* `complete_job`, never before, because the queue is keyed by `(stage, target)`:
+
+```rust
+// A periodic unit re-arms itself one interval out. `run_after` is the
+// cursor recording when it last ran, and it is already indexed, so no
+// meta key is needed and no ticker has to hold the clock.
+```
+
+Re-arm on the **failure** paths too — §4.6. One failure ending a sweep forever is the one way this design could quietly stop the memory from learning; a test pins it.
+
+- [ ] **Step 3: `arm_missing_periodic`**
+
+On the repair tick: for each entry in `periodic_units`, if no row exists for `(stage, target)` in any state, arm it. This is what recovers a unit that died between claim and re-arm — the failure mode a ticker does not have, and the reason repair stays outside the schedule.
+
+- [ ] **Step 4: Delete the five tickers and their call sites**
+
+`spawn_consolidation_ticker`, `spawn_retention_ticker`, `spawn_dedupe_ticker`, `spawn_pursuit_ticker`, `spawn_associate_ticker` go, along with lines 266–273 of `src/main.rs` and their join handles in the shutdown path. `spawn_repair_ticker` stays untouched in its gating and its cadence.
+
+Boot still arms everything immediately: the repair ticker's first tick fires at once, and Step 3 arms whatever is missing — which on a fresh boot is all of them. That is what preserves "the first tick fires immediately, so a restart picks the work up rather than waiting a day".
+
+- [ ] **Step 5: Ordering — replay before pursue**
+
+`associate::run`, on completion, arms `Pursuit` instead of `Pursuit` keeping a period of its own. A sitting is then scored against links this run folded in. Keep `Pursuit` in `periodic_units` as its own floor anyway: with `associating()` on but the association sweep failing, pursuits must not stop entirely.
+
+- [ ] **Step 6: Test**
+
+- A completed sweep leaves exactly one pending copy of itself with `run_after` one interval out.
+- A **failed** sweep re-arms too.
+- A periodic unit deleted outright is re-armed by `repair_once`.
+- `a_crashed_capture_is_repaired_with_the_sweep_switched_off` still passes.
+- `Dedupe` runs only after the sweep that arms it; `Pursuit` only after `Associate`.
+
+## Task 5: The account
+
+**Files:** `src/store/sweeps.rs` (new), `src/jobs/mod.rs`, `src/store/feedback.rs`
+
+- [ ] **Step 1: `record_run(stage, started_at, ended_at, outcome, detail)`**, `detail` being the counts the sweep functions already return — links strengthened and pruned, pairs judged, merges written, clusters named, rows expired. No new counting.
+- [ ] **Step 2: Wrap the periodic dispatch arms** in `run_claimed` so both the `Ok` and the `Err` paths write a row. A sweep that fails is exactly the run the operator needs to see.
+- [ ] **Step 3: `last_day()` and `history(limit)`** — the summary block and the list under it. There is no "night" and nothing invents a cycle identity; §4.5 is quotable in the doc comment.
+- [ ] **Step 4: Trim to 2000 runs** on the retention unit. Housekeeping about housekeeping does not get a policy key.
+- [ ] **Step 5: Test** — a completed sweep writes exactly one row with its counts; a failed one writes `outcome = 'failed'`; the trim keeps the newest 2000.
+
+## Task 6: Ops shows the last day and the history
+
+**Files:** `src/web/ui.rs`, `src/web/templates/ops.html`
+
+- [ ] **Step 1:** The summary block — *412 links strengthened, 8 forgotten, 2 merges, 1 gap named* — over `last_day()`.
+- [ ] **Step 2:** The history beneath it, which is the thing a single overwritten summary could never give: whether this started yesterday or has been going wrong for a week.
+- [ ] **Step 3:** Test — a base with runs renders both; a base with none renders neither, and no empty table.
+
+**Commit 1 ends here.** Subject in the repo's voice, e.g. `feat(queue): the tickers become units that reschedule themselves`.
+
+---
+
+# Phase 2 — One queue for what is missing (spec §6)
+
+Visible on day one on any base with recorded feedback.
+
+## Task 7: `GapKind::Unmatched`
+
+**Files:** `src/store/gaps.rs`, `src/core/mod.rs`
+
+The similarity is not on `search_events`. It is `search_candidates.similarity` (nullable, `PRIMARY KEY (event_id, rank)`), so the source query is an aggregate, not a column read:
+
+```sql
+SELECT e.id, e.query AS text, e.query_vec, e.judged_at
+  FROM search_events e
+ WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
+   AND (e.verdict IS NULL OR e.verdict <> 'gap')
+   AND (SELECT MAX(c.similarity) FROM search_candidates c
+         WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?
+ ORDER BY e.judged_at DESC, e.id DESC LIMIT ?
+```
+
+- [ ] **Step 1:** Add the variant, its `as_str`/`parse` string (`"unmatched"`), and a third `macro_rules!` beside `ask_gaps_sql!` and `search_gaps_sql!` — the macro exists so the sweep's projection and the page's cannot drift, and a third source drifting would be the same bug.
+- [ ] **Step 2:** Bind `weak_below` from config. Exclude `verdict = 'gap'` so a judged search is not both a `Search` gap and an `Unmatched` one.
+- [ ] **Step 3:** `MAX(...)` over zero rows is `NULL` and `NULL < ?` is not true, so a search that recorded no candidates is not a gap. That is the right answer — nothing came close is a claim about what was measured — and it needs saying in a comment, because it looks like an oversight.
+- [ ] **Step 4:** Per-kind cap and capped-detection in `open_gaps`, exactly as the two existing kinds get, plus the same treatment in `open_gap_refs` and `calibration_vecs`. `MAX_OPEN_GAPS` is per kind, so the third kind gets its own count.
+- [ ] **Step 5:** `dismiss_gap` for `Unmatched` writes `search_events.dismissed_at` — the same column `Search` uses, which is correct: it is the same row, dismissed for the same reason.
+- [ ] **Step 6: Test** — a search whose best similarity is under `weak_below` becomes a gap; one with a single hit above it does not; one already judged `gap` appears once, not twice; dismissal sticks. Run it over the existing log shape, retroactively, since that is the claim §6.2 makes for it.
+
+## Task 8: `GapKind::Pursuit`
+
+**Files:** `src/jobs/pursuit.rs`, `src/store/pursuits.rs`, `src/store/gaps.rs`, `src/store/schema.sql`
+
+- [ ] **Step 1: Settle D3.** Add `query_vec BLOB`, `vec_dim INTEGER NOT NULL DEFAULT 0`, `embed_model TEXT` to `pursuits`, all nullable/defaulted so existing rows are valid.
+- [ ] **Step 2:** Write them when a pursuit closes, from the leading clustered event the sweep already holds.
+- [ ] **Step 3:** Source query — `state = 'unsatisfied' AND vec_dim > 0 AND embed_model = ?`, text from the clustered `queries` JSON (first entry, or joined — pick one and say why in the comment; the label prompt keeps the first twelve members, so the text wants to be the query, not a summary).
+- [ ] **Step 4:** Dismissal writes `pursuits.state = 'dismissed'`, which already exists in that column's enumeration.
+- [ ] **Step 5: Test** — a pursuit closed `unsatisfied` after this lands is a gap; one closed before it (no vector) is not; dismissal moves the state.
+
+## Task 9: A capture covers a gap
+
+**Files:** `src/jobs/gaps.rs`, `src/store/coverage.rs` (or `store/gaps.rs`), `src/store/schema.sql`
+
+- [ ] **Step 1: Settle D4** and add `gap_coverage`.
+- [ ] **Step 2:** When a corpus reaches `ready`, on the background handle: one filtered vector query per open gap, **against that corpus's new artifacts only**. No model call. Bounded by the open-gap cap that already exists.
+- [ ] **Step 3:** A gap whose best new hit reaches `weak_below` gets a `gap_coverage` row. Silent and reversible; the source row is untouched; nothing is deleted on a score.
+- [ ] **Step 4:** `open_gaps`/`open_gap_refs` exclude anything with a coverage row — one `NOT EXISTS`, applied in the shared macro so all four kinds get it at once.
+- [ ] **Step 5: Test** — a capture answering an open gap closes it and says which; one that does not, does not; deleting the covering capture reopens the gap (the cascade); the check makes no model call (assert against a `Core` with no synthesizer).
+
+## Task 10: One list on the capture page
+
+**Files:** `src/web/ui.rs`, `src/web/templates/_gaps.html`, `capture.html`, `ops.html`
+
+- [ ] **Step 1:** Kind badges — *judged*, *asked*, *nothing near*, *pursued*.
+- [ ] **Step 2:** The coverage line on capture: which gaps this capture closed.
+- [ ] **Step 3:** Ops loses its pursuits table and links into this list. `the_pursuit_section_is_not_there_when_pursuits_are_off` (`ui.rs:8096`) moves with it rather than being deleted.
+- [ ] **Step 4: Test** — all four badges render; the gaps block is still absent with feedback off (`the_capture_page_shows_no_gaps_block_when_feedback_is_off`).
+
+**Commit 2 ends here.** e.g. `feat(gaps): four ways to say nothing was there, one list`.
+
+---
+
+# Phase 3 — The sitting (spec §5)
+
+Carrying ships on. Priming ships off, behind `sitting.prime`, and is switched on — if ever — by a separate commit carrying the harness numbers in its message.
+
+## Task 11: The sitting itself
+
+**Files:** `src/core/sitting.rs` (new), `src/core/mod.rs`, `src/config.rs`
+
+- [ ] **Step 1:** `Sitting { touched: VecDeque<Touched>, queries: VecDeque<String>, last_at: i64 }`, `CARRY = 20`, a `Mutex<HashMap<String, Sitting>>` on `Core` keyed by `sessions.id`.
+- [ ] **Step 2:** Expiry at `pursuit.idle_secs` — the same number the sweep already uses, so the live definition and the reconstructed one agree by construction. Dropped lazily on read; no sweep, no table, no migration.
+- [ ] **Step 3:** In memory only. The doc comment carries the price plainly: a deploy mid-afternoon costs the operator their carried context, and a working memory that survives a restart is a long-term memory, which engram has one of.
+- [ ] **Step 4:** Writes on the paths that already record engagement — `mark_artifact_seen`, `record_interaction`, an ask's citations. A lock and a push; no vector call, no store write.
+- [ ] **Step 5: Test** — expires at `idle_secs`; caps at `CARRY`; **never writes activation** (assert directly — this is the guard most likely to be lost to a refactor); web door only, with no path from `/mcp` or the API reaching it.
+
+## Task 12: Carrying
+
+**Files:** `src/web/ui.rs`, `src/web/templates/search.html`, `ask.html`, `_ask_carried.html`
+
+Nothing here changes an order.
+
+- [ ] **Step 1:** Search → ask: the ask box prefilled with the sitting's last query when it is empty and the sitting is warm.
+- [ ] **Step 2:** Ask → capture: the keep-this-answer link gains the question it answered, as the note. The operator still decides, and the trace still records that a model wrote the text — that line does not move.
+- [ ] **Step 3:** The rail of what this sitting has touched, on search and ask. Six at most, each a link, **absent on a cold sitting** — not an empty box.
+- [ ] **Step 4: Test** — warm sitting prefills, cold one does not; a non-empty ask box is never overwritten; the rail is absent, not empty, when there is nothing to show.
+
+## Task 13: Priming, off
+
+**Files:** `src/core/search.rs`, `src/config.rs`, `config.example.toml`
+
+- [ ] **Step 1:** `[sitting] prime = false`.
+- [ ] **Step 2:** A hit in `touched` is primed by the same rank-based bounded rule `search::prime` already applies, **inside the same budget**: extend the existing function rather than running it twice. A hit cannot be lifted `prime_lift` places for activation and again for the sitting.
+- [ ] **Step 3:** Index 0 stays untouchable — the existing walk already starts at index 2 and floors the target at 1; do not weaken it.
+- [ ] **Step 4:** A hit the sitting lifted says so, in the same place a hit lifted by activation already says so.
+- [ ] **Step 5: Test** — with `prime` on, a hit in both `touched` and activation moves at most `prime_lift` places *in total*, and rank 0 never moves; with `prime` off, ranking is byte-identical to today's.
+
+## Task 14: The harness
+
+- [ ] **Step 1:** `cargo test --test eval` with `sitting.prime = false`, recorded.
+- [ ] **Step 2:** The same with `true`, recorded.
+- [ ] **Step 3:** The default moves only in a separate commit whose message carries both numbers. If it does not move, that is a result too and belongs in `ROADMAP.md`.
+
+**Commit 3 ends here.** e.g. `feat(sitting): what this sitting has touched, carried between the doors`.
+
+---
+
+## Final verification
+
+```bash
+cargo fmt --check && cargo clippy --all-targets -- -D warnings
+cargo test 2>&1 | tail -30
+```
+
+The four that matter most, by name:
+
+| Test | What it pins |
+|---|---|
+| `a_crashed_capture_is_repaired_with_the_sweep_switched_off` | Repair stayed outside the schedule |
+| the claim's `EXPLAIN QUERY PLAN` | The covering index survived priority and ageing |
+| within-class `attempts, seq, id` | A large ingest still cannot starve a small one |
+| the sitting never writes activation | Working memory stayed a read |
+
+Then `ROADMAP.md`: three seams marked closed, and the four items §2 lists as unchanged — engagement at every door, access reconsolidation, error-driven re-synthesis, the corpus map — left where they are, now easier.

--- a/docs/superpowers/plans/2026-08-20-ui-findings.md
+++ b/docs/superpowers/plans/2026-08-20-ui-findings.md
@@ -19,7 +19,7 @@
 - **Truncate by chars, never by bytes.** Slicing mid-codepoint panics; the corpus is largely German.
 - **Do not change:** the phone hiding KIND chips (`50-phone.css:108`), the phone badge dropping its number (`layout.html:130`), Judge's rank numbers stopping at nine (`judge.rs:190`), or Judge's IR vocabulary. All are deliberate and defended in comments.
 - **Comment style:** this codebase explains *why* in prose above the code, and expects it. Match it.
-- **Test fixtures:** several tasks call helpers like `render_ask_page_fixture()` or `chunk_fixture()`. Where one does not exist yet, build it in that task's test module following the pattern already in `ui.rs:4700` — construct the real struct with every field named, and render through `askama::Template::render`. Do not stub the type under test.
+- **Test fixtures:** several tasks call helpers like `render_ask_page_fixture()` or `chunk_fixture()`. Where one does not exist yet, build it in that task's test module following the pattern already in `ui.rs:4707` — construct the real struct with every field named, and render through `askama::Template::render`. Do not stub the type under test.
 
 ---
 
@@ -144,7 +144,7 @@ git commit -m "feat(ui): a name cut at a word, and never the punctuation in fron
 ### Task 2: `title_of` adopts the rule
 
 **Files:**
-- Modify: `src/web/ui.rs:1950` (`title_of`)
+- Modify: `src/web/ui.rs:1957` (`title_of`)
 - Test: `src/web/ui.rs` (inline `mod tests`)
 
 **Interfaces:**
@@ -185,7 +185,7 @@ Expected: FAIL — the assertion on `- schneller…`, because `title_of` returns
 
 - [ ] **Step 3: Implement**
 
-Replace `title_of` (`ui.rs:1950`):
+Replace `title_of` (`ui.rs:1957`):
 
 ```rust
 /// What to call an artifact in a place that must call it something.
@@ -289,7 +289,7 @@ git commit -m "fix(judge): no heading where there is no name, and no markup in t
 ### Task 4: The artifact pane stops saying "Chunk 56"
 
 **Files:**
-- Modify: `src/web/ui.rs:367`, `src/web/ui.rs:3095`
+- Modify: `src/web/ui.rs:367`, `src/web/ui.rs:3102`
 - Test: `src/web/ui.rs` (inline `mod tests`)
 
 **Interfaces:**
@@ -317,7 +317,7 @@ Expected: FAIL — title is `Chunk 56`.
 
 - [ ] **Step 3: Implement**
 
-At both `ui.rs:367` and `ui.rs:3095`, replace `.unwrap_or_else(|| format!("Chunk {}", c.ordinal))` with `.unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))`, with a comment saying why the ordinal is not a name.
+At both `ui.rs:367` and `ui.rs:3102`, replace `.unwrap_or_else(|| format!("Chunk {}", c.ordinal))` with `.unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))`, with a comment saying why the ordinal is not a name.
 
 - [ ] **Step 4: Run the tests**
 
@@ -376,83 +376,85 @@ git commit -m "fix(mcp): the door reads a passage's opening rather than the word
 
 ---
 
-### Task 6: Two rows with one name say what tells them apart
+### Task 6: The disambiguator that runs but cannot be seen
 
 **Files:**
-- Modify: `src/web/ui.rs` (the pair-row builder around `ui.rs:1895`)
+- Modify: `assets/css/41-capture.css:14-18` (`.qtitle`)
+- Modify: `src/web/ui.rs:1368` (`disambiguate_labels`, generalised)
+- Modify: `src/web/ui.rs` (pair rows, to reuse it)
 - Test: `src/web/ui.rs` (inline `mod tests`)
 
 **Interfaces:**
-- Produces: `PairRow.a_title` / `b_title` may carry a disambiguating suffix. Task 8 consumes the same rows.
+- Produces: `fn disambiguate_by<T>(rows: &mut [T], label: impl Fn(&T) -> &str, opening: impl Fn(&T) -> &str, set: impl Fn(&mut T, String))` — or, if the generic form fights the borrow checker, a `disambiguate_labels`-shaped function per row type sharing one helper for the collision set. Task 8 consumes the disambiguated pair rows.
 
-- [ ] **Step 1: Write the failing test**
+**Context you need before touching this.** Capture's Recent list already has a repair for shared titles: `disambiguate_labels` at `ui.rs:1368`, whose comment names this exact failure — "six rows read `HOCHSCHULE MITTWEIDA` and named nothing". It works. The reason the deployment still showed six identical rows is that `.qtitle` is one line with `text-overflow: ellipsis`, so the ` · opening` suffix it appends is cut off before it is ever visible. Do not rewrite the function; give its output somewhere to be seen. The dedupe pair rows are the opposite case — they have no disambiguation at all, and should borrow this one rather than grow a second copy.
+
+- [ ] **Step 1: Write the failing tests**
 
 ```rust
     #[test]
-    fn two_rows_sharing_a_title_say_what_tells_them_apart() {
-        // Three artifacts on the deployment carried the title "LevelDB:
-        // Funktionsweise und forensische Analyse", so the queue read as the
-        // same question asked three times.
-        let rows = disambiguate(vec![
-            ("a".to_string(), "LevelDB: Funktionsweise".to_string(), "Der Aufbau".to_string()),
-            ("b".to_string(), "LevelDB: Funktionsweise".to_string(), "Die Extraktion".to_string()),
-            ("c".to_string(), "SQLite und WAL".to_string(), "Pragma".to_string()),
+    fn a_disambiguated_row_shows_the_part_that_distinguishes_it() {
+        // `disambiguate_labels` appended the opening words and `.qtitle`
+        // truncated them away, so six rows still read "HOCHSCHULE MITTWEIDA ·
+        // HOCHSCH…" and the one column that exists to tell captures apart
+        // still could not.
+        let html = render_queue_fixture(vec![
+            ("HOCHSCHULE MITTWEIDA", "Fachbereich Angewandte Computer- und Biowissenschaften"),
+            ("HOCHSCHULE MITTWEIDA", "Ein Verfahren zur Sicherung flüchtiger Daten"),
         ]);
-        assert_ne!(rows[0].1, rows[1].1, "two rows still read identically");
-        assert!(rows[0].1.starts_with("LevelDB: Funktionsweise"));
-        assert_eq!(rows[2].1, "SQLite und WAL", "a unique title is left alone");
+        assert!(html.contains("qtitle-opening"), "the opening has no element of its own: {html}");
+    }
+
+    #[test]
+    fn pair_rows_sharing_a_title_are_disambiguated_too() {
+        // Three artifacts on the deployment were titled "LevelDB:
+        // Funktionsweise und forensische Analyse", so one cluster of
+        // questions read as the same question three times.
+        let mut rows = vec![
+            pair_row_fixture("LevelDB: Funktionsweise", "Der Aufbau der Datenlagerung"),
+            pair_row_fixture("LevelDB: Funktionsweise", "Die Extraktion der Keys"),
+            pair_row_fixture("SQLite und WAL", "Pragma-Abfragen"),
+        ];
+        disambiguate_pair_titles(&mut rows);
+        assert_ne!(rows[0].a_title, rows[1].a_title, "still identical");
+        assert_eq!(rows[2].a_title, "SQLite und WAL", "a unique title is left alone");
     }
 ```
 
-- [ ] **Step 2: Run it to verify it fails**
+- [ ] **Step 2: Run them to verify they fail**
 
-Run: `cargo test --lib web::ui::tests::two_rows_sharing_a_title`
-Expected: FAIL — `cannot find function disambiguate`.
+Run: `cargo test --lib web::ui::tests::a_disambiguated_row_shows web::ui::tests::pair_rows_sharing_a_title`
+Expected: FAIL — no `qtitle-opening` element, and `cannot find function disambiguate_pair_titles`.
 
 - [ ] **Step 3: Implement**
 
-```rust
-/// Make every title in one list distinguishable from the others.
-///
-/// Three artifacts named "LevelDB: Funktionsweise und forensische Analyse" is
-/// what made a queue of three different questions look like one question
-/// asked three times. A title that is already unique in its list is left
-/// exactly as it is: a suffix on a name that needs no suffix is noise.
-fn disambiguate(rows: Vec<(String, String, String)>) -> Vec<(String, String, String)> {
-    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
-    for (_, title, _) in &rows {
-        *seen.entry(title.as_str()).or_default() += 1;
-    }
-    let shared: std::collections::HashSet<String> = seen
-        .iter()
-        .filter(|(_, n)| **n > 1)
-        .map(|(t, _)| (*t).to_string())
-        .collect();
-    rows.into_iter()
-        .map(|(id, title, body)| {
-            if !shared.contains(&title) {
-                return (id, title, body);
-            }
-            let mark = crate::web::markdown::stand_in_title(&body, 40);
-            let title = if mark.is_empty() { title } else { format!("{title} — {mark}") };
-            (id, title, body)
-        })
-        .collect()
+Two changes, and neither touches `disambiguate_labels`' logic.
+
+First, give the suffix a place to live. In the queue template, render the label and the opening as two elements rather than one concatenated string, and in `41-capture.css` let the opening sit on its own line, dim and smaller, exempt from the parent's `nowrap`:
+
+```css
+/* The label truncates; what tells this row from the one above it does not.
+   `disambiguate_labels` appends the capture's opening words to a label that
+   collides, and a single `nowrap` line cut the appended half off — so the
+   repair ran, and six rows still read the same six words. */
+.qtitle-opening {
+  display: block; white-space: normal; overflow: visible;
+  font-size: 0.8125rem; color: var(--color-fg-muted);
 }
 ```
 
-Call it where `PairRow`s are collected, passing each side's body text, before they reach the template.
+Second, apply the same collision rule to the dedupe pair titles. Factor the collision-set half of `disambiguate_labels` into a small shared helper and call it from a `disambiguate_pair_titles(&mut [PairRow])` that appends `markdown::stand_in_title(&body, 40)` to any `a_title`/`b_title` shared by another row. Keep the three exemptions the original documents: a label already unique, a row with no opening to offer, and an opening equal to the label.
 
-- [ ] **Step 4: Run the tests**
+- [ ] **Step 4: Run the tests, then look at the page**
 
 Run: `cargo test --lib web::ui`
-Expected: PASS.
+Expected: PASS. Then load `/ui/capture` against a base with repeated headings and confirm Recent's rows are now distinguishable without hovering.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/web/ui.rs
-git commit -m "feat(ui): a name shared by three artifacts says which one it is"
+git add src/web/ui.rs assets/css/41-capture.css src/web/templates
+git commit -m "fix(capture): the half of the label that tells two rows apart survives the truncation"
 ```
 
 ---
@@ -514,12 +516,12 @@ git commit -m "fix(dedupe): an escalated pair says what it is escalating"
 ### Task 8: One cluster is one question
 
 **Files:**
-- Modify: `src/web/ui.rs` (pair collection, near `PAIR_LIMIT` at `ui.rs:1967`)
+- Modify: `src/web/ui.rs` (pair collection, near `PAIR_LIMIT` at `ui.rs:1974`)
 - Modify: `src/web/templates/_decide.html`
 - Test: `src/web/ui.rs` (inline `mod tests`)
 
 **Interfaces:**
-- Consumes: `disambiguate` (Task 6), the `Clusters` disjoint-set pattern in `jobs/consolidate.rs:60`.
+- Consumes: `disambiguate_pair_titles` (Task 6), the `Clusters` disjoint-set pattern in `jobs/consolidate.rs:60`.
 - Produces: the template iterates clusters, each carrying `Vec<PairRow>`.
 
 - [ ] **Step 1: Write the failing test**
@@ -940,7 +942,7 @@ git commit -m "feat(ui): a sentence that does not finish says where it goes on"
 ### Task 17: Elapsed time stops being borrowed from a future-tense helper
 
 **Files:**
-- Modify: `src/web/ui.rs:331` (add `fmt_elapsed` beside `fmt_duration`), `ui.rs:2286`
+- Modify: `src/web/ui.rs:331` (add `fmt_elapsed` beside `fmt_duration`), `ui.rs:2293`
 - Test: `src/web/ui.rs` (inline `mod tests`)
 
 **Interfaces:**
@@ -986,7 +988,7 @@ pub fn fmt_elapsed(secs: i64) -> String {
 }
 ```
 
-At `ui.rs:2286`, call `fmt_elapsed` instead of `fmt_duration`.
+At `ui.rs:2293`, call `fmt_elapsed` instead of `fmt_duration`.
 
 - [ ] **Step 4: Run the tests**
 

--- a/docs/superpowers/plans/2026-08-20-ui-findings.md
+++ b/docs/superpowers/plans/2026-08-20-ui-findings.md
@@ -1,0 +1,1215 @@
+# GUI Findings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the twenty-odd usability defects found by operating the live deployment, without disturbing the design decisions this codebase argues for in comments.
+
+**Architecture:** Almost every change is at the web door — one helper module for the rules that several call sites currently each invent (stand-in titles, elapsed time), then template, CSS and handler changes on top of it. One change reaches deeper: the consolidation queue groups pending pairs by the cluster `jobs/consolidate.rs` already computes. No schema migrations.
+
+**Tech Stack:** Rust, axum, askama templates (`src/web/templates/`), htmx + a single hand-written `assets/app.js`, plain layered CSS (`assets/css/00-…` through `50-phone.css`), SQLite via sqlx. Tests are inline `#[cfg(test)] mod tests` in the file under test, run with `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-ui-findings-design.md`
+
+## Global Constraints
+
+- **Branch:** `fix/ui-findings`, based on `origin/feat/one-system`. Not `master` — prod runs the former.
+- **Never render the word `Untitled`.** Existing test `a_result_with_no_title_of_its_own_is_given_no_heading` (`ui.rs:4700`) enforces this for the rail; the same must hold everywhere.
+- **Never render `Chunk N` as a title.**
+- **Two title rules, by context.** Where a snippet sits beside the name (search rail, judge card): no heading at all. Where a name is structurally required (button label, sitting list, artifact pane heading): a stand-in from the body, cut at a word boundary, leading punctuation stripped, marked as a stand-in.
+- **Truncate by chars, never by bytes.** Slicing mid-codepoint panics; the corpus is largely German.
+- **Do not change:** the phone hiding KIND chips (`50-phone.css:108`), the phone badge dropping its number (`layout.html:130`), Judge's rank numbers stopping at nine (`judge.rs:190`), or Judge's IR vocabulary. All are deliberate and defended in comments.
+- **Comment style:** this codebase explains *why* in prose above the code, and expects it. Match it.
+- **Test fixtures:** several tasks call helpers like `render_ask_page_fixture()` or `chunk_fixture()`. Where one does not exist yet, build it in that task's test module following the pattern already in `ui.rs:4700` — construct the real struct with every field named, and render through `askama::Template::render`. Do not stub the type under test.
+
+---
+
+### Task 1: A stand-in title that does not cut mid-word
+
+**Files:**
+- Modify: `src/web/markdown.rs` (add `stand_in_title`, fix `snippet` truncation)
+- Test: `src/web/markdown.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Produces: `pub fn stand_in_title(text: &str, max_chars: usize) -> String` — markdown stripped, leading punctuation and whitespace removed, truncated at a word boundary with an ellipsis. Used by Tasks 2, 3, 4, 5.
+- Produces: `snippet` keeps its signature `(markdown: &str, max_chars: usize) -> String` but also stops at a word boundary.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn a_stand_in_title_stops_at_a_word() {
+        // The sitting rendered "…zusätzlich darin vo" — a name cut mid-word
+        // reads as a truncated name, not as the opening of a passage.
+        let t = stand_in_title("Die digitale Forensik unterscheidet sich zusätzlich darin von einem Tatort", 60);
+        assert!(!t.contains("vo…"), "cut mid-word: {t:?}");
+        assert!(t.ends_with('…'), "{t:?}");
+        assert!(t.chars().count() <= 61, "{t:?}");
+    }
+
+    #[test]
+    fn a_stand_in_title_drops_leading_punctuation_and_markup() {
+        // "Keep \"- schneller Schreibzugriff (…) -\"" was a body opening,
+        // dashes and all, pressed into service as a name.
+        assert_eq!(stand_in_title("- schneller Schreibzugriff auf den Stapel", 60),
+                   "schneller Schreibzugriff auf den Stapel");
+        assert_eq!(stand_in_title("## 3.4.2 FESTE MFT RECORDS", 60), "3.4.2 FESTE MFT RECORDS");
+    }
+
+    #[test]
+    fn a_short_body_becomes_a_stand_in_unchanged() {
+        assert_eq!(stand_in_title("CPU fair scheduler parameter", 60), "CPU fair scheduler parameter");
+    }
+
+    #[test]
+    fn a_stand_in_of_nothing_is_empty() {
+        assert_eq!(stand_in_title("   \n\n  ", 60), "");
+        assert_eq!(stand_in_title("---", 60), "");
+    }
+
+    #[test]
+    fn a_snippet_stops_at_a_word_too() {
+        let s = snippet("Die digitale Forensik unterscheidet sich zusätzlich darin von einem Tatort", 30);
+        assert!(!s.contains("zusä…"), "cut mid-word: {s:?}");
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib web::markdown`
+Expected: FAIL — `cannot find function stand_in_title in this scope`, plus `a_snippet_stops_at_a_word_too` failing on the existing char-count truncation.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/web/markdown.rs`:
+
+```rust
+/// Truncate at a word, never inside one, and never inside a codepoint.
+///
+/// `chars().take(n)` was the whole of this and it produced "…darin vo" in the
+/// sitting and "Fake title: al…" in the corpus rail: a name cut mid-word reads
+/// as a broken name, where one cut at a space reads as an opening. Falls back
+/// to the hard cut when the text has no space to fall back to — one
+/// unbroken 200-character token is still better shortened than shown whole.
+fn truncate_at_word(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let hard: String = text.chars().take(max_chars).collect();
+    let cut = match hard.rfind(char::is_whitespace) {
+        // Not any space: one near the very start would leave a single word
+        // standing for a whole passage. Half the budget is the floor.
+        Some(i) if hard[..i].chars().count() * 2 >= max_chars => &hard[..i],
+        _ => hard.as_str(),
+    };
+    format!("{}…", cut.trim_end())
+}
+
+/// A name for something that has none, derived from its own opening.
+///
+/// A verbatim passage has no title by design. Where the layout can let a
+/// snippet speak for the row there should be no heading at all — see
+/// `render_hit`. Where a name is structurally required, a button label or a
+/// list of what this sitting touched, this is that name: the body's opening,
+/// with the markup and the leading punctuation that are structure rather than
+/// subject taken off the front.
+pub fn stand_in_title(text: &str, max_chars: usize) -> String {
+    let flat = snippet(text, usize::MAX);
+    let opening = flat.trim_start_matches(|c: char| {
+        c.is_whitespace() || matches!(c, '-' | '–' | '—' | '*' | '#' | '>' | '·' | '•' | '|')
+    });
+    truncate_at_word(opening.trim(), max_chars)
+}
+```
+
+And replace `snippet`'s tail (the `let mut out: String = text.chars().take(max_chars).collect(); out.push('…'); out` block) with:
+
+```rust
+    truncate_at_word(&text, max_chars)
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::markdown`
+Expected: PASS, including the pre-existing `snippet_returns_plain_text_and_truncates_on_a_char_boundary`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/markdown.rs
+git commit -m "feat(ui): a name cut at a word, and never the punctuation in front of it"
+```
+
+---
+
+### Task 2: `title_of` adopts the rule
+
+**Files:**
+- Modify: `src/web/ui.rs:1950` (`title_of`)
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `markdown::stand_in_title` from Task 1.
+- Produces: `title_of` keeps its signature `(c: &Chunk) -> String`; callers are the sitting rail (`ui.rs:472`) and the dedupe pair rows (`ui.rs` pair building).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn an_untitled_artifact_is_named_by_its_opening_not_by_its_first_sixty_bytes() {
+        // Both of these came off the deployment: the sitting cut a name
+        // mid-word, and "Needs you" offered a button reading
+        // `Keep "- schneller Schreibzugriff (…) -"`.
+        let c = |text: &str| crate::store::artifacts::Chunk {
+            title: None,
+            text: text.into(),
+            ..chunk_fixture()
+        };
+        let t = title_of(&c("Die digitale Forensik unterscheidet sich zusätzlich darin von einem Tatort"));
+        assert!(!t.ends_with("vo"), "cut mid-word: {t:?}");
+        assert_eq!(
+            title_of(&c("- schneller Schreibzugriff (Änderungen vom Key auf Stapel) -")),
+            "schneller Schreibzugriff (Änderungen vom Key auf Stapel) -"
+        );
+        assert_eq!(title_of(&crate::store::artifacts::Chunk {
+            title: Some("LevelDB".into()), ..c("body")
+        }), "LevelDB");
+    }
+```
+
+If no `chunk_fixture()` helper exists in `ui.rs`'s test module, add one that builds a `Chunk` with every field defaulted — copy the field list from `store/artifacts.rs:124` — and reuse it in later tasks.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::an_untitled_artifact_is_named_by_its_opening`
+Expected: FAIL — the assertion on `- schneller…`, because `title_of` returns the leading dash.
+
+- [ ] **Step 3: Implement**
+
+Replace `title_of` (`ui.rs:1950`):
+
+```rust
+/// What to call an artifact in a place that must call it something.
+///
+/// Sixty characters of raw body was this, and it is where the sitting's
+/// "…darin vo" and the dedupe queue's `Keep "- schneller Schreibzugriff …"`
+/// both came from. The rule now lives in one place — see
+/// `markdown::stand_in_title` — so the sitting, the pair cards and the judge
+/// cannot drift apart again.
+pub(crate) fn title_of(c: &crate::store::artifacts::Chunk) -> String {
+    c.title
+        .clone()
+        .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs
+git commit -m "fix(ui): the sitting and the pair cards stop naming things by their punctuation"
+```
+
+---
+
+### Task 3: The judge card stops saying "Untitled"
+
+**Files:**
+- Modify: `src/web/judge.rs:132` (`snippet_of`), `:179`, `:515`
+- Test: `src/web/judge.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `markdown::snippet` from Task 1.
+- Produces: `Choice.title` may now be empty; `_judge_card.html` must render no heading element when it is (Task 4 of this group — done here, in the same task, since the template and the field change together).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_judge_card_names_nothing_untitled_and_leaks_no_markdown() {
+        // Two thirds of the deployment's judge list read "Untitled", and the
+        // snippets under them carried `custom\_passphrase` and `# Configure`
+        // because this door flattened whitespace instead of stripping markup.
+        assert_eq!(snippet_of("## Configure **auditd**"), "Configure auditd");
+        assert!(!snippet_of(r"2 - A custom passphrase (custom\_passphrase)").contains('\\'));
+    }
+```
+
+Plus a rendering assertion in whichever test already builds a `Card` — assert `!html.contains("Untitled")`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::judge`
+Expected: FAIL — `snippet_of` returns `## Configure **auditd**` verbatim.
+
+- [ ] **Step 3: Implement**
+
+Replace `snippet_of` (`judge.rs:132`):
+
+```rust
+/// The card's preview: plain text, markup gone.
+///
+/// Flattening whitespace was the whole of this, so a card showed
+/// `# Configure Linux…` and `custom\_passphrase` — the escapes an artifact
+/// carries so that markdown renders it correctly, shown to a person as if
+/// they were the text.
+fn snippet_of(text: &str) -> String {
+    crate::web::markdown::snippet(text, 140)
+}
+```
+
+At `judge.rs:179` and `judge.rs:515`, replace `a.title.unwrap_or_else(|| "Untitled".into())` (and `h.title…`) with `a.title.unwrap_or_default()`.
+
+In `src/web/templates/_judge_card.html`, wrap the title so an empty one renders no element at all:
+
+```html
+{% if !c.title.is_empty() %}<span class="choice-title">{{ c.title }}</span>{% endif %}
+```
+
+Add a comment above it in the codebase's voice, pointing at `render_hit`'s reasoning.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::judge`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/judge.rs src/web/templates/_judge_card.html
+git commit -m "fix(judge): no heading where there is no name, and no markup in the preview"
+```
+
+---
+
+### Task 4: The artifact pane stops saying "Chunk 56"
+
+**Files:**
+- Modify: `src/web/ui.rs:367`, `src/web/ui.rs:3095`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `markdown::stand_in_title` from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn the_artifact_pane_does_not_call_a_passage_chunk_fifty_six() {
+        // "Chunk 56" is an ordinal in the ingest, not a name for anything a
+        // reader asked for.
+        let d = build_detail_fixture_with(None, "Die digitale Forensik unterscheidet sich");
+        assert!(!d.title.starts_with("Chunk"), "{:?}", d.title);
+        assert!(d.title.starts_with("Die digitale Forensik"), "{:?}", d.title);
+    }
+```
+
+Build the fixture with whatever the two sites construct; if a helper does not exist, assert directly on `title_of`-style output at both call sites instead.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::the_artifact_pane_does_not_call_a_passage_chunk`
+Expected: FAIL — title is `Chunk 56`.
+
+- [ ] **Step 3: Implement**
+
+At both `ui.rs:367` and `ui.rs:3095`, replace `.unwrap_or_else(|| format!("Chunk {}", c.ordinal))` with `.unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))`, with a comment saying why the ordinal is not a name.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs
+git commit -m "fix(ui): an ordinal in the ingest is not a name for a passage"
+```
+
+---
+
+### Task 5: The MCP door stops saying "Untitled"
+
+**Files:**
+- Modify: `src/mcp/mod.rs:19`
+- Test: `src/mcp/mod.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn the_mcp_door_names_a_passage_by_its_opening() {
+        // Claude Code reads this list. "Untitled" three times over is a list
+        // of a word that says nothing.
+        let out = render_result_line(&result_fixture(None, "Die digitale Forensik unterscheidet sich"));
+        assert!(!out.contains("Untitled"), "{out}");
+    }
+```
+
+Adapt the fixture name to whatever `mcp/mod.rs` already constructs at line 19.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib mcp`
+Expected: FAIL — output contains `Untitled`.
+
+- [ ] **Step 3: Implement**
+
+Replace `r.title.clone().unwrap_or_else(|| "Untitled".into())` with `r.title.clone().unwrap_or_else(|| crate::web::markdown::stand_in_title(&r.text, 60))`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib mcp`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/mod.rs
+git commit -m "fix(mcp): the door reads a passage's opening rather than the word Untitled"
+```
+
+---
+
+### Task 6: Two rows with one name say what tells them apart
+
+**Files:**
+- Modify: `src/web/ui.rs` (the pair-row builder around `ui.rs:1895`)
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Produces: `PairRow.a_title` / `b_title` may carry a disambiguating suffix. Task 8 consumes the same rows.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn two_rows_sharing_a_title_say_what_tells_them_apart() {
+        // Three artifacts on the deployment carried the title "LevelDB:
+        // Funktionsweise und forensische Analyse", so the queue read as the
+        // same question asked three times.
+        let rows = disambiguate(vec![
+            ("a".to_string(), "LevelDB: Funktionsweise".to_string(), "Der Aufbau".to_string()),
+            ("b".to_string(), "LevelDB: Funktionsweise".to_string(), "Die Extraktion".to_string()),
+            ("c".to_string(), "SQLite und WAL".to_string(), "Pragma".to_string()),
+        ]);
+        assert_ne!(rows[0].1, rows[1].1, "two rows still read identically");
+        assert!(rows[0].1.starts_with("LevelDB: Funktionsweise"));
+        assert_eq!(rows[2].1, "SQLite und WAL", "a unique title is left alone");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::two_rows_sharing_a_title`
+Expected: FAIL — `cannot find function disambiguate`.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Make every title in one list distinguishable from the others.
+///
+/// Three artifacts named "LevelDB: Funktionsweise und forensische Analyse" is
+/// what made a queue of three different questions look like one question
+/// asked three times. A title that is already unique in its list is left
+/// exactly as it is: a suffix on a name that needs no suffix is noise.
+fn disambiguate(rows: Vec<(String, String, String)>) -> Vec<(String, String, String)> {
+    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (_, title, _) in &rows {
+        *seen.entry(title.as_str()).or_default() += 1;
+    }
+    let shared: std::collections::HashSet<String> = seen
+        .iter()
+        .filter(|(_, n)| **n > 1)
+        .map(|(t, _)| (*t).to_string())
+        .collect();
+    rows.into_iter()
+        .map(|(id, title, body)| {
+            if !shared.contains(&title) {
+                return (id, title, body);
+            }
+            let mark = crate::web::markdown::stand_in_title(&body, 40);
+            let title = if mark.is_empty() { title } else { format!("{title} — {mark}") };
+            (id, title, body)
+        })
+        .collect()
+}
+```
+
+Call it where `PairRow`s are collected, passing each side's body text, before they reach the template.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs
+git commit -m "feat(ui): a name shared by three artifacts says which one it is"
+```
+
+---
+
+### Task 7: Find out why every escalated pair has no detail
+
+**Files:**
+- Modify: `src/jobs/dedupe.rs` (the `settle` path), or `src/infer/prompt.rs` (the parse) — whichever the investigation indicts
+- Test: `src/jobs/dedupe.rs` (inline `mod tests`)
+
+**This task is a debugging task, not a design task.** REQUIRED SUB-SKILL: use `superpowers:systematic-debugging`. Do not write a fix before the test reproduces the empty field.
+
+**What is known:** the field is stored (`store/pairs.rs:108`), rewritten on settle (`store/pairs.rs:318`), read and specially cased for the `link` marker (`ui.rs:1879`), and rendered (`_decide.html`, `{% if let Some(d) = p.detail %}`). The prompt demands it: "detail: one short sentence saying why. Always." (`prompt.rs`). All five `Contradiction` rows on the deployment have it null. Suspects, in order: the JSON parse at `prompt.rs:851` dropping `detail` for the `conflict` arm; `settle` passing `None` where the verdict had `Some`; a `Contradiction` written by a path that never had a verdict (`reopen_pairs_merged_into`, or the "merged member has lost its sources" escalation, which does pass a detail).
+
+- [ ] **Step 1: Reproduce it in a test**
+
+Write a test that parses a realistic `conflict` verdict and asserts the detail survives to the stored row:
+
+```rust
+    #[test]
+    fn a_conflict_verdict_carries_its_reason_to_the_stored_pair() {
+        // Every escalated pair on the deployment had a null detail, so each
+        // card said two artifacts disagreed and never what about — which is
+        // the whole of what a person needs to decide it.
+        let v = crate::infer::prompt::parse_dedupe(
+            r#"{"verdict":{"relation":"conflict","detail":"A says ext4 is supported, B says it is not."}}"#,
+        )
+        .unwrap();
+        assert_eq!(v.relation, crate::infer::prompt::Relation::Conflict);
+        assert_eq!(v.detail.as_deref(), Some("A says ext4 is supported, B says it is not."));
+    }
+```
+
+Adapt `parse_dedupe` to the real parser's name at `prompt.rs:851`.
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --lib infer::prompt jobs::dedupe`
+Expected: either FAIL, which names the parse as the cause — proceed to Step 3 — or PASS, which exonerates the parse and moves the investigation to `settle` and then to the writers of `Contradiction` that never saw a verdict. Follow the evidence; do not guess.
+
+- [ ] **Step 3: Fix the indicted layer**
+
+Minimal change at the layer the test indicted. If the cause is a path that legitimately has no verdict, the fix is that it writes a detail saying so, in the codebase's voice — never a card that names no dispute.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "fix(dedupe): an escalated pair says what it is escalating"
+```
+
+---
+
+### Task 8: One cluster is one question
+
+**Files:**
+- Modify: `src/web/ui.rs` (pair collection, near `PAIR_LIMIT` at `ui.rs:1967`)
+- Modify: `src/web/templates/_decide.html`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `disambiguate` (Task 6), the `Clusters` disjoint-set pattern in `jobs/consolidate.rs:60`.
+- Produces: the template iterates clusters, each carrying `Vec<PairRow>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn pairs_that_share_an_artifact_are_one_card() {
+        // The deployment showed one artifact against three others as three
+        // separate questions, 90%, 90% and 88% alike — the same decision
+        // asked three times, and answering one did not retire the others.
+        let grouped = group_pairs(vec![
+            pair_fixture(1, "a", "b"),
+            pair_fixture(2, "a", "c"),
+            pair_fixture(3, "a", "d"),
+            pair_fixture(4, "x", "y"),
+        ]);
+        assert_eq!(grouped.len(), 2, "{grouped:?}");
+        assert_eq!(grouped[0].pairs.len(), 3);
+        assert_eq!(grouped[1].pairs.len(), 1);
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::pairs_that_share_an_artifact`
+Expected: FAIL — `cannot find function group_pairs`.
+
+- [ ] **Step 3: Implement**
+
+Add a `PairCluster { pairs: Vec<PairRow> }` and a `group_pairs` using the same union-find shape as `jobs/consolidate.rs:60` — union on `a_id`/`b_id`, then bucket by root, preserving the incoming order so `PAIR_STATES`' priority survives. Comment why: resolving a cluster pairwise leaves the operator answering the same question N times, and `consolidate.rs` already documents the dead-end that pairwise resolution creates.
+
+In `_decide.html`, iterate clusters; a cluster of one renders exactly as it does today, so nothing regresses for the common case. For a cluster of several, state the shape once ("four artifacts, three open questions") above the pair rows.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs src/web/templates/_decide.html
+git commit -m "feat(capture): one cluster asks once, not once per pair"
+```
+
+---
+
+### Task 9: Deciding a pair without leaving the page
+
+**Files:**
+- Modify: `src/web/templates/_decide.html`
+- Modify: `assets/css/41-capture.css`
+- Test: `src/web/ui.rs` (inline `mod tests`, rendering assertion)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_pair_card_carries_both_texts_to_read_in_place() {
+        // The titles were links, so reading either side meant leaving the
+        // queue and coming back to it.
+        let html = render_capture_fixture_with_one_pair();
+        assert!(html.contains("<details"), "{html}");
+        assert!(html.contains("Auto Vacuum"), "the A side's text is not on the card: {html}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_pair_card_carries_both_texts`
+Expected: FAIL — no `<details>` in the card.
+
+- [ ] **Step 3: Implement**
+
+Add `a_excerpt` / `b_excerpt` to `PairRow` (via `markdown::snippet(&text, 400)`), and render each behind a `<details><summary>` inside the card, above the button row. Keep the existing title links — they remain the way to the whole artifact. Style the two excerpts as two columns at desk width, stacked on phone.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/_decide.html assets/css/41-capture.css src/web/ui.rs
+git commit -m "feat(capture): read both sides where the decision is made"
+```
+
+---
+
+### Task 10: Reasoning becomes something you open
+
+**Files:**
+- Modify: `src/web/templates/ask.html:42`
+- Modify: `assets/app.js:285-310`
+- Modify: `assets/css/45-ask.css`
+- Test: `src/web/ui.rs` (inline `mod tests`, rendering assertion)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn an_ask_page_does_not_open_with_the_models_reasoning_showing() {
+        // The deployment streamed the chain of thought into the page for
+        // fifty seconds, restating the prompt's own constraints verbatim:
+        // "Answer *only* using the provided knowledge-base excerpts".
+        let html = render_ask_page_fixture();
+        assert!(html.contains("<details"), "{html}");
+        assert!(!html.contains("<details open"), "reasoning must start closed: {html}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::an_ask_page_does_not_open_with_the_models_reasoning`
+Expected: FAIL — the page renders a bare `<div id="ask-reasoning">`.
+
+- [ ] **Step 3: Implement**
+
+In `ask.html`, replace the bare div with a closed disclosure, keeping the id on the inner element so `app.js` needs no rewiring:
+
+```html
+  {# What the model said on the way to the answer. Behind a disclosure, closed:
+     it is not the answer, nothing in it is cited, and it restates the prompt's
+     own constraints back at whoever is reading. Kept rather than dropped
+     because it is what a tuning session actually wants to see. #}
+  <details id="ask-reasoning-box" class="reasoning-box" hidden>
+    <summary>Reasoning</summary>
+    <div id="ask-reasoning" class="reasoning"></div>
+  </details>
+```
+
+In `app.js`, toggle `ask-reasoning-box`'s `hidden` where it currently toggles `reasoning.hidden` (lines 228, 287, 309, 350), and scroll `reasoning` to its end on append **only when the disclosure is open** — a closed box must not fight the page for scroll position.
+
+In `45-ask.css`, give `.reasoning` a `max-height` with `overflow-y: auto` so an opened box is bounded.
+
+- [ ] **Step 4: Run the tests, then check by hand**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS. Then run the app and ask a question: the box appears closed, opens on click, scrolls to the newest token while open, and disappears when the answer lands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/ask.html assets/app.js assets/css/45-ask.css src/web/ui.rs
+git commit -m "feat(ask): the reasoning is there when you want it and nowhere when you do not"
+```
+
+---
+
+### Task 11: A fifty-second wait says what it is doing
+
+**Files:**
+- Modify: `src/web/templates/ask.html:21-31`
+- Modify: `assets/app.js` (the ask driver, from line ~196)
+- Modify: `assets/css/45-ask.css`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn an_ask_in_flight_offers_a_way_to_stop_it() {
+        let html = render_ask_page_fixture();
+        assert!(html.contains(r#"id="ask-stop""#), "{html}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::an_ask_in_flight_offers_a_way_to_stop_it`
+Expected: FAIL — no such control.
+
+- [ ] **Step 3: Implement**
+
+Add `<button id="ask-stop" class="btn btn-ghost" type="button" hidden>Stop</button>` beside the spinner. In `app.js`: show it when the `EventSource` opens, hide it on `done`/`error`; on click call `source.close()`, hide the spinner, keep whatever `#ask-live` holds, and write "stopped" into `#ask-status`. Start a one-second interval on open that writes elapsed seconds into `#ask-spinner` (`thinking… 12s`), and clear it on close.
+
+Leave `#ask-progress` where it is — it already carries the retrieval line, and that line is the honest progress signal; the elapsed counter supplements it rather than replacing it.
+
+- [ ] **Step 4: Run the tests, then check by hand**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS. Then ask a question and press Stop mid-stream: partial text stays, no console error, a second ask still works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/ask.html assets/app.js assets/css/45-ask.css src/web/ui.rs
+git commit -m "feat(ask): a wait that says how long it has been, and a way out of it"
+```
+
+---
+
+### Task 12: The ask page's remaining copy, and the stylesheet that was never written
+
+**Files:**
+- Modify: `src/web/templates/_answer.html:16`
+- Modify: `src/web/templates/_ask_verdict.html:14`
+- Modify: `src/web/templates/_sitting.html`
+- Modify: `assets/css/45-ask.css`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn the_answer_says_what_was_dropped_in_words_a_person_uses() {
+        let html = render_answer_fixture(18);
+        assert!(!html.contains("excerpt(s)"), "{html}");
+        assert!(!html.contains("context budget"), "{html}");
+        assert!(html.contains("18 more excerpts"), "{html}");
+        let one = render_answer_fixture(1);
+        assert!(one.contains("1 more excerpt did not fit"), "{one}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::the_answer_says_what_was_dropped`
+Expected: FAIL — badge reads `18 excerpt(s) omitted for context budget`.
+
+- [ ] **Step 3: Implement**
+
+In `_answer.html`, replace the badge text with a properly pluralised sentence: `{{ dropped }} more excerpt{% if dropped != 1 %}s{% endif %} did not fit`, keeping the internal reason in the `title` attribute where an operator can still find it.
+
+In `_ask_verdict.html`, make `Right` / `Wrong` / `Nothing here` and "keep this answer" carry `btn btn-sm` rather than reading as bare text.
+
+In `_sitting.html`, change the heading from `This sitting` to something that says what it is — "Read just now" — and in `45-ask.css` write the `.sitting` rule that has never existed: it is a small aside, dim, above the answer, and its list must not read as a second set of results.
+
+- [ ] **Step 4: Run the tests, then look at the page**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS. Then load `/ui/ask` after reading an artifact and confirm the sitting block is styled rather than falling back to bare `<ul>` defaults.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates assets/css/45-ask.css src/web/ui.rs
+git commit -m "fix(ask): plain words for what did not fit, and a stylesheet for the sitting"
+```
+
+---
+
+### Task 13: The rail uses the width the pane is not using
+
+**Files:**
+- Modify: `assets/css/20-layout.css:69`, `assets/css/40-search.css`
+- Modify: `src/web/templates/search.html` (a class on `.regions` when nothing is selected)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_search_with_nothing_open_says_so_on_the_grid() {
+        // 22rem of rail beside a thousand pixels holding one line of
+        // placeholder is the whole complaint.
+        let html = render_search_fixture_without_selection();
+        assert!(html.contains("no-selection"), "{html}");
+        let open = render_search_fixture_with_selection();
+        assert!(!open.contains("no-selection"), "{open}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_search_with_nothing_open`
+Expected: FAIL — no such class.
+
+- [ ] **Step 3: Implement**
+
+Add `no-selection` to the `.regions` element when no artifact is open (mirroring the existing `has-selection` used by `50-phone.css:58`). In `20-layout.css`, under `.regions-rail-focus-source.no-selection`, widen the rail column to `40rem`. In `40-search.css`, let `.no-selection` rows show their whole snippet rather than clamping to two lines. Comment why the pane keeps its placeholder: opening the top hit would spend a read on every search, including the ones the rail already answers.
+
+- [ ] **Step 4: Run the tests, then look at it**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS. Then search at 1400px: results are readable before any click; clicking one returns the rail to its reading width.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/css src/web/templates/search.html src/web/ui.rs
+git commit -m "feat(search): the rail takes the width nothing else is using"
+```
+
+---
+
+### Task 14: Judge's answers stop being twenty-three cards away
+
+**Files:**
+- Modify: `src/web/templates/_judge_card.html:70-92`
+- Modify: `assets/css/42-judge.css`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn the_judges_own_answers_are_reachable_without_scrolling_past_the_choices() {
+        let html = render_judge_card_fixture(23);
+        let actions = html.find("None of these").expect("no action row");
+        let last = html.rfind("choice-").expect("no choices");
+        assert!(actions < last, "the actions still sit below every choice: {actions} vs {last}");
+    }
+```
+
+If moving the row in the DOM is wrong for the keyboard order, assert on the sticky class instead and keep the DOM order.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::judge::tests::the_judges_own_answers_are_reachable`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Wrap the three actions in a `.judge-actions` bar and make it `position: sticky; bottom: 0` with the page background behind it, so it is visible at every scroll position. The `N` / `S` / `X` shortcuts already work from anywhere; the bar makes that discoverable rather than replacing it.
+
+Then give the page the width it has. `judge.html` declares no `regions` block, so it falls to `regions-focus` — one 68rem column, which rendered as content in the left half of a 1300px window with the right half empty. Switch it to `regions-table` (as `ops.html:3` already does) or give the candidate list two columns; whichever reads better with twenty-three cards. Do the same check on `settings.html`, which declares no block either.
+
+- [ ] **Step 4: Run the tests, then look at it**
+
+Run: `cargo test --lib web::judge`
+Expected: PASS. Then open `/ui/judge` with a long candidate list and confirm the bar stays put.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/_judge_card.html assets/css/42-judge.css
+git commit -m "feat(judge): the three answers stay on screen with the question"
+```
+
+---
+
+### Task 15: The artifact pane stops fighting its own text
+
+**Files:**
+- Modify: `src/web/templates/_artifact_detail.html`
+- Modify: `assets/css/40-search.css`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn delete_is_not_shoulder_to_shoulder_with_verified() {
+        // Verified, Hide and Delete rendered as one flat row of equals.
+        let html = render_artifact_detail_fixture();
+        let bar = html.find("artifact-actions").expect("no action bar");
+        let danger = html.find("artifact-danger").expect("delete is not set apart");
+        assert!(bar < danger, "{html}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::delete_is_not_shoulder_to_shoulder`
+Expected: FAIL — no `artifact-danger` grouping.
+
+- [ ] **Step 3: Implement**
+
+Three changes in the pane, each small:
+
+1. Put `Delete` in its own `.artifact-danger` group, separated from `Verified`/`Hide`.
+2. Make the title row `position: sticky; top: 0` inside the scrolling pane, so what you are reading keeps its name.
+3. Move the `copy` control out of the text flow it currently overlaps — into the sticky title row, where it has somewhere to live that is not on top of the first paragraph.
+
+- [ ] **Step 4: Run the tests, then look at it**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS. Then open an artifact at both 1400px and 420px: `copy` never covers a word, the title stays while scrolling.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/_artifact_detail.html assets/css/40-search.css
+git commit -m "fix(ui): copy off the text, the name kept, and delete set apart"
+```
+
+---
+
+### Task 16: A passage cut mid-sentence says where the rest is
+
+**Files:**
+- Modify: `src/web/ui.rs` (`build_artifact_detail`, near `ui.rs:2963`)
+- Modify: `src/web/templates/_artifact_detail.html`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_passage_that_stops_mid_sentence_points_at_its_continuation() {
+        // The pane ended "…der bereits vorgestellte Einsatz von" while the
+        // source beside it showed the rest of the sentence.
+        let d = build_detail_fixture_ending("Die erste Vorkehrung ist der bereits vorgestellte Einsatz von");
+        assert!(d.continues_at.is_some(), "no way onward from a cut sentence");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_passage_that_stops_mid_sentence`
+Expected: FAIL — no such field.
+
+- [ ] **Step 3: Implement**
+
+Add `continues_at: Option<String>` to the detail struct, set to the id of the next artifact of the same corpus by ordinal when this one's text does not end on sentence-final punctuation. Render it as a quiet link at the foot of the artifact: "continues in the next passage". Comment why the test is on punctuation rather than on the chunker: the pane cannot know whether a boundary was semantic, but it can tell that a sentence did not finish.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs src/web/templates/_artifact_detail.html
+git commit -m "feat(ui): a sentence that does not finish says where it goes on"
+```
+
+---
+
+### Task 17: Elapsed time stops being borrowed from a future-tense helper
+
+**Files:**
+- Modify: `src/web/ui.rs:331` (add `fmt_elapsed` beside `fmt_duration`), `ui.rs:2286`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Produces: `pub fn fmt_elapsed(secs: i64) -> String`. `fmt_duration` is untouched — other callers depend on its future tense.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_sweep_that_took_no_time_does_not_say_it_happens_now() {
+        // Every row of Housekeeping's TOOK column read "now", because the
+        // column spends `fmt_duration`, which answers "when does this run
+        // next" — "now", "in 5m" — not "how long did this take".
+        assert_eq!(fmt_elapsed(0), "0s");
+        assert_eq!(fmt_elapsed(3), "3s");
+        assert_eq!(fmt_elapsed(75), "1m 15s");
+        assert_eq!(fmt_elapsed(3600), "1h 0m");
+        // And the future-tense helper keeps its own meaning.
+        assert_eq!(fmt_duration(0), "now");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_sweep_that_took_no_time`
+Expected: FAIL — `cannot find function fmt_elapsed`.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// How long something took, past tense.
+///
+/// `fmt_duration` above answers a different question — when does this run
+/// next — and says "now" for zero and "in 5m" for three hundred. Housekeeping
+/// spent it on the TOOK column, so every sweep in the history claimed to have
+/// taken "now".
+pub fn fmt_elapsed(secs: i64) -> String {
+    match secs.max(0) {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m {}s", s / 60, s % 60),
+        s => format!("{}h {}m", s / 3600, (s % 3600) / 60),
+    }
+}
+```
+
+At `ui.rs:2286`, call `fmt_elapsed` instead of `fmt_duration`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs
+git commit -m "fix(ops): how long a sweep took, in the tense that question is asked in"
+```
+
+---
+
+### Task 18: Housekeeping reads like a status, not a paragraph
+
+**Files:**
+- Modify: `src/web/templates/ops.html`
+- Modify: `assets/css/43-ops.css`
+- Modify: `src/web/ui.rs` (a display name per sweep stage)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn an_ops_row_shows_no_markup_in_a_title() {
+        // "**Was nicht abgedeckt ist:** *" was a row heading on the
+        // deployment.
+        let html = render_ops_fixture_with_merged_title("**Was nicht abgedeckt ist:** * Es werden keine");
+        assert!(!html.contains("**"), "{html}");
+    }
+
+    #[test]
+    fn a_sweep_stage_reads_as_words_and_keeps_its_identifier() {
+        assert_eq!(sweep_label("arm_dedupe"), "Arming dedupe");
+        assert_eq!(sweep_label("consolidate"), "Consolidating");
+        assert_eq!(sweep_label("retention"), "Retention");
+        // An identifier nobody has worded yet is shown, not swallowed.
+        assert_eq!(sweep_label("some_new_sweep"), "some_new_sweep");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_sweep_stage_reads_as_words`
+Expected: FAIL — `cannot find function sweep_label`.
+
+- [ ] **Step 3: Implement**
+
+Add `sweep_label`, mapping the known stages and returning the raw identifier unchanged for anything else — a new sweep must never silently render as nothing. Put the raw name in the row's `title` attribute so it stays greppable. Then break the opening counts paragraph into a stat row (`43-ops.css`), one figure per cell with its label under it.
+
+The Merged and Generated tables on this page list artifacts by title, and those titles carry their own markup — the deployment showed `**Was nicht abgedeckt ist:** *` as a row heading. Pass them through `markdown::stand_in_title` (Task 1) the same way every other list now does, so the page stops being the last place raw markdown reaches a reader.
+
+- [ ] **Step 4: Run the tests, then look at the page**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/ops.html assets/css/43-ops.css src/web/ui.rs
+git commit -m "feat(ops): the counts as figures, and the sweeps in words"
+```
+
+---
+
+### Task 19: One name for the page, and a 404 that belongs to the app
+
+**Files:**
+- Modify: `src/web/ui.rs` (router, near `ui.rs:3044`)
+- Create: `src/web/templates/not_found.html`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn housekeeping_is_one_name_and_one_url() {
+        // The nav says Housekeeping, the URL says /ui/ops, the title says Ops,
+        // and /ui/housekeeping was the browser's own error page.
+        let r = get("/ui/housekeeping").await;
+        assert_eq!(r.status(), 308);
+        assert_eq!(r.headers()["location"], "/ui/ops");
+    }
+
+    #[tokio::test]
+    async fn an_unknown_ui_path_gets_the_apps_own_page() {
+        let r = get("/ui/nothing-here").await;
+        assert_eq!(r.status(), 404);
+        let body = body_string(r).await;
+        assert!(body.contains("engram"), "the browser's error page, not ours: {body}");
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib web::ui::tests::housekeeping_is_one_name web::ui::tests::an_unknown_ui_path`
+Expected: FAIL — 404 from the router with no body, and no redirect route.
+
+- [ ] **Step 3: Implement**
+
+Add a permanent redirect from `/ui/housekeeping` to `/ui/ops`, and a router `.fallback` rendering a `not_found.html` that extends `layout.html` — so a mistyped URL still has the nav, and a way back. Settle the naming in one direction: keep the URL, and make the page title match the nav word rather than the route.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/ui.rs src/web/templates/not_found.html
+git commit -m "feat(ui): one name for housekeeping, and our own page for a wrong turn"
+```
+
+---
+
+### Task 20: An empty table says it is empty
+
+**Files:**
+- Modify: `src/web/templates/settings.html:27-56`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_token_table_with_no_tokens_says_so_instead_of_showing_its_headings() {
+        // Five column headings over nothing is a table pretending to have
+        // rows.
+        let html = render_settings_fixture(vec![]);
+        assert!(!html.contains("Minted by"), "{html}");
+        assert!(html.contains("No tokens yet"), "{html}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_token_table_with_no_tokens`
+Expected: FAIL — headings render unconditionally.
+
+- [ ] **Step 3: Implement**
+
+Wrap the `<table>` in `{% if !tokens.is_empty() %}`, with an `{% else %}` saying there are none yet and what minting one is for. This is the same reasoning `_decide.html` already states at its top — "the old Ops page answered five headings with 'None.' and made an empty base look like a backlog".
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/settings.html src/web/ui.rs
+git commit -m "fix(settings): no column headings over an empty table"
+```
+
+---
+
+### Task 21: A gap's state stops looking like a button
+
+**Files:**
+- Modify: `src/web/templates/_gaps.html`
+- Modify: `assets/css/41-capture.css`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn a_gaps_row_tells_its_state_apart_from_its_actions() {
+        // "asked", "ask again" and "covered" rendered as three identical
+        // ghost controls, one of which was not a control at all.
+        let html = render_gaps_fixture();
+        assert!(html.contains("gap-state"), "the state is styled as an action: {html}");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_gaps_row_tells_its_state_apart`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Give the state word (`asked`, `nothing near`, `pursued`, `judged`) a `.gap-state` badge class distinct from `.btn`, leaving `ask again` and `covered` as the only two things that look pressable. Also give `not yet grouped` a sentence saying what it means — the sweep has not run yet, and these are questions the base did not answer.
+
+- [ ] **Step 4: Run the tests, then look at the page**
+
+Run: `cargo test --lib web::ui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/templates/_gaps.html assets/css/41-capture.css src/web/ui.rs
+git commit -m "fix(capture): what a gap is, beside what you can do about it"
+```
+
+---
+
+### Task 22: The whole suite, and a look at the running app
+
+**Files:** none
+
+- [ ] **Step 1: Run everything**
+
+Run: `cargo test`
+Expected: PASS, with no test disabled or deleted along the way.
+
+- [ ] **Step 2: Run clippy and the formatter**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --check`
+Expected: clean.
+
+- [ ] **Step 3: Drive the app**
+
+Start it against a copy of a real base and walk the same path the review took: a search, an artifact, a full ask, capture, judge, housekeeping, settings — at 1400px and at 420px, in both themes. Confirm each finding this plan claims to fix is fixed, and that nothing in the "left as they are" list moved.
+
+- [ ] **Step 4: Commit anything the walk turned up**
+
+```bash
+git add -A
+git commit -m "fix(ui): what the walk through the running app turned up"
+```

--- a/docs/superpowers/specs/2026-08-20-one-system-design.md
+++ b/docs/superpowers/specs/2026-08-20-one-system-design.md
@@ -1,0 +1,429 @@
+# One system — sleep, the sitting, and one queue for what is missing — Design
+
+Date: 2026-08-20
+Status: draft
+Adds `src/jobs/sleep.rs`, `src/core/sitting.rs`; touches
+`src/core/background.rs`, `src/core/search.rs`, `src/store/gaps.rs`,
+`src/store/jobs.rs`, `src/store/schema.sql`, `src/web/ui.rs`, `ROADMAP.md`.
+Adds no model call anywhere. See §3 for what it is not allowed to break.
+
+## 1. Why
+
+The mechanisms are built. What is missing between them is not a mechanism.
+
+**The background work has no order.** Six tickers run on six intervals, each
+started separately in `main`, each gated separately, none aware of the others:
+`spawn_consolidation_ticker` (`consolidate.interval_hours`),
+`spawn_repair_ticker` (its own period, behind no setting at all),
+`spawn_retention_ticker` (`feedback.sweep_hours`, which also carries the gap
+sweep), `spawn_dedupe_ticker` (`consolidate.dedupe_interval_mins`),
+`spawn_pursuit_ticker` (`pursuit.idle_secs / 2`) and `spawn_associate_ticker`
+(`associate.interval_mins`). Where their work is directional, nothing expresses
+it: `Relate` arms the pairs that `Dedupe` and the consolidation sweep both
+read, the three sit on two tickers whose periods are configured in different
+units, and which of them runs first on a given night is whichever interval
+elapsed first. Inside one ticker the order is right — `associate::run` replays
+before it prunes, the retention ticker expires before it regroups the gaps —
+which is exactly the point: the ordering that was easy to see was written
+down, and the ordering that crosses a ticker boundary was not.
+
+And nothing reports. Each ticker logs its own line at `info`. There is no
+answer to *what did the memory do while I was away*, which is the question a
+system that describes itself as sleeping has to be able to answer.
+
+**The sitting exists, but only afterwards.** `jobs/pursuit.rs` reconstructs one
+from idle gaps in the search log: searches closer together than
+`pursuit.idle_secs` are one sitting, and a sitting that engaged several
+artifacts without the base answering earns a pursuit. So the base can name what
+you were working on last Tuesday. It cannot name what you are working on now.
+`Core::record_interaction` writes `interaction_events` on every open, and
+nothing reads that table until the sweep runs, `idle_secs` after you stopped.
+
+The cost is paid at every door: search, ask, capture and judge are four pages
+with nothing carried between them. A query typed on the rail is retyped into
+ask. An answer worth keeping prefills the capture box and loses the question it
+answered. Nothing anywhere says *these are the six artifacts this afternoon has
+been about*.
+
+**Four ways to say the base did not answer, ending in four places.** A search
+judged `gap` becomes a `GapKind::Search`. An ask verdict of *nothing here*
+becomes a `GapKind::Ask` by a second path. A quiet run of engaged searches
+becomes a **pursuit**, which lands on Ops and is never a gap. And a search
+abandoned with nothing opened — recorded deliberately, described in the README
+as *the most telling of all* — becomes nothing whatsoever. One statement about
+one hole, filed under four vocabularies, three of which the operator has to
+visit separately.
+
+## 2. Goal
+
+Three seams, no new mechanism, no model call that is not already being made:
+
+1. **Sleep.** One cycle, one ticker, phases in a fixed order, each phase
+   keeping its own rhythm. One report per cycle, on Ops.
+2. **The sitting.** A live, session-scoped working memory: what this sitting
+   has touched, carried between the doors, expiring with it.
+3. **One queue.** The four exits above become four `GapKind`s in the list that
+   already exists, closable three ways, and a capture says what it closed.
+
+### Non-goals
+
+- **A scheduler.** No cron expression, no calendar, no "sleep at 03:00". A
+  cycle is a loop with a period, as today; what changes is that there is one of
+  it and its phases are ordered.
+- **New background work.** Every phase is an existing function called in an
+  order it was not called in before. Nothing new runs, and nothing that runs
+  today stops.
+- **Persisting the sitting.** It lives in memory, dies with the process, and is
+  never written to `activation`. A working memory that survives a restart is a
+  long-term memory, and engram already has one.
+- **Moving ranking by default.** Working-memory priming changes the order of a
+  result list. It ships behind a flag that is **off**, until the harness has
+  been run on it. See §3 and §9.
+- **Engagement at every door.** Retrieval is recorded over `/mcp` and the API;
+  engagement is not (`mark_artifact_seen` and `record_interaction` have one
+  production caller between them, the dwell route). Making the other doors
+  engage is the natural next thing and is deliberately not here — it changes
+  what activation means, and this design changes when activation is read.
+  Named in `ROADMAP.md` [Associative Memory].
+- **Access reconsolidation, error-driven re-synthesis, the corpus map.**
+  Unchanged, still on the roadmap, and all three slot into the cycle §4 builds.
+
+## 3. What this must not break
+
+Four things in the tree are load-bearing and easy to lose here.
+
+**Lazy decay stays lazy.** Activation and link weight both fold their decay in
+at read and at bump. A cycle is a tempting place to put a decay pass, and it
+would be a regression: a scheduled pass makes every number stale between
+passes, and `bumping_folds_the_decay_in_rather_than_adding_to_a_stale_number`
+pins the behaviour that avoids it. No phase writes a decayed value.
+
+**Repair must not join the cycle.** `spawn_repair_ticker` carries a comment
+recording exactly this mistake: its four passes used to ride the consolidation
+sweep, and `consolidate.enabled = false` returned before their loop, so a
+corpus left `segmenting` by a crash was never repaired on an install that had
+switched consolidation off. `a_crashed_capture_is_repaired_with_the_sweep_switched_off`
+pins it. Repair is what fixes an *interrupted cycle*; a cycle that owns its own
+repair cannot recover from its own failure. It stays a separate ticker, behind
+no setting, and this design does not touch it.
+
+**One queued sweep, however often the ticker fires.** `jobs` is
+`UNIQUE(stage, target_id)`, and every collection-scoped sweep enqueues against
+the target `"collection"` to get at-most-one for free. The cycle keeps that
+shape: one `Stage::Sleep` unit, one target.
+
+**A default that changes ranking moves only after the harness has run.** The
+sitting's carry and its display change no order and ship on. Its priming
+changes order and ships off (§9).
+
+## 4. Sleep
+
+### 4.1 The shape
+
+One ticker, `spawn_sleep_ticker`, enqueueing `Stage::Sleep` against
+`"collection"`. One job handler, `jobs::sleep::run`, which calls the existing
+phase functions in a fixed order. The five tickers it replaces are deleted;
+`spawn_repair_ticker` is not (§3).
+
+The phases, in the only order their data dependencies allow:
+
+| # | Phase | What runs today | Rhythm |
+|---|---|---|---|
+| 1 | Replay | `jobs::associate::run` — events and verdicts folded into links, then `prune_learning_links` and `reopen_stale_judged_links` | `associate.interval_mins` |
+| 2 | Pursue | `jobs::pursuit` sweep — groups quiet sittings, decides, arms `Generate` | `pursuit.idle_secs / 2` |
+| 3 | Relate & dedupe | `Stage::Relate` arming, `jobs::dedupe` | `consolidate.dedupe_interval_mins` |
+| 4 | Consolidate | `jobs::consolidate` sweep | `consolidate.interval_hours` |
+| 5 | Retention | `expire_feedback` | `feedback.sweep_hours` |
+| 6 | Gaps | `jobs::gaps::sweep` | `feedback.sweep_hours` |
+
+Two of these orderings are already correct and are being written down rather
+than fixed: replay before prune, inside `associate::run`, and retention before
+the gap sweep, inside the retention ticker. Two are not expressed anywhere
+today and are the reason the table is worth having: **relate before dedupe
+before consolidate**, a pipeline spread over two tickers, and **replay before
+pursue**, so a sitting is scored against links this cycle folded in rather
+than against last half-hour's.
+
+Two things that look like phases and are not:
+
+- **Activation decay.** There is no decay pass and this design does not add
+  one. `decayed(value, stamp, at, half_life)` is folded in at every bump and
+  every read (`store/links.rs`), which is the better design — a lazily decayed
+  number is never stale — and it means nothing that reads activation has a
+  scheduling dependency on decay at all.
+- **Promotion.** `jobs::promote::maybe_promote` fires at the bump, from
+  `mark_artifact_seen` and from `associate`. It is event-driven, and the one
+  scheduled call to it — from the pursuit sweep — is the cheap backstop
+  `ROADMAP.md` [Core Platform] already proposes retiring. Nothing to schedule,
+  so no phase.
+
+### 4.2 Rhythms are kept, not flattened
+
+Replaying a search log wants half-hourly. A consolidation sweep wants six-hourly
+and would be wasteful hourly. Collapsing six intervals into one number would
+either make the cheap phases rare or the expensive ones constant, and both are
+worse than the accidental order this replaces.
+
+So the ticker fires at the **shortest configured rhythm**, and each phase
+carries a due-time: a phase runs when its own interval has elapsed since it last
+completed. The last-completed stamps live in `meta`, which already holds exactly
+this kind of cursor with no row to live on (`associate.events_after` and its
+two siblings). Keys: `sleep.phase.<name>.at`.
+
+A cycle where only phase 1 is due runs phase 1 and reports one line. The
+existing per-subsystem interval keys are unchanged and keep their meanings —
+this is the same six rhythms, ordered, in one loop.
+
+### 4.3 The report
+
+```sql
+CREATE TABLE IF NOT EXISTS sleep_cycles (
+  id         INTEGER PRIMARY KEY,
+  started_at INTEGER NOT NULL,
+  ended_at   INTEGER,
+  -- Per-phase outcome, JSON: name, ran|skipped|failed, duration, counts.
+  -- Read on Ops and rendered; never parsed for a decision.
+  phases     TEXT NOT NULL DEFAULT '[]'
+);
+```
+
+Bounded by the retention pass to the last 200 cycles — a cycle report is
+housekeeping about housekeeping and is not worth a policy.
+
+Each phase's counts are what its function already returns: links strengthened
+and pruned (`associate::run` has them), windows promoted, pairs judged, merges
+written, clusters named, rows expired. Ops gains one block at the top: *Last
+slept 03:14, 40s — 412 links strengthened, 8 forgotten, 3 windows synthesised,
+2 merges, 1 gap named.* A phase that failed says so and names its error; the
+cycle continues to the next phase, because a failed consolidation is not a
+reason to skip retention.
+
+### 4.4 Failure and shutdown
+
+Unchanged from what the tickers do now: a failed phase is retried on the next
+cycle, its due-stamp not advanced, and nothing takes the process down. The
+`Stage::Sleep` unit is claimed and released by the existing queue, so a cycle
+interrupted by a restart is re-armed by the repair ticker like any other
+interrupted unit.
+
+## 5. The sitting
+
+### 5.1 What it is
+
+An in-memory map on `Core`, keyed by **sitting id**: the web session id for a
+browser (`sessions.id`, which exists), the token id for the API and `/mcp`. One
+entry:
+
+```rust
+pub struct Sitting {
+    /// Artifact ids touched, most recent first, capped at CARRY.
+    touched: VecDeque<Touched>,
+    /// The queries typed in this sitting, most recent first, capped at CARRY.
+    queries: VecDeque<String>,
+    last_at: i64,
+}
+```
+
+`CARRY = 20`. An entry idle for `pursuit.idle_secs` — the same number that
+already defines a sitting for the sweep — is dropped, so the live definition
+and the reconstructed one agree by construction. No table, no persistence, no
+write to `activation`.
+
+Touched is written where engagement is already recorded: `mark_artifact_seen`,
+`record_interaction`, and an ask's citations. It costs a lock and a push, off
+the request path like every other bookkeeping write in `search.rs`.
+
+### 5.2 What it does — carrying (ships on)
+
+Nothing here changes an order.
+
+- **Search → ask.** The ask box arrives prefilled with the last query of the
+  sitting when it is empty and the sitting is warm.
+- **Ask → capture.** The keep-this-answer link already prefills the capture
+  box; it gains the question it answered, as the note, so the trace records
+  what the text was written for. This is the existing operator decision, better
+  recorded — nothing is written without the person, and that line does not move.
+- **A rail of what this sitting has touched**, on search and ask, six at most,
+  each a link. Dismissible, and absent on a cold sitting.
+
+### 5.3 What it does — priming (ships off)
+
+A hit that is in `touched` is primed, by the same rank-based, bounded rule
+`search::prime` already implements for activation, and **inside the same
+budget**: a hit cannot be lifted `prime_lift` places for activation and again
+for the sitting. Index 0 remains untouchable. A hit lifted by the sitting says
+so on the rail — *seen in this sitting* — for the same reason a primed hit says
+so today.
+
+This is the one part of this design that moves ranking. `sitting.prime` is
+`false` by default until `cargo test --test eval` has been run with it on and
+off against the judged-pair set. §9.
+
+### 5.4 What it does not do
+
+It does not write activation, open a pursuit, or survive the process. The
+pursuit sweep is unchanged and still reconstructs its own sittings from the
+log: the live sitting is a *read* of what is happening, and a sweep that
+depended on process memory would lose a day's pursuits to a restart.
+
+## 6. One queue for what is missing
+
+### 6.1 Two more kinds, not a new table
+
+`GapKind` is `{ Ask, Search }` and a gap is a reference to the row it came from
+plus its stored query vector. Both new exits fit that shape:
+
+```rust
+pub enum GapKind { Ask, Search, Abandoned, Pursuit }
+```
+
+- **`Abandoned`** — a recorded search that settled (past `feedback.coalesce_secs`,
+  the same predicate `associate` uses to decide an event is settled), was never
+  judged, has `answered = 0`, and has no `interaction_events` row in its window.
+  Nothing was opened; the list did not answer.
+- **`Pursuit`** — a pursuit that closed `unsatisfied`. Today it is a row on Ops
+  and nothing else. Its clustered queries are already stored on the row and are
+  exactly what a gap needs.
+
+`gap_clusters.members` is already `(kind, id)` pairs and needs no change.
+Clustering, naming, and the model call that names a group are untouched.
+
+### 6.2 An abandonment is a weak gap
+
+Most searches end without a click, and a system that called each of them a hole
+would file the operator's typing as failure. Two guards:
+
+1. An `Abandoned` gap is **never shown ungrouped**. The capture page's
+   ungrouped list stays judged gaps only. An abandonment reaches the operator
+   only by clustering with something else — and `MIN_CLUSTER` is 2, so the
+   floor is *two questions about one hole*, at least one of which someone
+   either judged or asked in earnest.
+2. Only the last search of a burst counts. A typing burst already folds into
+   one event by `coalesce_secs`; what survives folding is the query as it was
+   finished.
+
+### 6.3 Closing
+
+Three ways in, three ways out.
+
+- **A capture covers it.** When a corpus reaches `ready`, the open gaps' stored
+  query vectors are searched against **that corpus's new artifacts only** — one
+  filtered vector query per open gap, no model call, on the background handle.
+  A gap whose best new hit is at or above `vector.weak_below` is marked
+  covered, and the capture page says so: *this closes 2 open gaps*, naming them.
+  This is the same test `search_events.answered` already applies, against a
+  narrower set.
+- **A pursuit earns it.** Unchanged: a pursuit that generates an artifact
+  closes `generated`, and its gap closes with it.
+- **The operator dismisses it.** Unchanged: `dismissed_at`, the existing
+  button, now on one list instead of two.
+
+### 6.4 What the operator sees
+
+One list, on the capture page where it already is, each row badged with what
+asked it: *judged*, *asked*, *abandoned*, *pursued*. Ops loses its separate
+pursuits table and links into this list instead.
+
+## 7. Surface
+
+- **Ops** gains the sleep block (§4.3) at the top, and loses the pursuits table
+  to §6.4.
+- **Capture** gains kind badges and the coverage line.
+- **Search and ask** gain the sitting rail (§5.2) and, with `sitting.prime` on,
+  one more reason a hit can say it was lifted.
+- Nothing gains a graph, a dashboard, or a chart. The search box stays the
+  application.
+
+## 8. Data model summary
+
+| Change | Where |
+|---|---|
+| `sleep_cycles` table | new, §4.3 |
+| `sleep.phase.<name>.at` cursors | `meta`, existing table |
+| `Stage::Sleep` | `store/jobs.rs` |
+| `GapKind::{Abandoned, Pursuit}` | `store/gaps.rs` |
+| Sitting map | in memory on `Core`, no schema |
+
+No column is dropped, no existing table is altered, and the migration is one
+`CREATE TABLE IF NOT EXISTS`.
+
+## 9. Configuration
+
+```toml
+[sleep]
+enabled = true          # false runs nothing; repair is unaffected (§3)
+
+[sitting]
+prime = false           # moves ranking; off until the harness says otherwise
+```
+
+Two keys. The six existing interval keys keep their names and their meanings
+and become phase rhythms (§4.2), so an operator who tuned
+`associate.interval_mins` finds it still doing what it did.
+
+`sleep.enabled = false` is for the harness and for debugging a phase in
+isolation; it is not a supported way to run.
+
+## 10. Testing
+
+- **Order.** A cycle with all phases due runs them in the table's order —
+  asserted on the recorded `phases` JSON, which is what makes the ordering
+  claim testable at all.
+- **Rhythm.** A phase whose interval has not elapsed is skipped and its
+  due-stamp is not advanced; a phase that fails is skipped next cycle only if
+  its interval has not elapsed, and retried otherwise.
+- **The pinned regression.** `a_crashed_capture_is_repaired_with_the_sweep_switched_off`
+  must still pass with `sleep.enabled = false` (§3). This is the test that
+  fails if repair is ever folded in.
+- **One unit.** A ticker firing three times before the cycle is claimed leaves
+  one queued `Stage::Sleep`, as `the_ticker_queues_exactly_one_sweep` asserts
+  for consolidation today.
+- **Sitting expiry.** An entry idle past `pursuit.idle_secs` is gone; a warm
+  one carries. A sitting is never written to `activation` — asserted directly,
+  because it is the guard most likely to be lost to a convenient refactor.
+- **Priming budget.** A hit in `touched` and activated does not move more than
+  `prime_lift` places in total, and rank 0 never moves.
+- **Abandonment floor.** One abandoned search alone produces no visible gap;
+  two clustering ones produce a named group.
+- **Coverage.** A capture that answers an open gap closes it and reports it; a
+  capture that does not, does not.
+- **Harness.** `cargo test --test eval` with `sitting.prime` on and off, on the
+  judged-pair set, before that default moves.
+
+## 11. Rollout
+
+In three commits, in this order, because each is independently useful and
+independently revertible:
+
+1. **The cycle** (§4). Pure reorganisation: the same functions, in an order,
+   with a report. No behaviour the operator asked for changes, and the one
+   behaviour they did not ask for — promotion reading an undecayed activation —
+   stops.
+2. **The queue** (§6). Two kinds, two guards, one coverage check. Visible on
+   day one on any base with recorded feedback.
+3. **The sitting** (§5), carrying only. Priming lands behind its flag in the
+   same commit and is switched on, if at all, by a separate one carrying the
+   harness numbers in its message.
+
+## 12. Risks
+
+- **The cycle serialises what ran concurrently.** Six tickers could overlap;
+  one cycle cannot. A long consolidation now delays the next replay by its
+  duration. Mitigated by the rhythms (§4.2) — a phase that is not due costs a
+  timestamp comparison — and bounded by the fact that every phase already caps
+  its own work per tick (`REPLAY_LIMIT`, `PRUNE_SCAN_LIMIT`,
+  `max_dedupe_per_tick`). If it bites, the answer is to split the cycle in two
+  by cost, not to go back to six.
+- **Abandonment floods the gap list.** The two guards in §6.2 are a judgement,
+  not a measurement, and the right floor is a number nobody has. It ships
+  visible and easy to walk back: an abandoned gap is one `WHERE kind != …`
+  from being invisible again.
+- **The sitting makes results feel unstable.** The same query in two sittings
+  ranks differently, which is precisely what priming is for and precisely what
+  is disorienting about it. Hence off by default, hence the badge, hence rank 0
+  never moving.
+- **Coverage marks a gap closed that is not.** A vector hit above
+  `weak_below` from a new corpus is a weak claim to have answered a question.
+  It is the same claim `answered` already makes, and closing is reversible:
+  the gap's source row is untouched, so a covered gap can be reopened by the
+  operator without inventing a state for it.

--- a/docs/superpowers/specs/2026-08-20-one-system-design.md
+++ b/docs/superpowers/specs/2026-08-20-one-system-design.md
@@ -1,31 +1,40 @@
-# One system — sleep, the sitting, and one queue for what is missing — Design
+# One system — scheduling, the sitting, and one queue for what is missing — Design
 
 Date: 2026-08-20
 Status: draft
-Adds `src/jobs/sleep.rs`, `src/core/sitting.rs`; touches
+Adds `src/core/sitting.rs`; touches `src/store/jobs.rs`, `src/store/schema.sql`,
 `src/core/background.rs`, `src/core/search.rs`, `src/store/gaps.rs`,
-`src/store/jobs.rs`, `src/store/schema.sql`, `src/web/ui.rs`, `ROADMAP.md`.
-Adds no model call anywhere. See §3 for what it is not allowed to break.
+`src/web/ui.rs`, `ROADMAP.md`.
+Adds no model call anywhere, one column, one table, and no new subsystem.
+See §3 for what it is not allowed to break.
 
 ## 1. Why
 
 The mechanisms are built. What is missing between them is not a mechanism.
 
-**The background work has no order.** Six tickers run on six intervals, each
-started separately in `main`, each gated separately, none aware of the others:
-`spawn_consolidation_ticker` (`consolidate.interval_hours`),
+**The background work has no order and no account.** Six tickers run on six
+intervals, each started separately, each gated separately, none aware of the
+others: `spawn_consolidation_ticker` (`consolidate.interval_hours`),
 `spawn_repair_ticker` (its own period, behind no setting at all),
 `spawn_retention_ticker` (`feedback.sweep_hours`, which also carries the gap
 sweep), `spawn_dedupe_ticker` (`consolidate.dedupe_interval_mins`),
 `spawn_pursuit_ticker` (`pursuit.idle_secs / 2`) and `spawn_associate_ticker`
-(`associate.interval_mins`). Where their work is directional, nothing expresses
-it: `Relate` arms the pairs that `Dedupe` and the consolidation sweep both
-read, the three sit on two tickers whose periods are configured in different
-units, and which of them runs first on a given night is whichever interval
-elapsed first. Inside one ticker the order is right — `associate::run` replays
-before it prunes, the retention ticker expires before it regroups the gaps —
-which is exactly the point: the ordering that was easy to see was written
-down, and the ordering that crosses a ticker boundary was not.
+(`associate.interval_mins`).
+
+Where their work is directional, nothing expresses it: `Relate` arms the pairs
+that `Dedupe` and the consolidation sweep both read, the three sit on two
+tickers whose periods are configured in different units, and which runs first
+on a given night is whichever interval elapsed first. Inside one ticker the
+order is right — `associate::run` replays before it prunes, the retention
+ticker expires before it regroups the gaps — which is exactly the point: the
+ordering that was easy to see got written down, and the ordering that crosses a
+ticker boundary did not.
+
+Nor does anything decide what matters. A worker claims `ORDER BY attempts, seq,
+id`: least-tried, then oldest. So a capture the operator is watching queues
+behind a consolidation sweep armed a minute earlier, and waits for it. There is
+no way to say that one of those has somebody in front of it and the other does
+not.
 
 And nothing reports. Each ticker logs its own line at `info`. There is no
 answer to *what did the memory do while I was away*, which is the question a
@@ -33,236 +42,279 @@ system that describes itself as sleeping has to be able to answer.
 
 **The sitting exists, but only afterwards.** `jobs/pursuit.rs` reconstructs one
 from idle gaps in the search log: searches closer together than
-`pursuit.idle_secs` are one sitting, and a sitting that engaged several
-artifacts without the base answering earns a pursuit. So the base can name what
-you were working on last Tuesday. It cannot name what you are working on now.
+`pursuit.idle_secs` are one sitting. So the base can name what you were working
+on last Tuesday and not what you are working on now.
 `Core::record_interaction` writes `interaction_events` on every open, and
 nothing reads that table until the sweep runs, `idle_secs` after you stopped.
 
 The cost is paid at every door: search, ask, capture and judge are four pages
 with nothing carried between them. A query typed on the rail is retyped into
 ask. An answer worth keeping prefills the capture box and loses the question it
-answered. Nothing anywhere says *these are the six artifacts this afternoon has
-been about*.
+answered.
 
 **Four ways to say the base did not answer, ending in four places.** A search
 judged `gap` becomes a `GapKind::Search`. An ask verdict of *nothing here*
-becomes a `GapKind::Ask` by a second path. A quiet run of engaged searches
-becomes a **pursuit**, which lands on Ops and is never a gap. And a search
-abandoned with nothing opened — recorded deliberately, described in the README
-as *the most telling of all* — becomes nothing whatsoever. One statement about
-one hole, filed under four vocabularies, three of which the operator has to
-visit separately.
+becomes a `GapKind::Ask` by a second path. A pursuit that closes `unsatisfied`
+lands on Ops and is never a gap. And a search where **nothing came close** —
+every hit under `vector.weak_below`, the rail saying *nothing matches closely*
+in as many words — is recorded, read by nothing but the link replay and the
+export, and reaches the operator never.
 
 ## 2. Goal
 
-Three seams, no new mechanism, no model call that is not already being made:
+Three seams. No new subsystem, and no model call that is not already made.
 
-1. **Sleep.** One cycle, one ticker, phases in a fixed order, each phase
-   keeping its own rhythm. One report per cycle, on Ops.
+1. **Scheduling.** The job queue becomes what it is already three-quarters of:
+   a scheduler with states, priority, ageing and dependencies. One column, and
+   the tickers become units that reschedule themselves.
 2. **The sitting.** A live, session-scoped working memory: what this sitting
-   has touched, carried between the doors, expiring with it.
+   has touched, carried between the doors, gone when it goes.
 3. **One queue.** The four exits above become four `GapKind`s in the list that
-   already exists, closable three ways, and a capture says what it closed.
+   already exists, closable three ways.
 
 ### Non-goals
 
-- **A scheduler.** No cron expression, no calendar, no "sleep at 03:00". A
-  cycle is a loop with a period, as today; what changes is that there is one of
-  it and its phases are ordered.
-- **New background work.** Every phase is an existing function called in an
-  order it was not called in before. Nothing new runs, and nothing that runs
-  today stops.
-- **Persisting the sitting.** It lives in memory, dies with the process, and is
-  never written to `activation`. A working memory that survives a restart is a
-  long-term memory, and engram already has one.
-- **Moving ranking by default.** Working-memory priming changes the order of a
-  result list. It ships behind a flag that is **off**, until the harness has
-  been run on it. See §3 and §9.
-- **Engagement at every door.** Retrieval is recorded over `/mcp` and the API;
-  engagement is not (`mark_artifact_seen` and `record_interaction` have one
-  production caller between them, the dwell route). Making the other doors
-  engage is the natural next thing and is deliberately not here — it changes
-  what activation means, and this design changes when activation is read.
-  Named in `ROADMAP.md` [Associative Memory].
-- **Access reconsolidation, error-driven re-synthesis, the corpus map.**
-  Unchanged, still on the roadmap, and all three slot into the cycle §4 builds.
+- **Time slices.** A unit runs to completion. Every sweep already caps its own
+  work per run (`REPLAY_LIMIT`, `PRUNE_SCAN_LIMIT`, `max_dedupe_per_tick`), so
+  "to completion" is bounded already; yielding mid-sweep would mean every sweep
+  carrying its own resume point, and the queue already has one of those in
+  `segments`.
+- **A priority scale.** One distinction, not a number. §4.3.
+- **A calendar.** No cron expression, no "sleep at 03:00". Periods, as today.
+- **Persisting the sitting.** In memory, gone on restart. §5.1.
+- **The sitting at the other doors.** Web session only. §5.4.
+- **Engagement at every door**, **access reconsolidation**, **error-driven
+  re-synthesis**, **the corpus map.** Unchanged and still on the roadmap. All
+  four get easier once this lands, and none of them are here.
 
 ## 3. What this must not break
 
-Four things in the tree are load-bearing and easy to lose here.
+**The claim query stays covering and unsorted.** `idx_jobs_claim2` is
+`(state, attempts, seq, id, run_after)` and its comment records why that column
+order and not the obvious one: an inequality ends an index's usable ordering,
+so putting `run_after` earlier turns every poll into a temp B-tree sort.
+Priority goes in front of `attempts`, and ageing is written rather than
+computed (§4.4), precisely so the claim stays one index walk that stops at the
+first ready row.
 
-**Lazy decay stays lazy.** Activation and link weight both fold their decay in
-at read and at bump. A cycle is a tempting place to put a decay pass, and it
-would be a regression: a scheduled pass makes every number stale between
-passes, and `bumping_folds_the_decay_in_rather_than_adding_to_a_stale_number`
-pins the behaviour that avoids it. No phase writes a decayed value.
+**`seq` keeps doing its job.** Claiming orders by `seq` so that every
+document's first window runs before any document's second, which is what stops
+a large ingest starving a small one. Priority sorts *before* `seq`, never
+instead of it: within one class the existing fairness is untouched.
 
-**Repair must not join the cycle.** `spawn_repair_ticker` carries a comment
-recording exactly this mistake: its four passes used to ride the consolidation
+**Repair does not join the schedule.** `spawn_repair_ticker` carries a comment
+recording exactly this mistake: its passes used to ride the consolidation
 sweep, and `consolidate.enabled = false` returned before their loop, so a
-corpus left `segmenting` by a crash was never repaired on an install that had
-switched consolidation off. `a_crashed_capture_is_repaired_with_the_sweep_switched_off`
-pins it. Repair is what fixes an *interrupted cycle*; a cycle that owns its own
-repair cannot recover from its own failure. It stays a separate ticker, behind
-no setting, and this design does not touch it.
+corpus left `segmenting` by a crash was never repaired on an install with
+consolidation off. `a_crashed_capture_is_repaired_with_the_sweep_switched_off`
+pins it. Repair is what recovers an interrupted schedule; it cannot be
+scheduled by the thing it recovers. It stays its own ticker, behind no setting.
 
-**One queued sweep, however often the ticker fires.** `jobs` is
-`UNIQUE(stage, target_id)`, and every collection-scoped sweep enqueues against
-the target `"collection"` to get at-most-one for free. The cycle keeps that
-shape: one `Stage::Sleep` unit, one target.
+**Lazy decay stays lazy.** Activation and link weight both fold decay in at
+read and at bump — `decayed(value, stamp, at, half_life)` — and
+`bumping_folds_the_decay_in_rather_than_adding_to_a_stale_number` pins it. A
+schedule is a tempting place to hang a decay pass, and it would be a
+regression: a scheduled pass makes every number stale between passes. No unit
+writes a decayed value.
 
-**A default that changes ranking moves only after the harness has run.** The
-sitting's carry and its display change no order and ship on. Its priming
-changes order and ships off (§9).
+**A default that changes ranking waits for the harness.** The sitting's
+carrying changes no order and ships on. Its priming changes order and ships
+off (§5.3).
 
-## 4. Sleep
+## 4. Scheduling
 
-### 4.1 The shape
+### 4.1 What is already there
 
-One ticker, `spawn_sleep_ticker`, enqueueing `Stage::Sleep` against
-`"collection"`. One job handler, `jobs::sleep::run`, which calls the existing
-phase functions in a fixed order. The five tickers it replaces are deleted;
-`spawn_repair_ticker` is not (§3).
+The queue has four of the five things a scheduler needs, and the fifth is one
+column:
 
-The phases, in the only order their data dependencies allow:
+| Scheduler concept | In the tree today |
+|---|---|
+| Runnable | `state = 'pending'` and `run_after <= now` |
+| Sleeping on a timer | `state = 'pending'` and `run_after > now` |
+| Running | `state = 'claimed'`, with `claimed_at` |
+| Blocked on a predecessor | not enqueued yet — the predecessor arms it |
+| Fair order within a class | `ORDER BY attempts, seq, id` |
+| **Priority** | **missing** |
 
-| # | Phase | What runs today | Rhythm |
-|---|---|---|---|
-| 1 | Replay | `jobs::associate::run` — events and verdicts folded into links, then `prune_learning_links` and `reopen_stale_judged_links` | `associate.interval_mins` |
-| 2 | Pursue | `jobs::pursuit` sweep — groups quiet sittings, decides, arms `Generate` | `pursuit.idle_secs / 2` |
-| 3 | Relate & dedupe | `Stage::Relate` arming, `jobs::dedupe` | `consolidate.dedupe_interval_mins` |
-| 4 | Consolidate | `jobs::consolidate` sweep | `consolidate.interval_hours` |
-| 5 | Retention | `expire_feedback` | `feedback.sweep_hours` |
-| 6 | Gaps | `jobs::gaps::sweep` | `feedback.sweep_hours` |
+"Blocked" needs no representation because the tree already expresses
+dependencies the right way round: a unit that finishes arms its successor.
+`Synthesize` arms one `SegmentWindow` per window, `Associate` arms `LinkJudge`,
+the pursuit sweep arms `Generate`. A unit that has not been armed cannot be
+claimed, which is what blocked means.
 
-Two of these orderings are already correct and are being written down rather
-than fixed: replay before prune, inside `associate::run`, and retention before
-the gap sweep, inside the retention ticker. Two are not expressed anywhere
-today and are the reason the table is worth having: **relate before dedupe
-before consolidate**, a pipeline spread over two tickers, and **replay before
-pursue**, so a sitting is scored against links this cycle folded in rather
-than against last half-hour's.
+### 4.2 The tickers become units that reschedule themselves
 
-Two things that look like phases and are not:
+Each periodic sweep, on completion, enqueues itself with
+`run_after = now + its own interval`. A process that sleeps on a timer and
+wakes runnable — no ticker task, no external clock, and no cursor recording
+when it last ran, because `run_after` *is* that cursor and it is already
+indexed.
 
-- **Activation decay.** There is no decay pass and this design does not add
-  one. `decayed(value, stamp, at, half_life)` is folded in at every bump and
-  every read (`store/links.rs`), which is the better design — a lazily decayed
-  number is never stale — and it means nothing that reads activation has a
-  scheduling dependency on decay at all.
-- **Promotion.** `jobs::promote::maybe_promote` fires at the bump, from
-  `mark_artifact_seen` and from `associate`. It is event-driven, and the one
-  scheduled call to it — from the pursuit sweep — is the cheap backstop
-  `ROADMAP.md` [Core Platform] already proposes retiring. Nothing to schedule,
-  so no phase.
+Five tickers are deleted: consolidation, retention, dedupe, pursuit, associate.
+`spawn_repair_ticker` stays (§3) and gains one duty: arming a periodic unit
+that is missing entirely, which is how a schedule recovers from a crash between
+claim and re-arm.
 
-### 4.2 Rhythms are kept, not flattened
+`UNIQUE(stage, target_id)` still gives at-most-one of each sweep, for free and
+for the same reason as today.
 
-Replaying a search log wants half-hourly. A consolidation sweep wants six-hourly
-and would be wasteful hourly. Collapsing six intervals into one number would
-either make the cheap phases rare or the expensive ones constant, and both are
-worse than the accidental order this replaces.
+**Ordering falls out of it.** The dependency that crosses a ticker boundary is
+`Relate → Dedupe → Consolidate`, and it becomes expressed the way every other
+dependency in the tree is — the sweep that produces the pairs arms the unit
+that reads them, rather than that unit waking on a period of its own and
+finding whatever happens to be there. The one ordering worth adding beyond that
+is **replay before pursue**: a sitting scored against links this run folded in,
+not against last half-hour's, so the association sweep arms the pursuit sweep
+on completion instead of the pursuit sweep keeping a period.
 
-So the ticker fires at the **shortest configured rhythm**, and each phase
-carries a due-time: a phase runs when its own interval has elapsed since it last
-completed. The last-completed stamps live in `meta`, which already holds exactly
-this kind of cursor with no row to live on (`associate.events_after` and its
-two siblings). Keys: `sleep.phase.<name>.at`.
+### 4.3 Priority is one distinction
 
-A cycle where only phase 1 is due runs phase 1 and reports one line. The
-existing per-subsystem interval keys are unchanged and keep their meanings —
-this is the same six rhythms, ordered, in one loop.
+Not a scale and not a knob: **is someone waiting on this?**
 
-### 4.3 The report
+| Class | Stages |
+|---|---|
+| `0` — foreground | `Synthesize`, `SegmentWindow`, `Title`, `Embed`, `Describe`, `Extract` |
+| `1` — background | `Consolidate`, `Dedupe`, `Relate`, `Associate`, `LinkJudge`, `Pursuit`, `Generate` |
+
+Foreground is the capture pipeline: the operator pasted something and is
+watching it move through `raw → embedding → ready`. Background is everything
+whose result nobody is standing in front of.
+
+One column, one constant per stage, with the reason beside it. No configuration
+key: a priority the operator can set wrong presents as *the capture is
+hanging*, with nothing anywhere saying why, and the cliff constants in
+`search.rs` already record this project's answer to knobs of that kind.
 
 ```sql
-CREATE TABLE IF NOT EXISTS sleep_cycles (
-  id         INTEGER PRIMARY KEY,
-  started_at INTEGER NOT NULL,
-  ended_at   INTEGER,
-  -- Per-phase outcome, JSON: name, ran|skipped|failed, duration, counts.
-  -- Read on Ops and rendered; never parsed for a decision.
-  phases     TEXT NOT NULL DEFAULT '[]'
-);
+ALTER TABLE jobs ADD COLUMN class INTEGER NOT NULL DEFAULT 0;
 ```
 
-Bounded by the retention pass to the last 200 cycles — a cycle report is
-housekeeping about housekeeping and is not worth a policy.
+Claim becomes `ORDER BY class, attempts, seq, id`, and the index becomes
+`(state, class, attempts, seq, id, run_after)` — still covering, still stopping
+at the first ready row, still no sort.
 
-Each phase's counts are what its function already returns: links strengthened
-and pruned (`associate::run` has them), windows promoted, pairs judged, merges
-written, clusters named, rows expired. Ops gains one block at the top: *Last
-slept 03:14, 40s — 412 links strengthened, 8 forgotten, 3 windows synthesised,
-2 merges, 1 gap named.* A phase that failed says so and names its error; the
-cycle continues to the next phase, because a failed consolidation is not a
-reason to skip retention.
+Default `0` is deliberate: a row written before the migration is foreground,
+which is the safe direction to be wrong in. The backfill sets the sweeps to `1`.
 
-### 4.4 Failure and shutdown
+### 4.4 Ageing is a write, not a read
 
-Unchanged from what the tickers do now: a failed phase is retried on the next
-cycle, its due-stamp not advanced, and nothing takes the process down. The
-`Stage::Sleep` unit is claimed and released by the existing queue, so a cycle
-interrupted by a restart is re-armed by the repair ticker like any other
-interrupted unit.
+A background unit that has waited longer than `schedule.age_after_mins` becomes
+foreground. Without it, one long ingest keeps night work off the workers
+indefinitely — starvation, and the exact failure a priority scheduler is
+expected to have an answer for.
+
+It is an `UPDATE` on the repair ticker, not a term in the claim query:
+
+```sql
+UPDATE jobs SET class = 0
+ WHERE state = 'pending' AND class = 1 AND created_at < ?;
+```
+
+Computing age at claim time would put `created_at` — an inequality — into the
+ordering and cost the covering index (§3). Ageing a few rows every repair tick
+costs one indexed update and leaves the hot path exactly as fast as it is now.
+A unit that has aged stays aged; it has already waited.
+
+### 4.5 The account
+
+One row per completed run of a periodic unit:
+
+```sql
+CREATE TABLE IF NOT EXISTS sweep_runs (
+  id         INTEGER PRIMARY KEY,
+  stage      TEXT NOT NULL,
+  started_at INTEGER NOT NULL,
+  ended_at   INTEGER NOT NULL,
+  -- 'ok' | 'failed'
+  outcome    TEXT NOT NULL,
+  -- What it did, JSON: the counts each sweep already returns.
+  detail     TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_sweep_runs_at ON sweep_runs(started_at DESC);
+```
+
+The counts are what the functions already return: links strengthened and
+pruned, pairs judged, merges written, clusters named, rows expired.
+
+**One consequence to state plainly: there is no longer a "night".** Units that
+reschedule themselves on their own periods do not line up into one cycle, and
+pretending otherwise would mean inventing a cycle identity to group them by.
+What Ops shows instead is *the last day*: one block summarising the runs of the
+past 24 hours — *412 links strengthened, 8 forgotten, 2 merges, 1 gap named* —
+and under it the history, which is the thing a single overwritten summary could
+never give: whether this started yesterday or has been going wrong for a week.
+
+Trimmed by the retention sweep to the last 2000 runs. Housekeeping about
+housekeeping does not get a policy.
+
+### 4.6 Failure
+
+Unchanged: `attempts` and `run_after` are the existing backoff, a failed unit
+is retried, and nothing takes the process down. A periodic unit that fails
+still re-arms itself — otherwise one failure ends that sweep forever, which is
+the one way this design could quietly stop the memory from learning.
 
 ## 5. The sitting
 
 ### 5.1 What it is
 
-An in-memory map on `Core`, keyed by **sitting id**: the web session id for a
-browser (`sessions.id`, which exists), the token id for the API and `/mcp`. One
-entry:
+A map on `Core`, keyed by web session id (`sessions.id`, which exists):
 
 ```rust
 pub struct Sitting {
     /// Artifact ids touched, most recent first, capped at CARRY.
     touched: VecDeque<Touched>,
-    /// The queries typed in this sitting, most recent first, capped at CARRY.
+    /// Queries typed in this sitting, most recent first, capped at CARRY.
     queries: VecDeque<String>,
     last_at: i64,
 }
 ```
 
-`CARRY = 20`. An entry idle for `pursuit.idle_secs` — the same number that
-already defines a sitting for the sweep — is dropped, so the live definition
-and the reconstructed one agree by construction. No table, no persistence, no
-write to `activation`.
+`CARRY = 20`. An entry idle for `pursuit.idle_secs` is dropped — the same
+number that already defines a sitting for the sweep, so the live definition and
+the reconstructed one agree by construction.
 
-Touched is written where engagement is already recorded: `mark_artifact_seen`,
-`record_interaction`, and an ask's citations. It costs a lock and a push, off
-the request path like every other bookkeeping write in `search.rs`.
+**In memory only.** No table, no migration, no expiry sweep. It dies with the
+process, and a deploy mid-afternoon costs the operator their carried context.
+That is the accepted price: a working memory that survives a restart is a
+long-term memory, and engram has one of those already.
 
-### 5.2 What it does — carrying (ships on)
+Writing it costs a lock and a push, on the paths that already record
+engagement — `mark_artifact_seen`, `record_interaction`, and an ask's citations.
+
+### 5.2 Carrying (ships on)
 
 Nothing here changes an order.
 
-- **Search → ask.** The ask box arrives prefilled with the last query of the
-  sitting when it is empty and the sitting is warm.
+- **Search → ask.** The ask box arrives prefilled with the sitting's last query
+  when it is empty and the sitting is warm.
 - **Ask → capture.** The keep-this-answer link already prefills the capture
-  box; it gains the question it answered, as the note, so the trace records
-  what the text was written for. This is the existing operator decision, better
-  recorded — nothing is written without the person, and that line does not move.
-- **A rail of what this sitting has touched**, on search and ask, six at most,
-  each a link. Dismissible, and absent on a cold sitting.
+  box; it gains the question it answered, as the note. The operator still
+  decides and the trace still records that a model wrote the text — that line
+  does not move, it is only better documented.
+- **A rail of what this sitting has touched**, on search and ask. Six at most,
+  each a link, absent on a cold sitting.
 
-### 5.3 What it does — priming (ships off)
+### 5.3 Priming (ships off)
 
-A hit that is in `touched` is primed, by the same rank-based, bounded rule
-`search::prime` already implements for activation, and **inside the same
-budget**: a hit cannot be lifted `prime_lift` places for activation and again
-for the sitting. Index 0 remains untouchable. A hit lifted by the sitting says
-so on the rail — *seen in this sitting* — for the same reason a primed hit says
-so today.
+A hit in `touched` is primed by the same rank-based, bounded rule
+`search::prime` already applies to activation, and **inside the same budget**:
+a hit cannot be lifted `prime_lift` places for activation and again for the
+sitting. Index 0 stays untouchable. A hit the sitting lifted says so.
 
-This is the one part of this design that moves ranking. `sitting.prime` is
-`false` by default until `cargo test --test eval` has been run with it on and
-off against the judged-pair set. §9.
+This is the only part of this design that moves ranking, so `sitting.prime` is
+`false` until `cargo test --test eval` has been run with it both ways.
 
 ### 5.4 What it does not do
 
-It does not write activation, open a pursuit, or survive the process. The
-pursuit sweep is unchanged and still reconstructs its own sittings from the
+It does not write activation, open a pursuit, or survive the process. It exists
+at the web door only: for the API and `/mcp` an access token is not a
+conversation, and two agent sessions sharing a token would share a sitting,
+which is worse than having none. Giving those doors a real session identity is
+a change to the doors, not to this.
+
+The pursuit sweep is unchanged and still reconstructs its own sittings from the
 log: the live sitting is a *read* of what is happening, and a sweep that
 depended on process memory would lose a day's pursuits to a restart.
 
@@ -270,160 +322,168 @@ depended on process memory would lose a day's pursuits to a restart.
 
 ### 6.1 Two more kinds, not a new table
 
-`GapKind` is `{ Ask, Search }` and a gap is a reference to the row it came from
-plus its stored query vector. Both new exits fit that shape:
+A gap is a reference to the row it came from plus its stored query vector. Both
+new sources fit that shape:
 
 ```rust
-pub enum GapKind { Ask, Search, Abandoned, Pursuit }
+pub enum GapKind { Ask, Search, Unmatched, Pursuit }
 ```
 
-- **`Abandoned`** — a recorded search that settled (past `feedback.coalesce_secs`,
-  the same predicate `associate` uses to decide an event is settled), was never
-  judged, has `answered = 0`, and has no `interaction_events` row in its window.
-  Nothing was opened; the list did not answer.
-- **`Pursuit`** — a pursuit that closed `unsatisfied`. Today it is a row on Ops
-  and nothing else. Its clustered queries are already stored on the row and are
-  exactly what a gap needs.
+- **`Unmatched`** — a recorded search whose **best candidate similarity fell
+  under `vector.weak_below`**. Nothing came close, and the rail said so at the
+  time: *nothing matches closely* is already what the page renders when every
+  hit is loose.
+- **`Pursuit`** — a pursuit that closed `unsatisfied`. Today a row on Ops and
+  nothing else; its clustered queries are already stored and are exactly what a
+  gap needs.
 
 `gap_clusters.members` is already `(kind, id)` pairs and needs no change.
 Clustering, naming, and the model call that names a group are untouched.
 
-### 6.2 An abandonment is a weak gap
+### 6.2 Why distance and not behaviour
 
-Most searches end without a click, and a system that called each of them a hole
-would file the operator's typing as failure. Two guards:
+The first draft called the fourth source *abandoned*: a search after which
+nothing was opened. That was wrong twice over.
 
-1. An `Abandoned` gap is **never shown ungrouped**. The capture page's
-   ungrouped list stays judged gaps only. An abandonment reaches the operator
-   only by clustering with something else — and `MIN_CLUSTER` is 2, so the
-   floor is *two questions about one hole*, at least one of which someone
-   either judged or asked in earnest.
-2. Only the last search of a burst counts. A typing burst already folds into
-   one event by `coalesce_secs`; what survives folding is the query as it was
-   finished.
+It cannot be read. A result list is a rail of titles; not clicking one can mean
+the list was useless, or that the titles alone told the operator what they
+needed. The two readings are opposite and the system cannot separate them.
+
+And it is not even measurable on every install. An open is recorded only when
+pursuits *and* feedback are on — `record_interaction` returns early otherwise —
+so with pursuits off, every search in the log looks abandoned.
+
+Distance has neither problem. `weak_below` is an existing, configured and
+already-explained line; the similarities are stored on the candidate rows; the
+signal needs no interaction data, so it works whatever else is switched on; and
+it can be computed over the existing log retroactively. It is also the more
+honest claim: not *you gave up*, but *the base held nothing near this*.
+
+The one guard it needs exists already: a typing burst folds into one event by
+`feedback.coalesce_secs`, so what is measured is the finished query and not its
+first two letters.
 
 ### 6.3 Closing
 
-Three ways in, three ways out.
-
 - **A capture covers it.** When a corpus reaches `ready`, the open gaps' stored
-  query vectors are searched against **that corpus's new artifacts only** — one
+  query vectors are searched against that corpus's new artifacts only — one
   filtered vector query per open gap, no model call, on the background handle.
-  A gap whose best new hit is at or above `vector.weak_below` is marked
-  covered, and the capture page says so: *this closes 2 open gaps*, naming them.
-  This is the same test `search_events.answered` already applies, against a
-  narrower set.
-- **A pursuit earns it.** Unchanged: a pursuit that generates an artifact
-  closes `generated`, and its gap closes with it.
-- **The operator dismisses it.** Unchanged: `dismissed_at`, the existing
-  button, now on one list instead of two.
+  A gap whose best new hit reaches `weak_below` is closed, and the capture page
+  says which. Closed **silently and reversibly**: the source row is untouched,
+  so an operator who disagrees reopens it, and nothing is deleted on a score.
+- **A pursuit earns it.** Unchanged.
+- **The operator dismisses it.** Unchanged, now on one list instead of two.
 
 ### 6.4 What the operator sees
 
-One list, on the capture page where it already is, each row badged with what
-asked it: *judged*, *asked*, *abandoned*, *pursued*. Ops loses its separate
-pursuits table and links into this list instead.
+One list on the capture page, each row badged with what asked it: *judged*,
+*asked*, *nothing near*, *pursued*. Ops loses its separate pursuits table and
+links into this list.
 
 ## 7. Surface
 
-- **Ops** gains the sleep block (§4.3) at the top, and loses the pursuits table
-  to §6.4.
+- **Ops** gains the last day and the history (§4.5), and loses the pursuits
+  table to §6.4.
 - **Capture** gains kind badges and the coverage line.
-- **Search and ask** gain the sitting rail (§5.2) and, with `sitting.prime` on,
-  one more reason a hit can say it was lifted.
-- Nothing gains a graph, a dashboard, or a chart. The search box stays the
-  application.
+- **Search and ask** gain the sitting rail, and with `sitting.prime` on, one
+  more reason a hit can say it was lifted.
+- Nothing gains a graph or a dashboard. The search box stays the application.
 
 ## 8. Data model summary
 
 | Change | Where |
 |---|---|
-| `sleep_cycles` table | new, §4.3 |
-| `sleep.phase.<name>.at` cursors | `meta`, existing table |
-| `Stage::Sleep` | `store/jobs.rs` |
-| `GapKind::{Abandoned, Pursuit}` | `store/gaps.rs` |
-| Sitting map | in memory on `Core`, no schema |
+| `jobs.class` | one column, default 0, backfilled |
+| `idx_jobs_claim2` → `(state, class, attempts, seq, id, run_after)` | replaced index |
+| `sweep_runs` | new table, §4.5 |
+| `GapKind::{Unmatched, Pursuit}` | `store/gaps.rs` |
+| The sitting | in memory, no schema |
 
-No column is dropped, no existing table is altered, and the migration is one
-`CREATE TABLE IF NOT EXISTS`.
+No column is dropped and nothing stored is rewritten. The migration is one
+`ALTER TABLE`, one `CREATE TABLE`, one index swap and one backfill `UPDATE`.
 
 ## 9. Configuration
 
 ```toml
-[sleep]
-enabled = true          # false runs nothing; repair is unaffected (§3)
+[schedule]
+age_after_mins = 60     # a background unit waiting longer becomes foreground
 
 [sitting]
 prime = false           # moves ranking; off until the harness says otherwise
 ```
 
-Two keys. The six existing interval keys keep their names and their meanings
-and become phase rhythms (§4.2), so an operator who tuned
+Two keys. The existing interval keys keep their names and their meanings and
+become each unit's own `run_after` step, so an operator who tuned
 `associate.interval_mins` finds it still doing what it did.
-
-`sleep.enabled = false` is for the harness and for debugging a phase in
-isolation; it is not a supported way to run.
 
 ## 10. Testing
 
-- **Order.** A cycle with all phases due runs them in the table's order —
-  asserted on the recorded `phases` JSON, which is what makes the ordering
-  claim testable at all.
-- **Rhythm.** A phase whose interval has not elapsed is skipped and its
-  due-stamp is not advanced; a phase that fails is skipped next cycle only if
-  its interval has not elapsed, and retried otherwise.
+- **Priority.** A background unit armed first is claimed after a foreground
+  unit armed second. Within one class, `attempts, seq, id` order is unchanged —
+  asserted directly, because `seq`'s anti-starvation property is the easiest
+  thing to lose here.
+- **The index still covers.** `EXPLAIN QUERY PLAN` on the claim shows the index
+  and no temp B-tree. Pinned as a test, since the shape of §4.3 and §4.4 exists
+  to keep it.
+- **Ageing.** A background unit older than `age_after_mins` is claimed ahead of
+  a fresh foreground one, and having aged is durable.
+- **Rescheduling.** A completed sweep leaves exactly one pending copy of itself
+  with `run_after` one interval out. A *failed* sweep re-arms too — the test
+  that stops one failure from ending a sweep forever.
+- **Recovery.** A periodic unit deleted outright is re-armed by the repair
+  ticker.
 - **The pinned regression.** `a_crashed_capture_is_repaired_with_the_sweep_switched_off`
-  must still pass with `sleep.enabled = false` (§3). This is the test that
-  fails if repair is ever folded in.
-- **One unit.** A ticker firing three times before the cycle is claimed leaves
-  one queued `Stage::Sleep`, as `the_ticker_queues_exactly_one_sweep` asserts
-  for consolidation today.
-- **Sitting expiry.** An entry idle past `pursuit.idle_secs` is gone; a warm
-  one carries. A sitting is never written to `activation` — asserted directly,
-  because it is the guard most likely to be lost to a convenient refactor.
-- **Priming budget.** A hit in `touched` and activated does not move more than
-  `prime_lift` places in total, and rank 0 never moves.
-- **Abandonment floor.** One abandoned search alone produces no visible gap;
-  two clustering ones produce a named group.
-- **Coverage.** A capture that answers an open gap closes it and reports it; a
-  capture that does not, does not.
-- **Harness.** `cargo test --test eval` with `sitting.prime` on and off, on the
-  judged-pair set, before that default moves.
+  still passes. This is the test that fails if repair is ever folded in.
+- **Dependency.** Dedupe runs only after the sweep that arms it; pursue only
+  after replay.
+- **Sitting.** Expires at `pursuit.idle_secs`; never writes activation —
+  asserted directly, as the guard most likely to be lost to a refactor. With
+  `prime` on, a hit in both `touched` and activation moves at most `prime_lift`
+  places in total, and rank 0 never moves.
+- **Unmatched.** A search whose best similarity is under `weak_below` becomes a
+  gap; one with a single hit above it does not. Over the existing log,
+  retroactively.
+- **Coverage.** A capture answering an open gap closes it and says so; one that
+  does not, does not; a closed gap reopens.
+- **Harness.** `cargo test --test eval` with `sitting.prime` both ways before
+  that default moves.
 
 ## 11. Rollout
 
-In three commits, in this order, because each is independently useful and
-independently revertible:
+Three commits, in this order, each independently useful and revertible:
 
-1. **The cycle** (§4). Pure reorganisation: the same functions, in an order,
-   with a report. No behaviour the operator asked for changes, and the one
-   behaviour they did not ask for — promotion reading an undecayed activation —
-   stops.
-2. **The queue** (§6). Two kinds, two guards, one coverage check. Visible on
-   day one on any base with recorded feedback.
+1. **The scheduler** (§4). One column, one index, one table, five tickers
+   deleted. No behaviour the operator asked for changes; the behaviour they did
+   not ask for — a capture waiting behind a consolidation sweep — stops.
+2. **The queue** (§6). Two kinds, one distance rule, one coverage check.
+   Visible on day one on any base with recorded feedback.
 3. **The sitting** (§5), carrying only. Priming lands behind its flag in the
-   same commit and is switched on, if at all, by a separate one carrying the
+   same commit and is switched on, if ever, by a separate one carrying the
    harness numbers in its message.
 
 ## 12. Risks
 
-- **The cycle serialises what ran concurrently.** Six tickers could overlap;
-  one cycle cannot. A long consolidation now delays the next replay by its
-  duration. Mitigated by the rhythms (§4.2) — a phase that is not due costs a
-  timestamp comparison — and bounded by the fact that every phase already caps
-  its own work per tick (`REPLAY_LIMIT`, `PRUNE_SCAN_LIMIT`,
-  `max_dedupe_per_tick`). If it bites, the answer is to split the cycle in two
-  by cost, not to go back to six.
-- **Abandonment floods the gap list.** The two guards in §6.2 are a judgement,
-  not a measurement, and the right floor is a number nobody has. It ships
-  visible and easy to walk back: an abandoned gap is one `WHERE kind != …`
-  from being invisible again.
+- **Priority starves the background.** A base under constant capture could keep
+  workers on foreground work indefinitely. `age_after_mins` is the answer and
+  its default is a guess; the `sweep_runs` history is how the guess gets
+  checked — a sweep whose runs thin out is visible on Ops rather than silent.
+- **One class is too few.** Two classes cannot say that embedding matters more
+  than titling. Deliberate: the distinction that pays is *someone is waiting*,
+  and a second one can be added later without moving the column.
+- **Rescheduling loses a sweep.** A unit that dies between claim and re-arm
+  never runs again — the failure mode a ticker does not have. Two guards: a
+  failed unit re-arms itself (§4.6), and the repair ticker arms any periodic
+  unit that is missing entirely (§4.2). The second is the real one, and it is
+  why repair stays outside.
+- **`Unmatched` floods the list.** A young base is mostly holes and would say
+  so loudly. Grouping already needs two members to name a group, and the
+  ungrouped list is the operator's to dismiss. If it still floods, the fix is a
+  floor on how many the page shows, not on what is recorded.
+- **Coverage closes a gap that is not closed.** A hit at `weak_below` from a new
+  corpus is a weak claim to have answered a question. It closes silently
+  because a base with forty gaps would otherwise turn its own housekeeping into
+  a review queue — and it is reversible, the source row is untouched, and
+  nothing is deleted.
 - **The sitting makes results feel unstable.** The same query in two sittings
-  ranks differently, which is precisely what priming is for and precisely what
-  is disorienting about it. Hence off by default, hence the badge, hence rank 0
-  never moving.
-- **Coverage marks a gap closed that is not.** A vector hit above
-  `weak_below` from a new corpus is a weak claim to have answered a question.
-  It is the same claim `answered` already makes, and closing is reversible:
-  the gap's source row is untouched, so a covered gap can be reopened by the
-  operator without inventing a state for it.
+  ranks differently, which is what priming is for and what is disorienting
+  about it. Hence off by default, hence the badge, hence rank 0 never moving.

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -139,8 +139,9 @@ the card, with the differing values marked, makes the decision local.
 - A **Stop** control closes the `EventSource` and keeps what has arrived.
 - `{{ dropped }} excerpt(s) omitted for context budget` (`_answer.html:16`)
   becomes plain English, pluralised properly.
-- The verdict row (`_ask_verdict.html:14`) and "keep this answer" become
-  controls that look like controls.
+- The verdict row and "keep this answer" were a finding and are withdrawn:
+  both are already `btn btn-ghost btn-sm`. Ghost weight is subtle on purpose,
+  and it is used consistently for actions that are offered rather than urged.
 - **`.sitting` has no stylesheet.** `_sitting.html` renders `.sitting` and
   `.pane-label`; no rule for `.sitting` exists in any of the eleven CSS files.
   It needs one, and a heading that says what a sitting is.
@@ -184,8 +185,11 @@ which regions each page claims.
 - Unknown `/ui` paths get a real 404 instead of the browser's.
 - The API-tokens table renders bare headers with no rows; it gets an empty
   state.
-- Capture's gaps row styles `asked` (a state) exactly like `ask again` and
-  `covered` (actions).
+- Capture's "not yet grouped" says nothing about what grouping is. The rest of
+  that finding is withdrawn: `asked` already renders as `.badge` and the two
+  actions as `.btn`, so the state and the actions are distinct markup. That
+  they read alike is the ghost weight, which is the same deliberate choice as
+  in the verdict bar.
 - Markdown leaks into plain-text snippets — `custom\_passphrase`, `raw\_key`,
   `# Configure Linux…`, `**Was nicht abgedeckt ist:**`. Snippets get stripped.
 

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -1,0 +1,178 @@
+# Fixing what the GUI does badly
+
+A review of the live deployment at `engram.mikoshi.de`, and the design for
+what to do about it.
+
+## Base
+
+Prod runs `origin/feat/one-system`, nineteen commits ahead of `master` — the
+sitting, the sweep history on Housekeeping, and the knowledge gaps on Capture
+are all on that branch and on no other. The review was of that build, so the
+work branches from it (`fix/ui-findings`) rather than from `master`. Every
+finding below survives the rebase; only line numbers moved.
+
+## What this covers
+
+Findings from operating the deployment: search, the artifact pane, a full
+ask, capture, judge, housekeeping, settings, the light theme, and a 420px
+viewport. Deliberately out of scope, by the owner's triage:
+
+- **PDF ingest quality.** Most `Untitled` artifacts and the hex-dump and
+  table-rule segments come from PDF extraction. A general weakness, possibly
+  not fixable at this layer.
+- **Images inside PDFs.** Not extracted; rendered in the raw source only.
+- **An absolute relevance floor.** A nonsense query returns ten results
+  because hybrid scores are fused ranks with no cross-query meaning. Accepted
+  as fine in a vector base with no explicit tuning.
+- **Judge's IR vocabulary.** `recall@10`, `MRR`, `hits · finds · gaps ·
+  discarded` are tuning instruments, not a surface meant to survive.
+
+## The decisions
+
+**A `Conflict` still escalates.** The judge's four verdicts already implement
+the three forks a person would want: `Replaced` supersedes without asking,
+`Duplicate` merges into a new artifact naming both parents, `Distinct` leaves
+both alone. `Conflict` — same subject, different value, nothing in either text
+saying which is current — is the only one that reaches a person, and it stays
+that way. Nothing decides which of two facts is true without the operator.
+Recency was considered as a tiebreak, on the rule `keeper()` already uses for
+clusters, and rejected: a newer capture that is wrong would silently bury a
+correct older one, and `Undo` on Housekeeping is a poor place to discover
+that. If a recency tiebreak is ever wanted, its threshold belongs under
+`[consolidate]` beside `review_min` — recorded here so the option is not
+re-derived from scratch.
+
+**Reasoning becomes opt-in.** The ask page currently streams the model's
+chain of thought, which restates the prompt's constraints verbatim. It moves
+behind a closed disclosure rather than being deleted: it is genuinely useful
+while tuning, and it should never face a reader who did not ask for it.
+
+**The search rail widens; the pane keeps its placeholder.** Auto-opening the
+top hit was considered and rejected — it would spend a read on every search,
+including the ones whose answer is visible in the rail.
+
+## 1. Titles
+
+The multiplier. Every list in the app is a column of titles, so a bad title
+rule degrades search, judge, recent, and the dedupe queue at once.
+
+The right rule already exists, with its argument, at `ui.rs:1157`: a verbatim
+passage has no title by design, and `Untitled` is a word that says nothing
+while looking like it does. Three places do not follow it:
+
+- `web/judge.rs:179` and `:515` — `unwrap_or_else(|| "Untitled".into())`
+- `web/ui.rs:367` and `:3095` — `format!("Chunk {}", c.ordinal)`
+- `mcp/mod.rs:19` — `unwrap_or_else(|| "Untitled".into())`
+
+All adopt the rail's treatment: the opening of the body stands in for the
+heading, marked as a stand-in rather than presented as a name.
+
+**Truncation respects word boundaries.** The sitting renders
+`Die digitale Forensik unterscheidet sich zusätzlich darin vo` — a cut mid-word.
+Wherever a stand-in title is shortened, it ends at a word.
+
+**Colliding titles get a disambiguator.** Three distinct artifacts on the
+deployment carry the title `LevelDB: Funktionsweise und forensische Analyse`.
+When two rows of one list share a title, each says what distinguishes it.
+Without this, section 2's grouping still looks like a repeat.
+
+## 2. The consolidation queue
+
+Capture's "Needs you" showed five cards. Three were **one cluster of four
+artifacts asked as three separate pairwise questions** — `01a01f80…` against
+three others. `jobs/consolidate.rs` already holds the disjoint-set (`Clusters`)
+that knows they are one group; the capture page does not use it. One cluster
+becomes one card naming its members.
+
+**`detail` is null on every escalated pair, and should not be.** The field is
+stored (`store/pairs.rs:108`), read and rewritten for the `link` marker
+(`ui.rs:1879`), rendered (`_decide.html`), and the prompt requires it —
+"detail: one short sentence saying why. Always." Yet all five stored
+`Contradiction` rows have it empty, so no card says what the disagreement is
+about. This is a defect to root-cause before any UI work: a card that cannot
+name the dispute cannot be decided however it is laid out.
+
+**Each side becomes readable in place.** The titles are already links, but
+following one leaves the queue. An expandable excerpt of both artifacts inside
+the card, with the differing values marked, makes the decision local.
+
+## 3. Ask
+
+- Reasoning moves into a disclosure, closed by default (`ask.html:42`,
+  `app.js:285`).
+- The retrieval line (`#ask-progress`) becomes the primary progress signal,
+  with elapsed time. Today a fifty-second wait is signalled by a small grey
+  `thinking…` beside the button.
+- A **Stop** control closes the `EventSource` and keeps what has arrived.
+- `{{ dropped }} excerpt(s) omitted for context budget` (`_answer.html:16`)
+  becomes plain English, pluralised properly.
+- The verdict row (`_ask_verdict.html:14`) and "keep this answer" become
+  controls that look like controls.
+- **`.sitting` has no stylesheet.** `_sitting.html` renders `.sitting` and
+  `.pane-label`; no rule for `.sitting` exists in any of the eleven CSS files.
+  It needs one, and a heading that says what a sitting is.
+
+## 4. Layout
+
+The region grid (`20-layout.css`) is sound and documented; the problems are in
+which regions each page claims.
+
+- **Search**: the rail widens while nothing is selected, and shows whole
+  snippets rather than two clipped lines. The placeholder stays.
+- **Judge**: `None of these` / `Can't remember` / `Not a real search`
+  (`_judge_card.html:78-89`) sit below twenty-three candidate cards. They
+  become a sticky footer. Rank numbers stop after nine; they continue.
+- **The artifact pane**: the title becomes sticky, `copy` moves out of the text
+  flow it currently overlaps, `Delete` separates from `Verified`/`Hide`, and a
+  segment cut mid-sentence links to its continuation — the source pane beside
+  it already shows the rest.
+- **Judge, Ops and Settings** use the width they have.
+
+## 5. Copy and empty states
+
+- Housekeeping's counts are one run-on sentence; they become a stat row.
+- `TOOK` reads `now` for every sweep (`ops.html:60`); it reads a duration.
+- Sweep identifiers (`arm_dedupe`, `pursuit`, `consolidate`, `retention`)
+  get human labels, keeping the raw name available.
+- One name for the page: the link says Housekeeping, the URL is `/ui/ops`, the
+  title is `Ops`. `/ui/housekeeping` currently produces a browser error.
+- Unknown `/ui` paths get a real 404 instead of the browser's.
+- The API-tokens table renders bare headers with no rows; it gets an empty
+  state.
+- Capture's gaps row styles `asked` (a state) exactly like `ask again` and
+  `covered` (actions).
+- Markdown leaks into plain-text snippets — `custom\_passphrase`, `raw\_key`,
+  `# Configure Linux…`, `**Was nicht abgedeckt ist:**`. Snippets get stripped.
+
+## 6. Two tensions, left as they are
+
+Both of these were findings in the review, and both collide with a decision
+this codebase argues for in a comment. The comments win; they are recorded so
+the question is not reopened blind.
+
+- **KIND chips are hidden on the phone** (`50-phone.css:108`, "Not thumb
+  furniture"). The row is correctly banished, but the *capability* goes with
+  it — there is no way to filter by kind on a phone at all. Not fixed here.
+  If it is ever wanted, an active-filter chip that appears only when a filter
+  is set would respect the original reasoning.
+- **The phone badge drops its number** (`layout.html:130`, "the count is not
+  the point — that anything is waiting is"). Deliberate. Left alone.
+
+## Testing
+
+Every change is behavioural and most are template-level. The existing suite
+already asserts on rendered HTML (`ui.rs:4562` asserts `Untitled` never
+appears in the rail), which is the pattern to follow: assert on what the page
+says. Specifically —
+
+- Title fallback: a chunk with no title renders neither `Untitled` nor
+  `Chunk N`, in the judge card, the artifact pane, and the MCP door.
+- Truncation never splits a word.
+- Two same-titled rows in one list render distinguishably.
+- A cluster of three pending pairs renders one card, not three.
+- A settled `Conflict` carries a detail line through to the page.
+- Reasoning is not in the initial DOM of an ask.
+- A 404 route returns the app's own page.
+
+The dedupe `detail` defect gets a failing test reproducing the empty field
+before it gets a fix.

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -168,7 +168,11 @@ which regions each page claims.
 
 ## 5. Copy and empty states
 
-- Housekeeping's counts are one run-on sentence; they become a stat row.
+- Housekeeping's counts read as a run-on sentence. Reviewed as a finding and
+  withdrawn: the page argues for it — "the counts as a sentence rather than as
+  `done: 17`-style badges: this is a page you open to reassure yourself, and a
+  row of key-value chips reads as a debug dump of something going wrong" — and
+  every number in it says what it counts, which the chips would not.
 - `TOOK` reads `now` for every sweep (`ops.html:60`). The cause is a reused
   helper: `fmt_duration` (`ui.rs:331`) is future-tense — `"now"`, `"in 5m"` —
   written for when a job runs next, and Ops spends it on elapsed time. Elapsed

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -159,7 +159,8 @@ which regions each page claims.
   flow it currently overlaps, `Delete` separates from `Verified`/`Hide`, and a
   segment cut mid-sentence links to its continuation — the source pane beside
   it already shows the rest.
-- **Judge, Ops and Settings** use the width they have.
+- **Ops** already uses `regions-table`. Judge and Settings are left at their
+  reading measure — see the tension below.
 
 ## 5. Copy and empty states
 
@@ -193,6 +194,12 @@ the question is not reopened blind.
   is set would respect the original reasoning.
 - **The phone badge drops its number** (`layout.html:130`, "the count is not
   the point — that anything is waiting is"). Deliberate. Left alone.
+- **Judge's card is capped at 52rem** (`42-judge.css:9`), which is why its
+  content sits in the left half of a wide window. Reviewed as a finding and
+  withdrawn: the cap is a reading measure — "wide enough to read a snippet
+  without every line wrapping" — and a judgement made by scanning twenty
+  snippets is exactly the case a measure exists for. The sticky action bar is
+  what fixes the complaint underneath the finding.
 - **Judge's rank numbers stop at nine** (`judge.rs:190`). Reviewed as a
   finding and withdrawn: the number is a keyboard shortcut, the shortcut is one
   digit, and "the tenth choosable option and everything after it keeps its

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -156,9 +156,13 @@ which regions each page claims.
   (`_judge_card.html:78-89`) sit below twenty-three candidate cards. They
   become a sticky footer.
 - **The artifact pane**: the title becomes sticky, `copy` moves out of the text
-  flow it currently overlaps, `Delete` separates from `Verified`/`Hide`, and a
-  segment cut mid-sentence links to its continuation — the source pane beside
-  it already shows the rest.
+  flow it currently overlaps, and a segment cut mid-sentence links to its
+  continuation — the source pane beside it already shows the rest. `Delete` was
+  a finding here too and is withdrawn: it already carries `btn-icon-danger`, a
+  confirmation naming the undoable alternative, and
+  `.actions > form + form:last-of-type { margin-left: auto }`
+  (`40-search.css:255`), which is what sets it apart from `Verified` and
+  `Hide`.
 - **Ops** already uses `regions-table`. Judge and Settings are left at their
   reading measure — see the tension below.
 

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -61,14 +61,14 @@ passage has no title by design, and `Untitled` is a word that says nothing
 while looking like it does. Four sites decide a stand-in title, and no two
 agree:
 
-- `web/ui.rs:1950` — `title_of`, `c.text.chars().take(60)`
+- `web/ui.rs:1957` — `title_of`, `c.text.chars().take(60)`
 - `web/judge.rs:179` and `:515` — `unwrap_or_else(|| "Untitled".into())`
-- `web/ui.rs:367` and `:3095` — `format!("Chunk {}", c.ordinal)`
+- `web/ui.rs:367` and `:3102` — `format!("Chunk {}", c.ordinal)`
 - `mcp/mod.rs:19` — `unwrap_or_else(|| "Untitled".into())`
 
 They collapse into one rule, which is the rail's rule made precise. The rail
 shows *no heading at all* and lets the snippet speak (`render_hit`,
-`ui.rs:1323`). That is right wherever a snippet sits beside the name, and
+`ui.rs:1324`). That is right wherever a snippet sits beside the name, and
 impossible where a name is structurally required — a button reading `Keep ""`
 decides nothing. So:
 
@@ -79,7 +79,7 @@ decides nothing. So:
   trimmed at a word boundary, stripped of leading punctuation, and marked as a
   stand-in rather than presented as a name.
 
-`title_of` is the center of this, and it is worth being concrete about what it
+`title_of` (now `ui.rs:1957`) is the center of this, and it is worth being concrete about what it
 does today. A hard cut at sixty characters produces
 `Die digitale Forensik unterscheidet sich zusätzlich darin vo` in the sitting —
 mid-word — and it is the same function that titles the dedupe cards, which is
@@ -91,10 +91,23 @@ fixes the sitting, the dedupe queue, and the judge together.
 **Truncation respects word boundaries**, and a stand-in drops leading
 punctuation before it is shown as a heading.
 
-**Colliding titles get a disambiguator.** Three distinct artifacts on the
-deployment carry the title `LevelDB: Funktionsweise und forensische Analyse`.
-When two rows of one list share a title, each says what distinguishes it.
-Without this, section 2's grouping still looks like a repeat.
+**Colliding titles get a disambiguator, and it has to be visible.** Two
+different lists have this problem and they need opposite work.
+
+Capture's "Recent" already has the repair: `disambiguate_labels`
+(`ui.rs:1368`) appends the capture's opening words to any label that is not
+unique, and its comment names the exact failure this review found — "six rows
+read `HOCHSCHULE MITTWEIDA` and named nothing". It ran on the deployment and
+the rows still read identically, because `.qtitle` is
+`white-space: nowrap; text-overflow: ellipsis` (`41-capture.css:15`): the
+suffix that distinguishes the row is cut off before it can be seen. The
+function is right; the row gives it nowhere to appear. The distinguishing part
+must survive the truncation.
+
+The dedupe queue has the opposite problem — three artifacts genuinely titled
+`LevelDB: Funktionsweise und forensische Analyse`, with no disambiguation at
+all. There the rule from `disambiguate_labels` is what is missing, and it
+should be shared rather than written a second time.
 
 ## 2. The consolidation queue
 

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -58,18 +58,28 @@ rule degrades search, judge, recent, and the dedupe queue at once.
 
 The right rule already exists, with its argument, at `ui.rs:1157`: a verbatim
 passage has no title by design, and `Untitled` is a word that says nothing
-while looking like it does. Three places do not follow it:
+while looking like it does. Four sites decide a stand-in title, and no two
+agree:
 
+- `web/ui.rs:1950` — `title_of`, `c.text.chars().take(60)`
 - `web/judge.rs:179` and `:515` — `unwrap_or_else(|| "Untitled".into())`
 - `web/ui.rs:367` and `:3095` — `format!("Chunk {}", c.ordinal)`
 - `mcp/mod.rs:19` — `unwrap_or_else(|| "Untitled".into())`
 
-All adopt the rail's treatment: the opening of the body stands in for the
-heading, marked as a stand-in rather than presented as a name.
+They collapse into one rule, the rail's: the opening of the body stands in for
+the heading, marked as a stand-in rather than presented as a name.
 
-**Truncation respects word boundaries.** The sitting renders
-`Die digitale Forensik unterscheidet sich zusätzlich darin vo` — a cut mid-word.
-Wherever a stand-in title is shortened, it ends at a word.
+`title_of` is the center of this, and it is worth being concrete about what it
+does today. A hard cut at sixty characters produces
+`Die digitale Forensik unterscheidet sich zusätzlich darin vo` in the sitting —
+mid-word — and it is the same function that titles the dedupe cards, which is
+why "Needs you" offers
+`Keep "- schneller Schreibzugriff (Änderungen vom Key auf Stapel) -"`: a body
+opening, leading punctuation and all, pressed into service as a name. One rule
+fixes the sitting, the dedupe queue, and the judge together.
+
+**Truncation respects word boundaries**, and a stand-in drops leading
+punctuation before it is shown as a heading.
 
 **Colliding titles get a disambiguator.** Three distinct artifacts on the
 deployment carry the title `LevelDB: Funktionsweise und forensische Analyse`.

--- a/docs/superpowers/specs/2026-08-20-ui-findings-design.md
+++ b/docs/superpowers/specs/2026-08-20-ui-findings-design.md
@@ -66,8 +66,18 @@ agree:
 - `web/ui.rs:367` and `:3095` — `format!("Chunk {}", c.ordinal)`
 - `mcp/mod.rs:19` — `unwrap_or_else(|| "Untitled".into())`
 
-They collapse into one rule, the rail's: the opening of the body stands in for
-the heading, marked as a stand-in rather than presented as a name.
+They collapse into one rule, which is the rail's rule made precise. The rail
+shows *no heading at all* and lets the snippet speak (`render_hit`,
+`ui.rs:1323`). That is right wherever a snippet sits beside the name, and
+impossible where a name is structurally required — a button reading `Keep ""`
+decides nothing. So:
+
+- **Where a snippet accompanies the row** — the search rail, the judge card —
+  there is no heading.
+- **Where a name is structurally required** — a button label, the sitting list,
+  the artifact pane's own heading — a stand-in is derived from the body,
+  trimmed at a word boundary, stripped of leading punctuation, and marked as a
+  stand-in rather than presented as a name.
 
 `title_of` is the center of this, and it is worth being concrete about what it
 does today. A hard cut at sixty characters produces
@@ -131,7 +141,7 @@ which regions each page claims.
   snippets rather than two clipped lines. The placeholder stays.
 - **Judge**: `None of these` / `Can't remember` / `Not a real search`
   (`_judge_card.html:78-89`) sit below twenty-three candidate cards. They
-  become a sticky footer. Rank numbers stop after nine; they continue.
+  become a sticky footer.
 - **The artifact pane**: the title becomes sticky, `copy` moves out of the text
   flow it currently overlaps, `Delete` separates from `Verified`/`Hide`, and a
   segment cut mid-sentence links to its continuation — the source pane beside
@@ -141,7 +151,10 @@ which regions each page claims.
 ## 5. Copy and empty states
 
 - Housekeeping's counts are one run-on sentence; they become a stat row.
-- `TOOK` reads `now` for every sweep (`ops.html:60`); it reads a duration.
+- `TOOK` reads `now` for every sweep (`ops.html:60`). The cause is a reused
+  helper: `fmt_duration` (`ui.rs:331`) is future-tense — `"now"`, `"in 5m"` —
+  written for when a job runs next, and Ops spends it on elapsed time. Elapsed
+  time gets its own helper.
 - Sweep identifiers (`arm_dedupe`, `pursuit`, `consolidate`, `retention`)
   get human labels, keeping the raw name available.
 - One name for the page: the link says Housekeeping, the URL is `/ui/ops`, the
@@ -167,6 +180,12 @@ the question is not reopened blind.
   is set would respect the original reasoning.
 - **The phone badge drops its number** (`layout.html:130`, "the count is not
   the point — that anything is waiting is"). Deliberate. Left alone.
+- **Judge's rank numbers stop at nine** (`judge.rs:190`). Reviewed as a
+  finding and withdrawn: the number is a keyboard shortcut, the shortcut is one
+  digit, and "the tenth choosable option and everything after it keeps its
+  column and loses the number" is the correct reading of that constraint. The
+  sticky action bar in section 4 addresses what actually made the long list
+  hard to use.
 
 ## Testing
 

--- a/engram.service
+++ b/engram.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=engram
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=svc-engram
+WorkingDirectory=/home/svc-engram/engram
+EnvironmentFile=/home/svc-engram/engram/engram.env
+ExecStart=/home/svc-engram/engram/target/release/engram
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/src/auth/local.rs
+++ b/src/auth/local.rs
@@ -24,6 +24,9 @@ pub fn check_credentials(cfg: &LocalConfig, username: &str, password: &str) -> O
         Some(Identity {
             subject: cfg.username.clone(),
             email: None,
+            // The session does not exist yet: this is the check that decides
+            // whether to create one.
+            session: None,
         })
     } else {
         None

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -11,6 +11,14 @@ use axum::http::request::Parts;
 pub struct Identity {
     pub subject: String,
     pub email: Option<String>,
+    /// The web session this request came in on, where there is one.
+    ///
+    /// `None` for a bearer token, and that absence is load-bearing: it is what
+    /// keeps the live sitting at the web door. An access token is not a
+    /// conversation, and two agent sessions sharing one token would share a
+    /// sitting — worse than having none. Giving those doors a real session
+    /// identity is a change to the doors.
+    pub session: Option<String>,
 }
 
 /// Sliding session lifetime, 30 days.
@@ -80,6 +88,7 @@ impl FromRequestParts<AppState> for Identity {
             return Ok(Identity {
                 subject: session.subject,
                 email: session.email,
+                session: Some(sid),
             });
         }
 

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -342,7 +342,12 @@ impl OidcClient {
             return Err(Error::Forbidden);
         }
         tracing::info!(%subject, "oidc sign-in");
-        Ok(Identity { subject, email })
+        Ok(Identity {
+            subject,
+            email,
+            // The session is created from this, after it returns.
+            session: None,
+        })
     }
 }
 

--- a/src/auth/tokens.rs
+++ b/src/auth/tokens.rs
@@ -69,6 +69,8 @@ pub async fn verify(store: &Store, presented: &str) -> Result<Identity> {
             return Ok(Identity {
                 subject: t.subject,
                 email: None,
+                // A token is not a conversation. See `Identity::session`.
+                session: None,
             });
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,8 @@ pub struct Config {
     pub promote: PromoteConfig,
     #[serde(default)]
     pub pursuit: PursuitConfig,
+    #[serde(default)]
+    pub schedule: ScheduleConfig,
 }
 
 /// What the two supplied-from-outside capture paths are allowed to cost.
@@ -269,6 +271,32 @@ impl Default for ActivationConfig {
             opened: 0.5,
             confirmed: 3.0,
         }
+    }
+}
+
+/// What the queue does with work nobody is waiting on.
+///
+/// One key, because there is one thing to decide. `jobs.class` says whether
+/// somebody is standing in front of a unit, and that answer is a constant per
+/// stage rather than a setting — a priority the operator can set wrong presents
+/// as "the capture is hanging", with nothing anywhere saying why. What is left
+/// to configure is the one number that keeps priority from becoming starvation.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ScheduleConfig {
+    /// A background unit that has waited longer than this becomes foreground.
+    ///
+    /// Without it, one long ingest keeps night work off the workers
+    /// indefinitely, which is the exact failure a priority scheduler is
+    /// expected to have an answer for. The default is a guess; `sweep_runs` on
+    /// Ops is how the guess gets checked, since a sweep whose runs thin out is
+    /// visible there rather than silent.
+    pub age_after_mins: i64,
+}
+
+impl Default for ScheduleConfig {
+    fn default() -> Self {
+        Self { age_after_mins: 60 }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -300,8 +300,12 @@ pub struct SittingConfig {
     pub prime: bool,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for SittingConfig {
     fn default() -> Self {
+        // Spelled out rather than derived: `false` here is a decision with a
+        // reason above it, and a derived `Default` would put that reason a
+        // refactor away from the value it explains.
         Self { prime: false }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,13 +276,6 @@ impl Default for ActivationConfig {
     }
 }
 
-/// What the queue does with work nobody is waiting on.
-///
-/// One key, because there is one thing to decide. `jobs.class` says whether
-/// somebody is standing in front of a unit, and that answer is a constant per
-/// stage rather than a setting — a priority the operator can set wrong presents
-/// as "the capture is hanging", with nothing anywhere saying why. What is left
-/// to configure is the one number that keeps priority from becoming starvation.
 /// The live sitting: what this session has touched, carried between the doors.
 ///
 /// One key, because carrying changes no order and needs no permission. What
@@ -310,6 +303,13 @@ impl Default for SittingConfig {
     }
 }
 
+/// What the queue does with work nobody is waiting on.
+///
+/// One key, because there is one thing to decide. `jobs.class` says whether
+/// somebody is standing in front of a unit, and that answer is a constant per
+/// stage rather than a setting — a priority the operator can set wrong presents
+/// as "the capture is hanging", with nothing anywhere saying why. What is left
+/// to configure is the one number that keeps priority from becoming starvation.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct ScheduleConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,8 @@ pub struct Config {
     pub pursuit: PursuitConfig,
     #[serde(default)]
     pub schedule: ScheduleConfig,
+    #[serde(default)]
+    pub sitting: SittingConfig,
 }
 
 /// What the two supplied-from-outside capture paths are allowed to cost.
@@ -281,6 +283,29 @@ impl Default for ActivationConfig {
 /// stage rather than a setting — a priority the operator can set wrong presents
 /// as "the capture is hanging", with nothing anywhere saying why. What is left
 /// to configure is the one number that keeps priority from becoming starvation.
+/// The live sitting: what this session has touched, carried between the doors.
+///
+/// One key, because carrying changes no order and needs no permission. What
+/// moves ranking is priming, and that is what this switches.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct SittingConfig {
+    /// Let what this sitting has touched lift a result.
+    ///
+    /// Off until the harness says otherwise. It is the only part of the sitting
+    /// that moves an order, and the same query ranking differently in two
+    /// sittings is exactly what is disorienting about it — so it ships off, the
+    /// lift is bounded by the same budget activation's is, and rank 0 never
+    /// moves.
+    pub prime: bool,
+}
+
+impl Default for SittingConfig {
+    fn default() -> Self {
+        Self { prime: false }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct ScheduleConfig {

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -856,6 +856,7 @@ impl Core {
                 // assumed — in either direction.
                 weak: false,
                 primed: false,
+                in_sitting: false,
                 // The cliff was computed over scores this one was never in.
                 past_cliff: false,
                 // What makes a reached artifact tellable apart from a retrieved
@@ -2615,6 +2616,7 @@ mod tests {
                 last_verified_at: None,
                 weak: false,
                 primed: false,
+                in_sitting: false,
                 past_cliff: false,
                 via: None,
                 reason: None,

--- a/src/core/ask/retrieve.rs
+++ b/src/core/ask/retrieve.rs
@@ -327,6 +327,7 @@ mod tests {
             last_verified_at: None,
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: via.map(str::to_string),
             reason: None,

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -99,9 +99,10 @@ pub const CONSOLIDATE_TARGET: &str = "collection";
 /// on another feature's switch stops when that feature is switched off, and
 /// nobody asked for that.
 ///
-/// `Pursuit` is deliberately absent: it is armed by the association sweep on
-/// completion — replay before pursue — and keeps its own period as a floor, so
-/// it appears here too. See `periodic_period`.
+/// `Pursuit` is here despite being armed by the association sweep on completion
+/// — replay before pursue. That arming is what *orders* the two; the period it
+/// keeps here is a floor under it, and the row is what the repair pass needs to
+/// find in order to recover a pursuit that died mid-run. See `periodic_period`.
 pub fn periodic_units(core: &crate::core::Core) -> Vec<(crate::store::jobs::Stage, &'static str)> {
     use crate::store::jobs::Stage;
     let mut out = Vec::new();
@@ -313,6 +314,17 @@ pub(crate) async fn repair_once(core: &crate::core::Core) {
         Err(e) => tracing::warn!(error = %e, "could not age the units that have been waiting"),
         _ => {}
     }
+    // Housekeeping about housekeeping. It rode on the retention unit, which is
+    // behind `feedback`: an operator with capture off and `retain_days` at its
+    // default has no retention unit at all, while the sweeps that do run — the
+    // dedupe arming every fifteen minutes, consolidation every day — keep
+    // writing a row apiece into a table nothing was left to trim. The same
+    // mistake this whole pass exists to record, one table further in.
+    match core.store.trim_sweep_runs().await {
+        Ok(n) if n > 0 => tracing::info!(dropped = n, "trimmed the sweep history"),
+        Err(e) => tracing::warn!(error = %e, "could not trim the sweep history"),
+        _ => {}
+    }
 }
 
 /// Compare what SQLite says exists against what the vector store holds.
@@ -463,6 +475,41 @@ mod tests {
                 .live_job(crate::store::jobs::Stage::Relate, &ids[0])
                 .await
                 .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn the_sweep_history_is_trimmed_with_capture_switched_off() {
+        // The trim rode on the retention unit, and that unit does not exist
+        // when `feedback` is off and nothing is being retained — while the
+        // dedupe arming and consolidation keep running, and keep writing a row
+        // apiece into a table nothing was left to trim.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = false;
+        core.feedback.retain_days = 0;
+        assert!(
+            !periodic_units(&core)
+                .iter()
+                .any(|(s, _)| *s == crate::store::jobs::Stage::Retention),
+            "this base still has the unit that used to do the trimming"
+        );
+        let over = crate::store::sweeps::MAX_RUNS + 5;
+        for i in 0..over {
+            core.store
+                .record_sweep_run("consolidate", crate::store::now() - (over - i), "ok", "{}")
+                .await
+                .unwrap();
+        }
+
+        repair_once(&core).await;
+
+        assert_eq!(
+            core.store
+                .sweep_history(crate::store::sweeps::MAX_RUNS + 10)
+                .await
+                .unwrap()
+                .len() as i64,
+            crate::store::sweeps::MAX_RUNS,
         );
     }
 

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -341,6 +341,17 @@ pub(crate) async fn repair_once(core: &crate::core::Core) {
     // dedupe arming every fifteen minutes, consolidation every day — keep
     // writing a row apiece into a table nothing was left to trim. The same
     // mistake this whole pass exists to record, one table further in.
+    // A coverage row outlives what it covers. `gap_id` names one of three
+    // tables, so it is deliberately not a foreign key and nothing cascades onto
+    // it — while retention deletes searches and questions on a promise, and a
+    // purge takes every one of them. The rows left behind were kept for the
+    // life of the base and read back as nothing at all, `gaps_covered_by_each`
+    // skipping each one because the join found no text to show.
+    match core.store.trim_gap_coverage().await {
+        Ok(n) if n > 0 => tracing::info!(dropped = n, "dropped coverage of gaps that are gone"),
+        Err(e) => tracing::warn!(error = %e, "could not drop coverage of gaps that are gone"),
+        _ => {}
+    }
     match core.store.trim_sweep_runs().await {
         Ok(n) if n > 0 => tracing::info!(dropped = n, "trimmed the sweep history"),
         Err(e) => tracing::warn!(error = %e, "could not trim the sweep history"),

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -80,52 +80,120 @@ impl Background {
 
 /// The sweep's job target. A constant rather than a corpus id: consolidation
 /// looks at the whole collection, and the `UNIQUE(stage, target_id)` on `jobs`
-/// then guarantees at most one queued sweep however often the ticker fires.
+/// then guarantees at most one queued sweep however often it is armed.
 pub const CONSOLIDATE_TARGET: &str = "collection";
 
-/// Queue a consolidation sweep now and every `interval_hours` after.
+/// Every sweep that runs on a period, what switches it off, and how long it
+/// waits between runs.
 ///
-/// A timer rather than a trigger on write: a sweep after every capture would
-/// re-examine the whole collection for one new artifact, and the pairs it finds
-/// do not become interesting the instant they are written. The first tick fires
-/// immediately, so a restart picks the work up rather than waiting a day.
-pub fn spawn_consolidation_ticker(
-    core: crate::core::Core,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        if !core.consolidate.enabled {
-            tracing::info!("consolidation sweep disabled");
-            return;
+/// One list, where five ticker preambles used to be. Each of those started
+/// separately, was gated separately, and knew about none of the others; what
+/// ran first on a given night was whichever interval happened to elapse first.
+/// A periodic unit re-arms itself `run_after` an interval out when it finishes,
+/// so `run_after` *is* the cursor recording when it last ran — already indexed,
+/// with no clock to hold and no meta key to keep.
+///
+/// This is also where every gate that used to be an early `return` now lives,
+/// and each one keeps its original condition exactly. Getting that wrong
+/// re-creates the bug `spawn_repair_ticker` exists to record: a pass that rides
+/// on another feature's switch stops when that feature is switched off, and
+/// nobody asked for that.
+///
+/// `Pursuit` is deliberately absent: it is armed by the association sweep on
+/// completion — replay before pursue — and keeps its own period as a floor, so
+/// it appears here too. See `periodic_period`.
+pub fn periodic_units(core: &crate::core::Core) -> Vec<(crate::store::jobs::Stage, &'static str)> {
+    use crate::store::jobs::Stage;
+    let mut out = Vec::new();
+    // Duplicate hygiene, and the judging that needs a model to do it with.
+    if core.consolidate.enabled && core.synthesizes() {
+        out.push((Stage::Consolidate, CONSOLIDATE_TARGET));
+        // Zero units per tick is the off switch for the calls, not for the
+        // sweep that finds the pairs.
+        if core.consolidate.max_dedupe_per_tick > 0 {
+            out.push((Stage::ArmDedupe, CONSOLIDATE_TARGET));
         }
-        if !core.synthesizes() {
-            tracing::info!("no synthesizer; consolidation judging disabled");
-            return;
+    }
+    // Expiring and grouping. Behind neither consolidation nor association: an
+    // operator who switches duplicate hygiene off is not asking to keep their
+    // query log forever. With nothing to expire and nothing to group there is
+    // no unit at all, which is what the ticker's `return` used to say.
+    if core.feedback.retain_days > 0 || core.feedback.enabled {
+        out.push((Stage::Retention, CONSOLIDATE_TARGET));
+    }
+    if core.associating() {
+        out.push((Stage::Associate, ASSOCIATE_TARGET));
+        // Its own period as a floor. The association sweep arming it is what
+        // orders the two; this is what keeps pursuits running at the cadence
+        // they ran at before, rather than at the association sweep's.
+        if core.pursuit.enabled {
+            out.push((Stage::Pursuit, ASSOCIATE_TARGET));
         }
-        let period = std::time::Duration::from_secs(core.consolidate.interval_hours.max(1) * 3600);
-        let mut tick = tokio::time::interval(period);
-        loop {
-            tokio::select! {
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() { break; }
-                }
-                _ = tick.tick() => {
-                    if let Err(e) = core
-                        .store
-                        .enqueue(
-                            crate::store::jobs::Stage::Consolidate,
-                            "collection",
-                            CONSOLIDATE_TARGET,
-                        )
-                        .await
-                    {
-                        tracing::warn!(error = %e, "could not queue the consolidation sweep");
-                    }
+    }
+    out
+}
+
+/// How long this sweep waits between runs, or `None` if it is switched off.
+///
+/// The existing interval keys keep their names and their meanings and become
+/// each unit's own `run_after` step, so an operator who tuned
+/// `associate.interval_mins` finds it still doing what it did. The `max(1)` and
+/// the saturating multiply come with them: the operand is operator-typed, and a
+/// wrap here would turn a very long configured interval into a very short one.
+pub fn periodic_period(
+    core: &crate::core::Core,
+    stage: crate::store::jobs::Stage,
+) -> Option<std::time::Duration> {
+    use crate::store::jobs::Stage;
+    if !periodic_units(core).iter().any(|(s, _)| *s == stage) {
+        return None;
+    }
+    let secs = match stage {
+        Stage::Consolidate => core.consolidate.interval_hours.max(1).saturating_mul(3600),
+        Stage::ArmDedupe => core
+            .consolidate
+            .dedupe_interval_mins
+            .max(1)
+            .saturating_mul(60),
+        Stage::Retention => core.feedback.sweep_hours.max(1).saturating_mul(3600),
+        Stage::Associate => core.associate.interval_mins.max(1).saturating_mul(60),
+        // Shorter than the idle window, so a run of searches is grouped soon
+        // after it goes quiet.
+        Stage::Pursuit => (core.pursuit.idle_secs / 2).max(60),
+        _ => return None,
+    };
+    Some(std::time::Duration::from_secs(secs))
+}
+
+/// Arm every periodic unit that nothing is going to run.
+///
+/// The guard against the one failure mode a ticker does not have: a unit that
+/// dies between being claimed and re-arming itself would otherwise never run
+/// again. "Missing" means *not live* rather than *no row*, because a sweep
+/// closed without re-arming is just as gone as one that was deleted — and the
+/// two are indistinguishable from here, which is the point.
+///
+/// Armed to run now, not an interval out. This is also what arms them at boot,
+/// where the repair pass's first tick fires immediately, and a restart picking
+/// the work straight up is the behaviour the tickers had.
+pub(crate) async fn arm_missing_periodic(core: &crate::core::Core) {
+    for (stage, target) in periodic_units(core) {
+        match core.store.live_job(stage, target).await {
+            Ok(true) => {}
+            Ok(false) => {
+                if let Err(e) = core
+                    .store
+                    .arm_periodic(stage, "collection", target, 0)
+                    .await
+                {
+                    tracing::warn!(stage = stage.as_str(), error = %e, "could not arm a sweep");
                 }
             }
+            Err(e) => {
+                tracing::warn!(stage = stage.as_str(), error = %e, "could not look for a sweep")
+            }
         }
-        tracing::info!("consolidation ticker stopped");
-    })
+    }
 }
 
 /// How often the repair pass runs. A constant rather than a setting: this is
@@ -229,6 +297,10 @@ pub(crate) async fn repair_once(core: &crate::core::Core) {
             tracing::warn!(error = %e, "could not look for artifacts that were never related")
         }
     }
+    // A sweep that died between being claimed and re-arming itself would
+    // otherwise never run again — the one failure mode a ticker does not have,
+    // and the reason this pass stays outside the schedule.
+    arm_missing_periodic(core).await;
     // Priority without ageing is starvation: one long ingest would keep night
     // work off the workers for as long as it lasted. Here rather than in the
     // claim for the reason `age_background` gives — an inequality in the
@@ -258,199 +330,10 @@ pub(crate) async fn reconcile_stores_once(core: &crate::core::Core) {
     }
 }
 
-/// Enforce `feedback.retain_days` now and every `feedback.sweep_hours` after,
-/// and regroup the knowledge gaps on the same beat.
-///
-/// Its own ticker rather than a passenger on the consolidation sweep, which is
-/// where it used to live: an operator who switches duplicate hygiene off is not
-/// asking to keep their query log forever, and that is what the coupling
-/// quietly did. Runs even with capture disabled, so turning capture off also
-/// expires what it recorded while it was on. Grouping the gaps rides the same
-/// rhythm because it reads the same tables, and hours is the right cadence for
-/// something a person looks at when they next capture.
-pub fn spawn_retention_ticker(
-    core: crate::core::Core,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        if core.feedback.retain_days <= 0 {
-            tracing::info!("captured searches and questions kept indefinitely");
-            // Nothing to expire, and with capture off nothing to group either:
-            // the ticker would wake every `sweep_hours` for the rest of the
-            // process to do nothing at all. The line above is the whole of what
-            // this task has to say, so it says it and stops.
-            if !core.feedback.enabled {
-                return;
-            }
-        }
-        let period = std::time::Duration::from_secs(core.feedback.sweep_hours.max(1) * 3600);
-        let mut tick = tokio::time::interval(period);
-        loop {
-            tokio::select! {
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() { break; }
-                }
-                _ = tick.tick() => {
-                    if core.feedback.retain_days > 0 {
-                        match core.store.expire_feedback(core.feedback.retain_days).await {
-                            Ok(n) if n > 0 => {
-                                tracing::info!(dropped = n, "expired captured searches and questions")
-                            }
-                            // A failed sweep is retried on the next tick; there is
-                            // nothing here worth taking the process down for.
-                            Err(e) => {
-                                tracing::warn!(error = %e, "could not expire captured searches")
-                            }
-                            _ => {}
-                        }
-                    }
-                    if core.feedback.enabled {
-                        match crate::jobs::gaps::sweep(&core).await {
-                            Ok(r) if r.named > 0 || r.removed > 0 => tracing::info!(
-                                clusters = r.clusters, named = r.named, removed = r.removed,
-                                "knowledge gaps regrouped"
-                            ),
-                            Err(e) => tracing::warn!(error = %e, "could not group knowledge gaps"),
-                            _ => {}
-                        }
-                    }
-                }
-            }
-        }
-        tracing::info!("retention ticker stopped");
-    })
-}
-
-/// Arm dedupe units at a steady rate, independent of the consolidation sweep.
-///
-/// Its own ticker rather than a passenger on that sweep, for the same reason
-/// retention got one: the pacing of model calls has nothing to do with the
-/// rhythm of duplicate *discovery*. The sweep runs daily because re-examining
-/// the whole collection more often buys nothing; the calls want a rate the
-/// hardware can actually sustain.
-///
-/// What it does not do is cap units in flight. A unit the queue cannot get
-/// through — a dead endpoint — would then block every other
-/// pair permanently, which is the head-of-line blocking the per-pair units were
-/// introduced to remove. `live_job` skips a pair whose unit is already queued,
-/// and the ordering in `pairs_to_judge` keeps a pair that keeps failing from
-/// starving the rest.
-pub fn spawn_dedupe_ticker(
-    core: crate::core::Core,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        if !core.consolidate.enabled || core.consolidate.max_dedupe_per_tick == 0 {
-            tracing::info!("dedupe pass disabled");
-            return;
-        }
-        if !core.synthesizes() {
-            tracing::info!("no synthesizer; dedupe pass disabled");
-            return;
-        }
-        let period =
-            std::time::Duration::from_secs(core.consolidate.dedupe_interval_mins.max(1) * 60);
-        let mut tick = tokio::time::interval(period);
-        loop {
-            tokio::select! {
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() { break; }
-                }
-                _ = tick.tick() => {
-                    match crate::jobs::consolidate::arm_dedupe(&core).await {
-                        Ok(n) if n > 0 => tracing::info!(armed = n, "armed dedupe units"),
-                        // A failed tick is retried on the next one; there is
-                        // nothing here worth taking the process down for.
-                        Err(e) => tracing::warn!(error = %e, "could not arm dedupe units"),
-                        _ => {}
-                    }
-                }
-            }
-        }
-        tracing::info!("dedupe ticker stopped");
-    })
-}
-
 /// The association sweep's job target. A constant rather than an artifact id:
 /// the sweep replays the whole log, and `UNIQUE(stage, target_id)` then bounds
 /// the queue to one of them however often the ticker fires.
 pub const ASSOCIATE_TARGET: &str = "collection";
-
-/// Queue an association sweep now and every `associate.interval_mins` after.
-///
-/// Its own ticker, like retention and dedupe: the rhythm of replaying a search
-/// log has nothing to do with the rhythm of duplicate discovery, and coupling
-/// the two is how switching one feature off silently switches another one off.
-///
-/// Returns before its loop when there is nothing to learn from — either the
-/// feature is off, or searches are not being recorded, which is the same thing.
-/// Queue the pursuit sweep on a period shorter than the idle window, so a run
-/// of searches is grouped soon after it goes quiet.
-pub fn spawn_pursuit_ticker(
-    core: crate::core::Core,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        if !core.pursuit.enabled || !core.associating() {
-            tracing::info!("pursuit sweep disabled");
-            return;
-        }
-        let period = std::time::Duration::from_secs((core.pursuit.idle_secs / 2).max(60));
-        let mut tick = tokio::time::interval(period);
-        loop {
-            tokio::select! {
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() { break; }
-                }
-                _ = tick.tick() => {
-                    if let Err(e) = core
-                        .store
-                        .enqueue(crate::store::jobs::Stage::Pursuit, "collection", ASSOCIATE_TARGET)
-                        .await
-                    {
-                        tracing::warn!(error = %e, "could not queue the pursuit sweep");
-                    }
-                }
-            }
-        }
-        tracing::info!("pursuit ticker stopped");
-    })
-}
-
-pub fn spawn_associate_ticker(
-    core: crate::core::Core,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        if !core.associating() {
-            tracing::info!("association sweep disabled");
-            return;
-        }
-        // Saturating: the operand is operator-typed, and a wrap here would turn
-        // a very long configured interval into a very short one — a sweep
-        // hammering the queue is the opposite of what was asked for.
-        let period =
-            std::time::Duration::from_secs(core.associate.interval_mins.max(1).saturating_mul(60));
-        let mut tick = tokio::time::interval(period);
-        loop {
-            tokio::select! {
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() { break; }
-                }
-                _ = tick.tick() => {
-                    if let Err(e) = core
-                        .store
-                        .enqueue(crate::store::jobs::Stage::Associate, "collection", ASSOCIATE_TARGET)
-                        .await
-                    {
-                        tracing::warn!(error = %e, "could not queue the association sweep");
-                    }
-                }
-            }
-        }
-        tracing::info!("association ticker stopped");
-    })
-}
 
 #[cfg(test)]
 mod tests {
@@ -459,8 +342,8 @@ mod tests {
     use std::time::Duration;
 
     #[tokio::test]
-    async fn the_ticker_queues_exactly_one_sweep() {
-        // `jobs` is unique on (stage, target), so a ticker that fires while a
+    async fn the_consolidation_sweep_never_stacks_up_in_the_queue() {
+        // `jobs` is unique on (stage, target), so an arming that lands while a
         // sweep is still queued must collapse onto the same row rather than
         // stacking sweeps behind a slow one.
         let core = crate::core::test_support::test_core().await;
@@ -486,13 +369,14 @@ mod tests {
     async fn a_disabled_sweep_is_never_queued() {
         let mut core = crate::core::test_support::test_core().await;
         core.consolidate.enabled = false;
-        let (_tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_consolidation_ticker(core.clone(), rx);
-        let _ = h.await;
-        assert!(
-            core.store.claim_job().await.unwrap().is_none(),
-            "a disabled sweep must not be queued"
-        );
+        arm_missing_periodic(&core).await;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            assert_ne!(
+                j.stage,
+                crate::store::jobs::Stage::Consolidate,
+                "a disabled sweep must not be armed"
+            );
+        }
     }
 
     #[tokio::test]
@@ -582,182 +466,67 @@ mod tests {
         );
     }
 
-    /// One captured search, aged past any plausible window.
-    async fn seed_old_event(core: &crate::core::Core) {
-        let id = core
-            .store
-            .record_search(
-                crate::store::feedback::NewEvent {
-                    query: "old".into(),
-                    door: crate::store::feedback::Door::Ui,
-                    scope: None,
-                    filters: "{}".into(),
-                    query_vec: vec![0.0],
-                    embed_model: "fake".into(),
-                    candidates: vec![],
-                    answered: false,
-                },
-                0,
-            )
-            .await
-            .unwrap();
-        sqlx::query("UPDATE search_events SET created_at = ? WHERE id = ?")
-            .bind(crate::store::now() - 40 * 86_400)
-            .bind(&id)
-            .execute(&core.store.pool)
-            .await
-            .unwrap();
-    }
-
-    async fn captured(core: &crate::core::Core) -> i64 {
-        sqlx::query_scalar("SELECT count(*) FROM search_events")
-            .fetch_one(&core.store.pool)
-            .await
-            .unwrap()
-    }
-
     #[tokio::test]
-    async fn retention_runs_with_consolidation_switched_off() {
-        // Retention used to ride on the consolidation sweep, so switching
-        // duplicate hygiene off silently kept the query log forever.
-        let mut core = crate::core::test_support::test_core().await;
-        core.consolidate.enabled = false;
-        core.feedback.enabled = true;
-        core.feedback.retain_days = 30;
-        seed_old_event(&core).await;
-
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_retention_ticker(core.clone(), rx);
-        for _ in 0..50 {
-            if captured(&core).await == 0 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-        let _ = tx.send(true);
-        let _ = h.await;
-
-        assert_eq!(
-            captured(&core).await,
-            0,
-            "an event past the window outlived the retention ticker"
-        );
-    }
-
-    #[tokio::test]
-    async fn keeping_forever_expires_nothing() {
-        let core = crate::core::test_support::test_core().await; // retain_days defaults to 0
-        seed_old_event(&core).await;
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_retention_ticker(core.clone(), rx);
-        // Let the first tick land, then stop it. The ticker keeps running for
-        // the gap sweep, so it is stopped rather than awaited to its end.
-        for _ in 0..20 {
-            tokio::task::yield_now().await;
-        }
-        let _ = tx.send(true);
-        let _ = h.await;
-        assert_eq!(captured(&core).await, 1, "`0` must keep them forever");
-    }
-
-    /// Nothing to expire and, with capture off, nothing to group either. The
-    /// task used to return here; it lost the `return` when the gap sweep moved
-    /// in, and went on waking every `sweep_hours` for the life of the process to
-    /// do nothing at all.
-    #[tokio::test]
-    async fn a_ticker_with_nothing_to_do_stops_instead_of_idling() {
-        let mut core = crate::core::test_support::test_core().await;
-        core.feedback.retain_days = 0;
-        core.feedback.enabled = false;
-
-        let (_tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_retention_ticker(core.clone(), rx);
-        // No shutdown is sent: it has to end on its own account.
-        tokio::time::timeout(Duration::from_secs(2), h)
-            .await
-            .expect("the ticker sat waiting for a tick it has no work for")
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn the_ticker_groups_the_gaps_on_its_first_tick() {
-        let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
-        // Two of them: one gap is not a group, and the sweep no longer spends a
-        // naming call restating a single question.
-        for q in ["mount an E01", "mounting E01 images"] {
-            let id = core
-                .store
-                .record_ask(crate::store::asks::NewAsk {
-                    question: q.into(),
-                    scope: None,
-                    filters: "{}".into(),
-                    query_vec: vec![1.0; 4],
-                    embed_model: core.embedder.model().to_string(),
-                    answer: "Not in the knowledge base.".into(),
-                    abstained: true,
-                    dropped: 0,
-                    truncated: false,
-                    citations: vec![],
-                })
-                .await
-                .unwrap();
-            core.store
-                .judge_ask(&id, crate::store::asks::AskVerdict::NothingHere)
-                .await
-                .unwrap();
-        }
-
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_retention_ticker(core.clone(), rx);
-        for _ in 0..50 {
-            if !core.store.cluster_keys().await.unwrap().is_empty() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-        let _ = tx.send(true);
-        let _ = h.await;
-        assert_eq!(
-            core.store.cluster_keys().await.unwrap().len(),
-            1,
-            "the gap was never grouped"
-        );
-    }
-
-    #[tokio::test]
-    async fn the_ticker_queues_a_sweep_as_soon_as_it_starts() {
-        // `tokio::time::interval` fires immediately on its first tick, which is
-        // what makes a restart pick consolidation up rather than waiting a day.
+    async fn the_sweeps_are_armed_to_run_now_when_the_process_starts() {
+        // The repair pass's first tick fires immediately, and this is what it
+        // does with it. Armed at `run_after = 0` and not an interval out: a
+        // restart picking the work straight up is the behaviour the tickers
+        // had, and waiting a day after every deploy is not.
         let core = crate::core::test_support::test_core().await;
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_consolidation_ticker(core.clone(), rx);
 
-        // Give the first tick a chance to land, then stop the ticker.
-        for _ in 0..50 {
-            if core
-                .store
-                .job_counts()
-                .await
-                .unwrap()
-                .iter()
-                .any(|(_, n)| *n > 0)
-            {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-        let _ = tx.send(true);
-        let _ = h.await;
+        arm_missing_periodic(&core).await;
 
         let j = core
             .store
             .claim_job()
             .await
             .unwrap()
-            .expect("the ticker queued nothing");
+            .expect("nothing was armed");
         assert_eq!(j.stage, crate::store::jobs::Stage::Consolidate);
         assert_eq!(j.target_id, CONSOLIDATE_TARGET);
+    }
+
+    #[tokio::test]
+    async fn arming_what_is_missing_never_stacks_a_sweep_up() {
+        // `jobs` is unique on (stage, target), so a repair pass running while a
+        // sweep is still queued collapses onto the same row rather than
+        // stacking sweeps behind a slow one.
+        let core = crate::core::test_support::test_core().await;
+        for _ in 0..3 {
+            arm_missing_periodic(&core).await;
+        }
+        let mut consolidations = 0;
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            if j.stage == crate::store::jobs::Stage::Consolidate {
+                consolidations += 1;
+            }
+        }
+        assert_eq!(consolidations, 1, "the sweep stacked up in the queue");
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_died_between_claim_and_rearm_is_armed_again() {
+        // The one failure mode a ticker does not have: a unit that is claimed
+        // and never re-arms itself would otherwise never run again. "Missing"
+        // is *not live* rather than *no row*, because a sweep closed without
+        // re-arming is just as gone as one that was deleted.
+        let core = crate::core::test_support::test_core().await;
+        arm_missing_periodic(&core).await;
+        let j = core.store.claim_job().await.unwrap().unwrap();
+        // Closed without re-arming: the sweep died between the claim and the
+        // one write that would have put it back.
+        core.store.complete_job(j.id).await.unwrap();
+
+        arm_missing_periodic(&core).await;
+
+        let mut stages = Vec::new();
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            stages.push(j.stage);
+        }
+        assert!(
+            stages.contains(&crate::store::jobs::Stage::Consolidate),
+            "a sweep closed without re-arming was never put back"
+        );
     }
 
     #[tokio::test]
@@ -785,50 +554,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_association_ticker_queues_a_sweep_as_soon_as_it_starts() {
-        // `tokio::time::interval` fires immediately on its first tick, which
-        // is what makes a restart pick the association sweep up rather than
-        // waiting out a full `interval_mins`.
+    async fn the_association_sweep_is_armed_when_the_process_starts() {
         let mut core = crate::core::test_support::test_core().await;
         core.feedback.enabled = true;
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        let h = spawn_associate_ticker(core.clone(), rx);
-        for _ in 0..50 {
-            if core
-                .store
-                .job_counts()
-                .await
-                .unwrap()
-                .iter()
-                .any(|(_, n)| *n > 0)
-            {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-        let _ = tx.send(true);
-        let _ = h.await;
 
-        let j = core
-            .store
-            .claim_job()
-            .await
-            .unwrap()
-            .expect("the ticker queued nothing");
-        assert_eq!(j.stage, crate::store::jobs::Stage::Associate);
-        assert_eq!(j.target_id, ASSOCIATE_TARGET);
-        assert!(core.store.claim_job().await.unwrap().is_none());
+        arm_missing_periodic(&core).await;
+
+        let mut stages = Vec::new();
+        while let Some(j) = core.store.claim_job().await.unwrap() {
+            stages.push((j.stage, j.target_id));
+        }
+        assert!(
+            stages.contains(&(
+                crate::store::jobs::Stage::Associate,
+                ASSOCIATE_TARGET.to_string()
+            )),
+            "the association sweep was never armed: {stages:?}"
+        );
     }
 
     #[tokio::test]
-    async fn no_recorded_searches_means_no_association_ticker_at_all() {
+    async fn no_recorded_searches_means_no_association_sweep_at_all() {
         // `associate.enabled` without `feedback.enabled` is a warning at startup
-        // and nothing else: there is nothing to learn from.
+        // and nothing else: there is nothing to learn from, so there is no unit
+        // — which is the list's job now that there is no ticker to return from.
         let core = crate::core::test_support::test_core().await; // feedback off
-        let (_tx, rx) = tokio::sync::watch::channel(false);
-        // Returns rather than looping, so awaiting it cannot hang.
-        let _ = spawn_associate_ticker(core.clone(), rx).await;
-        assert!(core.store.claim_job().await.unwrap().is_none());
+        assert!(
+            !periodic_units(&core)
+                .iter()
+                .any(|(s, _)| *s == crate::store::jobs::Stage::Associate)
+        );
+    }
+
+    #[tokio::test]
+    async fn nothing_to_expire_and_nothing_to_group_is_no_retention_unit() {
+        // The ticker used to `return` here, and once lost the `return` and went
+        // on waking every `sweep_hours` for the life of the process to do
+        // nothing at all. A unit that is never armed cannot do that.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.retain_days = 0;
+        core.feedback.enabled = false;
+        assert!(
+            !periodic_units(&core)
+                .iter()
+                .any(|(s, _)| *s == crate::store::jobs::Stage::Retention)
+        );
     }
 
     #[tokio::test]

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -213,6 +213,18 @@ const REPAIR_INTERVAL_HOURS: u64 = 1;
 /// find, on almost every base, nothing.
 const STORE_DRIFT_INTERVAL_HOURS: u64 = 24;
 
+/// How many background units may be promoted on one repair tick.
+///
+/// A constant rather than a setting, and small on purpose. Ageing exists so
+/// that a unit which has waited goes ahead of a fresh capture (§4.4), and that
+/// stays true — but the queue fills on its own, and a slow judge endpoint can
+/// leave hundreds of units past the threshold at the same moment. Promoting
+/// all of them puts the whole backlog in front of something the operator just
+/// pasted, which is the head-of-line wait the class column exists to end.
+/// Twenty at a time keeps that wait bounded; the rest are still worked as
+/// background, and the next tick takes the next twenty.
+const AGE_PER_TICK: i64 = 20;
+
 /// Finish what a crash left half-done, now and every `REPAIR_INTERVAL_HOURS`,
 /// and compare the two stores every `STORE_DRIFT_INTERVAL_HOURS`.
 ///
@@ -308,8 +320,17 @@ pub(crate) async fn repair_once(core: &crate::core::Core) {
     // ordering costs the covering index — and here rather than on a sweep for
     // the reason everything else in this pass is here: it is what keeps the
     // schedule moving, so it cannot be scheduled by the thing it keeps moving.
-    let older_than = crate::store::now() - core.schedule.age_after_mins.max(0) * 60;
-    match core.store.age_background(older_than).await {
+    //
+    // Saturating for the same reason `periodic_period` is: `age_after_mins`
+    // comes out of `config.toml`, and a large enough value panics in debug and
+    // wraps in release, leaving an `older_than` that ages rows which have not
+    // waited at all. `0` is not a way to switch ageing off — it means every
+    // waiting unit is old enough, so the classes stop dividing anything, which
+    // is the behaviour from before the column existed. `config.example.toml`
+    // says so.
+    let older_than =
+        crate::store::now().saturating_sub(core.schedule.age_after_mins.max(0).saturating_mul(60));
+    match core.store.age_background(older_than, AGE_PER_TICK).await {
         Ok(n) if n > 0 => tracing::info!(aged = n, "background units have waited long enough"),
         Err(e) => tracing::warn!(error = %e, "could not age the units that have been waiting"),
         _ => {}

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -229,6 +229,18 @@ pub(crate) async fn repair_once(core: &crate::core::Core) {
             tracing::warn!(error = %e, "could not look for artifacts that were never related")
         }
     }
+    // Priority without ageing is starvation: one long ingest would keep night
+    // work off the workers for as long as it lasted. Here rather than in the
+    // claim for the reason `age_background` gives — an inequality in the
+    // ordering costs the covering index — and here rather than on a sweep for
+    // the reason everything else in this pass is here: it is what keeps the
+    // schedule moving, so it cannot be scheduled by the thing it keeps moving.
+    let older_than = crate::store::now() - core.schedule.age_after_mins.max(0) * 60;
+    match core.store.age_background(older_than).await {
+        Ok(n) if n > 0 => tracing::info!(aged = n, "background units have waited long enough"),
+        Err(e) => tracing::warn!(error = %e, "could not age the units that have been waiting"),
+        _ => {}
+    }
 }
 
 /// Compare what SQLite says exists against what the vector store holds.

--- a/src/core/gaps.rs
+++ b/src/core/gaps.rs
@@ -92,8 +92,15 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
 
 /// Single-linkage over cosine: two vectors join at `link_at`, and joining is
 /// transitive. Returns groups of indices, each sorted, ordered by their first
-/// member. N is bounded by `store::gaps::MAX_OPEN_GAPS`, so the quadratic pass
-/// is fine.
+/// member.
+///
+/// N is bounded by `store::gaps::MAX_OPEN_GAPS` *per kind*, and there are four
+/// kinds, so the quadratic pass is up to four times as many comparisons as that
+/// constant reads like — two million of them at today's numbers, on the
+/// retention tick. That is deliberate and it is the ceiling: it runs on a timer
+/// rather than on a request, nothing waits for it, and cutting the cap to make
+/// one number match the other would cost the operator gaps on the page to buy
+/// back time nobody is holding.
 ///
 /// Borrowed, not owned: the caller holds the vectors it read out of the store,
 /// and copying a thousand of them to pass them in was four million floats moved

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1064,8 +1064,9 @@ impl Core {
                 ));
             }
             // The pursuit sweep looks at every recorded search, not at one
-            // corpus.
-            Stage::Pursuit => {
+            // corpus; retention and dedupe arming look at the whole collection
+            // for the same reason.
+            Stage::Pursuit | Stage::Retention | Stage::ArmDedupe => {
                 return Err(Error::Validation(
                     "that stage is a collection-wide sweep, not a per-corpus stage".into(),
                 ));

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod image;
 pub mod ingest;
 pub mod pdf;
 pub mod search;
+pub mod sitting;
 
 use crate::config::Config;
 use crate::infer::budget::TokenCounter;
@@ -145,6 +146,12 @@ pub struct Core {
     /// What the queue does with work nobody is waiting on. Read by the repair
     /// pass, which is where ageing happens.
     pub schedule: crate::config::ScheduleConfig,
+    /// Whether the sitting may move a result. Carrying needs no setting.
+    pub sitting: crate::config::SittingConfig,
+    /// Every live sitting, keyed by web session. Shared by every clone of
+    /// `Core`, like the background queue — a per-clone map would be a per-clone
+    /// working memory, which is no working memory at all.
+    pub sittings: Arc<crate::core::sitting::Sittings>,
     /// The pacer every inference call passes through. Shared by every clone,
     /// because a per-clone gate would pace nothing: the point is one queue of
     /// calls in front of one GPU.
@@ -226,6 +233,8 @@ impl Core {
             promote: cfg.promote.clone(),
             pursuit: cfg.pursuit.clone(),
             schedule: cfg.schedule.clone(),
+            sitting: cfg.sitting.clone(),
+            sittings: Arc::new(Default::default()),
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::from_secs(cfg.pacing.cooldown_secs),
             )),
@@ -390,6 +399,8 @@ pub mod test_support {
             promote: crate::config::PromoteConfig::default(),
             pursuit: crate::config::PursuitConfig::default(),
             schedule: crate::config::ScheduleConfig::default(),
+            sitting: crate::config::SittingConfig::default(),
+            sittings: Arc::new(Default::default()),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.
             gate: Arc::new(crate::infer::gate::InferenceGate::new(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -142,6 +142,9 @@ pub struct Core {
     /// Whether and how a run of searches may be written up. See
     /// `PursuitConfig`.
     pub pursuit: crate::config::PursuitConfig,
+    /// What the queue does with work nobody is waiting on. Read by the repair
+    /// pass, which is where ageing happens.
+    pub schedule: crate::config::ScheduleConfig,
     /// The pacer every inference call passes through. Shared by every clone,
     /// because a per-clone gate would pace nothing: the point is one queue of
     /// calls in front of one GPU.
@@ -222,6 +225,7 @@ impl Core {
             activation: cfg.activation.clone(),
             promote: cfg.promote.clone(),
             pursuit: cfg.pursuit.clone(),
+            schedule: cfg.schedule.clone(),
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::from_secs(cfg.pacing.cooldown_secs),
             )),
@@ -385,6 +389,7 @@ pub mod test_support {
             activation: crate::config::ActivationConfig::default(),
             promote: crate::config::PromoteConfig::default(),
             pursuit: crate::config::PursuitConfig::default(),
+            schedule: crate::config::ScheduleConfig::default(),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.
             gate: Arc::new(crate::infer::gate::InferenceGate::new(

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -95,6 +95,12 @@ pub struct SearchResult {
     /// order is silent.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub primed: bool,
+    /// This sitting has already been in this artifact. Said beside `primed`,
+    /// because "you were just reading this" and "this is reached often" are
+    /// two different reasons to be higher up the list and the page should not
+    /// pass one off as the other.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub in_sitting: bool,
     /// This hit sits past the cliff: the one step in this list's scores that
     /// accounts for more of the fall than the rest of the list together. See
     /// `cliff`. It still competed and still placed — nothing is reordered or
@@ -137,6 +143,7 @@ impl From<SearchHit> for SearchResult {
             last_verified_at: h.payload.last_verified_at,
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: None,
             reason: None,
@@ -308,19 +315,37 @@ fn prime(
     activation: &HashMap<String, f64>,
     margin: f64,
     lift: usize,
+    sitting: &std::collections::HashSet<String>,
 ) -> Vec<SearchResult> {
     if lift == 0 || results.len() < 3 {
         return results;
     }
     let max = activation.values().copied().fold(0.0f64, f64::max);
-    if max <= 0.0 {
+    if max <= 0.0 && sitting.is_empty() {
         return results;
     }
     let n = results.len();
     // Normalised once, against the original list, and never touched again.
+    //
+    // The sitting enters here, as a value in the same scale, rather than as a
+    // second pass: one budget, one walk, one `lift`. A hit cannot be lifted
+    // `prime_lift` places for being accessible and then `prime_lift` again for
+    // having been read ten minutes ago — which is what two passes would do, and
+    // the second lift would be the one nobody bounded.
     let acts: Vec<f64> = results
         .iter()
-        .map(|r| activation.get(&r.artifact_id).copied().unwrap_or(0.0) / max)
+        .map(|r| {
+            let act = match max > 0.0 {
+                true => activation.get(&r.artifact_id).copied().unwrap_or(0.0) / max,
+                false => 0.0,
+            };
+            match sitting.contains(&r.artifact_id) {
+                // The top of the same normalised scale: what this sitting has
+                // been in is as accessible as anything in the base gets.
+                true => act.max(1.0),
+                false => act,
+            }
+        })
         .collect();
 
     // For each row, how many of its original predecessors — walked nearest
@@ -364,6 +389,7 @@ fn prime(
             // displaced by another row's climb did not move up, and
             // labelling it would say something untrue about it.
             r.primed = pos < i;
+            r.in_sitting = sitting.contains(&r.artifact_id);
             r
         })
         .collect()
@@ -689,6 +715,7 @@ impl Core {
                 last_verified_at: c.last_verified_at,
                 weak: false,
                 primed: false,
+                in_sitting: false,
                 past_cliff: false,
                 via: Some(l.via),
                 reason: l.reason,
@@ -950,11 +977,32 @@ impl Core {
         {
             let ids: Vec<String> = results.iter().map(|r| r.artifact_id.clone()).collect();
             let activation = self.activation_now(&ids).await;
+            // Off by default and empty when off: this is the only part of the
+            // sitting that moves an order, and the same query ranking
+            // differently in two sittings is what is disorienting about it.
+            // Held off the doors priming is already held off, for the same
+            // reasons, and off every door with no session for the reason in
+            // `Origin::session`.
+            let sitting: std::collections::HashSet<String> = match self.sitting.prime {
+                true => origin
+                    .session
+                    .as_deref()
+                    .map(|s| {
+                        self.sittings
+                            .read(s, now_secs(), self.pursuit.idle_secs as i64)
+                            .touched
+                            .into_iter()
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                false => Default::default(),
+            };
             results = prime(
                 results,
                 &activation,
                 self.associate.prime_margin,
                 self.associate.prime_lift,
+                &sitting,
             );
         }
 
@@ -1891,6 +1939,7 @@ mod tests {
                 last_verified_at: None,
                 weak: false,
                 primed: false,
+                in_sitting: false,
                 past_cliff: false,
                 via: None,
                 reason: None,
@@ -1911,7 +1960,13 @@ mod tests {
         // fused ranks and mean nothing across queries, while "moved up two
         // places" means the same thing every time — and can be tested here.
         let act = HashMap::from([("d".to_string(), 4.0)]);
-        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 2);
+        let out = prime(
+            ranked(&["a", "b", "c", "d"]),
+            &act,
+            0.5,
+            2,
+            &Default::default(),
+        );
         assert_eq!(order(&out), vec!["a", "d", "b", "c"]);
         assert!(out[1].primed, "the hit that moved must say so");
         assert!(!out[2].primed, "the hit it passed did not move up");
@@ -1920,15 +1975,59 @@ mod tests {
     #[test]
     fn the_most_active_hit_cannot_displace_an_exact_match() {
         let act = HashMap::from([("b".to_string(), 9.0)]);
-        let out = prime(ranked(&["a", "b", "c"]), &act, 0.5, 2);
+        let out = prime(ranked(&["a", "b", "c"]), &act, 0.5, 2, &Default::default());
         assert_eq!(order(&out), vec!["a", "b", "c"]);
         assert!(out.iter().all(|r| !r.primed));
     }
 
     #[test]
+    fn what_this_sitting_read_can_lift_a_hit() {
+        let sitting = std::collections::HashSet::from(["d".to_string()]);
+        let out = prime(
+            ranked(&["a", "b", "c", "d"]),
+            &HashMap::new(),
+            0.5,
+            2,
+            &sitting,
+        );
+        assert_eq!(order(&out), vec!["a", "d", "b", "c"]);
+        assert!(out[1].primed);
+        assert!(out[1].in_sitting, "the page cannot say why it moved");
+    }
+
+    #[test]
+    fn the_sitting_and_activation_share_one_budget() {
+        // Two passes would give a hit `prime_lift` places for being accessible
+        // and `prime_lift` again for having been read ten minutes ago — and the
+        // second lift would be the one nobody bounded. One walk, one `lift`.
+        let act = HashMap::from([("e".to_string(), 9.0)]);
+        let sitting = std::collections::HashSet::from(["e".to_string()]);
+        let out = prime(ranked(&["a", "b", "c", "d", "e"]), &act, 0.5, 2, &sitting);
+        assert_eq!(
+            order(&out),
+            vec!["a", "b", "e", "c", "d"],
+            "a hit in both moved further than one lift"
+        );
+    }
+
+    #[test]
+    fn the_sitting_cannot_displace_the_first_hit_either() {
+        // Rank 0 never moves, whatever the reason for moving would have been.
+        let sitting = std::collections::HashSet::from(["b".to_string(), "c".to_string()]);
+        let out = prime(ranked(&["a", "b", "c"]), &HashMap::new(), 0.5, 2, &sitting);
+        assert_eq!(order(&out)[0], "a");
+    }
+
+    #[test]
     fn a_lift_of_zero_turns_priming_off_entirely() {
         let act = HashMap::from([("d".to_string(), 4.0)]);
-        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 0);
+        let out = prime(
+            ranked(&["a", "b", "c", "d"]),
+            &act,
+            0.5,
+            0,
+            &Default::default(),
+        );
         assert_eq!(order(&out), vec!["a", "b", "c", "d"]);
     }
 
@@ -1937,7 +2036,13 @@ mod tests {
         // The margin is what keeps this from reshuffling every list: two hits
         // that are both somewhat active stay in the order the ranking gave.
         let act = HashMap::from([("c".to_string(), 4.0), ("d".to_string(), 3.6)]);
-        let out = prime(ranked(&["a", "b", "c", "d"]), &act, 0.5, 2);
+        let out = prime(
+            ranked(&["a", "b", "c", "d"]),
+            &act,
+            0.5,
+            2,
+            &Default::default(),
+        );
         assert_eq!(
             order(&out),
             vec!["a", "c", "b", "d"],
@@ -1952,7 +2057,13 @@ mod tests {
         // else moves through the position it landed on. Five elements is
         // enough to expose that: `e` should climb exactly two, not three.
         let act = HashMap::from([("e".to_string(), 1.0)]);
-        let out = prime(ranked(&["a", "b", "c", "d", "e"]), &act, 0.5, 2);
+        let out = prime(
+            ranked(&["a", "b", "c", "d", "e"]),
+            &act,
+            0.5,
+            2,
+            &Default::default(),
+        );
         assert_eq!(order(&out), vec!["a", "b", "e", "c", "d"]);
         let moved = order(&out).iter().position(|id| *id == "e").unwrap();
         assert_eq!(moved, 4 - 2, "e must climb exactly prime_lift positions");
@@ -1964,7 +2075,13 @@ mod tests {
         // Same shape, stretched to seven: the last row must still land
         // exactly `lift` positions up, at index 4 rather than index 1.
         let act = HashMap::from([("g".to_string(), 1.0)]);
-        let out = prime(ranked(&["a", "b", "c", "d", "e", "f", "g"]), &act, 0.5, 2);
+        let out = prime(
+            ranked(&["a", "b", "c", "d", "e", "f", "g"]),
+            &act,
+            0.5,
+            2,
+            &Default::default(),
+        );
         let moved = order(&out).iter().position(|id| *id == "g").unwrap();
         assert_eq!(moved, 4, "g must land at index 4, not be pulled to index 1");
         assert_eq!(6 - moved, 2, "the climb must equal prime_lift exactly");
@@ -2705,6 +2822,7 @@ mod tests {
             last_verified_at: None,
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: None,
             reason: None,
@@ -2810,6 +2928,7 @@ mod tests {
             last_verified_at: None,
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: None,
             reason: None,

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -828,6 +828,9 @@ impl Core {
             // the review queue and the undo need. A caller opts in explicitly.
             include_superseded: query.include_superseded,
             include_deprecated: query.include_deprecated,
+            // Ordinary search asks the whole base. Narrowing to one document is
+            // the coverage check's question, not a searcher's.
+            corpus_id: None,
         };
         // Over-fetch whenever something downstream narrows the list: both the
         // per-source cap and the reranker can only discard what they are given.

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -311,12 +311,20 @@ fn mark_past_cliff(results: &mut [SearchResult]) {
 /// every comparison reads from an activation snapshot untouched by any move,
 /// so no row can ever borrow a gap another row's move opened.
 fn prime(
-    results: Vec<SearchResult>,
+    mut results: Vec<SearchResult>,
     activation: &HashMap<String, f64>,
     margin: f64,
     lift: usize,
     sitting: &std::collections::HashSet<String>,
 ) -> Vec<SearchResult> {
+    // Marked before anything can return. `in_sitting` is a fact about the row —
+    // this sitting has been in it — and not a consequence of the reordering. A
+    // list of two is a list nothing can move in, not a list where the badge
+    // stops being true, and a badge that disappears on short result lists reads
+    // as the page forgetting rather than as a rule.
+    for r in &mut results {
+        r.in_sitting = sitting.contains(&r.artifact_id);
+    }
     if lift == 0 || results.len() < 3 {
         return results;
     }
@@ -389,7 +397,6 @@ fn prime(
             // displaced by another row's climb did not move up, and
             // labelling it would say something untrue about it.
             r.primed = pos < i;
-            r.in_sitting = sitting.contains(&r.artifact_id);
             r
         })
         .collect()
@@ -1993,6 +2000,19 @@ mod tests {
         assert_eq!(order(&out), vec!["a", "d", "b", "c"]);
         assert!(out[1].primed);
         assert!(out[1].in_sitting, "the page cannot say why it moved");
+    }
+
+    #[test]
+    fn a_list_too_short_to_reorder_still_says_what_the_sitting_read() {
+        // `in_sitting` is a fact about the row, not a consequence of a move. A
+        // list of two is a list nothing can be lifted in — but a badge that
+        // vanishes on short lists reads as the page forgetting, not as a rule.
+        let sitting = std::collections::HashSet::from(["b".to_string()]);
+        let out = prime(ranked(&["a", "b"]), &HashMap::new(), 0.5, 2, &sitting);
+        assert_eq!(order(&out), vec!["a", "b"], "nothing can move on two rows");
+        assert!(out[1].in_sitting);
+        assert!(!out[0].in_sitting);
+        assert!(out.iter().all(|r| !r.primed), "and nothing was primed");
     }
 
     #[test]

--- a/src/core/sitting.rs
+++ b/src/core/sitting.rs
@@ -106,8 +106,9 @@ impl Sittings {
     /// What this sitting has touched, or nothing if it has gone quiet.
     ///
     /// Expiry happens here and on write rather than on a timer: there is no
-    /// sweep to run and nothing to clean up, because a sitting nobody comes
-    /// back to is dropped by the next read that finds it stale.
+    /// sweep to run, because a sitting is dropped by the next read that finds
+    /// it stale — or, for the sitting nobody ever comes back to, by the next
+    /// write from any session at all. See `with`.
     pub fn read(&self, session: &str, at: i64, idle_secs: i64) -> Carried {
         let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         match map.get(session) {
@@ -123,19 +124,27 @@ impl Sittings {
         }
     }
 
-    /// The whole of the locking, once. An entry idle for longer than
-    /// `idle_secs` is not extended, it is replaced — the same number that
-    /// already defines a sitting for the pursuit sweep, so the live definition
-    /// and the reconstructed one agree by construction.
+    /// The whole of the locking, once, and the whole of the expiry with it. An
+    /// entry idle for longer than `idle_secs` is not extended, it is dropped —
+    /// the same number that already defines a sitting for the pursuit sweep, so
+    /// the live definition and the reconstructed one agree by construction.
+    ///
+    /// Every entry, not only this session's, because expiring only the one
+    /// being touched leaves out the case that matters: a browser tab closed and
+    /// never opened again is a session no later read or write ever names, so
+    /// nothing would find it stale and the map would grow for the life of the
+    /// process, one abandoned sitting at a time. The lock is already held here,
+    /// so the walk costs one integer comparison per live session — and the map
+    /// is only ever large in exactly the case where the walk is worth doing.
+    /// This session's own stale entry goes the same way, which is what makes a
+    /// returning sitting a new one rather than a continued one.
     fn with(&self, session: &str, at: i64, idle_secs: i64, f: impl FnOnce(&mut Sitting)) {
         if session.is_empty() {
             return;
         }
         let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        map.retain(|_, s| at - s.last_at <= idle_secs);
         let entry = map.entry(session.to_string()).or_default();
-        if entry.last_at > 0 && at - entry.last_at > idle_secs {
-            *entry = Sitting::default();
-        }
         entry.last_at = at;
         f(entry);
     }
@@ -167,6 +176,25 @@ mod tests {
 
         assert!(!s.read("sess", 100 + IDLE, IDLE).is_cold());
         assert!(s.read("sess", 100 + IDLE + 1, IDLE).is_cold());
+    }
+
+    #[test]
+    fn a_sitting_nobody_comes_back_to_is_swept_by_somebody_elses_write() {
+        // The abandoned tab is the case expiring-on-touch cannot reach: no
+        // later read or write ever names that session, so nothing would find it
+        // stale and the map would grow for the life of the process.
+        let s = Sittings::default();
+        s.touched("gone", "a", 100, IDLE);
+        assert_eq!(s.inner.lock().unwrap().len(), 1);
+
+        s.touched("here", "b", 100 + IDLE + 1, IDLE);
+
+        let live = s.inner.lock().unwrap();
+        assert_eq!(
+            live.keys().collect::<Vec<_>>(),
+            vec!["here"],
+            "the session that went quiet must not outlive the process"
+        );
     }
 
     #[test]

--- a/src/core/sitting.rs
+++ b/src/core/sitting.rs
@@ -96,8 +96,19 @@ impl Sittings {
                 // A backspace, or a repeat. The longer spelling stands.
                 return;
             }
-            s.queries
-                .retain(|q| !query.starts_with(q.as_str()) && q != query);
+            // Only the head is a prefix of the run being typed. Scanning the
+            // whole carried list deleted queries from earlier in the sitting
+            // that merely happen to be prefixes: "E01" in the morning and
+            // "E01 mounting on Linux" ten minutes later are two searches, and
+            // the rail kept one. Anything else is dropped only when it is the
+            // same query again, which is a repeat and not a run.
+            if s.queries
+                .front()
+                .is_some_and(|f| query.starts_with(f.as_str()))
+            {
+                s.queries.pop_front();
+            }
+            s.queries.retain(|q| q != query);
             s.queries.push_front(query.to_string());
             s.queries.truncate(CARRY);
         });
@@ -221,6 +232,36 @@ mod tests {
         assert_eq!(
             s.read("sess", 20, IDLE).queries,
             vec!["how do I mount an E01"]
+        );
+    }
+
+    #[test]
+    fn a_later_query_does_not_delete_an_earlier_one_it_happens_to_begin_with() {
+        // Folding a typing run is about the run, not about the whole sitting.
+        // Scanning everything carried meant that coming back to a subject with
+        // a longer question deleted the shorter question asked before it — two
+        // searches, ten minutes apart, and the rail remembered one.
+        let s = Sittings::default();
+        s.queried("sess", "E01", 10, IDLE);
+        s.queried("sess", "write blocker", 20, IDLE);
+        s.queried("sess", "E01 mounting on Linux", 30, IDLE);
+
+        assert_eq!(
+            s.read("sess", 40, IDLE).queries,
+            vec!["E01 mounting on Linux", "write blocker", "E01"]
+        );
+    }
+
+    #[test]
+    fn asking_the_same_thing_twice_moves_it_up_rather_than_listing_it_twice() {
+        let s = Sittings::default();
+        s.queried("sess", "E01", 10, IDLE);
+        s.queried("sess", "write blocker", 20, IDLE);
+        s.queried("sess", "E01", 30, IDLE);
+
+        assert_eq!(
+            s.read("sess", 40, IDLE).queries,
+            vec!["E01", "write blocker"]
         );
     }
 

--- a/src/core/sitting.rs
+++ b/src/core/sitting.rs
@@ -1,0 +1,226 @@
+//! What this sitting has touched.
+//!
+//! The base could already name what you were working on last Tuesday and not
+//! what you are working on now: `jobs/pursuit.rs` reconstructs a sitting from
+//! idle gaps in the search log, which means it exists only once it is over.
+//! This is the live half — a working memory, read while the sitting is
+//! happening, carried between the doors, gone when it goes.
+//!
+//! **In memory only.** No table, no migration, no expiry sweep. It dies with
+//! the process, and a deploy mid-afternoon costs the operator their carried
+//! context. That is the accepted price: a working memory that survives a
+//! restart is a long-term memory, and engram has one of those already.
+//!
+//! It does not write activation, it does not open a pursuit, and it exists at
+//! the web door only — for the API and `/mcp` an access token is not a
+//! conversation, and two agent sessions sharing a token would share a sitting,
+//! which is worse than having none.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+/// How much of a sitting is carried. Twenty is well past what any page shows;
+/// the cap is here so a long afternoon cannot grow the map without bound, not
+/// to decide what is worth remembering.
+pub const CARRY: usize = 20;
+
+/// An artifact this sitting has been in.
+#[derive(Debug, Clone)]
+pub struct Touched {
+    pub artifact_id: String,
+    pub at: i64,
+}
+
+/// One live sitting.
+#[derive(Debug, Default)]
+struct Sitting {
+    /// Most recent first, capped at `CARRY`.
+    touched: VecDeque<Touched>,
+    /// Most recent first, capped at `CARRY`.
+    queries: VecDeque<String>,
+    last_at: i64,
+}
+
+/// What a door reads: a copy, so nothing holds the lock across a render.
+#[derive(Debug, Default, Clone)]
+pub struct Carried {
+    /// Artifact ids, most recently touched first.
+    pub touched: Vec<String>,
+    /// Queries typed in this sitting, most recent first.
+    pub queries: Vec<String>,
+}
+
+impl Carried {
+    /// A cold sitting: nothing has happened, or what happened has gone quiet.
+    /// The pages render nothing at all for one, rather than an empty box.
+    pub fn is_cold(&self) -> bool {
+        self.touched.is_empty() && self.queries.is_empty()
+    }
+}
+
+/// Every live sitting, keyed by web session id.
+#[derive(Debug, Default)]
+pub struct Sittings {
+    inner: Mutex<HashMap<String, Sitting>>,
+}
+
+impl Sittings {
+    /// This sitting opened an artifact.
+    pub fn touched(&self, session: &str, artifact_id: &str, at: i64, idle_secs: i64) {
+        self.with(session, at, idle_secs, |s| {
+            s.touched.retain(|t| t.artifact_id != artifact_id);
+            s.touched.push_front(Touched {
+                artifact_id: artifact_id.to_string(),
+                at,
+            });
+            s.touched.truncate(CARRY);
+        });
+    }
+
+    /// This sitting typed a query.
+    ///
+    /// A typing burst folds into one entry, the same way `record_search` folds
+    /// one into a single event: the search box searches as you type, so a
+    /// finished query arrives as every prefix of itself, and a rail listing
+    /// "h", "ho", "how" would be a rail of one query spelled slowly. What is
+    /// kept is the longest of a run — the query that was actually meant.
+    pub fn queried(&self, session: &str, query: &str, at: i64, idle_secs: i64) {
+        let query = query.trim();
+        if query.is_empty() {
+            return;
+        }
+        self.with(session, at, idle_secs, |s| {
+            if let Some(front) = s.queries.front()
+                && front.starts_with(query)
+            {
+                // A backspace, or a repeat. The longer spelling stands.
+                return;
+            }
+            s.queries
+                .retain(|q| !query.starts_with(q.as_str()) && q != query);
+            s.queries.push_front(query.to_string());
+            s.queries.truncate(CARRY);
+        });
+    }
+
+    /// What this sitting has touched, or nothing if it has gone quiet.
+    ///
+    /// Expiry happens here and on write rather than on a timer: there is no
+    /// sweep to run and nothing to clean up, because a sitting nobody comes
+    /// back to is dropped by the next read that finds it stale.
+    pub fn read(&self, session: &str, at: i64, idle_secs: i64) -> Carried {
+        let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        match map.get(session) {
+            Some(s) if at - s.last_at <= idle_secs => Carried {
+                touched: s.touched.iter().map(|t| t.artifact_id.clone()).collect(),
+                queries: s.queries.iter().cloned().collect(),
+            },
+            Some(_) => {
+                map.remove(session);
+                Carried::default()
+            }
+            None => Carried::default(),
+        }
+    }
+
+    /// The whole of the locking, once. An entry idle for longer than
+    /// `idle_secs` is not extended, it is replaced — the same number that
+    /// already defines a sitting for the pursuit sweep, so the live definition
+    /// and the reconstructed one agree by construction.
+    fn with(&self, session: &str, at: i64, idle_secs: i64, f: impl FnOnce(&mut Sitting)) {
+        if session.is_empty() {
+            return;
+        }
+        let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.entry(session.to_string()).or_default();
+        if entry.last_at > 0 && at - entry.last_at > idle_secs {
+            *entry = Sitting::default();
+        }
+        entry.last_at = at;
+        f(entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IDLE: i64 = 900;
+
+    #[test]
+    fn what_was_touched_comes_back_most_recent_first() {
+        let s = Sittings::default();
+        s.touched("sess", "a", 10, IDLE);
+        s.touched("sess", "b", 20, IDLE);
+        // Touching something again moves it, rather than listing it twice.
+        s.touched("sess", "a", 30, IDLE);
+
+        let c = s.read("sess", 40, IDLE);
+        assert_eq!(c.touched, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn a_sitting_that_went_quiet_is_gone() {
+        // The same number the pursuit sweep uses to decide a sitting ended.
+        let s = Sittings::default();
+        s.queried("sess", "how do I mount an E01", 100, IDLE);
+
+        assert!(!s.read("sess", 100 + IDLE, IDLE).is_cold());
+        assert!(s.read("sess", 100 + IDLE + 1, IDLE).is_cold());
+    }
+
+    #[test]
+    fn coming_back_after_a_gap_starts_a_new_sitting() {
+        let s = Sittings::default();
+        s.queried("sess", "old subject", 100, IDLE);
+        s.queried("sess", "new subject", 100 + IDLE + 1, IDLE);
+
+        let c = s.read("sess", 100 + IDLE + 2, IDLE);
+        assert_eq!(c.queries, vec!["new subject"]);
+    }
+
+    #[test]
+    fn a_typing_burst_is_one_query() {
+        // The search box searches as you type, so a finished query arrives as
+        // every prefix of itself.
+        let s = Sittings::default();
+        for q in ["h", "how", "how do I mount an E01"] {
+            s.queried("sess", q, 10, IDLE);
+        }
+        // And a backspace afterwards does not undo it.
+        s.queried("sess", "how do I mount an E0", 11, IDLE);
+
+        assert_eq!(
+            s.read("sess", 20, IDLE).queries,
+            vec!["how do I mount an E01"]
+        );
+    }
+
+    #[test]
+    fn two_sittings_do_not_see_each_other() {
+        let s = Sittings::default();
+        s.queried("one", "mine", 10, IDLE);
+        s.queried("two", "theirs", 10, IDLE);
+
+        assert_eq!(s.read("one", 20, IDLE).queries, vec!["mine"]);
+        assert_eq!(s.read("two", 20, IDLE).queries, vec!["theirs"]);
+    }
+
+    #[test]
+    fn a_door_with_no_session_carries_nothing() {
+        // An access token is not a conversation, and two agent sessions sharing
+        // one would share a sitting — worse than having none.
+        let s = Sittings::default();
+        s.queried("", "from a token", 10, IDLE);
+        assert!(s.read("", 20, IDLE).is_cold());
+    }
+
+    #[test]
+    fn a_long_afternoon_stays_bounded() {
+        let s = Sittings::default();
+        for i in 0..(CARRY + 10) {
+            s.touched("sess", &format!("a-{i}"), i as i64, IDLE);
+        }
+        assert_eq!(s.read("sess", 100, IDLE).touched.len(), CARRY);
+    }
+}

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -8,6 +8,10 @@
 //! The corpus this measures is not in the repository and must not be: it is
 //! whatever documents the operator actually wants to search. What lives here is
 //! the shape of the files and the arithmetic over ranks.
+//!
+//! `docs/evaluation.md` is the whole of it in prose: what each harness
+//! measures, which knob to sweep for which metric, and — the part worth
+//! reading before trusting a number — what neither of them can measure.
 
 pub mod claims;
 pub mod export;

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -76,9 +76,26 @@ fn replayable(stamps: &[i64], limit: usize) -> usize {
 }
 
 /// One sweep over everything learned since the last one.
-pub async fn run(core: &Core) -> Result<()> {
+/// What one association sweep did. The numbers it already logged, given a
+/// shape so the account can keep them: a sweep whose runs thin out is then
+/// visible on Ops rather than only in a journal nobody is reading.
+#[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+pub struct Report {
+    /// Search events replayed into link weight.
+    pub events: usize,
+    /// Verdicts replayed.
+    pub verdicts: usize,
+    /// Learning links whose decayed weight fell under `prune_below`.
+    pub forgotten: u64,
+    /// Judged links reopened because one side was re-embedded.
+    pub reopened: u64,
+    /// Judge units armed. The calls happen later, one unit at a time.
+    pub armed: i64,
+}
+
+pub async fn run(core: &Core) -> Result<Report> {
     if !core.associating() {
-        return Ok(());
+        return Ok(Report::default());
     }
     let at = crate::store::now();
     let bound = replay_events(core, at).await?;
@@ -142,7 +159,13 @@ pub async fn run(core: &Core) -> Result<()> {
         armed,
         "association sweep"
     );
-    Ok(())
+    Ok(Report {
+        events: bound,
+        verdicts: confirmed,
+        forgotten,
+        reopened,
+        armed,
+    })
 }
 
 /// Every pair of shown candidates in every settled event past the watermark.

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -311,15 +311,23 @@ fn interpret(
         if !lost.is_empty() {
             // Escalated rather than retried: the merge is the thing that was
             // wrong, and refusing it hands the pair to a person, which is the
-            // finding. What is not written any more is a sentence naming the
-            // lost tokens — those are as often a bare "1, 4" as a version
-            // number, which is evidence too thin to put on a card someone has
-            // to act on, in a voice unlike every other line beside it. The
-            // judge's own detail goes with it: it was written to say why the
-            // two are the *same* ("same claim"), and under Contradiction the
-            // card renders it directly beneath "these two disagree", so the
-            // pair states the opposite of its own finding to the person the
+            // finding. Two sentences are still not written here. Not the lost
+            // tokens — those are as often a bare "1, 4" as a version number,
+            // which is evidence too thin to put on a card someone has to act
+            // on, in a voice unlike every other line beside it. And not the
+            // judge's own detail: it was written to say why the two are the
+            // *same* ("same claim"), and under Contradiction the card renders
+            // it directly beneath "these two disagree", so the pair would
+            // state the opposite of its own finding to the person the
             // escalation exists to hand it to.
+            //
+            // What is written is a third thing, true of this escalation and of
+            // no other: the merge was refused because it would have lost
+            // something. Saying nothing at all was the state before, and five
+            // cards reading "these two disagree" with nothing under them sat
+            // on a deployment — a dispute nobody can act on is not better than
+            // an imperfect sentence about it, it is the one thing a card in
+            // this queue must never be.
             //
             // Logged, though. Keeping the tokens off the card is a judgement
             // about what a person can act on; keeping them out of the process
@@ -333,7 +341,11 @@ fn interpret(
                 "refused a merge that would have dropped these"
             );
             relation = Relation::Conflict;
-            detail = None;
+            detail = Some(
+                "These two state a value differently, and merging them would have dropped \
+                 one of them. Which is current is the judgement this hands over."
+                    .to_string(),
+            );
             merged = None;
         }
     }
@@ -646,12 +658,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_merge_that_would_lose_a_value_is_escalated_without_a_sentence_about_it() {
-        // The loss check, from the unit's side. Refusing the merge and handing
-        // the pair to a person is the whole finding. The sentence this used to
-        // write named the lost tokens, and those are as often a bare "1, 4" as
-        // a version number — evidence too thin to put on a card someone has to
-        // act on, in a voice unlike every other line beside it.
+    async fn a_merge_that_would_lose_a_value_says_so_without_naming_the_tokens() {
+        // The loss check, from the unit's side. Two sentences must not be
+        // written here: the lost tokens, which are as often a bare "1, 4" as a
+        // version number and are evidence too thin to act on; and the judge's
+        // own line, which was written to say the two are the *same* and would
+        // contradict the "these two disagree" it renders under. Neither of
+        // those is an argument for saying nothing at all — a card naming no
+        // dispute is one nobody can decide, and five of them sat on the
+        // deployment.
         let mut core = test_core().await;
         core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"duplicate","detail":"same claim",
@@ -669,11 +684,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(found.len(), 1);
-        assert_eq!(
-            found[0].detail, None,
-            "no loss sentence is written, and the judge's own line said the two \
-             were the same — rendered under \"these two disagree\" it would \
-             contradict the card it sits on"
+        let detail = found[0].detail.as_deref().unwrap_or_default();
+        assert!(
+            detail.contains("dropped"),
+            "the card says nothing about why it was escalated: {detail:?}"
+        );
+        assert!(
+            !detail.contains("same claim"),
+            "the judge's line said these two were the same; under \"these two \
+             disagree\" it contradicts the card it sits on: {detail:?}"
+        );
+        assert!(
+            !detail.contains("1.30.0"),
+            "the lost tokens are evidence too thin to act on: {detail:?}"
         );
         for id in &ids {
             assert!(

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -918,7 +918,20 @@ pub async fn settle_corpus(core: &Core, corpus_id: &str) -> Result<()> {
     } else {
         CorpusStatus::Ready
     };
+    let ready = status == CorpusStatus::Ready;
     core.store.set_corpus_status(corpus_id, status).await?;
+    if ready {
+        // On the background handle, not on this path: the document is stored
+        // and settled either way, and a vector query per open gap is not
+        // something the last chunk's embedding should wait behind.
+        let core = core.clone();
+        let id = corpus_id.to_string();
+        core.clone().background.spawn(async move {
+            if let Err(e) = crate::jobs::gaps::cover(&core, &id).await {
+                tracing::warn!(corpus_id = %id, error = %e, "could not check what this capture answered");
+            }
+        });
+    }
     Ok(())
 }
 

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -13,6 +13,11 @@ use crate::core::gaps::{
 use crate::error::Result;
 use crate::store::gaps::{GapCluster, GapKind};
 
+/// How many coverage queries one capture keeps in the air at once. Small enough
+/// that a capture never becomes the load on the vector store, large enough that
+/// the wait is the slowest query and not the sum of them.
+const COVER_IN_FLIGHT: usize = 16;
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SweepReport {
     /// Groups of `MIN_CLUSTER` or more: the ones that are stored and shown as
@@ -29,6 +34,16 @@ pub struct SweepReport {
 /// only, and no model call anywhere. A gap whose best new hit reaches
 /// `weak_below` is closed — the same line that decided the gap was a gap in the
 /// first place, read the other way round.
+///
+/// The queries are issued `COVER_IN_FLIGHT` at a time rather than one after
+/// another. There are four kinds of gap, each capped at `MAX_OPEN_GAPS`, and
+/// since the unmatched ones are derived from the search log without anybody
+/// judging anything, a base with capture on reaches those caps as a matter of
+/// course rather than as a worst case. A round trip apiece, in series, is then
+/// minutes of a capture sitting at its last step for work that is entirely
+/// waiting. Bounded rather than unbounded because the same reasoning applies to
+/// the other end: two thousand simultaneous queries is not concurrency, it is
+/// an outage in the vector store the whole memory shares.
 ///
 /// Filtered to this corpus on purpose: the question is whether *this capture*
 /// answered something. A hit from anywhere else answers a different question —
@@ -60,15 +75,56 @@ pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
         include_deprecated: false,
         corpus_id: Some(corpus_id.to_string()),
     };
+    // One hit per gap: the question is whether the best new artifact reaches
+    // the line, and the second-best cannot answer it. Kept by the gap's index
+    // so the concurrent answers land back in the order the gaps were read,
+    // which is what makes the writes below deterministic.
+    let mut best: Vec<Option<crate::vector::SearchHit>> = vec![None; open.gaps.len()];
+    let mut failure: Option<crate::error::Error> = None;
+    let mut inflight = tokio::task::JoinSet::new();
+    let mut next = 0usize;
+    loop {
+        while inflight.len() < COVER_IN_FLIGHT && next < open.gaps.len() {
+            let at = next;
+            next += 1;
+            let vectors = core.vectors.clone();
+            let vec = open.gaps[at].vec.clone();
+            let filter = filter.clone();
+            inflight.spawn(async move {
+                (
+                    at,
+                    vectors.search(&vec, &Default::default(), 1, &filter).await,
+                )
+            });
+        }
+        let Some(joined) = inflight.join_next().await else {
+            break;
+        };
+        match joined {
+            Ok((at, Ok(hits))) => best[at] = hits.into_iter().next(),
+            Ok((_, Err(e))) => {
+                failure.get_or_insert(e);
+            }
+            // The task itself did not finish — a panic inside the vector
+            // client, or the runtime shutting down under us. Not this
+            // module's error, and not something a retry of the same search
+            // would answer, but it is still a search that did not happen and
+            // must not be reported as a gap that stayed open.
+            Err(e) => {
+                failure.get_or_insert(crate::error::Error::Internal(e.to_string()));
+            }
+        }
+    }
+    // Every search that was already in flight is allowed to finish before the
+    // first failure is returned: they cost nothing more once issued, and a gap
+    // one of them closed is closed whether or not another query failed.
+    if let Some(e) = failure {
+        return Err(e);
+    }
+
     let mut closed = 0;
-    for g in &open.gaps {
-        // One hit: the question is whether the best new artifact reaches the
-        // line, and the second-best cannot answer it.
-        let hits = core
-            .vectors
-            .search(&g.vec, &Default::default(), 1, &filter)
-            .await?;
-        let Some(hit) = hits.first() else { continue };
+    for (g, hit) in open.gaps.iter().zip(best) {
+        let Some(hit) = hit else { continue };
         // `None` is "no opinion" and not a low value — a lexical hit the dense
         // half never returned. It cannot close a gap, because closing one is a
         // claim about distance.

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -13,10 +13,26 @@ use crate::core::gaps::{
 use crate::error::Result;
 use crate::store::gaps::{GapCluster, GapKind};
 
-/// How many coverage queries one capture keeps in the air at once. Small enough
-/// that a capture never becomes the load on the vector store, large enough that
-/// the wait is the slowest query and not the sum of them.
+/// How many coverage queries are in the air at once. Small enough that captures
+/// never become the load on the vector store, large enough that the wait is the
+/// slowest query and not the sum of them.
 const COVER_IN_FLIGHT: usize = 16;
+
+/// The budget above, held by the process rather than by one pass.
+///
+/// A per-pass bound is not a bound: `settle_corpus` starts a coverage check for
+/// every document that finishes embedding, so an ingest of fifty documents
+/// settling together is fifty passes of sixteen queries — eight hundred at once
+/// against the vector store the whole memory shares, which is the outage the
+/// bound exists to prevent, reached by a route the bound did not cover.
+/// A permit per query, taken from one pool, makes the number in the comment
+/// above the number that is actually true.
+///
+/// A pass that cannot get a permit waits for one. Permits are only ever held
+/// across a single search, so the wait is bounded by the slowest query in
+/// flight, and no pass holds one while it waits for another.
+static COVER_SLOTS: std::sync::LazyLock<tokio::sync::Semaphore> =
+    std::sync::LazyLock::new(|| tokio::sync::Semaphore::new(COVER_IN_FLIGHT));
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SweepReport {
@@ -43,7 +59,9 @@ pub struct SweepReport {
 /// minutes of a capture sitting at its last step for work that is entirely
 /// waiting. Bounded rather than unbounded because the same reasoning applies to
 /// the other end: two thousand simultaneous queries is not concurrency, it is
-/// an outage in the vector store the whole memory shares.
+/// an outage in the vector store the whole memory shares. The bound is
+/// `COVER_SLOTS`, held by the process, so concurrent captures share the one
+/// budget instead of each being granted it.
 ///
 /// Filtered to this corpus on purpose: the question is whether *this capture*
 /// answered something. A hit from anywhere else answers a different question —
@@ -90,11 +108,18 @@ pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
             let vectors = core.vectors.clone();
             let vec = open.gaps[at].vec.clone();
             let filter = filter.clone();
+            // Nothing ever closes a static semaphore, so the only way this
+            // fails is a bug in the standard library.
+            let permit = COVER_SLOTS
+                .acquire()
+                .await
+                .expect("the coverage budget is never closed");
             inflight.spawn(async move {
-                (
-                    at,
-                    vectors.search(&vec, &Default::default(), 1, &filter).await,
-                )
+                let out = vectors.search(&vec, &Default::default(), 1, &filter).await;
+                // Held for exactly the query, and released before the answer is
+                // read back: what the budget limits is load on the store.
+                drop(permit);
+                (at, out)
             });
         }
         let Some(joined) = inflight.join_next().await else {

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -23,6 +23,76 @@ pub struct SweepReport {
     pub removed: usize,
 }
 
+/// Does this capture answer anything the base could not?
+///
+/// One filtered vector query per open gap, against this document's artifacts
+/// only, and no model call anywhere. A gap whose best new hit reaches
+/// `weak_below` is closed — the same line that decided the gap was a gap in the
+/// first place, read the other way round.
+///
+/// Filtered to this corpus on purpose: the question is whether *this capture*
+/// answered something. A hit from anywhere else answers a different question —
+/// the base held it all along, and the gap is open for a reason.
+///
+/// Closed silently and reversibly. The source row is untouched, so nothing an
+/// automatic score decided overwrites what a person judged, and an operator who
+/// disagrees reopens the gap. Silently, because a base with forty gaps would
+/// otherwise turn its own housekeeping into a review queue.
+///
+/// Every failure here is a warning and nothing more. A capture that is stored
+/// is stored; a coverage check that could not run is a line on the capture page
+/// that does not appear.
+pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
+    if !core.feedback.enabled {
+        return Ok(0);
+    }
+    let open = core
+        .store
+        .open_gaps(core.embedder.model(), core.weak_below)
+        .await?;
+    if open.gaps.is_empty() {
+        return Ok(0);
+    }
+    let filter = crate::vector::SearchFilter {
+        tags: Vec::new(),
+        category: None,
+        include_superseded: false,
+        include_deprecated: false,
+        corpus_id: Some(corpus_id.to_string()),
+    };
+    let mut closed = 0;
+    for g in &open.gaps {
+        // One hit: the question is whether the best new artifact reaches the
+        // line, and the second-best cannot answer it.
+        let hits = core
+            .vectors
+            .search(&g.vec, &Default::default(), 1, &filter)
+            .await?;
+        let Some(hit) = hits.first() else { continue };
+        // `None` is "no opinion" and not a low value — a lexical hit the dense
+        // half never returned. It cannot close a gap, because closing one is a
+        // claim about distance.
+        let Some(sim) = hit.similarity else { continue };
+        if sim < core.weak_below {
+            continue;
+        }
+        core.store
+            .cover_gap(
+                g.gap.kind,
+                &g.gap.id,
+                corpus_id,
+                &hit.payload.artifact_id,
+                sim,
+            )
+            .await?;
+        closed += 1;
+    }
+    if closed > 0 {
+        tracing::info!(corpus_id, closed, "a capture answered open gaps");
+    }
+    Ok(closed)
+}
+
 pub async fn sweep(core: &Core) -> Result<SweepReport> {
     let open = core
         .store
@@ -185,6 +255,169 @@ mod tests {
             .await
             .unwrap();
         id
+    }
+
+    /// A recorded search judged a gap, with a vector chosen by the caller.
+    async fn gap_search(core: &Core, q: &str, vec: Vec<f32>) -> String {
+        let id = core
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: q.into(),
+                    door: crate::store::feedback::Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec,
+                    embed_model: core.embedder.model().to_string(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        core.store
+            .judge(&id, crate::store::feedback::Verdict::Gap)
+            .await
+            .unwrap();
+        id
+    }
+
+    /// A document, embedded, with the queue drained and the coverage check
+    /// that reaching `ready` fires already finished.
+    ///
+    /// Every caller sets `weak_below = 1.0` first, so that pass closes nothing:
+    /// what a document actually scores is only knowable once it is embedded,
+    /// and a test that wants to sit either side of that line has to capture
+    /// before it can choose one.
+    async fn captured(core: &Core, text: &str) -> String {
+        let src = core.ingest(text, "web", None).await.unwrap();
+        while crate::jobs::run_one(core).await.unwrap() {}
+        core.background.wait_idle().await;
+        src.id
+    }
+
+    /// How close this vector gets to anything in that document. What the
+    /// coverage line is compared against, asked of the store directly so the
+    /// test does not have to predict the fake embedder's geometry.
+    async fn best_similarity(core: &Core, v: &[f32], corpus_id: &str) -> f32 {
+        core.vectors
+            .search(
+                v,
+                &Default::default(),
+                1,
+                &crate::vector::SearchFilter {
+                    corpus_id: Some(corpus_id.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .first()
+            .and_then(|h| h.similarity)
+            .expect("the document embedded nothing")
+    }
+
+    #[tokio::test]
+    async fn a_capture_that_answers_a_gap_closes_it_and_says_which() {
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        let v = vec![1.0, 0.0, 0.0, 0.0];
+        let id = gap_search(&core, "how do I mount an E01", v.clone()).await;
+        core.weak_below = 1.0;
+        let corpus = captured(&core, "Mounting an E01 image read-only.").await;
+        // Just under whatever this document actually scores: the capture
+        // reaches the line.
+        core.weak_below = best_similarity(&core, &v, &corpus).await - 0.01;
+
+        let closed = cover(&core, &corpus).await.unwrap();
+
+        assert_eq!(closed, 1);
+        assert!(
+            core.store
+                .open_gaps(core.embedder.model(), core.weak_below)
+                .await
+                .unwrap()
+                .gaps
+                .iter()
+                .all(|g| g.gap.id != id),
+            "the gap is still open"
+        );
+        let covered = core.store.gaps_covered_by(&corpus).await.unwrap();
+        assert_eq!(covered.len(), 1, "the capture page cannot say which");
+        assert_eq!(covered[0].text, "how do I mount an E01");
+    }
+
+    #[tokio::test]
+    async fn a_capture_that_answers_nothing_closes_nothing() {
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        let v = vec![1.0, 0.0, 0.0, 0.0];
+        gap_search(&core, "how do I mount an E01", v.clone()).await;
+        core.weak_below = 1.0;
+        let corpus = captured(&core, "Trimming a systemd journal.").await;
+        // Just over what this document scores: nothing here came close.
+        core.weak_below = best_similarity(&core, &v, &corpus).await + 0.01;
+
+        assert_eq!(cover(&core, &corpus).await.unwrap(), 0);
+        assert!(
+            core.store
+                .gaps_covered_by(&corpus)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_the_capture_that_closed_a_gap_reopens_it() {
+        // Reversible, and by the cascade rather than by a second mechanism.
+        // Nothing an automatic score decided overwrote what a person judged.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        let v = vec![1.0, 0.0, 0.0, 0.0];
+        let id = gap_search(&core, "how do I mount an E01", v.clone()).await;
+        core.weak_below = 1.0;
+        let corpus = captured(&core, "Mounting an E01 image read-only.").await;
+        core.weak_below = best_similarity(&core, &v, &corpus).await - 0.01;
+        assert_eq!(cover(&core, &corpus).await.unwrap(), 1);
+
+        core.delete_corpus(&corpus).await.unwrap();
+
+        assert!(
+            core.store
+                .open_gaps(core.embedder.model(), core.weak_below)
+                .await
+                .unwrap()
+                .gaps
+                .iter()
+                .any(|g| g.gap.id == id),
+            "the judgement went with the capture that answered it"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_coverage_check_embeds_nothing() {
+        // The gap's vector is stored and the artifacts' are stored; the
+        // question is a distance between two things that already exist. An
+        // embedding call here would be paying for a vector twice, on every
+        // capture, once per open gap.
+        let (mut core, embedder) =
+            crate::core::test_support::test_core_counting_embed_calls().await;
+        core.feedback.enabled = true;
+        let v = vec![1.0, 0.0, 0.0, 0.0];
+        gap_search(&core, "how do I mount an E01", v.clone()).await;
+        core.weak_below = 1.0;
+        let corpus = captured(&core, "Mounting an E01 image read-only.").await;
+        core.weak_below = best_similarity(&core, &v, &corpus).await - 0.01;
+        let before = embedder.calls();
+
+        assert_eq!(cover(&core, &corpus).await.unwrap(), 1);
+        assert_eq!(
+            embedder.calls(),
+            before,
+            "the coverage check embedded something"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -140,13 +140,6 @@ pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
             }
         }
     }
-    // Every search that was already in flight is allowed to finish before the
-    // first failure is returned: they cost nothing more once issued, and a gap
-    // one of them closed is closed whether or not another query failed.
-    if let Some(e) = failure {
-        return Err(e);
-    }
-
     let mut closed = 0;
     for (g, hit) in open.gaps.iter().zip(best) {
         let Some(hit) = hit else { continue };
@@ -157,7 +150,14 @@ pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
         if sim < core.weak_below {
             continue;
         }
-        core.store
+        // Warned and skipped rather than returned: the vector store can hand
+        // back an `artifact_id` SQLite no longer has — the drift
+        // `reconcile_stores_once` exists to repair — and `gap_coverage`
+        // carries a foreign key onto it. One such row must not take the
+        // remaining gaps of this capture down with it, because nothing comes
+        // back for them: `cover` is called once, from `settle_corpus`.
+        match core
+            .store
             .cover_gap(
                 g.gap.kind,
                 &g.gap.id,
@@ -165,11 +165,25 @@ pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
                 &hit.payload.artifact_id,
                 sim,
             )
-            .await?;
-        closed += 1;
+            .await
+        {
+            Ok(()) => closed += 1,
+            Err(e) => {
+                tracing::warn!(gap_id = %g.gap.id, error = %e, "could not record that a capture answered a gap");
+                failure.get_or_insert(e);
+            }
+        }
     }
     if closed > 0 {
         tracing::info!(corpus_id, closed, "a capture answered open gaps");
+    }
+    // Reported only once every gap the successful queries answered has been
+    // written. `cover` runs once, from `settle_corpus` when a corpus reaches
+    // `ready`, so there is no second pass: returning at the first failed query
+    // threw away the answers all the other queries had already found, and with
+    // forty open gaps and one flaky query it closed none of them.
+    if let Some(e) = failure {
+        return Err(e);
     }
     Ok(closed)
 }
@@ -447,6 +461,64 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn one_gap_the_capture_cannot_record_does_not_cost_the_others() {
+        // `cover` runs once, from `settle_corpus` when a corpus reaches
+        // `ready`, so a gap it skips is a gap nothing comes back for. It used
+        // to return at the first refusal and leave every remaining gap of the
+        // capture open — with forty of them and one bad answer, none closed.
+        //
+        // The refusal here is the reachable one: the vector store hands back an
+        // `artifact_id` SQLite no longer has, which is exactly the drift
+        // `reconcile_stores_once` exists to repair, and `gap_coverage` carries
+        // a foreign key onto it.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        let dangling = vec![0.0, 1.0, 0.0, 0.0];
+        let answerable = vec![1.0, 0.0, 0.0, 0.0];
+        gap_search(&core, "what does a torn write look like", dangling.clone()).await;
+        let answerable_id = gap_search(&core, "how do I mount an E01", answerable.clone()).await;
+        core.weak_below = 1.0;
+        let corpus = captured(&core, "Mounting an E01 image read-only.").await;
+        core.weak_below = best_similarity(&core, &answerable, &corpus).await - 0.01;
+
+        // Closer to the first gap than anything the capture wrote, and pointing
+        // at a row that is not there.
+        core.vectors
+            .upsert(vec![crate::vector::VectorPoint {
+                vector: dangling.clone(),
+                sparse: Default::default(),
+                payload: crate::vector::VectorPayload {
+                    artifact_id: "no-such-artifact".into(),
+                    corpus_id: corpus.clone(),
+                    text: "a torn write".into(),
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    created_at: crate::store::now(),
+                    last_seen_at: None,
+                    hit_count: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
+                    origin_corpora: vec![],
+                    provenance: None,
+                },
+            }])
+            .await
+            .unwrap();
+
+        // The pass still reports that something went wrong.
+        assert!(cover(&core, &corpus).await.is_err());
+
+        // And the gap it could answer is answered.
+        let covered = core.store.gaps_covered_by(&corpus).await.unwrap();
+        assert!(
+            covered.iter().any(|g| g.id == answerable_id),
+            "the gap the capture did answer was thrown away with the one it could not"
         );
     }
 

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -24,7 +24,10 @@ pub struct SweepReport {
 }
 
 pub async fn sweep(core: &Core) -> Result<SweepReport> {
-    let open = core.store.open_gaps(core.embedder.model()).await?;
+    let open = core
+        .store
+        .open_gaps(core.embedder.model(), core.weak_below)
+        .await?;
     // Measured from the base's own recorded queries rather than taken from the
     // constant, and only when there is something to group: `link_threshold`
     // reads a sample of every stored query vector, which is work worth nothing
@@ -202,7 +205,11 @@ mod tests {
             },
             "the lone 'FAT entries' gap is not a group and costs no call"
         );
-        let (rows, loose) = core.store.gap_rows(core.embedder.model()).await.unwrap();
+        let (rows, loose) = core
+            .store
+            .gap_rows(core.embedder.model(), core.weak_below)
+            .await
+            .unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].members.len(), 3);
         assert!(rows[0].label == "Fake topic" && rows[0].labelled_by == "model");
@@ -229,7 +236,11 @@ mod tests {
         nothing_here(&core, "mount an E01", vec![1.0, 0.0]).await;
         nothing_here(&core, "FAT entries", vec![0.0, 1.0]).await;
         assert_eq!(sweep(&core).await.unwrap(), SweepReport::default());
-        let (rows, loose) = core.store.gap_rows(core.embedder.model()).await.unwrap();
+        let (rows, loose) = core
+            .store
+            .gap_rows(core.embedder.model(), core.weak_below)
+            .await
+            .unwrap();
         assert!(rows.is_empty());
         assert_eq!(loose.len(), 2);
     }
@@ -244,7 +255,11 @@ mod tests {
         nothing_here(&core, "E01 mount read only", vec![1.0]).await;
         let r = sweep(&core).await.unwrap();
         assert_eq!((r.clusters, r.named), (1, 0));
-        let (rows, _) = core.store.gap_rows(core.embedder.model()).await.unwrap();
+        let (rows, _) = core
+            .store
+            .gap_rows(core.embedder.model(), core.weak_below)
+            .await
+            .unwrap();
         assert_eq!(rows[0].labelled_by, "terms");
         assert!(rows[0].label.contains("e01"), "{}", rows[0].label);
 
@@ -253,7 +268,12 @@ mod tests {
         }));
         assert_eq!(sweep(&core).await.unwrap().named, 1);
         assert_eq!(
-            core.store.gap_rows(core.embedder.model()).await.unwrap().0[0].label,
+            core.store
+                .gap_rows(core.embedder.model(), core.weak_below)
+                .await
+                .unwrap()
+                .0[0]
+                .label,
             "Image mounting"
         );
     }
@@ -319,7 +339,7 @@ mod tests {
         let after = sweep(&core).await.unwrap();
         assert!(
             core.store
-                .open_gaps(core.embedder.model())
+                .open_gaps(core.embedder.model(), core.weak_below)
                 .await
                 .unwrap()
                 .capped,
@@ -332,7 +352,11 @@ mod tests {
             "the key this pass replaced was kept alongside the one that replaced it"
         );
 
-        let (rows, _) = core.store.gap_rows(core.embedder.model()).await.unwrap();
+        let (rows, _) = core
+            .store
+            .gap_rows(core.embedder.model(), core.weak_below)
+            .await
+            .unwrap();
         let mut seen = std::collections::HashSet::new();
         for r in &rows {
             for m in &r.members {

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -34,6 +34,24 @@ const COVER_IN_FLIGHT: usize = 16;
 static COVER_SLOTS: std::sync::LazyLock<tokio::sync::Semaphore> =
     std::sync::LazyLock::new(|| tokio::sync::Semaphore::new(COVER_IN_FLIGHT));
 
+/// How many gaps one capture is checked against.
+///
+/// `COVER_SLOTS` bounds how many queries are in the air, which is not a bound
+/// on how many there are. `open_gaps` caps each of four kinds at
+/// `MAX_OPEN_GAPS`, so one capture can ask two thousand questions of the vector
+/// store, and `settle_corpus` asks them once per document that reaches `ready`:
+/// an ingest of fifty documents is a hundred thousand round trips. Nothing
+/// bursts and nothing breaks — it is a couple of minutes of steady load on the
+/// store the search box queries, which is the one path with a person waiting on
+/// it, and it grows with the age of the base rather than with anything the
+/// operator did, because `unmatched` fills itself from the search log.
+///
+/// Taken off the front of a list `open_gaps` already sorted newest-first across
+/// the kinds, so what a capture is checked against is the holes someone is
+/// still trying to fill. A gap older than that is not checked by this capture —
+/// the honest cost of the ceiling, and the reason it is this high.
+const COVER_MAX_GAPS: usize = 200;
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SweepReport {
     /// Groups of `MIN_CLUSTER` or more: the ones that are stored and shown as
@@ -51,17 +69,17 @@ pub struct SweepReport {
 /// `weak_below` is closed — the same line that decided the gap was a gap in the
 /// first place, read the other way round.
 ///
-/// The queries are issued `COVER_IN_FLIGHT` at a time rather than one after
-/// another. There are four kinds of gap, each capped at `MAX_OPEN_GAPS`, and
-/// since the unmatched ones are derived from the search log without anybody
-/// judging anything, a base with capture on reaches those caps as a matter of
-/// course rather than as a worst case. A round trip apiece, in series, is then
+/// Bounded twice over, because the two bounds are different bounds. How many
+/// queries are in the air is `COVER_SLOTS`, held by the process so that
+/// concurrent captures share one budget: a round trip apiece in series is
 /// minutes of a capture sitting at its last step for work that is entirely
-/// waiting. Bounded rather than unbounded because the same reasoning applies to
-/// the other end: two thousand simultaneous queries is not concurrency, it is
-/// an outage in the vector store the whole memory shares. The bound is
-/// `COVER_SLOTS`, held by the process, so concurrent captures share the one
-/// budget instead of each being granted it.
+/// waiting, and two thousand at once is not concurrency but an outage in the
+/// vector store the whole memory shares. How many there are at all is
+/// `COVER_MAX_GAPS`, because concurrency is not a ceiling on the total — there
+/// are four kinds of gap, each capped at `MAX_OPEN_GAPS`, and since the
+/// unmatched ones are derived from the search log without anybody judging
+/// anything, a base with capture on reaches those caps as a matter of course
+/// rather than as a worst case.
 ///
 /// Filtered to this corpus on purpose: the question is whether *this capture*
 /// answered something. A hit from anywhere else answers a different question —
@@ -79,12 +97,21 @@ pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
     if !core.feedback.enabled {
         return Ok(0);
     }
-    let open = core
+    let mut open = core
         .store
         .open_gaps(core.embedder.model(), core.weak_below)
         .await?;
     if open.gaps.is_empty() {
         return Ok(0);
+    }
+    if open.gaps.len() > COVER_MAX_GAPS {
+        tracing::debug!(
+            corpus_id,
+            open = open.gaps.len(),
+            checked = COVER_MAX_GAPS,
+            "more open gaps than one capture is checked against; the oldest are left out"
+        );
+        open.gaps.truncate(COVER_MAX_GAPS);
     }
     let filter = crate::vector::SearchFilter {
         tags: Vec::new(),

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -11,6 +11,7 @@ pub mod promote;
 pub mod pursuit;
 pub mod reconcile;
 pub mod relate;
+pub mod retention;
 pub mod synthesize;
 pub mod window;
 
@@ -110,6 +111,13 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Extract, _) => extract::run(core, &job.target_id).await,
         (Stage::Pursuit, _) => pursuit::run(core).await.map(|_| ()),
         (Stage::Generate, _) => pursuit::generate(core, &job.target_id).await,
+        // Both look at the whole collection, so both ignore the target.
+        (Stage::Retention, _) => retention::run(core).await.map(|_| ()),
+        (Stage::ArmDedupe, _) => consolidate::arm_dedupe(core).await.map(|n| {
+            if n > 0 {
+                tracing::info!(armed = n, "armed dedupe units");
+            }
+        }),
     };
 
     match result {

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -98,10 +98,6 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         // for oversize splits, and for isolating a chunk the batch chokes on.
         (Stage::Embed, "corpus") => embed::run_corpus(core, &job.target_id).await,
         (Stage::Embed, _) => embed::run(core, &job.target_id).await,
-        // The sweep looks at the whole collection, so it ignores the target.
-        (Stage::Consolidate, _) => consolidate::run(core).await.map(|_| ()),
-        // The sweep looks at the whole collection, so it ignores the target.
-        (Stage::Associate, _) => associate::run(core).await,
         (Stage::LinkJudge, _) => associate::judge(core, &job.target_id).await,
         (Stage::SegmentWindow, _) => window::run(core, &job.target_id).await,
         (Stage::Title, _) => synthesize::run_title(core, &job.target_id).await,
@@ -109,15 +105,18 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
         (Stage::Relate, _) => relate::run(core, &job.target_id).await,
         (Stage::Describe, _) => describe::run(core, &job.target_id).await,
         (Stage::Extract, _) => extract::run(core, &job.target_id).await,
-        (Stage::Pursuit, _) => pursuit::run(core).await.map(|_| ()),
         (Stage::Generate, _) => pursuit::generate(core, &job.target_id).await,
-        // Both look at the whole collection, so both ignore the target.
-        (Stage::Retention, _) => retention::run(core).await.map(|_| ()),
-        (Stage::ArmDedupe, _) => consolidate::arm_dedupe(core).await.map(|n| {
-            if n > 0 {
-                tracing::info!(armed = n, "armed dedupe units");
-            }
-        }),
+        // Every periodic unit goes through one path, because every periodic
+        // unit is accounted for. The sweeps below look at the whole collection,
+        // so they ignore the target.
+        (
+            Stage::Consolidate
+            | Stage::Associate
+            | Stage::Pursuit
+            | Stage::Retention
+            | Stage::ArmDedupe,
+            _,
+        ) => run_accounted(core, job.stage).await,
     };
 
     match result {
@@ -215,6 +214,58 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
             Ok(true)
         }
     }
+}
+
+/// Run one periodic unit and write down what it did.
+///
+/// The counts are the ones each sweep already returns; nothing here is counted
+/// for the account's sake. A failed run is recorded too — it is exactly the run
+/// an operator needs to see, and a history that kept only the successes would
+/// show a sweep going quiet with nothing anywhere saying why.
+///
+/// The row is written whatever happens to the unit afterwards, which is why it
+/// is written here rather than beside `complete_job`: a failed sweep stays
+/// queued behind a backoff, and that is a retry of the same unit rather than a
+/// run that never happened.
+async fn run_accounted(core: &Core, stage: Stage) -> Result<()> {
+    let started_at = crate::store::now();
+    let outcome = match stage {
+        Stage::Consolidate => consolidate::run(core).await.and_then(detail),
+        Stage::Associate => associate::run(core).await.and_then(detail),
+        Stage::Retention => retention::run(core).await.and_then(detail),
+        Stage::Pursuit => pursuit::run(core)
+            .await
+            .and_then(|n| detail(serde_json::json!({ "pursuits": n }))),
+        Stage::ArmDedupe => consolidate::arm_dedupe(core).await.and_then(|n| {
+            if n > 0 {
+                tracing::info!(armed = n, "armed dedupe units");
+            }
+            detail(serde_json::json!({ "armed": n }))
+        }),
+        // `run_claimed` sends only the five above here, and a sixth arriving
+        // silently unaccounted for is worse than a row saying so.
+        _ => detail(serde_json::json!({})),
+    };
+    let (state, written) = match &outcome {
+        Ok(d) => ("ok", d.clone()),
+        Err(e) => (
+            "failed",
+            serde_json::json!({ "error": e.to_string() }).to_string(),
+        ),
+    };
+    if let Err(e) = core
+        .store
+        .record_sweep_run(stage.as_str(), started_at, state, &written)
+        .await
+    {
+        tracing::warn!(stage = stage.as_str(), error = %e, "could not record what the sweep did");
+    }
+    outcome.map(|_| ())
+}
+
+/// The counts a sweep returned, as the JSON the account stores.
+fn detail<T: serde::Serialize>(report: T) -> Result<String> {
+    Ok(serde_json::to_string(&report).unwrap_or_else(|_| "{}".into()))
 }
 
 /// A sweep that has finished arms itself one interval out.
@@ -385,6 +436,36 @@ mod tests {
             .fetch_optional(&core.store.pool)
             .await
             .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_ran_says_what_it_did() {
+        // The question a system that describes itself as sleeping has to be
+        // able to answer: what did the memory do while I was away.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        core.store
+            .arm_periodic(
+                Stage::Associate,
+                "collection",
+                crate::core::background::ASSOCIATE_TARGET,
+                0,
+            )
+            .await
+            .unwrap();
+
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        run_claimed(&core, job).await.unwrap();
+
+        let runs = core.store.sweep_history(10).await.unwrap();
+        assert_eq!(runs.len(), 1, "the run was never recorded");
+        assert_eq!(runs[0].stage, "associate");
+        assert_eq!(runs[0].outcome, "ok");
+        assert!(
+            runs[0].detail.contains("forgotten"),
+            "the counts the sweep already returns were not kept: {}",
+            runs[0].detail
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -129,6 +129,8 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
             if job.stage == Stage::Embed && job.target_kind == "corpus" {
                 embed::rearm_if_more(core, &job.target_id).await?;
             }
+            rearm_periodic(core, &job).await;
+            arm_successor(core, &job).await;
             Ok(true)
         }
         // The target was deleted while the job waited. Retrying can never
@@ -212,6 +214,58 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
             }
             Ok(true)
         }
+    }
+}
+
+/// A sweep that has finished arms itself one interval out.
+///
+/// After completing, never before: the queue is keyed by `(stage, target)`, so
+/// a handler that re-armed itself would be upserting the very row
+/// `complete_job` then closes.
+///
+/// Nothing is done for a *failed* sweep, and nothing needs to be: `fail_job`
+/// leaves the row pending behind a backoff, which is already the re-arming. One
+/// failure ending a sweep for the life of the process is the one way this
+/// design could quietly stop the memory from learning, and there is a test
+/// saying it does not.
+///
+/// A sweep switched off since it was armed re-arms as nothing: `periodic_period`
+/// returns `None`, the row stays closed, and the repair pass will not put it
+/// back either, because it is no longer in `periodic_units`.
+async fn rearm_periodic(core: &Core, job: &Job) {
+    let Some(period) = crate::core::background::periodic_period(core, job.stage) else {
+        return;
+    };
+    let at = crate::store::now() + period.as_secs() as i64;
+    if let Err(e) = core
+        .store
+        .arm_periodic(job.stage, &job.target_kind, &job.target_id, at)
+        .await
+    {
+        tracing::warn!(stage = job.stage.as_str(), error = %e, "could not re-arm the sweep");
+    }
+}
+
+/// Replay before pursue.
+///
+/// The one ordering worth expressing beyond what the tree already expresses by
+/// arming: a sitting scored against the links this run folded in, not against
+/// the last half-hour's. The pursuit sweep keeps its own period as a floor, so
+/// this pulls it forward rather than being the only thing that runs it.
+async fn arm_successor(core: &Core, job: &Job) {
+    if job.stage != Stage::Associate || !core.pursuit.enabled {
+        return;
+    }
+    if let Err(e) = core
+        .store
+        .arm_now(
+            Stage::Pursuit,
+            "collection",
+            crate::core::background::ASSOCIATE_TARGET,
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "could not bring the pursuit sweep forward");
     }
 }
 
@@ -323,6 +377,151 @@ mod tests {
     use crate::store::corpora::CorpusStatus;
     use crate::store::jobs::{MAX_ATTEMPTS, backoff_secs};
     use std::sync::Arc;
+
+    /// The row a sweep leaves behind, whatever state it left in.
+    async fn pending_run_after(core: &Core, stage: Stage) -> Option<i64> {
+        sqlx::query_scalar("SELECT run_after FROM jobs WHERE stage = ? AND state = 'pending'")
+            .bind(stage.as_str())
+            .fetch_optional(&core.store.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_finished_sweep_arms_itself_one_interval_out() {
+        // No ticker holds the period any more: `run_after` is the cursor
+        // recording when the sweep last ran, and it is already indexed.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        core.store
+            .arm_periodic(
+                Stage::Associate,
+                "collection",
+                crate::core::background::ASSOCIATE_TARGET,
+                0,
+            )
+            .await
+            .unwrap();
+
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        assert_eq!(job.stage, Stage::Associate);
+        run_claimed(&core, job).await.unwrap();
+
+        let at = pending_run_after(&core, Stage::Associate)
+            .await
+            .expect("the sweep did not arm itself again");
+        let interval = core.associate.interval_mins as i64 * 60;
+        let expected = crate::store::now() + interval;
+        assert!(
+            (at - expected).abs() <= 5,
+            "armed at {at}, expected about {expected}"
+        );
+        // And exactly one of it: `UNIQUE(stage, target_id)` still does that
+        // work, for free and for the same reason it always did.
+        let n: i64 = sqlx::query_scalar("SELECT count(*) FROM jobs WHERE stage = 'associate'")
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_failed_is_still_going_to_run_again() {
+        // The one way this design could quietly stop the memory from learning:
+        // one failure ending a sweep for the life of the process. `fail_job`
+        // leaves the row pending behind a backoff, which is the re-arming — so
+        // what this asserts is that nothing closes it instead.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        // A pursuit sweep with no store behind it fails; what it fails on does
+        // not matter, only that the row survives it.
+        core.store
+            .arm_periodic(Stage::Pursuit, "collection", "collection", 0)
+            .await
+            .unwrap();
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        let id = job.id;
+        core.store
+            .fail_job(id, 1, "the endpoint was down")
+            .await
+            .unwrap();
+
+        let state: String = sqlx::query_scalar("SELECT state FROM jobs WHERE id = ?")
+            .bind(id)
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            state, "pending",
+            "a failed sweep was closed rather than left to retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_switched_off_since_it_was_armed_does_not_arm_itself_again() {
+        // The gates live on the list now, so this is what "switched off" means
+        // for a unit already in the queue: it runs once more and stops.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        core.store
+            .arm_periodic(
+                Stage::Associate,
+                "collection",
+                crate::core::background::ASSOCIATE_TARGET,
+                0,
+            )
+            .await
+            .unwrap();
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        core.associate.enabled = false;
+
+        run_claimed(&core, job).await.unwrap();
+
+        assert!(
+            pending_run_after(&core, Stage::Associate).await.is_none(),
+            "a sweep switched off armed itself anyway"
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_comes_before_pursue() {
+        // A sitting scored against the links this run folded in, not against
+        // the last half-hour's. The pursuit sweep keeps its own period as a
+        // floor; this is what pulls it forward.
+        let mut core = test_core().await;
+        core.feedback.enabled = true;
+        core.pursuit.enabled = true;
+        // Pursuit asleep on its own period, as it is for all but a moment of
+        // every cycle.
+        core.store
+            .arm_periodic(
+                Stage::Pursuit,
+                "collection",
+                crate::core::background::ASSOCIATE_TARGET,
+                crate::store::now() + 3600,
+            )
+            .await
+            .unwrap();
+        core.store
+            .arm_periodic(
+                Stage::Associate,
+                "collection",
+                crate::core::background::ASSOCIATE_TARGET,
+                0,
+            )
+            .await
+            .unwrap();
+
+        let job = core.store.claim_job().await.unwrap().unwrap();
+        assert_eq!(job.stage, Stage::Associate);
+        run_claimed(&core, job).await.unwrap();
+
+        assert_eq!(
+            pending_run_after(&core, Stage::Pursuit).await,
+            Some(0),
+            "the pursuit sweep was left asleep after the replay it depends on"
+        );
+    }
 
     #[tokio::test]
     async fn a_batch_embed_the_endpoint_rejects_is_retried_chunk_by_chunk() {

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -378,9 +378,20 @@ pub async fn run(core: &Core) -> Result<usize> {
         ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
         let sources: Vec<String> = ranked.into_iter().map(|(id, _)| id).collect();
         let decision = decide(&need, core.pursuit.min_sources, core.pursuit.min_engagement);
+        // The leading event's vector, carried onto the row. A pursuit that
+        // closes unsatisfied is a gap, and a gap is a question plus the vector
+        // it was found by; the sweep is holding both right here, and embedding
+        // the words again later would be a call spent on a vector that has
+        // already been computed.
+        let lead = members.first().map(|&m| &evs[m]);
         let pid = core
             .store
-            .insert_pursuit(need.opened_at, &need.queries, &sources)
+            .insert_pursuit(
+                need.opened_at,
+                &need.queries,
+                &sources,
+                lead.map(|e| (e.vec.as_slice(), core.embedder.model())),
+            )
             .await?;
         // `insert_pursuit` is keyed on the cluster, so a sitting the previous
         // sweep already reached comes back with the row it wrote. Only a
@@ -649,7 +660,7 @@ mod tests {
         let ids = two_sources(&core).await;
         let pid = core
             .store
-            .insert_pursuit(100, &["how do I read the journal".into()], &ids)
+            .insert_pursuit(100, &["how do I read the journal".into()], &ids, None)
             .await
             .unwrap();
 
@@ -693,7 +704,7 @@ mod tests {
         let ids = two_sources(&core).await;
         let pid = core
             .store
-            .insert_pursuit(100, &["q".into()], &ids)
+            .insert_pursuit(100, &["q".into()], &ids, None)
             .await
             .unwrap();
         generate(&core, &pid).await.unwrap();

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -59,6 +59,14 @@ pub async fn run(core: &Core) -> Result<Report> {
         }
     }
 
+    // Housekeeping about housekeeping: the account is trimmed by the unit that
+    // already decides what is past keeping.
+    match core.store.trim_sweep_runs().await {
+        Ok(n) if n > 0 => tracing::info!(dropped = n, "trimmed the sweep history"),
+        Err(e) => tracing::warn!(error = %e, "could not trim the sweep history"),
+        _ => {}
+    }
+
     Ok(report)
 }
 

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -1,0 +1,187 @@
+//! Expire what is past keeping, then regroup what is left.
+//!
+//! One unit, two passes, in this order: grouping reads the rows expiring
+//! removes, and grouping first would name a cluster around a search deleted a
+//! second later. It was one ticker before it was one unit, and the ordering
+//! inside it is the half that was already written down.
+//!
+//! Runs even with capture disabled, so turning capture off also expires what it
+//! recorded while it was on.
+
+use crate::core::Core;
+use crate::error::Result;
+
+/// What one pass did. The counts the two halves already returned; nothing here
+/// is counted for the account's sake.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct Report {
+    /// Searches and questions dropped for being past `retain_days`.
+    pub expired: u64,
+    pub clusters: usize,
+    pub named: usize,
+    pub removed: usize,
+}
+
+pub async fn run(core: &Core) -> Result<Report> {
+    let mut report = Report::default();
+
+    // Each half is reported on its own and neither stops the other: they are
+    // independent, both are retried on the next run, and a base whose grouping
+    // is failing still wants its log trimmed.
+    if core.feedback.retain_days > 0 {
+        match core.store.expire_feedback(core.feedback.retain_days).await {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!(dropped = n, "expired captured searches and questions");
+                }
+                report.expired = n;
+            }
+            Err(e) => tracing::warn!(error = %e, "could not expire captured searches"),
+        }
+    }
+
+    if core.feedback.enabled {
+        match crate::jobs::gaps::sweep(core).await {
+            Ok(r) => {
+                if r.named > 0 || r.removed > 0 {
+                    tracing::info!(
+                        clusters = r.clusters,
+                        named = r.named,
+                        removed = r.removed,
+                        "knowledge gaps regrouped"
+                    );
+                }
+                report.clusters = r.clusters;
+                report.named = r.named;
+                report.removed = r.removed;
+            }
+            Err(e) => tracing::warn!(error = %e, "could not group knowledge gaps"),
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One search, old enough to be past any window.
+    async fn seed_old_event(core: &Core) {
+        let id = core
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "old".into(),
+                    door: crate::store::feedback::Door::Ui,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![0.0],
+                    embed_model: "fake".into(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        sqlx::query("UPDATE search_events SET created_at = ? WHERE id = ?")
+            .bind(crate::store::now() - 40 * 86_400)
+            .bind(&id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+    }
+
+    async fn captured(core: &Core) -> i64 {
+        sqlx::query_scalar("SELECT count(*) FROM search_events")
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn retention_runs_with_consolidation_switched_off() {
+        // Retention used to ride on the consolidation sweep, so switching
+        // duplicate hygiene off silently kept the query log forever. It is its
+        // own unit now, and it stays its own unit.
+        let mut core = crate::core::test_support::test_core().await;
+        core.consolidate.enabled = false;
+        core.feedback.enabled = true;
+        core.feedback.retain_days = 30;
+        seed_old_event(&core).await;
+
+        let report = run(&core).await.unwrap();
+
+        assert_eq!(report.expired, 1);
+        assert_eq!(
+            captured(&core).await,
+            0,
+            "an event past the window outlived the retention unit"
+        );
+    }
+
+    #[tokio::test]
+    async fn keeping_forever_expires_nothing() {
+        let core = crate::core::test_support::test_core().await; // retain_days defaults to 0
+        seed_old_event(&core).await;
+
+        let report = run(&core).await.unwrap();
+
+        assert_eq!(report.expired, 0);
+        assert_eq!(captured(&core).await, 1, "`0` must keep them forever");
+    }
+
+    #[tokio::test]
+    async fn the_unit_groups_the_gaps() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        // Two of them: one gap is not a group, and the sweep no longer spends a
+        // naming call restating a single question.
+        for q in ["mount an E01", "mounting E01 images"] {
+            let id = core
+                .store
+                .record_ask(crate::store::asks::NewAsk {
+                    question: q.into(),
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0; 4],
+                    embed_model: core.embedder.model().to_string(),
+                    answer: "Not in the knowledge base.".into(),
+                    abstained: true,
+                    dropped: 0,
+                    truncated: false,
+                    citations: vec![],
+                })
+                .await
+                .unwrap();
+            core.store
+                .judge_ask(&id, crate::store::asks::AskVerdict::NothingHere)
+                .await
+                .unwrap();
+        }
+
+        run(&core).await.unwrap();
+
+        assert_eq!(
+            core.store.cluster_keys().await.unwrap().len(),
+            1,
+            "the gap was never grouped"
+        );
+    }
+
+    #[tokio::test]
+    async fn expiring_comes_before_grouping() {
+        // The ordering is the whole reason these two share a unit: grouping
+        // reads the rows expiring removes, and naming a cluster around a search
+        // deleted a second later is a call spent on nothing.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        core.feedback.retain_days = 30;
+        seed_old_event(&core).await;
+
+        run(&core).await.unwrap();
+
+        assert_eq!(captured(&core).await, 0);
+    }
+}

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -75,16 +75,10 @@ pub async fn run(core: &Core) -> Result<Report> {
         }
     }
 
-    // Housekeeping about housekeeping: the account is trimmed by the unit that
-    // already decides what is past keeping.
-    match core.store.trim_sweep_runs().await {
-        Ok(n) if n > 0 => tracing::info!(dropped = n, "trimmed the sweep history"),
-        Err(e) => {
-            tracing::warn!(error = %e, "could not trim the sweep history");
-            failure.get_or_insert(e);
-        }
-        _ => {}
-    }
+    // The sweep history is trimmed by the repair pass, not here. This unit is
+    // behind `feedback`, and an operator with capture off keeps no retention
+    // unit at all — while the sweeps that do run keep writing a row apiece.
+    // See `background::repair_once`.
 
     match failure {
         Some(e) => Err(e),

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -24,10 +24,20 @@ pub struct Report {
 
 pub async fn run(core: &Core) -> Result<Report> {
     let mut report = Report::default();
+    // The first thing that went wrong, held rather than returned. Neither half
+    // stops the other — they are independent, and a base whose grouping is
+    // failing still wants its log trimmed — but a pass where nothing worked
+    // must not report itself as a pass. `run_accounted` reads the return value
+    // and nothing else, so swallowing these into warnings is what would make
+    // the `failed` flag on `sweep_runs` unreachable for this sweep, and the
+    // history's whole reason for existing is that a sweep going wrong is
+    // visible there rather than only in the log.
+    //
+    // The error is carried as itself, not flattened to a string: `retryable`
+    // classifies the variant, and that decides whether the worker spends
+    // another attempt.
+    let mut failure: Option<crate::error::Error> = None;
 
-    // Each half is reported on its own and neither stops the other: they are
-    // independent, both are retried on the next run, and a base whose grouping
-    // is failing still wants its log trimmed.
     if core.feedback.retain_days > 0 {
         match core.store.expire_feedback(core.feedback.retain_days).await {
             Ok(n) => {
@@ -36,7 +46,10 @@ pub async fn run(core: &Core) -> Result<Report> {
                 }
                 report.expired = n;
             }
-            Err(e) => tracing::warn!(error = %e, "could not expire captured searches"),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not expire captured searches");
+                failure.get_or_insert(e);
+            }
         }
     }
 
@@ -55,7 +68,10 @@ pub async fn run(core: &Core) -> Result<Report> {
                 report.named = r.named;
                 report.removed = r.removed;
             }
-            Err(e) => tracing::warn!(error = %e, "could not group knowledge gaps"),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not group knowledge gaps");
+                failure.get_or_insert(e);
+            }
         }
     }
 
@@ -63,11 +79,17 @@ pub async fn run(core: &Core) -> Result<Report> {
     // already decides what is past keeping.
     match core.store.trim_sweep_runs().await {
         Ok(n) if n > 0 => tracing::info!(dropped = n, "trimmed the sweep history"),
-        Err(e) => tracing::warn!(error = %e, "could not trim the sweep history"),
+        Err(e) => {
+            tracing::warn!(error = %e, "could not trim the sweep history");
+            failure.get_or_insert(e);
+        }
         _ => {}
     }
 
-    Ok(report)
+    match failure {
+        Some(e) => Err(e),
+        None => Ok(report),
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +148,29 @@ mod tests {
             captured(&core).await,
             0,
             "an event past the window outlived the retention unit"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_where_nothing_worked_does_not_report_a_clean_run() {
+        // `run_accounted` reads the return value and nothing else, so a pass
+        // that warned about every half and then returned `Ok` would be written
+        // into `sweep_runs` as `ok` with no counts — and the `failed` flag, the
+        // stated reason that history exists, could never fire for this sweep.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        core.feedback.retain_days = 30;
+        // The expiry's table, taken out from under it.
+        sqlx::query("DROP TABLE search_events")
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        let err = run(&core).await.unwrap_err();
+
+        assert!(
+            err.to_string().contains("search_events"),
+            "the failure has to reach the account, and say what failed: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,6 +396,7 @@ mod startup_tests {
             promote: engram::config::PromoteConfig::default(),
             pursuit: engram::config::PursuitConfig::default(),
             schedule: engram::config::ScheduleConfig::default(),
+            sitting: engram::config::SittingConfig::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,7 @@ mod startup_tests {
             activation: ActivationConfig::default(),
             promote: engram::config::PromoteConfig::default(),
             pursuit: engram::config::PursuitConfig::default(),
+            schedule: engram::config::ScheduleConfig::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,24 +262,17 @@ async fn main() -> anyhow::Result<()> {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let background = core.background.clone();
-    let ticker =
-        engram::core::background::spawn_consolidation_ticker(core.clone(), shutdown_rx.clone());
-    let retention =
-        engram::core::background::spawn_retention_ticker(core.clone(), shutdown_rx.clone());
-    let dedupe = engram::core::background::spawn_dedupe_ticker(core.clone(), shutdown_rx.clone());
+    // One ticker left. The five that queued the sweeps are gone: a sweep arms
+    // itself an interval out when it finishes, so the queue holds the schedule
+    // and `run_after` is the cursor. Repair stays outside it — it is what
+    // recovers an interrupted schedule, including arming a sweep that died
+    // between being claimed and re-arming itself, so it cannot be scheduled by
+    // the thing it recovers.
     let repair = engram::core::background::spawn_repair_ticker(core.clone(), shutdown_rx.clone());
-    let associate =
-        engram::core::background::spawn_associate_ticker(core.clone(), shutdown_rx.clone());
-    let pursuit = engram::core::background::spawn_pursuit_ticker(core.clone(), shutdown_rx.clone());
     let mut handles = engram::jobs::Worker::spawn(core, cfg.server.workers, shutdown_rx);
-    // Joined with the workers so shutdown waits for them too, rather than
-    // leaving tasks the runtime drops mid-enqueue.
-    handles.push(ticker);
-    handles.push(retention);
-    handles.push(dedupe);
+    // Joined with the workers so shutdown waits for it too, rather than
+    // leaving a task the runtime drops mid-enqueue.
     handles.push(repair);
-    handles.push(associate);
-    handles.push(pursuit);
 
     let listener = tokio::net::TcpListener::bind(&cfg.server.bind).await?;
     tracing::info!(bind = %cfg.server.bind, mode = ?cfg.auth.mode, "engram listening");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -24,6 +24,15 @@ pub fn format_search_results(results: &[SearchResult]) -> String {
                 .title
                 .clone()
                 .unwrap_or_else(|| crate::web::markdown::stand_in_title(&r.text, 60));
+            // `stand_in_title` takes markup and leading punctuation off the
+            // front, so a passage that is only those leaves nothing — and a
+            // heading with no text after it is a numbered entry an agent
+            // cannot refer back to. The id is a poor name and a working one.
+            let title = if title.is_empty() {
+                r.artifact_id.clone()
+            } else {
+                title
+            };
             let tags = if r.tags.is_empty() {
                 String::new()
             } else {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -376,6 +376,7 @@ mod tests {
             last_verified_at: None,
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: via.map(str::to_string),
             reason: None,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -16,7 +16,14 @@ pub fn format_search_results(results: &[SearchResult]) -> String {
     results
         .iter()
         .map(|r| {
-            let title = r.title.clone().unwrap_or_else(|| "Untitled".into());
+            // Never "Untitled": a verbatim passage has no title by design, and
+            // an agent reading a list of them has the same problem the search
+            // rail has — a column of a word that says nothing where a name
+            // would say something. The opening of the passage says what it is.
+            let title = r
+                .title
+                .clone()
+                .unwrap_or_else(|| crate::web::markdown::stand_in_title(&r.text, 60));
             let tags = if r.tags.is_empty() {
                 String::new()
             } else {
@@ -261,6 +268,43 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
+
+    fn search_hit(title: Option<&str>, text: &str) -> SearchResult {
+        SearchResult {
+            artifact_id: "a".into(),
+            corpus_id: "s".into(),
+            title: title.map(str::to_string),
+            text: text.into(),
+            category: None,
+            tags: vec![],
+            score: 0.5,
+            status: None,
+            superseded_by: None,
+            last_verified_at: None,
+            weak: false,
+            primed: false,
+            in_sitting: false,
+            past_cliff: false,
+            via: None,
+            reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
+        }
+    }
+
+    #[test]
+    fn the_mcp_door_names_a_passage_by_its_opening() {
+        // Claude Code reads this list. A verbatim passage has no title by
+        // design, and three headings reading "Untitled" is a list of a word
+        // that says nothing where a name would say something.
+        let out = format_search_results(&[search_hit(
+            None,
+            "Die digitale Forensik unterscheidet sich zusätzlich",
+        )]);
+        assert!(!out.contains("Untitled"), "{out}");
+        assert!(out.contains("Die digitale Forensik"), "{out}");
+    }
 
     fn answer(unsupported: &[&str]) -> crate::core::ask::AskResponse {
         crate::core::ask::AskResponse {

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -142,7 +142,7 @@ pub struct RecordedEvent {
     pub shown: Vec<(String, Option<f32>)>,
 }
 
-fn vec_to_blob(v: &[f32]) -> Vec<u8> {
+pub(crate) fn vec_to_blob(v: &[f32]) -> Vec<u8> {
     v.iter().flat_map(|f| f.to_le_bytes()).collect()
 }
 
@@ -1373,7 +1373,10 @@ mod tests {
         // ever elapsing, and the sweep that waits for quiet never ran at all.
         assert_eq!(store.newest_event_at().await.unwrap(), Some(now));
         // The forget button takes the pursuits along.
-        store.insert_pursuit(now, &["q".into()], &[]).await.unwrap();
+        store
+            .insert_pursuit(now, &["q".into()], &[], None)
+            .await
+            .unwrap();
         store.purge_feedback().await.unwrap();
         assert!(store.recent_pursuits(10).await.unwrap().is_empty());
     }

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -166,9 +166,13 @@ pub(crate) fn vec_to_blob(v: &[f32]) -> Vec<u8> {
 }
 
 pub fn blob_to_vec(b: &[u8]) -> Vec<f32> {
-    b.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect()
+    // `as_chunks` rather than `chunks_exact`: the width is a constant, so the
+    // chunk arrives as `[u8; 4]` and `from_le_bytes` takes it whole instead of
+    // being handed a slice this has to re-assert the length of. `.0` drops the
+    // trailing bytes of a blob that is not a whole number of floats, which is
+    // what `chunks_exact` did with its remainder.
+    let (chunks, _) = b.as_chunks::<4>();
+    chunks.iter().map(|c| f32::from_le_bytes(*c)).collect()
 }
 
 impl Store {

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -79,11 +79,20 @@ pub struct Origin {
     /// The authenticated subject, for coalescing. `None` means unscoped, which
     /// folds only with other unscoped events from the same door.
     pub scope: Option<String>,
+    /// The live sitting this search belongs to, where there is one — a web
+    /// session id. `None` for every other door, which is what keeps the live
+    /// sitting out of the API and `/mcp`: an access token is not a
+    /// conversation. Read only by priming, and only when `sitting.prime` is on.
+    pub session: Option<String>,
 }
 
 impl From<Door> for Origin {
     fn from(door: Door) -> Self {
-        Origin { door, scope: None }
+        Origin {
+            door,
+            scope: None,
+            session: None,
+        }
     }
 }
 
@@ -93,7 +102,17 @@ impl Door {
         Origin {
             door: self,
             scope: Some(scope.into()),
+            session: None,
         }
+    }
+}
+
+impl Origin {
+    /// This search belongs to a live sitting. Only a door with a real session
+    /// identity may say so — see `Origin::session`.
+    pub fn in_sitting(mut self, session: Option<String>) -> Origin {
+        self.session = session;
+        self
     }
 }
 

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -117,7 +117,17 @@ pub struct GapRow {
 /// A cap rather than the whole table, because both readers scale badly in this
 /// number and neither says so: `jobs::gaps::sweep` compares every pair of them
 /// on every retention tick, and `ui::capture_page` — the page the app opens on —
-/// walks the same list with its full query vectors on every load. `cluster`'s
+/// walks the same list with its full query vectors on every load.
+///
+/// Per kind, and there are four of them, so what either reader actually gets is
+/// up to four times this. The sweep's clustering is quadratic in that total and
+/// the capture page renders one row of it apiece, which is two million cosines
+/// on a timer and two thousand `<li>` before the first sweep has grouped
+/// anything. Both are the accepted cost of showing every kind of gap rather
+/// than the newest few hundred whatever kind they are — see `core::gaps::cluster`.
+/// What is *not* accepted at that width is `jobs::gaps::cover`, which turns
+/// each of them into a network round trip on a path a capture waits on; it
+/// takes the newest `COVER_MAX_GAPS` and leaves the rest. `cluster`'s
 /// "N is tens, so the quadratic pass is fine" was an assumption about an
 /// operator's habits, not a property of the query; a few thousand searches
 /// judged `gap` made both costs real.

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -146,6 +146,8 @@ macro_rules! ask_gaps_sql {
             " FROM ask_events
               WHERE verdict = 'nothing_here' AND dismissed_at IS NULL
                 AND embed_model = ? AND vec_dim > 0
+                AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                                 WHERE kind = 'ask' AND gap_id = ask_events.id)
               ORDER BY judged_at DESC, id DESC LIMIT ?"
         )
     };
@@ -159,6 +161,8 @@ macro_rules! search_gaps_sql {
             " FROM search_events
               WHERE verdict = 'gap' AND dismissed_at IS NULL
                 AND embed_model = ? AND vec_dim > 0
+                AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                                 WHERE kind = 'search' AND gap_id = search_events.id)
               ORDER BY judged_at DESC, id DESC LIMIT ?"
         )
     };
@@ -187,6 +191,8 @@ macro_rules! unmatched_gaps_sql {
             " FROM search_events e
               WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
                 AND (e.verdict IS NULL OR e.verdict <> 'gap')
+                AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                                 WHERE kind = 'unmatched' AND gap_id = e.id)
                 AND (SELECT MAX(c.similarity) FROM search_candidates c
                       WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?
               ORDER BY e.created_at DESC, e.id DESC LIMIT ?"
@@ -207,6 +213,8 @@ macro_rules! pursuit_gaps_sql {
             $cols,
             " FROM pursuits
               WHERE state = 'unsatisfied' AND embed_model = ? AND vec_dim > 0
+                AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                                 WHERE kind = 'pursuit' AND gap_id = pursuits.id)
               ORDER BY opened_at DESC, id DESC LIMIT ?"
         )
     };
@@ -437,6 +445,85 @@ impl Store {
             }
         }
         Ok(out)
+    }
+
+    /// This capture answered this gap.
+    ///
+    /// Silent and reversible. The source row is untouched, so an operator who
+    /// disagrees reopens the gap by deleting this row — and nothing is deleted
+    /// on a score. Silent because a base with forty gaps would otherwise turn
+    /// its own housekeeping into a review queue.
+    pub async fn cover_gap(
+        &self,
+        kind: GapKind,
+        gap_id: &str,
+        corpus_id: &str,
+        artifact_id: &str,
+        score: f32,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO gap_coverage
+               (kind, gap_id, corpus_id, artifact_id, score, covered_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(kind.as_str())
+        .bind(gap_id)
+        .bind(corpus_id)
+        .bind(artifact_id)
+        .bind(score)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// The gaps this capture answered, newest first: what the capture page says
+    /// it did beyond being stored.
+    pub async fn gaps_covered_by(&self, corpus_id: &str) -> Result<Vec<Gap>> {
+        let mut out = Vec::new();
+        for r in sqlx::query(
+            "SELECT c.kind, c.gap_id,
+                    COALESCE(a.question, s.query, p.queries) AS text
+               FROM gap_coverage c
+               LEFT JOIN ask_events a    ON c.kind = 'ask'    AND a.id = c.gap_id
+               LEFT JOIN search_events s ON c.kind IN ('search', 'unmatched') AND s.id = c.gap_id
+               LEFT JOIN pursuits p      ON c.kind = 'pursuit' AND p.id = c.gap_id
+              WHERE c.corpus_id = ?
+              ORDER BY c.covered_at DESC",
+        )
+        .bind(corpus_id)
+        .fetch_all(&self.pool)
+        .await?
+        {
+            let Some(kind) = GapKind::parse(&r.get::<String, _>("kind")) else {
+                continue;
+            };
+            let text: Option<String> = r.get("text");
+            // The source row can be gone — a search expired by retention, a
+            // pursuit purged. The coverage row outlives it and says nothing
+            // useful without it, so it is skipped rather than rendered blank.
+            let Some(text) = text else { continue };
+            out.push(Gap {
+                kind,
+                id: r.get("gap_id"),
+                text: match kind {
+                    GapKind::Pursuit => pursuit_text(&text),
+                    _ => text,
+                },
+            });
+        }
+        Ok(out)
+    }
+
+    /// Undo a coverage: the gap is open again, and the judgement behind it was
+    /// never touched.
+    pub async fn uncover_gap(&self, kind: GapKind, gap_id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM gap_coverage WHERE kind = ? AND gap_id = ?")
+            .bind(kind.as_str())
+            .bind(gap_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     pub async fn dismiss_gap(&self, kind: GapKind, id: &str) -> Result<()> {

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -163,6 +163,17 @@ macro_rules! ask_gaps_sql {
     };
 }
 
+/// A search someone judged a hole in the base.
+///
+/// Coverage of *either* search kind closes it, for the same reason
+/// `dismiss_gap` writes one `dismissed_at` for both: `search` and `unmatched`
+/// are two readings of one row, not two rows. A search the base could not
+/// answer is picked up as `unmatched` on its own, a capture covers it as
+/// `unmatched`, and the operator then marks that same search a gap from the
+/// results bar — with only `kind = 'search'` excluded here, a stored capture
+/// that already answers it puts it back on the capture page as a fresh hole.
+/// The other direction cannot happen: `unmatched` is `verdict IS NULL`, so a
+/// judged search never enters by that door.
 macro_rules! search_gaps_sql {
     ($cols:literal) => {
         concat!(
@@ -172,7 +183,8 @@ macro_rules! search_gaps_sql {
               WHERE verdict = 'gap' AND dismissed_at IS NULL
                 AND embed_model = ? AND vec_dim > 0
                 AND NOT EXISTS (SELECT 1 FROM gap_coverage
-                                 WHERE kind = 'search' AND gap_id = search_events.id)
+                                 WHERE kind IN ('search', 'unmatched')
+                                   AND gap_id = search_events.id)
               ORDER BY judged_at DESC, id DESC LIMIT ?"
         )
     };
@@ -547,8 +559,10 @@ impl Store {
             };
             let text: Option<String> = r.get("text");
             // The source row can be gone — a search expired by retention, a
-            // pursuit purged. The coverage row outlives it and says nothing
-            // useful without it, so it is skipped rather than rendered blank.
+            // pursuit purged — and the coverage row outlives it until
+            // `trim_gap_coverage` collects it on the next repair pass. In that
+            // window it says nothing useful, so it is skipped rather than
+            // rendered blank.
             let Some(text) = text else { continue };
             out.entry(r.get::<String, _>("corpus_id"))
                 .or_default()
@@ -562,6 +576,39 @@ impl Store {
                 });
         }
         Ok(out)
+    }
+
+    /// Coverage rows whose gap no longer exists, dropped.
+    ///
+    /// `gap_id` names one of three tables, so it cannot be a foreign key and
+    /// nothing cascades from the row it points at — while the rows it points at
+    /// are deleted routinely: `expire_feedback` ages out searches and questions
+    /// on the retention promise, `purge_feedback` takes the lot on one press.
+    /// What was left behind was a row per gap ever covered, kept for the life
+    /// of the base, and `gaps_covered_by_each` quietly skipping every one of
+    /// them because the join came back with no text.
+    ///
+    /// A sweep rather than a delete beside each of those, because the same
+    /// orphan arrives by more routes than there are call sites — a purge, an
+    /// expiry, a pursuit deleted by hand — and one statement that asks what is
+    /// actually orphaned cannot be the one that forgets a route.
+    ///
+    /// The cascades on `corpus_id` and `artifact_id` are untouched and still do
+    /// their half: delete the capture that closed a gap and the gap comes back.
+    pub async fn trim_gap_coverage(&self) -> Result<u64> {
+        Ok(sqlx::query(
+            "DELETE FROM gap_coverage
+              WHERE (kind = 'ask'
+                     AND NOT EXISTS (SELECT 1 FROM ask_events WHERE id = gap_coverage.gap_id))
+                 OR (kind IN ('search', 'unmatched')
+                     AND NOT EXISTS (SELECT 1 FROM search_events WHERE id = gap_coverage.gap_id))
+                 OR (kind = 'pursuit'
+                     AND NOT EXISTS (SELECT 1 FROM pursuits WHERE id = gap_coverage.gap_id))
+                 OR kind NOT IN ('ask', 'search', 'unmatched', 'pursuit')",
+        )
+        .execute(&self.pool)
+        .await?
+        .rows_affected())
     }
 
     /// Undo a coverage: the gap is open again, and the judgement behind it was
@@ -964,6 +1011,97 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["mount an E01".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn a_covered_search_stays_covered_when_it_is_later_judged_a_gap() {
+        // One row, two readings. A capture answers the search while it is
+        // `unmatched`; the operator then marks that same search a gap from the
+        // results bar. It must not come back as a hole the base has already
+        // been given an answer to.
+        let store = Store::memory().await.unwrap();
+        sqlx::query(
+            "INSERT INTO corpora (id, raw_text, origin, content_hash, status,
+                                  created_at, updated_at)
+             VALUES ('corpus-a', 'text', 'paste', 'h', 'ready', 0, 0)",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, ordinal, text, created_at)
+             VALUES ('art-1', 'corpus-a', 0, 'text', 0)",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        let id = search_with(&store, "mount an E01", &[0.10]).await;
+        store
+            .cover_gap(GapKind::Unmatched, &id, "corpus-a", "art-1", 0.8)
+            .await
+            .unwrap();
+        assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
+
+        store.judge(&id, Verdict::Gap).await.unwrap();
+
+        assert!(
+            store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty(),
+            "a capture already answered this search; judging it reopened it"
+        );
+        // And undoing the coverage still brings it back, under the kind it is
+        // now judged as.
+        store.uncover_gap(GapKind::Unmatched, &id).await.unwrap();
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        assert_eq!(gaps.len(), 1, "{gaps:?}");
+        assert_eq!(gaps[0].gap.kind, GapKind::Search);
+    }
+
+    #[tokio::test]
+    async fn coverage_of_a_gap_that_is_gone_is_collected() {
+        // Retention deletes the search; nothing deletes the row saying a
+        // capture answered it, because `gap_id` cannot be a foreign key.
+        let store = Store::memory().await.unwrap();
+        sqlx::query(
+            "INSERT INTO corpora (id, raw_text, origin, content_hash, status,
+                                  created_at, updated_at)
+             VALUES ('corpus-a', 'text', 'paste', 'h', 'ready', 0, 0)",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, ordinal, text, created_at)
+             VALUES ('art-1', 'corpus-a', 0, 'text', 0)",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        let kept = search_with(&store, "mount an E01", &[0.10]).await;
+        let expired = search_with(&store, "grep a pcap", &[0.10]).await;
+        for id in [&kept, &expired] {
+            store
+                .cover_gap(GapKind::Unmatched, id, "corpus-a", "art-1", 0.8)
+                .await
+                .unwrap();
+        }
+        sqlx::query("DELETE FROM search_events WHERE id = ?")
+            .bind(&expired)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(store.trim_gap_coverage().await.unwrap(), 1);
+
+        let left: Vec<String> = sqlx::query("SELECT gap_id FROM gap_coverage")
+            .fetch_all(&store.pool)
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.get("gap_id"))
+            .collect();
+        assert_eq!(left, vec![kept], "the coverage of a gap that still exists");
+        // And a second pass has nothing left to do.
+        assert_eq!(store.trim_gap_coverage().await.unwrap(), 0);
     }
 
     #[tokio::test]

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -24,6 +24,13 @@ pub enum GapKind {
     /// computed over the existing log retroactively. It is also the more honest
     /// claim: not *you gave up*, but *the base held nothing near this*.
     Unmatched,
+    /// A pursuit that closed `unsatisfied`: a run of searches on one subject
+    /// that the base did not answer. It landed on Ops and nowhere else, and its
+    /// clustered queries were already stored — what it lacked was a vector, so
+    /// the sweep now carries the leading query's forward when it writes the
+    /// row. A pursuit written before that has none and is not a gap, which is
+    /// the same rule `vec_dim > 0` already applies to everything else here.
+    Pursuit,
 }
 
 impl GapKind {
@@ -32,6 +39,7 @@ impl GapKind {
             GapKind::Ask => "ask",
             GapKind::Search => "search",
             GapKind::Unmatched => "unmatched",
+            GapKind::Pursuit => "pursuit",
         }
     }
     pub fn parse(s: &str) -> Option<Self> {
@@ -39,6 +47,7 @@ impl GapKind {
             "ask" => Some(GapKind::Ask),
             "search" => Some(GapKind::Search),
             "unmatched" => Some(GapKind::Unmatched),
+            "pursuit" => Some(GapKind::Pursuit),
             _ => None,
         }
     }
@@ -185,6 +194,32 @@ macro_rules! unmatched_gaps_sql {
     };
 }
 
+/// A run of searches the base did not answer.
+///
+/// The text is the leading clustered query rather than all of them joined: the
+/// naming prompt keeps the first twelve members, and a member that is itself a
+/// paragraph of queries would crowd out eleven other gaps. `queries` is JSON,
+/// so the first element is read out in Rust rather than in SQL.
+macro_rules! pursuit_gaps_sql {
+    ($cols:literal) => {
+        concat!(
+            "SELECT id, queries",
+            $cols,
+            " FROM pursuits
+              WHERE state = 'unsatisfied' AND embed_model = ? AND vec_dim > 0
+              ORDER BY opened_at DESC, id DESC LIMIT ?"
+        )
+    };
+}
+
+/// The words a pursuit gap shows: its leading clustered query.
+fn pursuit_text(queries_json: &str) -> String {
+    serde_json::from_str::<Vec<String>>(queries_json)
+        .ok()
+        .and_then(|q| q.into_iter().next())
+        .unwrap_or_default()
+}
+
 /// How many stored query vectors the linkage calibration reads, per table.
 ///
 /// Every recorded search and question counts, not only the gaps: what
@@ -282,7 +317,29 @@ impl Store {
         let unmatched_capped = (out.len() - asks - searches) as i64 > MAX_OPEN_GAPS;
         out.truncate(asks + searches + MAX_OPEN_GAPS as usize);
         let unmatched = out.len() - asks - searches;
-        let capped = asks_capped || searches_capped || unmatched_capped;
+        let before_pursuits = out.len();
+        for r in sqlx::query(pursuit_gaps_sql!(", query_vec, opened_at"))
+            .bind(embed_model)
+            .bind(MAX_OPEN_GAPS + 1)
+            .fetch_all(&self.pool)
+            .await?
+        {
+            out.push((
+                r.get("opened_at"),
+                GapVec {
+                    gap: Gap {
+                        kind: GapKind::Pursuit,
+                        id: r.get("id"),
+                        text: pursuit_text(&r.get::<String, _>("queries")),
+                    },
+                    vec: blob_to_vec(&r.get::<Vec<u8>, _>("query_vec")),
+                },
+            ));
+        }
+        let pursuits_capped = (out.len() - before_pursuits) as i64 > MAX_OPEN_GAPS;
+        out.truncate(before_pursuits + MAX_OPEN_GAPS as usize);
+        let pursuits = out.len() - before_pursuits;
+        let capped = asks_capped || searches_capped || unmatched_capped || pursuits_capped;
         // The same key each half was already read by, applied across both:
         // whole-second `judged_at`, ties broken by a uuid v7 id, so a second's
         // worth of gaps is still ordered by when they were recorded.
@@ -294,6 +351,7 @@ impl Store {
                 asks,
                 searches,
                 unmatched,
+                pursuits,
                 "more open gaps than one pass reads; the oldest are left out of this one"
             );
         }
@@ -337,6 +395,18 @@ impl Store {
                 kind: GapKind::Unmatched,
                 id: r.get("id"),
                 text: r.get("text"),
+            });
+        }
+        for r in sqlx::query(pursuit_gaps_sql!(""))
+            .bind(embed_model)
+            .bind(MAX_OPEN_GAPS)
+            .fetch_all(&self.pool)
+            .await?
+        {
+            out.push(Gap {
+                kind: GapKind::Pursuit,
+                id: r.get("id"),
+                text: pursuit_text(&r.get::<String, _>("queries")),
             });
         }
         Ok(out)
@@ -386,6 +456,16 @@ impl Store {
             // either — the operator has already said this one is answered.
             GapKind::Search | GapKind::Unmatched => {
                 sqlx::query("UPDATE search_events SET dismissed_at = ? WHERE id = ?")
+                    .bind(now())
+                    .bind(id)
+                    .execute(&self.pool)
+                    .await?
+            }
+            // A pursuit has a state rather than a dismissal column, and
+            // `dismissed` is already one of the states it can be in — set by
+            // the operator on Ops, meaning the same thing it means here.
+            GapKind::Pursuit => {
+                sqlx::query("UPDATE pursuits SET state = 'dismissed', closed_at = ? WHERE id = ?")
                     .bind(now())
                     .bind(id)
                     .execute(&self.pool)
@@ -655,6 +735,82 @@ mod tests {
 
         store.dismiss_gap(GapKind::Unmatched, &id).await.unwrap();
 
+        assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_pursuit_that_ended_unsatisfied_is_a_gap() {
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .insert_pursuit(
+                100,
+                &["how do I mount an E01".into(), "E01 mount".into()],
+                &[],
+                Some((&[1.0, 0.0], "fake")),
+            )
+            .await
+            .unwrap();
+        store
+            .close_pursuit(&id, "unsatisfied", "nothing strong was engaged", 200)
+            .await
+            .unwrap();
+        // A pursuit that got its answer is not a hole in the base.
+        let happy = store
+            .insert_pursuit(
+                300,
+                &["grep a pcap".into()],
+                &[],
+                Some((&[0.0, 1.0], "fake")),
+            )
+            .await
+            .unwrap();
+        store
+            .close_pursuit(&happy, "satisfied", "a strong hit was engaged", 400)
+            .await
+            .unwrap();
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        let mine: Vec<(&str, &str)> = gaps
+            .iter()
+            .filter(|g| g.gap.kind == GapKind::Pursuit)
+            .map(|g| (g.gap.id.as_str(), g.gap.text.as_str()))
+            .collect();
+        assert_eq!(mine, vec![(id.as_str(), "how do I mount an E01")]);
+    }
+
+    #[tokio::test]
+    async fn a_pursuit_written_before_the_vector_was_carried_is_not_a_gap() {
+        // Nothing to group it by. The same rule `vec_dim > 0` already applies
+        // to a search whose vector the cache had evicted: an uncomparable
+        // vector is left out rather than compared anyway.
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .insert_pursuit(100, &["how do I mount an E01".into()], &[], None)
+            .await
+            .unwrap();
+        store
+            .close_pursuit(&id, "unsatisfied", "nothing strong was engaged", 200)
+            .await
+            .unwrap();
+
+        assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dismissing_a_pursuit_gap_closes_the_pursuit() {
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .insert_pursuit(100, &["q".into()], &[], Some((&[1.0, 0.0], "fake")))
+            .await
+            .unwrap();
+        store
+            .close_pursuit(&id, "unsatisfied", "nothing strong was engaged", 200)
+            .await
+            .unwrap();
+
+        store.dismiss_gap(GapKind::Pursuit, &id).await.unwrap();
+
+        assert_eq!(store.get_pursuit(&id).await.unwrap().state, "dismissed");
         assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
     }
 

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -449,6 +449,32 @@ impl Store {
         Ok(out)
     }
 
+    /// The ids of the pursuits the capture page's gap list is showing.
+    ///
+    /// Housekeeping says how many recent pursuits went unanswered and links
+    /// that sentence to the list. `state = 'unsatisfied'` on its own is not
+    /// that number: a pursuit a later capture answered keeps the state it ended
+    /// with — coverage never rewrites what happened — while the gap list drops
+    /// it. On a base where captures are answering pursuits the sentence sent
+    /// the operator to a list that did not hold what it promised.
+    ///
+    /// The same predicate the list itself is built from, so the two cannot
+    /// disagree about what is on it — including the embedder: a pursuit whose
+    /// vector is under another model is not on the page either.
+    pub async fn open_pursuit_gap_ids(
+        &self,
+        embed_model: &str,
+    ) -> Result<std::collections::HashSet<String>> {
+        Ok(sqlx::query(pursuit_gaps_sql!(""))
+            .bind(embed_model)
+            .bind(MAX_OPEN_GAPS)
+            .fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(|r| r.get::<String, _>("id"))
+            .collect())
+    }
+
     /// Query vectors from every recorded search and question under this
     /// embedder — gap or not, judged or not — newest first, `CALIBRATION_SAMPLE`
     /// of each. What `core::gaps::link_threshold` measures the embedder's own

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -10,6 +10,20 @@ use sqlx::Row;
 pub enum GapKind {
     Ask,
     Search,
+    /// A recorded search where nothing came close: every candidate's similarity
+    /// under `vector.weak_below`, which is what the rail was already saying at
+    /// the time in as many words.
+    ///
+    /// Distance rather than behaviour. The first draft of this counted a search
+    /// after which nothing was opened, and that was wrong twice over: not
+    /// clicking a result can mean the list was useless or that the titles alone
+    /// told the operator what they needed, and the two readings are opposite;
+    /// and an open is only recorded when pursuits *and* feedback are on, so on
+    /// most installs every search in the log looks abandoned. A distance needs
+    /// no interaction data, works whatever else is switched on, and can be
+    /// computed over the existing log retroactively. It is also the more honest
+    /// claim: not *you gave up*, but *the base held nothing near this*.
+    Unmatched,
 }
 
 impl GapKind {
@@ -17,12 +31,14 @@ impl GapKind {
         match self {
             GapKind::Ask => "ask",
             GapKind::Search => "search",
+            GapKind::Unmatched => "unmatched",
         }
     }
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "ask" => Some(GapKind::Ask),
             "search" => Some(GapKind::Search),
+            "unmatched" => Some(GapKind::Unmatched),
             _ => None,
         }
     }
@@ -139,6 +155,36 @@ macro_rules! search_gaps_sql {
     };
 }
 
+/// A search nothing came close to answering.
+///
+/// The similarity is not a column on `search_events` — it is on the candidate
+/// rows, one per result — so the test is an aggregate rather than a read.
+/// `MAX(...)` over no rows is `NULL`, and `NULL < ?` is not true, so a search
+/// that recorded no candidates is *not* a gap. That looks like an oversight and
+/// is not one: "nothing came close" is a claim about what was measured, and
+/// nothing was.
+///
+/// A search already judged `gap` is left out, or it would be two gaps: the same
+/// row, said twice, in two different words.
+///
+/// The guard this needs already exists. A typing burst folds into one event by
+/// `feedback.coalesce_secs`, so what is measured is the finished query and not
+/// its first two letters.
+macro_rules! unmatched_gaps_sql {
+    ($cols:literal) => {
+        concat!(
+            "SELECT e.id, e.query AS text",
+            $cols,
+            " FROM search_events e
+              WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
+                AND (e.verdict IS NULL OR e.verdict <> 'gap')
+                AND (SELECT MAX(c.similarity) FROM search_candidates c
+                      WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?
+              ORDER BY e.created_at DESC, e.id DESC LIMIT ?"
+        )
+    };
+}
+
 /// How many stored query vectors the linkage calibration reads, per table.
 ///
 /// Every recorded search and question counts, not only the gaps: what
@@ -160,7 +206,7 @@ impl Store {
     /// order to `gap_label_prompt`, which keeps the first twelve. A group with a
     /// dozen questions in it named itself from those and never saw a search gap,
     /// however recent.
-    pub async fn open_gaps(&self, embed_model: &str) -> Result<OpenGaps> {
+    pub async fn open_gaps(&self, embed_model: &str, weak_below: f32) -> Result<OpenGaps> {
         // `(judged_at, GapVec)`: the sort key is not part of what the caller
         // gets, only of the order it gets it in.
         let mut out: Vec<(i64, GapVec)> = Vec::new();
@@ -212,7 +258,31 @@ impl Store {
         let searches_capped = (out.len() - asks) as i64 > MAX_OPEN_GAPS;
         out.truncate(asks + MAX_OPEN_GAPS as usize);
         let searches = out.len() - asks;
-        let capped = asks_capped || searches_capped;
+        for r in sqlx::query(unmatched_gaps_sql!(
+            ", e.query_vec, e.created_at AS judged_at"
+        ))
+        .bind(embed_model)
+        .bind(weak_below)
+        .bind(MAX_OPEN_GAPS + 1)
+        .fetch_all(&self.pool)
+        .await?
+        {
+            out.push((
+                r.get("judged_at"),
+                GapVec {
+                    gap: Gap {
+                        kind: GapKind::Unmatched,
+                        id: r.get("id"),
+                        text: r.get("text"),
+                    },
+                    vec: blob_to_vec(&r.get::<Vec<u8>, _>("query_vec")),
+                },
+            ));
+        }
+        let unmatched_capped = (out.len() - asks - searches) as i64 > MAX_OPEN_GAPS;
+        out.truncate(asks + searches + MAX_OPEN_GAPS as usize);
+        let unmatched = out.len() - asks - searches;
+        let capped = asks_capped || searches_capped || unmatched_capped;
         // The same key each half was already read by, applied across both:
         // whole-second `judged_at`, ties broken by a uuid v7 id, so a second's
         // worth of gaps is still ordered by when they were recorded.
@@ -223,6 +293,7 @@ impl Store {
                 cap = MAX_OPEN_GAPS,
                 asks,
                 searches,
+                unmatched,
                 "more open gaps than one pass reads; the oldest are left out of this one"
             );
         }
@@ -234,7 +305,7 @@ impl Store {
     /// The page shows a gap's words, its kind and its id and nothing else, and
     /// it is the page the app opens on. Reading the vectors for it decoded four
     /// million floats per load to throw all of them away.
-    pub async fn open_gap_refs(&self, embed_model: &str) -> Result<Vec<Gap>> {
+    pub async fn open_gap_refs(&self, embed_model: &str, weak_below: f32) -> Result<Vec<Gap>> {
         let mut out = Vec::new();
         for (sql, kind) in [
             (ask_gaps_sql!(""), GapKind::Ask),
@@ -252,6 +323,21 @@ impl Store {
                     text: r.get("text"),
                 });
             }
+        }
+        // One more bind than the other two, so it is read on its own rather
+        // than joining the loop above.
+        for r in sqlx::query(unmatched_gaps_sql!(""))
+            .bind(embed_model)
+            .bind(weak_below)
+            .bind(MAX_OPEN_GAPS)
+            .fetch_all(&self.pool)
+            .await?
+        {
+            out.push(Gap {
+                kind: GapKind::Unmatched,
+                id: r.get("id"),
+                text: r.get("text"),
+            });
         }
         Ok(out)
     }
@@ -294,7 +380,11 @@ impl Store {
                     .execute(&self.pool)
                     .await?
             }
-            GapKind::Search => {
+            // The same column `Search` writes, and correctly so: it is the same
+            // row, dismissed for the same reason. A search dismissed as
+            // unmatched is not offered again if it is later judged a gap
+            // either — the operator has already said this one is answered.
+            GapKind::Search | GapKind::Unmatched => {
                 sqlx::query("UPDATE search_events SET dismissed_at = ? WHERE id = ?")
                     .bind(now())
                     .bind(id)
@@ -375,8 +465,12 @@ impl Store {
     /// cluster names yet (judged since the last sweep). A member that has been
     /// dismissed since the sweep is simply absent from its row; a row left with
     /// no members is not returned.
-    pub async fn gap_rows(&self, embed_model: &str) -> Result<(Vec<GapRow>, Vec<Gap>)> {
-        let open = self.open_gap_refs(embed_model).await?;
+    pub async fn gap_rows(
+        &self,
+        embed_model: &str,
+        weak_below: f32,
+    ) -> Result<(Vec<GapRow>, Vec<Gap>)> {
+        let open = self.open_gap_refs(embed_model, weak_below).await?;
         // Indexed once, not scanned per member. Resolving with a linear `find`
         // and then a `retain` over the whole list cost two passes over every
         // open gap for every member of every cluster — a million moves at the
@@ -471,6 +565,99 @@ mod tests {
         id
     }
 
+    /// A recorded search with candidates at the given similarities. No verdict:
+    /// nobody judged it, which is the case `Unmatched` exists for.
+    async fn search_with(store: &Store, q: &str, sims: &[f32]) -> String {
+        store
+            .record_search(
+                NewEvent {
+                    query: q.into(),
+                    door: Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0, 0.0],
+                    embed_model: "fake".into(),
+                    candidates: sims
+                        .iter()
+                        .enumerate()
+                        .map(|(i, s)| crate::store::feedback::NewCandidate {
+                            artifact_id: format!("a-{i}"),
+                            score: *s,
+                            similarity: Some(*s),
+                            shown: true,
+                        })
+                        .collect(),
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_search_nothing_came_close_to_is_a_gap() {
+        let store = Store::memory().await.unwrap();
+        let far = search_with(&store, "mount an E01", &[0.20, 0.11]).await;
+        // One hit above the line is enough: something came close, and the base
+        // is not being asked about a hole.
+        search_with(&store, "grep a pcap", &[0.51, 0.10]).await;
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+
+        let unmatched: Vec<&str> = gaps
+            .iter()
+            .filter(|g| g.gap.kind == GapKind::Unmatched)
+            .map(|g| g.gap.id.as_str())
+            .collect();
+        assert_eq!(unmatched, vec![far.as_str()]);
+    }
+
+    #[tokio::test]
+    async fn a_search_that_measured_nothing_is_not_a_gap() {
+        // `MAX(...)` over no candidate rows is NULL, and NULL is not under the
+        // line. "Nothing came close" is a claim about what was measured.
+        let store = Store::memory().await.unwrap();
+        search_with(&store, "mount an E01", &[]).await;
+
+        assert!(
+            store
+                .open_gaps("fake", 0.35)
+                .await
+                .unwrap()
+                .gaps
+                .iter()
+                .all(|g| g.gap.kind != GapKind::Unmatched)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_search_judged_a_gap_is_not_also_an_unmatched_one() {
+        // The same row, said twice, in two different words.
+        let store = Store::memory().await.unwrap();
+        let id = search_with(&store, "mount an E01", &[0.10]).await;
+        store.judge(&id, Verdict::Gap).await.unwrap();
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        let mine: Vec<GapKind> = gaps
+            .iter()
+            .filter(|g| g.gap.id == id)
+            .map(|g| g.gap.kind)
+            .collect();
+        assert_eq!(mine, vec![GapKind::Search]);
+    }
+
+    #[tokio::test]
+    async fn dismissing_an_unmatched_search_closes_it() {
+        let store = Store::memory().await.unwrap();
+        let id = search_with(&store, "mount an E01", &[0.10]).await;
+        assert!(!store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
+
+        store.dismiss_gap(GapKind::Unmatched, &id).await.unwrap();
+
+        assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
+    }
+
     #[tokio::test]
     async fn open_gaps_are_the_unanswered_questions_and_the_gap_searches_under_this_model() {
         let store = Store::memory().await.unwrap();
@@ -494,7 +681,7 @@ mod tests {
             .unwrap();
         store.judge_ask(&right, AskVerdict::Right).await.unwrap();
         nothing_here(&store, "no vector", vec![]).await;
-        let gaps = store.open_gaps("fake").await.unwrap().gaps;
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
         // Newest first across both kinds. Judged inside the same second, so the
         // uuid v7 ids break the tie — and being time-ordered they break it the
         // same way the stamps would have: the search was recorded second.
@@ -508,7 +695,7 @@ mod tests {
         );
         assert!(
             store
-                .open_gaps("other-model")
+                .open_gaps("other-model", 0.35)
                 .await
                 .unwrap()
                 .gaps
@@ -516,7 +703,7 @@ mod tests {
         );
 
         // The display path reads the same gaps and no vectors.
-        let refs = store.open_gap_refs("fake").await.unwrap();
+        let refs = store.open_gap_refs("fake", 0.35).await.unwrap();
         assert_eq!(
             refs.iter().map(|g| g.text.as_str()).collect::<Vec<_>>(),
             vec!["q1", "s1"]
@@ -532,7 +719,7 @@ mod tests {
         for i in 0..MAX_OPEN_GAPS + 1 {
             nothing_here(&store, &format!("q{i}"), vec![1.0, 0.0]).await;
         }
-        let open = store.open_gaps("fake").await.unwrap();
+        let open = store.open_gaps("fake", 0.35).await.unwrap();
         assert_eq!(open.gaps.len() as i64, MAX_OPEN_GAPS);
         assert_eq!(
             open.gaps[0].gap.text,
@@ -545,7 +732,7 @@ mod tests {
              pass as a set of dismissals otherwise"
         );
         assert_eq!(
-            store.open_gap_refs("fake").await.unwrap().len() as i64,
+            store.open_gap_refs("fake", 0.35).await.unwrap().len() as i64,
             MAX_OPEN_GAPS,
             "the display path is bounded by the same cap"
         );
@@ -561,7 +748,7 @@ mod tests {
         for i in 0..MAX_OPEN_GAPS {
             nothing_here(&store, &format!("q{i}"), vec![1.0, 0.0]).await;
         }
-        let open = store.open_gaps("fake").await.unwrap();
+        let open = store.open_gaps("fake", 0.35).await.unwrap();
         assert_eq!(open.gaps.len() as i64, MAX_OPEN_GAPS);
         assert!(!open.capped, "nothing was left out of this pass");
     }
@@ -572,9 +759,9 @@ mod tests {
         let a = nothing_here(&store, "q1", vec![1.0]).await;
         let s = gap_search(&store, "s1", vec![1.0]).await;
         store.dismiss_gap(GapKind::Ask, &a).await.unwrap();
-        assert_eq!(store.open_gaps("fake").await.unwrap().gaps.len(), 1);
+        assert_eq!(store.open_gaps("fake", 0.35).await.unwrap().gaps.len(), 1);
         store.dismiss_gap(GapKind::Search, &s).await.unwrap();
-        assert!(store.open_gaps("fake").await.unwrap().gaps.is_empty());
+        assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
         assert!(matches!(
             store.dismiss_gap(GapKind::Ask, "nope").await,
             Err(Error::NotFound)
@@ -596,7 +783,7 @@ mod tests {
             })
             .await
             .unwrap();
-        let (rows, loose) = store.gap_rows("fake").await.unwrap();
+        let (rows, loose) = store.gap_rows("fake", 0.35).await.unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].label, "Mounting");
         assert_eq!(rows[0].members.len(), 2);
@@ -607,9 +794,14 @@ mod tests {
 
         // Dismissing a member thins the row; dismissing both removes it.
         store.dismiss_gap(GapKind::Ask, &a).await.unwrap();
-        assert_eq!(store.gap_rows("fake").await.unwrap().0[0].members.len(), 1);
+        assert_eq!(
+            store.gap_rows("fake", 0.35).await.unwrap().0[0]
+                .members
+                .len(),
+            1
+        );
         store.dismiss_gap(GapKind::Ask, &b).await.unwrap();
-        assert!(store.gap_rows("fake").await.unwrap().0.is_empty());
+        assert!(store.gap_rows("fake", 0.35).await.unwrap().0.is_empty());
     }
 
     #[tokio::test]

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -177,8 +177,15 @@ macro_rules! search_gaps_sql {
 /// is not one: "nothing came close" is a claim about what was measured, and
 /// nothing was.
 ///
-/// A search already judged `gap` is left out, or it would be two gaps: the same
-/// row, said twice, in two different words.
+/// A search that has been judged at all is left out. `gap` for the obvious
+/// reason — it would be two gaps, the same row said twice in two different
+/// words — but `discard` and `hit` equally, and those are the ones worth
+/// naming. `discard` is the operator saying this was never a search: a typo, or
+/// poking at the box. A typo's candidates are exactly what scores below
+/// `weak_below`, so a rule that only skipped `gap` would take every dismissed
+/// typo and put it back on the capture page as a hole in the base. And a `hit`
+/// whose candidates all scored weakly is a search someone answered; the
+/// scores say the ranking was poor, not that the knowledge is missing.
 ///
 /// The guard this needs already exists. A typing burst folds into one event by
 /// `feedback.coalesce_secs`, so what is measured is the finished query and not
@@ -190,7 +197,7 @@ macro_rules! unmatched_gaps_sql {
             $cols,
             " FROM search_events e
               WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
-                AND (e.verdict IS NULL OR e.verdict <> 'gap')
+                AND e.verdict IS NULL
                 AND NOT EXISTS (SELECT 1 FROM gap_coverage
                                  WHERE kind = 'unmatched' AND gap_id = e.id)
                 AND (SELECT MAX(c.similarity) FROM search_candidates c
@@ -480,21 +487,51 @@ impl Store {
     /// The gaps this capture answered, newest first: what the capture page says
     /// it did beyond being stored.
     pub async fn gaps_covered_by(&self, corpus_id: &str) -> Result<Vec<Gap>> {
-        let mut out = Vec::new();
-        for r in sqlx::query(
-            "SELECT c.kind, c.gap_id,
+        let one = [corpus_id.to_string()];
+        Ok(self
+            .gaps_covered_by_each(&one)
+            .await?
+            .remove(corpus_id)
+            .unwrap_or_default())
+    }
+
+    /// The same, for a list of captures at once.
+    ///
+    /// One statement rather than one per capture. The queue fragment renders a
+    /// page of rows and the capture page polls it while anything is in flight,
+    /// so asking per row makes a three-way `LEFT JOIN` into a round of them on
+    /// a hot path — for an answer the same join gives in a single pass.
+    ///
+    /// Captures with nothing covered are absent from the map rather than
+    /// present and empty, which is the same thing to every caller: they ask for
+    /// a list and take `unwrap_or_default`.
+    pub async fn gaps_covered_by_each(
+        &self,
+        corpus_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<Gap>>> {
+        let mut out: std::collections::HashMap<String, Vec<Gap>> = std::collections::HashMap::new();
+        if corpus_ids.is_empty() {
+            return Ok(out);
+        }
+        // The ids are bound, never spliced; what is spliced is a count of
+        // placeholders.
+        let holes = vec!["?"; corpus_ids.len()].join(", ");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT c.corpus_id, c.kind, c.gap_id,
                     COALESCE(a.question, s.query, p.queries) AS text
                FROM gap_coverage c
                LEFT JOIN ask_events a    ON c.kind = 'ask'    AND a.id = c.gap_id
                LEFT JOIN search_events s ON c.kind IN ('search', 'unmatched') AND s.id = c.gap_id
                LEFT JOIN pursuits p      ON c.kind = 'pursuit' AND p.id = c.gap_id
-              WHERE c.corpus_id = ?
-              ORDER BY c.covered_at DESC",
-        )
-        .bind(corpus_id)
-        .fetch_all(&self.pool)
-        .await?
-        {
+              WHERE c.corpus_id IN ({holes})
+              ORDER BY c.covered_at DESC"
+        )));
+        for id in corpus_ids {
+            q = q.bind(id);
+        }
+        // One descending order over the whole set is still newest-first inside
+        // each capture, because a filter never reorders what it keeps.
+        for r in q.fetch_all(&self.pool).await? {
             let Some(kind) = GapKind::parse(&r.get::<String, _>("kind")) else {
                 continue;
             };
@@ -503,14 +540,16 @@ impl Store {
             // pursuit purged. The coverage row outlives it and says nothing
             // useful without it, so it is skipped rather than rendered blank.
             let Some(text) = text else { continue };
-            out.push(Gap {
-                kind,
-                id: r.get("gap_id"),
-                text: match kind {
-                    GapKind::Pursuit => pursuit_text(&text),
-                    _ => text,
-                },
-            });
+            out.entry(r.get::<String, _>("corpus_id"))
+                .or_default()
+                .push(Gap {
+                    kind,
+                    id: r.get("gap_id"),
+                    text: match kind {
+                        GapKind::Pursuit => pursuit_text(&text),
+                        _ => text,
+                    },
+                });
         }
         Ok(out)
     }
@@ -812,6 +851,109 @@ mod tests {
             .map(|g| g.gap.kind)
             .collect();
         assert_eq!(mine, vec![GapKind::Search]);
+    }
+
+    #[tokio::test]
+    async fn a_search_the_operator_settled_is_not_an_unmatched_one() {
+        // `discard` is the operator saying this was never a search — a typo, or
+        // poking at the box. A typo's candidates are exactly what scores below
+        // the line, so a rule that only skipped `gap` would take every judgement
+        // of "this was nothing" and put it straight back on the capture page as
+        // a hole in the base. A `hit` whose candidates all scored weakly is the
+        // other half of the same mistake: the ranking was poor, the knowledge
+        // was there.
+        let store = Store::memory().await.unwrap();
+        let typo = search_with(&store, "mont an E01", &[0.10]).await;
+        store.judge(&typo, Verdict::Discard).await.unwrap();
+        let weak_hit = search_with(&store, "grep a pcap", &[0.12]).await;
+        store.judge(&weak_hit, Verdict::Hit).await.unwrap();
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+
+        assert!(
+            gaps.iter().all(|g| g.gap.kind != GapKind::Unmatched),
+            "a judged search is settled, whatever the judgement was: {:?}",
+            gaps.iter().map(|g| &g.gap.id).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn the_gaps_a_page_of_captures_answered_come_back_grouped() {
+        // The queue fragment is polled while anything is in flight, and asking
+        // per row turns one three-way join into a round of them.
+        let store = Store::memory().await.unwrap();
+        // `gap_coverage` names both a capture and the artifact of it that
+        // answered, and both are foreign keys.
+        for (c, a) in [("corpus-a", "art-1"), ("corpus-b", "art-2")] {
+            sqlx::query(
+                "INSERT INTO corpora (id, raw_text, origin, content_hash, status,
+                                      created_at, updated_at)
+                 VALUES (?, 'text', 'paste', ?, 'ready', 0, 0)",
+            )
+            .bind(c)
+            .bind(c)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO artifacts (id, corpus_id, ordinal, text, created_at)
+                 VALUES (?, ?, 0, 'text', 0)",
+            )
+            .bind(a)
+            .bind(c)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        }
+        let one = search_with(&store, "mount an E01", &[0.10]).await;
+        let two = search_with(&store, "grep a pcap", &[0.10]).await;
+        store
+            .cover_gap(GapKind::Unmatched, &one, "corpus-a", "art-1", 0.8)
+            .await
+            .unwrap();
+        store
+            .cover_gap(GapKind::Unmatched, &two, "corpus-b", "art-2", 0.9)
+            .await
+            .unwrap();
+
+        let by_corpus = store
+            .gaps_covered_by_each(&[
+                "corpus-a".to_string(),
+                "corpus-b".to_string(),
+                "corpus-c".to_string(),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            by_corpus["corpus-a"]
+                .iter()
+                .map(|g| g.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["mount an E01"]
+        );
+        assert_eq!(
+            by_corpus["corpus-b"]
+                .iter()
+                .map(|g| g.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["grep a pcap"]
+        );
+        assert!(
+            !by_corpus.contains_key("corpus-c"),
+            "a capture that answered nothing is absent, not present and empty"
+        );
+        // And the single-capture reader is the same answer.
+        assert_eq!(
+            store
+                .gaps_covered_by("corpus-a")
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|g| g.text)
+                .collect::<Vec<_>>(),
+            vec!["mount an E01".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -674,13 +674,26 @@ impl Store {
     /// A job that was never delayed has `run_after = 0`, so for everything that
     /// is not periodic the later stamp is `created_at` and this reads exactly as
     /// it did.
-    pub async fn age_background(&self, older_than: i64) -> Result<u64> {
+    /// At most `limit` rows move per call, oldest first. Background units
+    /// accumulate on their own — every `arm_dedupe` tick arms a batch of judge
+    /// units — and a slow judge endpoint leaves hundreds of them waiting past
+    /// the threshold. Promoting the whole backlog at once puts every one of
+    /// them ahead of a capture the operator has just pasted, since within a
+    /// class the order is `attempts, seq, id` and they were all armed first.
+    /// An aged unit going ahead of a fresh capture is the promise (§4.4) and
+    /// stays; the whole queue doing it at once is not.
+    pub async fn age_background(&self, older_than: i64, limit: i64) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE jobs SET class = 0
-              WHERE state = 'pending' AND class = 1
-                AND max(created_at, run_after) < ?",
+              WHERE id IN (
+                SELECT id FROM jobs
+                 WHERE state = 'pending' AND class = 1
+                   AND max(created_at, run_after) < ?
+                 ORDER BY max(created_at, run_after)
+                 LIMIT ?)",
         )
         .bind(older_than)
+        .bind(limit)
         .execute(&self.pool)
         .await?;
         Ok(res.rows_affected())
@@ -828,7 +841,7 @@ mod tests {
             .await
             .unwrap();
 
-        let aged = s.age_background(now() - 3600).await.unwrap();
+        let aged = s.age_background(now() - 3600, 100).await.unwrap();
         assert_eq!(aged, 1);
 
         let first = s.claim_job().await.unwrap().unwrap();
@@ -842,6 +855,72 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(class, 0, "having aged must be durable, not recomputed");
+    }
+
+    #[tokio::test]
+    async fn only_so_many_units_may_age_on_one_pass() {
+        // Ageing lets a unit that has waited go ahead of a fresh capture, which
+        // is the promise. The whole backlog doing it at once is not: background
+        // units arm themselves — a judge endpoint that is slow for an hour
+        // leaves hundreds of them past the threshold — and within one class the
+        // order is `attempts, seq, id`, so every one of them was armed before
+        // the capture the operator just pasted and every one of them goes
+        // first. That is the head-of-line wait the class exists to end,
+        // arriving an hour late.
+        let s = Store::memory().await.unwrap();
+        for i in 0..5 {
+            s.enqueue(Stage::Relate, "artifact", &format!("a-{i}"))
+                .await
+                .unwrap();
+        }
+        sqlx::query("UPDATE jobs SET created_at = ? WHERE stage = 'relate'")
+            .bind(now() - 7200)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(s.age_background(now() - 3600, 2).await.unwrap(), 2);
+
+        let still: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM jobs WHERE class = 1 AND stage = 'relate'")
+                .fetch_one(&s.pool)
+                .await
+                .unwrap();
+        assert_eq!(still, 3, "the rest wait for the next pass");
+
+        // And they do get their turn.
+        assert_eq!(s.age_background(now() - 3600, 100).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn the_oldest_units_age_first() {
+        // The cap is a cap on how many jump the queue, not a reason for the
+        // one that has waited longest to keep waiting.
+        let s = Store::memory().await.unwrap();
+        for i in 0..3 {
+            s.enqueue(Stage::Relate, "artifact", &format!("a-{i}"))
+                .await
+                .unwrap();
+        }
+        sqlx::query("UPDATE jobs SET created_at = ? WHERE target_id = 'a-2'")
+            .bind(now() - 86_400)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET created_at = ? WHERE target_id <> 'a-2'")
+            .bind(now() - 7200)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(s.age_background(now() - 3600, 1).await.unwrap(), 1);
+
+        let aged: String =
+            sqlx::query_scalar("SELECT target_id FROM jobs WHERE class = 0 AND stage = 'relate'")
+                .fetch_one(&s.pool)
+                .await
+                .unwrap();
+        assert_eq!(aged, "a-2", "the longest wait goes first");
     }
 
     #[tokio::test]
@@ -863,7 +942,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            s.age_background(now() - 3600).await.unwrap(),
+            s.age_background(now() - 3600, 100).await.unwrap(),
             0,
             "a unit that is not due yet has not been waiting"
         );
@@ -873,7 +952,7 @@ mod tests {
             .execute(&s.pool)
             .await
             .unwrap();
-        assert_eq!(s.age_background(now() - 3600).await.unwrap(), 1);
+        assert_eq!(s.age_background(now() - 3600, 100).await.unwrap(), 1);
     }
 
     #[tokio::test]
@@ -896,7 +975,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            s.age_background(now() - 3600).await.unwrap(),
+            s.age_background(now() - 3600, 100).await.unwrap(),
             0,
             "a sweep one minute past due has not waited an hour for a worker"
         );
@@ -907,7 +986,7 @@ mod tests {
             .execute(&s.pool)
             .await
             .unwrap();
-        assert_eq!(s.age_background(now() - 3600).await.unwrap(), 1);
+        assert_eq!(s.age_background(now() - 3600, 100).await.unwrap(), 1);
     }
 
     #[tokio::test]
@@ -931,7 +1010,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            s.age_background(now() - 3600).await.unwrap(),
+            s.age_background(now() - 3600, 100).await.unwrap(),
             0,
             "a unit that was just armed is not a unit that waited two hours"
         );

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -376,11 +376,18 @@ impl Store {
     /// arms it. A unit that is closed is armed outright.
     ///
     /// A unit a worker is already inside is left alone by both: it is running.
+    ///
+    /// The pulled-forward row has its class restored along with its `run_after`,
+    /// the way the closed-row path does. Ageing is a statement about how long
+    /// something has been waiting, and a unit that is being armed is not the
+    /// unit that waited: leaving the aged class on it would hand a sweep
+    /// foreground priority for the rest of its life, one arming at a time.
     pub async fn arm_now(&self, stage: Stage, target_kind: &str, target_id: &str) -> Result<()> {
         sqlx::query(
-            "UPDATE jobs SET run_after = 0
+            "UPDATE jobs SET run_after = 0, class = ?
               WHERE stage = ? AND target_id = ? AND state = 'pending' AND run_after > 0",
         )
+        .bind(stage.class())
         .bind(stage.as_str())
         .bind(target_id)
         .execute(&self.pool)
@@ -635,12 +642,21 @@ impl Store {
     ///
     /// A unit that has aged stays aged: it has already waited, and demoting it
     /// again would be starting its wait over.
+    ///
+    /// Only units that are actually ready age. A unit asleep on its own period
+    /// carries the `created_at` of the moment it was rescheduled, so waiting and
+    /// sleeping look identical from `created_at` alone — and every sweep whose
+    /// period is longer than `age_after_mins` (consolidation's day, retention's
+    /// six hours) would be promoted while it is still resting, then jump ahead
+    /// of the captures the class exists to protect. `run_after` is what tells
+    /// the two apart: a unit that is not due yet is not waiting.
     pub async fn age_background(&self, older_than: i64) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE jobs SET class = 0
-              WHERE state = 'pending' AND class = 1 AND created_at < ?",
+              WHERE state = 'pending' AND class = 1 AND created_at < ? AND run_after <= ?",
         )
         .bind(older_than)
+        .bind(now())
         .execute(&self.pool)
         .await?;
         Ok(res.rows_affected())
@@ -802,6 +818,66 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(class, 0, "having aged must be durable, not recomputed");
+    }
+
+    #[tokio::test]
+    async fn a_sweep_asleep_on_its_own_period_is_not_waiting() {
+        // `arm_periodic` stamps `created_at` when it reschedules, so a sweep
+        // resting on a day-long period looks, from `created_at` alone, exactly
+        // like one that has been queued a day. Ageing it would hand the front
+        // of the queue to work that is not even due — ahead of the captures
+        // somebody is watching, which is the one thing the class exists to
+        // stop.
+        let s = Store::memory().await.unwrap();
+        s.arm_periodic(Stage::Retention, "collection", "collection", now() + 21_600)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET created_at = ? WHERE stage = 'retention'")
+            .bind(now() - 7200)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.age_background(now() - 3600).await.unwrap(),
+            0,
+            "a unit that is not due yet has not been waiting"
+        );
+
+        // Due, and now it ages.
+        sqlx::query("UPDATE jobs SET run_after = 0 WHERE stage = 'retention'")
+            .execute(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(s.age_background(now() - 3600).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn arming_a_sleeping_unit_gives_back_the_class_it_had() {
+        // Ageing says how long something has waited. Pulling a unit forward
+        // makes it a unit that has not waited, and leaving the aged class on it
+        // would let a sweep hold foreground priority for the rest of its life,
+        // one arming at a time.
+        let s = Store::memory().await.unwrap();
+        s.arm_periodic(Stage::Pursuit, "collection", "collection", now() + 600)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET class = 0 WHERE stage = 'pursuit'")
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        s.arm_now(Stage::Pursuit, "collection", "collection")
+            .await
+            .unwrap();
+
+        let (run_after, class): (i64, i64) =
+            sqlx::query_as("SELECT run_after, class FROM jobs WHERE stage = 'pursuit'")
+                .fetch_one(&s.pool)
+                .await
+                .unwrap();
+        assert_eq!(run_after, 0, "the unit must have been pulled forward");
+        assert_eq!(class, 1, "and it must be background again");
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -57,6 +57,26 @@ pub enum Stage {
 }
 
 impl Stage {
+    /// Every stage there is. Written out rather than derived, and the compiler
+    /// is no help here — a stage left out of this list is not an error, it is a
+    /// stage the class backfill silently never sees.
+    pub const ALL: [Stage; 14] = [
+        Stage::Synthesize,
+        Stage::Enrich,
+        Stage::SegmentWindow,
+        Stage::Title,
+        Stage::Embed,
+        Stage::Consolidate,
+        Stage::Dedupe,
+        Stage::Relate,
+        Stage::Describe,
+        Stage::Extract,
+        Stage::Associate,
+        Stage::LinkJudge,
+        Stage::Pursuit,
+        Stage::Generate,
+    ];
+
     pub fn as_str(&self) -> &'static str {
         match self {
             Stage::Synthesize => "synthesize",
@@ -75,6 +95,38 @@ impl Stage {
             Stage::Generate => "generate",
         }
     }
+    /// Is someone waiting on this? `0` foreground, `1` background.
+    ///
+    /// Foreground is the capture pipeline: the operator pasted something and is
+    /// watching it move `raw → embedding → ready`. Background is every sweep
+    /// whose result nobody is standing in front of. One distinction and not a
+    /// scale — two classes cannot say that embedding matters more than titling,
+    /// and deliberately so: the distinction that pays is *someone is waiting*,
+    /// and a second one can be added later without moving the column.
+    ///
+    /// Exhaustive on purpose. A stage added later has to answer this question
+    /// rather than inherit an answer from a wildcard arm.
+    pub fn class(self) -> i64 {
+        match self {
+            // `Enrich` shares `synthesize::plan` with `Synthesize` and is
+            // foreground for the same reason: it is a capture in flight.
+            Stage::Synthesize
+            | Stage::Enrich
+            | Stage::SegmentWindow
+            | Stage::Title
+            | Stage::Embed
+            | Stage::Describe
+            | Stage::Extract => 0,
+            Stage::Consolidate
+            | Stage::Dedupe
+            | Stage::Relate
+            | Stage::Associate
+            | Stage::LinkJudge
+            | Stage::Pursuit
+            | Stage::Generate => 1,
+        }
+    }
+
     pub fn parse(s: &str) -> Option<Stage> {
         match s {
             "synthesize" => Some(Stage::Synthesize),
@@ -177,6 +229,7 @@ async fn upsert_job_with<'e>(
         .bind(target_id)
         .bind(now())
         .bind(seq)
+        .bind(stage.class())
         .execute(exec)
         .await?;
     Ok(())
@@ -187,11 +240,16 @@ async fn upsert_job_with<'e>(
 macro_rules! arm_job {
     ($guard:literal) => {
         concat!(
-            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq)
-             VALUES (?, ?, ?, 'pending', 0, 0, ?, ?)
+            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq, class)
+             VALUES (?, ?, ?, 'pending', 0, 0, ?, ?, ?)
              ON CONFLICT(stage, target_id) DO UPDATE SET
                state = 'pending', attempts = 0, run_after = 0, last_error = NULL,
-               claimed_at = NULL, created_at = excluded.created_at, seq = excluded.seq ",
+               claimed_at = NULL, created_at = excluded.created_at, seq = excluded.seq,
+               -- Re-armed rows take the stage's class back, ageing included: an
+               -- arming resets `attempts` and `created_at` too, so what it
+               -- leaves behind is a fresh unit, and a fresh background unit has
+               -- not waited for anything yet.
+               class = excluded.class ",
             $guard
         )
     };
@@ -363,6 +421,13 @@ impl Store {
     /// `seq` then interleaves whole documents. Without it, a corpus armed as
     /// thirty-four units takes thirty-four consecutive ids and reproduces the
     /// same head-of-line blocking one level down.
+    ///
+    /// `class` sorts ahead of all of that and answers one question: is somebody
+    /// waiting on this? Without it a capture the operator is watching queues
+    /// behind a consolidation sweep armed a minute earlier and waits for it,
+    /// with nothing anywhere able to say that one of the two has a person in
+    /// front of it. It sorts *before* `seq` and never instead of it: within one
+    /// class the fairness above is untouched.
     pub async fn claim_job(&self) -> Result<Option<Job>> {
         let row = sqlx::query(
             "UPDATE jobs
@@ -370,7 +435,7 @@ impl Store {
               WHERE id = (
                 SELECT id FROM jobs
                  WHERE state = 'pending' AND run_after <= ?
-                 ORDER BY attempts, seq, id LIMIT 1
+                 ORDER BY class, attempts, seq, id LIMIT 1
               )
               RETURNING id, stage, target_kind, target_id, attempts",
         )
@@ -523,6 +588,89 @@ mod tests {
         assert!(
             s.claim_job().await.unwrap().is_none(),
             "duplicate enqueue created a second job"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_capture_does_not_wait_behind_a_sweep() {
+        // The whole point of the class column: a sweep armed first is not what
+        // the operator is standing in front of.
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::Associate, "collection", "collection")
+            .await
+            .unwrap();
+        s.enqueue(Stage::Synthesize, "corpus", "src-1")
+            .await
+            .unwrap();
+
+        let first = s.claim_job().await.unwrap().unwrap();
+        assert_eq!(
+            first.stage,
+            Stage::Synthesize,
+            "the capture queued behind the sweep that was armed a moment earlier"
+        );
+        let second = s.claim_job().await.unwrap().unwrap();
+        assert_eq!(second.stage, Stage::Associate, "the sweep must still run");
+    }
+
+    #[tokio::test]
+    async fn within_one_class_the_order_is_still_attempts_then_seq() {
+        // `seq`'s anti-starvation property is the easiest thing to lose to a
+        // priority column, so it is asserted directly rather than inferred from
+        // the claim ordering being "unchanged".
+        let s = Store::memory().await.unwrap();
+        // Two documents' worth of windows, interleaved by seq: the second
+        // document's first window must beat the first document's second.
+        s.enqueue_seq(Stage::SegmentWindow, "corpus", "a#0", 0)
+            .await
+            .unwrap();
+        s.enqueue_seq(Stage::SegmentWindow, "corpus", "a#1", 1)
+            .await
+            .unwrap();
+        s.enqueue_seq(Stage::SegmentWindow, "corpus", "b#0", 0)
+            .await
+            .unwrap();
+
+        let mut order = Vec::new();
+        while let Some(j) = s.claim_job().await.unwrap() {
+            order.push(j.target_id);
+        }
+        assert_eq!(
+            order,
+            vec!["a#0", "b#0", "a#1"],
+            "seq no longer interleaves whole documents"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_claim_still_walks_one_index_and_never_sorts() {
+        // The shape of the class column, and of ageing being a write rather
+        // than a read, exists to keep this true. An inequality or a computed
+        // age in the ordering turns every poll into a temp B-tree sort, and
+        // nothing about the queue's behaviour would say so.
+        let s = Store::memory().await.unwrap();
+        let rows = sqlx::query(
+            "EXPLAIN QUERY PLAN
+             SELECT id FROM jobs
+              WHERE state = 'pending' AND run_after <= ?
+              ORDER BY class, attempts, seq, id LIMIT 1",
+        )
+        .bind(now())
+        .fetch_all(&s.pool)
+        .await
+        .unwrap();
+        let plan = rows
+            .iter()
+            .map(|r| r.get::<String, _>("detail"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            plan.contains("idx_jobs_claim3"),
+            "the claim stopped using its covering index: {plan}"
+        );
+        assert!(
+            !plan.to_uppercase().contains("TEMP B-TREE"),
+            "the claim now sorts: {plan}"
         );
     }
 

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -549,6 +549,28 @@ impl Store {
             .collect())
     }
 
+    /// A background unit that has waited long enough becomes foreground.
+    ///
+    /// Written, not computed. Ageing at claim time would put `created_at` — an
+    /// inequality — into the ordering, and an inequality ends an index's usable
+    /// ordering: every poll would find the ready rows and then sort them in a
+    /// temp B-tree, which is the cost `idx_jobs_claim3`'s column order exists to
+    /// avoid. Ageing a few rows on the repair tick is one indexed update and
+    /// leaves the hot path exactly as fast as it was.
+    ///
+    /// A unit that has aged stays aged: it has already waited, and demoting it
+    /// again would be starting its wait over.
+    pub async fn age_background(&self, older_than: i64) -> Result<u64> {
+        let res = sqlx::query(
+            "UPDATE jobs SET class = 0
+              WHERE state = 'pending' AND class = 1 AND created_at < ?",
+        )
+        .bind(older_than)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+
     /// How long the longest-waiting pending job has been queued, in seconds.
     ///
     /// Measured from `created_at`, not `run_after`: a job that was never
@@ -672,6 +694,39 @@ mod tests {
             !plan.to_uppercase().contains("TEMP B-TREE"),
             "the claim now sorts: {plan}"
         );
+    }
+
+    #[tokio::test]
+    async fn a_background_unit_that_has_waited_long_enough_goes_first() {
+        // Priority without ageing is starvation. The claim is unchanged: what
+        // moves is the row.
+        let s = Store::memory().await.unwrap();
+        s.enqueue(Stage::Associate, "collection", "collection")
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET created_at = ? WHERE stage = 'associate'")
+            .bind(now() - 7200)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+        s.enqueue(Stage::Synthesize, "corpus", "src-1")
+            .await
+            .unwrap();
+
+        let aged = s.age_background(now() - 3600).await.unwrap();
+        assert_eq!(aged, 1);
+
+        let first = s.claim_job().await.unwrap().unwrap();
+        assert_eq!(
+            first.stage,
+            Stage::Associate,
+            "a sweep that has waited an hour is still behind a fresh capture"
+        );
+        let class: i64 = sqlx::query_scalar("SELECT class FROM jobs WHERE stage = 'associate'")
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(class, 0, "having aged must be durable, not recomputed");
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -217,7 +217,14 @@ pub fn backoff_secs(attempts: i64) -> i64 {
 enum Guard {
     /// Anything, running included. An operator's reprocess.
     Any,
-    /// Only a row closed while its work was not.
+    /// Only a row nothing is going to run: closed, or given up on.
+    ///
+    /// `'failed'` belongs here with `'done'`. Nothing writes that state any
+    /// more — a job out of attempts is delayed rather than abandoned — but bases
+    /// upgraded across that change still hold rows in it, and a row that is
+    /// neither live nor armable is a unit that never runs again. For a periodic
+    /// sweep that is silent and permanent: `arm_missing_periodic` sees a unit
+    /// nothing is going to run, and the arming it answers with is refused.
     Closed,
 }
 
@@ -277,7 +284,7 @@ impl Guard {
     fn statement(self) -> &'static str {
         match self {
             Guard::Any => arm_job!(""),
-            Guard::Closed => arm_job!("WHERE jobs.state = 'done'"),
+            Guard::Closed => arm_job!("WHERE jobs.state IN ('done', 'failed')"),
         }
     }
 }
@@ -340,6 +347,8 @@ impl Store {
     /// Guarded on the row being closed, like every automatic arming: a sweep
     /// already queued is already going to run, and pushing its `run_after` an
     /// interval further out on every pass is how a sweep would recede forever.
+    /// `'failed'` counts as closed here for the reason `Guard::Closed` gives —
+    /// a row nothing will run is not a row that is going to recede.
     pub async fn arm_periodic(
         &self,
         stage: Stage,
@@ -354,7 +363,7 @@ impl Store {
                state = 'pending', attempts = 0, run_after = excluded.run_after,
                last_error = NULL, claimed_at = NULL,
                created_at = excluded.created_at, class = excluded.class
-             WHERE jobs.state = 'done'",
+             WHERE jobs.state IN ('done', 'failed')",
         )
         .bind(stage.as_str())
         .bind(target_kind)
@@ -382,12 +391,18 @@ impl Store {
     /// something has been waiting, and a unit that is being armed is not the
     /// unit that waited: leaving the aged class on it would hand a sweep
     /// foreground priority for the rest of its life, one arming at a time.
+    ///
+    /// `created_at` moves with them, for the same reason: pulling `run_after`
+    /// down to zero on a row stamped a period ago would leave a unit that has
+    /// been ready for one instant looking, to `age_background`, like one that
+    /// has been waiting all period.
     pub async fn arm_now(&self, stage: Stage, target_kind: &str, target_id: &str) -> Result<()> {
         sqlx::query(
-            "UPDATE jobs SET run_after = 0, class = ?
+            "UPDATE jobs SET run_after = 0, class = ?, created_at = ?
               WHERE stage = ? AND target_id = ? AND state = 'pending' AND run_after > 0",
         )
         .bind(stage.class())
+        .bind(now())
         .bind(stage.as_str())
         .bind(target_id)
         .execute(&self.pool)
@@ -643,20 +658,29 @@ impl Store {
     /// A unit that has aged stays aged: it has already waited, and demoting it
     /// again would be starting its wait over.
     ///
-    /// Only units that are actually ready age. A unit asleep on its own period
+    /// The wait is measured from the moment the unit became *ready*, which is
+    /// the later of the two stamps it carries. A unit asleep on its own period
     /// carries the `created_at` of the moment it was rescheduled, so waiting and
     /// sleeping look identical from `created_at` alone — and every sweep whose
     /// period is longer than `age_after_mins` (consolidation's day, retention's
-    /// six hours) would be promoted while it is still resting, then jump ahead
-    /// of the captures the class exists to protect. `run_after` is what tells
-    /// the two apart: a unit that is not due yet is not waiting.
+    /// six hours) would arrive at its `run_after` with a `created_at` already a
+    /// whole period old, and be promoted on the very next repair tick without
+    /// having waited in the queue at all. That is the promotion the class exists
+    /// to stop, arriving a period late instead of never. `run_after` is what
+    /// tells resting from waiting, and taking the later of the two stamps says
+    /// both things at once: a unit that is not due yet cannot age, and a unit
+    /// that has just come due starts its wait then.
+    ///
+    /// A job that was never delayed has `run_after = 0`, so for everything that
+    /// is not periodic the later stamp is `created_at` and this reads exactly as
+    /// it did.
     pub async fn age_background(&self, older_than: i64) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE jobs SET class = 0
-              WHERE state = 'pending' AND class = 1 AND created_at < ? AND run_after <= ?",
+              WHERE state = 'pending' AND class = 1
+                AND max(created_at, run_after) < ?",
         )
         .bind(older_than)
-        .bind(now())
         .execute(&self.pool)
         .await?;
         Ok(res.rows_affected())
@@ -850,6 +874,94 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(s.age_background(now() - 3600).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_has_just_come_due_has_not_been_waiting() {
+        // The other half of the test above, and the one the `run_after` guard
+        // alone did not answer: a sweep re-armed for six hours' time carries a
+        // `created_at` six hours old by the moment it comes due, so the very
+        // next repair tick would promote a unit that had been ready for
+        // seconds. The wait has to be measured from when it became ready.
+        let s = Store::memory().await.unwrap();
+        s.arm_periodic(Stage::Retention, "collection", "collection", now() + 21_600)
+            .await
+            .unwrap();
+        // Six hours later: due a minute ago, stamped when it was rescheduled.
+        sqlx::query("UPDATE jobs SET created_at = ?, run_after = ? WHERE stage = 'retention'")
+            .bind(now() - 21_600)
+            .bind(now() - 60)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.age_background(now() - 3600).await.unwrap(),
+            0,
+            "a sweep one minute past due has not waited an hour for a worker"
+        );
+
+        // An hour of actually being ready, and now it ages.
+        sqlx::query("UPDATE jobs SET run_after = ? WHERE stage = 'retention'")
+            .bind(now() - 7200)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(s.age_background(now() - 3600).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn arming_a_sleeping_unit_starts_its_wait_over() {
+        // `arm_now` pulls `run_after` to zero, which leaves `created_at` as the
+        // only stamp — and on a sweep armed an interval ago that stamp is an
+        // interval old, so the unit would be ready and immediately ageable
+        // without having waited at all.
+        let s = Store::memory().await.unwrap();
+        s.arm_periodic(Stage::Pursuit, "collection", "collection", now() + 600)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET created_at = ? WHERE stage = 'pursuit'")
+            .bind(now() - 7200)
+            .execute(&s.pool)
+            .await
+            .unwrap();
+
+        s.arm_now(Stage::Pursuit, "collection", "collection")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.age_background(now() - 3600).await.unwrap(),
+            0,
+            "a unit that was just armed is not a unit that waited two hours"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_left_failed_by_an_older_build_can_still_be_armed() {
+        // Nothing writes `failed` any more — a job out of attempts is delayed
+        // rather than abandoned — but a base upgraded across that change still
+        // holds rows in it. Such a row is not live, so the repair pass asks for
+        // it; if the arming refuses, the sweep never runs again, silently, for
+        // the life of the install.
+        let s = Store::memory().await.unwrap();
+        s.arm_periodic(Stage::Consolidate, "collection", "collection", 0)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE jobs SET state = 'failed' WHERE stage = 'consolidate'")
+            .execute(&s.pool)
+            .await
+            .unwrap();
+        assert!(!s.live_job(Stage::Consolidate, "collection").await.unwrap());
+
+        s.arm_periodic(Stage::Consolidate, "collection", "collection", 0)
+            .await
+            .unwrap();
+
+        assert!(
+            s.live_job(Stage::Consolidate, "collection").await.unwrap(),
+            "a sweep nothing was going to run stayed that way"
+        );
     }
 
     #[tokio::test]

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -331,6 +331,63 @@ impl Store {
             .await
     }
 
+    /// Arm a periodic unit to run at `run_after`.
+    ///
+    /// What a self-rescheduling sweep does when it finishes: `run_after` is the
+    /// cursor recording when it last ran, and it is already indexed, so nothing
+    /// has to hold a clock and no meta key has to remember a period.
+    ///
+    /// Guarded on the row being closed, like every automatic arming: a sweep
+    /// already queued is already going to run, and pushing its `run_after` an
+    /// interval further out on every pass is how a sweep would recede forever.
+    pub async fn arm_periodic(
+        &self,
+        stage: Stage,
+        target_kind: &str,
+        target_id: &str,
+        run_after: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO jobs (stage, target_kind, target_id, state, attempts, run_after, created_at, seq, class)
+             VALUES (?, ?, ?, 'pending', 0, ?, ?, 0, ?)
+             ON CONFLICT(stage, target_id) DO UPDATE SET
+               state = 'pending', attempts = 0, run_after = excluded.run_after,
+               last_error = NULL, claimed_at = NULL,
+               created_at = excluded.created_at, class = excluded.class
+             WHERE jobs.state = 'done'",
+        )
+        .bind(stage.as_str())
+        .bind(target_kind)
+        .bind(target_id)
+        .bind(run_after)
+        .bind(now())
+        .bind(stage.class())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// This unit has just become worth running: let it go now.
+    ///
+    /// Two statements, because there are two cases and neither is the other's.
+    /// A unit sleeping on its own period has its `run_after` pulled forward —
+    /// and only that, so a sweep that keeps failing does not have its attempt
+    /// count wound back and reclaim the front of the queue every time something
+    /// arms it. A unit that is closed is armed outright.
+    ///
+    /// A unit a worker is already inside is left alone by both: it is running.
+    pub async fn arm_now(&self, stage: Stage, target_kind: &str, target_id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE jobs SET run_after = 0
+              WHERE stage = ? AND target_id = ? AND state = 'pending' AND run_after > 0",
+        )
+        .bind(stage.as_str())
+        .bind(target_id)
+        .execute(&self.pool)
+        .await?;
+        self.rearm_idle_seq(stage, target_kind, target_id, 0).await
+    }
+
     /// The one upsert the three above differ only in the guard on.
     async fn upsert_job(
         &self,

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -54,13 +54,23 @@ pub enum Stage {
     Pursuit,
     /// One pursuit, one call: write the artifact it earned.
     Generate,
+    /// The periodic retention sweep: expire what `feedback.retain_days` says is
+    /// past keeping, then regroup the knowledge gaps. In that order, which is
+    /// the order the ticker it replaces used — grouping reads the rows expiring
+    /// removes. Local work, no call.
+    Retention,
+    /// The periodic dedupe arming: walks the pairs `Relate` found and arms
+    /// `Dedupe` units for the ones worth a call. Named for what it does — it
+    /// arms judgements, it is not one — and local, since the call belongs to
+    /// the units it arms.
+    ArmDedupe,
 }
 
 impl Stage {
     /// Every stage there is. Written out rather than derived, and the compiler
     /// is no help here — a stage left out of this list is not an error, it is a
     /// stage the class backfill silently never sees.
-    pub const ALL: [Stage; 14] = [
+    pub const ALL: [Stage; 16] = [
         Stage::Synthesize,
         Stage::Enrich,
         Stage::SegmentWindow,
@@ -75,6 +85,8 @@ impl Stage {
         Stage::LinkJudge,
         Stage::Pursuit,
         Stage::Generate,
+        Stage::Retention,
+        Stage::ArmDedupe,
     ];
 
     pub fn as_str(&self) -> &'static str {
@@ -93,6 +105,8 @@ impl Stage {
             Stage::LinkJudge => "link_judge",
             Stage::Pursuit => "pursuit",
             Stage::Generate => "generate",
+            Stage::Retention => "retention",
+            Stage::ArmDedupe => "arm_dedupe",
         }
     }
     /// Is someone waiting on this? `0` foreground, `1` background.
@@ -123,7 +137,9 @@ impl Stage {
             | Stage::Associate
             | Stage::LinkJudge
             | Stage::Pursuit
-            | Stage::Generate => 1,
+            | Stage::Generate
+            | Stage::Retention
+            | Stage::ArmDedupe => 1,
         }
     }
 
@@ -143,6 +159,8 @@ impl Stage {
             "link_judge" => Some(Stage::LinkJudge),
             "pursuit" => Some(Stage::Pursuit),
             "generate" => Some(Stage::Generate),
+            "retention" => Some(Stage::Retention),
+            "arm_dedupe" => Some(Stage::ArmDedupe),
             _ => None,
         }
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -12,6 +12,7 @@ pub mod pairs;
 pub mod pursuits;
 pub mod segments;
 pub mod shingle;
+pub mod sweeps;
 
 use crate::config::StoreConfig;
 use crate::error::Result;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -63,21 +63,22 @@ impl Store {
     /// already has it. Changing a column means changing `schema.sql` and
     /// recreating the database.
     ///
-    /// Which is exactly why it checks afterwards. `CREATE TABLE IF NOT EXISTS`
+    /// Which is exactly why it checks first. `CREATE TABLE IF NOT EXISTS`
     /// leaves an existing table as it is, columns and all, so adding a column
     /// to `schema.sql` without recreating the base changes nothing here and
     /// fails much later, inside a request, with a bare `ColumnNotFound` that
     /// names no cause. Nothing is altered to fix that — recreating is still the
     /// answer — but it is said here, at boot, with the columns named.
+    ///
+    /// The check runs *before* the file rather than after it because the file
+    /// is not inert on an old base. It drops a superseded index by name and
+    /// creates its replacement over a column such a base does not have, and
+    /// `raw_sql` runs statements one after another with no transaction around
+    /// them: applied first, the drop commits, the create fails with the bare
+    /// `no such column` this message exists to replace, and the base is left
+    /// with neither index. Read first, nothing has happened yet.
     pub async fn migrate(&self) -> Result<()> {
         const SCHEMA: &str = include_str!("schema.sql");
-
-        sqlx::raw_sql(SCHEMA)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::Store(e.to_string()))?;
-
-        self.backfill_job_class().await?;
 
         let mut missing = Vec::new();
         for (table, columns) in schema_columns(SCHEMA) {
@@ -91,6 +92,12 @@ impl Store {
                 .iter()
                 .map(|r| r.get::<String, _>("name"))
                 .collect();
+            // No columns at all means no such table — a fresh base, or a table
+            // this schema adds. That is not a base that is behind; it is one
+            // the statement below is about to create.
+            if have.is_empty() {
+                continue;
+            }
             for c in columns {
                 if !have.iter().any(|h| h.eq_ignore_ascii_case(&c)) {
                     missing.push(format!("{table}.{c}"));
@@ -104,6 +111,13 @@ impl Store {
                 missing.join(", ")
             )));
         }
+
+        sqlx::raw_sql(SCHEMA)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| crate::error::Error::Store(e.to_string()))?;
+
+        self.backfill_job_class().await?;
         Ok(())
     }
 
@@ -240,6 +254,59 @@ mod tests {
         assert!(
             before.iter().any(|(_, n)| n == "artifacts"),
             "the schema must actually have been applied"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_base_older_than_the_schema_is_named_before_anything_is_touched() {
+        // The check runs before the file, not after it. `schema.sql` drops a
+        // superseded index by name and creates its replacement over `class` —
+        // so applying it to a base without that column would commit the drop,
+        // fail the create with a bare `no such column`, and leave the base with
+        // neither index and no idea why it would not boot.
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .foreign_keys(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .unwrap();
+        // A `jobs` table as it was before the column existed, and the index the
+        // schema means to replace.
+        sqlx::raw_sql(
+            "CREATE TABLE jobs (
+               id INTEGER PRIMARY KEY AUTOINCREMENT, stage TEXT NOT NULL,
+               target_kind TEXT NOT NULL, target_id TEXT NOT NULL,
+               state TEXT NOT NULL DEFAULT 'pending', attempts INTEGER NOT NULL DEFAULT 0,
+               run_after INTEGER NOT NULL DEFAULT 0, last_error TEXT,
+               claimed_at INTEGER, created_at INTEGER NOT NULL DEFAULT 0,
+               seq INTEGER NOT NULL DEFAULT 0, UNIQUE(stage, target_id));
+             CREATE INDEX idx_jobs_claim2 ON jobs(state, attempts, seq, id, run_after);",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let store = Store {
+            pool,
+            capture: Default::default(),
+        };
+
+        let err = store.migrate().await.unwrap_err().to_string();
+        assert!(
+            err.contains("older than the schema") && err.contains("jobs.class"),
+            "the operator has to be told which column is missing, not shown \
+             a bare column error from the middle of the file: {err}"
+        );
+        let indexes: Vec<(String,)> =
+            sqlx::query_as("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='jobs'")
+                .fetch_all(&store.pool)
+                .await
+                .unwrap();
+        assert!(
+            indexes.iter().any(|(n,)| n == "idx_jobs_claim2"),
+            "a refused migration must not have dropped the index the old \
+             binary still claims through: {indexes:?}"
         );
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -124,18 +124,22 @@ impl Store {
     /// Put the sweeps in the background class.
     ///
     /// `jobs.class` defaults to `0`, which is foreground — the safe direction
-    /// to be wrong in for a row written before the column existed, and the
-    /// wrong answer for every sweep among them. This is the one statement that
-    /// corrects them, and it runs on every connect rather than once: it is
-    /// idempotent by construction, since it only ever moves rows that are still
-    /// `0` *and* whose stage says they should not be, which is why
+    /// to be wrong in, and the wrong answer for every sweep. Not for a row
+    /// written before the column existed: `migrate` reads the columns before it
+    /// applies the schema and refuses a base without `jobs.class` outright, so
+    /// no such row ever reaches this. What it corrects is a row written by an
+    /// older binary for a stage that was foreground then and is background now
+    /// — pending work outlives an upgrade, and nothing else revisits its class.
+    ///
+    /// It runs on every connect rather than once: it is idempotent by
+    /// construction, since it only ever moves rows that are still `0` *and*
+    /// whose stage says they should not be, which is why
     /// `applying_the_schema_twice_changes_nothing` still holds.
     ///
-    /// It does undo an ageing (§4.4) across a restart, turning an aged sweep
-    /// back into a background one. That costs nothing: the ageing predicate is
-    /// `created_at` older than `schedule.age_after_mins`, and a row that had
-    /// already aged still satisfies it, so the first repair tick after boot
-    /// ages it straight back.
+    /// It cannot tell such a row from one that aged (§4.4) and so undoes an
+    /// ageing across a restart. That costs a moment: the repair ticker's first
+    /// tick fires immediately at boot, the ageing predicate is still satisfied
+    /// by a row that had already aged, and it ages straight back.
     async fn backfill_job_class(&self) -> Result<()> {
         let background: Vec<&str> = crate::store::jobs::Stage::ALL
             .iter()

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -76,6 +76,8 @@ impl Store {
             .await
             .map_err(|e| crate::error::Error::Store(e.to_string()))?;
 
+        self.backfill_job_class().await?;
+
         let mut missing = Vec::new();
         for (table, columns) in schema_columns(SCHEMA) {
             // The table-valued form of `PRAGMA table_info`, which takes a bind
@@ -101,6 +103,40 @@ impl Store {
                 missing.join(", ")
             )));
         }
+        Ok(())
+    }
+
+    /// Put the sweeps in the background class.
+    ///
+    /// `jobs.class` defaults to `0`, which is foreground — the safe direction
+    /// to be wrong in for a row written before the column existed, and the
+    /// wrong answer for every sweep among them. This is the one statement that
+    /// corrects them, and it runs on every connect rather than once: it is
+    /// idempotent by construction, since it only ever moves rows that are still
+    /// `0` *and* whose stage says they should not be, which is why
+    /// `applying_the_schema_twice_changes_nothing` still holds.
+    ///
+    /// It does undo an ageing (§4.4) across a restart, turning an aged sweep
+    /// back into a background one. That costs nothing: the ageing predicate is
+    /// `created_at` older than `schedule.age_after_mins`, and a row that had
+    /// already aged still satisfies it, so the first repair tick after boot
+    /// ages it straight back.
+    async fn backfill_job_class(&self) -> Result<()> {
+        let background: Vec<&str> = crate::store::jobs::Stage::ALL
+            .iter()
+            .filter(|s| s.class() == 1)
+            .map(|s| s.as_str())
+            .collect();
+        // The stage names are `&'static str` from our own enum, never anything
+        // a request supplied, so splicing the placeholders is splicing a count.
+        let holes = vec!["?"; background.len()].join(", ");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "UPDATE jobs SET class = 1 WHERE class = 0 AND stage IN ({holes})"
+        )));
+        for stage in background {
+            q = q.bind(stage);
+        }
+        q.execute(&self.pool).await?;
         Ok(())
     }
 

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -150,21 +150,39 @@ impl Store {
     /// re-clusters them identically. Without this the operator would find the
     /// sitting listed once per crash on Ops, each copy able to arm its own
     /// generation.
+    /// `query_vec` is the leading clustered query's vector and the model that
+    /// produced it, carried forward because a pursuit that closes unsatisfied
+    /// is a gap and a gap is a question plus the vector it was found by. The
+    /// sweep is holding both already; re-embedding the words later would be a
+    /// call spent on a vector that has been computed once.
     pub async fn insert_pursuit(
         &self,
         opened_at: i64,
         queries: &[String],
         sources: &[String],
+        query_vec: Option<(&[f32], &str)>,
     ) -> Result<String> {
         let id = pursuit_id(opened_at, queries);
+        let (blob, dim, model) = match query_vec {
+            Some((v, m)) if !v.is_empty() => (
+                crate::store::feedback::vec_to_blob(v),
+                v.len() as i64,
+                Some(m.to_string()),
+            ),
+            _ => (Vec::new(), 0, None),
+        };
         sqlx::query(
-            "INSERT OR IGNORE INTO pursuits (id, opened_at, state, queries, sources)
-             VALUES (?, ?, 'open', ?, ?)",
+            "INSERT OR IGNORE INTO pursuits
+               (id, opened_at, state, queries, sources, query_vec, vec_dim, embed_model)
+             VALUES (?, ?, 'open', ?, ?, ?, ?, ?)",
         )
         .bind(&id)
         .bind(opened_at)
         .bind(serde_json::to_string(queries).unwrap_or_else(|_| "[]".into()))
         .bind(serde_json::to_string(sources).unwrap_or_else(|_| "[]".into()))
+        .bind(blob)
+        .bind(dim)
+        .bind(model)
         .execute(&self.pool)
         .await?;
         Ok(id)
@@ -277,7 +295,12 @@ mod tests {
     async fn a_pursuit_round_trips_and_closes() {
         let s = Store::memory().await.unwrap();
         let id = s
-            .insert_pursuit(100, &["how to mount".into()], &["a1".into(), "a2".into()])
+            .insert_pursuit(
+                100,
+                &["how to mount".into()],
+                &["a1".into(), "a2".into()],
+                None,
+            )
             .await
             .unwrap();
         let p = s.get_pursuit(&id).await.unwrap();

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -218,18 +218,59 @@ CREATE TABLE IF NOT EXISTS jobs (
   -- orders by it, so every document's first window runs before any document's
   -- second — which is what stops a large ingest starving a small one behind it.
   seq         INTEGER NOT NULL DEFAULT 0,
+  -- Is someone waiting on this? 0 = foreground (the capture pipeline the
+  -- operator is watching move raw → ready), 1 = background (work nobody is
+  -- standing in front of). One distinction and not a scale: a priority the
+  -- operator can set wrong presents as "the capture is hanging", with nothing
+  -- anywhere saying why. Default 0 because a row written before this column
+  -- existed is foreground, which is the safe direction to be wrong in; the
+  -- backfill in `migrate` puts the sweeps where they belong.
+  class       INTEGER NOT NULL DEFAULT 0,
   UNIQUE(stage, target_id)
 );
--- Ready work in the order `claim_job` takes it: least-tried first, then oldest.
+-- Ready work in the order `claim_job` takes it: what someone is waiting on
+-- first, then least-tried, then oldest.
 --
 -- The column order is the query's, not the filter's. `run_after` last looks
 -- wrong until you try it the other way round: an inequality ends an index's
 -- usable ordering, so `(state, run_after, attempts, id)` finds the ready rows
 -- and then sorts them in a temp B-tree on every poll. This walks `state`,
--- `attempts`, `id` in claim order, tests `run_after` on each entry, and stops
--- at the first row that is ready — covering, and no sort.
-CREATE INDEX IF NOT EXISTS idx_jobs_claim2  ON jobs(state, attempts, seq, id, run_after);
+-- `class`, `attempts`, `id` in claim order, tests `run_after` on each entry,
+-- and stops at the first row that is ready — covering, and no sort. `class`
+-- leads for the same reason `run_after` trails: it is an equality the walk can
+-- carry, so priority costs the hot path nothing. Ageing is a written column
+-- rather than a computed age precisely so that stays true — see
+-- `Store::age_background`.
+--
+-- Superseded index dropped by name: `CREATE INDEX IF NOT EXISTS` leaves an
+-- existing index's columns alone, so a base that already had `idx_jobs_claim2`
+-- would keep claiming through the old order — silently, and on exactly the
+-- installs the new one exists to serve.
+DROP INDEX IF EXISTS idx_jobs_claim2;
+CREATE INDEX IF NOT EXISTS idx_jobs_claim3  ON jobs(state, class, attempts, seq, id, run_after);
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at);
+
+-- One row per completed run of a periodic unit: what the memory did while
+-- nobody was looking.
+--
+-- There is no "night" to group these by. Units that reschedule themselves on
+-- their own periods do not line up into one cycle, and inventing a cycle
+-- identity to group them by would be inventing it. What Ops shows instead is
+-- the last day, and under it this history -- which is the thing a single
+-- overwritten summary could never give: whether a sweep started going wrong
+-- yesterday or has been going wrong for a week.
+CREATE TABLE IF NOT EXISTS sweep_runs (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  stage      TEXT NOT NULL,
+  started_at INTEGER NOT NULL,
+  ended_at   INTEGER NOT NULL,
+  -- 'ok' | 'failed'. A sweep that failed is exactly the run an operator needs
+  -- to see, so it is recorded like any other rather than only logged.
+  outcome    TEXT NOT NULL,
+  -- What it did, JSON: the counts each sweep already returns.
+  detail     TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_sweep_runs_at ON sweep_runs(started_at DESC);
 
 -- ── Consolidation ────────────────────────────────────────────────────────────
 -- Two artifacts that may say the same thing differently. The only question a

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -407,7 +407,10 @@ CREATE TABLE IF NOT EXISTS gap_clusters (
 -- comes back.
 CREATE TABLE IF NOT EXISTS gap_coverage (
   -- The `GapKind` and the id of the row it came from: an ask event, a search
-  -- event, a pursuit. Not a foreign key, because it names one of three tables.
+  -- event, a pursuit. Not a foreign key, because it names one of three tables
+  -- — so nothing cascades from the row it points at, and retention deletes
+  -- those rows routinely. `Store::trim_gap_coverage`, on the repair pass, is
+  -- the collection this cannot have declaratively.
   kind        TEXT NOT NULL,
   gap_id      TEXT NOT NULL,
   corpus_id   TEXT NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -463,7 +463,17 @@ CREATE TABLE IF NOT EXISTS pursuits (
   -- The engaged artifact ids, JSON, in engagement order. What generation reads.
   sources      TEXT NOT NULL DEFAULT '[]',
   -- The generated artifact, once there is one.
-  artifact_id  TEXT REFERENCES artifacts(id) ON DELETE SET NULL
+  artifact_id  TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
+  -- The leading clustered query's vector, carried forward when the pursuit is
+  -- written. A pursuit that closes unsatisfied is a gap, and a gap is a
+  -- question plus the vector it was found by — `queries` holds the words and
+  -- the words alone, and re-embedding them to group the gap would be a call
+  -- spent on a vector that was already computed. Null on a pursuit written
+  -- before this column existed, which is why `vec_dim > 0` is the test: an
+  -- uncomparable vector is exactly what `open_gaps` already leaves out.
+  query_vec    BLOB,
+  vec_dim      INTEGER NOT NULL DEFAULT 0,
+  embed_model  TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_pursuits_state ON pursuits(state, opened_at);
 

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -397,6 +397,29 @@ CREATE TABLE IF NOT EXISTS gap_clusters (
   created_at  INTEGER NOT NULL
 );
 
+-- A gap the base has since answered, and the capture that answered it.
+--
+-- Its own table rather than a column on the source row, which is deliberately
+-- left untouched: nothing an automatic score decides should overwrite what a
+-- person judged, and an operator who disagrees reopens the gap by deleting the
+-- row here rather than by re-judging anything. The cascades are that
+-- reversibility for free — delete the capture that closed a gap and the gap
+-- comes back.
+CREATE TABLE IF NOT EXISTS gap_coverage (
+  -- The `GapKind` and the id of the row it came from: an ask event, a search
+  -- event, a pursuit. Not a foreign key, because it names one of three tables.
+  kind        TEXT NOT NULL,
+  gap_id      TEXT NOT NULL,
+  corpus_id   TEXT NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+  artifact_id TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- Similarity of the best new hit. Kept so the page can say how strong a
+  -- claim this was; a hit at exactly `weak_below` is a weak one.
+  score       REAL NOT NULL,
+  covered_at  INTEGER NOT NULL,
+  PRIMARY KEY (kind, gap_id)
+);
+CREATE INDEX IF NOT EXISTS idx_gap_coverage_corpus ON gap_coverage(corpus_id);
+
 -- ── Association ──────────────────────────────────────────────────────────────
 -- Two artifacts that keep being retrieved by the same searches. The other half
 -- of relatedness: `artifact_pairs` is about two texts saying the same thing,

--- a/src/store/sweeps.rs
+++ b/src/store/sweeps.rs
@@ -1,0 +1,160 @@
+//! What the memory did while nobody was looking.
+//!
+//! One row per completed run of a periodic unit. There is no "night" to group
+//! them by: units that reschedule themselves on their own periods do not line
+//! up into one cycle, and inventing a cycle identity to group them by would be
+//! inventing it. What Ops shows is the last day, and under it the history —
+//! which is the thing a single overwritten summary could never give, namely
+//! whether a sweep started going wrong yesterday or has been going wrong for a
+//! week.
+
+use super::{Store, now};
+use crate::error::Result;
+use sqlx::Row;
+
+/// How many runs are kept. Trimmed by the retention unit, which is already the
+/// unit that decides what is past keeping. Housekeeping about housekeeping does
+/// not get a policy key.
+pub const MAX_RUNS: i64 = 2000;
+
+/// One recorded run.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SweepRun {
+    pub stage: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    /// `ok` or `failed`.
+    pub outcome: String,
+    /// The counts the sweep returned, as JSON.
+    pub detail: String,
+}
+
+impl Store {
+    /// Record what one run of a periodic unit did.
+    ///
+    /// A failed run is recorded like any other. It is exactly the run an
+    /// operator needs to see, and a history that only kept the successes would
+    /// show a sweep going quiet with nothing anywhere saying why.
+    pub async fn record_sweep_run(
+        &self,
+        stage: &str,
+        started_at: i64,
+        outcome: &str,
+        detail: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO sweep_runs (stage, started_at, ended_at, outcome, detail)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(stage)
+        .bind(started_at)
+        .bind(now())
+        .bind(outcome)
+        .bind(detail)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Every run since `since`, newest first.
+    pub async fn sweep_runs_since(&self, since: i64, limit: i64) -> Result<Vec<SweepRun>> {
+        let rows = sqlx::query(
+            "SELECT stage, started_at, ended_at, outcome, detail FROM sweep_runs
+              WHERE started_at >= ? ORDER BY started_at DESC LIMIT ?",
+        )
+        .bind(since)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(read_run).collect())
+    }
+
+    /// The history: the most recent runs, newest first, whenever they were.
+    pub async fn sweep_history(&self, limit: i64) -> Result<Vec<SweepRun>> {
+        let rows = sqlx::query(
+            "SELECT stage, started_at, ended_at, outcome, detail FROM sweep_runs
+              ORDER BY started_at DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(read_run).collect())
+    }
+
+    /// Keep the newest `MAX_RUNS` and forget the rest.
+    pub async fn trim_sweep_runs(&self) -> Result<u64> {
+        let res = sqlx::query(
+            "DELETE FROM sweep_runs WHERE id NOT IN (
+               SELECT id FROM sweep_runs ORDER BY started_at DESC, id DESC LIMIT ?
+             )",
+        )
+        .bind(MAX_RUNS)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+}
+
+fn read_run(r: &sqlx::sqlite::SqliteRow) -> SweepRun {
+    SweepRun {
+        stage: r.get("stage"),
+        started_at: r.get("started_at"),
+        ended_at: r.get("ended_at"),
+        outcome: r.get("outcome"),
+        detail: r.get("detail"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_failed_run_is_recorded_like_any_other() {
+        let s = Store::memory().await.unwrap();
+        s.record_sweep_run("associate", now(), "ok", r#"{"events":3}"#)
+            .await
+            .unwrap();
+        s.record_sweep_run("consolidate", now(), "failed", "{}")
+            .await
+            .unwrap();
+
+        let runs = s.sweep_history(10).await.unwrap();
+        assert_eq!(runs.len(), 2);
+        assert!(
+            runs.iter().any(|r| r.outcome == "failed"),
+            "a history that keeps only the successes shows a sweep going quiet \
+             with nothing saying why"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_last_day_leaves_out_what_is_older() {
+        let s = Store::memory().await.unwrap();
+        s.record_sweep_run("associate", now() - 2 * 86_400, "ok", "{}")
+            .await
+            .unwrap();
+        s.record_sweep_run("associate", now(), "ok", "{}")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.sweep_runs_since(now() - 86_400, 100).await.unwrap().len(),
+            1
+        );
+        assert_eq!(s.sweep_history(100).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn the_trim_keeps_the_newest() {
+        let s = Store::memory().await.unwrap();
+        for i in 0..(MAX_RUNS + 5) {
+            s.record_sweep_run("retention", now() - (MAX_RUNS + 5 - i), "ok", "{}")
+                .await
+                .unwrap();
+        }
+        assert_eq!(s.trim_sweep_runs().await.unwrap(), 5);
+        let kept = s.sweep_history(MAX_RUNS + 10).await.unwrap();
+        assert_eq!(kept.len() as i64, MAX_RUNS);
+    }
+}

--- a/src/store/sweeps.rs
+++ b/src/store/sweeps.rs
@@ -12,9 +12,10 @@ use super::{Store, now};
 use crate::error::Result;
 use sqlx::Row;
 
-/// How many runs are kept. Trimmed by the retention unit, which is already the
-/// unit that decides what is past keeping. Housekeeping about housekeeping does
-/// not get a policy key.
+/// How many runs are kept. Trimmed by the repair pass, which is behind no
+/// setting: a trim that rode on the retention unit stopped whenever capture was
+/// switched off, and the sweeps that kept running kept writing rows.
+/// Housekeeping about housekeeping does not get a policy key.
 pub const MAX_RUNS: i64 = 2000;
 
 /// One recorded run.

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -320,6 +320,10 @@ impl VectorStore for MemoryVectors {
                         .category
                         .as_ref()
                         .is_none_or(|c| p.payload.category.as_ref() == Some(c))
+                    && filter
+                        .corpus_id
+                        .as_ref()
+                        .is_none_or(|c| &p.payload.corpus_id == c)
             })
             .map(|p| {
                 // Dense only here, so the ranking score *is* the similarity.

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -79,6 +79,11 @@ pub struct SearchFilter {
     /// statuses mean different things and callers may want to audit one
     /// without the other.
     pub include_deprecated: bool,
+    /// Only artifacts of this one document. What the gap coverage check needs:
+    /// the question is whether *this capture* answered something, and a hit
+    /// from anywhere else answers a different question — the base held it all
+    /// along, and the gap is open for a reason.
+    pub corpus_id: Option<String>,
 }
 
 impl SearchFilter {
@@ -88,6 +93,7 @@ impl SearchFilter {
     pub fn is_empty(&self) -> bool {
         self.tags.is_empty()
             && self.category.is_none()
+            && self.corpus_id.is_none()
             && self.include_superseded
             && self.include_deprecated
     }

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -147,6 +147,9 @@ fn build_filter(filter: &SearchFilter) -> Option<Value> {
     if let Some(c) = &filter.category {
         must.push(json!({ "key": "category", "match": { "value": c } }));
     }
+    if let Some(c) = &filter.corpus_id {
+        must.push(json!({ "key": "corpus_id", "match": { "value": c } }));
+    }
 
     // `must` is omitted rather than sent empty. A search that only excludes
     // superseded points has no positive condition, and an empty condition list
@@ -2029,6 +2032,7 @@ mod tests {
             category: Some("procedure".into()),
             include_superseded: false,
             include_deprecated: false,
+            corpus_id: None,
         })
         .unwrap();
         let must = f["must"].as_array().unwrap();

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2315,6 +2315,7 @@ mod patch_tests {
                     category: None,
                     include_superseded: false,
                     include_deprecated: false,
+                    corpus_id: None,
                 },
             )
             .await

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -129,12 +129,15 @@ fn ago(then: i64) -> String {
     }
 }
 
+/// The card's preview: plain text, markup gone.
+///
+/// Flattening whitespace was the whole of this, so a card showed
+/// `# Configure Linux…` and `custom\_passphrase` — the escapes an artifact
+/// carries so that markdown renders it correctly, shown to a person as if they
+/// were the text. `markdown::snippet` already strips them, and already stops
+/// at a word rather than mid-one.
 fn snippet_of(text: &str) -> String {
-    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    match flat.char_indices().nth(140) {
-        Some((i, _)) => format!("{}…", &flat[..i]),
-        None => flat,
-    }
+    crate::web::markdown::snippet(text, 140)
 }
 
 /// Shuffle without pulling in a random-number crate: the event id is already a
@@ -176,7 +179,7 @@ async fn card_for(st: &AppState, event: PendingEvent) -> Result<Card> {
                 // card, before the keystroke, instead of after it.
                 usable: a.in_results(),
                 artifact_id: a.id,
-                title: a.title.unwrap_or_else(|| "Untitled".into()),
+                title: a.title.unwrap_or_default(),
                 snippet: snippet_of(&a.text),
                 key: None,
             }),
@@ -512,7 +515,7 @@ async fn assign_results(
             .enumerate()
             .map(|(i, h)| Choice {
                 artifact_id: h.artifact_id,
-                title: h.title.unwrap_or_else(|| "Untitled".into()),
+                title: h.title.unwrap_or_default(),
                 snippet: snippet_of(&h.text),
                 // The search that produced these excluded deprecated and
                 // superseded artifacts, so everything offered here is something
@@ -558,6 +561,20 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
+
+    #[test]
+    fn a_judge_card_names_nothing_untitled_and_leaks_no_markdown() {
+        // Two thirds of the deployment's judge list read "Untitled", and the
+        // snippets under them carried the backslash escapes and the leading
+        // "#" that an artifact carries so a renderer reads it correctly —
+        // shown to a person as if they were the text.
+        assert_eq!(
+            super::snippet_of("## Configure **auditd**"),
+            "Configure auditd"
+        );
+        let s = super::snippet_of(r"2 - A custom passphrase (custom\_passphrase)");
+        assert!(!s.contains('\\'), "escape shown as text: {s:?}");
+    }
 
     /// A session, `real` genuine artifacts, and one captured search whose pool
     /// is those artifacts followed by `phantom` ids that name nothing.

--- a/src/web/markdown.rs
+++ b/src/web/markdown.rs
@@ -59,13 +59,45 @@ pub fn snippet(markdown: &str, max_chars: usize) -> String {
         }
     }
     let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_at_word(&text, max_chars)
+}
+
+/// Truncate at a word, never inside one, and never inside a codepoint.
+///
+/// `chars().take(n)` was the whole of this, and it is what produced "…darin
+/// vo" in the sitting: a name cut mid-word reads as a broken name, where one
+/// cut at a space reads as an opening. Falls back to the hard cut when there
+/// is no space to fall back to — one unbroken 200-character token is still
+/// better shortened than shown whole — and refuses a break so early that a
+/// single word would stand for a whole passage.
+fn truncate_at_word(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
-        return text;
+        return text.to_string();
     }
     // Truncate by chars, never by bytes: slicing mid-codepoint panics.
-    let mut out: String = text.chars().take(max_chars).collect();
-    out.push('…');
-    out
+    let hard: String = text.chars().take(max_chars).collect();
+    let cut = match hard.rfind(char::is_whitespace) {
+        Some(i) if hard[..i].chars().count() * 2 >= max_chars => &hard[..i],
+        _ => hard.as_str(),
+    };
+    format!("{}…", cut.trim_end())
+}
+
+/// A name for something that has none, derived from its own opening.
+///
+/// A verbatim passage has no title by design. Where the layout can let a
+/// snippet speak for the row there should be no heading at all — see
+/// `render_hit`. Where a name is structurally required, a button label or a
+/// list of what this sitting touched, this is that name: the body's opening,
+/// with the markup and the leading punctuation that are structure rather than
+/// subject taken off the front. `Keep "- schneller Schreibzugriff (…) -"` is
+/// what the dedupe queue offered without this.
+pub fn stand_in_title(text: &str, max_chars: usize) -> String {
+    let flat = snippet(text, usize::MAX);
+    let opening = flat.trim_start_matches(|c: char| {
+        c.is_whitespace() || matches!(c, '-' | '–' | '—' | '*' | '#' | '>' | '·' | '•' | '|')
+    });
+    truncate_at_word(opening.trim(), max_chars)
 }
 
 #[cfg(test)]
@@ -153,6 +185,56 @@ mod tests {
         let html = render("Payload:\n\n```html\n<script>alert(1)</script>\n```");
         assert!(html.contains("&lt;script&gt;"), "{html}");
         assert!(!html.contains("<script>"), "{html}");
+    }
+
+    #[test]
+    fn a_stand_in_title_stops_at_a_word() {
+        // The sitting rendered "…zusätzlich darin vo" — a name cut mid-word
+        // reads as a truncated name, not as the opening of a passage.
+        let t = stand_in_title(
+            "Die digitale Forensik unterscheidet sich zusätzlich darin von einem Tatort",
+            60,
+        );
+        assert!(!t.contains("vo…"), "cut mid-word: {t:?}");
+        assert!(t.ends_with('…'), "{t:?}");
+        assert!(t.chars().count() <= 61, "{t:?}");
+    }
+
+    #[test]
+    fn a_stand_in_title_drops_leading_punctuation_and_markup() {
+        // `Keep "- schneller Schreibzugriff (…) -"` was a body opening,
+        // dashes and all, pressed into service as a name.
+        assert_eq!(
+            stand_in_title("- schneller Schreibzugriff auf den Stapel", 60),
+            "schneller Schreibzugriff auf den Stapel"
+        );
+        assert_eq!(
+            stand_in_title("## 3.4.2 FESTE MFT RECORDS", 60),
+            "3.4.2 FESTE MFT RECORDS"
+        );
+    }
+
+    #[test]
+    fn a_short_body_becomes_a_stand_in_unchanged() {
+        assert_eq!(
+            stand_in_title("CPU fair scheduler parameter", 60),
+            "CPU fair scheduler parameter"
+        );
+    }
+
+    #[test]
+    fn a_stand_in_of_nothing_is_empty() {
+        assert_eq!(stand_in_title("   \n\n  ", 60), "");
+        assert_eq!(stand_in_title("---", 60), "");
+    }
+
+    #[test]
+    fn a_snippet_stops_at_a_word_too() {
+        let s = snippet(
+            "Die digitale Forensik unterscheidet sich zusätzlich darin von einem Tatort",
+            30,
+        );
+        assert!(!s.contains("zusä…"), "cut mid-word: {s:?}");
     }
 
     #[test]

--- a/src/web/markdown.rs
+++ b/src/web/markdown.rs
@@ -97,7 +97,46 @@ pub fn stand_in_title(text: &str, max_chars: usize) -> String {
     let opening = flat.trim_start_matches(|c: char| {
         c.is_whitespace() || matches!(c, '-' | '–' | '—' | '*' | '#' | '>' | '·' | '•' | '|')
     });
-    truncate_at_word(opening.trim(), max_chars)
+    // Put back a number the parse took for structure. `snippet` is a whole
+    // CommonMark read that keeps the text events, so `1. Einleitung` arrives
+    // here as `Einleitung`: an ordered-list marker is structure to the parser
+    // and part of the name to everyone else. It matters twice over now that
+    // stored titles come through here too — two syntheses called `1. Einleitung`
+    // and `2. Einleitung` were shown under one name, and the number is the
+    // whole of what told them apart.
+    let name = match leading_enumerator(text) {
+        Some(marker) => format!("{marker} {opening}"),
+        None => opening.to_string(),
+    };
+    truncate_at_word(name.trim(), max_chars)
+}
+
+/// The `1.` or `1)` a text opens with, if it opens with one.
+///
+/// Only what CommonMark itself would have eaten: digits, one `.` or `)`, and
+/// whitespace after it. A date written `1.9. Termin` has no space after the
+/// first dot and is not a list to the parser either, so both leave it whole.
+/// Returns the marker as the text wrote it — `10.` stays `10.`, and `)` does not
+/// come back as `.` — because a name is what was written.
+fn leading_enumerator(text: &str) -> Option<&str> {
+    let start = text.trim_start();
+    let digits = start.len() - start.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    // Nine is CommonMark's own limit on how long an ordered marker may be; past
+    // it the parser stops reading a list, and so does this.
+    if digits == 0 || digits > 9 {
+        return None;
+    }
+    let delim = start[digits..].chars().next()?;
+    if !matches!(delim, '.' | ')') {
+        return None;
+    }
+    // A marker with nothing after it is not a list item, and a title that is
+    // only `3.` has nothing for this to be the marker of.
+    let marker = &start[..digits + delim.len_utf8()];
+    match start[marker.len()..].starts_with(|c: char| c.is_whitespace()) {
+        true => Some(marker),
+        false => None,
+    }
 }
 
 #[cfg(test)]
@@ -212,6 +251,31 @@ mod tests {
             stand_in_title("## 3.4.2 FESTE MFT RECORDS", 60),
             "3.4.2 FESTE MFT RECORDS"
         );
+    }
+
+    #[test]
+    fn a_stand_in_title_keeps_the_number_a_section_opens_with() {
+        // The number is structure to the parser and part of the name to
+        // everyone else: without it two syntheses are shown under one name.
+        assert_eq!(stand_in_title("1. Einleitung", 60), "1. Einleitung");
+        assert_eq!(stand_in_title("2. Einleitung", 60), "2. Einleitung");
+        // As written: the width of the number and the delimiter both survive.
+        assert_eq!(stand_in_title("10. Kapitel Zehn", 60), "10. Kapitel Zehn");
+        assert_eq!(stand_in_title("1) Foo", 60), "1) Foo");
+        // A marker inside a heading was never a list marker; the heading's own
+        // `#` still goes, and the text under it is untouched either way.
+        assert_eq!(stand_in_title("## 1. Einleitung", 60), "1. Einleitung");
+    }
+
+    #[test]
+    fn a_number_that_is_not_a_marker_is_left_alone() {
+        // No space after the dot: not a list to CommonMark, and not one here.
+        assert_eq!(stand_in_title("1.9. Termin im Mai", 60), "1.9. Termin im Mai");
+        // Nothing for the marker to mark: an empty list item, which flattens
+        // to nothing at all, exactly as `---` does. `title_of` falls back to
+        // the id there rather than showing a name that is one number.
+        assert_eq!(stand_in_title("3.", 60), "");
+        assert_eq!(stand_in_title("2024 war ein Jahr", 60), "2024 war ein Jahr");
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -183,7 +183,10 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
         let body = crate::web::test_support::body_of(res).await;
-        assert!(!body.contains("<html"), "an API 404 came back as a page: {body}");
+        assert!(
+            !body.contains("<html"),
+            "an API 404 came back as a page: {body}"
+        );
     }
 
     #[tokio::test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -190,6 +190,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_unknown_path_is_behind_a_session_like_every_other_page() {
+        // The fallback took no `Identity`, so the one path nobody had routed
+        // was the one path that rendered the whole nav — `judge_pending`, a
+        // live count out of the base, included — to a visitor with no session.
+        let core = crate::core::test_support::test_core().await;
+        let app = crate::web::test_support::router(core, None);
+        let res = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/ui/nothing-here")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER, "{res:?}");
+        assert!(
+            res.headers()["location"]
+                .to_str()
+                .unwrap()
+                .starts_with("/auth/login"),
+            "an unknown path rendered rather than bouncing: {res:?}"
+        );
+
+        // And the API answer is unchanged: a caller with no credentials asking
+        // for a route that does not exist is told the route does not exist,
+        // not sent to an interactive login it cannot follow.
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/nothing-here")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "{res:?}");
+    }
+
+    #[tokio::test]
     async fn a_bounced_page_load_tells_the_login_where_it_was_going() {
         let core = crate::core::test_support::test_core().await;
         let app = crate::web::test_support::router(core, None);

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -165,6 +165,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_missing_asset_is_a_missing_asset_and_not_a_login() {
+        // The fallback is the whole application's, not the UI router's, so a
+        // stylesheet nobody routed arrived at the page — which for a browser
+        // with no session is a 401, which the redirect middleware then turns
+        // into the login screen. A 303 to `/auth/login` in place of a 404 on a
+        // `<link>` is not a missing stylesheet, it is a mystery.
+        let core = crate::core::test_support::test_core().await;
+        let (app, _cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/assets/nothing-here.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "{res:?}");
+    }
+
+    #[tokio::test]
+    async fn an_unrouted_mcp_path_is_not_a_web_page_either() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/mcp/nothing-here")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let body = crate::web::test_support::body_of(res).await;
+        assert!(!body.contains("<html"), "an HTML document to parse: {body}");
+    }
+
+    #[tokio::test]
+    async fn a_post_to_a_path_nobody_routed_is_not_handed_a_page() {
+        // Nobody types a POST into a browser bar, so there is nobody to show a
+        // page to; whatever sent it wants the status.
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/ui/nothing-here")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let body = crate::web::test_support::body_of(res).await;
+        assert!(!body.contains("<html"), "an HTML document to parse: {body}");
+    }
+
+    #[tokio::test]
     async fn an_unknown_api_path_is_still_not_a_web_page() {
         // The fallback is for people typing URLs. An agent asking the API for
         // a route that does not exist must not be handed a login-shaped HTML

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -84,6 +84,7 @@ pub fn router(state: AppState) -> Router {
                 state.core.capture.pdf_max_bytes,
             ),
         )
+        .fallback(ui::not_found)
         .layer(axum::middleware::from_fn(redirect_unauthenticated_browsers))
         .layer(axum::extract::DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(tower_http::trace::TraceLayer::new_for_http())
@@ -118,6 +119,71 @@ mod tests {
         let res = app.oneshot(get(None)).await.unwrap();
         assert_eq!(res.status(), StatusCode::SEE_OTHER, "{res:?}");
         assert_eq!(res.headers()["location"], "/ui/search");
+    }
+
+    #[tokio::test]
+    async fn housekeeping_is_one_name_and_one_url() {
+        // The nav says Housekeeping, the URL says /ui/ops, the page title said
+        // Ops — and /ui/housekeeping, the name a reader would type, was the
+        // browser's own error page.
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/ui/housekeeping")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT, "{res:?}");
+        assert_eq!(res.headers()["location"], "/ui/ops");
+    }
+
+    #[tokio::test]
+    async fn an_unknown_ui_path_gets_the_apps_own_page() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/ui/nothing-here")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let body = crate::web::test_support::body_of(res).await;
+        assert!(
+            body.contains("engram"),
+            "the browser's error page, not ours: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_api_path_is_still_not_a_web_page() {
+        // The fallback is for people typing URLs. An agent asking the API for
+        // a route that does not exist must not be handed a login-shaped HTML
+        // document to parse.
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/nothing-here")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let body = crate::web::test_support::body_of(res).await;
+        assert!(!body.contains("<html"), "an API 404 came back as a page: {body}");
     }
 
     #[tokio::test]

--- a/src/web/templates/_answer.html
+++ b/src/web/templates/_answer.html
@@ -10,10 +10,15 @@
     {% if !unsupported.is_empty() %}
       <span class="card-meta"><span class="badge badge-warning"
         title="These appear in no cited excerpt. The model wrote them; the base does not hold them.">
-        {{ unsupported.len() }} unsupported literal(s)</span></span>
+        {{ unsupported.len() }} literal{% if unsupported.len() != 1 %}s{% endif %} no excerpt supports</span></span>
     {% endif %}
     {% if dropped > 0 %}
-      <span class="card-meta"><span class="badge badge-warning">{{ dropped }} excerpt(s) omitted for context budget</span></span>
+      {# In words a reader uses. "excerpt(s) omitted for context budget" is
+         the accounting behind it, which belongs where an operator can still
+         find it and not on the face of the badge. #}
+      <span class="card-meta"><span class="badge badge-warning"
+        title="They did not fit the model's context window, so the answer was written without them.">
+        {{ dropped }} more excerpt{% if dropped != 1 %}s{% endif %} did not fit</span></span>
     {% endif %}
   </div>
   <div class="md">{{ answer|safe }}</div>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -31,9 +31,25 @@
       <div>Something near-identical and newer
         (<a href="/ui/artifacts/{{ winner }}">this one</a>) was kept instead.</div>
       <div class="chips">
-        {# `to`: these buttons also live on Ops, whose copies send nothing and
-           land back on the queue. Pressed from here, they come back here. #}
-        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/unsupersede">
+        {# Swapped, not navigated. What these buttons change is the artifact,
+           so what they answer with is the artifact, re-rendered in place —
+           `closest [data-artifact]` is this fragment's own root, and it is the
+           root in both places this fragment is rendered: the standalone page,
+           and the pane beside the search results. The hidden `to` could only
+           ever name one of the two, and it named the page, so pressing one of
+           these on a search result took the whole window there and the results
+           being worked through were gone.
+
+           `method`/`action` and `to` stay for a browser with no htmx, which
+           still posts and still follows the redirect. `terms` rides along so
+           the highlighting survives the swap.
+
+           These buttons also live on Ops, whose copies send no `to` and land
+           back on the queue — there the queue *is* the thing being worked
+           through, and a row leaving it is the point. #}
+        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/unsupersede"
+          hx-post="/ui/ops/artifacts/{{ d.id }}/unsupersede?terms={{ d.terms|urlencode }}"
+          hx-target="closest [data-artifact]" hx-swap="outerHTML">
           <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
           <button class="btn btn-sm" type="submit">Put it back</button>
         </form>
@@ -79,18 +95,22 @@
      about. #}
   <div class="actions pane-header">
     {% if d.superseded_by.is_none() && d.status.as_str() != "deprecated" %}
-    <form method="post" action="/ui/ops/artifacts/{{ d.id }}/verify">
+    <form method="post" action="/ui/ops/artifacts/{{ d.id }}/verify"
+          hx-post="/ui/ops/artifacts/{{ d.id }}/verify?terms={{ d.terms|urlencode }}"
+          hx-target="closest [data-artifact]" hx-swap="outerHTML">
       <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
       <button class="btn-icon" type="submit"
               title="Confirm still accurate" aria-label="Confirm still accurate">
         {% include "_icon_check.html" %}<span>Verified</span>
       </button>
     </form>
-    <form method="post" action="/ui/ops/artifacts/{{ d.id }}/deprecate">
+    <form method="post" action="/ui/ops/artifacts/{{ d.id }}/deprecate"
+          hx-post="/ui/ops/artifacts/{{ d.id }}/deprecate?terms={{ d.terms|urlencode }}"
+          hx-target="closest [data-artifact]" hx-swap="outerHTML">
       <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
       <button class="btn-icon" type="submit"
-              title="Deprecate — hide from results, keep the artifact"
-              aria-label="Deprecate: hide from results, keep the artifact">
+              title="Hide from results — the artifact is kept, and this can be undone"
+              aria-label="Hide from results: the artifact is kept, and this can be undone">
         {% include "_icon_hide.html" %}<span>Hide</span>
       </button>
     </form>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -60,11 +60,14 @@
   <div class="flag" role="status">
     <div aria-hidden="true">⚠</div>
     <div>
-      <b>Deprecated</b>
-      <div>Flagged stale, with no specific replacement. Still stored and still
-        readable; kept out of results only.</div>
+      <b>Hidden as stale</b>
+      <div>Flagged stale, with no specific replacement. Search will not return
+        it and Ask will not read from it; it is still stored, and this link
+        still works. Reactivate puts it back in results.</div>
       <div class="chips">
-        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/reactivate">
+        <form method="post" action="/ui/ops/artifacts/{{ d.id }}/reactivate"
+          hx-post="/ui/ops/artifacts/{{ d.id }}/reactivate?terms={{ d.terms|urlencode }}"
+          hx-target="closest [data-artifact]" hx-swap="outerHTML">
           <input type="hidden" name="to" value="/ui/artifacts/{{ d.id }}">
           <button class="btn btn-sm" type="submit">Reactivate</button>
         </form>
@@ -119,7 +122,7 @@
        stores and cannot be undone. Nothing else deletes an artifact — see
        `Core::heal_store_drift`. #}
     <form method="post" action="/ui/artifacts/{{ d.id }}/delete"
-          onsubmit="return confirm('Delete this artifact for good? Deprecating hides it instead and can be undone.')">
+          onsubmit="return confirm('Delete this artifact for good? It goes from both stores, anything written from it loses it as a source, and none of that can be undone. Hide keeps the artifact and only takes it out of results.')">
       <button class="btn-icon btn-icon-danger" type="submit"
               title="Delete permanently" aria-label="Delete artifact permanently">
         {% include "_icon_trash.html" %}<span>Delete</span>

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -151,6 +151,12 @@
                            f.querySelector('textarea').focus()">edit</button>
         </div>
         <div class="md clampable" data-copyable>{{ d.html|safe }}</div>
+        {# The passage stopped mid-sentence, so the window it was cut from did.
+           The source column beside this already shows the rest of the line;
+           this is the way to the artifact that carries it. #}
+        {% if let Some(next) = d.continues_at %}
+        <p class="continues"><a class="quiet-link" href="/ui/artifacts/{{ next }}">continues in the next passage →</a></p>
+        {% endif %}
         {% if !d.caveats.is_empty() %}
         {# Emitted by the same synthesis call that wrote the artifact, from what
            the source states. Shown but deliberately not embedded. #}

--- a/src/web/templates/_decide.html
+++ b/src/web/templates/_decide.html
@@ -35,6 +35,16 @@
     <b>{% if p.contradiction %}these two disagree{% else %}these two cover the same ground{% endif %}</b>{% if p.via_link %}, no similarity was measured{% else %}, {{ p.percent }}% alike{% endif %}.
   </div>
   {% if let Some(d) = p.detail %}<div class="decide-finding">{{ d }}</div>{% endif %}
+  {# Both sides, readable where the decision is made. Closed by default: the
+     titles answer most cards on their own, and five open cards would be a page
+     of text above the buttons that clear it. #}
+  <details class="decide-read">
+    <summary>Read both</summary>
+    <div class="decide-sides">
+      <div><b>{{ p.a_title }}</b><p>{{ p.a_excerpt }}</p></div>
+      <div><b>{{ p.b_title }}</b><p>{{ p.b_excerpt }}</p></div>
+    </div>
+  </details>
   <div class="row">
     {# The judge's pick, when it has one, is the accented button rather than a
        separate action — a recommendation about which of these two to press,

--- a/src/web/templates/_decide.html
+++ b/src/web/templates/_decide.html
@@ -9,7 +9,15 @@
 
    Each button names the artifact it keeps. "Keep one" and "Keep the other"
    made you look back at the columns to know what you were about to press. #}
-{% for p in pairs %}
+{# One cluster, one card. A cluster of two artifacts renders exactly as a
+   single pair always did; a larger one says what it is asking about before the
+   rows do, because three questions about one artifact arrived looking like the
+   same question asked three times. #}
+{% for cluster in pairs %}
+{% if cluster.members > 2 %}
+<p class="decide-cluster">{{ cluster.members }} artifacts, {{ cluster.pairs.len() }} open questions between them.</p>
+{% endif %}
+{% for p in cluster.pairs %}
 <div class="decide">
   {# The titles lead. What the pair is *about* is the content of the card, and
      whether they disagree and by how much is the qualifier on it — the other
@@ -61,4 +69,5 @@
     </form>
   </div>
 </div>
+{% endfor %}
 {% endfor %}

--- a/src/web/templates/_decide.html
+++ b/src/web/templates/_decide.html
@@ -20,8 +20,10 @@
      through repeated co-retrieval, not cosine — so `percent` would read as a
      measured similarity that was never computed. #}
   <div class="decide-head">
-    <a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a> vs
-    <a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a> —
+    <a href="/ui/artifacts/{{ p.a_id }}">{{ p.a_title }}</a>{% if !p.a_opening.is_empty() %}
+    <span class="decide-opening">{{ p.a_opening }}</span>{% endif %} vs
+    <a href="/ui/artifacts/{{ p.b_id }}">{{ p.b_title }}</a>{% if !p.b_opening.is_empty() %}
+    <span class="decide-opening">{{ p.b_opening }}</span>{% endif %} —
     <b>{% if p.contradiction %}these two disagree{% else %}these two cover the same ground{% endif %}</b>{% if p.via_link %}, no similarity was measured{% else %}, {{ p.percent }}% alike{% endif %}.
   </div>
   {% if let Some(d) = p.detail %}<div class="decide-finding">{{ d }}</div>{% endif %}

--- a/src/web/templates/_gaps.html
+++ b/src/web/templates/_gaps.html
@@ -1,8 +1,14 @@
 {# The holes, where capturing happens. A group is a name over the questions
    in it; a question not yet grouped is shown under itself until the sweep
-   runs. "covered" is the operator's word, never the system's. #}
+   runs. "covered" is the operator's word, never the system's.
+
+   Four ways of saying the base did not answer, on one list: a search judged a
+   gap, a question answered "nothing here", a search nothing came close to, and
+   a run of searches that ended unsatisfied. The badge says which, because they
+   are not the same claim and an operator reading the list can tell them
+   apart. #}
 {% if !gaps.is_empty() || !loose.is_empty() %}
-<h3>Knowledge gaps</h3>
+<h3 id="gaps">Knowledge gaps</h3>
 <div class="gaps">
   {% for g in gaps %}
   <details class="gap">
@@ -11,6 +17,7 @@
       {% for m in g.members %}
       <li id="gap-{{ m.kind }}-{{ m.id }}" class="row">
         <span>{{ m.text }}</span>
+        <span class="badge">{{ m.badge }}</span>
         {% if ask_enabled %}<a class="btn btn-ghost btn-sm" href="/ui/ask?q={{ m.text|urlencode }}">ask again</a>{% endif %}
         <button class="btn btn-ghost btn-sm" hx-post="/ui/gaps/{{ m.kind }}/{{ m.id }}/dismiss"
                 hx-target="closest li" hx-swap="outerHTML">covered</button>
@@ -26,6 +33,7 @@
       {% for m in loose %}
       <li id="gap-{{ m.kind }}-{{ m.id }}" class="row">
         <span>{{ m.text }}</span>
+        <span class="badge">{{ m.badge }}</span>
         {% if ask_enabled %}<a class="btn btn-ghost btn-sm" href="/ui/ask?q={{ m.text|urlencode }}">ask again</a>{% endif %}
         <button class="btn btn-ghost btn-sm" hx-post="/ui/gaps/{{ m.kind }}/{{ m.id }}/dismiss"
                 hx-target="closest li" hx-swap="outerHTML">covered</button>

--- a/src/web/templates/_gaps.html
+++ b/src/web/templates/_gaps.html
@@ -28,7 +28,11 @@
   {% endfor %}
   {% if !loose.is_empty() %}
   <details class="gap">
-    <summary>not yet grouped <span class="muted">({{ loose.len() }})</span></summary>
+    {# Grouping is a sweep, not a property of the question: these are the ones
+       asked since it last ran. Without saying so, "not yet grouped" reads as
+       something wrong with the question itself. #}
+    <summary>not yet grouped <span class="muted">({{ loose.len() }})</span>
+      <span class="muted"> — the sweep that groups them has not run yet</span></summary>
     <ul>
       {% for m in loose %}
       <li id="gap-{{ m.kind }}-{{ m.id }}" class="row">

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -43,7 +43,12 @@
            disabled one would advertise a key that refuses. The column stays
            either way so the titles line up. #}
         <span class="judge-key">{% if let Some(k) = o.key %}{{ k }}{% endif %}</span>
-        <span class="judge-title">{{ o.title }}</span>
+        {# No heading where there is no name. A verbatim passage has no title
+           by design, and a list of "Untitled" is a column of a word that says
+           nothing where a name would say something — the same reasoning
+           `render_hit` states for the search rail. The snippet below carries
+           the row. #}
+        {% if !o.title.is_empty() %}<span class="judge-title">{{ o.title }}</span>{% endif %}
         {% if o.usable %}
         <span class="judge-snippet">{{ o.snippet }}</span>
         {% else %}

--- a/src/web/templates/_queue.html
+++ b/src/web/templates/_queue.html
@@ -14,7 +14,15 @@
   {% for r in rows %}
   <div class="qrow">
     {% if r.in_flight %}<span class="qdot" aria-hidden="true"></span>{% endif %}
-    <a class="qtitle {% if r.unnamed %}pending{% endif %}" href="/ui/corpora/{{ r.id }}">{{ r.label }}</a>
+    {# The opening words on a line of their own, and only where the label they
+       belong to is shared with another row. Inside the link, so the whole of
+       what names a capture is the same target; outside `.qtitle`, so the
+       truncation that keeps one label on one line cannot cut off the half
+       that says which capture this is. #}
+    <a class="qname {% if r.unnamed %}pending{% endif %}" href="/ui/corpora/{{ r.id }}">
+      <span class="qtitle">{{ r.label }}</span>
+      {% if !r.opening.is_empty() %}<span class="qtitle-opening">{{ r.opening }}</span>{% endif %}
+    </a>
     <span class="qmeta">
       {% if let Some(p) = r.progress %}
         <span class="badge badge-accent">segmenting {{ p }}</span>

--- a/src/web/templates/_queue.html
+++ b/src/web/templates/_queue.html
@@ -52,6 +52,15 @@
       {% endif %}
       <span class="qtime">{{ r.created }}</span>
     </span>
+    {# What this capture did beyond being stored. Closed silently — nothing
+       asked the operator to confirm it — so this is the only place it is
+       said, and it says nothing at all on the captures that answered
+       nothing, which is nearly all of them. #}
+    {% if !r.covered.is_empty() %}
+    <div class="qmeta muted">
+      answers {% for q in r.covered %}&ldquo;{{ q }}&rdquo;{% if !loop.last %}, {% endif %}{% endfor %}
+    </div>
+    {% endif %}
   </div>
   {% endfor %}
   {% if rows.is_empty() %}<p class="muted">Nothing captured yet.</p>{% endif %}

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -95,17 +95,14 @@
       </p>
       {% endif %}
     </a>
-    {# Swaps its own row out and leaves the rest of the results alone, so the
-       search you were reading is still on screen afterwards. #}
-    <div class="rail-del">
-      <button class="btn-icon btn-icon-danger" title="Delete artifact"
-              aria-label="Delete artifact"
-              hx-post="/ui/artifacts/{{ r.artifact_id }}/delete"
-              hx-target="closest .rail-row" hx-swap="outerHTML"
-              hx-confirm="Delete this artifact for good? Deprecating hides it instead and can be undone.">
-        {% include "_icon_trash.html" %}
-      </button>
-    </div>
+    {# No delete control here. It was the only irreversible act in the app that
+       could be fired on something nobody had opened — a title, a snippet and a
+       confirm dialog were the whole of what stood behind it — and it was the
+       *only* one-click act a result row offered, so the permanent choice was
+       the easy one and hiding, which can be undone, meant opening the artifact
+       first. A result is an answer to what was typed, not an inventory row.
+       Deleting lives where the artifact is open and readable; a whole bad
+       capture goes from the corpus page in one action. #}
   </div>
   {% endfor %}
   {% if !associated.is_empty() %}

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -49,7 +49,11 @@
         <span class="rail-rank mono">{{ r.rank }}</span>
         {% endif %}
         {% if r.primed %}
+        {% if r.in_sitting %}
+        <span class="badge" title="Moved up: you have been in this one already today">primed · seen</span>
+        {% else %}
         <span class="badge" title="Moved up: you reach this one often">primed</span>
+        {% endif %}
         {% endif %}
         {% if r.model_written %}
         {# Never silently indistinguishable from captured text. The count comes
@@ -85,7 +89,7 @@
          about. The badges stay, as the scannable form. #}
       {% if r.primed || r.weak || r.model_written %}
       <p class="rail-why">
-        {%- if r.primed %}moved up — you reach this one often{% endif -%}
+        {%- if r.primed %}{% if r.in_sitting %}moved up — you have been in this one already{% else %}moved up — you reach this one often{% endif %}{% endif -%}
         {%- if r.weak %}{% if r.primed %} · {% endif %}a loose match{% endif -%}
         {%- if r.model_written %}{% if r.primed || r.weak %} · {% endif %}written by a model{% if r.origin_count > 0 %} from {{ r.origin_count }} source{% if r.origin_count > 1 %}s{% endif %}{% endif %}{% endif -%}
       </p>

--- a/src/web/templates/_sitting.html
+++ b/src/web/templates/_sitting.html
@@ -6,7 +6,7 @@
    second set of results beside the real ones. #}
 {% if !sitting.is_empty() %}
 <div class="sitting">
-  <p class="pane-label">This sitting</p>
+  <p class="pane-label">Read just now</p>
   <ul>
     {% for s in sitting %}
     <li><a href="/ui/artifacts/{{ s.id }}">{{ s.title }}</a></li>

--- a/src/web/templates/_sitting.html
+++ b/src/web/templates/_sitting.html
@@ -1,0 +1,16 @@
+{# What this sitting has been in. A way back to what you were just reading,
+   carried between the doors — the pages had nothing between them, so a hit
+   opened on search and wanted again on ask meant searching for it twice.
+   Absent, not empty, on a cold sitting: a box saying "nothing yet" is worse
+   than no box. Six at most; a list long enough to need reading would be a
+   second set of results beside the real ones. #}
+{% if !sitting.is_empty() %}
+<div class="sitting">
+  <p class="pane-label">This sitting</p>
+  <ul>
+    {% for s in sitting %}
+    <li><a href="/ui/artifacts/{{ s.id }}">{{ s.title }}</a></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}

--- a/src/web/templates/ask.html
+++ b/src/web/templates/ask.html
@@ -37,9 +37,19 @@
    this column would put the finished answer on a grid row below the excerpts
    rather than beside them. #}
 <div class="region-focus">
-  {# What the model said on the way to the answer, kept dim and out of the way:
-     it is not the answer, and nothing in it is cited. #}
-  <div id="ask-reasoning" class="reasoning" hidden></div>
+  {# What the model said on the way to the answer. Behind a disclosure and
+     closed, rather than dim and out of the way: it is not the answer, nothing
+     in it is cited, and what it actually contains is the prompt's own
+     constraints restated back at whoever is reading — "Answer *only* using the
+     provided knowledge-base excerpts", for fifty seconds, above an empty
+     space where the answer will be. Kept rather than dropped because it is
+     what a tuning session wants to see; closed because nobody else asked for
+     it. The id stays on the inner element, so the stream appends where it
+     always did. #}
+  <details id="ask-reasoning-box" class="reasoning-box" hidden>
+    <summary>Reasoning</summary>
+    <div id="ask-reasoning" class="reasoning"></div>
+  </details>
   {# The answer as it is being written, in plain text; the markdown is rendered
      by the server and swapped in whole at the end. `aria-live="polite"` so a
      reader who cannot see it knows the answer is arriving — the announcement is

--- a/src/web/templates/ask.html
+++ b/src/web/templates/ask.html
@@ -22,6 +22,11 @@
     <input class="input" name="q" value="{{ q }}" placeholder="Ask a question…" autofocus>
     <button class="btn btn-accent" type="submit">Ask</button>
     <span id="ask-spinner" class="spinner">thinking…</span>
+    {# A way out of a wait whose length nothing on the page predicts. Closing
+       the stream is what it does — the model call is already paid for either
+       way — so the tokens that did arrive stay where they are rather than
+       being thrown away with it. #}
+    <button id="ask-stop" class="btn btn-ghost btn-sm" type="button" hidden>Stop</button>
   </form>
   {# What the retrieval did before the model was asked anything, when there was
      more of it than usual. Silent on an ask the first round already covered: no

--- a/src/web/templates/ask.html
+++ b/src/web/templates/ask.html
@@ -29,6 +29,7 @@
      searches are otherwise a silent pause of unknown length in front of the
      answer, and what they went looking for is nowhere on the page. #}
   <p id="ask-progress" class="muted" hidden></p>
+  {% include "_sitting.html" %}
 </div>
 
 {# One focus region, not two with the excerpts wedged between them: everything

--- a/src/web/templates/capture.html
+++ b/src/web/templates/capture.html
@@ -37,6 +37,12 @@
      written from — kept even if the operator rewrites every word above, because
      the claim it makes is about where the text came from, not what it says. #}
   {% if !prefill_ask.is_empty() %}
+  {# What this answer was an answer to. The provenance already records it; the
+     box used to arrive holding the answer with no sign of the question, and
+     the person deciding whether to keep it is the one who most needs to see
+     it. The operator still decides, and the trace still says a model wrote
+     the text. #}
+  <p class="muted">Kept from: &ldquo;{{ prefill_question }}&rdquo;</p>
   <input type="hidden" name="from_ask" value="{{ prefill_ask }}">
   <p class="muted" style="margin:0">
     From an answer engram wrote. Edit it as you like — saving is yours, and the

--- a/src/web/templates/not_found.html
+++ b/src/web/templates/not_found.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% block title %}Not found — engram{% endblock %}
+{# Our own page rather than the browser's. A mistyped URL kept the nav, the
+   session and a way back on every other wrong turn in the app; an unmatched
+   path was the one place that dropped the reader out of it entirely. #}
+{% block content %}
+<div class="empty">
+  <h2>Nothing at this address</h2>
+  <p class="muted">The page you asked for is not one this base has. Nothing is wrong with what you have stored.</p>
+  <p><a class="btn btn-ghost btn-sm" href="/ui/search">Search</a>
+     <a class="btn btn-ghost btn-sm" href="/ui/capture">Capture</a></p>
+</div>
+{% endblock %}

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -115,8 +115,8 @@
 <p class="muted">
   Artifacts written from a pursuit: what was asked, and what was engaged with
   while the base did not answer. Each supersedes nothing — what it was written
-  from stays in results beside it. Deprecating one hides it; it can be
-  reactivated from the deprecated list.
+  from stays in results beside it. Hiding one takes it out of results and
+  keeps it; the list below puts it back.
 </p>
 <table class="grid">
   <thead><tr><th>Artifact</th><th>Written because</th><th>Written from</th><th></th></tr></thead>
@@ -140,7 +140,7 @@
       </td>
       <td>
         <form method="post" action="/ui/ops/artifacts/{{ g.id }}/deprecate">
-          <button class="btn btn-sm" type="submit">Deprecate</button>
+          <button class="btn btn-sm" type="submit">Hide</button>
         </form>
       </td>
     </tr>
@@ -169,8 +169,10 @@
 {% endif %}
 
 {% if !deprecated.is_empty() %}
-<h3>Deprecated</h3>
-<p class="muted">Flagged stale with no specific replacement. Still stored and still readable; kept out of results only.</p>
+<h3>Hidden as stale</h3>
+<p class="muted">Flagged stale, with no specific replacement. Search does not
+  return them and Ask does not read from them; each is still stored and still
+  readable by its own link. Reactivate puts one back in results.</p>
 <table class="grid">
   <thead><tr><th>Artifact</th><th></th></tr></thead>
   <tbody>
@@ -215,8 +217,8 @@
           </form>
           <form method="post" action="/ui/ops/artifacts/{{ s.id }}/deprecate">
             <button class="btn-icon" type="submit"
-                    title="Deprecate — hide from results, keep the artifact"
-                    aria-label="Deprecate: hide from results, keep the artifact">
+                    title="Hide from results — the artifact is kept, and this can be undone"
+                    aria-label="Hide from results: the artifact is kept, and this can be undone">
               {% include "_icon_hide.html" %}
             </button>
           </form>
@@ -307,6 +309,6 @@
 {# One sentence for everything that is empty. Five headings each answered
    "None." made a base with nothing wrong with it look like a backlog. #}
 {% if deprecated.is_empty() && stale.is_empty() && superseded.is_empty() && merged.is_empty() && parked.is_empty() && retrying.is_empty() %}
-<p class="muted">Nothing deprecated, nothing hidden, nothing waiting on a decision, nothing retrying.</p>
+<p class="muted">Nothing hidden, nothing waiting on a decision, nothing retrying.</p>
 {% endif %}
 {% endblock %}

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}Ops — engram{% endblock %}
+{% block title %}Housekeeping — engram{% endblock %}
 {% block regions %}regions-table{% endblock %}
 {% block content %}
 

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -162,7 +162,8 @@
 <p class="muted">
   {{ pursuit_recent }} recent{% if pursuit_unsatisfied > 0 %},
   of which {{ pursuit_unsatisfied }} went unanswered and
-  <a href="/ui/capture#gaps">are on the gap list</a>{% endif %}.
+  {% if pursuit_unsatisfied == 1 %}is{% else %}are{% endif %}
+  <a href="/ui/capture#gaps">on the gap list</a>{% endif %}.
 </p>
 {% endif %}
 {% endif %}

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -151,25 +151,19 @@
 
 {% if pursuit_enabled %}
 <h3>Pursuits</h3>
-{% if pursuits.is_empty() %}
+{# No table here any more. A pursuit that ended unsatisfied is a hole in the
+   base, and holes have one list — on the capture page, where capturing
+   happens, beside the searches and questions that said the same thing another
+   way. One that ended satisfied needs nobody, and one that was written up is
+   under Generated above. #}
+{% if pursuit_recent == 0 %}
 <p class="muted">No run of searches has gone quiet yet.</p>
 {% else %}
-<table class="grid">
-  <thead><tr><th>When</th><th>Asked</th><th>Outcome</th></tr></thead>
-  <tbody>
-  {% for p in pursuits %}
-    <tr>
-      <td>{{ p.when }}</td>
-      <td>{% for q in p.queries %}<div>{{ q }}</div>{% endfor %}</td>
-      <td>
-        {{ p.state }}
-        {% if let Some(a) = p.artifact_id %} · <a href="/ui/artifacts/{{ a }}">the artifact</a>{% endif %}
-        {% if !p.reason.is_empty() %}<div class="muted row-sub">{{ p.reason }}</div>{% endif %}
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+<p class="muted">
+  {{ pursuit_recent }} recent{% if pursuit_unsatisfied > 0 %},
+  of which {{ pursuit_unsatisfied }} went unanswered and
+  <a href="/ui/capture#gaps">are on the gap list</a>{% endif %}.
+</p>
 {% endif %}
 {% endif %}
 

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -24,6 +24,47 @@
   {% endif %}
 </p>
 
+{# The last day, not "last night". Units that reschedule themselves on their
+   own periods do not line up into one cycle, and grouping them by an invented
+   cycle identity would be inventing it. The history under the summary is the
+   half a single overwritten line could never give: whether a sweep started
+   going wrong yesterday or has been going wrong for a week. #}
+{% if !last_day.is_empty() || last_day_failures > 0 || !sweep_history.is_empty() %}
+<h3>The last day</h3>
+<p class="muted">
+  {% if last_day.is_empty() %}The sweeps ran and found nothing to do.{% else %}
+  {% for c in last_day %}{{ c.n }} {{ c.what }}{% if !loop.last %}, {% endif %}{% endfor %}.
+  {% endif %}
+  {% if last_day_failures > 0 %}
+  {{ last_day_failures }} run{% if last_day_failures != 1 %}s{% endif %} failed.
+  {% endif %}
+</p>
+{% if !sweep_history.is_empty() %}
+<table class="grid">
+  <thead><tr><th>When</th><th>Sweep</th><th>Did</th><th>Took</th></tr></thead>
+  <tbody>
+  {% for r in sweep_history %}
+    <tr>
+      <td>{{ r.when }}</td>
+      <td>{{ r.stage }}</td>
+      <td>
+        {% if !r.error.is_empty() %}
+        <span class="flag">failed</span>
+        <div class="muted row-sub">{{ r.error }}</div>
+        {% else if r.counts.is_empty() %}
+        <span class="muted">nothing to do</span>
+        {% else %}
+        {% for c in r.counts %}{{ c.n }} {{ c.what }}{% if !loop.last %}, {% endif %}{% endfor %}
+        {% endif %}
+      </td>
+      <td class="muted">{{ r.took }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endif %}
+
 {% if !merged.is_empty() %}
 <h3>Merged</h3>
 <p class="muted">

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -46,7 +46,7 @@
   {% for r in sweep_history %}
     <tr>
       <td>{{ r.when }}</td>
-      <td>{{ r.stage }}</td>
+      <td title="{{ r.stage_id }}">{{ r.stage }}</td>
       <td>
         {% if !r.error.is_empty() %}
         <span class="flag">failed</span>

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -28,7 +28,7 @@
    in the box — and nothing on screen says so. Replace aborts the request in
    flight, so the answer shown is always the answer to the last thing typed. #}
 <div class="region-bar">
-<form id="filters" hx-get="/ui/search/results" hx-target="#rail" hx-swap="innerHTML"
+<form id="filters" hx-get="/ui/search/results" hx-target="#results" hx-swap="innerHTML"
       hx-sync="this:replace"
       hx-trigger="change from:#kind-chips,
                   keyup changed delay:120ms from:input[name=q],
@@ -103,8 +103,18 @@
 </p>
 </div>
 
-<div id="rail" class="region-rail rail" role="listbox" aria-label="Results">
+{# The sitting sits beside the results and outside the swap. It used to be the
+   whole of what `#rail` held, and the filter form replaces `#rail` wholesale —
+   so the first keystroke wiped "Read just now" and nothing brought it back.
+   It was on screen only on a search page with no query, which is the one
+   moment it has nothing to say.
+
+   The listbox is the inner div rather than this one for the same reason: the
+   arrow keys walk `.rail-item`, and a way back to what you were reading is not
+   a result of the search you are typing. #}
+<div id="rail" class="region-rail rail">
 {% include "_sitting.html" %}
+<div id="results" role="listbox" aria-label="Results"></div>
 </div>
 <div id="pane" class="region-focus pane">
   {# Before a search there is no rail beside this, so the sentence used to sit

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -103,7 +103,9 @@
 </p>
 </div>
 
-<div id="rail" class="region-rail rail" role="listbox" aria-label="Results"></div>
+<div id="rail" class="region-rail rail" role="listbox" aria-label="Results">
+{% include "_sitting.html" %}
+</div>
 <div id="pane" class="region-focus pane">
   {# Before a search there is no rail beside this, so the sentence used to sit
      in a column that did not exist yet — stranded in empty space, pointing at

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -23,6 +23,13 @@ reading, and search from a panel beside it.</p>
   <button class="btn btn-accent" type="submit">Mint</button>
 </form>
 
+{# Column headings over no rows is a table pretending to have some — the same
+   thing the decide list names at its top: five headings answered with "None."
+   made an empty base look like a backlog. #}
+{% if tokens.is_empty() %}
+<p class="muted">No tokens yet. Mint one to let Claude Code, Claude Desktop or
+  anything else on the API read and write this base without your session.</p>
+{% else %}
 <table class="grid">
   <thead><tr><th>Name</th><th>Minted by</th><th>Created</th><th>Last used</th><th>State</th><th></th></tr></thead>
   <tbody>
@@ -55,6 +62,7 @@ reading, and search from a panel beside it.</p>
   {% endfor %}
   </tbody>
 </table>
+{% endif %}
 {% match feedback %}
 {% when Some with (f) %}
 <h3>Feedback</h3>

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -356,6 +356,21 @@ pub fn fmt_duration(secs: i64) -> String {
     }
 }
 
+/// How long something took, past tense.
+///
+/// `fmt_duration` above answers a different question — when does this run next
+/// — and says "now" for zero and "in 5m" for three hundred. Housekeeping spent
+/// it on the TOOK column, so every sweep in the history claimed to have taken
+/// "now", and a sweep that genuinely ran for five minutes would have claimed
+/// to be about to happen.
+pub fn fmt_elapsed(secs: i64) -> String {
+    match secs.max(0) {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m {}s", s / 60, s % 60),
+        s => format!("{}h {}m", s / 3600, (s % 3600) / 60),
+    }
+}
+
 /// Unix seconds as an ISO-ish UTC stamp, computed directly so the project does
 /// not pull in a date library for one display string.
 pub fn fmt_time(ts: i64) -> String {
@@ -2467,7 +2482,7 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
                         .unwrap_or_else(|| "it failed".into()),
                     false => String::new(),
                 },
-                took: fmt_duration((r.ended_at - r.started_at).max(0)),
+                took: fmt_elapsed(r.ended_at - r.started_at),
                 stage: r.stage,
                 counts: counts
                     .into_iter()
@@ -3583,6 +3598,21 @@ mod tests {
             verdict_bar: String::new(),
         })
         .unwrap()
+    }
+
+    #[test]
+    fn a_sweep_that_took_no_time_does_not_say_it_happens_now() {
+        // Every row of Housekeeping's TOOK column read "now", because the
+        // column spends `fmt_duration` — which answers when something runs
+        // next, not how long it took.
+        assert_eq!(fmt_elapsed(0), "0s");
+        assert_eq!(fmt_elapsed(3), "3s");
+        assert_eq!(fmt_elapsed(75), "1m 15s");
+        assert_eq!(fmt_elapsed(3600), "1h 0m");
+        assert_eq!(fmt_elapsed(-5), "0s", "a clock that went backwards");
+        // And the future-tense helper keeps its own meaning.
+        assert_eq!(fmt_duration(0), "now");
+        assert_eq!(fmt_duration(300), "in 5m");
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -46,6 +46,10 @@ pub struct RenderedResult {
     /// This hit moved up on activation. A small marker, because the claim is
     /// small: it passed a near-tie, it did not become a better match.
     pub primed: bool,
+    /// This sitting has already been in it. Said beside `primed` rather than
+    /// folded into it: "you were just reading this" and "this is reached
+    /// often" are two different reasons to be higher up a list.
+    pub in_sitting: bool,
     /// Past the point where this list's relevance falls off. Greyed, under a
     /// rule; the rank stays, because it did place — the claim withdrawn is
     /// "this is an answer", not "this is fifth". See `search::cliff`.
@@ -1251,7 +1255,11 @@ async fn search_results(
             // Scoped to the operator, because coalescing folds a keystroke into
             // the query it was an early spelling of, and two people typing at
             // once are not spelling the same thing.
-            crate::store::feedback::Door::Ui.by(id.subject),
+            crate::store::feedback::Door::Ui
+                .by(id.subject)
+                // The live sitting, for priming. Off unless `sitting.prime` is
+                // on, and impossible at any door with no session.
+                .in_sitting(id.session.clone()),
         )
         .await?;
 
@@ -1331,6 +1339,7 @@ fn render_hit(
         },
         weak: h.weak,
         primed: h.primed,
+        in_sitting: h.in_sitting,
         past_cliff: h.past_cliff,
         via_title: h.via.as_ref().and_then(|v| titles.get(v).cloned()),
         reason: h.reason.clone(),
@@ -4610,6 +4619,7 @@ mod tests {
             last_verified_at: None,
             weak,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: None,
             reason: None,
@@ -4705,6 +4715,7 @@ mod tests {
             last_verified_at: None,
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via: via.map(str::to_string),
             reason: None,
@@ -4742,6 +4753,7 @@ mod tests {
             rank: String::new(),
             weak: false,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via_title: via.map(str::to_string),
             reason: reason.map(str::to_string),
@@ -4856,6 +4868,7 @@ mod tests {
             rank: if weak { String::new() } else { "#1".into() },
             weak,
             primed: false,
+            in_sitting: false,
             past_cliff: false,
             via_title: None,
             reason: None,
@@ -6905,6 +6918,63 @@ mod tests {
         let page = get_body(&app, &cookie, "/ui/search").await;
         assert!(page.contains("This sitting"), "{page}");
         assert!(page.contains("Mounting an E01"), "{page}");
+    }
+
+    #[tokio::test]
+    async fn with_priming_off_the_sitting_moves_no_result() {
+        // The default. Carrying ships on because it changes no order; this is
+        // the part that does, and it waits for the harness.
+        let mut c = crate::core::test_support::test_core().await;
+        c.feedback.enabled = true;
+        assert!(!c.sitting.prime, "priming must ship off");
+        let core = c.clone();
+        let (app, cookie) = app_with_cookie(c).await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let ids: Vec<String> = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &["alpha one", "alpha two", "alpha three", "alpha four"]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, t)| crate::store::artifacts::NewArtifact {
+                        ordinal: i as i64,
+                        text: (*t).into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(0),
+                        caveats: vec![],
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        crate::jobs::embed::run_corpus(&core, &src.id)
+            .await
+            .unwrap();
+
+        let before = get_body(&app, &cookie, "/ui/search/results?q=alpha").await;
+        // Read the last one this list returns, then search again.
+        for id in &ids {
+            get_body(&app, &cookie, &format!("/ui/artifacts/{id}")).await;
+        }
+        let after = get_body(&app, &cookie, "/ui/search/results?q=alpha").await;
+
+        let rank_of = |html: &str| -> Vec<String> {
+            html.match_indices("/ui/artifacts/")
+                .map(|(i, _)| html[i + 14..i + 50].to_string())
+                .collect()
+        };
+        assert_eq!(
+            rank_of(&before),
+            rank_of(&after),
+            "the sitting moved a result with priming off"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -418,7 +418,9 @@ struct CaptureTemplate {
     ask_enabled: bool,
     /// Decisions waiting on a person, shown where the work arrives rather than
     /// on a page you have to remember to visit. Empty renders nothing at all.
-    pairs: Vec<PairRow>,
+    /// Grouped, because one artifact against three others is one decision and
+    /// arrived as three — see `group_pairs`.
+    pairs: Vec<PairCluster>,
     /// How many more are behind the ones shown. Said once under the list, so a
     /// short list does not read as an empty queue when it is a capped one.
     more_pairs: i64,
@@ -1008,6 +1010,7 @@ async fn capture_page(
     Query(p): Query<CapturePrefill>,
 ) -> Result<Response> {
     let (pairs, more_pairs) = pair_rows(&st).await?;
+    let pairs = group_pairs(pairs);
     // A prefill that names an ask nobody recorded is not an error worth a page
     // for: the box is simply empty, which is what an ordinary visit looks like.
     let prefilled = match &p.from_ask {
@@ -2147,6 +2150,71 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
     let more = (waiting - pairs.len() as i64).max(0);
     disambiguate_pair_titles(&mut pairs);
     Ok((pairs, more))
+}
+
+/// One decision, however many pairs it takes to state it.
+pub struct PairCluster {
+    pub pairs: Vec<PairRow>,
+    /// How many distinct artifacts the cluster names, so the card can say what
+    /// it is asking about before the rows do.
+    pub members: usize,
+}
+
+/// Group the open pairs into the clusters they actually describe.
+///
+/// The same disjoint-set `jobs::consolidate` runs before it settles anything,
+/// and for the same reason it gives: resolving pairs one at a time does not
+/// work, and the way it fails is quiet. Here the failure is the operator's
+/// rather than the base's — one artifact against three others arrived as three
+/// separate questions, 90%, 90% and 88% alike, and answering one of them left
+/// the other two on the page looking identical to the one just answered.
+///
+/// Order is the incoming order, which is `PAIR_STATES`' priority: the cluster
+/// containing the most urgent pair leads, and within a cluster the rows keep
+/// the order they were read in.
+fn group_pairs(pairs: Vec<PairRow>) -> Vec<PairCluster> {
+    let mut parent: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    fn find(parent: &mut std::collections::HashMap<String, String>, x: &str) -> String {
+        let p = parent.get(x).cloned().unwrap_or_else(|| x.to_string());
+        if p == x {
+            return p;
+        }
+        let root = find(parent, &p);
+        parent.insert(x.to_string(), root.clone());
+        root
+    }
+    for r in &pairs {
+        let (ra, rb) = (find(&mut parent, &r.a_id), find(&mut parent, &r.b_id));
+        if ra != rb {
+            parent.insert(ra, rb);
+        }
+    }
+
+    let mut order: Vec<String> = Vec::new();
+    let mut by_root: std::collections::HashMap<String, Vec<PairRow>> =
+        std::collections::HashMap::new();
+    for r in pairs {
+        let root = find(&mut parent, &r.a_id);
+        if !by_root.contains_key(&root) {
+            order.push(root.clone());
+        }
+        by_root.entry(root).or_default().push(r);
+    }
+
+    order
+        .into_iter()
+        .filter_map(|root| {
+            let pairs = by_root.remove(&root)?;
+            let members: std::collections::HashSet<&str> = pairs
+                .iter()
+                .flat_map(|r| [r.a_id.as_str(), r.b_id.as_str()])
+                .collect();
+            Some(PairCluster {
+                members: members.len(),
+                pairs,
+            })
+        })
+        .collect()
 }
 
 /// The API tokens, formatted for a table.
@@ -3438,6 +3506,46 @@ mod tests {
             keeps_a: false,
             keeps_b: false,
         }
+    }
+
+    #[test]
+    fn pairs_that_share_an_artifact_are_one_card() {
+        // The deployment showed one artifact against three others as three
+        // separate questions, 90%, 90% and 88% alike — the same decision
+        // asked three times, where answering one did not retire the others.
+        let p = |id: i64, a: &str, b: &str| PairRow {
+            id,
+            a_id: a.into(),
+            b_id: b.into(),
+            ..pair_row_fixture(a, "t", "")
+        };
+        let grouped = group_pairs(vec![
+            p(1, "a", "b"),
+            p(2, "a", "c"),
+            p(3, "a", "d"),
+            p(4, "x", "y"),
+        ]);
+        assert_eq!(grouped.len(), 2, "{} groups", grouped.len());
+        assert_eq!(grouped[0].pairs.len(), 3);
+        assert_eq!(grouped[0].members, 4, "one artifact against three others");
+        assert_eq!(grouped[1].pairs.len(), 1);
+        assert_eq!(grouped[1].members, 2);
+    }
+
+    #[test]
+    fn a_chain_of_pairs_is_one_cluster_even_without_a_shared_artifact() {
+        // a–b and b–c name no artifact in common, but resolving them
+        // separately is what leaves A pointing at an artifact that is itself
+        // hidden — the dead end `jobs::consolidate` documents.
+        let p = |id: i64, a: &str, b: &str| PairRow {
+            id,
+            a_id: a.into(),
+            b_id: b.into(),
+            ..pair_row_fixture(a, "t", "")
+        };
+        let grouped = group_pairs(vec![p(1, "a", "b"), p(2, "b", "c")]);
+        assert_eq!(grouped.len(), 1, "the chain was split");
+        assert_eq!(grouped[0].members, 3);
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -178,6 +178,12 @@ pub struct ArtifactDetail {
     /// artifact was drawn from. Falls back to the plain source page for an
     /// artifact with no recorded span — a restored one, for instance.
     pub source_at_lines: String,
+    /// The next passage of the same document, when this one stops in the
+    /// middle of a sentence. A segmentation boundary landing mid-clause is not
+    /// a thing the pane can prevent, but leaving the reader at "…Einsatz von"
+    /// with the rest of the sentence visible in the column beside it and no
+    /// way onward is.
+    pub continues_at: Option<String>,
     pub segment_idx: Option<i64>,
     pub slice_label: String,
     pub slice_lines: Vec<crate::web::corpus_view::CorpusLine>,
@@ -2225,6 +2231,29 @@ fn group_pairs(pairs: Vec<PairRow>) -> Vec<PairCluster> {
         .collect()
 }
 
+/// Whether a passage stops in the middle of a sentence.
+///
+/// The pane rendered "…der bereits vorgestellte Einsatz von" and stopped,
+/// while the source column beside it showed the rest — a segmentation boundary
+/// landing mid-clause, with nothing on the artifact saying it had. This cannot
+/// know whether a boundary was semantic; it can tell that a sentence did not
+/// finish, which is the only claim the link it drives makes.
+///
+/// A closing bracket or quote after the stop counts as the stop: "…(siehe
+/// unten)" ends a sentence as much as the period would. A table row or a list
+/// marker does not — that passage ended where its structure ended, not
+/// mid-thought.
+fn ends_mid_sentence(text: &str) -> bool {
+    let t = text.trim_end();
+    let t = t.trim_end_matches([')', ']', '"', '»', '\'', '“', '”']);
+    match t.chars().last() {
+        None => false,
+        // A table row or a fence closes on its own punctuation.
+        Some('|') | Some('`') => false,
+        Some(c) => !matches!(c, '.' | '!' | '?' | ':' | ';' | '…'),
+    }
+}
+
 /// The API tokens, formatted for a table.
 async fn token_rows(st: &AppState) -> Result<Vec<TokenRow>> {
     Ok(st
@@ -3240,7 +3269,21 @@ pub(crate) async fn build_artifact_detail(
         (None, _) => String::new(),
     };
     let orphaned_source = c.flags.iter().any(|f| f == "orphaned_source");
+    // Only asked when the passage actually stops mid-sentence: the query is a
+    // second lookup per pane, and most passages end where a sentence does.
+    let continues_at = match (&c.corpus_id, ends_mid_sentence(&c.text)) {
+        (Some(cid), true) => core
+            .store
+            .adjacent_artifacts(cid, c.ordinal)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .find(|n| n.ordinal > c.ordinal)
+            .map(|n| n.id),
+        _ => None,
+    };
     Ok(ArtifactDetail {
+        continues_at,
         related,
         seen_together,
         orphaned_source,
@@ -3540,6 +3583,24 @@ mod tests {
             verdict_bar: String::new(),
         })
         .unwrap()
+    }
+
+    #[test]
+    fn a_passage_that_stops_mid_sentence_is_known_to_have_stopped() {
+        // The pane ended "…der bereits vorgestellte Einsatz von" while the
+        // source column beside it showed the rest of the sentence. The pane
+        // cannot know whether a boundary was semantic; it can tell that a
+        // sentence did not finish.
+        assert!(ends_mid_sentence(
+            "Die erste Vorkehrung ist der bereits vorgestellte Einsatz von"
+        ));
+        assert!(!ends_mid_sentence("Das ist der ganze Satz."));
+        assert!(!ends_mid_sentence("Ist das der ganze Satz?"));
+        assert!(!ends_mid_sentence("Ein Listenpunkt:"));
+        // A passage ending in a fenced block or a table row has not stopped
+        // mid-sentence; it has stopped where its structure ended.
+        assert!(!ends_mid_sentence("| ext4 | ja |"));
+        assert!(!ends_mid_sentence(""));
     }
 
     #[test]
@@ -3972,6 +4033,45 @@ mod tests {
             d.slice_label.starts_with("line ") || d.slice_label.starts_with("lines "),
             "{}",
             d.slice_label
+        );
+    }
+
+    #[tokio::test]
+    async fn a_passage_cut_mid_sentence_points_at_the_one_that_carries_the_rest() {
+        // The pane ended "…der bereits vorgestellte Einsatz von" and offered
+        // nothing onward, while the source column beside it showed the rest of
+        // the sentence.
+        let core = crate::core::test_support::test_core().await;
+        let out = core
+            .ingest(
+                "Die erste Vorkehrung ist der bereits vorgestellte Einsatz von\n\n\
+                 Hardware-Schreibschutzadaptern, wo immer es möglich ist.",
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert!(all.len() > 1, "the fixture produced one passage, not two");
+
+        let first = all.iter().min_by_key(|c| c.ordinal).unwrap();
+        let d = super::build_artifact_detail(&core, &first.id, "")
+            .await
+            .unwrap();
+        assert!(
+            d.continues_at.is_some(),
+            "no way onward from a cut sentence: {:?}",
+            first.text
+        );
+
+        let last = all.iter().max_by_key(|c| c.ordinal).unwrap();
+        let d = super::build_artifact_detail(&core, &last.id, "")
+            .await
+            .unwrap();
+        assert!(
+            d.continues_at.is_none(),
+            "the last passage ends on a period and has nothing after it"
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3518,6 +3518,31 @@ mod tests {
         }
     }
 
+    fn ask_page_fixture() -> String {
+        askama::Template::render(&AskTemplate {
+            judge_pending: None,
+            ask_enabled: true,
+            q: String::new(),
+            sitting: vec![],
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn an_ask_page_does_not_open_with_the_models_reasoning_showing() {
+        // The deployment streamed the chain of thought into the page for fifty
+        // seconds, restating the prompt's own constraints verbatim — "Answer
+        // *only* using the provided knowledge-base excerpts" — above the empty
+        // space where the answer was going to be.
+        let html = ask_page_fixture();
+        assert!(html.contains("ask-reasoning-box"), "{html}");
+        assert!(
+            !html.contains("<details open")
+                && !html.contains("<details id=\"ask-reasoning-box\" open"),
+            "reasoning must start closed: {html}"
+        );
+    }
+
     #[test]
     fn a_pair_card_carries_both_texts_to_read_in_place() {
         // The titles were links, so reading either side meant leaving the

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -5999,12 +5999,21 @@ mod tests {
                 "the {word} control has no label"
             );
         }
-        // The square is still right for the controls that repeat down a list,
-        // where the row already says what they act on.
+        // And a result row offers none of them. Deleting from the rail was the
+        // one irreversible act in the app that could be fired on something
+        // nobody had opened, and the only one-click act a result carried — so
+        // the permanent choice was the easy one, while hiding, which can be
+        // undone, meant opening the artifact first. The square icon button is
+        // still right where controls repeat down a list the operator is working
+        // through: the corpus page's own artifacts, and the pairs on Ops.
         let rail = include_str!("templates/_results.html");
         assert!(
-            rail.contains("btn-icon btn-icon-danger"),
-            "the rail's delete stopped being an icon button"
+            !rail.contains("/delete"),
+            "a result row must not delete what it is only showing"
+        );
+        assert!(
+            include_str!("templates/_artifact.html").contains("btn-icon btn-icon-danger"),
+            "the corpus page's artifact list stopped offering delete"
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -432,10 +432,14 @@ pub fn fmt_time(ts: i64) -> String {
 /// anything a reader went looking for — and it was the heading over every
 /// verbatim passage in the pane. The opening of the body at least says what
 /// the passage is about.
+///
+/// `title_of` itself, because the rule that strips markup off a *stored* title
+/// belongs here too: without this the corpus page and the artifact pane showed
+/// "**Was nicht abgedeckt ist:** * Es werden keine" with its asterisks while
+/// Housekeeping showed it cleaned, which is the drift `title_of` was gathered
+/// into one place to close.
 fn artifact_title(c: &crate::store::artifacts::Chunk) -> String {
-    c.title
-        .clone()
-        .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))
+    title_of(c)
 }
 
 /// How an artifact's own text is rendered.
@@ -2105,10 +2109,18 @@ pub(crate) fn title_of(c: &crate::store::artifacts::Chunk) -> String {
     // and nothing stopped it writing markup into one: Housekeeping listed a
     // merged artifact as "**Was nicht abgedeckt ist:** * Es werden keine". A
     // title is a name, and a name is never marked up.
-    match &c.title {
+    let name = match &c.title {
         Some(t) => crate::web::markdown::stand_in_title(t, 80),
         None => crate::web::markdown::stand_in_title(&c.text, 60),
+    };
+    // `stand_in_title` strips markup and leading punctuation, so a body that is
+    // only those leaves nothing at all — a rule the sitting rail cannot use,
+    // since a list entry with no text is a link nobody can see or click. The id
+    // is a poor name and a working one.
+    if name.is_empty() {
+        return c.id.clone();
     }
+    name
 }
 
 /// How many decisions Capture offers at once, and the order it looks for them
@@ -3352,6 +3364,9 @@ pub(crate) async fn build_artifact_detail(
             .map(|n| n.id),
         _ => None,
     };
+    // The same rule as `artifact_title`, and for the same reason: an ordinal in
+    // the ingest is not a name. Taken before the struct, which moves `c`.
+    let title = artifact_title(&c);
     Ok(ArtifactDetail {
         continues_at,
         related,
@@ -3360,12 +3375,7 @@ pub(crate) async fn build_artifact_detail(
         source_at_lines,
         lineage,
         id: c.id,
-        // The same rule as `artifact_title`, and for the same reason: an
-        // ordinal in the ingest is not a name.
-        title: c
-            .title
-            .clone()
-            .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60)),
+        title,
         html,
         text: c.text,
         category: c.category,
@@ -4061,6 +4071,33 @@ mod tests {
             "every row's B side is one artifact under one name — appearing three \
              times is a cluster, not a collision"
         );
+    }
+
+    #[test]
+    fn the_artifact_pane_shows_a_stored_title_by_the_same_rule_as_the_rest() {
+        // Synthesis writes titles and nothing stopped it writing markup into
+        // one. Housekeeping showed it cleaned while the corpus page and the
+        // pane showed the asterisks — the drift `title_of` was gathered into
+        // one place to close, still open on the path that read `c.title`
+        // straight.
+        assert_eq!(
+            artifact_title(&chunk_fixture(
+                Some("**Was nicht abgedeckt ist:** * Es werden keine"),
+                "body"
+            )),
+            "Was nicht abgedeckt ist: * Es werden keine"
+        );
+    }
+
+    #[test]
+    fn an_artifact_whose_opening_is_only_markup_still_has_a_name() {
+        // `stand_in_title` takes markup and leading punctuation off the front,
+        // so a body that is only those leaves nothing at all. The sitting rail
+        // rendered that as a list entry with no text — a link nobody can see
+        // or click. The id is a poor name and a working one.
+        let t = title_of(&chunk_fixture(None, "---"));
+        assert!(!t.is_empty(), "a rail entry with no text is not a link");
+        assert_eq!(t, "a", "the fixture's id");
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -259,6 +259,13 @@ pub struct PairRow {
     pub a_title: String,
     pub b_id: String,
     pub b_title: String,
+    /// Each side's opening words, said beside its title only when that title
+    /// is shared with another row on the page. Three artifacts genuinely
+    /// titled "LevelDB: Funktionsweise und forensische Analyse" turned one
+    /// cluster of questions into what looked like one question asked three
+    /// times. Same rule as `disambiguate_labels`, same reason.
+    pub a_opening: String,
+    pub b_opening: String,
     pub detail: Option<String>,
     /// The stored `detail` is exactly `"link"` — the judge's duplicate
     /// hand-off (§7), a provenance marker, not prose. The row renders a
@@ -1381,8 +1388,56 @@ fn disambiguate_labels(rows: &mut [QueueRow]) {
         .map(|(l, _)| l.to_string())
         .collect();
     for r in rows.iter_mut() {
-        if collides.contains(&r.label) && !r.opening.is_empty() && r.opening != r.label {
-            r.label = format!("{} · {}", r.label, r.opening);
+        // Kept beside the label rather than folded into it. Appending it was
+        // the whole of this repair, and the row then truncated the appended
+        // half away — `.qtitle` is one `nowrap` line — so six captures still
+        // read `HOCHSCHULE MITTWEIDA · HOCHSCH…` and the column that exists to
+        // tell them apart still could not. A field of its own has somewhere to
+        // wrap to.
+        if !(collides.contains(&r.label) && !r.opening.is_empty() && r.opening != r.label) {
+            r.opening.clear();
+        }
+    }
+}
+
+/// The same repair as `disambiguate_labels`, for the pair cards.
+///
+/// A pair names two artifacts, so a page of pairs has two columns of titles
+/// that can collide, and on the deployment they did: three of five cards read
+/// `… vs LevelDB: Funktionsweise und forensische Analyse` because three
+/// distinct artifacts carried that one name. Each side keeps its opening words
+/// only where its title is shared, for the reason the queue keeps them — a
+/// suffix on a name that needs no suffix is noise.
+fn disambiguate_pair_titles(rows: &mut [PairRow]) {
+    // By distinct artifact, never by how often a title appears. One artifact
+    // against three others — which is what a cluster looks like from here —
+    // puts its name on three rows without anything colliding: it is the same
+    // artifact each time, and a qualifier on it would say that three rows are
+    // about different things when they are about one. A title collides when
+    // two different ids carry it.
+    let mut ids: std::collections::HashMap<&str, std::collections::HashSet<&str>> =
+        std::collections::HashMap::new();
+    for r in rows.iter() {
+        ids.entry(r.a_title.as_str())
+            .or_default()
+            .insert(r.a_id.as_str());
+        ids.entry(r.b_title.as_str())
+            .or_default()
+            .insert(r.b_id.as_str());
+    }
+    let collides: std::collections::HashSet<String> = ids
+        .into_iter()
+        .filter(|(_, seen)| seen.len() > 1)
+        .map(|(t, _)| t.to_string())
+        .collect();
+    for r in rows.iter_mut() {
+        let a_collides = collides.contains(&r.a_title);
+        let b_collides = collides.contains(&r.b_title);
+        if !(a_collides && !r.a_opening.is_empty() && r.a_opening != r.a_title) {
+            r.a_opening.clear();
+        }
+        if !(b_collides && !r.b_opening.is_empty() && r.b_opening != r.b_title) {
+            r.b_opening.clear();
         }
     }
 }
@@ -2067,6 +2122,10 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
                 percent: (p.score * 100.0).round() as i64,
                 a_title: title_of(&a),
                 b_title: title_of(&b),
+                // Kept whether or not it is shown; `disambiguate_pair_titles`
+                // clears the ones the page does not need.
+                a_opening: crate::web::markdown::stand_in_title(&a.text, 40),
+                b_opening: crate::web::markdown::stand_in_title(&b.text, 40),
                 a_id: p.a_id,
                 b_id: p.b_id,
                 detail,
@@ -2086,6 +2145,7 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
     // artifacts have since gone missing — skipped above — is not announced as
     // something waiting that never appears.
     let more = (waiting - pairs.len() as i64).max(0);
+    disambiguate_pair_titles(&mut pairs);
     Ok((pairs, more))
 }
 
@@ -3316,6 +3376,108 @@ mod tests {
         }
     }
 
+    fn queue_row_fixture(label: &str, opening: &str) -> QueueRow {
+        QueueRow {
+            label: label.into(),
+            opening: opening.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_disambiguated_row_shows_the_part_that_distinguishes_it() {
+        // `disambiguate_labels` appended the opening words and `.qtitle`
+        // truncated them away, so six rows still read "HOCHSCHULE MITTWEIDA ·
+        // HOCHSCH…" and the one column that exists to tell captures apart
+        // still could not. The opening needs an element of its own.
+        let mut rows = vec![
+            queue_row_fixture(
+                "HOCHSCHULE MITTWEIDA",
+                "Fachbereich Angewandte Computer- und Biowissenschaften",
+            ),
+            queue_row_fixture(
+                "HOCHSCHULE MITTWEIDA",
+                "Ein Verfahren zur Sicherung fluechtiger Daten",
+            ),
+            queue_row_fixture("SQLite und WAL", "Pragma-Abfragen"),
+        ];
+        disambiguate_labels(&mut rows);
+        assert_eq!(
+            rows[0].label, "HOCHSCHULE MITTWEIDA",
+            "the label keeps its own name; the opening is said beside it"
+        );
+        assert!(!rows[0].opening.is_empty(), "nothing tells row 0 apart");
+        assert!(
+            rows[2].opening.is_empty(),
+            "a unique label needs no opening beside it: {:?}",
+            rows[2].opening
+        );
+        let html = askama::Template::render(&QueueTemplate {
+            rows,
+            active: false,
+        })
+        .unwrap();
+        assert!(html.contains("qtitle-opening"), "{html}");
+        assert!(html.contains("Fachbereich Angewandte"), "{html}");
+    }
+
+    fn pair_row_fixture(a_id: &str, a_title: &str, a_opening: &str) -> PairRow {
+        PairRow {
+            id: 1,
+            percent: 90,
+            a_id: a_id.into(),
+            a_title: a_title.into(),
+            b_id: "b".into(),
+            b_title: "SQLite-Datenbankeinstellungen und WAL".into(),
+            a_opening: a_opening.into(),
+            b_opening: "Einstellungen der SQLite-Datenbank".into(),
+            detail: None,
+            via_link: false,
+            contradiction: true,
+            obsolete_title: None,
+            keeps_a: false,
+            keeps_b: false,
+        }
+    }
+
+    #[test]
+    fn pair_rows_sharing_a_title_are_disambiguated_too() {
+        // Three artifacts on the deployment were titled "LevelDB:
+        // Funktionsweise und forensische Analyse", so one cluster of
+        // questions read as the same question asked three times.
+        let mut rows = vec![
+            // Two different artifacts that synthesis gave one name.
+            pair_row_fixture(
+                "a1",
+                "LevelDB: Funktionsweise",
+                "Der Aufbau der Datenlagerung",
+            ),
+            pair_row_fixture("a2", "LevelDB: Funktionsweise", "Die Extraktion der Keys"),
+            pair_row_fixture(
+                "a3",
+                "Auto Vacuum und die Free Page List",
+                "Freie Pages werden",
+            ),
+        ];
+        disambiguate_pair_titles(&mut rows);
+        assert!(!rows[0].a_opening.is_empty(), "nothing tells row 0 apart");
+        assert_ne!(
+            (&rows[0].a_title, &rows[0].a_opening),
+            (&rows[1].a_title, &rows[1].a_opening),
+            "still identical"
+        );
+        assert!(
+            rows[2].a_opening.is_empty(),
+            "a unique title needs no opening beside it: {:?}",
+            rows[2].a_opening
+        );
+        assert!(
+            rows[0].b_opening.is_empty(),
+            "every row's B side is one artifact under one name — appearing three \
+             times is a cluster, not a collision"
+        );
+    }
+
     #[test]
     fn the_artifact_pane_does_not_call_a_passage_chunk_fifty_six() {
         // "Chunk 56" is a position in the ingest, not a name for anything a
@@ -3994,7 +4156,7 @@ mod tests {
         let (app, cookie) = app_for(core).await;
         let html = get(&app, "/ui/queue", &cookie).await;
         assert!(
-            html.contains(">document</a>"),
+            html.contains(">document</span>"),
             "the row has no title to click: {html}"
         );
     }
@@ -5156,11 +5318,18 @@ mod tests {
             },
         ];
         disambiguate_labels(&mut rows);
-        assert_eq!(rows[0].label, "HOCHSCHULE MITTWEIDA · Kapitel 1 Einleitung");
-        assert_eq!(rows[1].label, "HOCHSCHULE MITTWEIDA · Kapitel 5 Malware");
-        // A label that was already unique is left alone: the suffix is a
-        // repair, not a decoration.
+        // The label keeps its own name and the opening is kept beside it,
+        // rather than being folded into it. Appended, it was cut off by the
+        // one `nowrap` line the row gives a title — so this repair ran on the
+        // deployment and six rows still read the same six words.
+        assert_eq!(rows[0].label, "HOCHSCHULE MITTWEIDA");
+        assert_eq!(rows[0].opening, "Kapitel 1 Einleitung");
+        assert_eq!(rows[1].label, "HOCHSCHULE MITTWEIDA");
+        assert_eq!(rows[1].opening, "Kapitel 5 Malware");
+        // A label that was already unique is left alone: the opening beside it
+        // is a repair, not a decoration.
         assert_eq!(rows[2].label, "Configure auditd");
+        assert!(rows[2].opening.is_empty());
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3528,6 +3528,32 @@ mod tests {
         .unwrap()
     }
 
+    fn answer_fixture(dropped: usize) -> String {
+        askama::Template::render(&AnswerTemplate {
+            answer: "<p>An answer.</p>".into(),
+            citations: vec![],
+            dropped,
+            truncated: false,
+            abstained: false,
+            unsupported: vec![],
+            event_id: None,
+            verdict_bar: String::new(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn the_answer_says_what_was_dropped_in_words_a_person_uses() {
+        // "18 excerpt(s) omitted for context budget" is the accounting, and
+        // the "(s)" is the plural nobody wrote out.
+        let html = answer_fixture(18);
+        assert!(!html.contains("excerpt(s)"), "{html}");
+        assert!(!html.contains("context budget"), "{html}");
+        assert!(html.contains("18 more excerpts did not fit"), "{html}");
+        let one = answer_fixture(1);
+        assert!(one.contains("1 more excerpt did not fit"), "{one}");
+    }
+
     #[test]
     fn an_ask_in_flight_offers_a_way_to_stop_it() {
         // Fifty seconds signalled by a small grey "thinking…" beside the
@@ -7328,7 +7354,7 @@ mod tests {
         // Absent, not empty: a box saying "nothing yet" is worse than no box.
         let (app, cookie) = app_with_session().await;
         let page = get_body(&app, &cookie, "/ui/search").await;
-        assert!(!page.contains("This sitting"), "{page}");
+        assert!(!page.contains("Read just now"), "{page}");
     }
 
     #[tokio::test]
@@ -7358,7 +7384,7 @@ mod tests {
         get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
 
         let page = get_body(&app, &cookie, "/ui/search").await;
-        assert!(page.contains("This sitting"), "{page}");
+        assert!(page.contains("Read just now"), "{page}");
         assert!(page.contains("Mounting an E01"), "{page}");
     }
 
@@ -8151,7 +8177,10 @@ mod tests {
         }));
         let (app, cookie) = app_with_cookie(core).await;
         let html = done_html(&ask_over_sse(&app, &cookie, "what+is+alpha").await);
-        assert!(html.contains("unsupported literal(s)"), "no badge: {html}");
+        assert!(
+            html.contains("literal no excerpt supports"),
+            "no badge: {html}"
+        );
         assert!(
             html.contains(r#"<mark class="unsupported">wipefs --all /dev/sdX</mark>"#),
             "the invented command is not marked in the prose: {html}"

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2751,14 +2751,43 @@ impl ReturnTo {
     }
 }
 
+/// What a lifecycle button answers with: the artifact it just changed.
+///
+/// These four buttons say something about an artifact, not about the page it is
+/// on — so the answer is that artifact, re-rendered where it already was, and
+/// nothing navigates. `_artifact_detail.html` is rendered in two places and the
+/// hidden `to` beside each button can only name one of them: it named the
+/// standalone artifact page, so pressing "Confirm still accurate" on a search
+/// result took the whole window there and the results the operator was working
+/// through were gone. That is the reason `ReturnTo` exists, arrived at from the
+/// other side.
+///
+/// The redirect is still what a browser without htmx gets, and `to` is still
+/// what it follows. Nothing here is the only way any of these buttons work.
+async fn artifact_changed(
+    st: &AppState,
+    headers: &axum::http::HeaderMap,
+    aid: &str,
+    terms: &str,
+    back: &ReturnTo,
+) -> Result<Response> {
+    if headers.contains_key("hx-request") {
+        let d = build_artifact_detail(&st.core, aid, terms).await?;
+        return Ok(HtmlTemplate(ArtifactDetailFragment { d }).into_response());
+    }
+    Ok(Redirect::to(back.path()).into_response())
+}
+
 async fn unsupersede_ui(
     State(st): State<AppState>,
     _id: Identity,
+    headers: axum::http::HeaderMap,
     Path(aid): Path<String>,
+    Query(p): Query<ArtifactViewParams>,
     Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.unsupersede(&aid).await?;
-    Ok(Redirect::to(back.path()).into_response())
+    artifact_changed(&st, &headers, &aid, &p.terms, &back).await
 }
 
 async fn dismiss_pair_ui(
@@ -2846,31 +2875,37 @@ async fn apply_pair_supersede_ui(
 async fn deprecate_ui(
     State(st): State<AppState>,
     _id: Identity,
+    headers: axum::http::HeaderMap,
     Path(aid): Path<String>,
+    Query(p): Query<ArtifactViewParams>,
     Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.deprecate(&aid).await?;
-    Ok(Redirect::to(back.path()).into_response())
+    artifact_changed(&st, &headers, &aid, &p.terms, &back).await
 }
 
 async fn reactivate_ui(
     State(st): State<AppState>,
     _id: Identity,
+    headers: axum::http::HeaderMap,
     Path(aid): Path<String>,
+    Query(p): Query<ArtifactViewParams>,
     Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.reactivate(&aid).await?;
-    Ok(Redirect::to(back.path()).into_response())
+    artifact_changed(&st, &headers, &aid, &p.terms, &back).await
 }
 
 async fn verify_ui(
     State(st): State<AppState>,
     _id: Identity,
+    headers: axum::http::HeaderMap,
     Path(aid): Path<String>,
+    Query(p): Query<ArtifactViewParams>,
     Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     st.core.verify(&aid).await?;
-    Ok(Redirect::to(back.path()).into_response())
+    artifact_changed(&st, &headers, &aid, &p.terms, &back).await
 }
 
 async fn ask_page(
@@ -5475,6 +5510,45 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.headers().get("location").unwrap(), "/ui/ops");
+    }
+
+    #[tokio::test]
+    async fn a_lifecycle_button_pressed_in_the_pane_swaps_the_artifact_not_the_page() {
+        // The same fragment is the standalone page and the pane beside the
+        // search results, and the hidden `to` can only name one of them. It
+        // named the page, so pressing "Confirm still accurate" on a result
+        // navigated the whole window there and took the results with it.
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let rail = get(&app, "/ui/search/results?q=alpha", &cookie).await;
+        let id = rail
+            .split(r#"hx-get="/ui/artifacts/"#)
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .and_then(|s| s.split('?').next())
+            .expect("no result to open")
+            .to_string();
+
+        let mut req = form(
+            &format!("/ui/ops/artifacts/{id}/verify"),
+            &cookie,
+            &format!("to=/ui/artifacts/{id}"),
+        );
+        req.headers_mut()
+            .insert("hx-request", "true".parse().unwrap());
+        let res = app.clone().oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(
+            res.headers().get("location").is_none(),
+            "a swap must not navigate"
+        );
+        let body = crate::web::test_support::body_of(res).await;
+        assert!(
+            body.contains(&format!(r#"data-artifact="{id}""#)),
+            "the answer is the artifact, re-rendered: {body}"
+        );
+        // A fragment, not a whole page: the pane is inside one already.
+        assert!(!body.contains("<nav"), "{body}");
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3542,6 +3542,24 @@ mod tests {
         .unwrap()
     }
 
+    #[test]
+    fn the_judges_own_answers_stay_with_the_question() {
+        // The three ways out sat below every candidate — twenty at
+        // `feedback.candidates`' default — so answering "None of these" meant
+        // scrolling past all of them first. The bar is sticky in CSS; what
+        // this holds is that it is one element, in one place, for the rule to
+        // key on.
+        let css = include_str!("../../assets/css/42-judge.css");
+        assert!(
+            css.contains(".judge-outs {") && css.contains("position: sticky"),
+            "the action bar is not sticky"
+        );
+        assert!(
+            css.contains("background: var(--color-bg-base)"),
+            "a sticky bar with no background is one the cards scroll through"
+        );
+    }
+
     #[tokio::test]
     async fn a_search_with_nothing_open_leaves_the_grid_free_to_widen_the_rail() {
         // 22rem of rail beside a thousand pixels holding one line of

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3543,6 +3543,19 @@ mod tests {
     }
 
     #[test]
+    fn the_copy_control_does_not_sit_on_top_of_the_passage() {
+        // A fenced code sample is short and the button over its top-right
+        // corner cost nothing. A passage kept as the document wrote it is one
+        // `<pre>` from end to end, and there the button landed on the first
+        // sentence of the artifact — at both widths.
+        let css = include_str!("../../assets/css/30-components.css");
+        assert!(
+            css.contains(".codewrap { position: relative; padding-top:"),
+            "no room is reserved for the copy control"
+        );
+    }
+
+    #[test]
     fn the_judges_own_answers_stay_with_the_question() {
         // The three ways out sat below every candidate — twenty at
         // `feedback.candidates`' default — so answering "None of these" meant

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -8226,7 +8226,7 @@ mod tests {
         crate::jobs::embed::run(&handle, &g.id).await.unwrap();
         handle
             .store
-            .insert_pursuit(1, &["why was this asked".into()], &[s[0].id.clone()])
+            .insert_pursuit(1, &["why was this asked".into()], &[s[0].id.clone()], None)
             .await
             .unwrap();
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3484,9 +3484,24 @@ struct NotFoundTemplate {
 /// Only for the pages: an agent asking `/api/v1` for a route that does not
 /// exist must not be handed an HTML document to parse, which is what a router
 /// fallback would do to every door at once.
-pub async fn not_found(State(st): State<AppState>, uri: axum::http::Uri) -> Response {
+///
+/// The page is behind a session like every other page. `Identity` is asked for
+/// optionally rather than required so that the `/api` answer above stays a 404
+/// for a caller with no credentials, but a browser with no session gets the
+/// same 401 the rest of the app gives it — which
+/// `redirect_unauthenticated_browsers` turns into the login. Without that, the
+/// one path nobody routed was the one path that rendered the whole nav,
+/// `judge_pending` — a live count out of the base — included.
+pub async fn not_found(
+    State(st): State<AppState>,
+    id: Option<Identity>,
+    uri: axum::http::Uri,
+) -> Response {
     if uri.path().starts_with("/api/") {
         return (axum::http::StatusCode::NOT_FOUND, "not found").into_response();
+    }
+    if id.is_none() {
+        return crate::error::Error::Unauthorized.into_response();
     }
     let page = NotFoundTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -436,6 +436,55 @@ struct CaptureTemplate {
     /// while this is the join back to the question and the artifacts the answer
     /// was built from, and `capture_submit` turns it into stored provenance.
     prefill_ask: String,
+    /// The question this answer answered, in the operator's own words.
+    ///
+    /// The provenance already recorded it — `with_ask` carries the question and
+    /// the citations into the corpus metadata. What was missing was saying so
+    /// on the page: the box arrived holding an answer with no sign of what it
+    /// was an answer to, and the operator deciding whether to keep it is the
+    /// person who most needs to see the question. The line does not move; it is
+    /// only better documented.
+    prefill_question: String,
+}
+
+/// One artifact this sitting has been in, as the rail lists it.
+pub struct SittingItem {
+    pub id: String,
+    pub title: String,
+}
+
+/// How many of the sitting's touched artifacts a page shows.
+///
+/// Six, against a carried twenty. The rail is a way back to what you were just
+/// reading, not a history: a list long enough to need reading is a second set
+/// of results beside the real ones.
+const SITTING_RAIL: usize = 6;
+
+/// What this sitting has touched, most recent first, ready to render.
+///
+/// Empty for a cold sitting and for every door that has no session — which is
+/// the whole of what keeps this at the web door. An artifact deleted since is
+/// simply absent: the sitting holds ids and the store is the truth.
+async fn sitting_rail(st: &AppState, id: &Identity) -> Vec<SittingItem> {
+    let Some(sess) = &id.session else {
+        return Vec::new();
+    };
+    let carried =
+        st.core
+            .sittings
+            .read(sess, crate::store::now(), st.core.pursuit.idle_secs as i64);
+    let mut out = Vec::new();
+    for aid in carried.touched.iter().take(SITTING_RAIL) {
+        if let Ok(c) = st.core.store.get_artifact(aid).await
+            && c.in_results()
+        {
+            out.push(SittingItem {
+                title: title_of(&c),
+                id: c.id,
+            });
+        }
+    }
+    out
 }
 
 /// One hole in the base, as the capture page lists it.
@@ -497,6 +546,9 @@ struct SearchTemplate {
     /// The chip a deep link arrived with, so the form comes back selected
     /// rather than reset to "all".
     category: String,
+    /// What this sitting has been in. Absent on a cold sitting — an empty box
+    /// saying "nothing yet" is worse than no box.
+    sitting: Vec<SittingItem>,
 }
 
 #[derive(Template)]
@@ -856,8 +908,11 @@ struct AskTemplate {
     judge_pending: Option<i64>,
     /// Whether the ask door is open. See `state::ask_enabled`.
     ask_enabled: bool,
-    /// A question to prefill the box with — a gap's "ask again".
+    /// A question to prefill the box with — a gap's "ask again", or the query
+    /// this sitting was just searching for.
     q: String,
+    /// What this sitting has been in. See `SearchTemplate::sitting`.
+    sitting: Vec<SittingItem>,
 }
 
 #[derive(serde::Deserialize)]
@@ -943,9 +998,9 @@ async fn capture_page(
         Some(id) => st.core.store.ask_event(id).await?,
         None => None,
     };
-    let (prefill_text, prefill_ask) = match prefilled {
-        Some(ev) => (ev.answer, ev.id),
-        None => (String::new(), String::new()),
+    let (prefill_text, prefill_ask, prefill_question) = match prefilled {
+        Some(ev) => (ev.answer, ev.id, ev.question),
+        None => (String::new(), String::new(), String::new()),
     };
     // Read, never computed: the page shows what the sweep grouped and named,
     // and whatever has been judged since sits under itself until the next
@@ -979,6 +1034,7 @@ async fn capture_page(
         loose,
         prefill_text,
         prefill_ask,
+        prefill_question,
     })
     .into_response())
 }
@@ -1062,7 +1118,7 @@ const FACET_LIMIT: usize = 12;
 
 async fn search_page(
     State(st): State<AppState>,
-    _id: Identity,
+    id: Identity,
     Query(p): Query<UiSearchParams>,
 ) -> Result<Response> {
     // A vector store that cannot answer must not take the search page down with
@@ -1089,6 +1145,7 @@ async fn search_page(
         q: p.q,
         facets,
         category,
+        sitting: sitting_rail(&st, &id).await,
     })
     .into_response())
 }
@@ -1166,6 +1223,17 @@ async fn search_results(
     // Function words are dropped: a query phrased as a situation is mostly
     // stopwords, and highlighting every "to" marks the whole card.
     let terms = highlightable_terms(p.q.trim());
+    // What this sitting is working on. A typing burst folds into one entry
+    // here as it does in the log, so what is carried is the query that was
+    // meant rather than every prefix of it.
+    if let Some(sess) = &id.session {
+        st.core.sittings.queried(
+            sess,
+            p.q.trim(),
+            crate::store::now(),
+            st.core.pursuit.idle_secs as i64,
+        );
+    }
     let (hits, t) = st
         .core
         .search_with(
@@ -2515,17 +2583,36 @@ async fn verify_ui(
 
 async fn ask_page(
     State(st): State<AppState>,
-    _id: Identity,
+    id: Identity,
     Query(p): Query<AskPrefill>,
 ) -> Result<Response> {
     // No ask model, no ask door: the route is not there. See `Core::asks`.
     if !st.core.asks() {
         return Err(Error::NotFound);
     }
+    // A query typed on the rail and then retyped into ask is the cost of two
+    // pages with nothing carried between them. Only when the box is empty: a
+    // question the operator arrived with — a gap's "ask again" — is never
+    // overwritten by what they searched for a minute ago.
+    let q = match p.q.trim().is_empty() {
+        true => match &id.session {
+            Some(sess) => st
+                .core
+                .sittings
+                .read(sess, crate::store::now(), st.core.pursuit.idle_secs as i64)
+                .queries
+                .first()
+                .cloned()
+                .unwrap_or_default(),
+            None => String::new(),
+        },
+        false => p.q,
+    };
     Ok(HtmlTemplate(AskTemplate {
         judge_pending: crate::web::state::judge_pending(&st).await,
         ask_enabled: crate::web::state::ask_enabled(&st),
-        q: p.q,
+        q,
+        sitting: sitting_rail(&st, &id).await,
     })
     .into_response())
 }
@@ -3045,6 +3132,17 @@ async fn artifact_detail(
     // And the act the pursuit sweep reads: opened, or pivoted through.
     st.core
         .record_interaction(&cid, p.via.as_deref(), Some(&id.subject));
+    // The live half of the same act. Written here rather than inside
+    // `record_interaction` because this is where the session is known — and
+    // that is the whole of what keeps the sitting at the web door.
+    if let Some(sess) = &id.session {
+        st.core.sittings.touched(
+            sess,
+            &cid,
+            crate::store::now(),
+            st.core.pursuit.idle_secs as i64,
+        );
+    }
     if headers.contains_key("hx-request") {
         return Ok(HtmlTemplate(ArtifactDetailFragment { d }).into_response());
     }
@@ -6735,6 +6833,126 @@ mod tests {
         assert!(
             !page.contains(&format!("gap-search-{gap}")),
             "a covered gap is still open: {page}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_query_typed_on_search_arrives_in_the_ask_box() {
+        // Two pages with nothing carried between them cost a retyped query
+        // every time. Nothing here changes an order.
+        let (app, cookie, core) = app_session_and_core().await;
+        get_body(
+            &app,
+            &cookie,
+            "/ui/search/results?q=how%20do%20I%20mount%20an%20E01",
+        )
+        .await;
+
+        let ask = get_body(&app, &cookie, "/ui/ask").await;
+        assert!(
+            ask.contains("how do I mount an E01"),
+            "the query was not carried: {ask}"
+        );
+        let _ = core;
+    }
+
+    #[tokio::test]
+    async fn a_question_the_operator_arrived_with_is_never_overwritten() {
+        // A gap's "ask again" is a question they chose. The sitting fills an
+        // empty box and nothing else.
+        let (app, cookie, _core) = app_session_and_core().await;
+        get_body(&app, &cookie, "/ui/search/results?q=something%20else").await;
+
+        let ask = get_body(&app, &cookie, "/ui/ask?q=the%20one%20I%20clicked").await;
+        assert!(ask.contains("the one I clicked"), "{ask}");
+        assert!(!ask.contains("something else"), "{ask}");
+    }
+
+    #[tokio::test]
+    async fn a_cold_sitting_renders_no_rail_at_all() {
+        // Absent, not empty: a box saying "nothing yet" is worse than no box.
+        let (app, cookie) = app_with_session().await;
+        let page = get_body(&app, &cookie, "/ui/search").await;
+        assert!(!page.contains("This sitting"), "{page}");
+    }
+
+    #[tokio::test]
+    async fn what_this_sitting_opened_is_a_way_back_to_it() {
+        let (app, cookie, core) = app_session_and_core().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "mounting an E01".into(),
+                    corpus_span: None,
+                    title: Some("Mounting an E01".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+
+        get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
+
+        let page = get_body(&app, &cookie, "/ui/search").await;
+        assert!(page.contains("This sitting"), "{page}");
+        assert!(page.contains("Mounting an E01"), "{page}");
+    }
+
+    #[tokio::test]
+    async fn the_sitting_writes_no_activation() {
+        // The guard most likely to be lost to a refactor: the sitting is a
+        // *read* of what is happening. Writing activation from it would be a
+        // loop that reinforces itself, which is the failure mode this whole
+        // area is built to close.
+        let mut c = crate::core::test_support::test_core().await;
+        c.feedback.enabled = true;
+        let core = c.clone();
+        let (app, cookie) = app_with_cookie(c).await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "mounting an E01".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        // Whatever opening it records, record it now, before the sitting is
+        // asked for anything.
+        get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
+        core.background.wait_idle().await;
+        let before = core.store.activation_of(&[a.clone()]).await.unwrap();
+
+        // Reading the sitting, repeatedly, from both pages.
+        for _ in 0..3 {
+            get_body(&app, &cookie, "/ui/search").await;
+        }
+        core.background.wait_idle().await;
+
+        assert_eq!(
+            core.store.activation_of(&[a]).await.unwrap(),
+            before,
+            "reading the sitting moved an activation"
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -88,6 +88,11 @@ pub struct QueueRow {
     /// cannot be attributed to anything. The warning stays; the link to
     /// `#uncovered` does not, because that section renders nothing for it.
     pub locatable: bool,
+    /// The open questions this capture answered, in the operator's words. What
+    /// a capture did beyond being stored — said on the row that reported it
+    /// arriving, because that is where somebody is looking. Empty for almost
+    /// every capture, and silent when empty.
+    pub covered: Vec<String>,
     /// Still on its way through the pipeline. Only these announce themselves;
     /// a finished capture is a title and a count.
     pub in_flight: bool,
@@ -433,10 +438,14 @@ struct CaptureTemplate {
     prefill_ask: String,
 }
 
-/// One unanswered question or gap search, as the capture page lists it.
+/// One hole in the base, as the capture page lists it.
 pub struct GapMember {
-    /// `ask` or `search`, for the dismiss route.
+    /// The `GapKind`, for the dismiss route.
     pub kind: String,
+    /// What asked it, in the operator's words: *judged*, *asked*, *nothing
+    /// near*, *pursued*. Four ways of saying the base did not answer, on one
+    /// list, each still able to say which one it was.
+    pub badge: &'static str,
     pub id: String,
     pub text: String,
 }
@@ -447,8 +456,15 @@ pub struct GapGroup {
 }
 
 fn gap_member(g: crate::store::gaps::Gap) -> GapMember {
+    use crate::store::gaps::GapKind;
     GapMember {
         kind: g.kind.as_str().into(),
+        badge: match g.kind {
+            GapKind::Search => "judged",
+            GapKind::Ask => "asked",
+            GapKind::Unmatched => "nothing near",
+            GapKind::Pursuit => "pursued",
+        },
         id: g.id,
         text: g.text,
     }
@@ -715,9 +731,14 @@ struct OpsTemplate {
     /// Artifacts written from pursuits, newest first, each one click from
     /// deprecated.
     generated: Vec<GeneratedRow>,
-    /// Recent pursuits, only when the feature is on.
+    /// Recent pursuits, only when the feature is on. A count and not a table:
+    /// a pursuit that ended unsatisfied is a hole in the base and belongs on
+    /// the one list of those, not on a second list of its own; one that ended
+    /// satisfied needs nobody; and one that was written up is in `generated`
+    /// above.
     pursuit_enabled: bool,
-    pursuits: Vec<PursuitRow>,
+    pursuit_recent: usize,
+    pursuit_unsatisfied: usize,
     /// What the sweeps did in the last twenty-four hours, added up. Not "last
     /// night": units that reschedule themselves on their own periods do not
     /// line up into one cycle, and there is no cycle identity to group them by.
@@ -756,15 +777,6 @@ struct GeneratedRow {
     subtitle: String,
     cues: Vec<String>,
     sources: Vec<SourceRow>,
-}
-
-/// One pursuit on Ops: what was wanted, what came of it.
-struct PursuitRow {
-    when: String,
-    state: String,
-    reason: String,
-    queries: Vec<String>,
-    artifact_id: Option<String>,
 }
 
 struct MergedRow {
@@ -1343,6 +1355,15 @@ async fn queue_fragment(State(st): State<AppState>, _id: Identity) -> Result<Res
             status: s.status.as_str().to_string(),
             artifact_count: st.core.store.count_artifacts_for_corpus(&s.id).await?,
             created: fmt_time(s.created_at),
+            covered: st
+                .core
+                .store
+                .gaps_covered_by(&s.id)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|g| g.text)
+                .collect(),
             id: s.id,
         });
     }
@@ -2142,23 +2163,12 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         });
     }
     let pursuit_enabled = st.core.pursuit.enabled;
-    let pursuits: Vec<PursuitRow> = if pursuit_enabled {
-        st.core
-            .store
-            .recent_pursuits(50)
-            .await?
-            .into_iter()
-            .map(|p| PursuitRow {
-                when: fmt_time(p.opened_at),
-                state: p.state,
-                reason: p.reason.unwrap_or_default(),
-                queries: p.queries,
-                artifact_id: p.artifact_id,
-            })
-            .collect()
-    } else {
-        Vec::new()
+    let recent = match pursuit_enabled {
+        true => st.core.store.recent_pursuits(50).await?,
+        false => Vec::new(),
     };
+    let pursuit_recent = recent.len();
+    let pursuit_unsatisfied = recent.iter().filter(|p| p.state == "unsatisfied").count();
     // What the memory did while nobody was looking. The last day as one
     // sentence, and under it the runs themselves — which is the half a single
     // overwritten summary could never give.
@@ -2265,7 +2275,8 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         },
         generated,
         pursuit_enabled,
-        pursuits,
+        pursuit_recent,
+        pursuit_unsatisfied,
         last_day,
         last_day_failures,
         sweep_history,
@@ -6657,6 +6668,159 @@ mod tests {
             !page.contains("Knowledge gaps"),
             "a covered gap must leave the page: {page}"
         );
+    }
+
+    #[tokio::test]
+    async fn a_capture_that_answered_something_says_so_on_its_row() {
+        // Coverage is closed silently — nothing asked the operator to confirm
+        // it — so the queue row is the only place it is said.
+        let mut c = crate::core::test_support::test_core().await;
+        c.feedback.enabled = true;
+        let core = c.clone();
+        let (app, cookie) = app_with_cookie(c).await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "mounting an E01".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let gap = core
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "how do I mount an E01".into(),
+                    door: crate::store::feedback::Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0; crate::core::test_support::TEST_DIM],
+                    embed_model: core.embedder.model().to_string(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        core.store
+            .judge(&gap, crate::store::feedback::Verdict::Gap)
+            .await
+            .unwrap();
+        core.store
+            .cover_gap(crate::store::gaps::GapKind::Search, &gap, &src.id, &a, 0.71)
+            .await
+            .unwrap();
+
+        // The queue is its own fragment: the capture page fetches it on load.
+        let queue = get_body(&app, &cookie, "/ui/queue").await;
+        assert!(
+            queue.contains("how do I mount an E01"),
+            "the row does not say what this capture answered: {queue}"
+        );
+        // And the gap itself is gone from the list it was on.
+        let page = get_body(&app, &cookie, "/ui/capture").await;
+        assert!(
+            !page.contains(&format!("gap-search-{gap}")),
+            "a covered gap is still open: {page}"
+        );
+    }
+
+    #[tokio::test]
+    async fn every_kind_of_gap_says_which_kind_it_is() {
+        // Four ways of saying the base did not answer, on one list. They are
+        // not the same claim, and an operator reading the list can tell them
+        // apart.
+        let mut c = crate::core::test_support::test_core().await;
+        c.feedback.enabled = true;
+        // The fake embedder's vectors are not a semantic space, so the shipped
+        // threshold would call everything weak. A line above what the
+        // candidate below scores and below nothing else.
+        c.weak_below = 0.5;
+        let core = c.clone();
+        let (app, cookie) = app_with_cookie(c).await;
+        // Judged a gap.
+        let judged = core
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "judged one".into(),
+                    door: crate::store::feedback::Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0; crate::core::test_support::TEST_DIM],
+                    embed_model: core.embedder.model().to_string(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        core.store
+            .judge(&judged, crate::store::feedback::Verdict::Gap)
+            .await
+            .unwrap();
+        // Nothing came close.
+        core.store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "nothing near one".into(),
+                    door: crate::store::feedback::Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0; crate::core::test_support::TEST_DIM],
+                    embed_model: core.embedder.model().to_string(),
+                    candidates: vec![crate::store::feedback::NewCandidate {
+                        artifact_id: "a-1".into(),
+                        score: 0.01,
+                        similarity: Some(0.01),
+                        shown: true,
+                    }],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        // A run of searches that ended unanswered.
+        let p = core
+            .store
+            .insert_pursuit(
+                1,
+                &["pursued one".into()],
+                &[],
+                Some((
+                    &[1.0; crate::core::test_support::TEST_DIM],
+                    core.embedder.model(),
+                )),
+            )
+            .await
+            .unwrap();
+        core.store
+            .close_pursuit(&p, "unsatisfied", "nothing strong was engaged", 2)
+            .await
+            .unwrap();
+
+        let html = get_body(&app, &cookie, "/ui/capture").await;
+        for badge in ["judged", "nothing near", "pursued"] {
+            assert!(
+                html.contains(badge),
+                "no `{badge}` badge on the list: {html}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -6941,7 +6941,11 @@ mod tests {
         // asked for anything.
         get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
         core.background.wait_idle().await;
-        let before = core.store.activation_of(&[a.clone()]).await.unwrap();
+        let before = core
+            .store
+            .activation_of(std::slice::from_ref(&a))
+            .await
+            .unwrap();
 
         // Reading the sitting, repeatedly, from both pages.
         for _ in 0..3 {

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1454,6 +1454,19 @@ fn disambiguate_labels(rows: &mut [QueueRow]) {
         .map(|(l, _)| l.to_string())
         .collect();
     for r in rows.iter_mut() {
+        // The opening is the capture's first words and the label is a heading
+        // lifted out of those same words, so the opening usually begins by
+        // repeating it: "HOCHSCHULE MITTWEIDA" beside "HOCHSCHULE MITTWEIDA
+        // Ein Verfahren zur…". Only the part that differs is worth the room —
+        // and the doubled reading is what the deployment showed, truncated to
+        // "HOCHSCHULE MITTWEIDA · HOCHSCH…", which is how a repair that had
+        // run looked exactly like one that never had.
+        if let Some(rest) = r.opening.strip_prefix(r.label.as_str()) {
+            let rest = rest
+                .trim_start_matches([' ', ':', '·', '—', '-', ','])
+                .trim();
+            r.opening = rest.to_string();
+        }
         // Kept beside the label rather than folded into it. Appending it was
         // the whole of this repair, and the row then truncated the appended
         // half away — `.qtitle` is one `nowrap` line — so six captures still
@@ -3596,6 +3609,27 @@ mod tests {
             opening: opening.into(),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn an_opening_that_repeats_its_own_label_says_only_the_rest() {
+        // Found by walking the running app, not by a fixture: the label is a
+        // heading lifted out of the capture's first words, so the opening
+        // beside it began by repeating it — "HOCHSCHULE MITTWEIDA" over
+        // "HOCHSCHULE MITTWEIDA Ein Verfahren zur…".
+        let mut rows = vec![
+            queue_row_fixture(
+                "HOCHSCHULE MITTWEIDA",
+                "HOCHSCHULE MITTWEIDA Ein Verfahren zur Sicherung",
+            ),
+            queue_row_fixture(
+                "HOCHSCHULE MITTWEIDA",
+                "HOCHSCHULE MITTWEIDA Fachbereich Angewandte",
+            ),
+        ];
+        disambiguate_labels(&mut rows);
+        assert_eq!(rows[0].opening, "Ein Verfahren zur Sicherung");
+        assert_eq!(rows[1].opening, "Fachbereich Angewandte");
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -621,6 +621,65 @@ struct ArtifactDetailPage {
     d: ArtifactDetail,
 }
 
+/// What a count in a sweep's `detail` is called on the page.
+///
+/// Keyed by stage as well as by field, because two sweeps both call a count
+/// `armed` and they are not the same thing. A field with no entry here is not
+/// rendered: the summary is a sentence about what happened, not a dump of every
+/// number a sweep returned.
+const SWEEP_WORDS: &[(&str, &str, &str)] = &[
+    ("associate", "events", "searches replayed"),
+    ("associate", "verdicts", "verdicts replayed"),
+    ("associate", "forgotten", "links forgotten"),
+    ("associate", "armed", "links sent to the judge"),
+    ("consolidate", "superseded", "artifacts merged"),
+    ("consolidate", "judged", "pairs sent to the judge"),
+    ("arm_dedupe", "armed", "duplicates sent to the judge"),
+    ("retention", "expired", "records expired"),
+    ("retention", "named", "gaps named"),
+    ("pursuit", "pursuits", "pursuits opened"),
+];
+
+/// One phrase of the last day: "412 links forgotten".
+struct SweepCount {
+    n: i64,
+    what: String,
+}
+
+/// One recorded run, as the history renders it.
+struct SweepRunRow {
+    when: String,
+    stage: String,
+    /// Empty unless it failed, in which case it is why.
+    error: String,
+    took: String,
+    /// The counts, already worded. Empty for a run that did nothing.
+    counts: Vec<SweepCount>,
+}
+
+/// Add up one run's `detail` into `totals`, keyed by the words it earns.
+fn tally_sweep(stage: &str, detail: &str, totals: &mut Vec<(String, i64)>) {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(detail) else {
+        return;
+    };
+    for (s, field, word) in SWEEP_WORDS {
+        if *s != stage {
+            continue;
+        }
+        let n = v
+            .get(field)
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        if n == 0 {
+            continue;
+        }
+        match totals.iter_mut().find(|(w, _)| w == word) {
+            Some((_, t)) => *t += n,
+            None => totals.push((word.to_string(), n)),
+        }
+    }
+}
+
 #[derive(Template)]
 #[template(path = "ops.html")]
 struct OpsTemplate {
@@ -659,6 +718,17 @@ struct OpsTemplate {
     /// Recent pursuits, only when the feature is on.
     pursuit_enabled: bool,
     pursuits: Vec<PursuitRow>,
+    /// What the sweeps did in the last twenty-four hours, added up. Not "last
+    /// night": units that reschedule themselves on their own periods do not
+    /// line up into one cycle, and there is no cycle identity to group them by.
+    last_day: Vec<SweepCount>,
+    /// Runs in the last day that failed. Said separately, because a summary of
+    /// what got done cannot report what did not.
+    last_day_failures: usize,
+    /// The runs themselves, newest first. What a single overwritten summary
+    /// could never give: whether this started yesterday or has been going
+    /// wrong for a week.
+    sweep_history: Vec<SweepRunRow>,
 }
 
 #[derive(Template)]
@@ -2085,6 +2155,53 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     } else {
         Vec::new()
     };
+    // What the memory did while nobody was looking. The last day as one
+    // sentence, and under it the runs themselves — which is the half a single
+    // overwritten summary could never give.
+    let day = st
+        .core
+        .store
+        .sweep_runs_since(crate::store::now() - 86_400, 500)
+        .await
+        .unwrap_or_default();
+    let last_day_failures = day.iter().filter(|r| r.outcome == "failed").count();
+    let mut totals: Vec<(String, i64)> = Vec::new();
+    for r in &day {
+        tally_sweep(&r.stage, &r.detail, &mut totals);
+    }
+    let last_day: Vec<SweepCount> = totals
+        .into_iter()
+        .map(|(what, n)| SweepCount { n, what })
+        .collect();
+    let sweep_history: Vec<SweepRunRow> = st
+        .core
+        .store
+        .sweep_history(TABLE_CAP)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|r| {
+            let mut counts = Vec::new();
+            tally_sweep(&r.stage, &r.detail, &mut counts);
+            SweepRunRow {
+                when: fmt_time(r.started_at),
+                error: match r.outcome == "failed" {
+                    true => serde_json::from_str::<serde_json::Value>(&r.detail)
+                        .ok()
+                        .and_then(|v| v.get("error").and_then(|e| e.as_str().map(String::from)))
+                        .unwrap_or_else(|| "it failed".into()),
+                    false => String::new(),
+                },
+                took: fmt_duration((r.ended_at - r.started_at).max(0)),
+                stage: r.stage,
+                counts: counts
+                    .into_iter()
+                    .map(|(what, n)| SweepCount { n, what })
+                    .collect(),
+            }
+        })
+        .collect();
+
     let more_superseded = superseded.len() > TABLE_CAP as usize;
     superseded.truncate(TABLE_CAP as usize);
 
@@ -2145,6 +2262,9 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         generated,
         pursuit_enabled,
         pursuits,
+        last_day,
+        last_day_failures,
+        sweep_history,
     })
     .into_response())
 }
@@ -5370,6 +5490,44 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn ops_says_what_the_sweeps_did_and_shows_the_runs() {
+        let (app, cookie, core) = app_session_and_core().await;
+        // Two runs of one sweep: the summary adds them up, the history keeps
+        // them apart. That difference is the whole reason both are there.
+        for _ in 0..2 {
+            core.store
+                .record_sweep_run(
+                    "associate",
+                    crate::store::now(),
+                    "ok",
+                    r#"{"events":0,"verdicts":0,"forgotten":206,"reopened":0,"armed":0}"#,
+                )
+                .await
+                .unwrap();
+        }
+        core.store
+            .record_sweep_run(
+                "consolidate",
+                crate::store::now(),
+                "failed",
+                r#"{"error":"the endpoint was down"}"#,
+            )
+            .await
+            .unwrap();
+
+        let html = get(&app, "/ui/ops", &cookie).await;
+        assert!(
+            html.contains("412 links forgotten"),
+            "the last day did not add the runs up: {html}"
+        );
+        assert!(html.contains("1 run failed"), "a failed run went unsaid");
+        assert!(
+            html.contains("the endpoint was down"),
+            "the history did not say why a run failed"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -361,10 +361,15 @@ pub fn fmt_time(ts: i64) -> String {
 }
 
 /// What to call an artifact that has no title of its own.
+///
+/// Not the ordinal. "Chunk 56" is a position in the ingest, not a name for
+/// anything a reader went looking for — and it was the heading over every
+/// verbatim passage in the pane. The opening of the body at least says what
+/// the passage is about.
 fn artifact_title(c: &crate::store::artifacts::Chunk) -> String {
     c.title
         .clone()
-        .unwrap_or_else(|| format!("Chunk {}", c.ordinal))
+        .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))
 }
 
 /// How an artifact's own text is rendered.
@@ -3106,7 +3111,12 @@ pub(crate) async fn build_artifact_detail(
         source_at_lines,
         lineage,
         id: c.id,
-        title: c.title.unwrap_or_else(|| format!("Chunk {}", c.ordinal)),
+        // The same rule as `artifact_title`, and for the same reason: an
+        // ordinal in the ingest is not a name.
+        title: c
+            .title
+            .clone()
+            .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60)),
         html,
         text: c.text,
         category: c.category,
@@ -3304,6 +3314,22 @@ mod tests {
             last_verified_at: None,
             cues: vec![],
         }
+    }
+
+    #[test]
+    fn the_artifact_pane_does_not_call_a_passage_chunk_fifty_six() {
+        // "Chunk 56" is a position in the ingest, not a name for anything a
+        // reader asked for. The fixture's ordinal is 56 for exactly that.
+        let t = artifact_title(&chunk_fixture(
+            None,
+            "Die digitale Forensik unterscheidet sich zusätzlich",
+        ));
+        assert!(!t.starts_with("Chunk"), "{t:?}");
+        assert!(t.starts_with("Die digitale Forensik"), "{t:?}");
+        assert_eq!(
+            artifact_title(&chunk_fixture(Some("SQLite und WAL"), "body")),
+            "SQLite und WAL"
+        );
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3676,6 +3676,28 @@ mod tests {
         .unwrap()
     }
 
+    fn settings_fixture(tokens: Vec<TokenRow>) -> String {
+        askama::Template::render(&SettingsTemplate {
+            judge_pending: None,
+            ask_enabled: true,
+            tokens,
+            feedback: None,
+            asks: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn a_token_table_with_no_tokens_says_so_instead_of_showing_its_headings() {
+        // Five column headings over nothing is a table pretending to have
+        // rows — the same thing `_decide.html` names at its top: the old Ops
+        // page answered five headings with "None." and made an empty base look
+        // like a backlog.
+        let html = settings_fixture(vec![]);
+        assert!(!html.contains("Minted by"), "{html}");
+        assert!(html.contains("No tokens yet"), "{html}");
+    }
+
     #[test]
     fn a_sweep_stage_reads_as_words_and_keeps_its_identifier() {
         // Housekeeping listed `arm_dedupe`, `link_judge` and `segment_window`

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -356,6 +356,38 @@ pub fn fmt_duration(secs: i64) -> String {
     }
 }
 
+/// A sweep in words, for a page a person reads.
+///
+/// Housekeeping printed the queue's own identifiers — `arm_dedupe`,
+/// `link_judge`, `segment_window` — in a column headed "Sweep". They are the
+/// right names in the code and in a log, and they are the wrong ones on a page
+/// somebody opens to see whether the base is well.
+///
+/// An identifier with no wording yet returns unchanged rather than blank: a
+/// stage added later must show up as *something*. `every_stage_the_queue_can_run_has_a_word_for_it`
+/// is what makes sure that fallback stays theoretical.
+fn sweep_label(stage: &str) -> &str {
+    match stage {
+        "synthesize" => "Writing artifacts",
+        "enrich" => "Enriching",
+        "segment_window" => "Segmenting",
+        "title" => "Naming captures",
+        "embed" => "Embedding",
+        "consolidate" => "Consolidating",
+        "dedupe" => "Judging duplicates",
+        "relate" => "Finding near-identicals",
+        "describe" => "Describing images",
+        "extract" => "Reading documents",
+        "associate" => "Associating",
+        "link_judge" => "Judging links",
+        "pursuit" => "Following up questions",
+        "generate" => "Answering gaps",
+        "retention" => "Retention",
+        "arm_dedupe" => "Arming dedupe",
+        other => other,
+    }
+}
+
 /// How long something took, past tense.
 ///
 /// `fmt_duration` above answers a different question — when does this run next
@@ -762,7 +794,11 @@ struct SweepCount {
 /// One recorded run, as the history renders it.
 struct SweepRunRow {
     when: String,
+    /// The stage in words. The identifier it was worded from is on the cell as
+    /// a `title`, because the log and the config still call it that and a
+    /// reader who greps for `arm_dedupe` should find it here too.
     stage: String,
+    stage_id: String,
     /// Empty unless it failed, in which case it is why.
     error: String,
     took: String,
@@ -2052,9 +2088,14 @@ async fn reprocess_ui(
 /// `markdown::stand_in_title` — so the sitting, the pair cards and the judge
 /// cannot drift apart again.
 pub(crate) fn title_of(c: &crate::store::artifacts::Chunk) -> String {
-    c.title
-        .clone()
-        .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))
+    // The stored title goes through the same rule, because synthesis writes it
+    // and nothing stopped it writing markup into one: Housekeeping listed a
+    // merged artifact as "**Was nicht abgedeckt ist:** * Es werden keine". A
+    // title is a name, and a name is never marked up.
+    match &c.title {
+        Some(t) => crate::web::markdown::stand_in_title(t, 80),
+        None => crate::web::markdown::stand_in_title(&c.text, 60),
+    }
 }
 
 /// How many decisions Capture offers at once, and the order it looks for them
@@ -2483,7 +2524,8 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
                     false => String::new(),
                 },
                 took: fmt_elapsed(r.ended_at - r.started_at),
-                stage: r.stage,
+                stage: sweep_label(&r.stage).to_string(),
+                stage_id: r.stage,
                 counts: counts
                     .into_iter()
                     .map(|(what, n)| SweepCount { n, what })
@@ -3598,6 +3640,56 @@ mod tests {
             verdict_bar: String::new(),
         })
         .unwrap()
+    }
+
+    #[test]
+    fn a_sweep_stage_reads_as_words_and_keeps_its_identifier() {
+        // Housekeeping listed `arm_dedupe`, `link_judge` and `segment_window`
+        // — the identifiers the queue keys on, on a page a person reads.
+        assert_eq!(sweep_label("arm_dedupe"), "Arming dedupe");
+        assert_eq!(sweep_label("consolidate"), "Consolidating");
+        assert_eq!(sweep_label("retention"), "Retention");
+        assert_eq!(sweep_label("link_judge"), "Judging links");
+        // An identifier nobody has worded yet is shown, never swallowed: a new
+        // sweep must not render as a blank cell.
+        assert_eq!(sweep_label("some_new_sweep"), "some_new_sweep");
+    }
+
+    #[test]
+    fn every_stage_the_queue_can_run_has_a_word_for_it() {
+        // The list above is a map, and a map goes stale silently. This is what
+        // notices when a stage is added and nothing on Housekeeping names it.
+        for stage in crate::store::jobs::Stage::ALL {
+            let id = stage.as_str();
+            assert_ne!(
+                sweep_label(id),
+                id,
+                "no wording for the {id} stage — add one to `sweep_label`"
+            );
+        }
+    }
+
+    #[test]
+    fn a_stored_title_that_carries_markup_is_shown_without_it() {
+        // Housekeeping listed a merged artifact as "**Was nicht abgedeckt
+        // ist:** * Es werden keine". Synthesis writes the title, and nothing
+        // stopped it writing markup into one — a title is a name, and a name
+        // is never marked up.
+        let t = title_of(&chunk_fixture(
+            Some("**Was nicht abgedeckt ist:** * Es werden keine"),
+            "body",
+        ));
+        assert!(t.starts_with("Was nicht abgedeckt ist:"), "{t:?}");
+        assert!(!t.contains("**"), "{t:?}");
+        assert_eq!(
+            title_of(&chunk_fixture(Some("# 3.4.2 FESTE MFT RECORDS"), "body")),
+            "3.4.2 FESTE MFT RECORDS"
+        );
+        // An ordinary title passes through untouched.
+        assert_eq!(
+            title_of(&chunk_fixture(Some("LevelDB: Funktionsweise"), "body")),
+            "LevelDB: Funktionsweise"
+        );
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3457,6 +3457,34 @@ async fn mark_artifact_reviewed(
     Ok(axum::response::Html(String::new()).into_response())
 }
 
+#[derive(Template)]
+#[template(path = "not_found.html")]
+struct NotFoundTemplate {
+    /// Waiting judgements for the nav. See `state::judge_pending`.
+    judge_pending: Option<i64>,
+    /// Whether the ask door is open. See `state::ask_enabled`.
+    ask_enabled: bool,
+}
+
+/// The app's own answer to a path it does not have.
+///
+/// Only for the pages: an agent asking `/api/v1` for a route that does not
+/// exist must not be handed an HTML document to parse, which is what a router
+/// fallback would do to every door at once.
+pub async fn not_found(State(st): State<AppState>, uri: axum::http::Uri) -> Response {
+    if uri.path().starts_with("/api/") {
+        return (axum::http::StatusCode::NOT_FOUND, "not found").into_response();
+    }
+    let page = NotFoundTemplate {
+        judge_pending: crate::web::state::judge_pending(&st).await,
+        ask_enabled: crate::web::state::ask_enabled(&st),
+    };
+    match askama::Template::render(&page) {
+        Ok(html) => (axum::http::StatusCode::NOT_FOUND, axum::response::Html(html)).into_response(),
+        Err(_) => (axum::http::StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}
+
 pub fn ui_router() -> Router<AppState> {
     Router::new()
         // The bare domain and `/ui` are the same door, and both open on the
@@ -3500,6 +3528,12 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/ask/{id}/carried", post(ask_carried))
         .route("/ui/gaps/{kind}/{id}/dismiss", post(gap_dismiss))
         .route("/ui/ops", get(ops))
+        // One name for the page. The nav word is Housekeeping and the route is
+        // `/ui/ops`; a reader who types the word they were shown lands here.
+        .route(
+            "/ui/housekeeping",
+            get(|| async { Redirect::permanent("/ui/ops") }),
+        )
         .route("/ui/settings", get(settings))
         .route("/ui/ops/tokens", post(mint_token))
         .route("/ui/ops/feedback/purge", post(purge_feedback_ui))

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3529,6 +3529,14 @@ mod tests {
     }
 
     #[test]
+    fn an_ask_in_flight_offers_a_way_to_stop_it() {
+        // Fifty seconds signalled by a small grey "thinking…" beside the
+        // button, and nothing on the page to end it with.
+        let html = ask_page_fixture();
+        assert!(html.contains(r#"id="ask-stop""#), "{html}");
+    }
+
+    #[test]
     fn an_ask_page_does_not_open_with_the_models_reasoning_showing() {
         // The deployment streamed the chain of thought into the page for fifty
         // seconds, restating the prompt's own constraints verbatim — "Answer

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -939,7 +939,11 @@ async fn capture_page(
     // and whatever has been judged since sits under itself until the next
     // pass. Nothing here embeds or calls a model.
     let (gaps, loose) = if st.core.feedback.enabled {
-        let (rows, loose) = st.core.store.gap_rows(st.core.embedder.model()).await?;
+        let (rows, loose) = st
+            .core
+            .store
+            .gap_rows(st.core.embedder.model(), st.core.weak_below)
+            .await?;
         (
             rows.into_iter()
                 .map(|r| GapGroup {

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2510,7 +2510,24 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         false => Vec::new(),
     };
     let pursuit_recent = recent.len();
-    let pursuit_unsatisfied = recent.iter().filter(|p| p.state == "unsatisfied").count();
+    // The ones the sentence below can honestly point at. `unsatisfied` is how a
+    // run of searches *ended*, and a capture that answers one afterwards leaves
+    // that word alone deliberately — coverage never rewrites what happened — so
+    // counting the state sent the operator to a gap list that had already
+    // dropped half of them.
+    let on_the_gap_list = match pursuit_enabled {
+        true => st
+            .core
+            .store
+            .open_pursuit_gap_ids(st.core.embedder.model())
+            .await
+            .unwrap_or_default(),
+        false => Default::default(),
+    };
+    let pursuit_unsatisfied = recent
+        .iter()
+        .filter(|p| p.state == "unsatisfied" && on_the_gap_list.contains(&p.id))
+        .count();
     // What the memory did while nobody was looking. The last day as one
     // sentence, and under it the runs themselves — which is the half a single
     // overwritten summary could never give.
@@ -8060,6 +8077,80 @@ mod tests {
                 "no `{badge}` badge on the list: {html}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn housekeeping_counts_only_the_pursuits_the_gap_list_still_holds() {
+        // `unsatisfied` is how the run ended, and a capture answering it later
+        // leaves that word alone on purpose. The gap list drops it all the
+        // same, so counting the state pointed the operator at entries that
+        // were not there.
+        let mut core = crate::core::test_support::test_core().await;
+        core.feedback.enabled = true;
+        core.pursuit.enabled = true;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        let core = handle;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let art = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "how to mount an E01".into(),
+                    corpus_span: None,
+                    title: Some("Mounting an E01".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let mut ids = Vec::new();
+        for q in ["pursued one", "pursued two"] {
+            let p = core
+                .store
+                .insert_pursuit(
+                    1,
+                    &[q.to_string()],
+                    &[],
+                    Some((
+                        &[1.0; crate::core::test_support::TEST_DIM],
+                        core.embedder.model(),
+                    )),
+                )
+                .await
+                .unwrap();
+            core.store
+                .close_pursuit(&p, "unsatisfied", "nothing strong was engaged", 2)
+                .await
+                .unwrap();
+            ids.push(p);
+        }
+
+        let both = get_body(&app, &cookie, "/ui/ops").await;
+        assert!(both.contains("2 went unanswered"), "{both}");
+
+        // A later capture answers one of them.
+        core.store
+            .cover_gap(
+                crate::store::gaps::GapKind::Pursuit,
+                &ids[0],
+                &src.id,
+                &art,
+                0.8,
+            )
+            .await
+            .unwrap();
+
+        let one = get_body(&app, &cookie, "/ui/ops").await;
+        assert!(one.contains("1 went unanswered"), "{one}");
+        assert!(one.contains("is\n  <a href=\"/ui/capture#gaps\""), "{one}");
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -266,6 +266,12 @@ pub struct PairRow {
     /// times. Same rule as `disambiguate_labels`, same reason.
     pub a_opening: String,
     pub b_opening: String,
+    /// Enough of each side to decide by. The titles are links, but following
+    /// one leaves the queue and comes back to a card whose other half you now
+    /// have to remember — which is not a comparison, it is two readings with a
+    /// navigation between them.
+    pub a_excerpt: String,
+    pub b_excerpt: String,
     pub detail: Option<String>,
     /// The stored `detail` is exactly `"link"` — the judge's duplicate
     /// hand-off (§7), a provenance marker, not prose. The row renders a
@@ -2129,6 +2135,8 @@ async fn pair_rows(st: &AppState) -> Result<(Vec<PairRow>, i64)> {
                 // clears the ones the page does not need.
                 a_opening: crate::web::markdown::stand_in_title(&a.text, 40),
                 b_opening: crate::web::markdown::stand_in_title(&b.text, 40),
+                a_excerpt: crate::web::markdown::snippet(&a.text, 400),
+                b_excerpt: crate::web::markdown::snippet(&b.text, 400),
                 a_id: p.a_id,
                 b_id: p.b_id,
                 detail,
@@ -3499,6 +3507,8 @@ mod tests {
             b_title: "SQLite-Datenbankeinstellungen und WAL".into(),
             a_opening: a_opening.into(),
             b_opening: "Einstellungen der SQLite-Datenbank".into(),
+            a_excerpt: "Auto Vacuum werden freie Pages in der Free Page List verwaltet".into(),
+            b_excerpt: "Einstellungen der SQLite-Datenbank koennen ueber Pragma".into(),
             detail: None,
             via_link: false,
             contradiction: true,
@@ -3506,6 +3516,33 @@ mod tests {
             keeps_a: false,
             keeps_b: false,
         }
+    }
+
+    #[test]
+    fn a_pair_card_carries_both_texts_to_read_in_place() {
+        // The titles were links, so reading either side meant leaving the
+        // queue and coming back to a card whose other half you now have to
+        // remember.
+        // `_decide.html` is only ever included, so it has no template struct
+        // of its own; this is one, standing in for the page that includes it.
+        #[derive(Template)]
+        #[template(path = "_decide.html")]
+        struct Decide {
+            pairs: Vec<PairCluster>,
+        }
+        let html = askama::Template::render(&Decide {
+            pairs: group_pairs(vec![pair_row_fixture("a1", "Auto Vacuum", "")]),
+        })
+        .unwrap();
+        assert!(html.contains("<details"), "{html}");
+        assert!(
+            html.contains("Auto Vacuum werden freie Pages"),
+            "the A side's text is not on the card: {html}"
+        );
+        assert!(
+            html.contains("Einstellungen der SQLite-Datenbank koennen"),
+            "the B side's text is not on the card: {html}"
+        );
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3483,7 +3483,13 @@ struct NotFoundTemplate {
 ///
 /// Only for the pages: an agent asking `/api/v1` for a route that does not
 /// exist must not be handed an HTML document to parse, which is what a router
-/// fallback would do to every door at once.
+/// fallback would do to every door at once. `/api/` is not the only such door.
+/// This is the fallback for the whole application, so a missing static asset,
+/// an unrouted `/mcp` path and every request that is not a `GET` arrive here
+/// too — and each of them was answered with the page, which for a browser with
+/// no session meant a 401 that `redirect_unauthenticated_browsers` turned into
+/// the login screen. A stylesheet that 303s to a login is not a missing
+/// stylesheet, it is a mystery. They get the plain 404 they asked for.
 ///
 /// The page is behind a session like every other page. `Identity` is asked for
 /// optionally rather than required so that the `/api` answer above stays a 404
@@ -3495,9 +3501,15 @@ struct NotFoundTemplate {
 pub async fn not_found(
     State(st): State<AppState>,
     id: Option<Identity>,
+    method: axum::http::Method,
     uri: axum::http::Uri,
 ) -> Response {
-    if uri.path().starts_with("/api/") {
+    let path = uri.path();
+    let machine = path.starts_with("/api/")
+        || path.starts_with("/assets/")
+        || path == "/mcp"
+        || path.starts_with("/mcp/");
+    if machine || method != axum::http::Method::GET {
         return (axum::http::StatusCode::NOT_FOUND, "not found").into_response();
     }
     if id.is_none() {

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3480,7 +3480,11 @@ pub async fn not_found(State(st): State<AppState>, uri: axum::http::Uri) -> Resp
         ask_enabled: crate::web::state::ask_enabled(&st),
     };
     match askama::Template::render(&page) {
-        Ok(html) => (axum::http::StatusCode::NOT_FOUND, axum::response::Html(html)).into_response(),
+        Ok(html) => (
+            axum::http::StatusCode::NOT_FOUND,
+            axum::response::Html(html),
+        )
+            .into_response(),
         Err(_) => (axum::http::StatusCode::NOT_FOUND, "not found").into_response(),
     }
 }
@@ -3685,6 +3689,37 @@ mod tests {
             asks: None,
         })
         .unwrap()
+    }
+
+    #[test]
+    fn the_ungrouped_gaps_say_what_being_ungrouped_means() {
+        // "not yet grouped (1)" over a question, with no indication that the
+        // grouping is a sweep that has not run rather than a state of the
+        // question itself.
+        // `_gaps.html` is only ever included, so it has no template struct of
+        // its own; this is one, standing in for the page that includes it.
+        #[derive(Template)]
+        #[template(path = "_gaps.html")]
+        struct Gaps {
+            gaps: Vec<GapGroup>,
+            loose: Vec<GapMember>,
+            ask_enabled: bool,
+        }
+        let html = askama::Template::render(&Gaps {
+            gaps: vec![],
+            loose: vec![GapMember {
+                kind: "ask".into(),
+                badge: "asked",
+                id: "g1".into(),
+                text: "wie werden bei chipkarten die private keys geschützt?".into(),
+            }],
+            ask_enabled: true,
+        })
+        .unwrap();
+        assert!(
+            html.contains("has not run yet"),
+            "nothing says why these are ungrouped: {html}"
+        );
     }
 
     #[test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1384,7 +1384,19 @@ fn disambiguate_labels(rows: &mut [QueueRow]) {
 
 async fn queue_fragment(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     let mut rows = Vec::new();
-    for s in st.core.store.list_corpora(10, 0).await? {
+    let corpora = st.core.store.list_corpora(10, 0).await?;
+    // Asked once for the page rather than once per row: this fragment is polled
+    // while anything is in flight, and the coverage read is a three-way join.
+    // Failure is the empty map for the reason a missing capture is: the line is
+    // what a capture did beyond being stored, and a page that cannot say so
+    // says nothing rather than failing to render the queue.
+    let covered = st
+        .core
+        .store
+        .gaps_covered_by_each(&corpora.iter().map(|c| c.id.clone()).collect::<Vec<_>>())
+        .await
+        .unwrap_or_default();
+    for s in corpora {
         let (resolved, total) = st.core.store.segment_progress(&s.id).await?;
         let progress = (total > 0 && resolved < total).then(|| format!("{resolved}/{total}"));
         // Terminal states: nothing else will happen without someone asking.
@@ -1432,15 +1444,10 @@ async fn queue_fragment(State(st): State<AppState>, _id: Identity) -> Result<Res
             status: s.status.as_str().to_string(),
             artifact_count: st.core.store.count_artifacts_for_corpus(&s.id).await?,
             created: fmt_time(s.created_at),
-            covered: st
-                .core
-                .store
-                .gaps_covered_by(&s.id)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .map(|g| g.text)
-                .collect(),
+            covered: covered
+                .get(&s.id)
+                .map(|gs| gs.iter().map(|g| g.text.clone()).collect())
+                .unwrap_or_default(),
             id: s.id,
         });
     }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -7843,6 +7843,28 @@ mod tests {
         let page = get_body(&app, &cookie, "/ui/search").await;
         assert!(page.contains("Read just now"), "{page}");
         assert!(page.contains("Mounting an E01"), "{page}");
+
+        // And it is still there after a search. The filter form replaces what
+        // it targets wholesale, so a sitting inside that target was wiped by
+        // the first keystroke and never came back — visible only on a search
+        // page with no query, which is the one moment it has nothing to say.
+        let form = page
+            .split("<form id=\"filters\"")
+            .nth(1)
+            .expect("the search page has a filter form");
+        let target = form
+            .split("hx-target=\"")
+            .nth(1)
+            .and_then(|t| t.split('"').next())
+            .expect("the filter form names a target");
+        let swapped = page
+            .split(&format!("id=\"{}\"", target.trim_start_matches('#')))
+            .nth(1)
+            .expect("the target is on the page");
+        assert!(
+            !swapped.contains("Read just now"),
+            "a search replaces {target}, and the sitting is inside it: {swapped}"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3542,6 +3542,21 @@ mod tests {
         .unwrap()
     }
 
+    #[tokio::test]
+    async fn a_search_with_nothing_open_leaves_the_grid_free_to_widen_the_rail() {
+        // 22rem of rail beside a thousand pixels holding one line of
+        // placeholder is the whole complaint. `has-selection` is what the pane
+        // gains when something is opened into it, so its absence on first
+        // paint is what the wide-rail rule keys on — see `40-search.css`.
+        let (app, cookie) = app_with_session().await;
+        let page = get_body(&app, &cookie, "/ui/search?q=write+blocker").await;
+        assert!(page.contains("regions-rail-focus-source"), "{page}");
+        assert!(
+            !page.contains("has-selection"),
+            "a fresh search already claims something is open: {page}"
+        );
+    }
+
     #[test]
     fn the_answer_says_what_was_dropped_in_words_a_person_uses() {
         // "18 excerpt(s) omitted for context budget" is the accounting, and

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -6693,8 +6693,8 @@ mod tests {
         // is where they are asserted now.
         // An empty base says so once, instead of answering five headings with
         // "None."
-        assert!(html.contains("Nothing deprecated"));
-        assert!(!html.contains("<h3>Deprecated</h3>"));
+        assert!(html.contains("Nothing hidden"));
+        assert!(!html.contains("<h3>Hidden as stale</h3>"));
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1952,12 +1952,19 @@ async fn reprocess_ui(
     Ok(Redirect::to(&format!("/ui/corpora/{cid}")).into_response())
 }
 
+/// What to call an artifact in a place that must call it something.
+///
 /// A title is what makes two near-identical artifacts tellable apart at a
-/// glance; falling back to the opening of the body beats an id.
+/// glance; falling back to the opening of the body beats an id. Sixty
+/// characters of raw body was that fallback, and it is where the sitting's
+/// "…darin vo" and the dedupe queue's `Keep "- schneller Schreibzugriff …"`
+/// both came from. The rule lives in one place now — see
+/// `markdown::stand_in_title` — so the sitting, the pair cards and the judge
+/// cannot drift apart again.
 pub(crate) fn title_of(c: &crate::store::artifacts::Chunk) -> String {
     c.title
         .clone()
-        .unwrap_or_else(|| c.text.chars().take(60).collect())
+        .unwrap_or_else(|| crate::web::markdown::stand_in_title(&c.text, 60))
 }
 
 /// How many decisions Capture offers at once, and the order it looks for them
@@ -3267,6 +3274,61 @@ pub fn ui_router() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A `Chunk` with every field named, so a test can say the one thing it
+    /// cares about and nothing else. `Chunk` has no `Default` on purpose —
+    /// most of its fields are decisions — so the fixture carries them here
+    /// rather than putting a misleading default on the type.
+    fn chunk_fixture(title: Option<&str>, text: &str) -> crate::store::artifacts::Chunk {
+        crate::store::artifacts::Chunk {
+            id: "a".into(),
+            corpus_id: Some("s".into()),
+            provenance: crate::store::artifacts::Provenance::Captured,
+            source_count: 0,
+            ordinal: 56,
+            text: text.into(),
+            corpus_span: None,
+            title: title.map(str::to_string),
+            category: None,
+            tags: vec![],
+            embed_state: crate::store::artifacts::EmbedState::Embedded,
+            embed_model: None,
+            created_at: 0,
+            embed_rev: 0,
+            segment_idx: None,
+            flags: vec![],
+            flag_detail: None,
+            superseded_by: None,
+            caveats: vec![],
+            status: crate::store::artifacts::ArtifactStatus::Active,
+            last_verified_at: None,
+            cues: vec![],
+        }
+    }
+
+    #[test]
+    fn an_untitled_artifact_is_named_by_its_opening_not_by_its_first_sixty_bytes() {
+        // Both of these came off the deployment: the sitting cut a name
+        // mid-word, and "Needs you" offered a button reading
+        // `Keep "- schneller Schreibzugriff (…) -"`.
+        let t = title_of(&chunk_fixture(
+            None,
+            "Die digitale Forensik unterscheidet sich zusätzlich darin von einem Tatort",
+        ));
+        assert!(!t.ends_with("vo"), "cut mid-word: {t:?}");
+        assert_eq!(
+            title_of(&chunk_fixture(
+                None,
+                "- schneller Schreibzugriff (Änderungen vom Key auf Stapel) -"
+            )),
+            "schneller Schreibzugriff (Änderungen vom Key auf Stapel) -"
+        );
+        assert_eq!(
+            title_of(&chunk_fixture(Some("LevelDB"), "body")),
+            "LevelDB",
+            "a real title is never replaced"
+        );
+    }
     use crate::web::test_support::{a_png, app_with_cookie, body_of};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -21,6 +21,11 @@
 //! The corpus it reads is whatever the operator actually wants to search, and
 //! is not in this repository. Nothing here prints artifact text; a miss is named
 //! by the leading characters of its own query.
+//!
+//! See `docs/evaluation.md` for what the numbers mean, which parameter to sweep
+//! for which of them, and what this harness cannot measure — notably anything
+//! about a *sequence* of queries, since every pair is scored independently and
+//! `Door::Ui` here carries no session.
 
 use engram::config::Config;
 use engram::core::Core;

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -551,6 +551,8 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         promote: engram::config::PromoteConfig::default(),
         pursuit: engram::config::PursuitConfig::default(),
         schedule: engram::config::ScheduleConfig::default(),
+        sitting: engram::config::SittingConfig::default(),
+        sittings: std::sync::Arc::new(Default::default()),
         // The benchmark makes no background inference call, so the pacer never
         // has anything to hold back.
         gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -550,6 +550,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         activation: engram::config::ActivationConfig::default(),
         promote: engram::config::PromoteConfig::default(),
         pursuit: engram::config::PursuitConfig::default(),
+        schedule: engram::config::ScheduleConfig::default(),
         // The benchmark makes no background inference call, so the pacer never
         // has anything to hold back.
         gate: std::sync::Arc::new(engram::infer::gate::InferenceGate::new(

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -145,6 +145,7 @@ async fn a_deprecated_artifact_is_hidden_by_default_and_reachable_on_request() {
     assert_eq!(
         ids(SearchFilter {
             include_deprecated: true,
+            corpus_id: None,
             ..Default::default()
         })
         .await,
@@ -235,6 +236,7 @@ async fn filtered_search_uses_payload_indexes() {
         category: None,
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -248,6 +250,7 @@ async fn filtered_search_uses_payload_indexes() {
         category: Some("concept".into()),
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     assert_eq!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -290,6 +293,7 @@ async fn multiple_tags_are_an_and_not_an_or() {
         category: None,
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -669,6 +673,7 @@ async fn set_payload_rewrites_metadata_without_touching_the_vector() {
         category: None,
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     assert_eq!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &f)
@@ -682,6 +687,7 @@ async fn set_payload_rewrites_metadata_without_touching_the_vector() {
         category: None,
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     assert!(
         v.search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 5, &stale)
@@ -809,6 +815,7 @@ async fn a_filter_still_applies_to_both_halves_of_a_hybrid_query() {
         category: None,
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &sparse, 10, &f)
@@ -1020,6 +1027,7 @@ async fn scoring_leaves_the_filter_alone() {
         category: None,
         include_superseded: false,
         include_deprecated: false,
+        corpus_id: None,
     };
     let hits = v
         .search(&[1.0, 0.0, 0.0, 0.0], &Default::default(), 10, &f)
@@ -1611,6 +1619,7 @@ async fn a_superseded_point_leaves_search_and_can_come_back() {
             &SearchFilter {
                 include_superseded: true,
                 include_deprecated: false,
+                corpus_id: None,
                 ..Default::default()
             },
         )


### PR DESCRIPTION
Closes the three seams in `docs/superpowers/specs/2026-08-20-one-system-design.md`. No new subsystem, and no model call that was not already made.

## The scheduler (§4)

The job queue had four of the five things a scheduler needs. It has the fifth now.

- **`jobs.class`** — one column, one distinction: *is somebody waiting on this?* Foreground is the capture pipeline the operator is watching move `raw → ready`; background is every sweep whose result nobody is standing in front of. A constant per stage, not a config key: a priority you can set wrong presents as *the capture is hanging*, with nothing anywhere saying why.
- **Ageing** is an `UPDATE` on the repair tick, not a term in the claim. Computing age at claim time would put an inequality into the ordering and cost the covering index. `EXPLAIN QUERY PLAN` is pinned as a test for exactly this.
- **Five tickers deleted.** A sweep arms itself one interval out when it finishes, so `run_after` *is* the cursor recording when it last ran — already indexed, no clock held anywhere. Every gate that used to be an early `return` now lives on one list, each keeping its original condition verbatim.
- **Repair stays outside**, and gains the two duties that make outside the right place: ageing, and arming any sweep that is not live. That second one is the guard against the failure mode a ticker does not have — a unit that dies between the claim and the re-arm.
- **`sweep_runs`** — one row per run, failures included. Ops shows the last day and the history under it.

**What did not survive contact: there is no "night".** Units on their own periods do not line up into one cycle, and grouping them by an invented cycle identity would be inventing it. Ops shows the last day instead, with the history beneath — which is the thing a single overwritten summary could never give.

## One queue for what is missing (§6)

Four `GapKind`s on the list the capture page already had, badged *judged*, *asked*, *nothing near*, *pursued*.

- **`Unmatched`** is distance, not behaviour. *Abandoned* was the first draft and was wrong twice: not clicking a result can mean the list was useless or that the titles told you what you needed, and an open is only recorded when pursuits *and* feedback are on — so with pursuits off every search in the log looks abandoned.
- **Coverage** lives in `gap_coverage`, not on the judged row. Nothing an automatic score decided overwrites what a person judged, and the two cascades are the reversibility for free: delete the capture that closed a gap and the gap comes back.

## The sitting (§5)

In memory, keyed by web session, expiring at `pursuit.idle_secs` — the same number the pursuit sweep uses, so the live definition and the reconstructed one agree by construction. It dies with the process, on purpose: a working memory that survives a restart is a long-term memory, and engram has one.

Carrying ships on and changes no order. Priming is behind `[sitting] prime = false`, folded into the existing `prime` walk so it shares one budget — two passes would lift a hit `prime_lift` places for being accessible and `prime_lift` again for having been read ten minutes ago, and the second lift would be the one nobody bounded.

## Four decisions the spec left open

1. **There is no `ALTER TABLE` path here.** `Store::migrate` applies `schema.sql` whole and then checks, failing at boot by name. Followed that doctrine rather than inventing a migration runner — **see the deploy note below**.
2. **The index swap needed a rename.** `CREATE INDEX IF NOT EXISTS idx_jobs_claim2` leaves an existing index's columns alone, so every existing base would have kept claiming through the old order — silently, on exactly the installs the new one serves. Dropped by name, replaced by `idx_jobs_claim3`.
3. **`GapKind::Pursuit` had no vector.** `pursuits.queries` holds words; a gap needs the vector it was found by. The sweep carries the leading clustered query's vector onto the row — three nullable columns beyond §8.
4. **"Closed silently, source row untouched" had nowhere to write.** Hence `gap_coverage`.

## Also

`SearchFilter` gains `corpus_id`, which is what makes "this document's artifacts only" one filtered query rather than a scan. `Identity` gains the session id, `None` for a bearer token — that absence is load-bearing, and is the whole of what keeps the sitting at the web door.

`docs/evaluation.md` documents the evaluation harness end to end: what each benchmark measures, which environment variable to sweep for which metric, and what neither can measure.

## Deploying this

`jobs.class` is declared in `schema.sql`, so an existing base fails at boot naming it. One statement, then restart:

```sql
ALTER TABLE jobs ADD COLUMN class INTEGER NOT NULL DEFAULT 0;
```

The backfill that marks the sweeps as background runs inside `migrate()` at startup. The other three schema changes are new tables and nullable columns, and need nothing.

## Not done

**`[sitting] prime` is unmeasured and ships off.** The harness cannot measure it: it scores each pair independently against a static index and searches through `Door::Ui`, which carries no session, so priming from the sitting cannot move a number there. Measuring it needs a harness that scores *runs* of queries. ROADMAP.md and `docs/evaluation.md` both record this. The default moves in a commit of its own carrying the numbers, or it does not move.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets` and `cargo test` are clean — 1442 lib tests, 0 failures. The four worth naming:

| Test | What it pins |
|---|---|
| `a_crashed_capture_is_repaired_with_the_sweep_switched_off` | Repair stayed outside the schedule |
| `the_claim_still_walks_one_index_and_never_sorts` | The covering index survived priority and ageing |
| `within_one_class_the_order_is_still_attempts_then_seq` | A large ingest still cannot starve a small one |
| `the_sitting_writes_no_activation` | Working memory stayed a read |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwPUskmnksJuBZJKuC8Vaz
