### PR TITLE
A recommendation under the search box, from context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1616,8 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.23.1",
+ "chrono",
+ "chrono-tz",
  "clap",
  "config",
  "docling",
@@ -3626,7 +3638,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "js-sys",
  "libloading",
  "log",
@@ -3707,6 +3719,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
@@ -3774,6 +3795,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,13 @@ schemars = "1.2.2"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "webp"] }
 # EXIF is where the phone says when and where a photo was taken.
 kamadak-exif = "0.6.1"
+# Local time, so "Friday at 15:00" is a question the base can ask of its own
+# log. Storage stays Unix seconds; this is only ever applied at the edge.
+chrono = { version = "0.4.45", default-features = false, features = ["clock", "std"] }
+# The IANA database, because the zone comes from the device
+# (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and a stored offset
+# cannot answer what happens across a DST boundary.
+chrono-tz = { version = "0.10.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 # `test-util` is not part of tokio's `full`. It carries the pausable clock the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,12 @@ as a paste the operator approves; one bounded round of planned retrieval behind
 `[infer.ask] plan`, fanning out to a search per uncovered subject; named model
 tiers, so a role picks a model by what the call is worth; judged questions with
 a second harness — citation recall, abstention, faithfulness by literals and by
-claim check; knowledge gaps grouped and named on the capture page.
+claim check; knowledge gaps grouped and named on the capture page; a
+recommendation under the search box, learned from the situations an artifact
+was opened in — the browser's time zone and local time, the device, the
+viewport, the network and the power state, clustered per artifact and stored as
+a `ctx` multivector scored with `max_sim`, with the blocks that decided each
+offer named beneath it and shown-against-clicked broken down by rung on Ops.
 Design records live in `docs/superpowers/specs/`.
 
 Three constraints decide what is on this list and what was cut from it.
@@ -336,6 +341,30 @@ to trust.
   and an artifact cannot currently tell the operator what earned it, or what it
   has ever answered. Last of the three, and the one that makes the other two
   worth reading.
+
+- **The offer's hit rate is on Ops.** Built. Shown against clicked, by rung,
+  over the last thirty days. The block weights the recommendation rests on are
+  chosen, not measured, and this is the instrument that would let them be
+  fitted — fitting them before the data exists would be guessing with extra
+  steps. It is here for the reason `[sitting] prime` is still `false`: a
+  default nobody can see the effect of never moves.
+
+- **Dropping the `scope` block.** Not built, and it waits on per-user
+  collections rather than on anyone's judgement. At weight 10 against a total
+  under 5, that block is what keeps one person's situations from being ranked
+  first for another; the read path cuts foreign clusters exactly, so the block
+  is a ranking aid rather than the guarantee, but it stays until each user has
+  their own collection. Then it goes to 0 and nothing else about the encoder
+  changes.
+
+- **Learned block weights.** Not built. Once the shown/clicked rate has months
+  behind it, the weights in `[recommend.weights]` can be fitted to it. Until
+  then they are the defaults in the design record, and the honest description
+  of them is "chosen".
+
+- **Conjunctions across scopes.** Not built. The context vector can hold
+  "on the phone the hour matters, at the desk it does not"; nothing yet learns
+  which of those conjunctions are real.
 
 ## [Core Platform & Tooling]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -386,15 +386,18 @@ to trust.
   three pages fold into `/ui/search` and the others become deep links to it.
   What has to be answered there and not here: where the rail, the filter chips
   and the judged-verdict bar live when the box is doing all three jobs.
-- **One dial instead of eight gates.** `feedback.enabled`, `[associate]`,
-  `[activation]`, `[pursuit]`, `[promote]` and `[consolidate]` are separate
-  switches over one faculty, and they depend on each other in ways only the
-  config comments admit: a pursuit needs feedback, promotion reads an
-  activation that only moves while searches are recorded, priming exists only
-  to be fed by activation. An operator who switches one off silently switches
-  off two more. A named mode — off, learning, full — setting a coherent bundle,
-  with the individual keys still there for whoever wants them, is an afternoon,
-  and it is what makes the rest of this list configurable at all.
+- **One dial instead of eight gates.** Three of them are gone: `[learn]` is now
+  the single switch over recording, association and pursuits, and the sections
+  below it keep their thresholds and no switch of their own. That was the half
+  of this item where the flags were not really independent — two of their
+  combinations were refused at startup and a third was a warning, which is how
+  you find out a setting has been written three times. What is left is the half
+  where they are genuinely different questions: `[activation]`, `[promote]` and
+  `[consolidate]` still depend on each other in ways only the config comments
+  admit — promotion reads an activation that only moves while `[learn]` is on,
+  and priming exists only to be fed by activation. A named mode — off,
+  learning, full — setting a coherent bundle across those, with the individual
+  keys still there for whoever wants them, is what would finish it.
 - **A CLI.** PDF capture is built: `docling` reads an uploaded PDF into markdown
   in `Stage::Extract`, locally and without a model, and the corpus is text like
   any other from there. Spans into it are line spans labelled `extraction`, not

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,10 @@ recommendation under the search box, learned from the situations an artifact
 was opened in — the browser's time zone and local time, the device, the
 viewport, the network and the power state, clustered per artifact and stored as
 a `ctx` multivector scored with `max_sim`, with the blocks that decided each
-offer named beneath it and shown-against-clicked broken down by rung on Ops.
+offer named beneath it and shown-against-clicked broken down by rung on Ops. A
+situation seen once or twice is offered too, saying so in words — "Twice
+before" — and held to a stricter match than an established one; with nothing
+learned about the situation a card is drawn at random and claims nothing.
 Design records live in `docs/superpowers/specs/`.
 
 Three constraints decide what is on this list and what was cut from it.

--- a/assets/app.js
+++ b/assets/app.js
@@ -600,12 +600,117 @@
     box.focus();
   }
 
+  // The situation this page view happened in.
+  //
+  // Synchronous, because htmx reads `hx-vals js:` synchronously. The two
+  // asynchronous sources — the Battery API and the device list — are read once
+  // at load and cached here, so the first page view of a session goes without
+  // them and the server zeroes their blocks rather than inventing a value.
+  //
+  // Deliberately not collected: canvas, WebGL, fonts, plugins. Those identify a
+  // device across a population; here the population is one authenticated
+  // person, so they are constant and say nothing about which situation this is
+  // — and a hardened browser randomises them per session, so every day would
+  // look like a new device.
+  var slow = { battery_level: null, charging: null, audio_outputs: null };
+
+  function primeSlow() {
+    if (navigator.getBattery) {
+      navigator.getBattery().then(function (b) {
+        slow.battery_level = b.level;
+        slow.charging = b.charging;
+      }).catch(function () {});
+    }
+    if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
+      navigator.mediaDevices.enumerateDevices().then(function (list) {
+        slow.audio_outputs = list.filter(function (d) {
+          return d.kind === 'audiooutput';
+        }).length;
+      }).catch(function () {});
+    }
+  }
+
+  function uaFamily() {
+    var d = navigator.userAgentData;
+    if (d && d.brands) {
+      for (var i = 0; i < d.brands.length; i++) {
+        // Chromium pads the list with a deliberately absurd brand to break
+        // exactly the kind of sniffing this is not doing; skip it.
+        if (!/Not.*Brand/i.test(d.brands[i].brand)) return d.brands[i].brand;
+      }
+    }
+    var m = /(Firefox|Edg|Chrome|Safari)\/[\d.]+/.exec(navigator.userAgent || '');
+    return m ? m[1] : null;
+  }
+
+  function netKind() {
+    var c = navigator.connection || navigator.mozConnection;
+    if (!c) return null;
+    if (c.type) return c.type;
+    // `effectiveType` describes speed rather than medium, and calling a slow
+    // wifi "cellular" would be inventing a fact. Absent instead.
+    return null;
+  }
+
+  window.engramContext = function () {
+    var b = {};
+    try {
+      b.tz = Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+      b.tz_offset_mins = -new Date().getTimezoneOffset();
+      b.language = navigator.language || null;
+      b.languages = navigator.languages ? Array.prototype.slice.call(navigator.languages) : [];
+      b.viewport_w = window.innerWidth;
+      b.viewport_h = window.innerHeight;
+      b.screen_w = screen.width;
+      b.screen_h = screen.height;
+      b.dpr = window.devicePixelRatio;
+      b.color_scheme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      b.platform = (navigator.userAgentData && navigator.userAgentData.platform)
+        || navigator.platform || null;
+      b.ua_family = uaFamily();
+      b.cores = navigator.hardwareConcurrency || null;
+      b.memory_gb = navigator.deviceMemory || null;
+      b.touch = navigator.maxTouchPoints > 0;
+      b.orientation = window.innerHeight >= window.innerWidth ? 'portrait' : 'landscape';
+      b.network = netKind();
+      b.battery_level = slow.battery_level;
+      b.charging = slow.charging;
+      b.audio_outputs = slow.audio_outputs;
+    } catch (e) {
+      // A partial bundle is a working one: the blocks it could not fill are
+      // zeroed server-side, and the weekday and the hour still stand.
+    }
+    return JSON.stringify(b);
+  };
+
+  // Removed on the first keystroke, and it does not come back when the box is
+  // cleared. The flag is what covers the race: the fetch fires on `load`, and
+  // its answer can land *after* the first keystroke — without this, an offer
+  // already dismissed would swap itself back in.
+  var offerDismissed = false;
+
+  function dropOffer() {
+    var area = document.getElementById('context-offer');
+    if (area) area.remove();
+  }
+
+  function contextOffer() {
+    var box = document.querySelector('input[name=q]');
+    if (!box) return;
+    box.addEventListener('input', function () {
+      offerDismissed = true;
+      dropOffer();
+    }, { once: true });
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
     enhance(document.body);
     commandBar();
     claimPaste();
     themeToggle();
     keyHint();
+    primeSlow();
+    contextOffer();
     restoreReading();
     askDriver();
     trackDwell();
@@ -625,6 +730,10 @@
       window.location.assign('/auth/login?go=' + encodeURIComponent(here));
     });
     document.body.addEventListener('htmx:afterSwap', function (e) {
+      // The offer's own fetch can land after the first keystroke has already
+      // dismissed it. Swapping it back in then would be exactly the flicker the
+      // removal exists to prevent.
+      if (e.target.id === 'context-offer' && offerDismissed) dropOffer();
       enhance(e.target);
       trackDwell();
       // The pane now holds something, so a narrow screen can hide the rail.

--- a/assets/css/40-search.css
+++ b/assets/css/40-search.css
@@ -521,3 +521,16 @@ body { overflow-x: hidden; }
 /* Said under the passage it belongs to, quietly: it is a way onward, not a
    warning that something is wrong. */
 .continues { margin: 0.5rem 0 0; font-size: 0.8125rem; }
+
+/* The area under the search box. `min-height` is what keeps the answer landing
+   from pushing the hint and the chips down a page that has already been read —
+   the fetch is one round trip after `load`, which is long enough to see. */
+.offer { min-height: 3.25rem; margin: 0.25rem 0 0.5rem; }
+.offer-title { font-size: var(--text-base); color: var(--color-fg-primary); }
+.offer-why { font-size: var(--text-xs); margin: 0.125rem 0 0; }
+.offer-detail { display: inline; }
+.offer-detail summary { display: inline; cursor: pointer; color: var(--color-accent); }
+.offer-detail pre {
+  white-space: pre-wrap; word-break: break-all;
+  margin: 0.375rem 0 0; font-size: var(--text-xs);
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -365,9 +365,23 @@ interval_hours = 24
 # is ever asked about.
 dedupe_interval_mins = 15
 max_dedupe_per_tick = 5
+# ── Learning from what happens here ─────────────────────────────────────────
+# One switch over the whole layer: recording searches, learning links from
+# co-retrieval, activation, pursuits, and the area under the search box. These
+# were three separate flags — [feedback], [associate] and [pursuit] each had
+# their own — and two of their combinations were refused at startup while a
+# third was a warning, which is how you find out they were one setting written
+# three times. The sections below keep their thresholds; this is the switch.
+#
+# On by default. Everything downstream of it moves only while the log is being
+# written, so off is the deliberate act. Nothing here leaves the machine, Ops
+# forgets all of it on one press, and off means nothing is recorded in the
+# first place.
+[learn]
+enabled = true
+
 # Recording real searches so they can be judged later, and turned into the
-# query/artifact pairs the evaluation harness scores against. Off by default: a
-# query log is personal, and it is useful to nobody but you.
+# query/artifact pairs the evaluation harness scores against.
 #
 # The queries a benchmark needs cannot be written from memory. Phrased while
 # looking at an artifact, they reuse its wording, and every retrieval system
@@ -379,10 +393,7 @@ max_dedupe_per_tick = 5
 # one there is. Typing bursts fold into their final wording, so `daten`,
 # `datentr`, `datenträger nicht erkannt` is one event rather than three.
 [feedback]
-# On by default: promotion at synthesis = "earned" reads activation, and
-# activation only moves while searches are recorded. Everything stays on this
-# machine and Ops forgets it on one press; set false to record nothing at all.
-enabled = true
+# No switch here: see [learn], which is the one switch over all of this.
 # Candidates stored per search. Wider than the answer on purpose — retrieval
 # over-fetches anyway, so the extra rows cost nothing, and they are what lets an
 # artifact the ranking buried still be confirmed as the right one. 0 is not a
@@ -408,10 +419,9 @@ sweep_hours = 6
 
 # Links learned from co-retrieval, and a decaying accessibility per artifact.
 # Both are learned from use and neither touches what is stored: the trace is
-# fixed, access is plastic. Needs `feedback.enabled` — without recorded searches
-# there is nothing to learn from, and saying otherwise is a warning at startup.
+# fixed, access is plastic. Runs behind [learn] — without recorded searches
+# there is nothing to learn from.
 [associate]
-enabled = true
 # How often the sweep replays the search log. Pure SQLite, no model call.
 interval_mins = 30
 # A link unused for this long has half the strength it had. One co-appearance is
@@ -467,12 +477,11 @@ resynthesize_after_unconfirmed = 0
 # A coherent run of searches, what was opened and pivoted through, and — when
 # the base did not answer or the answer was assembled by hand — one generated
 # artifact written from exactly that, carrying the questions it was written
-# for. Off until turned on: this writes model-written text into the index.
-# Needs feedback.enabled. Local only, nothing leaves the machine, and the
-# forget button on Settings clears all of it. The grouping line is measured,
-# not configured.
+# for. Runs behind [learn]: the events it reads are the ones recording writes,
+# and the sweep it rides on is the associative pass. Local only, nothing leaves
+# the machine, and the forget button on Settings clears all of it. The grouping
+# line is measured, not configured.
 [pursuit]
-enabled = false
 # A pursuit is over when nothing has happened for this long.
 idle_secs = 900
 # Fewer engaged artifacts than this is a promotion case, not generation.
@@ -488,10 +497,12 @@ min_engagement = 3.0
 # which artifact; a page view is one vector query against what it learned. No
 # model call and no embedding on this path, ever.
 #
-# Off until there is a base with weeks of situations in it — a weekly pattern
-# needs weeks, and until then every offer would sit on the bottom rung.
+# On, and behind [learn] as well: the situations it clusters are opens recorded
+# in the same log everything else here reads. A weekly pattern needs weeks, so a
+# young base sees the bottom rung — a card drawn at random, claiming nothing —
+# until it has something to say.
 [recommend]
-enabled = false
+enabled = true
 # Cosine above which an event joins a cluster rather than opening its own.
 cluster_merge_at = 0.82
 # Situations kept per artifact, per person. More than one is the point: a thing

--- a/config.example.toml
+++ b/config.example.toml
@@ -500,14 +500,20 @@ cluster_merge_at = 0.82
 max_clusters = 5
 # A pattern that stops fades rather than standing for ever.
 half_life_days = 45.0
-# A cluster lighter than this is dropped. Also what protects against the single
-# accident: one event never reaches it.
-min_weight = 2.0
-# Score at or above which the offer is called a pattern, and above which it is
-# called a resemblance. Below the second, the ladder falls through to what this
-# sitting has touched, and then to what has been forgotten. Scored without the
-# `scope` block, which decides *who* may be offered something rather than how
-# well the situation matches.
+# A cluster lighter than this is dropped. Low enough that a single recent event
+# survives: a thing done twice is worth saying so about, it is just not worth
+# calling a pattern.
+min_weight = 0.9
+# Weight at or above which a situation is spoken of as established. Below it the
+# offer says how many times it has happened instead — "Twice before" — and
+# demands a strong match before saying anything at all, because there is less
+# behind it. At the default half-life this is the third repetition.
+firm_at = 2.5
+# Score at or above which an established situation is called a pattern, and
+# above which it is called a resemblance. Below both, a card is drawn at random
+# with no reason printed beside it — something to look at while the base has
+# nothing to say about the situation. Scored without the `scope` block, which
+# decides *who* may be offered something rather than how well it matches.
 strong_at = 0.75
 weak_at = 0.45
 # What an open of something this offered counts for, back into the profile.

--- a/config.example.toml
+++ b/config.example.toml
@@ -481,6 +481,66 @@ min_sources = 2
 # pivoted 1.5, returned 2.0, confirmed 3.0.
 min_engagement = 3.0
 
+# ── A recommendation under the search box ────────────────────────────────────
+# The area under the search box, filled from the situation the page was opened
+# in: the time zone and local time the browser reports, the device, the
+# viewport, the network, the battery. A sweep learns which situations recur for
+# which artifact; a page view is one vector query against what it learned. No
+# model call and no embedding on this path, ever.
+#
+# Off until there is a base with weeks of situations in it — a weekly pattern
+# needs weeks, and until then every offer would sit on the bottom rung.
+[recommend]
+enabled = false
+# Cosine above which an event joins a cluster rather than opening its own.
+cluster_merge_at = 0.82
+# Situations kept per artifact, per person. More than one is the point: a thing
+# looked up on Friday afternoons and occasionally on Monday mornings is two
+# situations, and their mean is a situation that never happened.
+max_clusters = 5
+# A pattern that stops fades rather than standing for ever.
+half_life_days = 45.0
+# A cluster lighter than this is dropped. Also what protects against the single
+# accident: one event never reaches it.
+min_weight = 2.0
+# Score at or above which the offer is called a pattern, and above which it is
+# called a resemblance. Below the second, the ladder falls through to what this
+# sitting has touched, and then to what has been forgotten. Scored without the
+# `scope` block, which decides *who* may be offered something rather than how
+# well the situation matches.
+strong_at = 0.75
+weak_at = 0.45
+# What an open of something this offered counts for, back into the profile.
+# Zero: without it, the first lucky guess grows into a habit the system taught
+# itself.
+self_weight = 0.0
+
+# What each named block of the situation is worth. Each block is normalised to
+# length 1 and then scaled by its weight, so a block contributes exactly its
+# weight however many dimensions it uses — seven one-hot slots for the weekday
+# do not outweigh two for the hour because there are seven of them.
+[recommend.weights]
+# Interim, and load-bearing: every person shares one collection today, so this
+# is what keeps one person's situations from being offered to another. It goes
+# to 0 when each user has their own collection.
+scope = 10.0
+# The hour, as an angle — 23:30 and 00:30 are an hour apart, and 14:55 against a
+# 15:00 pattern costs almost nothing.
+time_of_day = 1.0
+# One-hot, because "Friday is three from Tuesday" means nothing and the pattern
+# is exactly Friday.
+weekday = 1.0
+# The part of the weekday that genuinely is gradual, kept separate and weak.
+weekend = 0.3
+device = 0.8
+viewport = 0.4
+locale = 0.3
+network = 0.6
+power = 0.2
+environment = 0.2
+# Off. A monthly rhythm is real, but nothing has shown one here yet.
+month_cycle = 0.0
+
 # ── Scheduling ───────────────────────────────────────────────────────────────
 # The queue is the scheduler. Whether somebody is waiting on a unit is a
 # constant per stage rather than a setting: a priority you can set wrong

--- a/docs/superpowers/plans/2026-08-21-context-recommendation.md
+++ b/docs/superpowers/plans/2026-08-21-context-recommendation.md
@@ -1,0 +1,4933 @@
+# A recommendation under the search box, from context — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Learn which situations recur for which artifact from the interaction log, and offer that artifact under the search box before it is asked for, with the reasons visible.
+
+**Architecture:** A browser bundle recorded on every page view (`context_events`); a sweep that agglomerates the situations an artifact was opened in into a handful of decayed clusters (`context_clusters`); each centroid stored as one element of a `ctx` multivector on the artifact's existing Qdrant point, scored with `max_sim`; one vector query at page load, its winning cluster re-derived locally so the display can name the blocks that decided it. No model call and no embedding anywhere on this path.
+
+**Tech Stack:** Rust 2024, axum 0.8, sqlx/SQLite, Qdrant over REST, askama templates, htmx, chrono + chrono-tz.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-context-recommendation-design.md`
+
+## Global Constraints
+
+- **No model call and no embedding at read time.** One vector query per page view, one exact scan over the profiled subset. Nothing here may add an inference call.
+- **The sweep writes vectors through `POST /points/vectors`, never `upsert`.** `upsert` replaces the whole payload; clearing `status` or `last_seen_at` puts hidden artifacts back into search (`src/vector/qdrant.rs:1095-1101`).
+- **This adds no stage to search ranking.** The recommendation is its own surface and disappears the moment a query exists.
+- **`scope` isolation is load-bearing.** Until per-user collections exist, the `scope` block's weight is the only thing keeping one person's clusters from being offered to another. Task 4 and Task 8 each carry a test for it.
+- **The reason must match the hit.** The local recomputation and the store must pick the same artifact. Task 8 carries the test.
+- **One gate.** Everything under `[recommend]` is `enabled` plus numbers. No second boolean.
+- **`schema.sql` is declarative, not a migration chain** (`src/store/mod.rs:60-80`). New tables are `CREATE TABLE IF NOT EXISTS`; a new *column* on an existing table means the boot check names it as missing and the operator recreates the database. That is the existing contract — do not add `ALTER TABLE`.
+- **Rust 1.94, edition 2024.** `cargo fmt` and `cargo clippy` must be clean.
+- Commit style: conventional prefix, lowercase subject in the repo's voice (`feat(context): …`).
+
+## Two refinements to the spec, decided here
+
+Both are consequences of the spec's own numbers. They are called out so an executor does not read them as drift.
+
+1. **The rung is scored without the `scope` block.** §6 sets `scope` to weight 10 against a total block weight of ~4.6, so a same-scope cosine never falls below ≈0.957 whatever the situation. `strong_at` and `weak_at` would have to live in a band four hundredths wide. So: Qdrant's `max_sim` over the **full** vector decides *which* artifact is offered (that is what the scope block is for — a foreign cluster can never win it), and the **rung** is decided by the cosine over the vector with the `scope` block sliced off. The two numbers have different jobs and now have different scales.
+2. **`context_clusters.representative` stores `{"at": <unix>, "bundle": {…}}`.** The display quotes the representative event's timestamp, and the raw bundle does not carry one. One TEXT column still, as the spec's schema fixes it.
+
+## File Structure
+
+**Created:**
+- `src/core/context.rs` — `Clock`, `Bundle`, `LocalTime`, the block table, `CTX_DIM`, `encode`, `contributions`, `device_key`. One pure module: everything here is a function of its arguments, which is what makes Task 4's table-driven tests possible.
+- `src/core/recommend.rs` — the read path: query the store, reload the candidates' clusters, reproduce the argmax, pick the rung, build the reason.
+- `src/store/context.rs` — `context_events` and `context_clusters` reads and writes.
+- `src/jobs/context.rs` — the sweep: bridge join, agglomeration, decay, slot allocation, centroid write.
+- `src/web/templates/_context.html` — the fragment under the search box.
+
+**Modified:**
+- `Cargo.toml` — `chrono`, `chrono-tz`.
+- `src/store/schema.sql` — `artifacts.updated_at`, `context_events`, `context_clusters`.
+- `src/store/artifacts.rs:747-812` — three UPDATEs bump `updated_at` beside `embed_rev`.
+- `src/store/pursuits.rs` — a `recommended_*` writer and the Ops rollup.
+- `src/config.rs` — `RecommendConfig`, `BlockWeights`, wired into `Config`.
+- `src/core/mod.rs` — `pub mod context; pub mod recommend;`, `Core::{clock, recommend}`, `Core::recommends()`, test builder.
+- `src/vector/mod.rs` — two trait methods.
+- `src/vector/memory.rs` — both, including `max_sim`.
+- `src/vector/qdrant.rs` — `CTX` const, `collection_body`, `reindex`, both trait methods.
+- `src/store/jobs.rs` — `Stage::Context`.
+- `src/core/background.rs`, `src/jobs/mod.rs` — the periodic unit.
+- `src/jobs/pursuit.rs:520` — exclude `recommended_shown` from engagement.
+- `src/jobs/retention.rs` — trim `context_events` on its own window.
+- `src/web/ui.rs` — `POST /ui/context`, `SearchTemplate::recommend`, the `rec=` branch in `artifact_detail`, the Ops rollup.
+- `src/web/templates/search.html`, `src/web/templates/ops.html`.
+- `assets/app.js`, `assets/css/40-search.css`.
+- `config.example.toml`, `ROADMAP.md`.
+
+---
+
+### Task 1: Time — `chrono`, a `Clock`, and `artifacts.updated_at`
+
+Storage stays Unix seconds. Nothing existing changes format, and the other
+`now()` call sites in the tree are **not** touched: they work, and rewriting
+them is a diff across the tree for nothing.
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `src/core/context.rs`
+- Modify: `src/core/mod.rs` (module declaration, `Core::clock`, test builder)
+- Modify: `src/store/schema.sql:66-120` (one column on `artifacts`)
+- Modify: `src/store/artifacts.rs:747-812` (three UPDATEs)
+- Test: in `src/core/context.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `crate::core::context::{Clock, LocalTime, local_time}`.
+  - `enum Clock { System, Fixed(i64) }`, `impl Clock { pub fn now(&self) -> i64 }`, `Copy + Clone + Debug`.
+  - `struct LocalTime { pub hour: f32, pub weekday: u32, pub day: u32, pub days_in_month: u32 }` — `hour` fractional 0.0..24.0, `weekday` 0 = Monday, `day` 1-based.
+  - `pub fn local_time(at: i64, tz: Option<&str>, offset_mins: Option<i32>) -> LocalTime`
+  - `Core::clock: Clock`.
+
+- [ ] **Step 1: Add the two crates**
+
+```bash
+cargo add chrono --no-default-features --features clock,std
+cargo add chrono-tz --no-default-features --features std
+```
+
+Then edit `Cargo.toml` so the two lines carry their reason, in the style of the
+file's other comments (put them just after the `url = "2"` line):
+
+```toml
+# Local time, so "Friday at 15:00" is a question the base can ask of its own
+# log. Storage stays Unix seconds; this is only ever applied at the edge.
+chrono = { version = "0.4.45", default-features = false, features = ["clock", "std"] }
+# The IANA database, because the zone comes from the device
+# (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and a stored offset
+# cannot answer what happens across a DST boundary.
+chrono-tz = { version = "0.10.4", default-features = false, features = ["std"] }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/core/context.rs`:
+
+```rust
+//! The situation a page view happened in: the clock it happened on, the bundle
+//! the browser sent, and the fixed-length vector both become.
+//!
+//! Everything here is a function of its arguments. That is deliberate: the
+//! encoder is the one part of this feature that can be silently wrong — a block
+//! that quietly outweighs another produces plausible recommendations for the
+//! wrong reason — and a pure function is the only shape that can be pinned by a
+//! table of cases.
+
+/// Where this feature reads the time. `System` everywhere but the tests, which
+/// need a seventh Friday at 14:52 to exist on demand.
+///
+/// Held by the sweep, the encoder's entry point and the endpoint, and by
+/// nothing else. The other `now()` call sites in the tree are not touched:
+/// they work, and rewriting them would be a diff across the tree for nothing.
+#[derive(Debug, Clone, Copy)]
+pub enum Clock {
+    System,
+    Fixed(i64),
+}
+
+impl Clock {
+    pub fn now(&self) -> i64 {
+        match self {
+            Clock::System => crate::store::now(),
+            Clock::Fixed(t) => *t,
+        }
+    }
+}
+
+/// A moment as the device experienced it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LocalTime {
+    /// Fractional, 0.0..24.0 — 15:30 is 15.5. Fractional because the hour is
+    /// encoded as an angle, and rounding to the hour would put 14:55 and 15:05
+    /// ten minutes apart on a circle they are five minutes apart on.
+    pub hour: f32,
+    /// 0 = Monday.
+    pub weekday: u32,
+    /// 1-based day of the month.
+    pub day: u32,
+    /// 1-based. Only the display reads it — "like 08.08., 15:04" — but it is
+    /// derived here because this is the one place that knows which zone the
+    /// moment is being read in.
+    pub month: u32,
+    pub days_in_month: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fixed_clock_does_not_move() {
+        assert_eq!(Clock::Fixed(1_000).now(), 1_000);
+        assert_eq!(Clock::Fixed(1_000).now(), 1_000);
+    }
+
+    // 2026-08-21T13:52:00Z is a Friday.
+    const FRIDAY_1352_UTC: i64 = 1_787_320_320;
+
+    #[test]
+    fn an_iana_zone_beats_a_stored_offset() {
+        // Berlin is UTC+2 in August. The offset argument is deliberately
+        // wrong: a zone, when there is one, is the authority.
+        let t = local_time(FRIDAY_1352_UTC, Some("Europe/Berlin"), Some(0));
+        assert_eq!(t.weekday, 4, "Friday");
+        assert!((t.hour - 15.866_666).abs() < 0.001, "15:52, got {}", t.hour);
+    }
+
+    #[test]
+    fn an_offset_answers_when_there_is_no_zone() {
+        let t = local_time(FRIDAY_1352_UTC, None, Some(120));
+        assert!((t.hour - 15.866_666).abs() < 0.001, "got {}", t.hour);
+    }
+
+    #[test]
+    fn an_unknown_zone_falls_back_rather_than_failing() {
+        // A device can send anything. Nothing here may panic on it, and UTC is
+        // the honest answer rather than a guess.
+        let t = local_time(FRIDAY_1352_UTC, Some("Mars/Olympus"), None);
+        assert!((t.hour - 13.866_666).abs() < 0.001, "got {}", t.hour);
+    }
+
+    #[test]
+    fn the_month_is_carried_with_its_length() {
+        let t = local_time(FRIDAY_1352_UTC, Some("UTC"), None);
+        assert_eq!(t.day, 21);
+        assert_eq!(t.month, 8);
+        assert_eq!(t.days_in_month, 31);
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test --lib core::context 2>&1 | tail -20`
+Expected: FAIL — `cannot find function local_time in this scope`.
+
+- [ ] **Step 4: Implement `local_time`**
+
+Add above the `#[cfg(test)]` block in `src/core/context.rs`:
+
+```rust
+/// The device's own reading of `at`.
+///
+/// The zone comes from the client, never from config:
+/// `Intl.DateTimeFormat().resolvedOptions().timeZone` is correct per device and
+/// carries DST with it, which a stored offset cannot. The offset is the fallback
+/// for a browser that reports one and no zone; UTC is the fallback for a row
+/// that has neither, which is every row written before this feature existed.
+/// That last case is not a pretence that the operator lives in London — it is
+/// the only reading available, and §12 leans on it: an old event still carries
+/// a weekday and an hour, and those two blocks are what stand from the first
+/// sweep.
+pub fn local_time(at: i64, tz: Option<&str>, offset_mins: Option<i32>) -> LocalTime {
+    use chrono::{DateTime, Datelike, TimeZone, Timelike};
+
+    let utc = DateTime::from_timestamp(at, 0).unwrap_or_default();
+    let naive = match tz.and_then(|z| z.parse::<chrono_tz::Tz>().ok()) {
+        Some(z) => z.from_utc_datetime(&utc.naive_utc()).naive_local(),
+        None => match offset_mins.and_then(|m| chrono::FixedOffset::east_opt(m * 60)) {
+            Some(o) => o.from_utc_datetime(&utc.naive_utc()).naive_local(),
+            None => utc.naive_utc(),
+        },
+    };
+    LocalTime {
+        hour: naive.hour() as f32 + naive.minute() as f32 / 60.0,
+        weekday: naive.weekday().num_days_from_monday(),
+        day: naive.day(),
+        month: naive.month(),
+        days_in_month: days_in_month(naive.year(), naive.month()),
+    }
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    use chrono::NaiveDate;
+    let (y, m) = if month == 12 { (year + 1, 1) } else { (year, month + 1) };
+    let first = NaiveDate::from_ymd_opt(year, month, 1);
+    let next = NaiveDate::from_ymd_opt(y, m, 1);
+    match (first, next) {
+        (Some(a), Some(b)) => (b - a).num_days() as u32,
+        // Unreachable for a date chrono just produced; 30 rather than a panic,
+        // because a month length is a scaling factor for one block worth 0.0 by
+        // default and nothing here is worth taking a page view down for.
+        _ => 30,
+    }
+}
+```
+
+- [ ] **Step 5: Declare the module and hang the clock on `Core`**
+
+In `src/core/mod.rs`, add `pub mod context;` to the module list at the top
+(alphabetical, between `pub mod ask;` and `pub mod extract;` — after
+`pub mod background;`).
+
+Add to the `Core` struct, just after `pub background: Arc<Background>,`:
+
+```rust
+    /// Where this feature reads the time. `System` in the binary; the
+    /// recommendation tests set a fixed one so a seventh Friday at 14:52
+    /// exists on demand. Nothing else in the tree reads it.
+    pub clock: crate::core::context::Clock,
+```
+
+Add to `Core::from_config`'s literal, beside `background`:
+
+```rust
+            clock: crate::core::context::Clock::System,
+```
+
+Add to `test_support::build`'s literal, in the same place:
+
+```rust
+            clock: crate::core::context::Clock::System,
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --lib core::context 2>&1 | tail -20`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 7: Add `artifacts.updated_at`**
+
+In `src/store/schema.sql`, inside `CREATE TABLE IF NOT EXISTS artifacts`,
+immediately after the `embed_rev` column and its comment (`schema.sql:99-101`):
+
+```sql
+  -- Bumped in the same UPDATE that bumps `embed_rev`. Unrelated to
+  -- recommendation, and the one question the base could not previously answer
+  -- about itself: when did this artifact last change. `created_at` answers when
+  -- it arrived, and `last_verified_at` answers when someone vouched for it;
+  -- neither says whether the text on screen is the text that was captured.
+  updated_at       INTEGER NOT NULL DEFAULT 0,
+```
+
+- [ ] **Step 8: Bump it wherever `embed_rev` is bumped**
+
+Three sites in `src/store/artifacts.rs`. In each, add `updated_at = ?` to the
+`SET` list and bind `super::now()` as the *first* bind (before the existing
+ones), matching each statement's placeholder order.
+
+`reset_embed_state` (`:747`):
+
+```rust
+        sqlx::query(
+            "UPDATE artifacts
+             SET embed_state = 'pending', embed_model = NULL, embed_rev = embed_rev + 1,
+                 updated_at = ?
+             WHERE corpus_id = ?",
+        )
+        .bind(super::now())
+        .bind(corpus_id)
+```
+
+`update_artifact_title` (`:784`):
+
+```rust
+            sqlx::query(
+                "UPDATE artifacts
+                 SET title = ?, embed_state = 'pending', embed_model = NULL,
+                     embed_rev = embed_rev + 1, updated_at = ?
+                 WHERE id = ?",
+            )
+            .bind(title)
+            .bind(super::now())
+            .bind(id)
+```
+
+`update_artifact_text` (`:799`):
+
+```rust
+            sqlx::query(
+                "UPDATE artifacts
+                 SET text = ?, embed_state = 'pending', embed_model = NULL,
+                     embed_rev = embed_rev + 1, updated_at = ?
+                 WHERE id = ?",
+            )
+            .bind(text)
+            .bind(super::now())
+            .bind(id)
+```
+
+- [ ] **Step 9: Write the failing test for the bump**
+
+Append to the existing `mod tests` in `src/store/artifacts.rs`:
+
+```rust
+    #[tokio::test]
+    async fn editing_an_artifact_stamps_when_it_changed() {
+        let store = Store::memory().await.unwrap();
+        let cid = seed_corpus(&store).await;
+        let id = seed_artifact(&store, &cid, "before").await;
+
+        let before: i64 = sqlx::query_scalar("SELECT updated_at FROM artifacts WHERE id = ?")
+            .bind(&id)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+        assert_eq!(before, 0, "a fresh row has never been edited");
+
+        store.update_artifact_text(&id, "after").await.unwrap();
+
+        let after: i64 = sqlx::query_scalar("SELECT updated_at FROM artifacts WHERE id = ?")
+            .bind(&id)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+        assert!(after > 0, "an edit says when it happened");
+    }
+```
+
+If `seed_corpus`/`seed_artifact` helpers do not already exist in that test
+module, read the module's existing tests and use whatever they use to create a
+corpus and an artifact — do not add new helpers.
+
+- [ ] **Step 10: Run it**
+
+Run: `cargo test --lib store::artifacts::tests::editing_an_artifact_stamps_when_it_changed 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 11: Whole suite, then commit**
+
+Run: `cargo fmt && cargo clippy --all-targets 2>&1 | tail -20 && cargo test --lib 2>&1 | tail -20`
+Expected: clean, all pass.
+
+```bash
+git add Cargo.toml Cargo.lock src/core/context.rs src/core/mod.rs \
+        src/store/schema.sql src/store/artifacts.rs
+git commit -m "feat(context): a clock that knows what Friday means, and a stamp for when an artifact changed"
+```
+
+---
+
+### Task 2: Config — `[recommend]`, one gate and a table of numbers
+
+`ROADMAP.md` under `[Core Platform]` already objects to eight gates over one
+faculty. This adds one, and everything else is a number.
+
+**Files:**
+- Modify: `src/config.rs` (new structs, one field on `Config`)
+- Modify: `src/core/mod.rs` (`Core::recommend`, `Core::recommends()`, both builders)
+- Modify: `config.example.toml`
+- Test: in `src/config.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `crate::config::BlockWeights { scope, time_of_day, weekday, weekend, device, viewport, locale, network, power, month_cycle, environment: f32 }` — `Debug + Deserialize + Clone`.
+  - `crate::config::RecommendConfig { enabled: bool, cluster_merge_at: f32, max_clusters: usize, half_life_days: f64, min_weight: f64, strong_at: f32, weak_at: f32, self_weight: f64, weights: BlockWeights }` — `Debug + Deserialize + Clone`.
+  - `impl BlockWeights { pub fn of(&self, block: &str) -> f32 }`
+  - `Core::recommend: RecommendConfig`, `Core::recommends() -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `mod tests` in `src/config.rs`:
+
+```rust
+    #[test]
+    fn the_recommender_ships_off_with_its_weights_named() {
+        let r = RecommendConfig::default();
+        assert!(!r.enabled, "a faculty that learns from a log ships off");
+        // §6: the scope block dominates so a foreign cluster can never win
+        // `max_sim`. When each user has their own collection this goes to 0
+        // and nothing else changes.
+        assert_eq!(r.weights.of("scope"), 10.0);
+        assert_eq!(r.weights.of("weekday"), 1.0);
+        assert_eq!(r.weights.of("month_cycle"), 0.0, "off by default");
+        // A block nobody named contributes nothing rather than a default.
+        assert_eq!(r.weights.of("phase_of_the_moon"), 0.0);
+    }
+
+    #[test]
+    fn a_partial_recommend_table_keeps_the_rest_of_the_defaults() {
+        // `#[serde(default)]` on both structs is what makes an operator able to
+        // move one weight without restating ten.
+        let cfg: RecommendConfig = toml::from_str(
+            "enabled = true\n[weights]\ndevice = 2.5\n",
+        )
+        .unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.weights.of("device"), 2.5);
+        assert_eq!(cfg.weights.of("weekday"), 1.0, "untouched");
+        assert_eq!(cfg.max_clusters, 5, "untouched");
+    }
+```
+
+If `toml` is not already a dev-dependency, use `config::Config::builder()` the
+way the module's neighbouring tests parse a fragment; read them first and match
+whichever they use rather than adding a crate.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib config::tests::the_recommender 2>&1 | tail -20`
+Expected: FAIL — `cannot find type RecommendConfig`.
+
+- [ ] **Step 3: Implement the two structs**
+
+Add to `src/config.rs`, after `SittingConfig`'s `impl Default` (around `:311`):
+
+```rust
+/// What each named block of the context vector is worth.
+///
+/// This is the whole of §6's argument in config form. Each block is normalised
+/// to length 1 and *then* scaled by its weight, so a block contributes exactly
+/// its weight however many dimensions it happens to use — seven one-hot slots
+/// for the weekday do not outweigh two for the hour because there are seven of
+/// them. That is what turns the encoding's implicit weighting, which nobody can
+/// tune, back into named numbers an operator can change.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct BlockWeights {
+    /// Interim, and load-bearing. Every scope shares one collection today, and
+    /// a point's multivector mixes the clusters of everyone who opened that
+    /// artifact — a payload filter cannot help, because it acts on the point
+    /// and not on elements of the set. A dominating `scope` block is what keeps
+    /// a foreign cluster from ever winning `max_sim`. When each user gets their
+    /// own collection this goes to 0 and nothing else changes.
+    pub scope: f32,
+    /// The hour, as an angle. See `encode`.
+    pub time_of_day: f32,
+    pub weekday: f32,
+    /// The part of the weekday that genuinely is gradual, kept apart from the
+    /// one-hot and kept weak.
+    pub weekend: f32,
+    pub device: f32,
+    pub viewport: f32,
+    pub locale: f32,
+    pub network: f32,
+    pub power: f32,
+    pub environment: f32,
+    /// Off. A monthly rhythm is real — rent, invoices — but nothing has shown
+    /// one here yet, and a block at zero costs two dimensions and no reasoning.
+    pub month_cycle: f32,
+}
+
+impl Default for BlockWeights {
+    fn default() -> Self {
+        Self {
+            scope: 10.0,
+            time_of_day: 1.0,
+            weekday: 1.0,
+            weekend: 0.3,
+            device: 0.8,
+            viewport: 0.4,
+            locale: 0.3,
+            network: 0.6,
+            power: 0.2,
+            environment: 0.2,
+            month_cycle: 0.0,
+        }
+    }
+}
+
+impl BlockWeights {
+    /// The weight of a block by name. A name nothing knows is worth nothing,
+    /// rather than a default: the block table and this lookup are edited
+    /// together, and a typo that silently gave a block weight 1.0 would be a
+    /// recommendation nobody could account for.
+    pub fn of(&self, block: &str) -> f32 {
+        match block {
+            "scope" => self.scope,
+            "time_of_day" => self.time_of_day,
+            "weekday" => self.weekday,
+            "weekend" => self.weekend,
+            "device" => self.device,
+            "viewport" => self.viewport,
+            "locale" => self.locale,
+            "network" => self.network,
+            "power" => self.power,
+            "environment" => self.environment,
+            "month_cycle" => self.month_cycle,
+            _ => 0.0,
+        }
+    }
+}
+
+/// Offering an artifact before it is asked for, from the situation the page was
+/// opened in.
+///
+/// One gate and a table of numbers, on purpose: `ROADMAP.md` under
+/// `[Core Platform]` objects to eight gates over one faculty, and this does not
+/// add a ninth. The learning cadence is not here either — see
+/// `jobs::context::INTERVAL_HOURS`.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RecommendConfig {
+    /// Off until there is a base with weeks of situations in it. A weekly
+    /// pattern needs weeks; shipping this on would show the bottom rung of the
+    /// ladder for a fortnight and teach the operator to ignore the area.
+    pub enabled: bool,
+    /// Cosine above which an event joins a cluster rather than opening its own.
+    pub cluster_merge_at: f32,
+    /// Per (scope, artifact). Multiple clusters are the point: a thing looked
+    /// up on Friday afternoons *and* occasionally on Monday mornings is two
+    /// situations, and their mean is a situation that never happened.
+    pub max_clusters: usize,
+    /// A pattern that stops fades rather than standing for ever.
+    pub half_life_days: f64,
+    /// A cluster below this is dropped. Also what protects against the single
+    /// accident: one event never reaches it.
+    pub min_weight: f64,
+    /// Context score (the vector without its `scope` block — see the plan's
+    /// note) at or above which the offer is called a pattern.
+    pub strong_at: f32,
+    /// And above which it is called a resemblance. Below it the ladder falls
+    /// through to the sitting, and then to what has been forgotten.
+    pub weak_at: f32,
+    /// What an open of something this feature offered counts for, back into the
+    /// profile. Zero, because without it the first lucky guess grows into a
+    /// habit the system taught itself.
+    pub self_weight: f64,
+}
+
+impl Default for RecommendConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            cluster_merge_at: 0.82,
+            max_clusters: 5,
+            half_life_days: 45.0,
+            min_weight: 2.0,
+            strong_at: 0.75,
+            weak_at: 0.45,
+            self_weight: 0.0,
+        }
+    }
+}
+```
+
+Note the `weights` field is deliberately *not* in the struct above — add it now,
+as the last field of `RecommendConfig`, so the TOML nests as
+`[recommend.weights]`:
+
+```rust
+    /// See `BlockWeights`.
+    pub weights: BlockWeights,
+```
+
+and in `Default`:
+
+```rust
+            weights: BlockWeights::default(),
+```
+
+- [ ] **Step 4: Wire it into `Config`**
+
+In `src/config.rs`, add to the `Config` struct after `pub sitting: SittingConfig,`:
+
+```rust
+    #[serde(default)]
+    pub recommend: RecommendConfig,
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib config:: 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Hang it on `Core`**
+
+In `src/core/mod.rs`, add to the `Core` struct after `pub sitting: …`:
+
+```rust
+    /// Whether and how the area under the search box is filled. Read by the
+    /// sweep and on the page-view path, so it lives here rather than being
+    /// threaded down.
+    pub recommend: crate::config::RecommendConfig,
+```
+
+In `from_config`'s literal, beside `sitting: cfg.sitting.clone(),`:
+
+```rust
+            recommend: cfg.recommend.clone(),
+```
+
+In `test_support::build`'s literal, beside `sitting: …`:
+
+```rust
+            // Off, like the shipped default. The recommendation tests switch it
+            // on; every other test asserts nothing is offered and nothing is
+            // recorded.
+            recommend: crate::config::RecommendConfig::default(),
+```
+
+Add beside `Core::asks` (around `:303`):
+
+```rust
+    /// Is the area under the search box filled? `false` means the placeholder
+    /// is not rendered, the endpoint records nothing, and the sweep does not
+    /// run — one gate, in one place.
+    pub fn recommends(&self) -> bool {
+        self.recommend.enabled
+    }
+```
+
+- [ ] **Step 7: Document it in `config.example.toml`**
+
+Append after the `[pursuit]` block (`config.example.toml:474-482`):
+
+```toml
+# ── A recommendation under the search box ────────────────────────────────────
+# The area under the search box, filled from the situation the page was opened
+# in: the time zone and local time the browser reports, the device, the
+# viewport, the network, the battery. A sweep learns which situations recur for
+# which artifact; a page view is one vector query against what it learned. No
+# model call and no embedding on this path, ever.
+#
+# Off until there is a base with weeks of situations in it — a weekly pattern
+# needs weeks, and until then every offer would sit on the bottom rung.
+[recommend]
+enabled = false
+# Cosine above which an event joins a cluster rather than opening its own.
+cluster_merge_at = 0.82
+# Situations kept per artifact, per person. More than one is the point: a thing
+# looked up on Friday afternoons and occasionally on Monday mornings is two
+# situations, and their mean is a situation that never happened.
+max_clusters = 5
+# A pattern that stops fades rather than standing for ever.
+half_life_days = 45.0
+# A cluster lighter than this is dropped. Also what protects against the single
+# accident: one event never reaches it.
+min_weight = 2.0
+# Score at or above which the offer is called a pattern, and above which it is
+# called a resemblance. Below the second, the ladder falls through to what this
+# sitting has touched, and then to what has been forgotten. Scored without the
+# `scope` block, which decides *who* may be offered something rather than how
+# well the situation matches.
+strong_at = 0.75
+weak_at = 0.45
+# What an open of something this offered counts for, back into the profile.
+# Zero: without it, the first lucky guess grows into a habit the system taught
+# itself.
+self_weight = 0.0
+
+# What each named block of the situation is worth. Each block is normalised to
+# length 1 and then scaled by its weight, so a block contributes exactly its
+# weight however many dimensions it uses — seven one-hot slots for the weekday
+# do not outweigh two for the hour because there are seven of them.
+[recommend.weights]
+# Interim, and load-bearing: every person shares one collection today, so this
+# is what keeps one person's situations from being offered to another. It goes
+# to 0 when each user has their own collection.
+scope = 10.0
+# The hour, as an angle — 23:30 and 00:30 are an hour apart, and 14:55 against a
+# 15:00 pattern costs almost nothing.
+time_of_day = 1.0
+# One-hot, because "Friday is three from Tuesday" means nothing and the pattern
+# is exactly Friday.
+weekday = 1.0
+# The part of the weekday that genuinely is gradual, kept separate and weak.
+weekend = 0.3
+device = 0.8
+viewport = 0.4
+locale = 0.3
+network = 0.6
+power = 0.2
+environment = 0.2
+# Off. A monthly rhythm is real, but nothing has shown one here yet.
+month_cycle = 0.0
+```
+
+- [ ] **Step 8: Verify the example file still parses**
+
+Run: `cargo test --lib config:: 2>&1 | tail -20`
+Expected: PASS. (`src/config.rs` has a test that loads `config.example.toml`; if
+it does not, run `cargo run -- --help` after pointing `ENGRAM_CONFIG` at the
+example to confirm it loads.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/config.rs src/core/mod.rs config.example.toml
+git commit -m "feat(recommend): one gate over the offer, and every weight it rests on named"
+```
+
+---
+
+### Task 3: Two tables and the store that reads them
+
+`context_events` holds the bundle **whole**, including fields the encoder does
+not read today. That is what makes §6's versioning cheap: a new block is a
+reindex plus a sweep, not the loss of history.
+
+**Files:**
+- Modify: `src/store/schema.sql` (two tables, two indexes, at the end of the feedback section)
+- Create: `src/store/context.rs`
+- Modify: `src/store/mod.rs` (module declaration)
+- Test: in `src/store/context.rs`
+
+**Interfaces:**
+- Consumes: `crate::store::feedback::{blob_to_vec, vec_to_blob}`.
+- Produces:
+  - `pub struct ContextEvent { pub id: i64, pub scope: Option<String>, pub at: i64, pub bundle: String, pub device_key: Option<String>, pub local_hour: Option<i64>, pub weekday: Option<i64>, pub tz: Option<String> }`
+  - `pub struct StoredCluster { pub scope: Option<String>, pub artifact_id: String, pub slot: i64, pub centroid: Vec<f32>, pub weight: f64, pub last_at: i64, pub encoder_version: i64, pub representative: String }`
+  - `pub const RETAIN_DAYS: i64 = 400;`
+  - `Store::record_context(&self, ev: &ContextEvent) -> Result<i64>` (the `id` on the argument is ignored; the row's own is returned)
+  - `Store::context_events_since(&self, since: i64) -> Result<Vec<ContextEvent>>` — oldest first
+  - `Store::expire_context_events(&self, retain_days: i64) -> Result<u64>`
+  - `Store::replace_context_clusters(&self, artifact_id: &str, clusters: &[StoredCluster]) -> Result<()>`
+  - `Store::context_clusters_of(&self, artifact_ids: &[String]) -> Result<HashMap<String, Vec<StoredCluster>>>`
+
+- [ ] **Step 1: Add the tables**
+
+In `src/store/schema.sql`, after the `interaction_events` index
+(`schema.sql:476`) and before the `pursuits` comment block:
+
+```sql
+-- ── The situation a page view happened in ────────────────────────────────────
+-- Joined to `search_events` and `interaction_events` through `scope` and `at`,
+-- never through a stored id — the same rule `interaction_events` states just
+-- above for pursuits. The clustering decides what belongs together, and
+-- re-clustering never has to rewrite these.
+CREATE TABLE IF NOT EXISTS context_events (
+  id          INTEGER PRIMARY KEY,
+  scope       TEXT,
+  at          INTEGER NOT NULL,
+  -- The whole bundle as received, including fields the encoder ignores. That
+  -- is what makes a new block cheap: a reindex plus a sweep, rather than the
+  -- loss of every situation recorded before it existed.
+  bundle      TEXT NOT NULL,
+  -- Hash over the stable fields only: platform, UA family, screen dimensions,
+  -- hardwareConcurrency, deviceMemory, language. Not canvas, WebGL or fonts —
+  -- those are what identify a device across a population, and here the
+  -- population is one authenticated person, so they are constant and say
+  -- nothing about *which situation* this is. They are also randomised per
+  -- session and origin by a hardened browser, so every day would look like a
+  -- new device.
+  device_key  TEXT,
+  -- Denormalised because the sweep reads them on every row.
+  local_hour  INTEGER,
+  weekday     INTEGER,
+  tz          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_context_scope_at ON context_events(scope, at);
+
+-- The situations one artifact is opened in, agglomerated. The centroids
+-- themselves live in the vector store as the `ctx` multivector; this is the
+-- bookkeeping, for two reasons: Qdrant holds numbers and cannot produce a
+-- reason, and this table survives a `--reindex` while the vectors are rewritten.
+CREATE TABLE IF NOT EXISTS context_clusters (
+  id              INTEGER PRIMARY KEY,
+  scope           TEXT,
+  artifact_id     TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- Position of this centroid within the point's `ctx` multivector. Unique per
+  -- artifact and NOT per (scope, artifact): the multivector is one array on one
+  -- point, shared by every scope that has opened this artifact, so a slot
+  -- numbered per scope would have two owners writing index 0.
+  slot            INTEGER NOT NULL,
+  centroid        BLOB NOT NULL,
+  weight          REAL NOT NULL,
+  last_at         INTEGER NOT NULL,
+  -- What layout `centroid` was written under. A reader that does not recognise
+  -- it skips the cluster rather than explaining a hit with the wrong blocks.
+  encoder_version INTEGER NOT NULL,
+  -- The member nearest the centroid, as `{"at": <unix>, "bundle": {…}}` — what
+  -- the display quotes. The stamp is carried with it because a bundle does not
+  -- contain one and the line says "like 08.08., 15:04".
+  representative  TEXT NOT NULL,
+  UNIQUE (artifact_id, slot)
+);
+CREATE INDEX IF NOT EXISTS idx_context_clusters_artifact ON context_clusters(artifact_id);
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/store/context.rs`:
+
+```rust
+//! What situation a page view happened in, and what the sweep made of them.
+//!
+//! Two tables with one rule between them: nothing here is joined by a stored
+//! id. A context event is matched to an open through `scope` and `at`, the way
+//! `interaction_events` is matched to a pursuit — so re-clustering never has to
+//! rewrite a row, and a sweep run under a new encoder starts from the raw
+//! bundles rather than from what the last one concluded.
+
+use super::{Store, now};
+use crate::error::Result;
+use crate::store::feedback::{blob_to_vec, vec_to_blob};
+use sqlx::Row;
+use std::collections::HashMap;
+
+/// How long a situation is kept.
+///
+/// Not `feedback.retain_days`, and not a setting. A weekly pattern needs weeks
+/// and a monthly one needs months, so the window this feature needs is not the
+/// window an operator sets for their query log — and it is longer than either
+/// default. Housekeeping about how long the base may remember a Friday
+/// afternoon is not a preference; it is what the feature costs to work at all.
+pub const RETAIN_DAYS: i64 = 400;
+
+/// One page view, as the browser described it.
+#[derive(Debug, Clone, Default)]
+pub struct ContextEvent {
+    pub id: i64,
+    pub scope: Option<String>,
+    pub at: i64,
+    /// The bundle as received, JSON.
+    pub bundle: String,
+    pub device_key: Option<String>,
+    pub local_hour: Option<i64>,
+    pub weekday: Option<i64>,
+    pub tz: Option<String>,
+}
+
+/// One learned situation, as SQLite holds it.
+#[derive(Debug, Clone)]
+pub struct StoredCluster {
+    pub scope: Option<String>,
+    pub artifact_id: String,
+    pub slot: i64,
+    pub centroid: Vec<f32>,
+    pub weight: f64,
+    pub last_at: i64,
+    pub encoder_version: i64,
+    pub representative: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(scope: &str, at: i64) -> ContextEvent {
+        ContextEvent {
+            id: 0,
+            scope: Some(scope.into()),
+            at,
+            bundle: r#"{"tz":"Europe/Berlin"}"#.into(),
+            device_key: Some("phone".into()),
+            local_hour: Some(15),
+            weekday: Some(4),
+            tz: Some("Europe/Berlin".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_recorded_situation_comes_back_whole() {
+        let store = Store::memory().await.unwrap();
+        store.record_context(&event("alice", 1_000)).await.unwrap();
+
+        let out = store.context_events_since(0).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].scope.as_deref(), Some("alice"));
+        assert_eq!(out[0].bundle, r#"{"tz":"Europe/Berlin"}"#);
+        assert_eq!(out[0].weekday, Some(4));
+        assert!(out[0].id > 0, "the row's own id, not the argument's");
+    }
+
+    #[tokio::test]
+    async fn situations_come_back_oldest_first() {
+        let store = Store::memory().await.unwrap();
+        for at in [3_000, 1_000, 2_000] {
+            store.record_context(&event("alice", at)).await.unwrap();
+        }
+        let ats: Vec<i64> = store
+            .context_events_since(0)
+            .await
+            .unwrap()
+            .iter()
+            .map(|e| e.at)
+            .collect();
+        assert_eq!(ats, vec![1_000, 2_000, 3_000]);
+    }
+
+    #[tokio::test]
+    async fn expiry_uses_this_features_own_window() {
+        let store = Store::memory().await.unwrap();
+        let day = 86_400;
+        store.record_context(&event("alice", now() - 500 * day)).await.unwrap();
+        store.record_context(&event("alice", now() - 10 * day)).await.unwrap();
+
+        let dropped = store.expire_context_events(RETAIN_DAYS).await.unwrap();
+        assert_eq!(dropped, 1);
+        assert_eq!(store.context_events_since(0).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn clusters_are_replaced_wholesale_not_merged() {
+        // The sweep is a full rebuild per artifact. A write that merged would
+        // leave a slot from a previous encoder standing beside fresh ones, and
+        // the multivector written from them would not match the table.
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 3.0), cluster(&aid, 1, 2.0)])
+            .await
+            .unwrap();
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 9.0)])
+            .await
+            .unwrap();
+
+        let back = store.context_clusters_of(&[aid.clone()]).await.unwrap();
+        let mine = &back[&aid];
+        assert_eq!(mine.len(), 1, "slot 1 is gone, not stale");
+        assert_eq!(mine[0].weight, 9.0);
+    }
+
+    #[tokio::test]
+    async fn a_centroid_survives_the_round_trip() {
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+        let mut c = cluster(&aid, 0, 1.0);
+        c.centroid = vec![0.5, -0.25, 0.125];
+        store.replace_context_clusters(&aid, &[c]).await.unwrap();
+
+        let back = store.context_clusters_of(&[aid.clone()]).await.unwrap();
+        assert_eq!(back[&aid][0].centroid, vec![0.5, -0.25, 0.125]);
+    }
+
+    #[tokio::test]
+    async fn an_artifact_with_no_clusters_is_absent_rather_than_empty() {
+        // The read path asks for the ten ids the store returned and expects to
+        // learn which of them it knows nothing about.
+        let store = Store::memory().await.unwrap();
+        let back = store
+            .context_clusters_of(&["nobody".to_string()])
+            .await
+            .unwrap();
+        assert!(back.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleting_an_artifact_takes_its_situations_with_it() {
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 1.0)])
+            .await
+            .unwrap();
+
+        sqlx::query("DELETE FROM artifacts WHERE id = ?")
+            .bind(&aid)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let back = store.context_clusters_of(&[aid]).await.unwrap();
+        assert!(back.is_empty(), "ON DELETE CASCADE");
+    }
+
+    fn cluster(artifact_id: &str, slot: i64, weight: f64) -> StoredCluster {
+        StoredCluster {
+            scope: Some("alice".into()),
+            artifact_id: artifact_id.into(),
+            slot,
+            centroid: vec![1.0, 0.0],
+            weight,
+            last_at: 1_000,
+            encoder_version: 1,
+            representative: r#"{"at":1000,"bundle":{}}"#.into(),
+        }
+    }
+
+    /// A corpus and one artifact in it, because `context_clusters.artifact_id`
+    /// is a foreign key and SQLite enforces it.
+    async fn seed_artifact(store: &Store) -> String {
+        let cid = crate::store::new_id();
+        sqlx::query(
+            "INSERT INTO corpora (id, title, text, status, created_at)
+             VALUES (?, 'c', 't', 'ready', 0)",
+        )
+        .bind(&cid)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        let aid = crate::store::new_id();
+        sqlx::query(
+            "INSERT INTO artifacts (id, corpus_id, ordinal, text, created_at)
+             VALUES (?, ?, 0, 'a', 0)",
+        )
+        .bind(&aid)
+        .bind(&cid)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        aid
+    }
+}
+```
+
+Before running: open `src/store/corpora.rs` and confirm the `corpora` column
+names used in `seed_artifact` match the real schema (`schema.sql:15-43`). Fix
+the two INSERTs to match rather than changing the schema.
+
+- [ ] **Step 3: Declare the module and run the tests to verify they fail**
+
+In `src/store/mod.rs`, add `pub mod context;` to the module list (alphabetical,
+after `pub mod corpora;`... place it before `corpora` so the list stays sorted).
+
+Run: `cargo test --lib store::context 2>&1 | tail -30`
+Expected: FAIL — `no method named record_context`.
+
+- [ ] **Step 4: Implement the store**
+
+Insert between the `StoredCluster` definition and `#[cfg(test)]`:
+
+```rust
+impl Store {
+    /// Record one page view's situation. Returns the row's own id.
+    pub async fn record_context(&self, ev: &ContextEvent) -> Result<i64> {
+        let res = sqlx::query(
+            "INSERT INTO context_events
+                 (scope, at, bundle, device_key, local_hour, weekday, tz)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&ev.scope)
+        .bind(ev.at)
+        .bind(&ev.bundle)
+        .bind(&ev.device_key)
+        .bind(ev.local_hour)
+        .bind(ev.weekday)
+        .bind(&ev.tz)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.last_insert_rowid())
+    }
+
+    /// Every situation recorded at or after `since`, oldest first.
+    ///
+    /// Unbounded on purpose, and bounded in practice by `RETAIN_DAYS`: the one
+    /// caller is the sweep, which rebuilds every profile from the raw bundles
+    /// and therefore needs all of them. Paging it would mean holding a cursor
+    /// across a rebuild that is only correct when it sees the whole window.
+    pub async fn context_events_since(&self, since: i64) -> Result<Vec<ContextEvent>> {
+        let rows = sqlx::query(
+            "SELECT id, scope, at, bundle, device_key, local_hour, weekday, tz
+               FROM context_events
+              WHERE at >= ?
+              ORDER BY at, id",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| ContextEvent {
+                id: r.get("id"),
+                scope: r.get("scope"),
+                at: r.get("at"),
+                bundle: r.get("bundle"),
+                device_key: r.get("device_key"),
+                local_hour: r.get("local_hour"),
+                weekday: r.get("weekday"),
+                tz: r.get("tz"),
+            })
+            .collect())
+    }
+
+    /// Drop situations past keeping. See `RETAIN_DAYS`.
+    pub async fn expire_context_events(&self, retain_days: i64) -> Result<u64> {
+        let cutoff = now() - retain_days * 86_400;
+        Ok(sqlx::query("DELETE FROM context_events WHERE at < ?")
+            .bind(cutoff)
+            .execute(&self.pool)
+            .await?
+            .rows_affected())
+    }
+
+    /// Replace everything this artifact has learned, in one transaction.
+    ///
+    /// Wholesale, never merged. The sweep rebuilds a profile from the raw
+    /// bundles every run, so a merge would leave a slot from a previous run
+    /// standing beside fresh ones — and the multivector written from the fresh
+    /// ones would then not match the table the reason is read out of. An empty
+    /// list is a clear, which is what an artifact whose every cluster fell
+    /// below `min_weight` needs.
+    pub async fn replace_context_clusters(
+        &self,
+        artifact_id: &str,
+        clusters: &[StoredCluster],
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM context_clusters WHERE artifact_id = ?")
+            .bind(artifact_id)
+            .execute(&mut *tx)
+            .await?;
+        for c in clusters {
+            sqlx::query(
+                "INSERT INTO context_clusters
+                     (scope, artifact_id, slot, centroid, weight, last_at,
+                      encoder_version, representative)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&c.scope)
+            .bind(artifact_id)
+            .bind(c.slot)
+            .bind(vec_to_blob(&c.centroid))
+            .bind(c.weight)
+            .bind(c.last_at)
+            .bind(c.encoder_version)
+            .bind(&c.representative)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// What these artifacts have learned, keyed by artifact, in slot order.
+    /// Ids with no clusters are absent from the answer rather than present and
+    /// empty — the read path asks for the ten the vector store returned and
+    /// needs to know which of them it can say nothing about.
+    pub async fn context_clusters_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<HashMap<String, Vec<StoredCluster>>> {
+        if artifact_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        // Built by hand because sqlx has no list binding for SQLite. The values
+        // are bound, never spliced; only the placeholders are generated.
+        let marks = std::iter::repeat_n("?", artifact_ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT scope, artifact_id, slot, centroid, weight, last_at,
+                    encoder_version, representative
+               FROM context_clusters
+              WHERE artifact_id IN ({marks})
+              ORDER BY artifact_id, slot"
+        );
+        let mut q = sqlx::query(&sql);
+        for id in artifact_ids {
+            q = q.bind(id);
+        }
+        let mut out: HashMap<String, Vec<StoredCluster>> = HashMap::new();
+        for r in q.fetch_all(&self.pool).await? {
+            let artifact_id: String = r.get("artifact_id");
+            out.entry(artifact_id.clone())
+                .or_default()
+                .push(StoredCluster {
+                    scope: r.get("scope"),
+                    artifact_id,
+                    slot: r.get("slot"),
+                    centroid: blob_to_vec(&r.get::<Vec<u8>, _>("centroid")),
+                    weight: r.get("weight"),
+                    last_at: r.get("last_at"),
+                    encoder_version: r.get("encoder_version"),
+                    representative: r.get("representative"),
+                });
+        }
+        Ok(out)
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib store::context 2>&1 | tail -30`
+Expected: PASS, 7 tests.
+
+If `deleting_an_artifact_takes_its_situations_with_it` fails, foreign keys are
+off on the test pool — check `Store::memory` for `PRAGMA foreign_keys` and
+follow whatever the other cascade tests in the tree do rather than changing the
+pragma.
+
+- [ ] **Step 6: Trim the log on its own window**
+
+In `src/jobs/retention.rs`, add a third field to `Report`:
+
+```rust
+    /// Situations dropped for being past `store::context::RETAIN_DAYS`.
+    pub contexts: u64,
+```
+
+and a third pass in `run`, after the gaps block and before the closing comment:
+
+```rust
+    // Its own window, and behind no key. §4: a weekly pattern needs weeks, and
+    // `feedback.retain_days` defaults to keeping for ever but is an operator
+    // switch — an operator who shortens their query log is not asking the base
+    // to forget what Friday afternoon looks like. Runs whenever this unit runs,
+    // which is why `periodic_units` now also arms it for `recommend.enabled`.
+    match core
+        .store
+        .expire_context_events(crate::store::context::RETAIN_DAYS)
+        .await
+    {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(dropped = n, "expired recorded situations");
+            }
+            report.contexts = n;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "could not expire recorded situations");
+            failure.get_or_insert(e);
+        }
+    }
+```
+
+In `src/core/background.rs`, extend the `Retention` gate (`background.rs:122`):
+
+```rust
+    if core.feedback.retain_days > 0 || core.feedback.enabled || core.recommends() {
+        out.push((Stage::Retention, CONSOLIDATE_TARGET));
+    }
+```
+
+- [ ] **Step 7: Run the retention tests, then the whole suite**
+
+Run: `cargo test --lib jobs::retention core::background 2>&1 | tail -20`
+Expected: PASS.
+
+Run: `cargo fmt && cargo clippy --all-targets 2>&1 | tail -20 && cargo test --lib 2>&1 | tail -10`
+Expected: clean, all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/store/schema.sql src/store/context.rs src/store/mod.rs \
+        src/jobs/retention.rs src/core/background.rs
+git commit -m "feat(context): where a situation is written down, and how long it is kept"
+```
+
+---
+
+### Task 4: The encoder
+
+A bundle becomes a fixed-length `f32` vector composed of named blocks. **Each
+block is normalised to length 1, then scaled by its weight.** That one rule is
+what makes the weights real numbers an operator can change instead of an
+accident of how many dimensions a block happens to use.
+
+**Files:**
+- Modify: `src/core/context.rs` (everything below `local_time`)
+- Test: in `src/core/context.rs`
+
+**Interfaces:**
+- Consumes: `crate::config::BlockWeights`, `crate::core::context::{LocalTime, local_time}`, `crate::vector::cosine`.
+- Produces:
+  - `pub const CTX_DIM: usize = 53;`
+  - `pub const SCOPE_DIMS: usize = 8;` — the leading block, sliced off when scoring a rung.
+  - `pub const ENCODER_VERSION: i64 = 1;`
+  - `pub struct Block { pub name: &'static str, pub label: &'static str, pub at: usize, pub dims: usize }`
+  - `pub const BLOCKS: [Block; 11]`
+  - `pub struct Bundle { … }` — `Default + Clone + Debug + Serialize + Deserialize`, every field optional
+  - `pub fn parse_bundle(raw: &str) -> Bundle`
+  - `pub fn device_key(b: &Bundle) -> Option<String>`
+  - `pub fn encode(at: i64, scope: Option<&str>, b: &Bundle, w: &BlockWeights) -> Vec<f32>`
+  - `pub fn contributions(now: &[f32], cluster: &[f32], w: &BlockWeights) -> Vec<(&'static str, f32)>` — descending, `scope` excluded
+  - `pub fn context_score(now: &[f32], cluster: &[f32]) -> f32` — cosine over the vector with `scope` sliced off
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `mod tests` block in `src/core/context.rs` (the one Task 1
+created):
+
+```rust
+    fn weights() -> crate::config::BlockWeights {
+        crate::config::BlockWeights::default()
+    }
+
+    /// A bundle a phone in Berlin would send.
+    fn phone() -> Bundle {
+        Bundle {
+            tz: Some("Europe/Berlin".into()),
+            tz_offset_mins: Some(120),
+            language: Some("de-DE".into()),
+            viewport_w: Some(390.0),
+            viewport_h: Some(844.0),
+            screen_w: Some(390.0),
+            screen_h: Some(844.0),
+            dpr: Some(3.0),
+            color_scheme: Some("dark".into()),
+            platform: Some("Android".into()),
+            ua_family: Some("Chrome".into()),
+            cores: Some(8.0),
+            memory_gb: Some(4.0),
+            touch: Some(true),
+            orientation: Some("portrait".into()),
+            battery_level: Some(0.4),
+            charging: Some(false),
+            network: Some("cellular".into()),
+            audio_outputs: Some(1),
+            ..Default::default()
+        }
+    }
+
+    fn slice_of<'a>(v: &'a [f32], name: &str) -> &'a [f32] {
+        let b = BLOCKS.iter().find(|b| b.name == name).unwrap();
+        &v[b.at..b.at + b.dims]
+    }
+
+    fn norm(v: &[f32]) -> f32 {
+        v.iter().map(|x| x * x).sum::<f32>().sqrt()
+    }
+
+    // 2026-08-21T13:52:00Z, a Friday. 15:52 in Berlin.
+    const FRIDAY: i64 = 1_787_320_320;
+
+    #[test]
+    fn the_layout_adds_up() {
+        // The one invariant everything else rests on: a block that overlaps its
+        // neighbour would silently mix two meanings into one dimension, and
+        // every recommendation after it would be explained by the wrong block.
+        let mut at = 0;
+        for b in BLOCKS {
+            assert_eq!(b.at, at, "{} starts where the last block ended", b.name);
+            at += b.dims;
+        }
+        assert_eq!(at, CTX_DIM);
+        assert_eq!(BLOCKS[0].name, "scope");
+        assert_eq!(BLOCKS[0].dims, SCOPE_DIMS);
+    }
+
+    #[test]
+    fn half_past_eleven_at_night_is_near_half_past_midnight() {
+        // The hour is a circle, so the two are an hour apart rather than
+        // twenty-three. A one-hot hour would have called them maximally
+        // different, which is the whole reason this block is an angle.
+        let late = encode(FRIDAY - 2 * 3600 - 22 * 60, None, &phone(), &weights());
+        let early = encode(FRIDAY - 3600 - 22 * 60, None, &phone(), &weights());
+        let c = crate::vector::cosine(slice_of(&late, "time_of_day"), slice_of(&early, "time_of_day"));
+        assert!(c > 0.96, "23:30 against 00:30 scored {c}");
+    }
+
+    #[test]
+    fn five_past_three_costs_almost_nothing_against_a_three_o_clock_pattern() {
+        let at_three = encode(FRIDAY - 52 * 60, None, &phone(), &weights());
+        let five_past = encode(FRIDAY - 47 * 60, None, &phone(), &weights());
+        let c = crate::vector::cosine(
+            slice_of(&at_three, "time_of_day"),
+            slice_of(&five_past, "time_of_day"),
+        );
+        assert!(c > 0.999, "15:00 against 15:05 scored {c}");
+    }
+
+    #[test]
+    fn a_seven_slot_block_contributes_exactly_its_weight() {
+        // The rule the whole design rests on. Seven one-hot slots for the
+        // weekday do not outweigh two for the hour because there are seven of
+        // them: each block is normalised and *then* scaled.
+        let v = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let w = weights();
+        assert!((norm(slice_of(&v, "weekday")) - w.weekday).abs() < 1e-5);
+        assert!((norm(slice_of(&v, "time_of_day")) - w.time_of_day).abs() < 1e-5);
+        assert!((norm(slice_of(&v, "scope")) - w.scope).abs() < 1e-5);
+    }
+
+    #[test]
+    fn a_block_switched_off_contributes_nothing() {
+        let mut w = weights();
+        w.month_cycle = 0.0;
+        let v = encode(FRIDAY, None, &phone(), &w);
+        assert_eq!(norm(slice_of(&v, "month_cycle")), 0.0);
+    }
+
+    #[test]
+    fn a_missing_value_zeroes_its_block_rather_than_inventing_a_default() {
+        // The Battery API does not exist on the desktop. An invented default
+        // would manufacture similarity between every desktop and every phone
+        // that happened to sit at that level.
+        let mut b = phone();
+        b.battery_level = None;
+        b.charging = None;
+        let v = encode(FRIDAY, None, &b, &weights());
+        assert_eq!(norm(slice_of(&v, "power")), 0.0, "power says nothing");
+        assert!(norm(slice_of(&v, "weekday")) > 0.0, "and nothing else changed");
+    }
+
+    #[test]
+    fn a_block_that_says_nothing_scores_zero_rather_than_opposed() {
+        // Two desktops with no battery must not read as *agreeing* about the
+        // battery, and must not read as disagreeing either. `cosine` returns
+        // 0.0 for a zero vector, which is the answer that means "no opinion".
+        let mut b = phone();
+        b.battery_level = None;
+        b.charging = None;
+        let v = encode(FRIDAY, None, &b, &weights());
+        let c = contributions(&v, &v, &weights());
+        let power = c.iter().find(|(n, _)| *n == "power").unwrap();
+        assert_eq!(power.1, 0.0);
+    }
+
+    #[test]
+    fn an_unidentifiable_device_is_a_state_rather_than_an_absence() {
+        // Unlike the battery, "this browser tells us nothing about itself" is
+        // itself stable and recurring, so it gets a slot of its own — a
+        // hardened browser is a situation, not a gap.
+        let bare = Bundle::default();
+        assert!(device_key(&bare).is_none());
+        let v = encode(FRIDAY, None, &bare, &weights());
+        assert!((norm(slice_of(&v, "device")) - weights().device).abs() < 1e-5);
+    }
+
+    #[test]
+    fn a_device_key_is_stable_and_ignores_the_situation() {
+        // It hashes what the machine *is*, never what it is doing: a phone that
+        // rotates or unplugs is the same phone. A key that moved would make
+        // every session look like a new device and no pattern could ever form.
+        let mut later = phone();
+        later.orientation = Some("landscape".into());
+        later.battery_level = Some(0.9);
+        later.viewport_w = Some(844.0);
+        assert_eq!(device_key(&phone()), device_key(&later));
+
+        let mut other = phone();
+        other.platform = Some("macOS".into());
+        assert_ne!(device_key(&phone()), device_key(&other));
+    }
+
+    #[test]
+    fn two_people_in_the_same_situation_are_still_far_apart() {
+        // §11: until each person has their own collection, the `scope` block is
+        // the only thing keeping one person's situations from being offered to
+        // another. It is load-bearing and this is the test that says so.
+        let alice = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let bob = encode(FRIDAY, Some("bob"), &phone(), &weights());
+        let same = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        assert!(
+            crate::vector::cosine(&alice, &bob) < crate::vector::cosine(&alice, &same),
+            "a foreign scope must never win max_sim"
+        );
+    }
+
+    #[test]
+    fn the_rung_is_scored_without_the_scope_block() {
+        // The scope block decides *who* may be offered something. If it counted
+        // towards the rung too, it would drag every same-scope score above 0.95
+        // and `strong_at` and `weak_at` would have to live four hundredths
+        // apart. Two different jobs, two different scales.
+        let friday_phone = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let mut desktop = phone();
+        desktop.platform = Some("macOS".into());
+        desktop.touch = Some(false);
+        desktop.network = Some("wired".into());
+        desktop.battery_level = None;
+        desktop.charging = None;
+        // A Monday morning at a desk: nothing about the situation agrees.
+        let monday_desk = encode(FRIDAY + 3 * 86_400 - 8 * 3600, Some("alice"), &desktop, &weights());
+
+        assert!(crate::vector::cosine(&friday_phone, &monday_desk) > 0.9, "scope alone");
+        assert!(
+            context_score(&friday_phone, &monday_desk) < 0.4,
+            "and the situation does not agree at all"
+        );
+    }
+
+    #[test]
+    fn the_reason_names_the_blocks_that_decided_it() {
+        let a = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let c = contributions(&a, &a, &weights());
+        assert!(!c.iter().any(|(n, _)| *n == "scope"), "scope explains nothing");
+        assert_eq!(c.len(), BLOCKS.len() - 1);
+        for pair in c.windows(2) {
+            assert!(pair[0].1 >= pair[1].1, "sorted, so the top three are the top three");
+        }
+        // Every block carries a `&'static str` and nothing generates prose.
+        assert!(BLOCKS.iter().all(|b| !b.label.is_empty()));
+    }
+
+    #[test]
+    fn a_bundle_that_is_not_json_is_an_empty_one_rather_than_an_error() {
+        // The bundle comes from a browser, and nothing a browser sends may take
+        // a page view down. An empty bundle zeroes the blocks it would have
+        // filled; the weekday and the hour still stand.
+        let b = parse_bundle("}{ not json");
+        assert!(b.tz.is_none());
+        let v = encode(FRIDAY, Some("alice"), &b, &weights());
+        assert_eq!(v.len(), CTX_DIM);
+        assert!(norm(slice_of(&v, "weekday")) > 0.0);
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib core::context 2>&1 | tail -20`
+Expected: FAIL — `cannot find value BLOCKS in this scope`.
+
+- [ ] **Step 3: Write the block table and the bundle**
+
+Add to `src/core/context.rs`, above the `#[cfg(test)]` block:
+
+```rust
+/// One named span of the context vector.
+///
+/// Named because the explanation falls out of the naming: each block is scored
+/// separately at read time, so "weekday, hour, device" is three lookups in this
+/// table rather than three sentences somebody had to write. A new block brings
+/// its label and is done.
+#[derive(Debug, Clone, Copy)]
+pub struct Block {
+    /// The config key its weight is read under. See `BlockWeights::of`.
+    pub name: &'static str,
+    /// What the line under the offer prints. No sentences and no values in
+    /// prose — generated prose per block was the first draft and was cut,
+    /// because it coupled every new dimension to a sentence template.
+    pub label: &'static str,
+    pub at: usize,
+    pub dims: usize,
+}
+
+/// The layout, in order. `scope` leads because `context_score` slices it off by
+/// taking everything after it, which only works while it is first.
+///
+/// Circular where there is a circle, one-hot where there is not. The hour is a
+/// circle, so 23:30 and 00:30 are an hour apart. The weekday is *not* a useful
+/// circle — "Friday is three from Tuesday" means nothing, and the pattern is
+/// exactly Friday — so it is one-hot, with a separate weak weekday/weekend
+/// block for the part that genuinely is gradual.
+pub const BLOCKS: [Block; 11] = [
+    Block { name: "scope",        label: "who",           at: 0,  dims: 8 },
+    Block { name: "time_of_day",  label: "hour",          at: 8,  dims: 2 },
+    Block { name: "weekday",      label: "weekday",       at: 10, dims: 7 },
+    Block { name: "weekend",      label: "weekend",       at: 17, dims: 2 },
+    Block { name: "device",       label: "device",        at: 19, dims: 8 },
+    Block { name: "viewport",     label: "screen",        at: 27, dims: 4 },
+    Block { name: "locale",       label: "language",      at: 31, dims: 8 },
+    Block { name: "network",      label: "network",       at: 39, dims: 4 },
+    Block { name: "power",        label: "battery",       at: 43, dims: 3 },
+    Block { name: "environment",  label: "surroundings",  at: 46, dims: 5 },
+    Block { name: "month_cycle",  label: "month",         at: 51, dims: 2 },
+];
+
+/// Fixed at collection creation, so a new block invalidates every stored
+/// centroid. That is what `ENCODER_VERSION` and §4's whole-bundle storage are
+/// for: the sweep rebuilds from the raw bundles rather than losing the history.
+pub const CTX_DIM: usize = 53;
+
+/// The width of the leading `scope` block. See `context_score`.
+pub const SCOPE_DIMS: usize = 8;
+
+/// Bumped whenever `BLOCKS` changes in any way — a width, an order, or what a
+/// slot means. A stored cluster carrying a different one is skipped by the read
+/// path and rebuilt by the next sweep; explaining a hit with the wrong block is
+/// worse than explaining nothing.
+pub const ENCODER_VERSION: i64 = 1;
+
+/// What the browser said about the situation, as received.
+///
+/// Every field optional, because every field is optional in a browser: the
+/// Battery API does not exist on the desktop, `connection` is Chromium-only,
+/// and a hardened browser withholds several. Absent is not zero — see `encode`.
+///
+/// Deliberately **not** collected: canvas, WebGL, font enumeration, plugin
+/// lists. Not out of squeamishness — they are the wrong tool. Those are what
+/// identify a device across a population, and here the population is one
+/// authenticated person, so they are constant and say nothing about *which
+/// situation* this is. They are also randomised per session and origin by a
+/// hardened browser, so a device identity built on them would rotate and every
+/// day would look like a new device.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct Bundle {
+    /// IANA, from `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+    pub tz: Option<String>,
+    pub tz_offset_mins: Option<i32>,
+    pub language: Option<String>,
+    /// The full preference list. Stored, not encoded — see the module note on
+    /// fields the encoder ignores.
+    pub languages: Vec<String>,
+    pub viewport_w: Option<f32>,
+    pub viewport_h: Option<f32>,
+    pub screen_w: Option<f32>,
+    pub screen_h: Option<f32>,
+    pub dpr: Option<f32>,
+    /// `dark` | `light`.
+    pub color_scheme: Option<String>,
+    pub platform: Option<String>,
+    /// The UA client hint's brand, or the family parsed from the UA string.
+    pub ua_family: Option<String>,
+    pub cores: Option<f32>,
+    pub memory_gb: Option<f32>,
+    pub touch: Option<bool>,
+    /// `portrait` | `landscape`.
+    pub orientation: Option<String>,
+    /// 0.0..1.0.
+    pub battery_level: Option<f32>,
+    pub charging: Option<bool>,
+    /// `wifi` | `cellular` | `wired` | anything else.
+    pub network: Option<String>,
+    pub audio_outputs: Option<u32>,
+}
+
+/// A bundle from whatever the browser posted.
+///
+/// Lenient on purpose: nothing a browser sends may take a page view down, and
+/// an empty bundle is a working one — the weekday and the hour come from the
+/// server's own clock and still stand. Unknown fields are dropped here but the
+/// raw string is what `context_events.bundle` stores, so nothing is lost.
+pub fn parse_bundle(raw: &str) -> Bundle {
+    serde_json::from_str(raw).unwrap_or_default()
+}
+
+/// What machine this is, over the fields that do not move.
+///
+/// Platform, browser family, screen, cores, memory, language — and nothing the
+/// situation changes. A phone that rotates, unplugs or joins a different
+/// network is the same phone; a key that moved with any of those would make
+/// every session look like a new device and no pattern could ever form.
+///
+/// `None` when the browser said nothing identifying at all, which `encode`
+/// gives its own slot rather than treating as an absence.
+pub fn device_key(b: &Bundle) -> Option<String> {
+    let parts = [
+        b.platform.clone(),
+        b.ua_family.clone(),
+        b.screen_w.map(|v| v.to_string()),
+        b.screen_h.map(|v| v.to_string()),
+        b.cores.map(|v| v.to_string()),
+        b.memory_gb.map(|v| v.to_string()),
+        b.language.clone(),
+    ];
+    if parts.iter().all(Option::is_none) {
+        return None;
+    }
+    let joined = parts
+        .iter()
+        .map(|p| p.as_deref().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("|");
+    Some(format!("{:016x}", fnv1a(&joined)))
+}
+
+/// FNV-1a, written out rather than reached for.
+///
+/// `DefaultHasher` is seeded per process, so a bucket chosen with it would move
+/// on every restart and every stored centroid would be indexed under a slot
+/// that no longer means what it meant. This is stable across runs, machines and
+/// releases, which is the only property being asked of it.
+fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in s.as_bytes() {
+        h ^= *byte as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn bucket(s: &str, n: usize) -> usize {
+    (fnv1a(s) % n as u64) as usize
+}
+```
+
+- [ ] **Step 4: Write `encode`**
+
+Append, still above `#[cfg(test)]`:
+
+```rust
+/// One situation as a vector.
+///
+/// Each block is filled with raw values, **normalised to length 1, then scaled
+/// by its weight**. That order is the whole design: a block contributes exactly
+/// its weight however many dimensions it uses, which is what puts the weighting
+/// back into config as named numbers instead of leaving it hidden in how the
+/// encoding happened to be written.
+///
+/// A block whose values are all zero is left at zero rather than normalised —
+/// dividing by nothing is how absence turns into a manufactured direction.
+pub fn encode(
+    at: i64,
+    scope: Option<&str>,
+    b: &Bundle,
+    w: &crate::config::BlockWeights,
+) -> Vec<f32> {
+    let t = local_time(at, b.tz.as_deref(), b.tz_offset_mins);
+    let mut v = vec![0.0f32; CTX_DIM];
+
+    for block in BLOCKS {
+        let slot = &mut v[block.at..block.at + block.dims];
+        fill(block.name, slot, &t, scope, b);
+        scale(slot, w.of(block.name));
+    }
+    v
+}
+
+/// Raw values into one block's slots. Every arm either fills or leaves zeros;
+/// leaving zeros is how "the browser did not say" is expressed.
+fn fill(name: &str, s: &mut [f32], t: &LocalTime, scope: Option<&str>, b: &Bundle) {
+    use std::f32::consts::TAU;
+    match name {
+        "scope" => {
+            // Hashed into buckets rather than looked up in a registry: there is
+            // no list of every subject that has ever searched, and one bucket
+            // shared by two people is a collision the per-user collections in
+            // §12 remove rather than a bug to work around here.
+            if let Some(sc) = scope {
+                s[bucket(sc, s.len())] = 1.0;
+            }
+        }
+        "time_of_day" => {
+            let a = TAU * t.hour / 24.0;
+            s[0] = a.sin();
+            s[1] = a.cos();
+        }
+        "weekday" => s[(t.weekday as usize).min(6)] = 1.0,
+        "weekend" => {
+            let idx = usize::from(t.weekday >= 5);
+            s[idx] = 1.0;
+        }
+        "device" => match device_key(b) {
+            // The last slot is "nothing identifying was sent" — a state, not an
+            // absence. A hardened browser is a situation that recurs, unlike a
+            // battery that does not exist.
+            Some(k) => s[bucket(&k, s.len() - 1)] = 1.0,
+            None => {
+                let last = s.len() - 1;
+                s[last] = 1.0;
+            }
+        },
+        "viewport" => {
+            // Logs *centred* on a thousand pixels, not raw. Raw logs put every
+            // screen ever built between 6.5 and 8, so any two of them scored
+            // 0.999 against each other and the block said nothing. Centred, a
+            // phone in portrait and a desktop in landscape point in genuinely
+            // different directions.
+            if let (Some(vw), Some(vh)) = (b.viewport_w, b.viewport_h)
+                && vw > 0.0
+                && vh > 0.0
+            {
+                s[0] = (vw / 1000.0).ln();
+                s[1] = (vh / 1000.0).ln();
+                s[2] = (vw / vh).ln();
+                s[3] = b.dpr.filter(|d| *d > 0.0).map(f32::ln).unwrap_or(0.0);
+            }
+        }
+        "locale" => {
+            // Two halves in one block, four slots each: what language this
+            // browser is in, and what zone it is in. They move together — a
+            // trip changes both — and neither is worth a weight of its own.
+            let half = s.len() / 2;
+            if let Some(l) = &b.language {
+                s[bucket(l, half)] = 1.0;
+            }
+            if let Some(z) = &b.tz {
+                s[half + bucket(z, half)] = 1.0;
+            }
+        }
+        "network" => {
+            // Four named states including unknown, so a browser that does not
+            // expose `connection` is grouped with the others that do not rather
+            // than with none of them.
+            let idx = match b.network.as_deref() {
+                Some("wifi") => 0,
+                Some("cellular") => 1,
+                Some("wired" | "ethernet") => 2,
+                _ => 3,
+            };
+            s[idx] = 1.0;
+        }
+        "power" => {
+            // All three zero when there is no Battery API at all. A desktop
+            // must not read as agreeing with a phone that happens to sit at
+            // whatever default would otherwise have been invented here.
+            if let Some(level) = b.battery_level {
+                match b.charging {
+                    Some(true) => s[0] = 1.0,
+                    Some(false) => s[1] = 1.0,
+                    None => {}
+                }
+                s[2] = level.clamp(0.0, 1.0);
+            }
+        }
+        "environment" => {
+            match b.color_scheme.as_deref() {
+                Some("dark") => s[0] = 1.0,
+                Some("light") => s[1] = 1.0,
+                _ => {}
+            }
+            if b.touch == Some(true) {
+                s[2] = 1.0;
+            }
+            // One signed slot rather than two, because the three states are
+            // portrait, landscape and "did not say" — and zero is already the
+            // third.
+            s[3] = match b.orientation.as_deref() {
+                Some("portrait") => 1.0,
+                Some("landscape") => -1.0,
+                _ => 0.0,
+            };
+            if let Some(n) = b.audio_outputs {
+                s[4] = (n.min(4) as f32) / 4.0;
+            }
+        }
+        "month_cycle" => {
+            let a = TAU * (t.day.saturating_sub(1)) as f32 / t.days_in_month.max(1) as f32;
+            s[0] = a.sin();
+            s[1] = a.cos();
+        }
+        // Unreachable while `BLOCKS` and this match are edited together, and a
+        // block silently left at zero is the safe way to be wrong: it
+        // contributes nothing rather than contributing noise.
+        _ => {}
+    }
+}
+
+/// Normalise to length 1, then scale. A block that is all zeros stays all
+/// zeros — there is no direction to normalise, and inventing one is exactly
+/// what "absent is not zero-valued" forbids.
+fn scale(s: &mut [f32], weight: f32) {
+    let n = s.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if n == 0.0 || weight == 0.0 {
+        if weight == 0.0 {
+            s.fill(0.0);
+        }
+        return;
+    }
+    let k = weight / n;
+    for x in s.iter_mut() {
+        *x *= k;
+    }
+}
+```
+
+- [ ] **Step 5: Write `contributions` and `context_score`**
+
+```rust
+/// How well the situation matches, ignoring who is asking.
+///
+/// The `scope` block decides *which* artifact may be offered — it is what keeps
+/// a foreign cluster from ever winning `max_sim`, at weight 10 against a total
+/// of under 5 — and that same dominance would drag every same-scope full cosine
+/// above 0.95, leaving `strong_at` and `weak_at` four hundredths apart. So the
+/// choice is made on the full vector and the rung is decided here. Two
+/// questions, two scales.
+pub fn context_score(now: &[f32], cluster: &[f32]) -> f32 {
+    if now.len() < SCOPE_DIMS || cluster.len() < SCOPE_DIMS {
+        return 0.0;
+    }
+    crate::vector::cosine(&now[SCOPE_DIMS..], &cluster[SCOPE_DIMS..])
+}
+
+/// What each named block contributed, largest first.
+///
+/// `w_b * cos(block_now, block_cluster)`. Because blocks are named and
+/// separately normalised, the per-dimension breakdown that a weighted sum of
+/// named terms would have produced by construction falls out of the vector as a
+/// by-product — which is the answer to the one thing that approach did better.
+///
+/// These do **not** sum to `context_score`, and are not meant to: the score is
+/// one cosine over the whole vector and each of these is a cosine over a slice,
+/// with a different denominator. They rank which blocks decided it, which is
+/// what the line under the offer needs and all it claims.
+///
+/// `scope` is excluded. It is always either a perfect match or a rejection, so
+/// it would lead every list while explaining nothing.
+pub fn contributions(
+    now: &[f32],
+    cluster: &[f32],
+    w: &crate::config::BlockWeights,
+) -> Vec<(&'static str, f32)> {
+    let mut out: Vec<(&'static str, f32)> = BLOCKS
+        .iter()
+        .filter(|b| b.name != "scope")
+        .filter(|b| now.len() >= b.at + b.dims && cluster.len() >= b.at + b.dims)
+        .map(|b| {
+            let a = &now[b.at..b.at + b.dims];
+            let c = &cluster[b.at..b.at + b.dims];
+            (b.label, w.of(b.name) * crate::vector::cosine(a, c))
+        })
+        .collect();
+    // Ties break on the label, so which of two equally strong blocks is named
+    // first does not depend on the order `BLOCKS` happens to be written in.
+    out.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(b.0))
+    });
+    out
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --lib core::context 2>&1 | tail -30`
+Expected: PASS, 18 tests.
+
+If `the_rung_is_scored_without_the_scope_block` fails on its second assertion,
+print `context_score` for the two vectors and check the `viewport` block — a raw
+(uncentred) log there is the most likely cause of a score that will not fall.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/context.rs
+git commit -m "feat(context): a situation as a vector, each block worth exactly what it is named"
+```
+
+---
+
+### Task 5: The trait, and `max_sim` in the in-memory store
+
+Without an in-memory implementation no test of this feature runs without a live
+Qdrant, which would mean the recommendation path is never tested at all.
+
+**Files:**
+- Modify: `src/vector/mod.rs` (two trait methods)
+- Modify: `src/vector/memory.rs` (both, plus a second map)
+- Test: in `src/vector/memory.rs`
+
+**Interfaces:**
+- Consumes: `crate::vector::cosine`, `SearchFilter`, `SearchHit`.
+- Produces, on `VectorStore`:
+  - `async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()>` — an empty `vectors` removes the set.
+  - `async fn context_query(&self, vector: &[f32], limit: usize, filter: &SearchFilter) -> Result<Vec<SearchHit>>` — `SearchHit::score` is the `max_sim`, `similarity` is `None`.
+
+- [ ] **Step 1: Add the trait methods**
+
+In `src/vector/mod.rs`, inside `pub trait VectorStore`, after `neighbours`
+(`:320`):
+
+```rust
+    /// Replace this artifact's set of context centroids — the `ctx`
+    /// multivector, scored with `max_sim`.
+    ///
+    /// A **vector** write, never a point write. `upsert` replaces the whole
+    /// payload, and a writer that does not know when the artifact was last
+    /// shown would clear `last_seen_at` and `status` with it — which puts every
+    /// artifact the sweep hid straight back into search. See `qdrant.rs`'s
+    /// `upsert` for the same hazard stated where it bites.
+    ///
+    /// An empty `vectors` removes the set. That is the ordinary case for an
+    /// artifact whose every cluster has decayed below `min_weight`, not an
+    /// error, and it must leave the point and its dense vector alone.
+    ///
+    /// An artifact with no point is not a failure: its embedding may never have
+    /// run. There is nothing to attach a set to, and nothing to complain about.
+    async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()>;
+    /// The artifacts whose learned situations most resemble this one.
+    ///
+    /// `max_sim` over each artifact's set: an artifact matches if *any* of its
+    /// situations does, which is the whole reason the profile is a set rather
+    /// than a mean. A thing looked up on Friday afternoons and occasionally on
+    /// Monday mornings must match both, and their average is a situation that
+    /// never happened.
+    ///
+    /// Points carrying no set are absent from the answer, so the candidates are
+    /// "anything ever opened" without a filter saying so.
+    ///
+    /// `score` is the `max_sim`. `similarity` is `None`: this is not a query
+    /// vector against a document vector, and calling it a similarity would
+    /// invite it into a ranking it has no business in.
+    async fn context_query(
+        &self,
+        vector: &[f32],
+        limit: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>>;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to the `mod tests` block in `src/vector/memory.rs` (create one if the
+file has none, following the pattern of another `src/vector/` test module):
+
+```rust
+    fn point(id: &str) -> VectorPoint {
+        VectorPoint {
+            vector: vec![1.0; 4],
+            sparse: Default::default(),
+            payload: VectorPayload {
+                artifact_id: id.into(),
+                corpus_id: "c".into(),
+                text: "t".into(),
+                title: None,
+                category: None,
+                tags: vec![],
+                created_at: 0,
+                last_seen_at: None,
+                hit_count: None,
+                status: None,
+                last_verified_at: None,
+                superseded_by: None,
+                origin_corpora: vec![],
+                provenance: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn an_artifact_matches_on_its_nearest_situation_not_its_average() {
+        // Friday afternoon *and* Monday morning. Their mean is a situation that
+        // never happened, and a store that scored the mean would answer neither.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a")]).await.unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0], vec![0.0, 1.0]])
+            .await
+            .unwrap();
+
+        let friday = v.context_query(&[1.0, 0.0], 5, &wide()).await.unwrap();
+        assert_eq!(friday.len(), 1);
+        assert!((friday[0].score - 1.0).abs() < 1e-5);
+
+        let monday = v.context_query(&[0.0, 1.0], 5, &wide()).await.unwrap();
+        assert!((monday[0].score - 1.0).abs() < 1e-5);
+    }
+
+    #[tokio::test]
+    async fn an_artifact_with_no_situations_is_not_a_candidate() {
+        // The candidate set is "anything ever opened", and that is expressed by
+        // the absence of a set rather than by a filter.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a"), point("b")]).await.unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]]).await.unwrap();
+
+        let out = v.context_query(&[1.0, 0.0], 5, &wide()).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].payload.artifact_id, "a");
+    }
+
+    #[tokio::test]
+    async fn an_empty_write_removes_the_set_and_leaves_the_point() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a")]).await.unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]]).await.unwrap();
+        v.set_context_vectors("a", vec![]).await.unwrap();
+
+        assert!(v.context_query(&[1.0, 0.0], 5, &wide()).await.unwrap().is_empty());
+        assert_eq!(v.count().await.unwrap(), 1, "the point is still there");
+    }
+
+    #[tokio::test]
+    async fn a_hidden_artifact_is_never_offered() {
+        // The same rule search obeys: superseded and deprecated are out.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a")]).await.unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]]).await.unwrap();
+        v.set_lifecycle("a", ArtifactStatus::Superseded, Some("b"))
+            .await
+            .unwrap();
+
+        let out = v
+            .context_query(&[1.0, 0.0], 5, &SearchFilter::default())
+            .await
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn results_come_back_best_first_and_capped() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("near"), point("far")]).await.unwrap();
+        v.set_context_vectors("near", vec![vec![1.0, 0.0]]).await.unwrap();
+        v.set_context_vectors("far", vec![vec![0.2, 1.0]]).await.unwrap();
+
+        let out = v.context_query(&[1.0, 0.0], 1, &wide()).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].payload.artifact_id, "near");
+    }
+
+    #[tokio::test]
+    async fn a_set_on_an_artifact_with_no_point_is_not_an_error() {
+        // An artifact whose embedding never ran has nothing to attach a set to.
+        // The sweep must not fail over one.
+        let v = MemoryVectors::new();
+        v.set_context_vectors("nobody", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+        assert!(v.context_query(&[1.0, 0.0], 5, &wide()).await.unwrap().is_empty());
+    }
+
+    /// Superseded and deprecated included, so a test asserting the ordinary
+    /// path is not silently asserting the filter instead.
+    fn wide() -> SearchFilter {
+        SearchFilter {
+            include_superseded: true,
+            include_deprecated: true,
+            ..Default::default()
+        }
+    }
+```
+
+- [ ] **Step 3: Run them to verify they fail**
+
+Run: `cargo test --lib vector::memory 2>&1 | tail -20`
+Expected: FAIL — `not all trait items implemented: set_context_vectors, context_query`.
+
+- [ ] **Step 4: Implement both in `memory.rs`**
+
+Add the second map to the struct:
+
+```rust
+pub struct MemoryVectors {
+    points: RwLock<HashMap<String, VectorPoint>>,
+    /// The `ctx` multivector per artifact, held apart from the point rather
+    /// than on it. A field on `VectorPoint` would put a context set in every
+    /// signature that carries a point — the embed job's, the reindex's — for
+    /// the sake of one caller that writes it and one that reads it.
+    ctx: RwLock<HashMap<String, Vec<Vec<f32>>>>,
+}
+```
+
+and to `new()`:
+
+```rust
+            ctx: RwLock::new(HashMap::new()),
+```
+
+Add the two methods to the `impl VectorStore for MemoryVectors` block, after
+`neighbours`:
+
+```rust
+    async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()> {
+        let mut w = self.ctx.write().unwrap();
+        if vectors.is_empty() {
+            w.remove(artifact_id);
+        } else {
+            w.insert(artifact_id.to_string(), vectors);
+        }
+        Ok(())
+    }
+
+    async fn context_query(
+        &self,
+        vector: &[f32],
+        limit: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>> {
+        let points = self.points.read().unwrap();
+        let ctx = self.ctx.read().unwrap();
+        let mut hits: Vec<SearchHit> = ctx
+            .iter()
+            // An artifact with a set but no point cannot be offered: there is
+            // no payload to render it from. That is the sweep having run
+            // against an artifact whose embedding has not, not an error.
+            .filter_map(|(id, set)| points.get(id).map(|p| (p, set)))
+            .filter(|(p, _)| {
+                let status = status_of(&p.payload);
+                (filter.include_superseded || status != ArtifactStatus::Superseded)
+                    && (filter.include_deprecated || status != ArtifactStatus::Deprecated)
+            })
+            .map(|(p, set)| SearchHit {
+                payload: p.payload.clone(),
+                // `max_sim`: the best of the artifact's situations, which is
+                // what makes a set worth more than a mean.
+                score: set
+                    .iter()
+                    .map(|c| cosine(vector, c))
+                    .fold(f32::NEG_INFINITY, f32::max),
+                // Not a query-to-document similarity, and calling it one would
+                // invite it into a ranking it has no business in.
+                similarity: None,
+            })
+            .collect();
+        // Ties break on the id, so a HashMap's iteration order never decides
+        // what is offered.
+        hits.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.payload.artifact_id.cmp(&b.payload.artifact_id))
+        });
+        hits.truncate(limit);
+        Ok(hits)
+    }
+```
+
+Check `delete_artifacts` and `delete_by_corpus` in the same file and drop the
+`ctx` entries there too — a set outliving its point would keep answering
+`context_query` with a payload that no longer exists.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib vector::memory 2>&1 | tail -20`
+Expected: PASS, 6 new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vector/mod.rs src/vector/memory.rs
+git commit -m "feat(vector): a set of situations per artifact, and max_sim over it"
+```
+
+---
+
+### Task 6: Qdrant — one named vector, written without touching the payload
+
+**Files:**
+- Modify: `src/vector/qdrant.rs` (`CTX` const, `collection_body`, `ctx_of`, `reindex`, two trait methods)
+- Test: in `src/vector/qdrant.rs`'s existing `mod tests` (unit tests over the
+  request bodies — the live-Qdrant path is not exercised here, matching how
+  `collection_body` is already tested at `:2144`)
+
+**Interfaces:**
+- Consumes: `crate::core::context::CTX_DIM`, the trait from Task 5.
+- Produces: `pub const CTX: &str = "ctx";`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mod tests` in `src/vector/qdrant.rs`:
+
+```rust
+    #[test]
+    fn the_collection_carries_a_context_multivector() {
+        let body = collection_body(768);
+        assert_eq!(body["vectors"][CTX]["size"], crate::core::context::CTX_DIM);
+        assert_eq!(body["vectors"][CTX]["distance"], "Cosine");
+        assert_eq!(body["vectors"][CTX]["multivector_config"]["comparator"], "max_sim");
+        // No HNSW, an exact scan. Right here rather than thrifty: the
+        // candidates are only artifacts ever opened — hundreds to a few
+        // thousand at 53 dimensions — and an index would be rebuilt on every
+        // sweep write to beat a scan it cannot beat at that size.
+        assert_eq!(body["vectors"][CTX]["hnsw_config"]["m"], 0);
+        // And nothing else moved.
+        assert_eq!(body["vectors"][DENSE]["size"], 768);
+        assert_eq!(body["sparse_vectors"][SPARSE]["modifier"], "idf");
+    }
+
+    #[test]
+    fn a_context_set_is_copied_by_a_rebuild_when_it_still_fits() {
+        let dim = crate::core::context::CTX_DIM;
+        let stored = json!({ DENSE: [1.0, 2.0], CTX: [vec![0.5; dim], vec![0.25; dim]] });
+        let copied = ctx_of(&stored).unwrap();
+        assert_eq!(copied.len(), 2);
+    }
+
+    #[test]
+    fn a_context_set_from_an_older_layout_is_dropped_rather_than_copied() {
+        // A changed encoder layout changes CTX_DIM. The old sets are discarded
+        // and the next sweep rebuilds them from the raw bundles in
+        // `context_events` — which costs no embedding call either way.
+        let stored = json!({ DENSE: [1.0, 2.0], CTX: [[0.5, 0.5, 0.5]] });
+        assert!(ctx_of(&stored).is_none());
+    }
+
+    #[test]
+    fn a_point_with_no_context_set_reindexes_without_one() {
+        assert!(ctx_of(&json!({ DENSE: [1.0, 2.0] })).is_none());
+        assert!(ctx_of(&json!([1.0, 2.0])).is_none());
+    }
+
+    #[test]
+    fn the_offer_excludes_hidden_artifacts_by_must_not() {
+        // `must_not` rather than a positive match, for the reason `build_filter`
+        // gives: a point carrying no `status` key at all reads as active, and a
+        // positive clause would drop every hand-written one.
+        let f = build_filter(&SearchFilter::default()).unwrap();
+        assert!(f.get("must").is_none());
+        let not = f["must_not"].as_array().unwrap();
+        assert_eq!(not.len(), 2);
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib vector::qdrant 2>&1 | tail -20`
+Expected: FAIL — `cannot find value CTX in this scope`.
+
+- [ ] **Step 3: Add the constant and the collection entry**
+
+Beside `DENSE` and `SPARSE` (`qdrant.rs:36-40`):
+
+```rust
+/// The context multivector: one element per learned situation, scored with
+/// `max_sim`. Not the multivector the roadmap cut — that was ColBERT-style
+/// late-interaction reranking, one reduced-width vector per *token* and
+/// thousands per artifact. This is two to five per artifact.
+pub const CTX: &str = "ctx";
+```
+
+Replace `collection_body` (`:209-215`):
+
+```rust
+/// The schema every generation is created with.
+fn collection_body(dim: usize) -> Value {
+    json!({
+        "vectors": {
+            DENSE: { "size": dim, "distance": "Cosine" },
+            CTX: {
+                "size": crate::core::context::CTX_DIM,
+                "distance": "Cosine",
+                "multivector_config": { "comparator": "max_sim" },
+                // No index, an exact scan. The candidates are only artifacts
+                // ever opened, at 53 dimensions, and an HNSW graph would be
+                // rebuilt on every sweep write to beat a scan it cannot beat at
+                // that size.
+                "hnsw_config": { "m": 0 },
+            },
+        },
+        "sparse_vectors": { SPARSE: { "modifier": "idf" } },
+    })
+}
+```
+
+**A collection created before this change has no `ctx` named vector, and
+writing one to it will fail.** `--reindex` is the migration: it creates a fresh
+generation from this body. Say so in the commit message.
+
+- [ ] **Step 4: Add `ctx_of` and carry sets through a rebuild**
+
+Beside `dense_of` (`:308-315`):
+
+```rust
+/// A stored point's context set, when it is still readable under the running
+/// encoder.
+///
+/// `None` covers three cases that a rebuild treats alike: no set at all, a
+/// pre-alias point with a single unnamed vector, and a set written under an
+/// older layout. The last is why the width is checked rather than trusted — a
+/// changed `BLOCKS` changes `CTX_DIM`, and copying the old numbers into the new
+/// space would give every artifact a profile assembled from the wrong blocks.
+/// Discarded, and the next sweep rebuilds from the raw bundles.
+fn ctx_of(vector: &Value) -> Option<Vec<Vec<f32>>> {
+    let set = vector.as_object()?.get(CTX)?.as_array()?;
+    if set.is_empty() {
+        return None;
+    }
+    let out: Option<Vec<Vec<f32>>> = set
+        .iter()
+        .map(|e| {
+            let row: Vec<f32> = e
+                .as_array()?
+                .iter()
+                .map(|x| x.as_f64().map(|f| f as f32))
+                .collect::<Option<_>>()?;
+            (row.len() == crate::core::context::CTX_DIM).then_some(row)
+        })
+        .collect();
+    out
+}
+```
+
+In `reindex`'s per-point loop (`:850-857`), after the sparse line:
+
+```rust
+                let mut vector = json!({ DENSE: dense });
+                if let Some(sp) = sparse_body(&sparse_of_payload(&p.payload)) {
+                    vector[SPARSE] = sp;
+                }
+                // Copied when the dimension matches, skipped when it does not.
+                // No embedding call in either case — a context vector is
+                // assembled from a bundle, and the bundles are all still in
+                // `context_events`.
+                if let Some(set) = ctx_of(&p.vector) {
+                    vector[CTX] = json!(set);
+                }
+```
+
+- [ ] **Step 5: Implement the two trait methods**
+
+In `impl VectorStore for QdrantVectors`, after `neighbours`:
+
+```rust
+    async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()> {
+        let id = point_uuid(artifact_id);
+        // `points/vectors`, never `upsert`. A point write replaces the entire
+        // payload — see the comment on `upsert` — and clearing `status` puts
+        // every artifact the sweep hid straight back into search, on every
+        // sweep run. This endpoint does not touch payload at all.
+        let (path, body) = match vectors.is_empty() {
+            true => (
+                format!("/collections/{}/points/vectors/delete?wait=true", self.alias),
+                json!({ "points": [id], "vector": [CTX] }),
+            ),
+            false => (
+                format!("/collections/{}/points/vectors?wait=true", self.alias),
+                json!({ "points": [{ "id": id, "vector": { CTX: vectors } }] }),
+            ),
+        };
+        // Absent is not a failure, for the same reason `set_lifecycle` gives:
+        // an artifact whose embedding never ran has no point, and a sweep that
+        // errored on one would take the whole run down over an artifact that
+        // has nothing to attach a set to.
+        let _: Option<Value> = self
+            .call_absent_point_as_none(Method::POST, &path, Some(body))
+            .await?;
+        Ok(())
+    }
+
+    async fn context_query(
+        &self,
+        vector: &[f32],
+        limit: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>> {
+        let mut body = json!({
+            "query": vector,
+            "using": CTX,
+            "limit": limit,
+            "with_payload": true,
+        });
+        if let Some(f) = build_filter(filter) {
+            body["filter"] = f;
+        }
+        // No recency stage and no pinning over this. Those exist to reorder a
+        // ranked list of answers to a question; there is no question here, and
+        // an artifact captured today is not a better answer to "it is Friday
+        // afternoon" than one captured last year.
+        let res: QueryResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/query", self.alias),
+                Some(body),
+            )
+            .await?;
+        // `hits_of` already skips points whose payload is not one of ours, and
+        // sets `similarity` from nothing — which is correct here: `max_sim` is
+        // not a query-to-document similarity.
+        Ok(hits_of(res))
+    }
+```
+
+Check `hits_of`'s signature and whether it sets `similarity: None`; if it sets
+it from a map, call it the way `resurface` or `neighbours` does rather than
+inventing a third path.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --lib vector::qdrant 2>&1 | tail -20`
+Expected: PASS.
+
+Run: `cargo clippy --all-targets 2>&1 | tail -20`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/vector/qdrant.rs
+git commit -m "feat(vector): the ctx multivector, written through points/vectors so the payload survives
+
+A collection created before this carries no `ctx` named vector. `--reindex` is
+the migration: it creates a fresh generation from the new collection body and
+copies every dense vector across, at no embedding cost."
+```
+
+---
+
+### Task 7: The sweep
+
+The learning half. One pass, no randomness, no model call: it reads the log,
+agglomerates, decays, and writes centroids.
+
+**Files:**
+- Create: `src/jobs/context.rs`
+- Modify: `src/jobs/mod.rs` (module declaration, dispatch, `run_accounted`)
+- Modify: `src/store/jobs.rs` (`Stage::Context`)
+- Modify: `src/store/context.rs` (one more read)
+- Modify: `src/core/background.rs` (`periodic_units`, `periodic_period`)
+- Test: in `src/jobs/context.rs`
+
+**Interfaces:**
+- Consumes: `Store::{context_events_since, replace_context_clusters, expire_context_events}`, `Store::interactions_between`, `Store::events_between`, `core::context::{encode, parse_bundle, device_key, local_time, ENCODER_VERSION, CTX_DIM}`, `VectorStore::set_context_vectors`, `Core::{clock, recommend}`.
+- Produces:
+  - `pub const INTERVAL_HOURS: u64 = 6;`
+  - `pub const BRIDGE_SECS: i64 = 900;`
+  - `pub const MATCH_SECS: i64 = 1800;`
+  - `pub const MAX_SLOTS: usize = 16;`
+  - `pub struct Member { pub vec: Vec<f32>, pub weight: f64, pub at: i64, pub bundle: String }`
+  - `pub struct Cluster { pub centroid: Vec<f32>, pub weight: f64, pub last_at: i64, pub representative: String }`
+  - `pub fn agglomerate(members: &[Member], merge_at: f32, max_clusters: usize, min_weight: f64) -> Vec<Cluster>`
+  - `pub struct Report { pub events: usize, pub profiled: usize, pub clusters: usize, pub cleared: usize }` — `Serialize`
+  - `pub async fn run(core: &Core) -> Result<Report>`
+  - `Stage::Context`, `"context"`, class 1 (background)
+  - `Store::artifacts_with_context_clusters(&self) -> Result<Vec<String>>`
+
+- [ ] **Step 1: Add the stage**
+
+In `src/store/jobs.rs`, add `Stage::Context` in four places, each beside
+`Stage::Retention`: the `ALL` list (`:88`), `as_str` → `"context"` (`:108`),
+the class match's background arm (`:141`), and `parse` → `"context" => Some(Stage::Context)`.
+
+- [ ] **Step 2: Add the one missing store read**
+
+Append to `impl Store` in `src/store/context.rs`:
+
+```rust
+    /// Every artifact that currently has a profile.
+    ///
+    /// What the sweep needs in order to *clear* one: an artifact whose every
+    /// situation has decayed below `min_weight` produces no clusters this run,
+    /// so nothing in the run's own output names it, and without this its old
+    /// centroids would stand for ever — offering it on a pattern that stopped
+    /// months ago.
+    pub async fn artifacts_with_context_clusters(&self) -> Result<Vec<String>> {
+        Ok(
+            sqlx::query_scalar("SELECT DISTINCT artifact_id FROM context_clusters")
+                .fetch_all(&self.pool)
+                .await?,
+        )
+    }
+```
+
+- [ ] **Step 3: Write the failing tests for the clustering**
+
+Create `src/jobs/context.rs` with the module doc, the constants, the types, and
+this test module. Implementation comes in Step 5.
+
+```rust
+//! What situations recur for which artifact.
+//!
+//! One pass over the log, no randomness, no model call. It joins three sources
+//! on `scope` and `at` — never on a stored id — agglomerates the situations an
+//! artifact was opened in, decays them, and writes the surviving centroids to
+//! the vector store as that artifact's `ctx` set.
+//!
+//! A full rebuild every run, from the raw bundles. That is what makes a change
+//! to the encoder a sweep rather than a migration, and it is why the sweep
+//! never reads what a previous run concluded.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::vector::cosine;
+
+/// How often this runs.
+///
+/// A constant rather than a setting, for the reason `REPAIR_INTERVAL_HOURS`
+/// gives: how often a faculty learns is not a preference, and §9 fixes the
+/// `[recommend]` keys as one gate and a table of weights. Six hours means a
+/// situation recorded this morning is offered this evening, which is as fast as
+/// anything here needs to be — the patterns being learned are weekly.
+pub const INTERVAL_HOURS: u64 = 6;
+
+/// How long after a search an open still counts as that search's.
+///
+/// The bridge: where an open followed a search, the event inherits the search's
+/// identity, so a recurring search resolves to the artifact it led to rather
+/// than to a rerun of the query. Fifteen minutes, which is the same order as
+/// `pursuit.idle_secs` and deliberately not that key — pursuits may be off, and
+/// this must still work.
+pub const BRIDGE_SECS: i64 = 900;
+
+/// How far from an open a recorded situation may sit and still be that open's.
+///
+/// Half an hour either way. A page view records a situation; the opens that
+/// follow it belong to it. Wider than `BRIDGE_SECS` because a person can read
+/// for a while after arriving, and a situation is a slower thing than a query.
+pub const MATCH_SECS: i64 = 1800;
+
+/// Centroids one artifact may carry, across every scope.
+///
+/// `max_clusters` bounds the situations per person per artifact; this bounds
+/// the array itself, which is shared by every scope that ever opened the
+/// artifact. On a base with one person it never binds. On one with many it is
+/// what keeps a popular artifact's multivector from growing with the user
+/// count — the heaviest survive, which is the same rule `min_weight` applies
+/// one level down.
+pub const MAX_SLOTS: usize = 16;
+
+/// One situation an artifact was opened in, ready to cluster.
+#[derive(Debug, Clone)]
+pub struct Member {
+    pub vec: Vec<f32>,
+    /// Already decayed, and already multiplied by `self_weight` where this was
+    /// an open of something this feature offered.
+    pub weight: f64,
+    pub at: i64,
+    /// The raw bundle, carried so the winner can be quoted.
+    pub bundle: String,
+}
+
+/// One learned situation.
+#[derive(Debug, Clone)]
+pub struct Cluster {
+    pub centroid: Vec<f32>,
+    pub weight: f64,
+    pub last_at: i64,
+    /// `{"at": <unix>, "bundle": {…}}` for the member nearest the centroid.
+    pub representative: String,
+}
+
+/// What one run did.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct Report {
+    /// Opens that found a situation to be encoded from.
+    pub events: usize,
+    /// Artifacts that came out of this run with at least one situation.
+    pub profiled: usize,
+    pub clusters: usize,
+    /// Artifacts whose every situation had decayed away.
+    pub cleared: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn member(v: Vec<f32>, weight: f64, at: i64) -> Member {
+        Member { vec: v, weight, at, bundle: format!(r#"{{"n":{at}}}"#) }
+    }
+
+    #[test]
+    fn six_fridays_and_one_monday_leave_one_situation() {
+        // §10.2, and the shape the whole feature is for. The outlier is real
+        // and recorded; it is simply not yet a pattern, and `min_weight` is
+        // what says so. Without it, one accident is a habit.
+        let mut members: Vec<Member> = (0..6)
+            .map(|i| member(vec![1.0, 0.02 * i as f32], 1.0, 1_000 + i))
+            .collect();
+        members.push(member(vec![0.0, 1.0], 1.0, 2_000));
+
+        let out = agglomerate(&members, 0.82, 5, 2.0);
+        assert_eq!(out.len(), 1, "the Monday is below the threshold");
+        assert!((out[0].weight - 6.0).abs() < 1e-6);
+        assert_eq!(out[0].last_at, 1_005, "the most recent member's stamp");
+    }
+
+    #[test]
+    fn two_real_situations_are_two_clusters_not_their_mean() {
+        // The recycling centre looked up on Friday afternoons *and*
+        // occasionally on Monday mornings. A mean of them is a situation that
+        // never happened, and it would match neither.
+        let mut members: Vec<Member> = (0..4).map(|i| member(vec![1.0, 0.0], 1.0, 1_000 + i)).collect();
+        members.extend((0..4).map(|i| member(vec![0.0, 1.0], 1.0, 2_000 + i)));
+
+        let out = agglomerate(&members, 0.82, 5, 2.0);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().any(|c| c.centroid[0] > 0.9));
+        assert!(out.iter().any(|c| c.centroid[1] > 0.9));
+    }
+
+    #[test]
+    fn the_same_input_clusters_the_same_way_twice() {
+        // One pass and no randomness, because otherwise it is not testable —
+        // and because a recommendation that changed its reason between two
+        // sweeps over identical data would be unaccountable.
+        let members: Vec<Member> = (0..12)
+            .map(|i| member(vec![(i % 3) as f32, ((i + 1) % 3) as f32, 1.0], 1.0, 1_000 + i))
+            .collect();
+        let a = agglomerate(&members, 0.82, 4, 0.0);
+        let b = agglomerate(&members, 0.82, 4, 0.0);
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(&b) {
+            assert_eq!(x.centroid, y.centroid);
+            assert_eq!(x.representative, y.representative);
+        }
+    }
+
+    #[test]
+    fn the_count_never_exceeds_the_cap() {
+        let members: Vec<Member> = (0..20)
+            .map(|i| {
+                let mut v = vec![0.0; 20];
+                v[i] = 1.0;
+                member(v, 1.0, 1_000 + i as i64)
+            })
+            .collect();
+        let out = agglomerate(&members, 0.99, 5, 0.0);
+        assert!(out.len() <= 5, "got {}", out.len());
+    }
+
+    #[test]
+    fn a_cluster_quotes_the_member_nearest_its_centre() {
+        // What the display shows is a real event that happened, not a
+        // reconstruction of the average of several.
+        let members = vec![
+            member(vec![1.0, 0.0], 1.0, 1_000),
+            member(vec![0.98, 0.2], 1.0, 1_001),
+            member(vec![0.99, 0.1], 1.0, 1_002),
+        ];
+        let out = agglomerate(&members, 0.5, 5, 0.0);
+        assert_eq!(out.len(), 1);
+        let rep: serde_json::Value = serde_json::from_str(&out[0].representative).unwrap();
+        assert!(rep["at"].is_i64(), "the stamp travels with the bundle");
+        assert!(rep["bundle"].is_object());
+    }
+
+    #[test]
+    fn heavier_members_pull_the_centroid_further() {
+        let members = vec![
+            member(vec![1.0, 0.0], 1.0, 1_000),
+            member(vec![0.9, 0.44], 9.0, 1_001),
+        ];
+        let out = agglomerate(&members, 0.5, 5, 0.0);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].centroid[1] > 0.3, "the heavy one dominates");
+    }
+
+    #[test]
+    fn nothing_in_means_nothing_out() {
+        assert!(agglomerate(&[], 0.82, 5, 2.0).is_empty());
+    }
+}
+```
+
+- [ ] **Step 4: Run them to verify they fail**
+
+Run: `cargo test --lib jobs::context 2>&1 | tail -20`
+Expected: FAIL — `cannot find function agglomerate`.
+
+- [ ] **Step 5: Implement `agglomerate`**
+
+Insert above `#[cfg(test)]`:
+
+```rust
+/// One deterministic pass, in event order.
+///
+/// An event joins the nearest cluster when cosine exceeds `merge_at`, otherwise
+/// it opens its own; when the count exceeds `max_clusters` the two nearest are
+/// merged. One pass and no randomness, because otherwise it is not testable —
+/// and because a recommendation whose reason changed between two sweeps over
+/// identical data could not be accounted for by anyone.
+///
+/// Members arrive already decayed. A cluster whose total weight falls below
+/// `min_weight` is dropped, which is what protects against the single accident:
+/// one event never reaches the threshold.
+pub fn agglomerate(
+    members: &[Member],
+    merge_at: f32,
+    max_clusters: usize,
+    min_weight: f64,
+) -> Vec<Cluster> {
+    struct Building {
+        centroid: Vec<f32>,
+        weight: f64,
+        last_at: i64,
+        /// Indices into `members`, so the representative can be chosen against
+        /// the *final* centroid rather than against whatever it was when each
+        /// member arrived.
+        members: Vec<usize>,
+    }
+
+    let cap = max_clusters.max(1);
+    let mut built: Vec<Building> = Vec::new();
+
+    for (i, m) in members.iter().enumerate() {
+        if m.weight <= 0.0 {
+            continue;
+        }
+        let nearest = built
+            .iter()
+            .enumerate()
+            .map(|(k, c)| (k, cosine(&m.vec, &c.centroid)))
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        match nearest {
+            Some((k, sim)) if sim > merge_at => {
+                let c = &mut built[k];
+                blend(&mut c.centroid, c.weight, &m.vec, m.weight);
+                c.weight += m.weight;
+                c.last_at = c.last_at.max(m.at);
+                c.members.push(i);
+            }
+            _ => built.push(Building {
+                centroid: m.vec.clone(),
+                weight: m.weight,
+                last_at: m.at,
+                members: vec![i],
+            }),
+        }
+
+        while built.len() > cap {
+            let Some((a, b)) = closest_pair(&built.iter().map(|c| &c.centroid[..]).collect::<Vec<_>>())
+            else {
+                break;
+            };
+            let victim = built.remove(b);
+            let host = &mut built[a];
+            blend(&mut host.centroid, host.weight, &victim.centroid, victim.weight);
+            host.weight += victim.weight;
+            host.last_at = host.last_at.max(victim.last_at);
+            host.members.extend(victim.members);
+        }
+    }
+
+    let mut out: Vec<Cluster> = built
+        .into_iter()
+        .filter(|c| c.weight >= min_weight)
+        .map(|c| {
+            // The representative is the member nearest the *finished* centroid.
+            // Ties break on the index, so which of two equally central events
+            // is quoted does not depend on a float comparison going either way.
+            let rep = c
+                .members
+                .iter()
+                .map(|&i| (i, cosine(&members[i].vec, &c.centroid)))
+                .max_by(|x, y| {
+                    x.1.partial_cmp(&y.1)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| y.0.cmp(&x.0))
+                })
+                .map(|(i, _)| i);
+            let representative = rep
+                .map(|i| {
+                    // The bundle plus its stamp, because a bundle carries no
+                    // time of its own and the line says "like 08.08., 15:04".
+                    // Stored as a string that is always valid JSON: a bundle
+                    // that will not re-parse becomes an empty object rather
+                    // than corrupting the row.
+                    let bundle: serde_json::Value = serde_json::from_str(&members[i].bundle)
+                        .unwrap_or_else(|_| serde_json::json!({}));
+                    serde_json::json!({ "at": members[i].at, "bundle": bundle }).to_string()
+                })
+                .unwrap_or_else(|| r#"{"at":0,"bundle":{}}"#.to_string());
+            Cluster {
+                centroid: c.centroid,
+                weight: c.weight,
+                last_at: c.last_at,
+                representative,
+            }
+        })
+        .collect();
+    // Heaviest first: this is the order slots are allocated in, and `MAX_SLOTS`
+    // keeps the front of it.
+    out.sort_by(|a, b| {
+        b.weight
+            .partial_cmp(&a.weight)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.last_at.cmp(&a.last_at))
+    });
+    out
+}
+
+/// Weighted mean, in place.
+fn blend(centroid: &mut [f32], have: f64, add: &[f32], w: f64) {
+    let total = have + w;
+    if total <= 0.0 {
+        return;
+    }
+    for (i, c) in centroid.iter_mut().enumerate() {
+        let other = add.get(i).copied().unwrap_or(0.0);
+        *c = ((*c as f64 * have + other as f64 * w) / total) as f32;
+    }
+}
+
+/// The two nearest centroids, as `(keep, drop)` with `keep < drop`.
+///
+/// Quadratic, over at most `max_clusters + 1` vectors of 53 dimensions. That is
+/// a few hundred multiplications on a path that runs every six hours.
+fn closest_pair(centroids: &[&[f32]]) -> Option<(usize, usize)> {
+    let mut best: Option<(usize, usize, f32)> = None;
+    for a in 0..centroids.len() {
+        for b in (a + 1)..centroids.len() {
+            let sim = cosine(centroids[a], centroids[b]);
+            if best.is_none_or(|(_, _, s)| sim > s) {
+                best = Some((a, b, sim));
+            }
+        }
+    }
+    best.map(|(a, b, _)| (a, b))
+}
+```
+
+- [ ] **Step 6: Run the clustering tests to verify they pass**
+
+Run: `cargo test --lib jobs::context 2>&1 | tail -20`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 7: Write the failing test for the whole sweep**
+
+Append to `mod tests` in `src/jobs/context.rs`:
+
+```rust
+    use crate::core::context::{Bundle, CTX_DIM};
+    use crate::core::test_support::test_core;
+
+    /// A core with the recommender on and a fixed clock.
+    async fn recommending_core(now: i64) -> Core {
+        let mut core = test_core().await;
+        core.recommend.enabled = true;
+        core.clock = crate::core::context::Clock::Fixed(now);
+        core
+    }
+
+    fn phone_bundle() -> String {
+        serde_json::to_string(&Bundle {
+            tz: Some("Europe/Berlin".into()),
+            platform: Some("Android".into()),
+            ua_family: Some("Chrome".into()),
+            screen_w: Some(390.0),
+            screen_h: Some(844.0),
+            viewport_w: Some(390.0),
+            viewport_h: Some(844.0),
+            dpr: Some(3.0),
+            cores: Some(8.0),
+            memory_gb: Some(4.0),
+            language: Some("de-DE".into()),
+            touch: Some(true),
+            orientation: Some("portrait".into()),
+            network: Some("cellular".into()),
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    /// A Friday at 15:00 Berlin time, `weeks` weeks before `FRIDAY_SEVENTH`.
+    const FRIDAY_SEVENTH: i64 = 1_787_320_320; // 2026-08-21T13:52Z
+    fn friday(weeks_back: i64) -> i64 {
+        FRIDAY_SEVENTH - weeks_back * 7 * 86_400 - 52 * 60
+    }
+
+    /// Six Fridays at 15:00 on the phone, opening `aid`.
+    async fn seed_six_fridays(core: &Core, aid: &str) {
+        for w in 1..=6 {
+            let at = friday(w);
+            core.store
+                .record_context(&crate::store::context::ContextEvent {
+                    id: 0,
+                    scope: Some("alice".into()),
+                    at,
+                    bundle: phone_bundle(),
+                    device_key: crate::core::context::device_key(
+                        &crate::core::context::parse_bundle(&phone_bundle()),
+                    ),
+                    local_hour: Some(15),
+                    weekday: Some(4),
+                    tz: Some("Europe/Berlin".into()),
+                })
+                .await
+                .unwrap();
+            core.store
+                .record_interaction(aid, "opened", None, Some("alice"), at + 5)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn six_fridays_become_one_stored_situation() {
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_one_artifact(&core).await;
+        seed_six_fridays(&core, &aid).await;
+
+        let r = run(&core).await.unwrap();
+        assert_eq!(r.events, 6);
+        assert_eq!(r.profiled, 1);
+        assert_eq!(r.clusters, 1);
+
+        let stored = core.store.context_clusters_of(&[aid.clone()]).await.unwrap();
+        let c = &stored[&aid][0];
+        assert_eq!(c.slot, 0);
+        assert_eq!(c.centroid.len(), CTX_DIM);
+        assert_eq!(c.encoder_version, crate::core::context::ENCODER_VERSION);
+        assert_eq!(c.scope.as_deref(), Some("alice"));
+
+        // And the vector store agrees, which is what the read path queries.
+        let hits = core
+            .vectors
+            .context_query(&c.centroid, 5, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits[0].payload.artifact_id, aid);
+    }
+
+    #[tokio::test]
+    async fn an_open_of_something_this_offered_raises_no_weight() {
+        // §5, and the named test the guard needs — the sitting has one saying
+        // it writes no activation, for the same reason. Without this, the first
+        // lucky guess grows into a habit the system taught itself.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_one_artifact(&core).await;
+        seed_six_fridays(&core, &aid).await;
+        let before = run(&core).await.unwrap();
+
+        // Six more Fridays, every one of them an open of the offer.
+        for w in 7..=12 {
+            let at = friday(w - 6) + 60;
+            core.store
+                .record_context(&crate::store::context::ContextEvent {
+                    id: 0,
+                    scope: Some("alice".into()),
+                    at,
+                    bundle: phone_bundle(),
+                    device_key: None,
+                    local_hour: Some(15),
+                    weekday: Some(4),
+                    tz: Some("Europe/Berlin".into()),
+                })
+                .await
+                .unwrap();
+            core.store
+                .record_interaction(&aid, "recommended_open", None, Some("alice"), at + 5)
+                .await
+                .unwrap();
+        }
+
+        let after = run(&core).await.unwrap();
+        assert_eq!(after.events, before.events, "not one of them counted");
+        let stored = core.store.context_clusters_of(&[aid.clone()]).await.unwrap();
+        assert!(
+            (stored[&aid][0].weight - 6.0).abs() < 0.5,
+            "weight {} moved",
+            stored[&aid][0].weight
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pattern_that_stopped_is_cleared_rather_than_left_standing() {
+        // A year of silence at a 45-day half-life is 2^-8 of the weight it had.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_one_artifact(&core).await;
+        seed_six_fridays(&core, &aid).await;
+        run(&core).await.unwrap();
+        assert!(!core.store.context_clusters_of(&[aid.clone()]).await.unwrap().is_empty());
+
+        let later = recommending_core(FRIDAY_SEVENTH + 365 * 86_400).await;
+        let later = Core { store: core.store.clone(), vectors: core.vectors.clone(), ..later };
+        let r = run(&later).await.unwrap();
+        assert_eq!(r.cleared, 1);
+        assert!(core.store.context_clusters_of(&[aid.clone()]).await.unwrap().is_empty());
+        assert!(
+            later
+                .vectors
+                .context_query(&vec![0.1; CTX_DIM], 5, &Default::default())
+                .await
+                .unwrap()
+                .is_empty(),
+            "and the vector store was cleared too"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_old_event_with_no_bundle_still_carries_a_weekday_and_an_hour() {
+        // §12's cold start, which is not a backfill path: it is the ordinary
+        // sweep reading older rows. Device and network contribute nothing
+        // because §6 zeroes an absent block rather than defaulting it.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_one_artifact(&core).await;
+        for w in 1..=6 {
+            core.store
+                .record_interaction(&aid, "opened", None, Some("alice"), friday(w))
+                .await
+                .unwrap();
+        }
+        let r = run(&core).await.unwrap();
+        assert_eq!(r.events, 6, "no context event, and they still count");
+        assert_eq!(r.clusters, 1);
+    }
+
+    #[tokio::test]
+    async fn the_sweep_does_not_run_when_the_faculty_is_off() {
+        let mut core = recommending_core(FRIDAY_SEVENTH).await;
+        core.recommend.enabled = false;
+        let aid = seed_one_artifact(&core).await;
+        seed_six_fridays(&core, &aid).await;
+
+        let r = run(&core).await.unwrap();
+        assert_eq!(r.events, 0);
+        assert!(core.store.context_clusters_of(&[aid]).await.unwrap().is_empty());
+    }
+
+    /// One corpus, one artifact, one point. Reuse whichever helper the
+    /// neighbouring job test modules already use for this; write it here only
+    /// if none exists.
+    async fn seed_one_artifact(core: &Core) -> String {
+        // See `src/jobs/pursuit.rs`'s test module for the shape this should
+        // take against the real `Core` — it must leave a vector point behind,
+        // or `context_query` has no payload to return.
+        todo!("mirror jobs::pursuit's seeding helper")
+    }
+```
+
+The `seed_one_artifact` helper is the one thing this plan does not spell out,
+because `jobs/pursuit.rs`'s test module already has exactly it. Read that module
+first and copy its approach; do not invent a third way to seed an artifact.
+
+- [ ] **Step 8: Implement `run`**
+
+```rust
+/// One pass: read the log, encode, cluster, write.
+pub async fn run(core: &Core) -> Result<Report> {
+    let mut report = Report::default();
+    if !core.recommends() {
+        return Ok(report);
+    }
+    let cfg = &core.recommend;
+    let now = core.clock.now();
+    let since = now - crate::store::context::RETAIN_DAYS * 86_400;
+
+    // Three sources, read whole. Bounded by the retention window rather than
+    // paged: the sweep rebuilds every profile from scratch, and a rebuild is
+    // only correct when it sees the whole window.
+    let interactions = core.store.interactions_between(since, now).await?;
+    let contexts = core.store.context_events_since(since).await?;
+    // The bridge. `events_between` excludes the judge door already, which is
+    // right here too: a benchmark run is not a situation anybody was in.
+    let searches = core.store.events_between(since, now).await?;
+
+    // (scope, artifact) -> the situations it was opened in.
+    let mut by_pair: std::collections::BTreeMap<(String, String), Vec<Member>> =
+        std::collections::BTreeMap::new();
+
+    for i in &interactions {
+        // `dwell` is not an open, and `recommended_shown` is not an
+        // interaction at all — it is this feature's own offer, and counting it
+        // would profile every artifact it ever guessed at.
+        let self_made = match i.kind.as_str() {
+            "opened" | "pivoted" => false,
+            "recommended_open" => true,
+            _ => continue,
+        };
+        let Some(artifact_id) = i.artifact_id.clone() else {
+            continue;
+        };
+        let scope = i.scope.clone().unwrap_or_default();
+
+        // Where the open followed a search, the situation is the search's, not
+        // the open's: a recurring search resolves to the artifact it led to
+        // rather than to a rerun of the query.
+        let anchor = searches
+            .iter()
+            .filter(|s| {
+                s.scope.as_deref().unwrap_or_default() == scope
+                    && s.created_at <= i.at
+                    && i.at - s.created_at <= BRIDGE_SECS
+                    && s.shown.iter().any(|(id, _)| id == &artifact_id)
+            })
+            .map(|s| s.created_at)
+            .max()
+            .unwrap_or(i.at);
+
+        // The nearest recorded situation, within half an hour either way.
+        let matched = contexts
+            .iter()
+            .filter(|c| {
+                c.scope.as_deref().unwrap_or_default() == scope
+                    && (c.at - anchor).abs() <= MATCH_SECS
+            })
+            .min_by_key(|c| ((c.at - anchor).abs(), c.id));
+
+        // No bundle is not no event. §12: `at` and `scope` were recorded from
+        // the beginning, and because §6 zeroes an absent block rather than
+        // defaulting it, an old row feeds in with no special handling —
+        // weekday and hour contribute, device and network contribute nothing.
+        let (raw, at) = match matched {
+            Some(c) => (c.bundle.clone(), c.at),
+            None => ("{}".to_string(), anchor),
+        };
+        let bundle = crate::core::context::parse_bundle(&raw);
+
+        // Age decay, and the self-reinforcement guard as a multiplier. At
+        // `self_weight = 0` a `recommended_open` produces a weightless member,
+        // which the clusterer skips — so the first lucky guess cannot grow into
+        // a habit the system taught itself.
+        let age_days = ((now - at).max(0) as f64) / 86_400.0;
+        let decayed = 0.5f64.powf(age_days / cfg.half_life_days.max(0.1));
+        let weight = decayed * if self_made { cfg.self_weight } else { 1.0 };
+        if weight <= 0.0 {
+            continue;
+        }
+
+        let scope_arg = (!scope.is_empty()).then_some(scope.as_str());
+        by_pair
+            .entry((scope.clone(), artifact_id))
+            .or_default()
+            .push(Member {
+                vec: crate::core::context::encode(at, scope_arg, &bundle, &cfg.weights),
+                weight,
+                at,
+                bundle: raw,
+            });
+        report.events += 1;
+    }
+
+    // Slots are numbered per *artifact*, not per (scope, artifact): the
+    // multivector is one array on one point, shared by every scope that has
+    // opened this artifact, so a slot numbered per scope would have two owners
+    // writing index 0.
+    let mut per_artifact: std::collections::BTreeMap<String, Vec<(Option<String>, Cluster)>> =
+        std::collections::BTreeMap::new();
+    for ((scope, artifact_id), members) in by_pair {
+        let scope = (!scope.is_empty()).then_some(scope);
+        for c in agglomerate(&members, cfg.cluster_merge_at, cfg.max_clusters, cfg.min_weight) {
+            per_artifact
+                .entry(artifact_id.clone())
+                .or_default()
+                .push((scope.clone(), c));
+        }
+    }
+
+    // Artifacts that had a profile and produced none this run. Their centroids
+    // must go, or a pattern that stopped months ago would still be offered.
+    let mut stale: std::collections::BTreeSet<String> = core
+        .store
+        .artifacts_with_context_clusters()
+        .await?
+        .into_iter()
+        .collect();
+
+    for (artifact_id, mut clusters) in per_artifact {
+        stale.remove(&artifact_id);
+        clusters.sort_by(|a, b| {
+            b.1.weight
+                .partial_cmp(&a.1.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| b.1.last_at.cmp(&a.1.last_at))
+        });
+        clusters.truncate(MAX_SLOTS);
+
+        let rows: Vec<crate::store::context::StoredCluster> = clusters
+            .iter()
+            .enumerate()
+            .map(|(slot, (scope, c))| crate::store::context::StoredCluster {
+                scope: scope.clone(),
+                artifact_id: artifact_id.clone(),
+                slot: slot as i64,
+                centroid: c.centroid.clone(),
+                weight: c.weight,
+                last_at: c.last_at,
+                encoder_version: crate::core::context::ENCODER_VERSION,
+                representative: c.representative.clone(),
+            })
+            .collect();
+
+        // SQLite first, then the vector store. If the second write fails the
+        // table names clusters the index does not carry — which offers nothing
+        // and explains nothing, and the next run repairs it. The other order
+        // would offer an artifact with no reason to show for it, which is the
+        // one failure §11 says this must not have.
+        core.store
+            .replace_context_clusters(&artifact_id, &rows)
+            .await?;
+        let vectors: Vec<Vec<f32>> = rows.iter().map(|r| r.centroid.clone()).collect();
+        core.vectors
+            .set_context_vectors(&artifact_id, vectors)
+            .await?;
+
+        report.profiled += 1;
+        report.clusters += rows.len();
+    }
+
+    for artifact_id in stale {
+        core.store.replace_context_clusters(&artifact_id, &[]).await?;
+        core.vectors.set_context_vectors(&artifact_id, vec![]).await?;
+        report.cleared += 1;
+    }
+
+    Ok(report)
+}
+```
+
+- [ ] **Step 9: Run the sweep tests to verify they pass**
+
+Run: `cargo test --lib jobs::context 2>&1 | tail -30`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 10: Wire it as a periodic unit**
+
+`src/jobs/mod.rs` — add `pub mod context;` to the module list; add
+`Stage::Context` to the periodic tuple match (`:113-118`), beside
+`Stage::Retention`; and add an arm to `run_accounted` (`:234`):
+
+```rust
+        Stage::Context => context::run(core).await.and_then(detail),
+```
+
+`src/core/background.rs` — in `periodic_units`, after the `Retention` block:
+
+```rust
+    // Learning which situations recur for which artifact. Behind its own gate
+    // and nothing else's: it reads the interaction log, which is not something
+    // an operator switches off by switching off duplicate hygiene.
+    if core.recommends() {
+        out.push((Stage::Context, CONSOLIDATE_TARGET));
+    }
+```
+
+and in `periodic_period`'s match:
+
+```rust
+        Stage::Context => crate::jobs::context::INTERVAL_HOURS.saturating_mul(3600),
+```
+
+- [ ] **Step 11: Write the failing test for the wiring**
+
+Append to `mod tests` in `src/core/background.rs`:
+
+```rust
+    #[tokio::test]
+    async fn the_context_sweep_is_armed_only_when_the_offer_is_on() {
+        let mut core = crate::core::test_support::test_core().await;
+        assert!(
+            !periodic_units(&core).iter().any(|(s, _)| *s == Stage::Context),
+            "off by default"
+        );
+        core.recommend.enabled = true;
+        assert!(periodic_units(&core).iter().any(|(s, _)| *s == Stage::Context));
+        assert_eq!(
+            periodic_period(&core, Stage::Context),
+            Some(std::time::Duration::from_secs(
+                crate::jobs::context::INTERVAL_HOURS * 3600
+            ))
+        );
+    }
+```
+
+- [ ] **Step 12: Run everything and commit**
+
+Run: `cargo fmt && cargo clippy --all-targets 2>&1 | tail -20 && cargo test --lib 2>&1 | tail -10`
+Expected: clean, all pass.
+
+```bash
+git add src/jobs/context.rs src/jobs/mod.rs src/store/jobs.rs \
+        src/store/context.rs src/core/background.rs
+git commit -m "feat(context): a sweep that learns what Friday afternoon looks like, and forgets when it stops"
+```
+
+---
+
+### Task 8: The read path — the ladder, and the reason that matches the hit
+
+One vector query, then arithmetic over at most fifty small vectors. No
+embedding, no model call.
+
+**Files:**
+- Create: `src/core/recommend.rs`
+- Modify: `src/core/mod.rs` (module declaration)
+- Test: in `src/core/recommend.rs`
+
+**Interfaces:**
+- Consumes: `VectorStore::context_query`, `Store::context_clusters_of`, `core::context::{encode, contributions, context_score, ENCODER_VERSION, CTX_DIM}`, `Core::{clock, recommend, sittings, resurface}`.
+- Produces:
+  - `pub enum Rung { Pattern, Similar, Sitting, Forgotten }` with `pub fn as_str(&self) -> &'static str` and `pub fn line(&self) -> &'static str`
+  - `pub struct Offer { pub artifact_id: String, pub title: String, pub rung: Rung, pub slot: Option<i64>, pub blocks: Vec<&'static str>, pub at: Option<i64>, pub detail: String }`
+  - `pub const CANDIDATES: usize = 10;`
+  - `pub const NAMED_BLOCKS: usize = 3;`
+  - `Core::offer(&self, scope: Option<&str>, bundle: &Bundle, session: Option<&str>) -> Result<Option<Offer>>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/core/recommend.rs` with the doc comment, types and this test module;
+implement in Step 3.
+
+```rust
+//! What to offer under the search box, and why.
+//!
+//! One vector query against the `ctx` multivector, then the winning cluster
+//! re-derived locally — because Qdrant returns the `max_sim` score and not
+//! *which* element produced it, and the display needs the element.
+//!
+//! That places the same arithmetic in two places. It is the price of holding
+//! the vectors in the index and the reason outside it, and a test pins that
+//! both pick the same artifact: if they drift, the line under the offer
+//! explains a hit it is not explaining.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::context::{Bundle, encode};
+    use crate::core::test_support::test_core;
+
+    const FRIDAY: i64 = 1_787_320_320;
+
+    async fn core_at(now: i64) -> Core {
+        let mut core = test_core().await;
+        core.recommend.enabled = true;
+        core.clock = crate::core::context::Clock::Fixed(now);
+        core
+    }
+
+    fn phone() -> Bundle {
+        Bundle {
+            tz: Some("Europe/Berlin".into()),
+            platform: Some("Android".into()),
+            ua_family: Some("Chrome".into()),
+            screen_w: Some(390.0),
+            screen_h: Some(844.0),
+            viewport_w: Some(390.0),
+            viewport_h: Some(844.0),
+            dpr: Some(3.0),
+            cores: Some(8.0),
+            memory_gb: Some(4.0),
+            language: Some("de-DE".into()),
+            touch: Some(true),
+            orientation: Some("portrait".into()),
+            network: Some("cellular".into()),
+            ..Default::default()
+        }
+    }
+
+    /// Give `aid` one learned situation, at `at`, in both stores.
+    async fn learn(core: &Core, aid: &str, scope: &str, at: i64, b: &Bundle) {
+        let v = encode(at, Some(scope), b, &core.recommend.weights);
+        core.store
+            .replace_context_clusters(
+                aid,
+                &[crate::store::context::StoredCluster {
+                    scope: Some(scope.into()),
+                    artifact_id: aid.into(),
+                    slot: 0,
+                    centroid: v.clone(),
+                    weight: 6.0,
+                    last_at: at,
+                    encoder_version: crate::core::context::ENCODER_VERSION,
+                    representative: serde_json::json!({ "at": at, "bundle": b }).to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+        core.vectors.set_context_vectors(aid, vec![v]).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn the_reason_explains_the_artifact_that_was_offered() {
+        // §10.3, and §11's last rule. If the local recomputation and the store
+        // disagree, the line explains a different artifact than the one shown —
+        // which is the one dishonesty this feature must not commit.
+        let core = core_at(FRIDAY).await;
+        let near = seed_one_artifact(&core).await;
+        let far = seed_one_artifact(&core).await;
+        learn(&core, &near, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        let mut desk = phone();
+        desk.platform = Some("macOS".into());
+        desk.touch = Some(false);
+        desk.network = Some("wired".into());
+        learn(&core, &far, "alice", FRIDAY - 10 * 86_400 - 7 * 3600, &desk).await;
+
+        let now = encode(FRIDAY, Some("alice"), &phone(), &core.recommend.weights);
+        let from_store = core
+            .vectors
+            .context_query(&now, CANDIDATES, &Default::default())
+            .await
+            .unwrap();
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap().unwrap();
+        assert_eq!(
+            offer.artifact_id, from_store[0].payload.artifact_id,
+            "the local argmax reproduces the store's"
+        );
+        assert_eq!(offer.artifact_id, near);
+    }
+
+    #[tokio::test]
+    async fn a_recurring_situation_is_called_a_pattern_and_names_its_blocks() {
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap().unwrap();
+        assert_eq!(offer.rung, Rung::Pattern);
+        assert_eq!(offer.slot, Some(0));
+        assert_eq!(offer.blocks.len(), NAMED_BLOCKS);
+        assert!(offer.blocks.contains(&"weekday"), "{:?}", offer.blocks);
+        assert!(offer.blocks.contains(&"hour"), "{:?}", offer.blocks);
+        assert!(offer.blocks.contains(&"device"), "{:?}", offer.blocks);
+        assert_eq!(offer.at, Some(FRIDAY - 7 * 86_400));
+    }
+
+    #[tokio::test]
+    async fn a_resemblance_is_not_called_a_pattern() {
+        // The wording says what it rests on. The distance between "Fridays
+        // around 15:00" and "similar to" is the whole honesty of the feature.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        // Same weekday and device, four hours off and on a different network.
+        let mut other = phone();
+        other.network = Some("wifi".into());
+        other.orientation = Some("landscape".into());
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400 - 4 * 3600, &other).await;
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap().unwrap();
+        assert_eq!(offer.rung, Rung::Similar);
+    }
+
+    #[tokio::test]
+    async fn one_persons_situations_are_never_offered_to_another() {
+        // §11. Until per-user collections exist, the `scope` block is the whole
+        // of the isolation, and it needs a test that says so.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        let offer = core.offer(Some("bob"), &phone(), None).await.unwrap();
+        assert!(
+            offer.as_ref().is_none_or(|o| o.rung != Rung::Pattern && o.rung != Rung::Similar),
+            "alice's Friday is not bob's, got {offer:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_nothing_learned_the_ladder_falls_to_what_this_sitting_touched() {
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        core.sittings.touched("sess-1", &aid, FRIDAY, 900);
+
+        let offer = core
+            .offer(Some("alice"), &phone(), Some("sess-1"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(offer.rung, Rung::Sitting);
+        assert_eq!(offer.artifact_id, aid);
+        assert!(offer.blocks.is_empty(), "nothing was matched, so nothing is named");
+        assert_eq!(offer.slot, None);
+    }
+
+    #[tokio::test]
+    async fn with_no_sitting_either_it_falls_to_what_has_been_forgotten() {
+        // Deliberately not phrased like a pattern. This rung *is* `resurface`,
+        // and it says so.
+        let core = core_at(FRIDAY).await;
+        let _aid = seed_old_artifact(&core).await;
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap().unwrap();
+        assert_eq!(offer.rung, Rung::Forgotten);
+        assert!(offer.rung.line().contains("long"), "{}", offer.rung.line());
+    }
+
+    #[tokio::test]
+    async fn an_empty_base_is_offered_nothing_rather_than_a_lie() {
+        let core = core_at(FRIDAY).await;
+        assert!(core.offer(Some("alice"), &phone(), None).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_cluster_from_an_older_encoder_explains_nothing() {
+        // Its centroid may still be in the index — a rebuild copies a set whose
+        // width matches — but the blocks it was built from are not the blocks
+        // this reader knows. Skipped, rather than described with the wrong ones.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        let mut rows = core.store.context_clusters_of(&[aid.clone()]).await.unwrap()[&aid].clone();
+        rows[0].encoder_version = crate::core::context::ENCODER_VERSION + 1;
+        core.store.replace_context_clusters(&aid, &rows).await.unwrap();
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap();
+        assert!(offer.as_ref().is_none_or(|o| o.slot.is_none()));
+    }
+
+    #[tokio::test]
+    async fn the_details_carry_the_bundle_and_the_numbers() {
+        // "The parameters must be visible" — whoever wants to know exactly,
+        // expands it. It is also the answer to what is being collected:
+        // inspectable rather than promised.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap().unwrap();
+        let d: serde_json::Value = serde_json::from_str(&offer.detail).unwrap();
+        assert!(d["bundle"]["tz"].is_string());
+        assert!(d["contributions"].is_object());
+        assert!(d["score"].is_number());
+    }
+
+    /// See Task 7 Step 7: mirror `jobs::pursuit`'s seeding helper.
+    async fn seed_one_artifact(core: &Core) -> String {
+        todo!("mirror jobs::pursuit's seeding helper")
+    }
+
+    /// The same, with `created_at` far enough back that `resurface` returns it.
+    async fn seed_old_artifact(core: &Core) -> String {
+        todo!("as above, with created_at = 0 and last_seen_at unset")
+    }
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib core::recommend 2>&1 | tail -20`
+Expected: FAIL — `cannot find type Rung`.
+
+- [ ] **Step 3: Implement the ladder**
+
+Insert above `#[cfg(test)]`:
+
+```rust
+use crate::core::Core;
+use crate::core::context::{Bundle, contributions, context_score, encode};
+use crate::error::Result;
+use crate::vector::cosine;
+
+/// How many artifacts the store is asked for.
+///
+/// Ten. Every one of them has its clusters reloaded and rescored locally, at
+/// most five clusters of 53 dimensions apiece — a few thousand multiplications,
+/// which is free next to the round trip that fetched them.
+pub const CANDIDATES: usize = 10;
+
+/// How many blocks the line names. Three, sorted by contribution: enough to say
+/// what decided it, short enough to stay one line.
+pub const NAMED_BLOCKS: usize = 3;
+
+/// Which rung of the ladder the offer rests on.
+///
+/// Something is always shown, and the wording says what it rests on.
+/// `Forgotten` is deliberately not phrased like a pattern: the distance between
+/// "Fridays around 15:00" and "not seen in a long time" is the whole honesty of
+/// this feature, and blurring it makes the area furniture within a fortnight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rung {
+    Pattern,
+    Similar,
+    Sitting,
+    Forgotten,
+}
+
+impl Rung {
+    /// For the recorded row, and for the Ops breakdown.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Rung::Pattern => "pattern",
+            Rung::Similar => "similar",
+            Rung::Sitting => "sitting",
+            Rung::Forgotten => "forgotten",
+        }
+    }
+
+    /// The four fixed strings the page prints. No prose is generated anywhere
+    /// on this path — a new block in the encoder brings its own label and needs
+    /// no sentence written for it.
+    pub fn line(&self) -> &'static str {
+        match self {
+            Rung::Pattern => "Pattern",
+            Rung::Similar => "Similar to",
+            Rung::Sitting => "Touched in this sitting",
+            Rung::Forgotten => "Not seen in a long time",
+        }
+    }
+}
+
+/// What is offered under the search box, and everything the page needs to say
+/// why.
+#[derive(Debug, Clone)]
+pub struct Offer {
+    pub artifact_id: String,
+    pub title: String,
+    pub rung: Rung,
+    /// The winning cluster, for the recorded row. `None` on the two rungs that
+    /// matched no situation.
+    pub slot: Option<i64>,
+    /// The blocks that decided it, largest contribution first, at most
+    /// `NAMED_BLOCKS`. Empty on the lower two rungs, which matched nothing.
+    pub blocks: Vec<&'static str>,
+    /// The representative event's stamp. What "like 08.08., 15:04" prints.
+    pub at: Option<i64>,
+    /// The raw bundle and the contribution numbers, JSON, for the `<details>`.
+    pub detail: String,
+}
+
+impl Core {
+    /// What to offer, from the situation this page view happened in.
+    ///
+    /// One vector query and no embedding. The winning cluster is re-derived
+    /// here because Qdrant's `max_sim` yields the maximum and not which element
+    /// produced it — and the display needs the element, both to quote it and to
+    /// name the blocks that decided it.
+    pub async fn offer(
+        &self,
+        scope: Option<&str>,
+        bundle: &Bundle,
+        session: Option<&str>,
+    ) -> Result<Option<Offer>> {
+        if !self.recommends() {
+            return Ok(None);
+        }
+        let now_at = self.clock.now();
+        let now = encode(now_at, scope, bundle, &self.recommend.weights);
+
+        // Superseded and deprecated are out, by `must_not` — the same rule
+        // search obeys, and for the same reason a hand-written point carrying
+        // no `status` key must still be offered.
+        let hits = self
+            .vectors
+            .context_query(&now, CANDIDATES, &Default::default())
+            .await
+            .unwrap_or_else(|e| {
+                // A vector store that cannot answer must not take the search
+                // page down with it: without an offer the page is what it was
+                // yesterday, and the ladder still has three rungs below this.
+                tracing::warn!(error = %e, "context query unavailable; falling through the ladder");
+                Vec::new()
+            });
+
+        let ids: Vec<String> = hits.iter().map(|h| h.payload.artifact_id.clone()).collect();
+        let clusters = self.store.context_clusters_of(&ids).await?;
+
+        // The argmax, over the **full** vector — that is what reproduces the
+        // store's choice, because that is what `max_sim` scored. The rung comes
+        // from `context_score`, which slices the `scope` block off: the two
+        // numbers answer different questions and live on different scales.
+        let mut best: Option<(&crate::vector::SearchHit, &crate::store::context::StoredCluster, f32)> =
+            None;
+        for hit in &hits {
+            let Some(mine) = clusters.get(&hit.payload.artifact_id) else {
+                continue;
+            };
+            for c in mine {
+                // A cluster written under another layout is skipped rather than
+                // explained with the wrong blocks. Its centroid may still be in
+                // the index — a rebuild copies any set whose width matches —
+                // and the next sweep replaces it.
+                if c.encoder_version != crate::core::context::ENCODER_VERSION
+                    || c.centroid.len() != now.len()
+                {
+                    continue;
+                }
+                let full = cosine(&now, &c.centroid);
+                if best.is_none_or(|(_, _, b)| full > b) {
+                    best = Some((hit, c, full));
+                }
+            }
+        }
+
+        if let Some((hit, cluster, _)) = best {
+            let score = context_score(&now, &cluster.centroid);
+            let rung = if score >= self.recommend.strong_at {
+                Some(Rung::Pattern)
+            } else if score >= self.recommend.weak_at {
+                Some(Rung::Similar)
+            } else {
+                None
+            };
+            if let Some(rung) = rung {
+                let all = contributions(&now, &cluster.centroid, &self.recommend.weights);
+                let rep: serde_json::Value =
+                    serde_json::from_str(&cluster.representative).unwrap_or_default();
+                return Ok(Some(Offer {
+                    artifact_id: hit.payload.artifact_id.clone(),
+                    title: title_of(&hit.payload),
+                    rung,
+                    slot: Some(cluster.slot),
+                    blocks: all.iter().take(NAMED_BLOCKS).map(|(l, _)| *l).collect(),
+                    at: rep.get("at").and_then(serde_json::Value::as_i64),
+                    detail: serde_json::json!({
+                        "score": score,
+                        "bundle": bundle,
+                        "representative": rep,
+                        "contributions": all.iter().copied().collect::<std::collections::BTreeMap<_, _>>(),
+                    })
+                    .to_string(),
+                }));
+            }
+        }
+
+        // Nothing in `ctx`, but this sitting is open. A way back to what was
+        // just being read is not a claim about a pattern, and the wording does
+        // not make one.
+        if let Some(sess) = session {
+            let carried = self
+                .sittings
+                .read(sess, now_at, self.pursuit.idle_secs as i64);
+            for aid in &carried.touched {
+                if let Ok(a) = self.store.get_artifact(aid).await
+                    && a.in_results()
+                {
+                    return Ok(Some(Offer {
+                        artifact_id: a.id.clone(),
+                        title: a.title.clone().unwrap_or_else(|| first_line(&a.text)),
+                        rung: Rung::Sitting,
+                        slot: None,
+                        blocks: Vec::new(),
+                        at: None,
+                        detail: serde_json::json!({ "bundle": bundle }).to_string(),
+                    }));
+                }
+            }
+        }
+
+        // The bottom rung, which *is* `resurface` — and says so.
+        let forgotten = self.resurface(1).await.unwrap_or_default();
+        Ok(forgotten.into_iter().next().map(|r| Offer {
+            artifact_id: r.artifact_id.clone(),
+            title: r.title.clone().unwrap_or_else(|| first_line(&r.text)),
+            rung: Rung::Forgotten,
+            slot: None,
+            blocks: Vec::new(),
+            at: None,
+            detail: serde_json::json!({ "bundle": bundle }).to_string(),
+        }))
+    }
+}
+
+fn title_of(p: &crate::vector::VectorPayload) -> String {
+    p.title.clone().filter(|t| !t.is_empty()).unwrap_or_else(|| first_line(&p.text))
+}
+
+/// The opening of the text, for something with no title. Deliberately short:
+/// the offer is one line under a search box, not a result card.
+fn first_line(text: &str) -> String {
+    let line = text.lines().next().unwrap_or("").trim();
+    match line.char_indices().nth(70) {
+        Some((i, _)) => format!("{}…", &line[..i]),
+        None => line.to_string(),
+    }
+}
+```
+
+Check `Core::resurface`'s return type (`src/core/search.rs:742`) and adjust the
+field names in the last block to match `SearchResult` rather than guessing.
+
+- [ ] **Step 4: Declare the module**
+
+In `src/core/mod.rs`, add `pub mod recommend;` to the module list (after
+`pub mod pdf;`).
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib core::recommend 2>&1 | tail -30`
+Expected: PASS, 9 tests.
+
+If `a_resemblance_is_not_called_a_pattern` lands on `Pattern` instead, the two
+bundles are closer than intended — widen the gap (change the weekday too) rather
+than moving `strong_at`, which is a shipped default.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/recommend.rs src/core/mod.rs
+git commit -m "feat(recommend): four rungs, and a reason that explains the hit it is shown beside"
+```
+
+---
+
+### Task 9: The display — one endpoint, two jobs
+
+The bundle originates in the browser, so the server does not have it at first
+render. `search_page` renders a placeholder with reserved height and htmx fills
+it. One endpoint records the situation *and* answers with the fragment;
+recording happens even when nothing is recommended.
+
+**Files:**
+- Modify: `src/core/recommend.rs` (one field on `Offer`)
+- Modify: `src/core/mod.rs` (`Core::record_context_event`)
+- Modify: `src/store/pursuits.rs` (`Store::record_recommendation`)
+- Modify: `src/web/ui.rs` (the route, the handler, the view struct, `SearchTemplate::recommend`)
+- Create: `src/web/templates/_context.html`
+- Modify: `src/web/templates/search.html`
+- Modify: `assets/app.js`, `assets/css/40-search.css`
+- Test: in `src/web/ui.rs`'s existing test module
+
+**Interfaces:**
+- Consumes: `Core::offer`, `Rung::{as_str, line}`, `core::context::{parse_bundle, device_key, local_time}`.
+- Produces:
+  - `pub at_tz: Option<String>` on `Offer` — an amendment to Task 8, set from `rep["bundle"]["tz"]`, so the quoted stamp is printed in the zone the device was actually in.
+  - `Store::record_recommendation(&self, artifact_id: &str, kind: &str, detail: &str, scope: Option<&str>, at: i64) -> Result<()>`
+  - `Core::record_context_event(&self, raw: &str, bundle: &Bundle, scope: Option<&str>)` — off the request path
+  - `Core::record_recommendation(&self, artifact_id: &str, kind: &str, rung: &str, slot: Option<i64>, scope: Option<&str>)` — off the request path
+  - `POST /ui/context`
+  - `window.engramContext()` in `app.js`
+
+- [ ] **Step 1: Amend `Offer` with the zone**
+
+In `src/core/recommend.rs`, add to `Offer` after `at`:
+
+```rust
+    /// The zone the representative event happened in, so "like 08.08., 15:04"
+    /// is printed as the device read it. Taking the *current* bundle's zone
+    /// would misdate every situation recorded on a trip.
+    pub at_tz: Option<String>,
+```
+
+Set it in the `Pattern`/`Similar` branch:
+
+```rust
+                    at_tz: rep
+                        .pointer("/bundle/tz")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+```
+
+and `at_tz: None` in the two lower rungs. Re-run `cargo test --lib core::recommend`.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to the test module in `src/web/ui.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_page_view_is_recorded_even_when_nothing_is_offered() {
+        // The endpoint has two jobs and does the first unconditionally. A base
+        // that has learned nothing yet is exactly the base that most needs its
+        // situations written down.
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let res = post_form(
+            &app,
+            &cookie,
+            "/ui/context",
+            "bundle=%7B%22tz%22%3A%22Europe%2FBerlin%22%7D",
+        )
+        .await;
+        assert_eq!(res.status(), 200);
+
+        let rows = store.context_events_since(0).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].tz.as_deref(), Some("Europe/Berlin"));
+        assert!(rows[0].local_hour.is_some(), "denormalised for the sweep");
+        assert_eq!(rows[0].scope.as_deref(), Some("user-1"));
+    }
+
+    #[tokio::test]
+    async fn a_bundle_the_browser_could_not_build_does_not_break_the_page() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let res = post_form(&app, &cookie, "/ui/context", "bundle=%7B%7Bnope").await;
+        assert_eq!(res.status(), 200, "an empty bundle is a working one");
+        assert_eq!(store.context_events_since(0).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn the_area_is_not_rendered_when_the_faculty_is_off() {
+        // One gate, in one place: no placeholder, no request, nothing recorded.
+        let core = crate::core::test_support::test_core().await;
+        let store = core.store.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let page = crate::web::test_support::body_of(get(&app, &cookie, "/ui/search").await).await;
+        assert!(!page.contains("/ui/context"), "no placeholder");
+
+        let res = post_form(&app, &cookie, "/ui/context", "bundle=%7B%7D").await;
+        assert_eq!(res.status(), 200);
+        assert!(store.context_events_since(0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_placeholder_reserves_its_height_so_the_page_does_not_jump() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let page = crate::web::test_support::body_of(get(&app, &cookie, "/ui/search").await).await;
+        assert!(page.contains(r#"id="context-offer""#));
+        assert!(page.contains("hx-post=\"/ui/context\""));
+        assert!(page.contains("engramContext()"));
+    }
+
+    #[tokio::test]
+    async fn what_was_offered_is_written_down_with_its_rung() {
+        // Shown against clicked, broken down by rung, is a hit rate. It is the
+        // only number that can later settle whether the weights are right, and
+        // a recommender with no visible hit rate becomes `[sitting] prime`:
+        // a default nobody ever measured.
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let aid = seed_forgotten_artifact(&core).await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let body = crate::web::test_support::body_of(
+            post_form(&app, &cookie, "/ui/context", "bundle=%7B%7D").await,
+        )
+        .await;
+        assert!(body.contains("Not seen in a long time"), "{body}");
+        assert!(body.contains(&aid));
+
+        let rows = store.interactions_between(0, i64::MAX).await.unwrap();
+        let shown: Vec<_> = rows.iter().filter(|r| r.kind == "recommended_shown").collect();
+        assert_eq!(shown.len(), 1);
+        assert!(shown[0].detail.as_deref().unwrap().contains("forgotten"));
+    }
+
+    /// One artifact old enough and unseen enough that `resurface` returns it.
+    /// Mirror whatever the search tests in this module already use.
+    async fn seed_forgotten_artifact(core: &crate::core::Core) -> String {
+        todo!("mirror this module's existing artifact seeding")
+    }
+```
+
+`post_form` and `get` are helpers this module already has under some name — read
+the module's other tests and use those rather than adding new ones.
+
+- [ ] **Step 3: Run them to verify they fail**
+
+Run: `cargo test --lib web::ui 2>&1 | tail -20`
+Expected: FAIL — no `/ui/context` route (404).
+
+- [ ] **Step 4: Add the two store writes**
+
+In `src/store/pursuits.rs`, beside `record_dwell`:
+
+```rust
+    /// What this base offered, and whether it was taken.
+    ///
+    /// `kind` is `recommended_shown` or `recommended_open`. Both live in
+    /// `interaction_events` because both are things that happened after a page
+    /// rendered — but neither counts as an ordinary open: the sweep reads
+    /// `recommended_open` at `recommend.self_weight` and ignores
+    /// `recommended_shown` entirely, and `jobs::pursuit` skips the latter too.
+    ///
+    /// `detail` carries the rung and the winning cluster as JSON, which is what
+    /// makes the Ops hit rate a breakdown rather than one number.
+    pub async fn record_recommendation(
+        &self,
+        artifact_id: &str,
+        kind: &str,
+        detail: &str,
+        scope: Option<&str>,
+        at: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO interaction_events (artifact_id, kind, detail, scope, at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(artifact_id)
+        .bind(kind)
+        .bind(detail)
+        .bind(scope)
+        .bind(at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 5: Add the two `Core` writes**
+
+In `src/core/recommend.rs`, inside `impl Core`:
+
+```rust
+    /// Write down the situation this page view happened in. Off the request
+    /// path: a page view must not get slower, or fail, because a bookkeeping
+    /// write did — and a situation dropped at shutdown is a Friday afternoon
+    /// the base never learns about, which is why it goes through `background`
+    /// rather than a bare `tokio::spawn`.
+    ///
+    /// The raw string is stored whole, including the fields the encoder does
+    /// not read today; the denormalised columns are what the sweep reads on
+    /// every row.
+    pub fn record_context_event(&self, raw: &str, bundle: &Bundle, scope: Option<&str>) {
+        if !self.recommends() {
+            return;
+        }
+        let at = self.clock.now();
+        let t = crate::core::context::local_time(at, bundle.tz.as_deref(), bundle.tz_offset_mins);
+        let row = crate::store::context::ContextEvent {
+            id: 0,
+            scope: scope.map(str::to_string),
+            at,
+            bundle: raw.to_string(),
+            device_key: crate::core::context::device_key(bundle),
+            local_hour: Some(t.hour as i64),
+            weekday: Some(t.weekday as i64),
+            tz: bundle.tz.clone(),
+        };
+        let store = self.store.clone();
+        self.background.spawn(async move {
+            if let Err(e) = store.record_context(&row).await {
+                tracing::warn!(error = %e, "could not record the situation of a page view");
+            }
+        });
+    }
+
+    /// Write down that something was offered, or that the offer was taken.
+    pub fn record_recommendation(
+        &self,
+        artifact_id: &str,
+        kind: &str,
+        rung: &str,
+        slot: Option<i64>,
+        scope: Option<&str>,
+    ) {
+        if !self.recommends() {
+            return;
+        }
+        let detail = serde_json::json!({ "rung": rung, "slot": slot }).to_string();
+        let (store, id, kind, scope) = (
+            self.store.clone(),
+            artifact_id.to_string(),
+            kind.to_string(),
+            scope.map(str::to_string),
+        );
+        let at = self.clock.now();
+        self.background.spawn(async move {
+            if let Err(e) = store
+                .record_recommendation(&id, &kind, &detail, scope.as_deref(), at)
+                .await
+            {
+                tracing::warn!(error = %e, "could not record what was offered");
+            }
+        });
+    }
+```
+
+- [ ] **Step 6: The endpoint and the view struct**
+
+In `src/web/ui.rs`, beside the other fragment templates:
+
+```rust
+/// One offer, flattened for the template. Every decision — which rung, which
+/// blocks, how the stamp reads — is made here, so the template holds no logic
+/// and a new block in the encoder changes no markup.
+#[derive(Default)]
+pub struct OfferView {
+    pub id: String,
+    pub title: String,
+    /// One of four fixed strings. See `Rung::line`.
+    pub rung: &'static str,
+    /// The blocks that decided it, joined. Empty on the lower two rungs.
+    pub blocks: String,
+    /// `08.08., 15:04`, or empty.
+    pub when: String,
+    /// `?rec=<slot>`, or empty — what tells `artifact_detail` this open came
+    /// from an offer.
+    pub rec: String,
+    /// The raw bundle and the contribution numbers, for the `<details>`.
+    pub detail: String,
+}
+
+#[derive(Template, Default)]
+#[template(path = "_context.html")]
+struct ContextTemplate {
+    offer: Option<OfferView>,
+}
+
+#[derive(serde::Deserialize)]
+struct ContextForm {
+    #[serde(default)]
+    bundle: String,
+}
+
+/// One endpoint, two jobs: it writes the situation and answers with the
+/// fragment. Recording happens even when nothing is recommended — a base that
+/// has learned nothing yet is exactly the one that most needs its situations
+/// written down.
+async fn context_offer(
+    State(st): State<AppState>,
+    id: Identity,
+    Form(f): Form<ContextForm>,
+) -> Result<Response> {
+    if !st.core.recommends() {
+        return Ok(HtmlTemplate(ContextTemplate::default()).into_response());
+    }
+    let bundle = crate::core::context::parse_bundle(&f.bundle);
+    st.core
+        .record_context_event(&f.bundle, &bundle, Some(&id.subject));
+
+    // A recommendation that cannot be computed is not worth a 500: the area is
+    // what it was yesterday, which is empty.
+    let offer = st
+        .core
+        .offer(Some(&id.subject), &bundle, id.session.as_deref())
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "could not build a recommendation");
+            None
+        });
+
+    if let Some(o) = &offer {
+        st.core.record_recommendation(
+            &o.artifact_id,
+            "recommended_shown",
+            o.rung.as_str(),
+            o.slot,
+            Some(&id.subject),
+        );
+    }
+    Ok(HtmlTemplate(ContextTemplate {
+        offer: offer.map(offer_view),
+    })
+    .into_response())
+}
+
+fn offer_view(o: crate::core::recommend::Offer) -> OfferView {
+    OfferView {
+        rung: o.rung.line(),
+        blocks: o.blocks.join(", "),
+        // The device's own reading of when this happened, in the zone it
+        // happened in. One date format, and the whole of the third part of the
+        // line.
+        when: o
+            .at
+            .map(|at| {
+                let t = crate::core::context::local_time(at, o.at_tz.as_deref(), None);
+                format!(
+                    "{:02}.{:02}., {:02}:{:02}",
+                    t.day,
+                    t.month,
+                    t.hour as u32,
+                    ((t.hour % 1.0) * 60.0).round() as u32
+                )
+            })
+            .unwrap_or_default(),
+        rec: match o.slot {
+            Some(s) => format!("?rec={s}"),
+            None => String::new(),
+        },
+        id: o.artifact_id,
+        title: o.title,
+        detail: o.detail,
+    }
+}
+```
+
+Add the route beside the other search routes (`ui.rs:3670`):
+
+```rust
+        .route("/ui/context", post(context_offer))
+```
+
+- [ ] **Step 7: The fragment**
+
+Create `src/web/templates/_context.html`:
+
+```html
+{# The area under the search box. Fetched rather than rendered because the
+   bundle originates in the browser and the server does not have it at first
+   render — `search_page` puts a placeholder here with reserved height, and this
+   replaces it.
+
+   Three parts, all cheap: the rung name, which is one of four fixed strings;
+   the blocks that decided it, which are `&'static str` labels sorted by
+   contribution; and the representative event's stamp, which is one date format.
+   No sentences are generated anywhere — a new block in the encoder brings its
+   own label and needs no template written for it. Generated prose per block was
+   the first draft and was cut, because it coupled every new dimension to a
+   sentence somebody had to keep in step with it.
+
+   The id is kept on the answer as well as on the placeholder: app.js removes
+   this area on the first keystroke, and it needs something to remove whichever
+   of the two is on screen when that happens. #}
+<div id="context-offer" class="offer">
+{% if let Some(o) = offer %}
+  <a class="offer-title" href="/ui/artifacts/{{ o.id }}{{ o.rec }}">{{ o.title }}</a>
+  <p class="muted offer-why">{{ o.rung }}{% if !o.blocks.is_empty() %} · {{ o.blocks }}{% endif %}{% if !o.when.is_empty() %} · like {{ o.when }}{% endif %}
+    {# `serde_json` over the raw bundle plus the contribution numbers, inside a
+       `<details>`. No formatting code, and it satisfies "the parameters must be
+       visible" completely: whoever wants to know exactly, expands it. It is
+       also the answer to what is being collected — inspectable rather than
+       promised. #}
+    <details class="offer-detail">
+      <summary>Details</summary>
+      <pre class="mono">{{ o.detail }}</pre>
+    </details>
+  </p>
+{% endif %}
+</div>
+```
+
+- [ ] **Step 8: The placeholder**
+
+In `src/web/templates/search.html`, immediately after the closing `</form>` of
+`#filters` and before the `keyhint` paragraph:
+
+```html
+{# Reserved height, so the answer landing does not push the hint and the chips
+   down a page that has already been read. The offer is for the state "no intent
+   expressed yet" — app.js removes it on the first keystroke, and it does not
+   come back when the box is cleared: once there is an intent the offer is
+   wrong, and reappearing because someone corrected a typo is flicker. It
+   returns on the next page view.
+
+   Without JavaScript the area stays empty, which is the honest failure: the
+   bundle is the browser's to send. #}
+{% if recommend %}
+<div id="context-offer" class="offer" hx-post="/ui/context" hx-trigger="load"
+     hx-vals='js:{bundle: engramContext()}' hx-swap="outerHTML"></div>
+{% endif %}
+```
+
+Add the field to `SearchTemplate` in `src/web/ui.rs`:
+
+```rust
+    /// Whether the area under the search box exists at all. See
+    /// `Core::recommends`.
+    recommend: bool,
+```
+
+and set it in `search_page`:
+
+```rust
+        recommend: st.core.recommends(),
+```
+
+- [ ] **Step 9: The client**
+
+In `assets/app.js`, inside the IIFE and above the `DOMContentLoaded` handler:
+
+```js
+  // The situation this page view happened in.
+  //
+  // Synchronous, because htmx reads `hx-vals js:` synchronously. The two
+  // asynchronous sources — the Battery API and the device list — are read once
+  // at load and cached here, so the first page view of a session goes without
+  // them and the server zeroes their blocks rather than inventing a value.
+  //
+  // Deliberately not collected: canvas, WebGL, fonts, plugins. Those identify a
+  // device across a population; here the population is one authenticated person,
+  // so they are constant and say nothing about which situation this is — and a
+  // hardened browser randomises them per session, so every day would look like a
+  // new device.
+  var slow = { battery_level: null, charging: null, audio_outputs: null };
+
+  function primeSlow() {
+    if (navigator.getBattery) {
+      navigator.getBattery().then(function (b) {
+        slow.battery_level = b.level;
+        slow.charging = b.charging;
+      }).catch(function () {});
+    }
+    if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
+      navigator.mediaDevices.enumerateDevices().then(function (list) {
+        slow.audio_outputs = list.filter(function (d) { return d.kind === 'audiooutput'; }).length;
+      }).catch(function () {});
+    }
+  }
+
+  function uaFamily() {
+    var d = navigator.userAgentData;
+    if (d && d.brands) {
+      for (var i = 0; i < d.brands.length; i++) {
+        // Chromium pads the list with a deliberately absurd brand to break
+        // exactly the kind of sniffing this is not doing; skip it.
+        if (!/Not.*Brand/i.test(d.brands[i].brand)) return d.brands[i].brand;
+      }
+    }
+    var m = /(Firefox|Chrome|Safari|Edg)\/[\d.]+/.exec(navigator.userAgent || '');
+    return m ? m[1] : null;
+  }
+
+  function netKind() {
+    var c = navigator.connection || navigator.mozConnection;
+    if (!c) return null;
+    if (c.type) return c.type;
+    // `effectiveType` describes speed rather than medium, and calling a slow
+    // wifi "cellular" would be inventing a fact. Absent instead.
+    return null;
+  }
+
+  window.engramContext = function () {
+    var b = {};
+    try {
+      b.tz = Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+      b.tz_offset_mins = -new Date().getTimezoneOffset();
+      b.language = navigator.language || null;
+      b.languages = navigator.languages ? Array.prototype.slice.call(navigator.languages) : [];
+      b.viewport_w = window.innerWidth;
+      b.viewport_h = window.innerHeight;
+      b.screen_w = screen.width;
+      b.screen_h = screen.height;
+      b.dpr = window.devicePixelRatio;
+      b.color_scheme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      b.platform = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || null;
+      b.ua_family = uaFamily();
+      b.cores = navigator.hardwareConcurrency || null;
+      b.memory_gb = navigator.deviceMemory || null;
+      b.touch = navigator.maxTouchPoints > 0;
+      b.orientation = window.innerHeight >= window.innerWidth ? 'portrait' : 'landscape';
+      b.network = netKind();
+      b.battery_level = slow.battery_level;
+      b.charging = slow.charging;
+      b.audio_outputs = slow.audio_outputs;
+    } catch (e) {
+      // A partial bundle is a working one: the blocks it could not fill are
+      // zeroed server-side, and the weekday and the hour still stand.
+    }
+    return JSON.stringify(b);
+  };
+
+  // Removed on the first keystroke, and it does not come back when the box is
+  // cleared. The flag is what covers the race: the fetch fires on `load`, and
+  // its answer can land *after* the first keystroke — without this, an offer
+  // already dismissed would swap itself back in.
+  var offerDismissed = false;
+
+  function dropOffer() {
+    var area = document.getElementById('context-offer');
+    if (area) area.remove();
+  }
+
+  function contextOffer() {
+    var box = document.querySelector('input[name=q]');
+    if (!box) return;
+    box.addEventListener('input', function () {
+      offerDismissed = true;
+      dropOffer();
+    }, { once: true });
+  }
+```
+
+In the `DOMContentLoaded` handler, beside the other initialisers:
+
+```js
+    primeSlow();
+    contextOffer();
+```
+
+and in the existing `htmx:afterSwap` listener, first thing inside:
+
+```js
+      if (e.target.id === 'context-offer' && offerDismissed) dropOffer();
+```
+
+- [ ] **Step 10: The rules**
+
+Append to `assets/css/40-search.css`:
+
+```css
+/* The area under the search box. `min-height` is what keeps the answer landing
+   from pushing the hint and the chips down a page that has already been read —
+   the fetch is one round trip after `load`, which is long enough to see. */
+.offer { min-height: 3.25rem; margin: 0.25rem 0 0.5rem; }
+.offer-title { font-size: var(--text-base); color: var(--color-fg-primary); }
+.offer-why { font-size: var(--text-xs); margin: 0.125rem 0 0; }
+.offer-detail { display: inline; }
+.offer-detail summary { display: inline; cursor: pointer; color: var(--color-accent); }
+.offer-detail pre { white-space: pre-wrap; word-break: break-all; margin: 0.375rem 0 0; font-size: var(--text-xs); }
+```
+
+- [ ] **Step 11: Run the tests to verify they pass**
+
+Run: `cargo test --lib web::ui 2>&1 | tail -30`
+Expected: PASS.
+
+- [ ] **Step 12: See it in the real app**
+
+Run the app against a real config with `[recommend] enabled = true`, open
+`/ui/search`, and confirm: the area shows something, the page does not jump when
+it lands, and the first keystroke removes it and clearing the box does not bring
+it back. Use the `run` skill if the project has one.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/core/recommend.rs src/core/mod.rs src/store/pursuits.rs \
+        src/web/ui.rs src/web/templates/_context.html \
+        src/web/templates/search.html assets/app.js assets/css/40-search.css \
+        src/core/context.rs
+git commit -m "feat(web): the area under the search box, and the reason under that"
+```
+
+---
+
+### Task 10: The guard, and a hit rate somebody can see
+
+Without this, the first lucky guess grows into a habit the system taught itself
+— and nobody can tell whether the weights in §6 are right. `[sitting] prime` has
+sat at `false` for months because nobody measured it; a recommender with no
+visible hit rate becomes the same case.
+
+**Files:**
+- Modify: `src/web/ui.rs` (`artifact_detail`'s `rec=` branch, the Ops rollup)
+- Modify: `src/jobs/pursuit.rs:520` (one filter)
+- Modify: `src/store/pursuits.rs` (the rollup query)
+- Modify: `src/web/templates/ops.html`
+- Test: in `src/jobs/pursuit.rs` and `src/web/ui.rs`
+
+**Interfaces:**
+- Consumes: `Store::record_recommendation`, `Rung::as_str`.
+- Produces:
+  - `pub struct OfferRate { pub rung: String, pub shown: i64, pub opened: i64 }`
+  - `Store::offer_rates(&self, since: i64) -> Result<Vec<OfferRate>>` — one row per rung, shown descending
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/jobs/pursuit.rs`'s test module:
+
+```rust
+    #[tokio::test]
+    async fn an_offer_that_was_only_shown_is_not_engagement() {
+        // `recommended_shown` is this feature's own guess, not something a
+        // person did. The sweep weighs any kind that is not `dwell` or
+        // `pivoted` at 1.0, so without an explicit exclusion every artifact the
+        // recommender ever guessed at would count as an engaged one — and a
+        // pursuit would be written around a list nobody clicked.
+        let core = test_core_for_pursuits().await;
+        let ids = seed_two(&core).await;
+        let t0 = crate::store::now() - 10_000;
+        record_search(&core, t0, &ids).await;
+        core.store
+            .record_recommendation(&ids[0], "recommended_shown", r#"{"rung":"pattern"}"#, Some("me"), t0 + 1)
+            .await
+            .unwrap();
+
+        let n = crate::jobs::pursuit::run(&core).await.unwrap();
+        let open = core.store.open_pursuits().await.unwrap();
+        assert!(
+            open.iter().all(|p| !p.sources.contains(&ids[0])),
+            "shown is not engaged (wrote {n})"
+        );
+    }
+```
+
+Adapt `test_core_for_pursuits`, `seed_two` and `record_search` to whatever that
+module already calls its helpers — read it first.
+
+In `src/web/ui.rs`'s test module:
+
+```rust
+    #[tokio::test]
+    async fn taking_an_offer_is_not_an_ordinary_open() {
+        // §5: without this the profile reinforces itself. The row is written,
+        // and it is written under its own kind so the sweep can weigh it at
+        // `self_weight` — which is zero.
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        core.pursuit.enabled = true;
+        core.feedback.enabled = true;
+        let store = core.store.clone();
+        let aid = seed_forgotten_artifact(&core).await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let res = get(&app, &cookie, &format!("/ui/artifacts/{aid}?rec=0")).await;
+        assert_eq!(res.status(), 200);
+        // Background writes; drain before asserting rather than sleeping.
+        drain_background(&app).await;
+
+        let kinds: Vec<String> = store
+            .interactions_between(0, i64::MAX)
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.kind.clone())
+            .collect();
+        assert!(kinds.contains(&"recommended_open".to_string()));
+        assert!(!kinds.contains(&"opened".to_string()), "not both: {kinds:?}");
+    }
+
+    #[tokio::test]
+    async fn ops_shows_shown_against_clicked_by_rung() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let aid = seed_forgotten_artifact(&core).await;
+        for _ in 0..4 {
+            store
+                .record_recommendation(&aid, "recommended_shown", r#"{"rung":"pattern"}"#, Some("me"), 100)
+                .await
+                .unwrap();
+        }
+        store
+            .record_recommendation(&aid, "recommended_open", r#"{"rung":"pattern"}"#, Some("me"), 101)
+            .await
+            .unwrap();
+
+        let rates = store.offer_rates(0).await.unwrap();
+        assert_eq!(rates.len(), 1);
+        assert_eq!(rates[0].rung, "pattern");
+        assert_eq!(rates[0].shown, 4);
+        assert_eq!(rates[0].opened, 1);
+
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let page = crate::web::test_support::body_of(get(&app, &cookie, "/ui/ops").await).await;
+        assert!(page.contains("pattern"), "{page}");
+        assert!(page.contains("4"));
+    }
+```
+
+`drain_background` is `core.background.wait_idle()` — reach it however the
+module's existing background-write tests do.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib jobs::pursuit web::ui 2>&1 | tail -20`
+Expected: FAIL.
+
+- [ ] **Step 3: Exclude the offer from engagement**
+
+In `src/jobs/pursuit.rs:520`, at the `mine` construction:
+
+```rust
+        let mine: Vec<&crate::store::pursuits::Interaction> = attached[m]
+            .iter()
+            .map(|&k| &interactions[k])
+            // What this base *offered* is not something a person did. Every
+            // kind that is not `dwell` or `pivoted` is weighed at 1.0 below, so
+            // without this every artifact the recommender ever guessed at would
+            // count as engaged — and `engaged` a few lines down would call a
+            // search followed by nothing a search that was followed.
+            .filter(|i| i.kind != "recommended_shown")
+            .collect();
+```
+
+- [ ] **Step 4: Record the click**
+
+In `src/web/ui.rs`, extend `ArtifactViewParams`:
+
+```rust
+    /// The cluster slot this was offered under, when the link came from the
+    /// area under the search box.
+    #[serde(default)]
+    rec: Option<i64>,
+    /// And the rung it was offered on. Carried on the link because the offer
+    /// was computed on a previous request and nothing server-side still holds
+    /// it — without it, every click lands in one bucket on Ops.
+    #[serde(default)]
+    rung: Option<String>,
+```
+
+and in `artifact_detail`, replace the `record_interaction` call:
+
+```rust
+    // And the act the pursuit sweep reads: opened, or pivoted through — unless
+    // this came from the area under the search box, in which case it is written
+    // under its own kind and *not* as an ordinary open. §5: a
+    // `recommended_open` counted as an open is the first lucky guess growing
+    // into a habit the system taught itself.
+    //
+    // The rung rides on the link because that is the only place it still
+    // exists: the offer was computed on a previous request, and Ops's
+    // breakdown is a breakdown only if the click knows which rung it came from.
+    match p.rec {
+        Some(slot) => st.core.record_recommendation(
+            &cid,
+            "recommended_open",
+            p.rung.as_deref().unwrap_or("unknown"),
+            Some(slot),
+            Some(&id.subject),
+        ),
+        None => st
+            .core
+            .record_interaction(&cid, p.via.as_deref(), Some(&id.subject)),
+    }
+```
+
+And the link has to carry it. In Task 9's `offer_view`, `rec` becomes:
+
+```rust
+        rec: match o.slot {
+            Some(s) => format!("?rec={s}&rung={}", o.rung.as_str()),
+            None => String::new(),
+        },
+```
+
+- [ ] **Step 5: The rollup**
+
+In `src/store/pursuits.rs`:
+
+```rust
+/// Shown against clicked, for one rung of the ladder.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OfferRate {
+    pub rung: String,
+    pub shown: i64,
+    pub opened: i64,
+}
+
+// … inside impl Store:
+
+    /// What was offered and what was taken, by rung, since `since`.
+    ///
+    /// The only number that can later settle whether §6's weights are right.
+    /// They are chosen, not measured, and fitting them before this data exists
+    /// would be guessing with extra steps — so this is the instrument, and it
+    /// goes on Ops, which is where `ROADMAP.md` puts mechanisms whose effect
+    /// nobody can otherwise see.
+    pub async fn offer_rates(&self, since: i64) -> Result<Vec<OfferRate>> {
+        let rows = sqlx::query(
+            "SELECT json_extract(detail, '$.rung') AS rung,
+                    SUM(kind = 'recommended_shown') AS shown,
+                    SUM(kind = 'recommended_open')  AS opened
+               FROM interaction_events
+              WHERE at >= ? AND kind IN ('recommended_shown', 'recommended_open')
+              GROUP BY rung
+              ORDER BY shown DESC, rung",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| OfferRate {
+                rung: r.get::<Option<String>, _>("rung").unwrap_or_default(),
+                shown: r.get("shown"),
+                opened: r.get("opened"),
+            })
+            .collect())
+    }
+```
+
+- [ ] **Step 6: Put it on Ops**
+
+In `src/web/ui.rs`'s `ops` handler, add to the template struct and populate it
+the way the neighbouring rollups are populated (`links`, `sweep_history`) —
+including the same "a store that cannot answer must not take the page down"
+treatment they use.
+
+In `src/web/templates/ops.html`, after the sweep history table:
+
+```html
+{# Shown against clicked, by rung. The one number that can settle whether the
+   weights the recommender rests on are right — they are chosen, not measured,
+   and until this has data, fitting them would be guessing with extra steps.
+   `[sitting] prime` has sat at `false` for months because nobody measured it;
+   this is here so the same thing does not happen twice. #}
+{% if !offer_rates.is_empty() %}
+<h3>What was offered</h3>
+<table class="grid">
+  <thead><tr><th>Rung</th><th>Shown</th><th>Opened</th></tr></thead>
+  <tbody>
+  {% for r in offer_rates %}
+    <tr><td>{{ r.rung }}</td><td>{{ r.shown }}</td><td>{{ r.opened }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+```
+
+- [ ] **Step 7: Run the tests, then everything**
+
+Run: `cargo test --lib jobs::pursuit web::ui store::pursuits 2>&1 | tail -20`
+Expected: PASS.
+
+Run: `cargo fmt && cargo clippy --all-targets 2>&1 | tail -20 && cargo test 2>&1 | tail -10`
+Expected: clean, all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/jobs/pursuit.rs src/web/ui.rs src/store/pursuits.rs \
+        src/web/templates/ops.html
+git commit -m "feat(recommend): what it offered does not teach it, and the hit rate is on the page"
+```
+
+---
+
+### Task 11: The acceptance test, and the roadmap
+
+The example the feature was asked for, end to end, and the entry that says what
+was built.
+
+**Files:**
+- Modify: `src/core/recommend.rs` (the acceptance test)
+- Modify: `ROADMAP.md`
+- Test: in `src/core/recommend.rs`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the acceptance test**
+
+Append to `mod tests` in `src/core/recommend.rs`:
+
+```rust
+    #[tokio::test]
+    async fn six_fridays_and_the_seventh_offers_it_before_it_is_asked_for() {
+        // §10.5, and the whole feature in one test: seed six Fridays, set the
+        // clock to the seventh at 14:52, send the phone bundle, and assert the
+        // artifact comes back at rung Pattern with weekday, hour and device
+        // named. Nothing here calls a model or an embedder — every step is the
+        // production path with a fixed clock in it.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_one_artifact(&core).await;
+        let noise = seed_one_artifact(&core).await;
+
+        // Six Fridays at 15:00 on the phone, opening `aid`.
+        for w in 1..=6 {
+            let at = FRIDAY - w * 7 * 86_400 - 52 * 60;
+            let raw = serde_json::to_string(&phone()).unwrap();
+            core.store
+                .record_context(&crate::store::context::ContextEvent {
+                    id: 0,
+                    scope: Some("alice".into()),
+                    at,
+                    bundle: raw,
+                    device_key: crate::core::context::device_key(&phone()),
+                    local_hour: Some(15),
+                    weekday: Some(4),
+                    tz: Some("Europe/Berlin".into()),
+                })
+                .await
+                .unwrap();
+            core.store
+                .record_interaction(&aid, "opened", None, Some("alice"), at + 5)
+                .await
+                .unwrap();
+        }
+        // And one Tuesday morning at a desk, opening something else — so the
+        // answer is a choice rather than the only candidate.
+        let mut desk = phone();
+        desk.platform = Some("macOS".into());
+        desk.touch = Some(false);
+        desk.network = Some("wired".into());
+        desk.orientation = Some("landscape".into());
+        desk.viewport_w = Some(1920.0);
+        desk.viewport_h = Some(1080.0);
+        desk.screen_w = Some(2560.0);
+        desk.screen_h = Some(1440.0);
+        desk.dpr = Some(2.0);
+        for w in 1..=6 {
+            let at = FRIDAY - w * 7 * 86_400 - 3 * 86_400 - 7 * 3600;
+            core.store
+                .record_context(&crate::store::context::ContextEvent {
+                    id: 0,
+                    scope: Some("alice".into()),
+                    at,
+                    bundle: serde_json::to_string(&desk).unwrap(),
+                    device_key: crate::core::context::device_key(&desk),
+                    local_hour: Some(9),
+                    weekday: Some(1),
+                    tz: Some("Europe/Berlin".into()),
+                })
+                .await
+                .unwrap();
+            core.store
+                .record_interaction(&noise, "opened", None, Some("alice"), at + 5)
+                .await
+                .unwrap();
+        }
+
+        let learned = crate::jobs::context::run(&core).await.unwrap();
+        assert_eq!(learned.profiled, 2, "both situations were learned");
+
+        // The seventh Friday, 14:52, on the phone.
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap().unwrap();
+        assert_eq!(offer.artifact_id, aid, "the Friday thing, not the Tuesday one");
+        assert_eq!(offer.rung, Rung::Pattern);
+        assert!(offer.blocks.contains(&"weekday"), "{:?}", offer.blocks);
+        assert!(offer.blocks.contains(&"hour"), "{:?}", offer.blocks);
+        assert!(offer.blocks.contains(&"device"), "{:?}", offer.blocks);
+        assert!(offer.at.is_some(), "and it quotes a Friday that happened");
+    }
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --lib core::recommend::tests::six_fridays 2>&1 | tail -30`
+Expected: PASS.
+
+If the rung lands on `Similar`, print `context_score` and the full
+`contributions` list before touching `strong_at`: the likeliest cause is the
+`viewport` block, whose two bundles above differ enough that the check is real.
+
+- [ ] **Step 3: Update the roadmap**
+
+In `ROADMAP.md`, add to the "What is built" paragraph, before
+`Design records live in`:
+
+```
+a recommendation under the search box, learned from the situations an artifact
+was opened in — the browser's time zone, local time, device, viewport, network
+and power, clustered per artifact and stored as a `ctx` multivector scored with
+`max_sim`, with the blocks that decided each offer named beneath it and shown
+against clicked broken down by rung on Ops;
+```
+
+And under `[What the base says about itself]`, add:
+
+```
+- **The offer's hit rate is on Ops.** Shown against clicked, by rung. §6's
+  block weights are chosen, not measured, and this is the instrument that would
+  let them be fitted — fitting them before the data exists would be guessing
+  with extra steps. It is here for the reason `[sitting] prime` is still
+  `false`: a default nobody can see the effect of never moves.
+```
+
+And under whatever section holds deferred work:
+
+```
+- **Dropping the `scope` block.** At weight 10 it is the only thing keeping one
+  person's situations from being offered to another, because every scope shares
+  one collection and a payload filter cannot act on elements of a multivector
+  set. It goes to 0 when each user has their own collection, and nothing else
+  about the encoder changes.
+- **Learned block weights.** Once the shown/clicked rate has months behind it.
+- **Conjunctions across scopes.** The vector can hold them; nothing yet learns
+  which ones matter.
+```
+
+- [ ] **Step 4: Everything, one last time**
+
+Run: `cargo fmt && cargo clippy --all-targets 2>&1 | tail -20 && cargo test 2>&1 | tail -15`
+Expected: clean, all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/recommend.rs ROADMAP.md
+git commit -m "feat(recommend): the seventh Friday, and what the roadmap now says about it"
+```
+
+---
+
+## What this is not allowed to break — the checklist to run at the end
+
+Each of these has a test above. Confirm each one is green by name before calling
+the branch done.
+
+| Rule | Test |
+|---|---|
+| Payload survives a sweep write | Task 6: `set_context_vectors` uses `points/vectors`, never `upsert` — read the diff, not just the tests |
+| Ranking is untouched | No file under `src/core/search.rs` is modified by any task above |
+| Read-time cost | Task 8: `offer` makes one `context_query` and no embedder call |
+| `scope` isolation | `core::context::two_people_in_the_same_situation_are_still_far_apart`, `core::recommend::one_persons_situations_are_never_offered_to_another` |
+| The reason matches the hit | `core::recommend::the_reason_explains_the_artifact_that_was_offered` |
+| The guard | `jobs::context::an_open_of_something_this_offered_raises_no_weight`, `web::ui::taking_an_offer_is_not_an_ordinary_open`, `jobs::pursuit::an_offer_that_was_only_shown_is_not_engagement` |
+| The ladder never lies | `core::recommend::{a_resemblance_is_not_called_a_pattern, with_no_sitting_either_it_falls_to_what_has_been_forgotten}` |
+
+**One operational note for whoever ships this:** a Qdrant collection created
+before Task 6 carries no `ctx` named vector, and the sweep's first write to it
+will fail with a 400 that `sweep_runs` will record as a failed run. `--reindex`
+is the migration — it creates a fresh generation from the new collection body
+and copies every dense vector across at no embedding cost. Run it before
+switching `[recommend] enabled` on.

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     #[serde(default)]
     pub consolidate: ConsolidateConfig,
     #[serde(default)]
+    pub learn: LearnConfig,
+    #[serde(default)]
     pub feedback: FeedbackConfig,
     #[serde(default)]
     pub pacing: PacingConfig,
@@ -92,6 +94,33 @@ pub struct PacingConfig {
     pub cooldown_secs: u64,
 }
 
+/// The one switch over everything learned from what happens here.
+///
+/// Recording searches, learning links from co-retrieval, and writing a pursuit
+/// were three flags that only ever meant something together: association reads
+/// recorded searches, and a pursuit is swept on the associative pass. Two of
+/// the three combinations were refused at startup and the third was a warning,
+/// which is a way of saying they were never really three settings. They are
+/// one now.
+///
+/// On by default. Everything downstream of it — activation, promotion at
+/// `synthesis = "earned"`, the associative spread, `[recommend]` — moves only
+/// while the log is being written, so off is the deliberate act. The wording of
+/// a query is personal and nothing here leaves the machine; this is the switch
+/// for the operator who wants none of it kept, and turning it off stops the
+/// recording as well as everything read from it.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct LearnConfig {
+    pub enabled: bool,
+}
+
+impl Default for LearnConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 /// Recording real searches so they can be judged later.
 ///
 /// The queries a benchmark needs cannot be written from memory: phrased while
@@ -101,12 +130,6 @@ pub struct PacingConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct FeedbackConfig {
-    /// Whether real searches are recorded at all. On by default: promotion at
-    /// `synthesis = "earned"` reads activation, and activation moves only
-    /// while searches are recorded. The wording of a query is personal and
-    /// nothing here leaves the machine; this is the switch for the operator
-    /// who wants none of it kept.
-    pub enabled: bool,
     /// Candidates stored per event. Wider than the answer on purpose — search
     /// over-fetches anyway, so the extra rows are free, and they are what lets a
     /// buried hit be confirmed later.
@@ -125,10 +148,6 @@ pub struct FeedbackConfig {
 impl Default for FeedbackConfig {
     fn default() -> Self {
         Self {
-            // On: promotion at `synthesis = "earned"` reads activation, and
-            // activation moves only while searches are recorded. Recording is
-            // the thing an operator turns *off*.
-            enabled: true,
             candidates: 20,
             coalesce_secs: 15,
             retain_days: 0,
@@ -145,9 +164,6 @@ impl Default for FeedbackConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct AssociateConfig {
-    /// Requires `feedback.enabled`. Without recorded searches there is nothing
-    /// to learn from, and that combination is a warning at startup.
-    pub enabled: bool,
     pub interval_mins: u64,
     pub half_life_days: f64,
     /// Decayed weight under which a `learning` link is deleted.
@@ -174,7 +190,6 @@ pub struct AssociateConfig {
 impl Default for AssociateConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
             interval_mins: 30,
             half_life_days: 30.0,
             prune_below: 0.5,
@@ -222,15 +237,13 @@ impl Default for PromoteConfig {
 
 /// What a coherent run of searches — a pursuit — may earn: one generated
 /// artifact, written from what was engaged with, when the base did not answer
-/// or the answer was assembled by hand. Off until turned on: this writes
-/// model-written text into the index, and that is a step an operator takes.
-/// Needs `feedback.enabled`, since the events it reads are the ones recording
-/// writes. The grouping line is not a key: it is measured, like the gap
-/// clusters', by `core::gaps::link_threshold`.
+/// or the answer was assembled by hand. Runs behind `[learn]`, which is the
+/// switch: the events it reads are the ones recording writes, and the sweep it
+/// rides on is the associative pass. The grouping line is not a key: it is
+/// measured, like the gap clusters', by `core::gaps::link_threshold`.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct PursuitConfig {
-    pub enabled: bool,
     /// A pursuit is over when nothing has happened for this long.
     pub idle_secs: u64,
     /// Fewer engaged artifacts than this is a promotion case, not generation.
@@ -242,7 +255,6 @@ pub struct PursuitConfig {
 impl Default for PursuitConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
             idle_secs: 900,
             min_sources: 2,
             min_engagement: 3.0,
@@ -391,9 +403,11 @@ impl BlockWeights {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct RecommendConfig {
-    /// Off until there is a base with weeks of situations in it. A weekly
-    /// pattern needs weeks; shipping this on would show the bottom rung of the
-    /// ladder for a fortnight and teach the operator to ignore the area.
+    /// On, with the floor of the ladder as the honest answer while the base is
+    /// young. A weekly pattern needs weeks, so a new base sees the random card
+    /// for a fortnight — that card claims nothing, and an area that says
+    /// nothing until it has something to say is an area nobody discovers.
+    /// Needs `learn.enabled`: the situations are read from the same log.
     pub enabled: bool,
     /// Cosine above which an event joins a cluster rather than opening its own.
     pub cluster_merge_at: f32,
@@ -439,7 +453,7 @@ pub struct RecommendConfig {
 impl Default for RecommendConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             cluster_merge_at: 0.82,
             max_clusters: 5,
             half_life_days: 45.0,
@@ -1659,26 +1673,6 @@ impl Config {
                 self.infer.synthesis.as_str()
             )));
         }
-        if self.pursuit.enabled && !self.feedback.enabled {
-            return Err(ConfigError::Invalid(
-                "pursuit.enabled = true needs feedback.enabled = true: the events it reads are \
-                 the ones recording writes"
-                    .into(),
-            ));
-        }
-        // The other half of the same gate. Both the sweep and its ticker run
-        // behind `associating()`, which is these two flags together, so a
-        // pursuit configured without associating is not a degraded feature —
-        // it is a ticker that returns on its first line and a config that
-        // never writes a pursuit at all. Refused rather than warned, because
-        // the `feedback` half above is refused and the effect is identical.
-        if self.pursuit.enabled && !self.associate.enabled {
-            return Err(ConfigError::Invalid(
-                "pursuit.enabled = true needs associate.enabled = true: pursuits are swept on \
-                 the associative pass, which does not run without it"
-                    .into(),
-            ));
-        }
         if let Some(v) = &self.infer.vision
             && v.base_url.is_none()
             && self.infer.synthesize.is_none()
@@ -1697,21 +1691,15 @@ impl Config {
         Ok(())
     }
 
-    /// Two switches that only mean something together: say so once at startup
-    /// rather than letting an operator discover the association pass has been
-    /// idle since they turned recording off.
+    /// Settings that are on but cannot act: say so once at startup rather than
+    /// letting an operator discover a faculty has been idle since they turned
+    /// `[learn]` off. The combinations that used to be refused here are gone —
+    /// there is one switch now, and it cannot disagree with itself.
     fn warn_on_inert_settings(&self) {
-        if self.infer.synthesis == SynthesisMode::Earned && !self.feedback.enabled {
+        if self.infer.synthesis == SynthesisMode::Earned && !self.learn.enabled {
             tracing::warn!(
-                "infer.synthesis = \"earned\" with feedback.enabled = false: activation never \
+                "infer.synthesis = \"earned\" with learn.enabled = false: activation never \
                  moves, so nothing is ever promoted — this is `off` under another name."
-            );
-        }
-        if self.associate.enabled && !self.feedback.enabled {
-            tracing::warn!(
-                "associate.enabled has no effect while feedback.enabled is false: links are \
-                 learned from recorded searches, and none are being recorded. Recording queries \
-                 is a privacy decision, so it keeps its own switch."
             );
         }
     }
@@ -1889,9 +1877,12 @@ mod tests {
     }
 
     #[test]
-    fn the_recommender_ships_off_with_its_weights_named() {
+    fn the_recommender_ships_on_with_its_weights_named() {
         let r = RecommendConfig::default();
-        assert!(!r.enabled, "a faculty that learns from a log ships off");
+        // On, with the floor of the ladder as the honest answer while the base
+        // is young. It still needs `[learn]`, which is where the log it reads
+        // is switched on — see `Core::recommends`.
+        assert!(r.enabled);
         // The scope block dominates so a foreign cluster can never win
         // `max_sim`. When each user has their own collection this goes to 0
         // and nothing else changes.
@@ -1942,7 +1933,12 @@ mod tests {
         // And it parses: a mistyped value or a table the loader cannot reach
         // fails here rather than at somebody's boot.
         let cfg = Config::load(Some(path)).unwrap();
-        assert!(!cfg.recommend.enabled);
+        assert!(cfg.recommend.enabled);
+        // And the one switch it runs behind, in the file rather than only in
+        // the defaults: an operator turning the layer off must be able to find
+        // the key without reading the source.
+        assert!(raw.contains("\n[learn]\n"), "the example names no [learn]");
+        assert!(cfg.learn.enabled);
         assert_eq!(cfg.recommend.max_clusters, 5);
         assert_eq!(cfg.recommend.weights.of("network"), 0.6);
     }
@@ -2039,7 +2035,7 @@ mod tests {
             cfg.feedback.candidates,
             FeedbackConfig::default().candidates
         );
-        assert!(cfg.feedback.enabled, "the rest of the section was dropped");
+        assert!(cfg.learn.enabled, "the rest of the section was dropped");
     }
 
     #[test]
@@ -2337,7 +2333,6 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
     #[test]
     fn the_association_defaults_are_the_documented_ones() {
         let a = AssociateConfig::default();
-        assert!(a.enabled);
         assert_eq!(a.interval_mins, 30);
         assert_eq!(a.half_life_days, 30.0);
         assert_eq!((a.show_min, a.judge_min, a.prune_below), (2.0, 4.0, 0.5));
@@ -2354,11 +2349,11 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         let dir = tempfile::tempdir().unwrap();
         let p = write(&dir, MINIMAL);
         let cfg = Config::load(Some(&p)).unwrap();
-        assert!(cfg.associate.enabled);
+        assert!(cfg.learn.enabled);
         // ...and recording is on too, so the feature is live out of the box:
         // promotion reads activation, and activation moves only while
         // searches are recorded.
-        assert!(cfg.feedback.enabled);
+        assert!(cfg.learn.enabled);
     }
 
     #[test]
@@ -3081,7 +3076,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 0);
         // Opt-out now: promotion reads activation, and activation only moves
         // while searches are recorded.
-        assert!(cfg.feedback.enabled);
+        assert!(cfg.learn.enabled);
         let cfg = load_infer(&format!(
             "{BARE_PREAMBLE}
             [infer.synthesize]
@@ -3092,40 +3087,48 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
             [promote]
             activation_above = 2.5
             resynthesize_after_unconfirmed = 12
-            [feedback]
+            [learn]
             enabled = false
             "
         ))
         .unwrap();
         assert_eq!(cfg.promote.activation_above, 2.5);
         assert_eq!(cfg.promote.resynthesize_after_unconfirmed, 12);
-        assert!(!cfg.feedback.enabled);
+        assert!(!cfg.learn.enabled);
     }
 
     #[test]
-    fn pursuit_defaults_and_requires_feedback() {
+    fn the_learning_layer_is_one_switch_that_nothing_can_contradict() {
         let _guard = env_guard();
         let roles = "[infer.synthesize]\ntier = \"efficient\"\noutput_ratio = 8.0\n[infer.ask]\ntier = \"efficient\"\n";
         let cfg = load_infer(&format!("{BARE_PREAMBLE}\n{roles}")).unwrap();
-        assert!(!cfg.pursuit.enabled);
+        // On, and the sections it governs carry no switch of their own. There
+        // used to be three — `feedback`, `associate`, `pursuit` — and two of
+        // their eight combinations were refused at startup while a third was a
+        // warning, which is how you find out they were one setting written
+        // three times. Nothing to refuse now: a config cannot express the
+        // combination that had to be rejected.
+        assert!(cfg.learn.enabled);
         assert_eq!(cfg.pursuit.idle_secs, 900);
         assert_eq!(cfg.pursuit.min_sources, 2);
         assert_eq!(cfg.pursuit.min_engagement, 3.0);
-        let err = load_infer(&format!(
-            "{BARE_PREAMBLE}\n{roles}[pursuit]\nenabled = true\n[feedback]\nenabled = false\n"
+        assert_eq!(cfg.associate.interval_mins, 30);
+        assert_eq!(cfg.feedback.candidates, 20);
+
+        // One key turns the whole layer off, including the recording that the
+        // rest of it reads.
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}\n{roles}[learn]\nenabled = false\n"
         ))
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("pursuit.enabled"), "{err}");
-        // Associating is both flags, so the other half is refused the same
-        // way: with feedback on and associate off, the sweep and its ticker
-        // still never run, and a config that silently writes no pursuit is
-        // the thing this refusal exists to prevent.
-        let err = load_infer(&format!(
-            "{BARE_PREAMBLE}\n{roles}[pursuit]\nenabled = true\n[associate]\nenabled = false\n"
+        .unwrap();
+        assert!(!cfg.learn.enabled);
+        // And the tuning under each faculty still loads with it off: a section
+        // is thresholds now, not a gate.
+        let cfg = load_infer(&format!(
+            "{BARE_PREAMBLE}\n{roles}[learn]\nenabled = false\n[pursuit]\nidle_secs = 60\n"
         ))
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("associate.enabled = true"), "{err}");
+        .unwrap();
+        assert_eq!(cfg.pursuit.idle_secs, 60);
+        assert!(!cfg.learn.enabled);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -403,9 +403,20 @@ pub struct RecommendConfig {
     pub max_clusters: usize,
     /// A pattern that stops fades rather than standing for ever.
     pub half_life_days: f64,
-    /// A cluster below this is dropped. Also what protects against the single
-    /// accident: one event never reaches it.
+    /// A cluster below this is dropped.
+    ///
+    /// Low enough that a single recent event survives, because a thing done
+    /// twice is worth saying so about — it just is not worth calling a
+    /// pattern. What separates the two is `firm_at`, and what protects against
+    /// the single accident is that a thin cluster has to match the situation
+    /// *better* before anything is offered at all.
     pub min_weight: f64,
+    /// Weight at or above which a cluster is spoken of as established.
+    ///
+    /// Below it the offer says how many times it has happened instead —
+    /// "Twice before" — and demands a strong situational match before saying
+    /// anything. At the default half-life this is the third repetition.
+    pub firm_at: f64,
     /// Context score — the vector with its `scope` block sliced off — at or
     /// above which the offer is called a pattern.
     ///
@@ -432,7 +443,8 @@ impl Default for RecommendConfig {
             cluster_merge_at: 0.82,
             max_clusters: 5,
             half_life_days: 45.0,
-            min_weight: 2.0,
+            min_weight: 0.9,
+            firm_at: 2.5,
             strong_at: 0.75,
             weak_at: 0.45,
             self_weight: 0.0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ pub struct Config {
     pub schedule: ScheduleConfig,
     #[serde(default)]
     pub sitting: SittingConfig,
+    #[serde(default)]
+    pub recommend: RecommendConfig,
 }
 
 /// What the two supplied-from-outside capture paths are allowed to cost.
@@ -300,6 +302,142 @@ impl Default for SittingConfig {
         // reason above it, and a derived `Default` would put that reason a
         // refactor away from the value it explains.
         Self { prime: false }
+    }
+}
+
+/// What each named block of the context vector is worth.
+///
+/// This is the whole of the encoder's argument in config form. Each block is
+/// normalised to length 1 and *then* scaled by its weight, so a block
+/// contributes exactly its weight however many dimensions it uses — seven
+/// one-hot slots for the weekday do not outweigh two for the hour because there
+/// are seven of them. That is what turns the encoding's implicit weighting,
+/// which nobody can tune, back into named numbers an operator can change.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct BlockWeights {
+    /// Interim, and load-bearing. Every scope shares one collection today, and
+    /// a point's multivector mixes the clusters of everyone who opened that
+    /// artifact — a payload filter cannot help, because it acts on the point
+    /// and not on elements of the set. A dominating `scope` block is what keeps
+    /// a foreign cluster from ever winning `max_sim`. When each user gets their
+    /// own collection this goes to 0 and nothing else changes.
+    pub scope: f32,
+    /// The hour, as an angle. See `core::context::encode`.
+    pub time_of_day: f32,
+    pub weekday: f32,
+    /// The part of the weekday that genuinely is gradual, kept apart from the
+    /// one-hot and kept weak.
+    pub weekend: f32,
+    pub device: f32,
+    pub viewport: f32,
+    pub locale: f32,
+    pub network: f32,
+    pub power: f32,
+    pub environment: f32,
+    /// Off. A monthly rhythm is real — rent, invoices — but nothing has shown
+    /// one here yet, and a block at zero costs two dimensions and no reasoning.
+    pub month_cycle: f32,
+}
+
+impl Default for BlockWeights {
+    fn default() -> Self {
+        Self {
+            scope: 10.0,
+            time_of_day: 1.0,
+            weekday: 1.0,
+            weekend: 0.3,
+            device: 0.8,
+            viewport: 0.4,
+            locale: 0.3,
+            network: 0.6,
+            power: 0.2,
+            environment: 0.2,
+            month_cycle: 0.0,
+        }
+    }
+}
+
+impl BlockWeights {
+    /// The weight of a block by name. A name nothing knows is worth nothing,
+    /// rather than a default: the block table and this lookup are edited
+    /// together, and a typo that silently gave a block weight 1.0 would be a
+    /// recommendation nobody could account for.
+    pub fn of(&self, block: &str) -> f32 {
+        match block {
+            "scope" => self.scope,
+            "time_of_day" => self.time_of_day,
+            "weekday" => self.weekday,
+            "weekend" => self.weekend,
+            "device" => self.device,
+            "viewport" => self.viewport,
+            "locale" => self.locale,
+            "network" => self.network,
+            "power" => self.power,
+            "environment" => self.environment,
+            "month_cycle" => self.month_cycle,
+            _ => 0.0,
+        }
+    }
+}
+
+/// Offering an artifact before it is asked for, from the situation the page was
+/// opened in.
+///
+/// One gate and a table of numbers, on purpose: `ROADMAP.md` under
+/// `[Core Platform]` objects to eight gates over one faculty, and this does not
+/// add a ninth. The learning cadence is not here either — see
+/// `jobs::context::INTERVAL_HOURS`.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RecommendConfig {
+    /// Off until there is a base with weeks of situations in it. A weekly
+    /// pattern needs weeks; shipping this on would show the bottom rung of the
+    /// ladder for a fortnight and teach the operator to ignore the area.
+    pub enabled: bool,
+    /// Cosine above which an event joins a cluster rather than opening its own.
+    pub cluster_merge_at: f32,
+    /// Per (scope, artifact). Multiple clusters are the point: a thing looked
+    /// up on Friday afternoons *and* occasionally on Monday mornings is two
+    /// situations, and their mean is a situation that never happened.
+    pub max_clusters: usize,
+    /// A pattern that stops fades rather than standing for ever.
+    pub half_life_days: f64,
+    /// A cluster below this is dropped. Also what protects against the single
+    /// accident: one event never reaches it.
+    pub min_weight: f64,
+    /// Context score — the vector with its `scope` block sliced off — at or
+    /// above which the offer is called a pattern.
+    ///
+    /// Scored without `scope` because that block decides *who* may be offered
+    /// something, at weight 10 against a total of under 5. Counting it here
+    /// would drag every same-scope score above 0.95 and leave these two
+    /// thresholds four hundredths apart.
+    pub strong_at: f32,
+    /// And above which it is called a resemblance. Below it the ladder falls
+    /// through to the sitting, and then to what has been forgotten.
+    pub weak_at: f32,
+    /// What an open of something this feature offered counts for, back into the
+    /// profile. Zero, because without it the first lucky guess grows into a
+    /// habit the system taught itself.
+    pub self_weight: f64,
+    /// See `BlockWeights`.
+    pub weights: BlockWeights,
+}
+
+impl Default for RecommendConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            cluster_merge_at: 0.82,
+            max_clusters: 5,
+            half_life_days: 45.0,
+            min_weight: 2.0,
+            strong_at: 0.75,
+            weak_at: 0.45,
+            self_weight: 0.0,
+            weights: BlockWeights::default(),
+        }
     }
 }
 
@@ -1736,6 +1874,65 @@ mod tests {
         // The floor below which extraction is reported as a failure rather
         // than stored as a corpus.
         assert_eq!(c.min_extracted_chars, 200);
+    }
+
+    #[test]
+    fn the_recommender_ships_off_with_its_weights_named() {
+        let r = RecommendConfig::default();
+        assert!(!r.enabled, "a faculty that learns from a log ships off");
+        // The scope block dominates so a foreign cluster can never win
+        // `max_sim`. When each user has their own collection this goes to 0
+        // and nothing else changes.
+        assert_eq!(r.weights.of("scope"), 10.0);
+        assert_eq!(r.weights.of("weekday"), 1.0);
+        assert_eq!(r.weights.of("month_cycle"), 0.0, "off by default");
+        // A block nobody named contributes nothing rather than a default. The
+        // block table and this lookup are edited together, and a typo that
+        // silently gave a block weight 1.0 would be a recommendation nobody
+        // could account for.
+        assert_eq!(r.weights.of("phase_of_the_moon"), 0.0);
+        // The two rungs are far enough apart to mean different things, which
+        // is only true because `scope` is left out of the score.
+        assert!(r.strong_at > r.weak_at + 0.2);
+        assert_eq!(r.self_weight, 0.0, "the offer does not teach itself");
+    }
+
+    #[test]
+    fn the_example_config_carries_the_recommend_block() {
+        // Every value here equals its struct default, which is the point — the
+        // example file documents what ships. That also makes a load-and-compare
+        // test vacuous on its own: it would pass with the block deleted, because
+        // `#[serde(default)]` would fill in the same numbers. So the file is
+        // read as text first, and only then parsed.
+        let path = std::path::Path::new("config.example.toml");
+        let raw = std::fs::read_to_string(path).unwrap();
+        assert!(raw.contains("\n[recommend]\n"), "the block is documented");
+        assert!(
+            raw.contains("\n[recommend.weights]\n"),
+            "and so is every weight the offer rests on"
+        );
+        for block in [
+            "scope",
+            "time_of_day",
+            "weekday",
+            "weekend",
+            "device",
+            "viewport",
+            "locale",
+            "network",
+            "power",
+            "environment",
+            "month_cycle",
+        ] {
+            assert!(raw.contains(&format!("\n{block} = ")), "{block} is unnamed");
+        }
+
+        // And it parses: a mistyped value or a table the loader cannot reach
+        // fails here rather than at somebody's boot.
+        let cfg = Config::load(Some(path)).unwrap();
+        assert!(!cfg.recommend.enabled);
+        assert_eq!(cfg.recommend.max_clusters, 5);
+        assert_eq!(cfg.recommend.weights.of("network"), 0.6);
     }
 
     #[test]

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -881,7 +881,7 @@ impl Core {
         origin: &Origin,
         mut response: AskResponse,
     ) -> Result<AskResponse> {
-        if !(self.feedback.enabled && origin.door == Door::Ui) {
+        if !(self.learn.enabled && origin.door == Door::Ui) {
             return Ok(response);
         }
         let ask = NewAsk {
@@ -1928,9 +1928,9 @@ mod tests {
     #[tokio::test]
     async fn an_artifact_linked_to_a_hit_is_reached_where_adjacency_cannot_go() {
         let mut core = test_core().await;
-        // `associate.enabled` is already the shipped default; links are learned
-        // from recorded searches, so the reach stays shut until this is on too.
-        core.feedback.enabled = true;
+        // Links are learned from recorded searches, and `test_core` records
+        // none, so the reach stays shut until the layer is switched on.
+        core.learn.enabled = true;
         seed(&core, 5, 4).await;
 
         // A second corpus, on a subject the query does not ask about. Its raw
@@ -2065,7 +2065,7 @@ mod tests {
     #[tokio::test]
     async fn a_ui_ask_is_recorded_with_its_citations_when_feedback_is_on() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed(&core, 3, 4).await;
         let out = core.ask(&req("chunk"), Door::Ui.by("me")).await.unwrap();
         let id = out.event_id.expect("a UI ask is recorded");
@@ -2097,7 +2097,7 @@ mod tests {
     #[tokio::test]
     async fn an_api_or_mcp_ask_is_never_recorded() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed(&core, 3, 4).await;
         for door in [Door::Api, Door::Mcp] {
             let out = core.ask(&req("chunk"), door).await.unwrap();
@@ -2117,7 +2117,7 @@ mod tests {
     #[tokio::test]
     async fn an_ask_with_no_hits_is_recorded_as_an_abstention_without_a_model_call() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let out = core
             .ask(&req("nothing is stored"), Door::Ui.by("me"))
             .await
@@ -2288,7 +2288,7 @@ mod tests {
     #[tokio::test]
     async fn a_streamed_ask_is_recorded_exactly_once() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed(&core, 3, 4).await;
 
         let before = core.store.ask_stats().await.unwrap().asked;
@@ -2389,7 +2389,7 @@ mod tests {
     async fn a_reader_who_leaves_mid_answer_does_not_hand_the_gpu_to_the_worker() {
         let release = std::sync::Arc::new(tokio::sync::Notify::new());
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.completer = Some(std::sync::Arc::new(Stalling {
             release: release.clone(),
         }));

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -119,7 +119,7 @@ pub fn periodic_units(core: &crate::core::Core) -> Vec<(crate::store::jobs::Stag
     // operator who switches duplicate hygiene off is not asking to keep their
     // query log forever. With nothing to expire and nothing to group there is
     // no unit at all, which is what the ticker's `return` used to say.
-    if core.feedback.retain_days > 0 || core.feedback.enabled || core.recommends() {
+    if core.feedback.retain_days > 0 || core.learn.enabled || core.recommends() {
         out.push((Stage::Retention, CONSOLIDATE_TARGET));
     }
     // Learning which situations recur for which artifact. Behind its own gate
@@ -132,10 +132,10 @@ pub fn periodic_units(core: &crate::core::Core) -> Vec<(crate::store::jobs::Stag
         out.push((Stage::Associate, ASSOCIATE_TARGET));
         // Its own period as a floor. The association sweep arming it is what
         // orders the two; this is what keeps pursuits running at the cadence
-        // they ran at before, rather than at the association sweep's.
-        if core.pursuit.enabled {
-            out.push((Stage::Pursuit, ASSOCIATE_TARGET));
-        }
+        // they ran at before, rather than at the association sweep's. No second
+        // condition of its own any more — a pursuit runs behind `[learn]`, and
+        // `associating()` is `[learn]`.
+        out.push((Stage::Pursuit, ASSOCIATE_TARGET));
     }
     out
 }
@@ -405,6 +405,8 @@ mod tests {
         assert_eq!(periodic_period(&core, Stage::Context), None);
 
         core.recommend.enabled = true;
+
+        core.learn.enabled = true;
         assert!(
             periodic_units(&core)
                 .iter()
@@ -558,7 +560,7 @@ mod tests {
         // dedupe arming and consolidation keep running, and keep writing a row
         // apiece into a table nothing was left to trim.
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = false;
+        core.learn.enabled = false;
         core.feedback.retain_days = 0;
         assert!(
             !periodic_units(&core)
@@ -676,7 +678,7 @@ mod tests {
     #[tokio::test]
     async fn the_association_sweep_is_armed_when_the_process_starts() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
 
         arm_missing_periodic(&core).await;
 
@@ -695,10 +697,10 @@ mod tests {
 
     #[tokio::test]
     async fn no_recorded_searches_means_no_association_sweep_at_all() {
-        // `associate.enabled` without `feedback.enabled` is a warning at startup
-        // and nothing else: there is nothing to learn from, so there is no unit
-        // — which is the list's job now that there is no ticker to return from.
-        let core = crate::core::test_support::test_core().await; // feedback off
+        // With `[learn]` off nothing is recorded, so there is nothing to learn
+        // from and there is no unit — which is the list's job now that there is
+        // no ticker to return from.
+        let core = crate::core::test_support::test_core().await; // `[learn]` off
         assert!(
             !periodic_units(&core)
                 .iter()
@@ -713,7 +715,7 @@ mod tests {
         // nothing at all. A unit that is never armed cannot do that.
         let mut core = crate::core::test_support::test_core().await;
         core.feedback.retain_days = 0;
-        core.feedback.enabled = false;
+        core.learn.enabled = false;
         assert!(
             !periodic_units(&core)
                 .iter()

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -119,7 +119,7 @@ pub fn periodic_units(core: &crate::core::Core) -> Vec<(crate::store::jobs::Stag
     // operator who switches duplicate hygiene off is not asking to keep their
     // query log forever. With nothing to expire and nothing to group there is
     // no unit at all, which is what the ticker's `return` used to say.
-    if core.feedback.retain_days > 0 || core.feedback.enabled {
+    if core.feedback.retain_days > 0 || core.feedback.enabled || core.recommends() {
         out.push((Stage::Retention, CONSOLIDATE_TARGET));
     }
     if core.associating() {

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -122,6 +122,12 @@ pub fn periodic_units(core: &crate::core::Core) -> Vec<(crate::store::jobs::Stag
     if core.feedback.retain_days > 0 || core.feedback.enabled || core.recommends() {
         out.push((Stage::Retention, CONSOLIDATE_TARGET));
     }
+    // Learning which situations recur for which artifact. Behind its own gate
+    // and nothing else's: it reads the interaction log, which is not something
+    // an operator switches off by switching off duplicate hygiene.
+    if core.recommends() {
+        out.push((Stage::Context, CONSOLIDATE_TARGET));
+    }
     if core.associating() {
         out.push((Stage::Associate, ASSOCIATE_TARGET));
         // Its own period as a floor. The association sweep arming it is what
@@ -157,6 +163,7 @@ pub fn periodic_period(
             .max(1)
             .saturating_mul(60),
         Stage::Retention => core.feedback.sweep_hours.max(1).saturating_mul(3600),
+        Stage::Context => crate::jobs::context::INTERVAL_HOURS.saturating_mul(3600),
         Stage::Associate => core.associate.interval_mins.max(1).saturating_mul(60),
         // Shorter than the idle window, so a run of searches is grouped soon
         // after it goes quiet.
@@ -384,6 +391,40 @@ mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn the_context_sweep_is_armed_only_when_the_offer_is_on() {
+        use crate::store::jobs::Stage;
+        let mut core = crate::core::test_support::test_core().await;
+        assert!(
+            !periodic_units(&core)
+                .iter()
+                .any(|(s, _)| *s == Stage::Context),
+            "off by default"
+        );
+        assert_eq!(periodic_period(&core, Stage::Context), None);
+
+        core.recommend.enabled = true;
+        assert!(
+            periodic_units(&core)
+                .iter()
+                .any(|(s, _)| *s == Stage::Context)
+        );
+        assert_eq!(
+            periodic_period(&core, Stage::Context),
+            Some(Duration::from_secs(
+                crate::jobs::context::INTERVAL_HOURS * 3600
+            ))
+        );
+        // And it drags the retention unit along with it: `context_events` has
+        // its own window, and the trim rides that unit.
+        assert!(
+            periodic_units(&core)
+                .iter()
+                .any(|(s, _)| *s == Stage::Retention),
+            "nothing else would expire a recorded situation"
+        );
+    }
 
     #[tokio::test]
     async fn the_consolidation_sweep_never_stacks_up_in_the_queue() {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -592,6 +592,46 @@ mod tests {
     const FRIDAY: i64 = FRIDAY_1352_UTC;
 
     #[test]
+    fn the_browser_sends_exactly_the_fields_this_struct_reads() {
+        // The one seam in this feature with a compiler on neither side: the
+        // bundle is assembled in `assets/app.js` and parsed here, and a field
+        // renamed on one side is silently `None` on the other — a block that
+        // quietly stops contributing, with nothing failing anywhere.
+        //
+        // Both files are in the repository, so the check is just reading them.
+        let js = include_str!("../../assets/app.js");
+        let sent: std::collections::BTreeSet<&str> = js
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("b."))
+            .filter_map(|l| l.split_once(" = "))
+            .map(|(name, _)| name)
+            .collect();
+        assert!(!sent.is_empty(), "found no bundle assignments in app.js");
+
+        // The struct's own field list, read off the source rather than kept by
+        // hand — a hand-kept list is the thing everyone forgets to append to.
+        let src = include_str!("context.rs");
+        let body = src
+            .split_once("pub struct Bundle {")
+            .expect("Bundle struct")
+            .1
+            .split_once("\n}")
+            .expect("end of Bundle")
+            .0;
+        let expected: std::collections::BTreeSet<&str> = body
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("pub "))
+            .filter_map(|l| l.split_once(':'))
+            .map(|(name, _)| name)
+            .collect();
+
+        assert_eq!(
+            sent, expected,
+            "app.js and Bundle disagree about what a situation is"
+        );
+    }
+
+    #[test]
     fn the_layout_adds_up() {
         // The one invariant everything else rests on: a block that overlaps its
         // neighbour would silently mix two meanings into one dimension, and

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -63,7 +63,17 @@ pub fn local_time(at: i64, tz: Option<&str>, offset_mins: Option<i32>) -> LocalT
     let utc = DateTime::from_timestamp(at, 0).unwrap_or_default();
     let naive = match tz.and_then(|z| z.parse::<chrono_tz::Tz>().ok()) {
         Some(z) => z.from_utc_datetime(&utc.naive_utc()).naive_local(),
-        None => match offset_mins.and_then(|m| chrono::FixedOffset::east_opt(m * 60)) {
+        // `checked_mul` because the offset arrives from the browser and a
+        // browser may say anything: `tz_offset_mins` is a bare `i32` off the
+        // wire, and any value past ±35 791 394 overflows the seconds it is
+        // converted to — a panic in a debug build, inside a handler whose whole
+        // rule is that nothing a browser sends may take a page view down. An
+        // overflow reads as "no offset given", which is the same fallback as a
+        // browser that reported nothing: UTC.
+        None => match offset_mins
+            .and_then(|m| m.checked_mul(60))
+            .and_then(chrono::FixedOffset::east_opt)
+        {
             Some(o) => o.from_utc_datetime(&utc.naive_utc()).naive_local(),
             None => utc.naive_utc(),
         },
@@ -191,7 +201,7 @@ pub const BLOCKS: [Block; 11] = [
 ];
 
 /// Fixed at collection creation, so a new block invalidates every stored
-/// centroid. That is what `ENCODER_VERSION` and whole-bundle storage are for:
+/// centroid. That is what `encoder_version` and whole-bundle storage are for:
 /// the sweep rebuilds from the raw bundles rather than losing the history.
 pub const CTX_DIM: usize = 53;
 
@@ -199,10 +209,37 @@ pub const CTX_DIM: usize = 53;
 pub const SCOPE_DIMS: usize = 8;
 
 /// Bumped whenever `BLOCKS` changes in any way — a width, an order, or what a
-/// slot means. A stored cluster carrying a different one is skipped by the read
-/// path and rebuilt by the next sweep; explaining a hit with the wrong block is
-/// worse than explaining nothing.
-pub const ENCODER_VERSION: i64 = 1;
+/// slot means. Not what is stored: see `encoder_version`.
+pub const LAYOUT_VERSION: i64 = 1;
+
+/// What a stored cluster carries, and what the read path insists on matching.
+///
+/// The layout is half of it. The other half is `[recommend.weights]`, because
+/// every block is scaled by its weight before anything is compared — a weight
+/// is not a knob on top of the encoding, it *is* the geometry. An operator who
+/// edits one and restarts leaves the store full of centroids built under the
+/// old numbers, while `offer` encodes the present situation under the new ones
+/// and compares the two; for the six hours until the next sweep, `context_score`
+/// and the argmax are computed across two different encodings. That is exactly
+/// the recommendation nobody can account for that `BlockWeights::of` refuses a
+/// typo to avoid.
+///
+/// So the weights are hashed into the version. A cluster written under other
+/// numbers is skipped by the read path — the area falls to its floor rather
+/// than explaining a hit with an encoding that no longer exists — and the next
+/// sweep, which rebuilds every profile from the raw bundles, replaces it.
+pub fn encoder_version(w: &crate::config::BlockWeights) -> i64 {
+    let mut key = format!("layout{LAYOUT_VERSION}");
+    for b in BLOCKS {
+        // The bits, not the printed value: two weights that differ below what
+        // `{}` prints are two different geometries.
+        key.push_str(&format!("|{}={:08x}", b.name, w.of(b.name).to_bits()));
+    }
+    // Shifted down one bit so the version is always positive: it goes into a
+    // signed column, and a negative version is a value no operator reading the
+    // table would recognise as one.
+    (fnv1a(&key) >> 1) as i64
+}
 
 /// What the browser said about the situation, as received.
 ///
@@ -869,5 +906,82 @@ mod tests {
         assert_eq!(t.day, 21);
         assert_eq!(t.month, 8);
         assert_eq!(t.days_in_month, 31);
+    }
+
+    #[test]
+    fn an_offset_no_zone_could_hold_falls_back_rather_than_overflowing() {
+        // `tz_offset_mins` is a bare `i32` off the wire and a browser may say
+        // anything. Past ±35 791 394 the conversion to seconds overflows —
+        // a panic in a debug build, inside a handler whose whole rule is that
+        // nothing a browser sends may take a page view down.
+        for m in [i32::MAX, i32::MIN, 35_791_395, -35_791_395] {
+            let t = local_time(FRIDAY_1352_UTC, None, Some(m));
+            assert!(
+                (t.hour - 13.866_666).abs() < 0.001,
+                "offset {m} did not fall back to UTC: got {}",
+                t.hour
+            );
+        }
+    }
+
+    #[test]
+    fn the_stored_version_moves_when_a_weight_does() {
+        // A weight is not a knob on top of the encoding — every block is scaled
+        // by it before anything is compared, so it *is* the geometry. An
+        // operator who edits one leaves the store full of centroids built under
+        // the old numbers while `offer` encodes the present situation under the
+        // new ones, and for the six hours until the next sweep the two are
+        // compared across different encodings.
+        let a = weights();
+        let mut b = weights();
+        b.network += 0.01;
+        assert_ne!(
+            encoder_version(&a),
+            encoder_version(&b),
+            "an edited weight left the version standing"
+        );
+        // Even a change below what `{}` would print: two weights that differ at
+        // all are two geometries.
+        let mut c = weights();
+        c.power += f32::EPSILON;
+        assert_ne!(encoder_version(&a), encoder_version(&c));
+        // Stable across calls, and positive — it goes into a signed column and
+        // a negative version is a value no operator would recognise as one.
+        assert_eq!(encoder_version(&a), encoder_version(&weights()));
+        assert!(encoder_version(&a) > 0);
+    }
+
+    #[test]
+    fn a_block_that_agreed_on_nothing_is_not_one_of_the_reasons() {
+        // `cosine` returns zero for a zero vector — which is what an absent
+        // block is — and zero sorts above every negative contribution. Naming
+        // the top three unconditionally printed "battery" on a pair where
+        // neither side ever sent a battery reading.
+        let w = weights();
+        let bare = Bundle {
+            tz: Some("Europe/Berlin".into()),
+            ..Default::default()
+        };
+        let v = encode(FRIDAY_1352_UTC, Some("alice"), &bare, &w);
+        let named = contributions(&v, &v, &w);
+        // Every block is still in the list — the `<details>` pane is where
+        // exactness lives — but the ones the browser said nothing about are
+        // worth zero, and the line above it takes only what is worth something.
+        // `device`, `network` and `language` are not among them: their last
+        // slot means "nothing identifying was sent", which is a state that
+        // recurs and not an absence.
+        assert_eq!(named.len(), BLOCKS.len() - 1, "{named:?}");
+        let spoken: Vec<&str> = named
+            .iter()
+            .filter(|(_, c)| *c > 0.0)
+            .map(|(l, _)| *l)
+            .collect();
+        assert!(spoken.contains(&"weekday"), "{named:?}");
+        for absent in ["battery", "month", "screen", "surroundings"] {
+            assert!(
+                !spoken.contains(&absent),
+                "{absent} was named on a bundle that never carried it: {named:?}"
+            );
+        }
     }
 }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -1,0 +1,141 @@
+//! The situation a page view happened in: the clock it happened on, the bundle
+//! the browser sent, and the fixed-length vector both become.
+//!
+//! Everything here is a function of its arguments. That is deliberate: the
+//! encoder is the one part of this feature that can be silently wrong — a block
+//! that quietly outweighs another produces plausible recommendations for the
+//! wrong reason — and a pure function is the only shape that can be pinned by a
+//! table of cases.
+
+/// Where this feature reads the time. `System` everywhere but the tests, which
+/// need a seventh Friday at 14:52 to exist on demand.
+///
+/// Held by the sweep, the encoder's entry point and the endpoint, and by
+/// nothing else. The other `now()` call sites in the tree are not touched:
+/// they work, and rewriting them would be a diff across the tree for nothing.
+#[derive(Debug, Clone, Copy)]
+pub enum Clock {
+    System,
+    Fixed(i64),
+}
+
+impl Clock {
+    pub fn now(&self) -> i64 {
+        match self {
+            Clock::System => crate::store::now(),
+            Clock::Fixed(t) => *t,
+        }
+    }
+}
+
+/// A moment as the device experienced it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LocalTime {
+    /// Fractional, 0.0..24.0 — 15:30 is 15.5. Fractional because the hour is
+    /// encoded as an angle, and rounding to the hour would put 14:55 and 15:05
+    /// ten minutes apart on a circle they are five minutes apart on.
+    pub hour: f32,
+    /// 0 = Monday.
+    pub weekday: u32,
+    /// 1-based day of the month.
+    pub day: u32,
+    /// 1-based. Only the display reads it — "like 08.08., 15:04" — but it is
+    /// derived here because this is the one place that knows which zone the
+    /// moment is being read in.
+    pub month: u32,
+    pub days_in_month: u32,
+}
+
+/// The device's own reading of `at`.
+///
+/// The zone comes from the client, never from config:
+/// `Intl.DateTimeFormat().resolvedOptions().timeZone` is correct per device and
+/// carries DST with it, which a stored offset cannot. The offset is the fallback
+/// for a browser that reports one and no zone; UTC is the fallback for a row
+/// that has neither, which is every row written before this feature existed.
+/// That last case is not a pretence that the operator lives in London — it is
+/// the only reading available, and §12 leans on it: an old event still carries
+/// a weekday and an hour, and those two blocks are what stand from the first
+/// sweep.
+pub fn local_time(at: i64, tz: Option<&str>, offset_mins: Option<i32>) -> LocalTime {
+    use chrono::{DateTime, Datelike, TimeZone, Timelike};
+
+    let utc = DateTime::from_timestamp(at, 0).unwrap_or_default();
+    let naive = match tz.and_then(|z| z.parse::<chrono_tz::Tz>().ok()) {
+        Some(z) => z.from_utc_datetime(&utc.naive_utc()).naive_local(),
+        None => match offset_mins.and_then(|m| chrono::FixedOffset::east_opt(m * 60)) {
+            Some(o) => o.from_utc_datetime(&utc.naive_utc()).naive_local(),
+            None => utc.naive_utc(),
+        },
+    };
+    LocalTime {
+        hour: naive.hour() as f32 + naive.minute() as f32 / 60.0,
+        weekday: naive.weekday().num_days_from_monday(),
+        day: naive.day(),
+        month: naive.month(),
+        days_in_month: days_in_month(naive.year(), naive.month()),
+    }
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    use chrono::NaiveDate;
+    let (y, m) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    let first = NaiveDate::from_ymd_opt(year, month, 1);
+    let next = NaiveDate::from_ymd_opt(y, m, 1);
+    match (first, next) {
+        (Some(a), Some(b)) => (b - a).num_days() as u32,
+        // Unreachable for a date chrono just produced; 30 rather than a panic,
+        // because a month length is a scaling factor for one block worth 0.0 by
+        // default and nothing here is worth taking a page view down for.
+        _ => 30,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fixed_clock_does_not_move() {
+        assert_eq!(Clock::Fixed(1_000).now(), 1_000);
+        assert_eq!(Clock::Fixed(1_000).now(), 1_000);
+    }
+
+    // 2026-08-21T13:52:00Z is a Friday.
+    const FRIDAY_1352_UTC: i64 = 1_787_320_320;
+
+    #[test]
+    fn an_iana_zone_beats_a_stored_offset() {
+        // Berlin is UTC+2 in August. The offset argument is deliberately
+        // wrong: a zone, when there is one, is the authority.
+        let t = local_time(FRIDAY_1352_UTC, Some("Europe/Berlin"), Some(0));
+        assert_eq!(t.weekday, 4, "Friday");
+        assert!((t.hour - 15.866_666).abs() < 0.001, "15:52, got {}", t.hour);
+    }
+
+    #[test]
+    fn an_offset_answers_when_there_is_no_zone() {
+        let t = local_time(FRIDAY_1352_UTC, None, Some(120));
+        assert!((t.hour - 15.866_666).abs() < 0.001, "got {}", t.hour);
+    }
+
+    #[test]
+    fn an_unknown_zone_falls_back_rather_than_failing() {
+        // A device can send anything. Nothing here may panic on it, and UTC is
+        // the honest answer rather than a guess.
+        let t = local_time(FRIDAY_1352_UTC, Some("Mars/Olympus"), None);
+        assert!((t.hour - 13.866_666).abs() < 0.001, "got {}", t.hour);
+    }
+
+    #[test]
+    fn the_month_is_carried_with_its_length() {
+        let t = local_time(FRIDAY_1352_UTC, Some("UTC"), None);
+        assert_eq!(t.day, 21);
+        assert_eq!(t.month, 8);
+        assert_eq!(t.days_in_month, 31);
+    }
+}

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -95,9 +95,684 @@ fn days_in_month(year: i32, month: u32) -> u32 {
     }
 }
 
+/// One named span of the context vector.
+///
+/// Named because the explanation falls out of the naming: each block is scored
+/// separately at read time, so "weekday, hour, device" is three lookups in this
+/// table rather than three sentences somebody had to write. A new block brings
+/// its label and is done.
+#[derive(Debug, Clone, Copy)]
+pub struct Block {
+    /// The config key its weight is read under. See `BlockWeights::of`.
+    pub name: &'static str,
+    /// What the line under the offer prints. No sentences and no values in
+    /// prose — generated prose per block was the first draft and was cut,
+    /// because it coupled every new dimension to a sentence template.
+    pub label: &'static str,
+    pub at: usize,
+    pub dims: usize,
+}
+
+/// The layout, in order. `scope` leads because `context_score` slices it off by
+/// taking everything after it, which only works while it is first.
+///
+/// Circular where there is a circle, one-hot where there is not. The hour is a
+/// circle, so 23:30 and 00:30 are an hour apart. The weekday is *not* a useful
+/// circle — "Friday is three from Tuesday" means nothing, and the pattern is
+/// exactly Friday — so it is one-hot, with a separate weak weekday/weekend
+/// block for the part that genuinely is gradual.
+pub const BLOCKS: [Block; 11] = [
+    Block {
+        name: "scope",
+        label: "who",
+        at: 0,
+        dims: 8,
+    },
+    Block {
+        name: "time_of_day",
+        label: "hour",
+        at: 8,
+        dims: 2,
+    },
+    Block {
+        name: "weekday",
+        label: "weekday",
+        at: 10,
+        dims: 7,
+    },
+    Block {
+        name: "weekend",
+        label: "weekend",
+        at: 17,
+        dims: 2,
+    },
+    Block {
+        name: "device",
+        label: "device",
+        at: 19,
+        dims: 8,
+    },
+    Block {
+        name: "viewport",
+        label: "screen",
+        at: 27,
+        dims: 4,
+    },
+    Block {
+        name: "locale",
+        label: "language",
+        at: 31,
+        dims: 8,
+    },
+    Block {
+        name: "network",
+        label: "network",
+        at: 39,
+        dims: 4,
+    },
+    Block {
+        name: "power",
+        label: "battery",
+        at: 43,
+        dims: 3,
+    },
+    Block {
+        name: "environment",
+        label: "surroundings",
+        at: 46,
+        dims: 5,
+    },
+    Block {
+        name: "month_cycle",
+        label: "month",
+        at: 51,
+        dims: 2,
+    },
+];
+
+/// Fixed at collection creation, so a new block invalidates every stored
+/// centroid. That is what `ENCODER_VERSION` and whole-bundle storage are for:
+/// the sweep rebuilds from the raw bundles rather than losing the history.
+pub const CTX_DIM: usize = 53;
+
+/// The width of the leading `scope` block. See `context_score`.
+pub const SCOPE_DIMS: usize = 8;
+
+/// Bumped whenever `BLOCKS` changes in any way — a width, an order, or what a
+/// slot means. A stored cluster carrying a different one is skipped by the read
+/// path and rebuilt by the next sweep; explaining a hit with the wrong block is
+/// worse than explaining nothing.
+pub const ENCODER_VERSION: i64 = 1;
+
+/// What the browser said about the situation, as received.
+///
+/// Every field optional, because every field is optional in a browser: the
+/// Battery API does not exist on the desktop, `connection` is Chromium-only,
+/// and a hardened browser withholds several. Absent is not zero — see `encode`.
+///
+/// Deliberately **not** collected: canvas, WebGL, font enumeration, plugin
+/// lists. Not out of squeamishness — they are the wrong tool. Those are what
+/// identify a device across a population, and here the population is one
+/// authenticated person, so they are constant and say nothing about *which
+/// situation* this is. They are also randomised per session and origin by a
+/// hardened browser, so a device identity built on them would rotate and every
+/// day would look like a new device.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct Bundle {
+    /// IANA, from `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+    pub tz: Option<String>,
+    pub tz_offset_mins: Option<i32>,
+    pub language: Option<String>,
+    /// The full preference list. Stored, not encoded — see the module note on
+    /// fields the encoder ignores.
+    pub languages: Vec<String>,
+    pub viewport_w: Option<f32>,
+    pub viewport_h: Option<f32>,
+    pub screen_w: Option<f32>,
+    pub screen_h: Option<f32>,
+    pub dpr: Option<f32>,
+    /// `dark` | `light`.
+    pub color_scheme: Option<String>,
+    pub platform: Option<String>,
+    /// The UA client hint's brand, or the family parsed from the UA string.
+    pub ua_family: Option<String>,
+    pub cores: Option<f32>,
+    pub memory_gb: Option<f32>,
+    pub touch: Option<bool>,
+    /// `portrait` | `landscape`.
+    pub orientation: Option<String>,
+    /// 0.0..1.0.
+    pub battery_level: Option<f32>,
+    pub charging: Option<bool>,
+    /// `wifi` | `cellular` | `wired` | anything else.
+    pub network: Option<String>,
+    pub audio_outputs: Option<u32>,
+}
+
+/// A bundle from whatever the browser posted.
+///
+/// Lenient on purpose: nothing a browser sends may take a page view down, and
+/// an empty bundle is a working one — the weekday and the hour come from the
+/// server's own clock and still stand. Unknown fields are dropped here but the
+/// raw string is what `context_events.bundle` stores, so nothing is lost.
+pub fn parse_bundle(raw: &str) -> Bundle {
+    serde_json::from_str(raw).unwrap_or_default()
+}
+
+/// What machine this is, over the fields that do not move.
+///
+/// Platform, browser family, screen, cores, memory, language — and nothing the
+/// situation changes. A phone that rotates, unplugs or joins a different
+/// network is the same phone; a key that moved with any of those would make
+/// every session look like a new device and no pattern could ever form.
+///
+/// `None` when the browser said nothing identifying at all, which `encode`
+/// gives its own slot rather than treating as an absence.
+pub fn device_key(b: &Bundle) -> Option<String> {
+    let parts = [
+        b.platform.clone(),
+        b.ua_family.clone(),
+        b.screen_w.map(|v| v.to_string()),
+        b.screen_h.map(|v| v.to_string()),
+        b.cores.map(|v| v.to_string()),
+        b.memory_gb.map(|v| v.to_string()),
+        b.language.clone(),
+    ];
+    if parts.iter().all(Option::is_none) {
+        return None;
+    }
+    let joined = parts
+        .iter()
+        .map(|p| p.as_deref().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("|");
+    Some(format!("{:016x}", fnv1a(&joined)))
+}
+
+/// FNV-1a, written out rather than reached for.
+///
+/// `DefaultHasher` is seeded per process, so a bucket chosen with it would move
+/// on every restart and every stored centroid would be indexed under a slot
+/// that no longer means what it meant. This is stable across runs, machines and
+/// releases, which is the only property being asked of it.
+fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in s.as_bytes() {
+        h ^= *byte as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn bucket(s: &str, n: usize) -> usize {
+    (fnv1a(s) % n as u64) as usize
+}
+
+/// One situation as a vector.
+///
+/// Each block is filled with raw values, **normalised to length 1, then scaled
+/// by its weight**. That order is the whole design: a block contributes exactly
+/// its weight however many dimensions it uses, which is what puts the weighting
+/// back into config as named numbers instead of leaving it hidden in how the
+/// encoding happened to be written.
+///
+/// A block whose values are all zero is left at zero rather than normalised —
+/// dividing by nothing is how absence turns into a manufactured direction.
+pub fn encode(
+    at: i64,
+    scope: Option<&str>,
+    b: &Bundle,
+    w: &crate::config::BlockWeights,
+) -> Vec<f32> {
+    let t = local_time(at, b.tz.as_deref(), b.tz_offset_mins);
+    let mut v = vec![0.0f32; CTX_DIM];
+
+    for block in BLOCKS {
+        let slot = &mut v[block.at..block.at + block.dims];
+        fill(block.name, slot, &t, scope, b);
+        scale(slot, w.of(block.name));
+    }
+    v
+}
+
+/// Raw values into one block's slots. Every arm either fills or leaves zeros;
+/// leaving zeros is how "the browser did not say" is expressed.
+fn fill(name: &str, s: &mut [f32], t: &LocalTime, scope: Option<&str>, b: &Bundle) {
+    use std::f32::consts::TAU;
+    match name {
+        "scope" => {
+            // Hashed into buckets rather than looked up in a registry: there is
+            // no list of every subject that has ever searched, and one bucket
+            // shared by two people is a collision per-user collections remove
+            // rather than a bug to work around here.
+            if let Some(sc) = scope {
+                s[bucket(sc, s.len())] = 1.0;
+            }
+        }
+        "time_of_day" => {
+            let a = TAU * t.hour / 24.0;
+            s[0] = a.sin();
+            s[1] = a.cos();
+        }
+        "weekday" => s[(t.weekday as usize).min(6)] = 1.0,
+        "weekend" => {
+            let idx = usize::from(t.weekday >= 5);
+            s[idx] = 1.0;
+        }
+        "device" => match device_key(b) {
+            // The last slot is "nothing identifying was sent" — a state, not an
+            // absence. A hardened browser is a situation that recurs, unlike a
+            // battery that does not exist.
+            Some(k) => s[bucket(&k, s.len() - 1)] = 1.0,
+            None => {
+                let last = s.len() - 1;
+                s[last] = 1.0;
+            }
+        },
+        "viewport" => {
+            // Logs *centred* on a thousand pixels, not raw. Raw logs put every
+            // screen ever built between 6.5 and 8, so any two of them scored
+            // 0.999 against each other and the block said nothing. Centred, a
+            // phone in portrait and a desktop in landscape point in genuinely
+            // different directions.
+            if let (Some(vw), Some(vh)) = (b.viewport_w, b.viewport_h)
+                && vw > 0.0
+                && vh > 0.0
+            {
+                s[0] = (vw / 1000.0).ln();
+                s[1] = (vh / 1000.0).ln();
+                s[2] = (vw / vh).ln();
+                s[3] = b.dpr.filter(|d| *d > 0.0).map(f32::ln).unwrap_or(0.0);
+            }
+        }
+        "locale" => {
+            // Two halves in one block, four slots each: what language this
+            // browser is in, and what zone it is in. They move together — a
+            // trip changes both — and neither is worth a weight of its own.
+            let half = s.len() / 2;
+            if let Some(l) = &b.language {
+                s[bucket(l, half)] = 1.0;
+            }
+            if let Some(z) = &b.tz {
+                s[half + bucket(z, half)] = 1.0;
+            }
+        }
+        "network" => {
+            // Four named states including unknown, so a browser that does not
+            // expose `connection` is grouped with the others that do not rather
+            // than with none of them.
+            let idx = match b.network.as_deref() {
+                Some("wifi") => 0,
+                Some("cellular") => 1,
+                Some("wired" | "ethernet") => 2,
+                _ => 3,
+            };
+            s[idx] = 1.0;
+        }
+        "power" => {
+            // All three zero when there is no Battery API at all. A desktop
+            // must not read as agreeing with a phone that happens to sit at
+            // whatever default would otherwise have been invented here.
+            if let Some(level) = b.battery_level {
+                match b.charging {
+                    Some(true) => s[0] = 1.0,
+                    Some(false) => s[1] = 1.0,
+                    None => {}
+                }
+                s[2] = level.clamp(0.0, 1.0);
+            }
+        }
+        "environment" => {
+            match b.color_scheme.as_deref() {
+                Some("dark") => s[0] = 1.0,
+                Some("light") => s[1] = 1.0,
+                _ => {}
+            }
+            if b.touch == Some(true) {
+                s[2] = 1.0;
+            }
+            // One signed slot rather than two, because the three states are
+            // portrait, landscape and "did not say" — and zero is already the
+            // third.
+            s[3] = match b.orientation.as_deref() {
+                Some("portrait") => 1.0,
+                Some("landscape") => -1.0,
+                _ => 0.0,
+            };
+            if let Some(n) = b.audio_outputs {
+                s[4] = (n.min(4) as f32) / 4.0;
+            }
+        }
+        "month_cycle" => {
+            let a = TAU * (t.day.saturating_sub(1)) as f32 / t.days_in_month.max(1) as f32;
+            s[0] = a.sin();
+            s[1] = a.cos();
+        }
+        // Unreachable while `BLOCKS` and this match are edited together, and a
+        // block silently left at zero is the safe way to be wrong: it
+        // contributes nothing rather than contributing noise.
+        _ => {}
+    }
+}
+
+/// Normalise to length 1, then scale. A block that is all zeros stays all
+/// zeros — there is no direction to normalise, and inventing one is exactly
+/// what "absent is not zero-valued" forbids.
+fn scale(s: &mut [f32], weight: f32) {
+    if weight == 0.0 {
+        s.fill(0.0);
+        return;
+    }
+    let n = s.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if n == 0.0 {
+        return;
+    }
+    let k = weight / n;
+    for x in s.iter_mut() {
+        *x *= k;
+    }
+}
+
+/// How well the situation matches, ignoring who is asking.
+///
+/// The `scope` block decides *which* artifact may be offered — it is what keeps
+/// a foreign cluster from ever winning `max_sim`, at weight 10 against a total
+/// of under 5 — and that same dominance would drag every same-scope full cosine
+/// above 0.95, leaving `strong_at` and `weak_at` four hundredths apart. So the
+/// choice is made on the full vector and the rung is decided here. Two
+/// questions, two scales.
+pub fn context_score(now: &[f32], cluster: &[f32]) -> f32 {
+    if now.len() < SCOPE_DIMS || cluster.len() < SCOPE_DIMS {
+        return 0.0;
+    }
+    crate::vector::cosine(&now[SCOPE_DIMS..], &cluster[SCOPE_DIMS..])
+}
+
+/// What each named block contributed, largest first.
+///
+/// `w_b * cos(block_now, block_cluster)`. Because blocks are named and
+/// separately normalised, the per-dimension breakdown that a weighted sum of
+/// named terms would have produced by construction falls out of the vector as a
+/// by-product — which is the answer to the one thing that approach did better.
+///
+/// These do **not** sum to `context_score`, and are not meant to: the score is
+/// one cosine over the whole vector and each of these is a cosine over a slice,
+/// with a different denominator. They rank which blocks decided it, which is
+/// what the line under the offer needs and all it claims.
+///
+/// `scope` is excluded. It is always either a perfect match or a rejection, so
+/// it would lead every list while explaining nothing.
+pub fn contributions(
+    now: &[f32],
+    cluster: &[f32],
+    w: &crate::config::BlockWeights,
+) -> Vec<(&'static str, f32)> {
+    let mut out: Vec<(&'static str, f32)> = BLOCKS
+        .iter()
+        .filter(|b| b.name != "scope")
+        .filter(|b| now.len() >= b.at + b.dims && cluster.len() >= b.at + b.dims)
+        .map(|b| {
+            let a = &now[b.at..b.at + b.dims];
+            let c = &cluster[b.at..b.at + b.dims];
+            (b.label, w.of(b.name) * crate::vector::cosine(a, c))
+        })
+        .collect();
+    // Ties break on the label, so which of two equally strong blocks is named
+    // first does not depend on the order `BLOCKS` happens to be written in.
+    out.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(b.0))
+    });
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn weights() -> crate::config::BlockWeights {
+        crate::config::BlockWeights::default()
+    }
+
+    /// A bundle a phone in Berlin would send.
+    fn phone() -> Bundle {
+        Bundle {
+            tz: Some("Europe/Berlin".into()),
+            tz_offset_mins: Some(120),
+            language: Some("de-DE".into()),
+            viewport_w: Some(390.0),
+            viewport_h: Some(844.0),
+            screen_w: Some(390.0),
+            screen_h: Some(844.0),
+            dpr: Some(3.0),
+            color_scheme: Some("dark".into()),
+            platform: Some("Android".into()),
+            ua_family: Some("Chrome".into()),
+            cores: Some(8.0),
+            memory_gb: Some(4.0),
+            touch: Some(true),
+            orientation: Some("portrait".into()),
+            battery_level: Some(0.4),
+            charging: Some(false),
+            network: Some("cellular".into()),
+            audio_outputs: Some(1),
+            ..Default::default()
+        }
+    }
+
+    fn slice_of<'a>(v: &'a [f32], name: &str) -> &'a [f32] {
+        let b = BLOCKS.iter().find(|b| b.name == name).unwrap();
+        &v[b.at..b.at + b.dims]
+    }
+
+    fn norm(v: &[f32]) -> f32 {
+        v.iter().map(|x| x * x).sum::<f32>().sqrt()
+    }
+
+    // 2026-08-21T13:52:00Z, a Friday. 15:52 in Berlin.
+    const FRIDAY: i64 = FRIDAY_1352_UTC;
+
+    #[test]
+    fn the_layout_adds_up() {
+        // The one invariant everything else rests on: a block that overlaps its
+        // neighbour would silently mix two meanings into one dimension, and
+        // every recommendation after it would be explained by the wrong block.
+        let mut at = 0;
+        for b in BLOCKS {
+            assert_eq!(b.at, at, "{} starts where the last block ended", b.name);
+            at += b.dims;
+        }
+        assert_eq!(at, CTX_DIM);
+        assert_eq!(BLOCKS[0].name, "scope");
+        assert_eq!(BLOCKS[0].dims, SCOPE_DIMS);
+    }
+
+    #[test]
+    fn half_past_eleven_at_night_is_near_half_past_midnight() {
+        // The hour is a circle, so the two are an hour apart rather than
+        // twenty-three. A one-hot hour would have called them maximally
+        // different, which is the whole reason this block is an angle.
+        let late = encode(FRIDAY - 2 * 3600 - 22 * 60, None, &phone(), &weights());
+        let early = encode(FRIDAY - 3600 - 22 * 60, None, &phone(), &weights());
+        let c = crate::vector::cosine(
+            slice_of(&late, "time_of_day"),
+            slice_of(&early, "time_of_day"),
+        );
+        assert!(c > 0.96, "23:30 against 00:30 scored {c}");
+    }
+
+    #[test]
+    fn five_past_three_costs_almost_nothing_against_a_three_o_clock_pattern() {
+        let at_three = encode(FRIDAY - 52 * 60, None, &phone(), &weights());
+        let five_past = encode(FRIDAY - 47 * 60, None, &phone(), &weights());
+        let c = crate::vector::cosine(
+            slice_of(&at_three, "time_of_day"),
+            slice_of(&five_past, "time_of_day"),
+        );
+        assert!(c > 0.999, "15:00 against 15:05 scored {c}");
+    }
+
+    #[test]
+    fn a_seven_slot_block_contributes_exactly_its_weight() {
+        // The rule the whole design rests on. Seven one-hot slots for the
+        // weekday do not outweigh two for the hour because there are seven of
+        // them: each block is normalised and *then* scaled.
+        let v = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let w = weights();
+        assert!((norm(slice_of(&v, "weekday")) - w.weekday).abs() < 1e-5);
+        assert!((norm(slice_of(&v, "time_of_day")) - w.time_of_day).abs() < 1e-5);
+        assert!((norm(slice_of(&v, "scope")) - w.scope).abs() < 1e-5);
+    }
+
+    #[test]
+    fn a_block_switched_off_contributes_nothing() {
+        let mut w = weights();
+        w.month_cycle = 0.0;
+        let v = encode(FRIDAY, None, &phone(), &w);
+        assert_eq!(norm(slice_of(&v, "month_cycle")), 0.0);
+    }
+
+    #[test]
+    fn a_missing_value_zeroes_its_block_rather_than_inventing_a_default() {
+        // The Battery API does not exist on the desktop. An invented default
+        // would manufacture similarity between every desktop and every phone
+        // that happened to sit at that level.
+        let mut b = phone();
+        b.battery_level = None;
+        b.charging = None;
+        let v = encode(FRIDAY, None, &b, &weights());
+        assert_eq!(norm(slice_of(&v, "power")), 0.0, "power says nothing");
+        assert!(
+            norm(slice_of(&v, "weekday")) > 0.0,
+            "and nothing else changed"
+        );
+    }
+
+    #[test]
+    fn a_block_that_says_nothing_scores_zero_rather_than_opposed() {
+        // Two desktops with no battery must not read as *agreeing* about the
+        // battery, and must not read as disagreeing either. `cosine` returns
+        // 0.0 for a zero vector, which is the answer that means "no opinion".
+        let mut b = phone();
+        b.battery_level = None;
+        b.charging = None;
+        let v = encode(FRIDAY, None, &b, &weights());
+        let c = contributions(&v, &v, &weights());
+        let power = c.iter().find(|(n, _)| *n == "battery").unwrap();
+        assert_eq!(power.1, 0.0);
+    }
+
+    #[test]
+    fn an_unidentifiable_device_is_a_state_rather_than_an_absence() {
+        // Unlike the battery, "this browser tells us nothing about itself" is
+        // itself stable and recurring, so it gets a slot of its own — a
+        // hardened browser is a situation, not a gap.
+        let bare = Bundle::default();
+        assert!(device_key(&bare).is_none());
+        let v = encode(FRIDAY, None, &bare, &weights());
+        assert!((norm(slice_of(&v, "device")) - weights().device).abs() < 1e-5);
+    }
+
+    #[test]
+    fn a_device_key_is_stable_and_ignores_the_situation() {
+        // It hashes what the machine *is*, never what it is doing: a phone that
+        // rotates or unplugs is the same phone. A key that moved would make
+        // every session look like a new device and no pattern could ever form.
+        let mut later = phone();
+        later.orientation = Some("landscape".into());
+        later.battery_level = Some(0.9);
+        later.viewport_w = Some(844.0);
+        assert_eq!(device_key(&phone()), device_key(&later));
+
+        let mut other = phone();
+        other.platform = Some("macOS".into());
+        assert_ne!(device_key(&phone()), device_key(&other));
+    }
+
+    #[test]
+    fn two_people_in_the_same_situation_are_still_far_apart() {
+        // Until each person has their own collection, the `scope` block is the
+        // only thing keeping one person's situations from being offered to
+        // another. It is load-bearing and this is the test that says so.
+        let alice = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let bob = encode(FRIDAY, Some("bob"), &phone(), &weights());
+        let same = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        assert!(
+            crate::vector::cosine(&alice, &bob) < crate::vector::cosine(&alice, &same),
+            "a foreign scope must never win max_sim"
+        );
+    }
+
+    #[test]
+    fn the_rung_is_scored_without_the_scope_block() {
+        // The scope block decides *who* may be offered something. If it counted
+        // towards the rung too, it would drag every same-scope score above 0.95
+        // and `strong_at` and `weak_at` would have to live four hundredths
+        // apart. Two different jobs, two different scales.
+        let friday_phone = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let mut desktop = phone();
+        desktop.platform = Some("macOS".into());
+        desktop.ua_family = Some("Firefox".into());
+        desktop.touch = Some(false);
+        desktop.orientation = Some("landscape".into());
+        desktop.network = Some("wired".into());
+        desktop.color_scheme = Some("light".into());
+        desktop.language = Some("en-GB".into());
+        desktop.viewport_w = Some(1920.0);
+        desktop.viewport_h = Some(1080.0);
+        desktop.screen_w = Some(2560.0);
+        desktop.screen_h = Some(1440.0);
+        desktop.dpr = Some(2.0);
+        desktop.battery_level = None;
+        desktop.charging = None;
+        // A Monday morning at a desk: nothing about the situation agrees.
+        let monday_desk = encode(
+            FRIDAY + 3 * 86_400 - 8 * 3600,
+            Some("alice"),
+            &desktop,
+            &weights(),
+        );
+
+        assert!(
+            crate::vector::cosine(&friday_phone, &monday_desk) > 0.9,
+            "scope alone carries it, which is the problem being solved"
+        );
+        let s = context_score(&friday_phone, &monday_desk);
+        assert!(s < 0.4, "and the situation does not agree at all, got {s}");
+    }
+
+    #[test]
+    fn the_reason_names_the_blocks_that_decided_it() {
+        let a = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let c = contributions(&a, &a, &weights());
+        assert!(
+            !c.iter().any(|(n, _)| *n == "who"),
+            "scope explains nothing"
+        );
+        assert_eq!(c.len(), BLOCKS.len() - 1);
+        for pair in c.windows(2) {
+            assert!(
+                pair[0].1 >= pair[1].1,
+                "sorted, so the top three are the top three"
+            );
+        }
+        // Every block carries a `&'static str` and nothing generates prose.
+        assert!(BLOCKS.iter().all(|b| !b.label.is_empty()));
+    }
+
+    #[test]
+    fn a_bundle_that_is_not_json_is_an_empty_one_rather_than_an_error() {
+        // The bundle comes from a browser, and nothing a browser sends may take
+        // a page view down. An empty bundle zeroes the blocks it would have
+        // filled; the weekday and the hour still stand.
+        let b = parse_bundle("}{ not json");
+        assert!(b.tz.is_none());
+        let v = encode(FRIDAY, Some("alice"), &b, &weights());
+        assert_eq!(v.len(), CTX_DIM);
+        assert!(norm(slice_of(&v, "weekday")) > 0.0);
+    }
 
     #[test]
     fn a_fixed_clock_does_not_move() {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -342,12 +342,29 @@ fn fill(name: &str, s: &mut [f32], t: &LocalTime, scope: Option<&str>, b: &Bundl
     use std::f32::consts::TAU;
     match name {
         "scope" => {
-            // Hashed into buckets rather than looked up in a registry: there is
-            // no list of every subject that has ever searched, and one bucket
-            // shared by two people is a collision per-user collections remove
-            // rather than a bug to work around here.
+            // A deterministic pseudo-random direction per scope, spread over
+            // every slot — *not* one-hot over eight buckets.
+            //
+            // One-hot was the first version and was wrong: two people had a
+            // one-in-eight chance of landing in the same bucket, and a shared
+            // bucket means identical scope blocks, which means one person's
+            // Friday afternoon offered to another at a perfect score. A test
+            // with two names caught it on the first run.
+            //
+            // Spread this way, two distinct scopes are near-orthogonal rather
+            // than identical. That keeps a foreign cluster from ranking first
+            // in the store; what *guarantees* isolation is the exact scope
+            // check in `Core::offer`, because a near-orthogonal direction is
+            // still a probability and isolation must not be one.
             if let Some(sc) = scope {
-                s[bucket(sc, s.len())] = 1.0;
+                for (i, x) in s.iter_mut().enumerate() {
+                    let h = fnv1a(&format!("{sc}#{i}"));
+                    // The top 53 bits into [-1, 1): the low bits of FNV-1a move
+                    // least between neighbouring inputs, and `sc#0`..`sc#7` are
+                    // exactly neighbouring inputs.
+                    let unit = (h >> 11) as f64 / (1u64 << 53) as f64;
+                    *x = (unit * 2.0 - 1.0) as f32;
+                }
             }
         }
         "time_of_day" => {

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -1064,9 +1064,9 @@ impl Core {
                 ));
             }
             // The pursuit sweep looks at every recorded search, not at one
-            // corpus; retention and dedupe arming look at the whole collection
-            // for the same reason.
-            Stage::Pursuit | Stage::Retention | Stage::ArmDedupe => {
+            // corpus; retention, dedupe arming and the context sweep look at
+            // the whole collection for the same reason.
+            Stage::Pursuit | Stage::Retention | Stage::ArmDedupe | Stage::Context => {
                 return Err(Error::Validation(
                     "that stage is a collection-wide sweep, not a per-corpus stage".into(),
                 ));

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -153,6 +153,10 @@ pub struct Core {
     pub schedule: crate::config::ScheduleConfig,
     /// Whether the sitting may move a result. Carrying needs no setting.
     pub sitting: crate::config::SittingConfig,
+    /// Whether and how the area under the search box is filled. Read by the
+    /// sweep and on the page-view path, so it lives here rather than being
+    /// threaded down.
+    pub recommend: crate::config::RecommendConfig,
     /// Every live sitting, keyed by web session. Shared by every clone of
     /// `Core`, like the background queue — a per-clone map would be a per-clone
     /// working memory, which is no working memory at all.
@@ -240,6 +244,7 @@ impl Core {
             pursuit: cfg.pursuit.clone(),
             schedule: cfg.schedule.clone(),
             sitting: cfg.sitting.clone(),
+            recommend: cfg.recommend.clone(),
             sittings: Arc::new(Default::default()),
             gate: Arc::new(crate::infer::gate::InferenceGate::new(
                 std::time::Duration::from_secs(cfg.pacing.cooldown_secs),
@@ -310,6 +315,13 @@ impl Core {
     /// page, no nav entry, no MCP tool, no `/api/ask`.
     pub fn asks(&self) -> bool {
         self.completer.is_some()
+    }
+
+    /// Is the area under the search box filled? `false` means the placeholder
+    /// is not rendered, the endpoint records nothing, and the sweep does not
+    /// run — one gate, in one place.
+    pub fn recommends(&self) -> bool {
+        self.recommend.enabled
     }
 }
 
@@ -407,6 +419,10 @@ pub mod test_support {
             pursuit: crate::config::PursuitConfig::default(),
             schedule: crate::config::ScheduleConfig::default(),
             sitting: crate::config::SittingConfig::default(),
+            // Off, like the shipped default. The recommendation tests switch it
+            // on; every other test asserts nothing is offered and nothing is
+            // recorded.
+            recommend: crate::config::RecommendConfig::default(),
             sittings: Arc::new(Default::default()),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod ask;
 pub mod background;
+pub mod context;
 pub mod extract;
 pub mod fetch;
 pub mod gaps;
@@ -119,6 +120,10 @@ pub struct Core {
     /// Writes that run off the request path. Shared by every clone of `Core`,
     /// so draining one drains them all.
     pub background: Arc<Background>,
+    /// Where this feature reads the time. `System` in the binary; the
+    /// recommendation tests set a fixed one so a seventh Friday at 14:52
+    /// exists on demand. Nothing else in the tree reads it.
+    pub clock: crate::core::context::Clock,
     /// Shared by every clone of `Core`, like the background queue.
     pub query_cache: Arc<std::sync::Mutex<QueryCache>>,
     /// Thresholds and budgets for duplicate hygiene. Read on the capture path
@@ -223,6 +228,7 @@ impl Core {
             chunk_tokens: cfg.infer.embed.effective_chunk_tokens(),
             counter: Arc::new(TokenCounter),
             background: Arc::new(Background::default()),
+            clock: crate::core::context::Clock::System,
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: cfg.consolidate.clone(),
             weak_below: cfg.vector.weak_below,
@@ -378,6 +384,7 @@ pub mod test_support {
             chunk_tokens: crate::config::DEFAULT_CHUNK_TOKENS,
             counter: Arc::new(TokenCounter),
             background: Arc::new(Background::default()),
+            clock: crate::core::context::Clock::System,
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: crate::config::ConsolidateConfig::default(),
             // The fake embedder's vectors are not a semantic space, so a

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -133,8 +133,12 @@ pub struct Core {
     /// Cosine similarity below which a result is reported as only loosely
     /// related. See `VectorConfig::weak_below`.
     pub weak_below: f32,
-    /// Whether and how real searches are recorded for later judging. Read on
-    /// the search path, so it lives here rather than being threaded down.
+    /// The one switch over everything learned from what happens here. Read on
+    /// the search path and by every sweep downstream of it, so it lives here
+    /// rather than being threaded down. See `LearnConfig`.
+    pub learn: crate::config::LearnConfig,
+    /// How real searches are recorded for later judging. Read on the search
+    /// path, so it lives here rather than being threaded down.
     pub feedback: crate::config::FeedbackConfig,
     /// Limits for the upload, link and extension capture paths. Read on the
     /// request path, so it lives here rather than being threaded down.
@@ -237,6 +241,7 @@ impl Core {
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: cfg.consolidate.clone(),
             weak_below: cfg.vector.weak_below,
+            learn: cfg.learn.clone(),
             feedback: cfg.feedback.clone(),
             capture: cfg.capture.clone(),
             associate: cfg.associate.clone(),
@@ -294,16 +299,13 @@ impl Core {
     /// Whether the associative layer — links and priming — is actually live,
     /// not merely configured on.
     ///
-    /// Links are learned from recorded searches (`search_events`), and
-    /// recording queries is a separate privacy decision the operator makes
-    /// with `feedback.enabled`. Without recordings there is nothing to learn
-    /// from, so `associate.enabled` alone must not let the layer read or
-    /// write anything: every site that primes, associates, bumps activation
-    /// from a search, or renders "seen together" has to check both flags, or
-    /// an install that never opted into `feedback` still has its ranking and
-    /// activation quietly touched.
+    /// Links are learned from recorded searches (`search_events`), and nothing
+    /// is recorded while `[learn]` is off. Kept as a named predicate rather
+    /// than inlined: every site that primes, associates, bumps activation from
+    /// a search, or renders "seen together" asks this one question, and the
+    /// name says which question it is.
     pub fn associating(&self) -> bool {
-        self.associate.enabled && self.feedback.enabled
+        self.learn.enabled
     }
 
     /// Is there a synthesizer to call? `false` means no `[infer.synthesize]`:
@@ -320,9 +322,15 @@ impl Core {
 
     /// Is the area under the search box filled? `false` means the placeholder
     /// is not rendered, the endpoint records nothing, and the sweep does not
-    /// run — one gate, in one place.
+    /// run — one question, asked in one place.
+    ///
+    /// `[learn]` as well as `[recommend]`, and not as a second gate over the
+    /// faculty: the situations it clusters are opens recorded in the same log
+    /// everything else here reads, so with the log unwritten the sweep profiles
+    /// nothing and the ladder falls to its floor for ever. Saying so here is
+    /// what stops that being a silent state.
     pub fn recommends(&self) -> bool {
-        self.recommend.enabled
+        self.recommend.enabled && self.learn.enabled
     }
 }
 
@@ -405,14 +413,12 @@ pub mod test_support {
             // search test would be asserting against noise. Tests that care
             // about the labelling set it themselves.
             weak_below: 0.0,
-            // Off in tests, whatever ships: the capture tests switch it on and
-            // the rest assert nothing is recorded.
-            feedback: crate::config::FeedbackConfig {
-                enabled: false,
-                ..Default::default()
-            },
+            // Off in tests, whatever ships: the tests that need a log switch
+            // it on and the rest assert nothing is recorded.
+            learn: crate::config::LearnConfig { enabled: false },
+            feedback: crate::config::FeedbackConfig::default(),
             capture: crate::config::CaptureConfig::default(),
-            // On, like the shipped default — and inert in most tests, because
+            // Inert in most tests whatever it says, because `learn` is off and
             // nothing has learned a link yet. The association tests seed one.
             associate: crate::config::AssociateConfig::default(),
             activation: crate::config::ActivationConfig::default(),
@@ -420,10 +426,13 @@ pub mod test_support {
             pursuit: crate::config::PursuitConfig::default(),
             schedule: crate::config::ScheduleConfig::default(),
             sitting: crate::config::SittingConfig::default(),
-            // Off, like the shipped default. The recommendation tests switch it
-            // on; every other test asserts nothing is offered and nothing is
-            // recorded.
-            recommend: crate::config::RecommendConfig::default(),
+            // Off, unlike the shipped default: `recommends()` is two flags and
+            // a test that leaves both alone must offer nothing. The
+            // recommendation tests switch both on.
+            recommend: crate::config::RecommendConfig {
+                enabled: false,
+                ..Default::default()
+            },
             sittings: Arc::new(Default::default()),
             // No cooldown: a test that wants pacing builds its
             // own gate, and every other test would otherwise pay for one.
@@ -471,23 +480,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn associating_requires_both_flags_and_the_shipped_default_has_both() {
-        // Shipped defaults: `associate.enabled = true`, `feedback.enabled =
-        // true` — promotion reads activation, and activation only moves while
-        // searches are recorded, so recording is opt-out. The test core keeps
-        // feedback off so every other test starts from nothing recorded, and
-        // the layer must still stay dark until both are on.
-        assert!(crate::config::FeedbackConfig::default().enabled);
-        assert!(crate::config::AssociateConfig::default().enabled);
+    async fn the_layer_is_one_switch_and_it_ships_on() {
+        // Recording searches, learning links and writing pursuits were three
+        // flags that only ever meant something together — two of their
+        // combinations were refused at startup and the third was a warning.
+        // One switch now, on by default: promotion reads activation, and
+        // activation only moves while the log is being written, so off is the
+        // deliberate act. The test core keeps it off so every other test
+        // starts from nothing recorded.
+        assert!(crate::config::LearnConfig::default().enabled);
         let mut core = test_support::test_core().await;
-        assert!(core.associate.enabled && !core.feedback.enabled);
-        assert!(!core.associating(), "on with only associate.enabled set");
+        assert!(!core.learn.enabled);
+        assert!(
+            !core.associating(),
+            "the layer is dark while `[learn]` is off"
+        );
+        assert!(
+            !core.recommends(),
+            "and so is the area under the search box"
+        );
 
-        core.feedback.enabled = true;
-        assert!(core.associating(), "both flags set");
+        core.learn.enabled = true;
+        assert!(core.associating());
+    }
 
-        core.associate.enabled = false;
-        assert!(!core.associating(), "on with only feedback.enabled set");
+    #[tokio::test]
+    async fn the_offer_needs_the_log_as_well_as_its_own_switch() {
+        // The situations it clusters are opens recorded in the same log
+        // everything else reads. `[recommend]` alone over an unwritten log is
+        // a sweep that profiles nothing and a ladder that falls to its floor
+        // for ever — the inert state this predicate exists to make impossible.
+        let mut core = test_support::test_core().await;
+        core.recommend.enabled = true;
+        assert!(!core.recommends(), "its own switch is not enough");
+        core.learn.enabled = true;
+        assert!(core.recommends());
+        core.recommend.enabled = false;
+        assert!(!core.recommends(), "and neither is the log");
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod gaps;
 pub mod image;
 pub mod ingest;
 pub mod pdf;
+pub mod recommend;
 pub mod search;
 pub mod sitting;
 

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -473,6 +473,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn six_fridays_and_the_seventh_offers_it_before_it_is_asked_for() {
+        // The whole feature in one test, and the example it was asked for:
+        // seed six Fridays, set the clock to the seventh at 14:52, send the
+        // phone bundle, and assert the artifact comes back at rung Pattern with
+        // weekday, hour and device named. Nothing here calls a model or an
+        // embedder — every step is the production path with a fixed clock in
+        // it, and the sweep is the real one.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre opening hours").await;
+        let noise = seed_artifact(&core, "invoice template").await;
+
+        // Six Fridays at 15:00 on the phone, opening the recycling centre.
+        for w in 1..=6 {
+            let at = FRIDAY - w * 7 * 86_400;
+            seen_and_opened(&core, &aid, at, &phone()).await;
+        }
+        // And six Tuesday mornings at a desk, opening something else — so the
+        // answer is a choice rather than the only candidate.
+        for w in 1..=6 {
+            let at = FRIDAY - w * 7 * 86_400 - 3 * 86_400 - 7 * 3600;
+            seen_and_opened(&core, &noise, at, &desk()).await;
+        }
+
+        let learned = crate::jobs::context::run(&core).await.unwrap();
+        assert_eq!(learned.events, 12);
+        assert_eq!(learned.profiled, 2, "both situations were learned");
+
+        // The seventh Friday, eight minutes before the usual hour.
+        let mut seventh = core.clone();
+        seventh.clock = Clock::Fixed(FRIDAY - 8 * 60);
+
+        let offer = seventh
+            .offer(Some("alice"), &phone(), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            offer.artifact_id, aid,
+            "the Friday thing, not the Tuesday one"
+        );
+        assert_eq!(offer.title, "recycling centre opening hours");
+        assert_eq!(offer.rung, Rung::Pattern);
+        assert!(offer.blocks.contains(&"weekday"), "{:?}", offer.blocks);
+        assert!(offer.blocks.contains(&"hour"), "{:?}", offer.blocks);
+        assert!(offer.blocks.contains(&"device"), "{:?}", offer.blocks);
+        // And it quotes a Friday that actually happened.
+        let at = offer.at.expect("a representative event");
+        assert!(
+            (1..=6).any(|w| at == FRIDAY - w * 7 * 86_400),
+            "quoted {at}, which is not one of the six"
+        );
+    }
+
+    /// One page view and the open that followed it, at `at`.
+    async fn seen_and_opened(core: &Core, aid: &str, at: i64, b: &Bundle) {
+        let raw = serde_json::to_string(b).unwrap();
+        let t = crate::core::context::local_time(at, b.tz.as_deref(), None);
+        core.store
+            .record_context(&crate::store::context::ContextEvent {
+                id: 0,
+                scope: Some("alice".into()),
+                at,
+                bundle: raw.clone(),
+                device_key: crate::core::context::device_key(b),
+                local_hour: Some(t.hour as i64),
+                weekday: Some(t.weekday as i64),
+                tz: b.tz.clone(),
+            })
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(aid, "opened", None, Some("alice"), at + 5)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn the_reason_explains_the_artifact_that_was_offered() {
         // If the local recomputation and the store disagree, the line explains a
         // different artifact than the one shown — which is the one dishonesty

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -156,7 +156,8 @@ impl Core {
                 // explained with the wrong blocks. Its centroid may still be in
                 // the index — a rebuild copies any set whose width matches —
                 // and the next sweep replaces it.
-                if c.encoder_version != crate::core::context::ENCODER_VERSION
+                if c.encoder_version
+                    != crate::core::context::encoder_version(&self.recommend.weights)
                     || c.centroid.len() != now.len()
                 {
                     continue;
@@ -191,7 +192,22 @@ impl Core {
                     rung,
                     slot: Some(cluster.slot),
                     events: cluster.events,
-                    blocks: all.iter().take(NAMED_BLOCKS).map(|(l, _)| *l).collect(),
+                    // Only the blocks that actually agreed. `cosine` returns
+                    // zero for a zero vector — which is what an absent block
+                    // is — and zero sorts above every negative contribution,
+                    // so taking the top three unconditionally printed
+                    // "Pattern · weekday, hour, battery" on a pair where
+                    // neither side ever sent a battery reading. The line names
+                    // what decided it, or fewer things, or nothing. The
+                    // `<details>` still carries every block including the ones
+                    // that disagreed: that is the pane for exactness, and this
+                    // is the line a person reads.
+                    blocks: all
+                        .iter()
+                        .filter(|(_, v)| *v > 0.0)
+                        .take(NAMED_BLOCKS)
+                        .map(|(l, _)| *l)
+                        .collect(),
                     at: rep.get("at").and_then(serde_json::Value::as_i64),
                     at_tz: rep
                         .pointer("/bundle/tz")
@@ -337,7 +353,7 @@ fn first_line(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::context::{Clock, ENCODER_VERSION};
+    use crate::core::context::{Clock, encoder_version};
     use crate::core::test_support::test_core;
 
     /// 2026-08-21T13:52:00Z — a Friday, 15:52 in Berlin.
@@ -346,6 +362,7 @@ mod tests {
     async fn core_at(now: i64) -> Core {
         let mut core = test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         core.clock = Clock::Fixed(now);
         core
     }
@@ -421,7 +438,7 @@ mod tests {
                     weight,
                     events,
                     last_at: at,
-                    encoder_version: ENCODER_VERSION,
+                    encoder_version: encoder_version(&core.recommend.weights),
                     representative: serde_json::json!({ "at": at, "bundle": b }).to_string(),
                 }],
             )
@@ -837,7 +854,7 @@ mod tests {
             .await
             .unwrap()[&aid]
             .clone();
-        rows[0].encoder_version = ENCODER_VERSION + 1;
+        rows[0].encoder_version = encoder_version(&core.recommend.weights) + 1;
         core.store
             .replace_context_clusters(&aid, &rows)
             .await
@@ -848,6 +865,68 @@ mod tests {
             offer.as_ref().is_none_or(|o| o.slot.is_none()),
             "got {offer:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn a_cluster_built_under_other_weights_is_not_compared_against_new_ones() {
+        // The weights are the geometry, not a knob on top of it: `encode`
+        // scales every block by its weight before anything is compared. An
+        // operator who edits one and restarts leaves the store full of
+        // centroids built under the old numbers while this path encodes the
+        // present situation under the new ones — and for the six hours until
+        // the next sweep rebuilds them, `context_score` and the argmax are
+        // computed across two different encodings. Which is exactly the
+        // recommendation nobody can account for that `BlockWeights::of` refuses
+        // a typo to avoid.
+        let mut core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        for w in 1..=6 {
+            learn(&core, &aid, "alice", FRIDAY - w * 7 * 86_400, &phone()).await;
+        }
+        let offered = core.offer(Some("alice"), &phone()).await.unwrap();
+        assert!(
+            offered.as_ref().is_some_and(|o| o.slot.is_some()),
+            "this test needs a learned offer to invalidate: {offered:?}"
+        );
+
+        // One weight moved, nothing else touched. The stored centroids are now
+        // a geometry this reader does not know.
+        core.recommend.weights.network += 0.5;
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap();
+        assert!(
+            offer.as_ref().is_none_or(|o| o.slot.is_none()),
+            "a centroid from the old geometry was still explained: {offer:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_reason_names_only_the_blocks_that_agreed() {
+        // `cosine` returns zero for a zero vector — which is what a block the
+        // browser said nothing about is — and zero sorts above every negative
+        // contribution. Taking the top three unconditionally printed
+        // "Pattern · weekday, hour, battery" on a pair where neither side ever
+        // sent a battery reading.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        let bare = Bundle {
+            tz: Some("Europe/Berlin".into()),
+            ..Default::default()
+        };
+        for w in 1..=6 {
+            learn(&core, &aid, "alice", FRIDAY - w * 7 * 86_400, &bare).await;
+        }
+        let offer = core.offer(Some("alice"), &bare).await.unwrap().unwrap();
+        for absent in ["battery", "month", "screen", "surroundings"] {
+            assert!(
+                !offer.blocks.contains(&absent),
+                "the line claimed {absent} on a bundle that never carried it: {:?}",
+                offer.blocks
+            );
+        }
+        // The `<details>` pane still carries every block, including the ones
+        // worth nothing: that is the pane for exactness, and this is the line a
+        // person reads.
+        assert!(offer.detail.contains("battery"), "{}", offer.detail);
     }
 
     #[tokio::test]
@@ -897,6 +976,7 @@ mod tests {
         let (mut core, embedder) =
             crate::core::test_support::test_core_counting_embed_calls().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         core.clock = Clock::Fixed(FRIDAY);
         let aid = seed_artifact(&core, "recycling centre").await;
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -250,6 +250,78 @@ impl Core {
     }
 }
 
+impl Core {
+    /// Write down the situation this page view happened in.
+    ///
+    /// Off the request path: a page view must not get slower, or fail, because
+    /// a bookkeeping write did — and a situation dropped at shutdown is a
+    /// Friday afternoon the base never learns about, which is why it goes
+    /// through `background` rather than a bare `tokio::spawn`.
+    ///
+    /// The raw string is stored whole, including the fields the encoder does
+    /// not read today; the denormalised columns are what the sweep reads on
+    /// every row.
+    pub fn record_context_event(&self, raw: &str, bundle: &Bundle, scope: Option<&str>) {
+        if !self.recommends() {
+            return;
+        }
+        let at = self.clock.now();
+        let t = crate::core::context::local_time(at, bundle.tz.as_deref(), bundle.tz_offset_mins);
+        let row = crate::store::context::ContextEvent {
+            id: 0,
+            scope: scope.map(str::to_string),
+            at,
+            bundle: raw.to_string(),
+            device_key: crate::core::context::device_key(bundle),
+            local_hour: Some(t.hour as i64),
+            weekday: Some(t.weekday as i64),
+            tz: bundle.tz.clone(),
+        };
+        let store = self.store.clone();
+        self.background.spawn(async move {
+            if let Err(e) = store.record_context(&row).await {
+                tracing::warn!(error = %e, "could not record the situation of a page view");
+            }
+        });
+    }
+
+    /// Write down that something was offered, or that the offer was taken.
+    ///
+    /// Shown against clicked, broken down by rung, is a hit rate — the only
+    /// number that can later settle whether the block weights are right. They
+    /// are chosen, not measured, and a recommender with no visible hit rate
+    /// becomes `[sitting] prime`: a default nobody ever moved because nobody
+    /// could see its effect.
+    pub fn record_recommendation(
+        &self,
+        artifact_id: &str,
+        kind: &str,
+        rung: &str,
+        slot: Option<i64>,
+        scope: Option<&str>,
+    ) {
+        if !self.recommends() {
+            return;
+        }
+        let detail = serde_json::json!({ "rung": rung, "slot": slot }).to_string();
+        let (store, id, kind, scope) = (
+            self.store.clone(),
+            artifact_id.to_string(),
+            kind.to_string(),
+            scope.map(str::to_string),
+        );
+        let at = self.clock.now();
+        self.background.spawn(async move {
+            if let Err(e) = store
+                .record_recommendation(&id, &kind, &detail, scope.as_deref(), at)
+                .await
+            {
+                tracing::warn!(error = %e, "could not record what was offered");
+            }
+        });
+    }
+}
+
 fn title_of(p: &crate::vector::VectorPayload) -> String {
     p.title
         .clone()

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -27,39 +27,42 @@ pub const NAMED_BLOCKS: usize = 3;
 
 /// Which rung of the ladder the offer rests on.
 ///
-/// Something is always shown, and the wording says what it rests on.
-/// `Forgotten` is deliberately not phrased like a pattern: the distance between
-/// "Fridays around 15:00" and "not seen in a long time" is the whole honesty of
-/// this feature, and blurring it makes the area furniture within a fortnight.
+/// Two questions decide it, not one. *How well does the situation match* —
+/// which separates `Pattern` from `Similar` — and *how often has it happened*,
+/// which separates both from `Tentative`. The second used to be thrown away
+/// after the sweep applied it as a cutoff, and throwing it away is what made a
+/// thing done twice indistinguishable from a thing done twenty times.
+///
+/// `Random` is the floor, and it is not a claim. Nothing about the situation
+/// produced it, so nothing is printed beside it: it exists because a base that
+/// has not learned anything yet should still have something to look at, and
+/// saying "here is a card, no reason" is the honest way to do that.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Rung {
     Pattern,
     Similar,
-    Sitting,
-    Forgotten,
+    /// A real situation, seen once or twice. Held to a higher bar on the match
+    /// than `Similar` is, because there is less behind it.
+    Tentative,
+    Random,
 }
 
 impl Rung {
-    /// For the recorded row, and for the Ops breakdown.
+    /// For the recorded row, and for the Ops breakdown. Fixed buckets, unlike
+    /// the wording, which varies with the count.
     pub fn as_str(&self) -> &'static str {
         match self {
             Rung::Pattern => "pattern",
             Rung::Similar => "similar",
-            Rung::Sitting => "sitting",
-            Rung::Forgotten => "forgotten",
+            Rung::Tentative => "tentative",
+            Rung::Random => "random",
         }
     }
 
-    /// The four fixed strings the page prints. No prose is generated anywhere
-    /// on this path — a new block in the encoder brings its own label and needs
-    /// no sentence written for it.
-    pub fn line(&self) -> &'static str {
-        match self {
-            Rung::Pattern => "Pattern",
-            Rung::Similar => "Similar to",
-            Rung::Sitting => "Touched in this sitting",
-            Rung::Forgotten => "Not seen in a long time",
-        }
+    /// Whether this rung explains itself at all. `Random` does not, and the
+    /// page prints no line beside it.
+    pub fn is_explained(&self) -> bool {
+        !matches!(self, Rung::Random)
     }
 }
 
@@ -70,11 +73,13 @@ pub struct Offer {
     pub artifact_id: String,
     pub title: String,
     pub rung: Rung,
-    /// The winning cluster, for the recorded row. `None` on the two rungs that
-    /// matched no situation.
+    /// The winning cluster, for the recorded row. `None` on the random card.
     pub slot: Option<i64>,
+    /// How many events the winning cluster was built from. Zero on the random
+    /// card. What `Tentative` puts into words.
+    pub events: i64,
     /// The blocks that decided it, largest contribution first, at most
-    /// `NAMED_BLOCKS`. Empty on the lower two rungs, which matched nothing.
+    /// `NAMED_BLOCKS`. Empty on the random card, which matched nothing.
     pub blocks: Vec<&'static str>,
     /// The representative event's stamp. What "like 08.08., 15:04" prints.
     pub at: Option<i64>,
@@ -93,12 +98,7 @@ impl Core {
     /// here because Qdrant's `max_sim` yields the maximum and not which element
     /// produced it — and the display needs the element, both to quote it and to
     /// name the blocks that decided it.
-    pub async fn offer(
-        &self,
-        scope: Option<&str>,
-        bundle: &Bundle,
-        session: Option<&str>,
-    ) -> Result<Option<Offer>> {
+    pub async fn offer(&self, scope: Option<&str>, bundle: &Bundle) -> Result<Option<Offer>> {
         if !self.recommends() {
             return Ok(None);
         }
@@ -170,12 +170,16 @@ impl Core {
 
         if let Some((hit, cluster, _)) = best {
             let score = context_score(&now, &cluster.centroid);
-            let rung = if score >= self.recommend.strong_at {
-                Some(Rung::Pattern)
-            } else if score >= self.recommend.weak_at {
-                Some(Rung::Similar)
-            } else {
-                None
+            // Established, or seen only once or twice. A thin cluster has to
+            // match the situation *better* before anything is said, which is
+            // what keeps a single accident from being offered as if it meant
+            // something.
+            let firm = cluster.weight >= self.recommend.firm_at;
+            let rung = match (firm, score) {
+                (true, s) if s >= self.recommend.strong_at => Some(Rung::Pattern),
+                (true, s) if s >= self.recommend.weak_at => Some(Rung::Similar),
+                (false, s) if s >= self.recommend.strong_at => Some(Rung::Tentative),
+                _ => None,
             };
             if let Some(rung) = rung {
                 let all = contributions(&now, &cluster.centroid, &self.recommend.weights);
@@ -186,6 +190,7 @@ impl Core {
                     title: title_of(&hit.payload),
                     rung,
                     slot: Some(cluster.slot),
+                    events: cluster.events,
                     blocks: all.iter().take(NAMED_BLOCKS).map(|(l, _)| *l).collect(),
                     at: rep.get("at").and_then(serde_json::Value::as_i64),
                     at_tz: rep
@@ -194,6 +199,8 @@ impl Core {
                         .map(str::to_string),
                     detail: serde_json::json!({
                         "score": score,
+                        "events": cluster.events,
+                        "weight": cluster.weight,
                         "bundle": bundle,
                         "representative": rep,
                         "contributions": all
@@ -206,47 +213,35 @@ impl Core {
             }
         }
 
-        // Nothing in `ctx`, but this sitting is open. A way back to what was
-        // just being read is not a claim about a pattern, and the wording does
-        // not make one.
-        if let Some(sess) = session {
-            let carried = self
-                .sittings
-                .read(sess, now_at, self.pursuit.idle_secs as i64);
-            for aid in &carried.touched {
-                if let Ok(a) = self.store.get_artifact(aid).await
-                    && a.in_results()
-                {
-                    return Ok(Some(Offer {
-                        artifact_id: a.id.clone(),
-                        title: a.title.clone().unwrap_or_else(|| first_line(&a.text)),
-                        rung: Rung::Sitting,
-                        slot: None,
-                        blocks: Vec::new(),
-                        at: None,
-                        at_tz: None,
-                        detail: serde_json::json!({ "bundle": bundle }).to_string(),
-                    }));
-                }
-            }
-        }
-
-        // The bottom rung, which *is* `resurface` — and says so.
-        let forgotten = self.resurface(1).await.unwrap_or_default();
-        Ok(forgotten.into_iter().next().map(|r| Offer {
-            title: r
-                .title
-                .clone()
-                .filter(|t| !t.is_empty())
-                .unwrap_or_else(|| first_line(&r.text)),
-            artifact_id: r.artifact_id,
-            rung: Rung::Forgotten,
-            slot: None,
-            blocks: Vec::new(),
-            at: None,
-            at_tz: None,
-            detail: serde_json::json!({ "bundle": bundle }).to_string(),
-        }))
+        // The floor: something to look at while the base has nothing to say
+        // about this situation. Drawn at random and claimed to be nothing —
+        // no blocks, no stamp, no line under it.
+        //
+        // Deliberately not `resurface`. That answers "what has been forgotten",
+        // which on a base anyone has just started using is nothing at all, and
+        // it stamps what it draws as seen — draining the pool the search page's
+        // own resurfacing lives on, one page view at a time.
+        Ok(self
+            .store
+            .random_artifact()
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "could not draw a card");
+                None
+            })
+            .map(|(id, title, text)| Offer {
+                artifact_id: id,
+                title: title
+                    .filter(|t| !t.is_empty())
+                    .unwrap_or_else(|| first_line(&text)),
+                rung: Rung::Random,
+                slot: None,
+                events: 0,
+                blocks: Vec::new(),
+                at: None,
+                at_tz: None,
+                detail: serde_json::json!({ "bundle": bundle }).to_string(),
+            }))
     }
 }
 
@@ -398,8 +393,22 @@ mod tests {
         }
     }
 
-    /// Give `aid` one learned situation, at `at`, in both stores.
+    /// Give `aid` one established situation, at `at`, in both stores.
     async fn learn(core: &Core, aid: &str, scope: &str, at: i64, b: &Bundle) {
+        learn_n(core, aid, scope, at, b, 6.0, 6).await;
+    }
+
+    /// The same, with the weight and the count said explicitly — so a test can
+    /// build a situation that is real but thin.
+    async fn learn_n(
+        core: &Core,
+        aid: &str,
+        scope: &str,
+        at: i64,
+        b: &Bundle,
+        weight: f64,
+        events: i64,
+    ) {
         let v = encode(at, Some(scope), b, &core.recommend.weights);
         core.store
             .replace_context_clusters(
@@ -409,7 +418,8 @@ mod tests {
                     artifact_id: aid.into(),
                     slot: 0,
                     centroid: v.clone(),
-                    weight: 6.0,
+                    weight,
+                    events,
                     last_at: at,
                     encoder_version: ENCODER_VERSION,
                     representative: serde_json::json!({ "at": at, "bundle": b }).to_string(),
@@ -505,7 +515,7 @@ mod tests {
         seventh.clock = Clock::Fixed(FRIDAY - 8 * 60);
 
         let offer = seventh
-            .offer(Some("alice"), &phone(), None)
+            .offer(Some("alice"), &phone())
             .await
             .unwrap()
             .unwrap();
@@ -574,11 +584,7 @@ mod tests {
             .await
             .unwrap();
 
-        let offer = core
-            .offer(Some("alice"), &phone(), None)
-            .await
-            .unwrap()
-            .unwrap();
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
         assert_eq!(
             offer.artifact_id, from_store[0].payload.artifact_id,
             "the local argmax reproduces the store's"
@@ -592,11 +598,7 @@ mod tests {
         let aid = seed_artifact(&core, "recycling centre").await;
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
 
-        let offer = core
-            .offer(Some("alice"), &phone(), None)
-            .await
-            .unwrap()
-            .unwrap();
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
         assert_eq!(offer.rung, Rung::Pattern);
         assert_eq!(offer.slot, Some(0));
         assert_eq!(offer.title, "recycling centre");
@@ -617,11 +619,7 @@ mod tests {
         other.orientation = Some("landscape".into());
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400 - 4 * 3600, &other).await;
 
-        let offer = core
-            .offer(Some("alice"), &phone(), None)
-            .await
-            .unwrap()
-            .unwrap();
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
         assert_eq!(offer.rung, Rung::Similar, "blocks: {:?}", offer.blocks);
     }
 
@@ -641,7 +639,7 @@ mod tests {
         // it like one.
         for n in 0..20 {
             let who = format!("person-{n}");
-            let offer = core.offer(Some(&who), &phone(), None).await.unwrap();
+            let offer = core.offer(Some(&who), &phone()).await.unwrap();
             assert!(
                 offer
                     .as_ref()
@@ -678,7 +676,7 @@ mod tests {
             "the store has nothing else to return, so it returns alice's"
         );
 
-        let offer = core.offer(Some("bob"), &phone(), None).await.unwrap();
+        let offer = core.offer(Some("bob"), &phone()).await.unwrap();
         assert!(
             offer.as_ref().is_none_or(|o| o.slot.is_none()),
             "and the read path cut it anyway: {offer:?}"
@@ -686,50 +684,133 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn with_nothing_learned_the_ladder_falls_to_what_this_sitting_touched() {
+    async fn a_situation_seen_twice_says_twice_rather_than_pattern() {
+        // The middle ground. Two occurrences are a real thing that happened and
+        // worth offering, and calling them a pattern would be a claim the
+        // evidence does not carry. The line says the number instead.
         let core = core_at(FRIDAY).await;
         let aid = seed_artifact(&core, "recycling centre").await;
-        core.sittings.touched("sess-1", &aid, FRIDAY, 900);
+        // Weight below `firm_at`, which at the default half-life is what two
+        // weekly repetitions come to.
+        learn_n(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone(), 1.9, 2).await;
 
-        let offer = core
-            .offer(Some("alice"), &phone(), Some("sess-1"))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(offer.rung, Rung::Sitting);
-        assert_eq!(offer.artifact_id, aid);
-        assert!(
-            offer.blocks.is_empty(),
-            "nothing was matched, so nothing is named"
-        );
-        assert_eq!(offer.slot, None);
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
+        assert_eq!(offer.rung, Rung::Tentative);
+        assert_eq!(offer.events, 2, "and it knows how many");
+        assert_eq!(offer.slot, Some(0), "still a real cluster");
+        assert!(!offer.blocks.is_empty(), "and it still says what matched");
     }
 
     #[tokio::test]
-    async fn with_no_sitting_either_it_falls_to_what_has_been_forgotten() {
-        // Deliberately not phrased like a pattern. This rung *is* `resurface`,
-        // and it says so.
+    async fn a_thin_situation_is_held_to_a_higher_bar_than_an_established_one() {
+        // With less behind it, the situation has to match *better* before
+        // anything is said at all. Otherwise one accident on a Tuesday would be
+        // offered every Tuesday after it.
         let core = core_at(FRIDAY).await;
-        let _aid = seed_artifact(&core, "recycling centre").await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        // A middling match — the kind that earns `Similar` when established.
+        let mut other = phone();
+        other.network = Some("wifi".into());
+        other.orientation = Some("landscape".into());
+        learn_n(
+            &core,
+            &aid,
+            "alice",
+            FRIDAY - 7 * 86_400 - 4 * 3600,
+            &other,
+            1.0,
+            1,
+        )
+        .await;
+
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
+        assert_eq!(
+            offer.rung,
+            Rung::Random,
+            "a middling match on one event is not worth a sentence"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_nothing_learned_a_card_is_drawn_and_claims_nothing() {
+        // The floor. Something to look at while the base has nothing to say
+        // about the situation — and nothing printed beside it, because nothing
+        // about the situation produced it.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
+        assert_eq!(offer.rung, Rung::Random);
+        assert_eq!(offer.artifact_id, aid);
+        assert!(!offer.rung.is_explained(), "no line is printed beside it");
+        assert!(offer.blocks.is_empty());
+        assert_eq!(offer.slot, None);
+        assert_eq!(offer.events, 0);
+        assert!(offer.at.is_none(), "nothing to quote");
+    }
+
+    #[tokio::test]
+    async fn the_card_works_on_a_base_nobody_has_used_yet() {
+        // The whole reason this is not `resurface`: that one answers "older
+        // than thirty days and unshown for thirty days", which on a base
+        // somebody started this morning is nothing at all — empty in exactly
+        // the moment this rung exists for.
+        let core = core_at(FRIDAY).await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        core.store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "captured five minutes ago".into(),
+                    corpus_span: None,
+                    title: Some("brand new".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
 
         let offer = core
-            .offer(Some("alice"), &phone(), None)
+            .offer(Some("alice"), &phone())
             .await
             .unwrap()
+            .expect("a fresh base still has something to show");
+        assert_eq!(offer.title, "brand new");
+        assert_eq!(offer.rung, Rung::Random);
+    }
+
+    #[tokio::test]
+    async fn drawing_a_card_does_not_mark_anything_as_seen() {
+        // `resurface` stamps what it draws, which is right for a list somebody
+        // asked for and wrong for something that fires on every page view: it
+        // would drain the pool the search page's own resurfacing lives on, one
+        // page view at a time.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        for _ in 0..5 {
+            core.offer(Some("alice"), &phone()).await.unwrap();
+        }
+        core.background.wait_idle().await;
+
+        let payloads = core
+            .vectors
+            .payloads_of(std::slice::from_ref(&aid))
+            .await
             .unwrap();
-        assert_eq!(offer.rung, Rung::Forgotten);
-        assert!(offer.rung.line().contains("long"), "{}", offer.rung.line());
+        assert!(
+            payloads[&aid].last_seen_at.is_none(),
+            "five page views must not count as having read it"
+        );
     }
 
     #[tokio::test]
     async fn an_empty_base_is_offered_nothing_rather_than_a_lie() {
         let core = core_at(FRIDAY).await;
-        assert!(
-            core.offer(Some("alice"), &phone(), None)
-                .await
-                .unwrap()
-                .is_none()
-        );
+        assert!(core.offer(Some("alice"), &phone()).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -739,12 +820,7 @@ mod tests {
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
         core.recommend.enabled = false;
 
-        assert!(
-            core.offer(Some("alice"), &phone(), None)
-                .await
-                .unwrap()
-                .is_none()
-        );
+        assert!(core.offer(Some("alice"), &phone()).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -767,7 +843,7 @@ mod tests {
             .await
             .unwrap();
 
-        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap();
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap();
         assert!(
             offer.as_ref().is_none_or(|o| o.slot.is_none()),
             "got {offer:?}"
@@ -788,7 +864,7 @@ mod tests {
             .await
             .unwrap();
 
-        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap();
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap();
         assert!(
             offer.as_ref().is_none_or(|o| o.rung != Rung::Pattern),
             "got {offer:?}"
@@ -804,11 +880,7 @@ mod tests {
         let aid = seed_artifact(&core, "recycling centre").await;
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
 
-        let offer = core
-            .offer(Some("alice"), &phone(), None)
-            .await
-            .unwrap()
-            .unwrap();
+        let offer = core.offer(Some("alice"), &phone()).await.unwrap().unwrap();
         let d: serde_json::Value = serde_json::from_str(&offer.detail).unwrap();
         assert_eq!(d["bundle"]["tz"], "Europe/Berlin");
         assert!(d["contributions"].is_object());
@@ -830,7 +902,7 @@ mod tests {
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
         let before = embedder.calls();
 
-        core.offer(Some("alice"), &phone(), None).await.unwrap();
+        core.offer(Some("alice"), &phone()).await.unwrap();
         assert_eq!(embedder.calls(), before, "not one embedding call");
     }
 }

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -1,0 +1,687 @@
+//! What to offer under the search box, and why.
+//!
+//! One vector query against the `ctx` multivector, then the winning cluster
+//! re-derived locally — because Qdrant returns the `max_sim` score and not
+//! *which* element produced it, and the display needs the element.
+//!
+//! That places the same arithmetic in two places. It is the price of holding
+//! the vectors in the index and the reason outside it, and a test pins that
+//! both pick the same artifact: if they drift, the line under the offer
+//! explains a hit it is not explaining.
+
+use crate::core::Core;
+use crate::core::context::{Bundle, context_score, contributions, encode};
+use crate::error::Result;
+use crate::vector::cosine;
+
+/// How many artifacts the store is asked for.
+///
+/// Ten. Every one of them has its clusters reloaded and rescored locally, at
+/// most five clusters of 53 dimensions apiece — a few thousand multiplications,
+/// which is free next to the round trip that fetched them.
+pub const CANDIDATES: usize = 10;
+
+/// How many blocks the line names. Three, sorted by contribution: enough to say
+/// what decided it, short enough to stay one line.
+pub const NAMED_BLOCKS: usize = 3;
+
+/// Which rung of the ladder the offer rests on.
+///
+/// Something is always shown, and the wording says what it rests on.
+/// `Forgotten` is deliberately not phrased like a pattern: the distance between
+/// "Fridays around 15:00" and "not seen in a long time" is the whole honesty of
+/// this feature, and blurring it makes the area furniture within a fortnight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rung {
+    Pattern,
+    Similar,
+    Sitting,
+    Forgotten,
+}
+
+impl Rung {
+    /// For the recorded row, and for the Ops breakdown.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Rung::Pattern => "pattern",
+            Rung::Similar => "similar",
+            Rung::Sitting => "sitting",
+            Rung::Forgotten => "forgotten",
+        }
+    }
+
+    /// The four fixed strings the page prints. No prose is generated anywhere
+    /// on this path — a new block in the encoder brings its own label and needs
+    /// no sentence written for it.
+    pub fn line(&self) -> &'static str {
+        match self {
+            Rung::Pattern => "Pattern",
+            Rung::Similar => "Similar to",
+            Rung::Sitting => "Touched in this sitting",
+            Rung::Forgotten => "Not seen in a long time",
+        }
+    }
+}
+
+/// What is offered under the search box, and everything the page needs to say
+/// why.
+#[derive(Debug, Clone)]
+pub struct Offer {
+    pub artifact_id: String,
+    pub title: String,
+    pub rung: Rung,
+    /// The winning cluster, for the recorded row. `None` on the two rungs that
+    /// matched no situation.
+    pub slot: Option<i64>,
+    /// The blocks that decided it, largest contribution first, at most
+    /// `NAMED_BLOCKS`. Empty on the lower two rungs, which matched nothing.
+    pub blocks: Vec<&'static str>,
+    /// The representative event's stamp. What "like 08.08., 15:04" prints.
+    pub at: Option<i64>,
+    /// The zone the representative event happened in, so that stamp is printed
+    /// as the device read it. Taking the *current* bundle's zone would misdate
+    /// every situation recorded on a trip.
+    pub at_tz: Option<String>,
+    /// The raw bundle and the contribution numbers, JSON, for the `<details>`.
+    pub detail: String,
+}
+
+impl Core {
+    /// What to offer, from the situation this page view happened in.
+    ///
+    /// One vector query and no embedding. The winning cluster is re-derived
+    /// here because Qdrant's `max_sim` yields the maximum and not which element
+    /// produced it — and the display needs the element, both to quote it and to
+    /// name the blocks that decided it.
+    pub async fn offer(
+        &self,
+        scope: Option<&str>,
+        bundle: &Bundle,
+        session: Option<&str>,
+    ) -> Result<Option<Offer>> {
+        if !self.recommends() {
+            return Ok(None);
+        }
+        let now_at = self.clock.now();
+        let now = encode(now_at, scope, bundle, &self.recommend.weights);
+
+        // Superseded and deprecated are out, by `must_not` — the same rule
+        // search obeys, and for the same reason a hand-written point carrying
+        // no `status` key must still be offered.
+        let hits = self
+            .vectors
+            .context_query(&now, CANDIDATES, &Default::default())
+            .await
+            .unwrap_or_else(|e| {
+                // A vector store that cannot answer must not take the search
+                // page down with it: without an offer the page is what it was
+                // yesterday, and the ladder still has two rungs below this.
+                tracing::warn!(error = %e, "context query unavailable; falling through the ladder");
+                Vec::new()
+            });
+
+        let ids: Vec<String> = hits.iter().map(|h| h.payload.artifact_id.clone()).collect();
+        let clusters = self.store.context_clusters_of(&ids).await?;
+
+        // The argmax, over the **full** vector — that is what reproduces the
+        // store's choice, because that is what `max_sim` scored. The rung comes
+        // from `context_score`, which slices the `scope` block off: the two
+        // numbers answer different questions and live on different scales.
+        let mut best: Option<(
+            &crate::vector::SearchHit,
+            &crate::store::context::StoredCluster,
+            f32,
+        )> = None;
+        for hit in &hits {
+            let Some(mine) = clusters.get(&hit.payload.artifact_id) else {
+                continue;
+            };
+            for c in mine {
+                // Exact, not probabilistic. The `scope` block keeps a foreign
+                // cluster from ranking first in the store, but it is a
+                // direction in 53 dimensions and two of them are only ever
+                // *near*-orthogonal — and isolation must not be a probability.
+                // A cluster belongs to whoever opened the artifact, and this
+                // reads only the ones that belong to the caller.
+                //
+                // This is also why the multivector's own `scope` block cannot
+                // be the guarantee: a payload filter acts on the point, not on
+                // elements of the set, so Qdrant cannot make this cut. Loading
+                // the clusters is what makes it available, and the read path
+                // loads them anyway to produce the reason.
+                if c.scope.as_deref() != scope {
+                    continue;
+                }
+                // A cluster written under another layout is skipped rather than
+                // explained with the wrong blocks. Its centroid may still be in
+                // the index — a rebuild copies any set whose width matches —
+                // and the next sweep replaces it.
+                if c.encoder_version != crate::core::context::ENCODER_VERSION
+                    || c.centroid.len() != now.len()
+                {
+                    continue;
+                }
+                let full = cosine(&now, &c.centroid);
+                if best.is_none_or(|(_, _, b)| full > b) {
+                    best = Some((hit, c, full));
+                }
+            }
+        }
+
+        if let Some((hit, cluster, _)) = best {
+            let score = context_score(&now, &cluster.centroid);
+            let rung = if score >= self.recommend.strong_at {
+                Some(Rung::Pattern)
+            } else if score >= self.recommend.weak_at {
+                Some(Rung::Similar)
+            } else {
+                None
+            };
+            if let Some(rung) = rung {
+                let all = contributions(&now, &cluster.centroid, &self.recommend.weights);
+                let rep: serde_json::Value =
+                    serde_json::from_str(&cluster.representative).unwrap_or_default();
+                return Ok(Some(Offer {
+                    artifact_id: hit.payload.artifact_id.clone(),
+                    title: title_of(&hit.payload),
+                    rung,
+                    slot: Some(cluster.slot),
+                    blocks: all.iter().take(NAMED_BLOCKS).map(|(l, _)| *l).collect(),
+                    at: rep.get("at").and_then(serde_json::Value::as_i64),
+                    at_tz: rep
+                        .pointer("/bundle/tz")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                    detail: serde_json::json!({
+                        "score": score,
+                        "bundle": bundle,
+                        "representative": rep,
+                        "contributions": all
+                            .iter()
+                            .copied()
+                            .collect::<std::collections::BTreeMap<_, _>>(),
+                    })
+                    .to_string(),
+                }));
+            }
+        }
+
+        // Nothing in `ctx`, but this sitting is open. A way back to what was
+        // just being read is not a claim about a pattern, and the wording does
+        // not make one.
+        if let Some(sess) = session {
+            let carried = self
+                .sittings
+                .read(sess, now_at, self.pursuit.idle_secs as i64);
+            for aid in &carried.touched {
+                if let Ok(a) = self.store.get_artifact(aid).await
+                    && a.in_results()
+                {
+                    return Ok(Some(Offer {
+                        artifact_id: a.id.clone(),
+                        title: a.title.clone().unwrap_or_else(|| first_line(&a.text)),
+                        rung: Rung::Sitting,
+                        slot: None,
+                        blocks: Vec::new(),
+                        at: None,
+                        at_tz: None,
+                        detail: serde_json::json!({ "bundle": bundle }).to_string(),
+                    }));
+                }
+            }
+        }
+
+        // The bottom rung, which *is* `resurface` — and says so.
+        let forgotten = self.resurface(1).await.unwrap_or_default();
+        Ok(forgotten.into_iter().next().map(|r| Offer {
+            title: r
+                .title
+                .clone()
+                .filter(|t| !t.is_empty())
+                .unwrap_or_else(|| first_line(&r.text)),
+            artifact_id: r.artifact_id,
+            rung: Rung::Forgotten,
+            slot: None,
+            blocks: Vec::new(),
+            at: None,
+            at_tz: None,
+            detail: serde_json::json!({ "bundle": bundle }).to_string(),
+        }))
+    }
+}
+
+fn title_of(p: &crate::vector::VectorPayload) -> String {
+    p.title
+        .clone()
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| first_line(&p.text))
+}
+
+/// The opening of the text, for something with no title. Deliberately short:
+/// the offer is one line under a search box, not a result card.
+fn first_line(text: &str) -> String {
+    let line = text.lines().next().unwrap_or("").trim();
+    match line.char_indices().nth(70) {
+        Some((i, _)) => format!("{}…", &line[..i]),
+        None => line.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::context::{Clock, ENCODER_VERSION};
+    use crate::core::test_support::test_core;
+
+    /// 2026-08-21T13:52:00Z — a Friday, 15:52 in Berlin.
+    const FRIDAY: i64 = 1_787_320_320;
+
+    async fn core_at(now: i64) -> Core {
+        let mut core = test_core().await;
+        core.recommend.enabled = true;
+        core.clock = Clock::Fixed(now);
+        core
+    }
+
+    fn phone() -> Bundle {
+        Bundle {
+            tz: Some("Europe/Berlin".into()),
+            platform: Some("Android".into()),
+            ua_family: Some("Chrome".into()),
+            screen_w: Some(390.0),
+            screen_h: Some(844.0),
+            viewport_w: Some(390.0),
+            viewport_h: Some(844.0),
+            dpr: Some(3.0),
+            cores: Some(8.0),
+            memory_gb: Some(4.0),
+            language: Some("de-DE".into()),
+            color_scheme: Some("dark".into()),
+            touch: Some(true),
+            orientation: Some("portrait".into()),
+            network: Some("cellular".into()),
+            ..Default::default()
+        }
+    }
+
+    /// A desktop, agreeing with `phone()` about nothing.
+    fn desk() -> Bundle {
+        Bundle {
+            tz: Some("Europe/Berlin".into()),
+            platform: Some("macOS".into()),
+            ua_family: Some("Firefox".into()),
+            screen_w: Some(2560.0),
+            screen_h: Some(1440.0),
+            viewport_w: Some(1920.0),
+            viewport_h: Some(1080.0),
+            dpr: Some(2.0),
+            cores: Some(16.0),
+            memory_gb: Some(32.0),
+            language: Some("en-GB".into()),
+            color_scheme: Some("light".into()),
+            touch: Some(false),
+            orientation: Some("landscape".into()),
+            network: Some("wired".into()),
+            ..Default::default()
+        }
+    }
+
+    /// Give `aid` one learned situation, at `at`, in both stores.
+    async fn learn(core: &Core, aid: &str, scope: &str, at: i64, b: &Bundle) {
+        let v = encode(at, Some(scope), b, &core.recommend.weights);
+        core.store
+            .replace_context_clusters(
+                aid,
+                &[crate::store::context::StoredCluster {
+                    scope: Some(scope.into()),
+                    artifact_id: aid.into(),
+                    slot: 0,
+                    centroid: v.clone(),
+                    weight: 6.0,
+                    last_at: at,
+                    encoder_version: ENCODER_VERSION,
+                    representative: serde_json::json!({ "at": at, "bundle": b }).to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+        core.vectors
+            .set_context_vectors(aid, vec![v])
+            .await
+            .unwrap();
+    }
+
+    /// One artifact with a vector point behind it. `created_at` is 0 and
+    /// nothing has been shown, so `resurface` will also return it — which is
+    /// what the bottom rung needs.
+    async fn seed_artifact(core: &Core, title: &str) -> String {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: format!("text of {title}"),
+                    corpus_span: None,
+                    title: Some(title.into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0);
+        core.vectors
+            .upsert(vec![crate::vector::VectorPoint {
+                vector: vec![1.0; 8],
+                sparse: Default::default(),
+                payload: crate::vector::VectorPayload {
+                    artifact_id: a.id.clone(),
+                    corpus_id: src.id.clone(),
+                    text: a.text.clone(),
+                    title: Some(title.into()),
+                    category: None,
+                    tags: vec![],
+                    created_at: 0,
+                    last_seen_at: None,
+                    hit_count: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
+                    origin_corpora: vec![],
+                    provenance: None,
+                },
+            }])
+            .await
+            .unwrap();
+        a.id
+    }
+
+    #[tokio::test]
+    async fn the_reason_explains_the_artifact_that_was_offered() {
+        // If the local recomputation and the store disagree, the line explains a
+        // different artifact than the one shown — which is the one dishonesty
+        // this feature must not commit.
+        let core = core_at(FRIDAY).await;
+        let near = seed_artifact(&core, "recycling centre").await;
+        let far = seed_artifact(&core, "invoice template").await;
+        learn(&core, &near, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        learn(
+            &core,
+            &far,
+            "alice",
+            FRIDAY - 10 * 86_400 - 7 * 3600,
+            &desk(),
+        )
+        .await;
+
+        let now = encode(FRIDAY, Some("alice"), &phone(), &core.recommend.weights);
+        let from_store = core
+            .vectors
+            .context_query(&now, CANDIDATES, &Default::default())
+            .await
+            .unwrap();
+
+        let offer = core
+            .offer(Some("alice"), &phone(), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            offer.artifact_id, from_store[0].payload.artifact_id,
+            "the local argmax reproduces the store's"
+        );
+        assert_eq!(offer.artifact_id, near);
+    }
+
+    #[tokio::test]
+    async fn a_recurring_situation_is_called_a_pattern_and_names_its_blocks() {
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        let offer = core
+            .offer(Some("alice"), &phone(), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(offer.rung, Rung::Pattern);
+        assert_eq!(offer.slot, Some(0));
+        assert_eq!(offer.title, "recycling centre");
+        assert_eq!(offer.blocks.len(), NAMED_BLOCKS);
+        assert_eq!(offer.at, Some(FRIDAY - 7 * 86_400));
+        assert_eq!(offer.at_tz.as_deref(), Some("Europe/Berlin"));
+    }
+
+    #[tokio::test]
+    async fn a_resemblance_is_not_called_a_pattern() {
+        // The wording says what it rests on. The distance between "Fridays
+        // around 15:00" and "similar to" is the whole honesty of the feature.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        // Same Friday and same phone, four hours off, on wifi and in landscape.
+        let mut other = phone();
+        other.network = Some("wifi".into());
+        other.orientation = Some("landscape".into());
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400 - 4 * 3600, &other).await;
+
+        let offer = core
+            .offer(Some("alice"), &phone(), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(offer.rung, Rung::Similar, "blocks: {:?}", offer.blocks);
+    }
+
+    #[tokio::test]
+    async fn one_persons_situations_are_never_offered_to_another() {
+        // Until per-user collections exist, the `scope` block is the whole of
+        // the isolation, and it needs a test that says so.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        // Twenty other names, not one. The first version of the `scope` block
+        // was one-hot over eight buckets, so any two people had a one-in-eight
+        // chance of sharing a slot outright — and a single hand-picked pair
+        // that happened not to collide would have passed while the guarantee
+        // was worth 87%. Isolation is not a probability, so this does not test
+        // it like one.
+        for n in 0..20 {
+            let who = format!("person-{n}");
+            let offer = core.offer(Some(&who), &phone(), None).await.unwrap();
+            assert!(
+                offer
+                    .as_ref()
+                    .is_none_or(|o| o.rung != Rung::Pattern && o.rung != Rung::Similar),
+                "alice's Friday was offered to {who}: {offer:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_foreign_scope_is_cut_exactly_rather_than_out_scored() {
+        // The `scope` block keeps a foreign cluster from ranking first in the
+        // store, but it is a direction in 53 dimensions and two of them are
+        // only ever near-orthogonal. What makes isolation exact is that the
+        // read path loads the clusters — which it does anyway, to produce the
+        // reason — and reads only the ones belonging to the caller.
+        //
+        // So: bob has learned nothing, and alice's cluster is the *only* thing
+        // in the index. The store therefore returns it however anyone scores,
+        // and bob must still not be offered it as a pattern.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        let now = encode(FRIDAY, Some("bob"), &phone(), &core.recommend.weights);
+        let from_store = core
+            .vectors
+            .context_query(&now, CANDIDATES, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            from_store.len(),
+            1,
+            "the store has nothing else to return, so it returns alice's"
+        );
+
+        let offer = core.offer(Some("bob"), &phone(), None).await.unwrap();
+        assert!(
+            offer.as_ref().is_none_or(|o| o.slot.is_none()),
+            "and the read path cut it anyway: {offer:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_nothing_learned_the_ladder_falls_to_what_this_sitting_touched() {
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        core.sittings.touched("sess-1", &aid, FRIDAY, 900);
+
+        let offer = core
+            .offer(Some("alice"), &phone(), Some("sess-1"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(offer.rung, Rung::Sitting);
+        assert_eq!(offer.artifact_id, aid);
+        assert!(
+            offer.blocks.is_empty(),
+            "nothing was matched, so nothing is named"
+        );
+        assert_eq!(offer.slot, None);
+    }
+
+    #[tokio::test]
+    async fn with_no_sitting_either_it_falls_to_what_has_been_forgotten() {
+        // Deliberately not phrased like a pattern. This rung *is* `resurface`,
+        // and it says so.
+        let core = core_at(FRIDAY).await;
+        let _aid = seed_artifact(&core, "recycling centre").await;
+
+        let offer = core
+            .offer(Some("alice"), &phone(), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(offer.rung, Rung::Forgotten);
+        assert!(offer.rung.line().contains("long"), "{}", offer.rung.line());
+    }
+
+    #[tokio::test]
+    async fn an_empty_base_is_offered_nothing_rather_than_a_lie() {
+        let core = core_at(FRIDAY).await;
+        assert!(
+            core.offer(Some("alice"), &phone(), None)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn nothing_is_offered_when_the_faculty_is_off() {
+        let mut core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        core.recommend.enabled = false;
+
+        assert!(
+            core.offer(Some("alice"), &phone(), None)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cluster_from_an_older_encoder_explains_nothing() {
+        // Its centroid may still be in the index — a rebuild copies a set whose
+        // width matches — but the blocks it was built from are not the blocks
+        // this reader knows. Skipped, rather than described with the wrong ones.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        let mut rows = core
+            .store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap()[&aid]
+            .clone();
+        rows[0].encoder_version = ENCODER_VERSION + 1;
+        core.store
+            .replace_context_clusters(&aid, &rows)
+            .await
+            .unwrap();
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap();
+        assert!(
+            offer.as_ref().is_none_or(|o| o.slot.is_none()),
+            "got {offer:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_hidden_artifact_is_never_the_offer() {
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        core.vectors
+            .set_lifecycle(
+                &aid,
+                crate::store::artifacts::ArtifactStatus::Superseded,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let offer = core.offer(Some("alice"), &phone(), None).await.unwrap();
+        assert!(
+            offer.as_ref().is_none_or(|o| o.rung != Rung::Pattern),
+            "got {offer:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_details_carry_the_bundle_and_the_numbers() {
+        // "The parameters must be visible" — whoever wants to know exactly,
+        // expands it. It is also the answer to what is being collected:
+        // inspectable rather than promised.
+        let core = core_at(FRIDAY).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+
+        let offer = core
+            .offer(Some("alice"), &phone(), None)
+            .await
+            .unwrap()
+            .unwrap();
+        let d: serde_json::Value = serde_json::from_str(&offer.detail).unwrap();
+        assert_eq!(d["bundle"]["tz"], "Europe/Berlin");
+        assert!(d["contributions"].is_object());
+        assert!(d["contributions"]["weekday"].is_number());
+        assert!(d["score"].is_number());
+        assert_eq!(d["representative"]["at"], FRIDAY - 7 * 86_400);
+    }
+
+    #[tokio::test]
+    async fn the_offer_costs_one_query_and_no_embedding() {
+        // The constraint from the top of the roadmap: no model call and no
+        // embedding at read time. A counting embedder proves it rather than a
+        // comment claiming it.
+        let (mut core, embedder) =
+            crate::core::test_support::test_core_counting_embed_calls().await;
+        core.recommend.enabled = true;
+        core.clock = Clock::Fixed(FRIDAY);
+        let aid = seed_artifact(&core, "recycling centre").await;
+        learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
+        let before = embedder.calls();
+
+        core.offer(Some("alice"), &phone(), None).await.unwrap();
+        assert_eq!(embedder.calls(), before, "not one embedding call");
+    }
+}

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -59,6 +59,22 @@ impl Rung {
         }
     }
 
+    /// The inverse, for the one place a rung arrives as text: the marker the
+    /// offer link carries back on the open. A viewer can type anything into a
+    /// query string, and the value goes straight into the recorded row and from
+    /// there into `offer_rates`' `GROUP BY rung` — so an unrecognised word
+    /// would appear on Ops as a rung of the ladder, beside the four that exist.
+    /// Anything not written by `as_str` is not a rung.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pattern" => Some(Rung::Pattern),
+            "similar" => Some(Rung::Similar),
+            "tentative" => Some(Rung::Tentative),
+            "random" => Some(Rung::Random),
+            _ => None,
+        }
+    }
+
     /// Whether this rung explains itself at all. `Random` does not, and the
     /// page prints no line beside it.
     pub fn is_explained(&self) -> bool {

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -541,10 +541,12 @@ impl Core {
     /// What happened after the list rendered: this artifact was opened, or
     /// reached from `via` — a neighbour, an association, a continuation. The
     /// pursuit sweep attaches it to a search by time and scope; nothing here
-    /// names one. Off the request path, and a no-op unless pursuits are on
-    /// and searches are being recorded.
+    /// names one, and the context sweep reads the same rows to learn which
+    /// situations an artifact is opened in. Off the request path, and a no-op
+    /// only while `[learn]` is off — this is the log, and every faculty
+    /// downstream reads it rather than writing its own.
     pub fn record_interaction(&self, artifact_id: &str, via: Option<&str>, scope: Option<&str>) {
-        if !self.pursuit.enabled || !self.feedback.enabled {
+        if !self.learn.enabled {
             return;
         }
         let store = self.store.clone();
@@ -566,9 +568,9 @@ impl Core {
     }
 
     /// How long an artifact stayed open. Capped — a tab left open overnight is
-    /// not a day of reading — and a no-op unless pursuits are on.
+    /// not a day of reading — and a no-op while `[learn]` is off.
     pub fn record_dwell(&self, artifact_id: &str, secs: i64, scope: Option<&str>) {
-        if !self.pursuit.enabled || !self.feedback.enabled || secs <= 0 {
+        if !self.learn.enabled || secs <= 0 {
             return;
         }
         let secs = secs.min(600);
@@ -883,7 +885,7 @@ impl Core {
         // Widening the fetch is also the cost of the setting: `Config::normalize`
         // caps `candidates` at `MAX_LIMIT * CANDIDATE_MULTIPLIER` so this can
         // never exceed what the widest ordinary search already fetches.
-        let candidates = if self.feedback.enabled && door.captured() {
+        let candidates = if self.learn.enabled && door.captured() {
             candidates.max(self.feedback.candidates)
         } else {
             candidates
@@ -911,7 +913,7 @@ impl Core {
         // Taken for the same reason: the similarity is dropped when a payload
         // becomes a `SearchResult`, and capture wants the value rather than the
         // `weak` verdict computed from it.
-        let sims: HashMap<String, Option<f32>> = if self.feedback.enabled && door.captured() {
+        let sims: HashMap<String, Option<f32>> = if self.learn.enabled && door.captured() {
             hits.iter()
                 .map(|h| (h.payload.artifact_id.clone(), h.similarity))
                 .collect()
@@ -942,7 +944,7 @@ impl Core {
             // capture a pool exactly as wide as what the searcher saw. A hit
             // the reranker buried would then be unconfirmable, and the whole
             // point of storing a pool is that it can be.
-            let top_n = if self.feedback.enabled && door.captured() {
+            let top_n = if self.learn.enabled && door.captured() {
                 limit.max(self.feedback.candidates)
             } else {
                 limit
@@ -1017,7 +1019,7 @@ impl Core {
         // ordering is final. Off the request path via `Background`, like
         // `mark_seen` below it: a search must not get slower, or fail, because
         // bookkeeping did.
-        if self.feedback.enabled && door.captured() {
+        if self.learn.enabled && door.captured() {
             let candidates: Vec<crate::store::feedback::NewCandidate> = results
                 .iter()
                 .take(self.feedback.candidates)
@@ -1301,7 +1303,7 @@ mod tests {
     #[tokio::test]
     async fn a_deliberate_search_makes_what_it_returned_more_accessible() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
@@ -1330,7 +1332,7 @@ mod tests {
         // retrieval, and letting every keystroke raise activation would make
         // accessibility a function of how slowly someone types.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
@@ -1361,7 +1363,7 @@ mod tests {
         // `resurface` shows what has been forgotten. Counting that as a reason
         // to be more accessible is the loop this whole design is built to close.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "old", &[("long forgotten", "c", &[])]).await;
         sqlx::query("UPDATE artifacts SET created_at = ?")
             .bind(now_secs() - FORGOTTEN_AFTER_DAYS * SECONDS_PER_DAY - 1)
@@ -1393,7 +1395,7 @@ mod tests {
     #[tokio::test]
     async fn opening_an_artifact_makes_it_more_accessible_by_less_than_a_retrieval() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
         let before = core
@@ -2110,7 +2112,7 @@ mod tests {
     #[tokio::test]
     async fn priming_changes_the_order_a_search_returns_and_says_which_hit_moved() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.associate.prime_lift = 2;
         let texts: Vec<(&str, &str, &[&str])> = (0..6)
             .map(|_| ("alpha text about it", "note", &[][..]))
@@ -2151,14 +2153,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_marked_search_does_not_touch_activation_while_feedback_is_off() {
-        // Shipped defaults: `feedback.enabled = false`, `associate.enabled =
-        // true`. Links are learned from recorded searches, and none are being
-        // recorded, so the whole associative layer — including activation,
-        // which exists only to feed priming — must stay dark. `test_core()`
-        // is exactly this combination; nothing here turns `feedback` on.
+    async fn a_marked_search_does_not_touch_activation_while_learning_is_off() {
+        // Nothing is recorded while `[learn]` is off, and links are learned
+        // from recorded searches — so the whole associative layer, including
+        // activation, which exists only to feed priming, must stay dark.
+        // `test_core()` ships with the switch off; nothing here turns it on.
         let core = test_core().await;
-        assert!(!core.feedback.enabled && core.associate.enabled);
+        assert!(!core.learn.enabled);
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         let id = core.store.list_all_artifact_ids().await.unwrap()[0].clone();
@@ -2182,18 +2183,18 @@ mod tests {
             .0;
         assert_eq!(
             after, before,
-            "a marked search raised activation with feedback.enabled false"
+            "a marked search raised activation with `[learn]` off"
         );
     }
 
     #[tokio::test]
-    async fn priming_never_reaches_the_order_while_feedback_is_off() {
+    async fn priming_never_reaches_the_order_while_learning_is_off() {
         // The spec promise (§11): "existing installs see nothing change until
-        // they opt in." `associate.enabled` alone must not let a large
-        // activation move the ranked order — the order must be byte-identical
-        // to `prime_lift = 0`, not merely bounded.
+        // they opt in." With `[learn]` off, a large activation must not move
+        // the ranked order — the order must be byte-identical to
+        // `prime_lift = 0`, not merely bounded.
         let core = test_core().await;
-        assert!(!core.feedback.enabled && core.associate.enabled);
+        assert!(!core.learn.enabled);
         assert_eq!(core.associate.prime_lift, 2, "the shipped default");
         let texts: Vec<(&str, &str, &[&str])> = (0..6)
             .map(|_| ("alpha text about it", "note", &[][..]))
@@ -2228,7 +2229,7 @@ mod tests {
             .collect();
         assert_eq!(
             plain_ids, after_ids,
-            "the order changed even though feedback.enabled is false"
+            "the order changed even though `[learn]` is off"
         );
         assert!(with_huge_activation.iter().all(|r| !r.primed));
     }
@@ -2242,7 +2243,7 @@ mod tests {
         // dropped is the one that answered best, invisibly. `judge` needs the
         // pool it labels to be the pool the ranking produced.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.associate.prime_lift = 2;
         let texts: Vec<(&str, &str, &[&str])> = (0..6)
             .map(|_| ("alpha text about it", "note", &[][..]))
@@ -2290,7 +2291,7 @@ mod tests {
         // satisfy it, or the search hands back exactly the rows they narrowed
         // away.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.associate.show_min = 1.0;
         seed(
             &core,
@@ -2355,7 +2356,7 @@ mod tests {
         // The stored pool is wider than the answer: the judging card offers all
         // of it, so an artifact the ranking buried can still be confirmed.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let texts: Vec<(&str, &str, &[&str])> = (0..12)
             .map(|_| ("alpha text about it", "note", &[][..]))
             .collect();
@@ -2391,7 +2392,7 @@ mod tests {
         // the six missing candidates are exactly the buried ones the judging
         // card exists to surface.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.feedback.candidates = 12;
         let texts: Vec<(&str, &str, &[&str])> = (0..20)
             .map(|_| ("alpha text about it", "note", &[][..]))
@@ -2420,7 +2421,7 @@ mod tests {
         // hand capture a pool exactly as wide as the answer — and a hit the
         // reranker buried would become unconfirmable.
         let (mut core, _r) = crate::core::test_support::test_core_counting_reranked_docs().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let texts: Vec<(&str, &str, &[&str])> = (0..12)
             .map(|_| ("alpha text about it", "note", &[][..]))
             .collect();
@@ -2457,7 +2458,7 @@ mod tests {
         // category would score the judged pair against a base the search
         // never saw.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed(&core, &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
 
@@ -2485,7 +2486,7 @@ mod tests {
 
     #[tokio::test]
     async fn capture_writes_nothing_while_it_is_switched_off() {
-        let core = test_core().await; // feedback.enabled defaults to false
+        let core = test_core().await; // `[learn]` is off in tests
         seed(&core, &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
         core.search(&q("alpha text"), Door::Ui).await.unwrap();
@@ -2497,7 +2498,7 @@ mod tests {
         // Deliberately unlike `mark_seen`, which skips an empty list because
         // there is nothing to stamp. Here the empty list is the finding.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.search(&q("nothing is indexed yet"), Door::Ui)
             .await
             .unwrap();
@@ -2509,7 +2510,7 @@ mod tests {
         // Judging composes its queries while reading the artifact, and `ask`
         // has no single right answer to judge. Both would only add noise.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed(&core, &[("alpha text", "note", &[])]).await;
         reembed_all(&core).await;
 
@@ -2532,7 +2533,7 @@ mod tests {
     #[tokio::test]
     async fn a_linked_artifact_is_recalled_beside_the_answer_and_says_what_recalled_it() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -2569,7 +2570,7 @@ mod tests {
         // gate is door-shaped rather than coincidental, so this checks both
         // an excluded door and an included one against the same link.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -2605,7 +2606,7 @@ mod tests {
     #[tokio::test]
     async fn an_artifact_already_in_the_answer_is_not_recalled_again() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(
             &core,
             "one",
@@ -2673,7 +2674,7 @@ mod tests {
         // the fixture rather than a bug.
         async fn seeded() -> (crate::core::Core, String, String) {
             let mut core = test_core().await;
-            core.feedback.enabled = true;
+            core.learn.enabled = true;
             seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
             seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
             reembed_all(&core).await;
@@ -2738,7 +2739,7 @@ mod tests {
     #[tokio::test]
     async fn a_hidden_artifact_is_never_recalled_by_association() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -2758,7 +2759,7 @@ mod tests {
     #[tokio::test]
     async fn a_weak_link_is_not_strong_enough_to_recall_anything() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         seed_from(&core, "one", &[("alpha text", "note", &[])]).await;
         seed_from(&core, "two", &[("something else entirely", "note", &[])]).await;
         reembed_all(&core).await;
@@ -2984,7 +2985,7 @@ mod tests {
     #[tokio::test]
     async fn a_synthesized_artifact_leading_the_list_marks_the_search_answered() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let captured = core
             .store
@@ -3049,9 +3050,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_interaction_is_recorded_only_with_pursuits_on() {
+    async fn an_interaction_is_recorded_whenever_the_layer_is_learning() {
+        // It used to take pursuits as well, which made the log a pursuit's
+        // private record rather than the layer's. It is not: the context sweep
+        // reads the same `opened` and `pivoted` rows to learn which situations
+        // an artifact is opened in, and gating the only writer behind a second
+        // faculty left that sweep profiling nothing at all. One switch, and
+        // everything downstream reads what it writes.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let a = core
             .store
@@ -3080,9 +3086,10 @@ mod tests {
                 .interactions_between(0, now + 1)
                 .await
                 .unwrap()
-                .is_empty()
+                .is_empty(),
+            "an open was written down with `[learn]` off"
         );
-        core.pursuit.enabled = true;
+        core.learn.enabled = true;
         core.record_interaction(&a, None, Some("me"));
         core.record_interaction(&a, Some("other"), Some("me"));
         core.background.wait_idle().await;

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -389,11 +389,11 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
     // sweep will not arm more (`run` returns early), but a unit armed before
     // the flag flipped is still sitting in the queue when this runs.
     //
-    // `associating()` and not `associate.enabled`: switching search recording
-    // off switches this layer off too — that is what the predicate means, and
-    // every other surface (priming, association, the detail pane, Ops) already
-    // reads it. A verdict written after that switch would name a relation on a
-    // page that no longer shows one.
+    // `associating()`, which is `[learn]`: switching the layer off switches
+    // this off with it — that is what the predicate means, and every other
+    // surface (priming, association, the detail pane, Ops) already reads it. A
+    // verdict written after that switch would name a relation on a page that no
+    // longer shows one.
     if !core.associating() {
         return Ok(());
     }
@@ -623,7 +623,7 @@ mod tests {
     }
 
     async fn on(core: &mut Core) {
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
     }
 
     #[tokio::test]
@@ -1138,10 +1138,10 @@ mod tests {
 
     #[tokio::test]
     async fn a_queued_unit_spends_no_call_once_search_recording_is_switched_off() {
-        // `associating()`, not `associate.enabled`: turning capture off turns
-        // this whole layer off — priming, association and the pane all read
-        // that predicate — and a verdict written afterwards would name a
-        // relation on a page that no longer shows one.
+        // `associating()`: turning `[learn]` off turns this whole layer off —
+        // priming, association and the pane all read that predicate — and a
+        // verdict written afterwards would name a relation on a page that no
+        // longer shows one.
         let mut core = test_core().await;
         on(&mut core).await;
         let scripted = std::sync::Arc::new(crate::infer::fake::ScriptedCompleter::new(vec![
@@ -1153,7 +1153,7 @@ mod tests {
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
             .await
             .unwrap();
-        core.feedback.enabled = false;
+        core.learn.enabled = false;
 
         judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
 
@@ -1389,7 +1389,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_unit_already_queued_when_the_feature_is_switched_off_spends_no_call() {
-        // The sweep will not arm more once `associate.enabled` is false — see
+        // The sweep will not arm more once `[learn]` is off — see
         // `the_sweep_does_nothing_at_all_while_nothing_is_recorded` — but a unit
         // already in the queue when the operator disables the feature must not
         // spend the one scarce thing in the system after they said stop.
@@ -1404,7 +1404,7 @@ mod tests {
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
             .await
             .unwrap();
-        core.associate.enabled = false;
+        core.learn.enabled = false;
 
         judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
 

--- a/src/jobs/context.rs
+++ b/src/jobs/context.rs
@@ -238,6 +238,21 @@ fn closest_pair(centroids: &[&[f32]]) -> Option<(usize, usize)> {
     best.map(|(a, b, _)| (a, b))
 }
 
+/// The slice of an `at`-ordered log that falls in `[lo, hi]`.
+///
+/// The three sources come back ordered by time — `ORDER BY at, id` in each of
+/// the three queries — and the sweep asks each of them the same question once
+/// per interaction: what is near this moment. Scanning the whole vector for
+/// that made the pass quadratic, which on a base with a year of page views and
+/// a log that is never pruned is a background job doing hundreds of millions of
+/// string comparisons every six hours. Two `partition_point` calls answer it
+/// against the order the rows already arrive in.
+fn window<T>(v: &[T], at: impl Fn(&T) -> i64, lo: i64, hi: i64) -> &[T] {
+    let start = v.partition_point(|x| at(x) < lo);
+    let end = v.partition_point(|x| at(x) <= hi);
+    &v[start..end.max(start)]
+}
+
 /// One pass: read the log, encode, cluster, write.
 pub async fn run(core: &Core) -> Result<Report> {
     let mut report = Report::default();
@@ -276,12 +291,10 @@ pub async fn run(core: &Core) -> Result<Report> {
         // Where the open followed a search, the situation is the search's, not
         // the open's: a recurring search resolves to the artifact it led to
         // rather than to a rerun of the query.
-        let anchor = searches
+        let anchor = window(&searches, |s| s.created_at, i.at - BRIDGE_SECS, i.at)
             .iter()
             .filter(|s| {
                 s.scope.as_deref().unwrap_or_default() == scope
-                    && s.created_at <= i.at
-                    && i.at - s.created_at <= BRIDGE_SECS
                     && s.shown.iter().any(|(id, _)| id == &artifact_id)
             })
             .map(|s| s.created_at)
@@ -289,13 +302,15 @@ pub async fn run(core: &Core) -> Result<Report> {
             .unwrap_or(i.at);
 
         // The nearest recorded situation, within half an hour either way.
-        let matched = contexts
-            .iter()
-            .filter(|c| {
-                c.scope.as_deref().unwrap_or_default() == scope
-                    && (c.at - anchor).abs() <= MATCH_SECS
-            })
-            .min_by_key(|c| ((c.at - anchor).abs(), c.id));
+        let matched = window(
+            &contexts,
+            |c| c.at,
+            anchor - MATCH_SECS,
+            anchor + MATCH_SECS,
+        )
+        .iter()
+        .filter(|c| c.scope.as_deref().unwrap_or_default() == scope)
+        .min_by_key(|c| ((c.at - anchor).abs(), c.id));
 
         // No bundle is not no event. `at` and `scope` were recorded from the
         // beginning, and because an absent block is zeroed rather than
@@ -382,7 +397,7 @@ pub async fn run(core: &Core) -> Result<Report> {
                 weight: c.weight,
                 events: c.events as i64,
                 last_at: c.last_at,
-                encoder_version: crate::core::context::ENCODER_VERSION,
+                encoder_version: crate::core::context::encoder_version(&cfg.weights),
                 representative: c.representative.clone(),
             })
             .collect();
@@ -430,7 +445,7 @@ mod tests {
         }
     }
 
-    use crate::core::context::{Bundle, CTX_DIM, ENCODER_VERSION, device_key, parse_bundle};
+    use crate::core::context::{Bundle, CTX_DIM, device_key, encoder_version, parse_bundle};
     use crate::core::test_support::test_core;
 
     /// 2026-08-21T13:52:00Z — a Friday, 15:52 in Berlin.
@@ -445,6 +460,7 @@ mod tests {
     async fn recommending_core(now: i64) -> Core {
         let mut core = test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         core.clock = crate::core::context::Clock::Fixed(now);
         core
     }
@@ -567,7 +583,7 @@ mod tests {
         let c = &stored[&aid][0];
         assert_eq!(c.slot, 0);
         assert_eq!(c.centroid.len(), CTX_DIM);
-        assert_eq!(c.encoder_version, ENCODER_VERSION);
+        assert_eq!(c.encoder_version, encoder_version(&core.recommend.weights));
         assert_eq!(c.scope.as_deref(), Some("alice"));
 
         // And the vector store agrees, which is what the read path queries.
@@ -852,5 +868,25 @@ mod tests {
     #[test]
     fn nothing_in_means_nothing_out() {
         assert!(agglomerate(&[], 0.82, 5, 2.0).is_empty());
+    }
+
+    #[test]
+    fn the_window_is_the_slice_and_nothing_either_side_of_it() {
+        // The sweep asks each of three ordered logs the same question once per
+        // interaction — what is near this moment — and scanning them whole made
+        // the pass quadratic over a 400-day window. The answer has to be the
+        // same slice a filter would have produced.
+        let ats: Vec<i64> = vec![10, 20, 20, 30, 40, 50];
+        let got = |lo, hi| -> Vec<i64> { window(&ats, |a| *a, lo, hi).to_vec() };
+        assert_eq!(got(20, 40), vec![20, 20, 30, 40], "both bounds inclusive");
+        assert_eq!(got(21, 39), vec![30]);
+        assert_eq!(got(0, 100), ats);
+        assert_eq!(got(51, 100), Vec::<i64>::new(), "past the end");
+        assert_eq!(got(0, 9), Vec::<i64>::new(), "before the start");
+        assert_eq!(got(41, 41), Vec::<i64>::new(), "a gap");
+        // An empty log, and a window whose bounds have crossed — neither may
+        // panic on a slice index.
+        assert_eq!(window::<i64>(&[], |a| *a, 0, 10).len(), 0);
+        assert_eq!(got(40, 20).len(), 0);
     }
 }

--- a/src/jobs/context.rs
+++ b/src/jobs/context.rs
@@ -65,6 +65,10 @@ pub struct Member {
 pub struct Cluster {
     pub centroid: Vec<f32>,
     pub weight: f64,
+    /// How many events went into it, undecayed. `weight` says how much this
+    /// still counts; this says how often it happened, which is what the line
+    /// under the offer can put in words a person reads.
+    pub events: usize,
     pub last_at: i64,
     /// `{"at": <unix>, "bundle": {…}}` for the member nearest the centroid.
     pub representative: String,
@@ -187,6 +191,7 @@ pub fn agglomerate(
                 .unwrap_or_else(|| r#"{"at":0,"bundle":{}}"#.to_string());
             Cluster {
                 centroid: c.centroid,
+                events: c.members.len(),
                 weight: c.weight,
                 last_at: c.last_at,
                 representative,
@@ -375,6 +380,7 @@ pub async fn run(core: &Core) -> Result<Report> {
                 slot: slot as i64,
                 centroid: c.centroid.clone(),
                 weight: c.weight,
+                events: c.events as i64,
                 last_at: c.last_at,
                 encoder_version: crate::core::context::ENCODER_VERSION,
                 representative: c.representative.clone(),

--- a/src/jobs/context.rs
+++ b/src/jobs/context.rs
@@ -1,0 +1,850 @@
+//! What situations recur for which artifact.
+//!
+//! One pass over the log, no randomness, no model call. It joins three sources
+//! on `scope` and `at` — never on a stored id — agglomerates the situations an
+//! artifact was opened in, decays them, and writes the surviving centroids to
+//! the vector store as that artifact's `ctx` set.
+//!
+//! A full rebuild every run, from the raw bundles. That is what makes a change
+//! to the encoder a sweep rather than a migration, and it is why the sweep
+//! never reads what a previous run concluded.
+
+use crate::core::Core;
+use crate::error::Result;
+use crate::vector::cosine;
+
+/// How often this runs.
+///
+/// A constant rather than a setting, for the reason `REPAIR_INTERVAL_HOURS`
+/// gives: how often a faculty learns is not a preference, and `[recommend]` is
+/// one gate and a table of weights. Six hours means a situation recorded this
+/// morning is offered this evening, which is as fast as anything here needs to
+/// be — the patterns being learned are weekly.
+pub const INTERVAL_HOURS: u64 = 6;
+
+/// How long after a search an open still counts as that search's.
+///
+/// The bridge: where an open followed a search, the event inherits the search's
+/// identity, so a recurring search resolves to the artifact it led to rather
+/// than to a rerun of the query. Fifteen minutes, which is the same order as
+/// `pursuit.idle_secs` and deliberately not that key — pursuits may be off, and
+/// this must still work.
+pub const BRIDGE_SECS: i64 = 900;
+
+/// How far from an open a recorded situation may sit and still be that open's.
+///
+/// Half an hour either way. A page view records a situation; the opens that
+/// follow it belong to it. Wider than `BRIDGE_SECS` because a person can read
+/// for a while after arriving, and a situation is a slower thing than a query.
+pub const MATCH_SECS: i64 = 1800;
+
+/// Centroids one artifact may carry, across every scope.
+///
+/// `max_clusters` bounds the situations per person per artifact; this bounds
+/// the array itself, which is shared by every scope that ever opened the
+/// artifact. On a base with one person it never binds. On one with many it is
+/// what keeps a popular artifact's multivector from growing with the user
+/// count — the heaviest survive, which is the same rule `min_weight` applies
+/// one level down.
+pub const MAX_SLOTS: usize = 16;
+
+/// One situation an artifact was opened in, ready to cluster.
+#[derive(Debug, Clone)]
+pub struct Member {
+    pub vec: Vec<f32>,
+    /// Already decayed, and already multiplied by `self_weight` where this was
+    /// an open of something this feature offered.
+    pub weight: f64,
+    pub at: i64,
+    /// The raw bundle, carried so the winner can be quoted.
+    pub bundle: String,
+}
+
+/// One learned situation.
+#[derive(Debug, Clone)]
+pub struct Cluster {
+    pub centroid: Vec<f32>,
+    pub weight: f64,
+    pub last_at: i64,
+    /// `{"at": <unix>, "bundle": {…}}` for the member nearest the centroid.
+    pub representative: String,
+}
+
+/// What one run did.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct Report {
+    /// Opens that found a situation to be encoded from.
+    pub events: usize,
+    /// Artifacts that came out of this run with at least one situation.
+    pub profiled: usize,
+    pub clusters: usize,
+    /// Artifacts whose every situation had decayed away.
+    pub cleared: usize,
+}
+
+/// One deterministic pass, in event order.
+///
+/// An event joins the nearest cluster when cosine exceeds `merge_at`, otherwise
+/// it opens its own; when the count exceeds `max_clusters` the two nearest are
+/// merged. One pass and no randomness, because otherwise it is not testable —
+/// and because a recommendation whose reason changed between two sweeps over
+/// identical data could not be accounted for by anyone.
+///
+/// Members arrive already decayed. A cluster whose total weight falls below
+/// `min_weight` is dropped, which is what protects against the single accident:
+/// one event never reaches the threshold.
+pub fn agglomerate(
+    members: &[Member],
+    merge_at: f32,
+    max_clusters: usize,
+    min_weight: f64,
+) -> Vec<Cluster> {
+    struct Building {
+        centroid: Vec<f32>,
+        weight: f64,
+        last_at: i64,
+        /// Indices into `members`, so the representative can be chosen against
+        /// the *final* centroid rather than against whatever it was when each
+        /// member arrived.
+        members: Vec<usize>,
+    }
+
+    let cap = max_clusters.max(1);
+    let mut built: Vec<Building> = Vec::new();
+
+    for (i, m) in members.iter().enumerate() {
+        if m.weight <= 0.0 {
+            continue;
+        }
+        let nearest = built
+            .iter()
+            .enumerate()
+            .map(|(k, c)| (k, cosine(&m.vec, &c.centroid)))
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        match nearest {
+            Some((k, sim)) if sim > merge_at => {
+                let c = &mut built[k];
+                blend(&mut c.centroid, c.weight, &m.vec, m.weight);
+                c.weight += m.weight;
+                c.last_at = c.last_at.max(m.at);
+                c.members.push(i);
+            }
+            _ => built.push(Building {
+                centroid: m.vec.clone(),
+                weight: m.weight,
+                last_at: m.at,
+                members: vec![i],
+            }),
+        }
+
+        while built.len() > cap {
+            let centroids: Vec<&[f32]> = built.iter().map(|c| &c.centroid[..]).collect();
+            let Some((a, b)) = closest_pair(&centroids) else {
+                break;
+            };
+            let victim = built.remove(b);
+            let host = &mut built[a];
+            blend(
+                &mut host.centroid,
+                host.weight,
+                &victim.centroid,
+                victim.weight,
+            );
+            host.weight += victim.weight;
+            host.last_at = host.last_at.max(victim.last_at);
+            host.members.extend(victim.members);
+        }
+    }
+
+    let mut out: Vec<Cluster> = built
+        .into_iter()
+        .filter(|c| c.weight >= min_weight)
+        .map(|c| {
+            // The representative is the member nearest the *finished* centroid.
+            // Ties break on the index, so which of two equally central events
+            // is quoted does not depend on a float comparison going either way.
+            let rep = c
+                .members
+                .iter()
+                .map(|&i| (i, cosine(&members[i].vec, &c.centroid)))
+                .max_by(|x, y| {
+                    x.1.partial_cmp(&y.1)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| y.0.cmp(&x.0))
+                })
+                .map(|(i, _)| i);
+            let representative = rep
+                .map(|i| {
+                    // The bundle plus its stamp, because a bundle carries no
+                    // time of its own and the line says "like 08.08., 15:04".
+                    // Always valid JSON: a bundle that will not re-parse becomes
+                    // an empty object rather than corrupting the row.
+                    let bundle: serde_json::Value = serde_json::from_str(&members[i].bundle)
+                        .unwrap_or_else(|_| serde_json::json!({}));
+                    serde_json::json!({ "at": members[i].at, "bundle": bundle }).to_string()
+                })
+                .unwrap_or_else(|| r#"{"at":0,"bundle":{}}"#.to_string());
+            Cluster {
+                centroid: c.centroid,
+                weight: c.weight,
+                last_at: c.last_at,
+                representative,
+            }
+        })
+        .collect();
+    // Heaviest first: this is the order slots are allocated in, and `MAX_SLOTS`
+    // keeps the front of it.
+    out.sort_by(|a, b| {
+        b.weight
+            .partial_cmp(&a.weight)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.last_at.cmp(&a.last_at))
+    });
+    out
+}
+
+/// Weighted mean, in place.
+fn blend(centroid: &mut [f32], have: f64, add: &[f32], w: f64) {
+    let total = have + w;
+    if total <= 0.0 {
+        return;
+    }
+    for (i, c) in centroid.iter_mut().enumerate() {
+        let other = add.get(i).copied().unwrap_or(0.0);
+        *c = ((*c as f64 * have + other as f64 * w) / total) as f32;
+    }
+}
+
+/// The two nearest centroids, as `(keep, drop)` with `keep < drop`.
+///
+/// Quadratic, over at most `max_clusters + 1` vectors of 53 dimensions. That is
+/// a few hundred multiplications on a path that runs every six hours.
+fn closest_pair(centroids: &[&[f32]]) -> Option<(usize, usize)> {
+    let mut best: Option<(usize, usize, f32)> = None;
+    for a in 0..centroids.len() {
+        for b in (a + 1)..centroids.len() {
+            let sim = cosine(centroids[a], centroids[b]);
+            if best.is_none_or(|(_, _, s)| sim > s) {
+                best = Some((a, b, sim));
+            }
+        }
+    }
+    best.map(|(a, b, _)| (a, b))
+}
+
+/// One pass: read the log, encode, cluster, write.
+pub async fn run(core: &Core) -> Result<Report> {
+    let mut report = Report::default();
+    if !core.recommends() {
+        return Ok(report);
+    }
+    let cfg = &core.recommend;
+    let now = core.clock.now();
+    let since = now - crate::store::context::RETAIN_DAYS * 86_400;
+
+    // Three sources, read whole. Bounded by the retention window rather than
+    // paged: the sweep rebuilds every profile from scratch, and a rebuild is
+    // only correct when it sees the whole window.
+    let interactions = core.store.interactions_between(since, now).await?;
+    let contexts = core.store.context_events_since(since).await?;
+    // The bridge. `events_between` excludes the judge door already, which is
+    // right here too: a benchmark run is not a situation anybody was in.
+    let searches = core.store.events_between(since, now).await?;
+
+    // (scope, artifact) -> the situations it was opened in.
+    let mut by_pair: std::collections::BTreeMap<(String, String), Vec<Member>> =
+        std::collections::BTreeMap::new();
+
+    for i in &interactions {
+        // `dwell` is not an open, and `recommended_shown` is not an
+        // interaction at all — it is this feature's own offer, and counting it
+        // would profile every artifact it ever guessed at.
+        let self_made = match i.kind.as_str() {
+            "opened" | "pivoted" => false,
+            "recommended_open" => true,
+            _ => continue,
+        };
+        let artifact_id = i.artifact_id.clone();
+        let scope = i.scope.clone().unwrap_or_default();
+
+        // Where the open followed a search, the situation is the search's, not
+        // the open's: a recurring search resolves to the artifact it led to
+        // rather than to a rerun of the query.
+        let anchor = searches
+            .iter()
+            .filter(|s| {
+                s.scope.as_deref().unwrap_or_default() == scope
+                    && s.created_at <= i.at
+                    && i.at - s.created_at <= BRIDGE_SECS
+                    && s.shown.iter().any(|(id, _)| id == &artifact_id)
+            })
+            .map(|s| s.created_at)
+            .max()
+            .unwrap_or(i.at);
+
+        // The nearest recorded situation, within half an hour either way.
+        let matched = contexts
+            .iter()
+            .filter(|c| {
+                c.scope.as_deref().unwrap_or_default() == scope
+                    && (c.at - anchor).abs() <= MATCH_SECS
+            })
+            .min_by_key(|c| ((c.at - anchor).abs(), c.id));
+
+        // No bundle is not no event. `at` and `scope` were recorded from the
+        // beginning, and because an absent block is zeroed rather than
+        // defaulted, an old row feeds in with no special handling — weekday and
+        // hour contribute, device and network contribute nothing.
+        let (raw, at) = match matched {
+            Some(c) => (c.bundle.clone(), c.at),
+            None => ("{}".to_string(), anchor),
+        };
+        let bundle = crate::core::context::parse_bundle(&raw);
+
+        // Age decay, and the self-reinforcement guard as a multiplier. At
+        // `self_weight = 0` a `recommended_open` produces a weightless member,
+        // which the clusterer skips — so the first lucky guess cannot grow into
+        // a habit the system taught itself.
+        let age_days = ((now - at).max(0) as f64) / 86_400.0;
+        let decayed = 0.5f64.powf(age_days / cfg.half_life_days.max(0.1));
+        let weight = decayed * if self_made { cfg.self_weight } else { 1.0 };
+        if weight <= 0.0 {
+            continue;
+        }
+
+        let scope_arg = (!scope.is_empty()).then_some(scope.as_str());
+        by_pair
+            .entry((scope.clone(), artifact_id))
+            .or_default()
+            .push(Member {
+                vec: crate::core::context::encode(at, scope_arg, &bundle, &cfg.weights),
+                weight,
+                at,
+                bundle: raw,
+            });
+        report.events += 1;
+    }
+
+    // Slots are numbered per *artifact*, not per (scope, artifact): the
+    // multivector is one array on one point, shared by every scope that has
+    // opened this artifact, so a slot numbered per scope would have two owners
+    // writing index 0.
+    let mut per_artifact: std::collections::BTreeMap<String, Vec<(Option<String>, Cluster)>> =
+        std::collections::BTreeMap::new();
+    for ((scope, artifact_id), members) in by_pair {
+        let scope = (!scope.is_empty()).then_some(scope);
+        for c in agglomerate(
+            &members,
+            cfg.cluster_merge_at,
+            cfg.max_clusters,
+            cfg.min_weight,
+        ) {
+            per_artifact
+                .entry(artifact_id.clone())
+                .or_default()
+                .push((scope.clone(), c));
+        }
+    }
+
+    // Artifacts that had a profile and produced none this run. Their centroids
+    // must go, or a pattern that stopped months ago would still be offered.
+    let mut stale: std::collections::BTreeSet<String> = core
+        .store
+        .artifacts_with_context_clusters()
+        .await?
+        .into_iter()
+        .collect();
+
+    for (artifact_id, mut clusters) in per_artifact {
+        stale.remove(&artifact_id);
+        clusters.sort_by(|a, b| {
+            b.1.weight
+                .partial_cmp(&a.1.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| b.1.last_at.cmp(&a.1.last_at))
+        });
+        clusters.truncate(MAX_SLOTS);
+
+        let rows: Vec<crate::store::context::StoredCluster> = clusters
+            .iter()
+            .enumerate()
+            .map(|(slot, (scope, c))| crate::store::context::StoredCluster {
+                scope: scope.clone(),
+                artifact_id: artifact_id.clone(),
+                slot: slot as i64,
+                centroid: c.centroid.clone(),
+                weight: c.weight,
+                last_at: c.last_at,
+                encoder_version: crate::core::context::ENCODER_VERSION,
+                representative: c.representative.clone(),
+            })
+            .collect();
+
+        // SQLite first, then the vector store. If the second write fails the
+        // table names clusters the index does not carry — which offers nothing
+        // and explains nothing, and the next run repairs it. The other order
+        // would offer an artifact with no reason to show for it, which is the
+        // one failure this must not have.
+        core.store
+            .replace_context_clusters(&artifact_id, &rows)
+            .await?;
+        let vectors: Vec<Vec<f32>> = rows.iter().map(|r| r.centroid.clone()).collect();
+        core.vectors
+            .set_context_vectors(&artifact_id, vectors)
+            .await?;
+
+        report.profiled += 1;
+        report.clusters += rows.len();
+    }
+
+    for artifact_id in stale {
+        core.store
+            .replace_context_clusters(&artifact_id, &[])
+            .await?;
+        core.vectors
+            .set_context_vectors(&artifact_id, vec![])
+            .await?;
+        report.cleared += 1;
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn member(v: Vec<f32>, weight: f64, at: i64) -> Member {
+        Member {
+            vec: v,
+            weight,
+            at,
+            bundle: format!(r#"{{"n":{at}}}"#),
+        }
+    }
+
+    use crate::core::context::{Bundle, CTX_DIM, ENCODER_VERSION, device_key, parse_bundle};
+    use crate::core::test_support::test_core;
+
+    /// 2026-08-21T13:52:00Z — a Friday, 15:52 in Berlin.
+    const FRIDAY_SEVENTH: i64 = 1_787_320_320;
+
+    /// A Friday at ~15:00 Berlin time, `weeks_back` weeks before the seventh.
+    fn friday(weeks_back: i64) -> i64 {
+        FRIDAY_SEVENTH - weeks_back * 7 * 86_400 - 52 * 60
+    }
+
+    /// A core with the recommender on and a clock that does not move.
+    async fn recommending_core(now: i64) -> Core {
+        let mut core = test_core().await;
+        core.recommend.enabled = true;
+        core.clock = crate::core::context::Clock::Fixed(now);
+        core
+    }
+
+    fn phone() -> Bundle {
+        Bundle {
+            tz: Some("Europe/Berlin".into()),
+            platform: Some("Android".into()),
+            ua_family: Some("Chrome".into()),
+            screen_w: Some(390.0),
+            screen_h: Some(844.0),
+            viewport_w: Some(390.0),
+            viewport_h: Some(844.0),
+            dpr: Some(3.0),
+            cores: Some(8.0),
+            memory_gb: Some(4.0),
+            language: Some("de-DE".into()),
+            color_scheme: Some("dark".into()),
+            touch: Some(true),
+            orientation: Some("portrait".into()),
+            network: Some("cellular".into()),
+            ..Default::default()
+        }
+    }
+
+    /// One artifact with a vector point behind it, because `context_query`
+    /// renders from the payload and an artifact whose embedding never ran has
+    /// none.
+    async fn seed_artifact(core: &Core, title: &str) -> String {
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: format!("text of {title}"),
+                    corpus_span: None,
+                    title: Some(title.into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0);
+        core.vectors
+            .upsert(vec![crate::vector::VectorPoint {
+                vector: vec![1.0; 8],
+                sparse: Default::default(),
+                payload: crate::vector::VectorPayload {
+                    artifact_id: a.id.clone(),
+                    corpus_id: src.id.clone(),
+                    text: a.text.clone(),
+                    title: Some(title.into()),
+                    category: None,
+                    tags: vec![],
+                    created_at: 0,
+                    last_seen_at: None,
+                    hit_count: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
+                    origin_corpora: vec![],
+                    provenance: None,
+                },
+            }])
+            .await
+            .unwrap();
+        a.id
+    }
+
+    /// One page view and the open that followed it.
+    async fn seen_and_opened(core: &Core, aid: &str, at: i64, bundle: &Bundle, kind: &str) {
+        let raw = serde_json::to_string(bundle).unwrap();
+        let t = crate::core::context::local_time(at, bundle.tz.as_deref(), None);
+        core.store
+            .record_context(&crate::store::context::ContextEvent {
+                id: 0,
+                scope: Some("alice".into()),
+                at,
+                bundle: raw.clone(),
+                device_key: device_key(&parse_bundle(&raw)),
+                local_hour: Some(t.hour as i64),
+                weekday: Some(t.weekday as i64),
+                tz: bundle.tz.clone(),
+            })
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(aid, kind, None, Some("alice"), at + 5)
+            .await
+            .unwrap();
+    }
+
+    async fn seed_six_fridays(core: &Core, aid: &str) {
+        for w in 1..=6 {
+            seen_and_opened(core, aid, friday(w), &phone(), "opened").await;
+        }
+    }
+
+    #[tokio::test]
+    async fn six_fridays_become_one_stored_situation() {
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        seed_six_fridays(&core, &aid).await;
+
+        let r = run(&core).await.unwrap();
+        assert_eq!(r.events, 6);
+        assert_eq!(r.profiled, 1);
+        assert_eq!(r.clusters, 1);
+
+        let stored = core
+            .store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap();
+        let c = &stored[&aid][0];
+        assert_eq!(c.slot, 0);
+        assert_eq!(c.centroid.len(), CTX_DIM);
+        assert_eq!(c.encoder_version, ENCODER_VERSION);
+        assert_eq!(c.scope.as_deref(), Some("alice"));
+
+        // And the vector store agrees, which is what the read path queries.
+        let hits = core
+            .vectors
+            .context_query(&c.centroid, 5, &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(hits[0].payload.artifact_id, aid);
+    }
+
+    #[tokio::test]
+    async fn an_open_of_something_this_offered_raises_no_weight() {
+        // The named test the guard needs — the sitting has one saying it writes
+        // no activation, for the same reason. Without this, the first lucky
+        // guess grows into a habit the system taught itself.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        seed_six_fridays(&core, &aid).await;
+        let before = run(&core).await.unwrap();
+        let weight_before = core
+            .store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap()[&aid][0]
+            .weight;
+
+        // Six more Fridays, every one of them an open of the offer.
+        for w in 1..=6 {
+            seen_and_opened(&core, &aid, friday(w) + 60, &phone(), "recommended_open").await;
+        }
+
+        let after = run(&core).await.unwrap();
+        assert_eq!(after.events, before.events, "not one of them counted");
+        let weight_after = core
+            .store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap()[&aid][0]
+            .weight;
+        assert!(
+            (weight_after - weight_before).abs() < 1e-6,
+            "weight moved from {weight_before} to {weight_after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pattern_that_stopped_is_cleared_rather_than_left_standing() {
+        // A year of silence at a 45-day half-life is 2^-8 of the weight it had.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        seed_six_fridays(&core, &aid).await;
+        run(&core).await.unwrap();
+        assert!(
+            !core
+                .store
+                .context_clusters_of(std::slice::from_ref(&aid))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // The same base, a year later.
+        let mut later = core.clone();
+        later.clock = crate::core::context::Clock::Fixed(FRIDAY_SEVENTH + 365 * 86_400);
+        let r = run(&later).await.unwrap();
+        assert_eq!(r.cleared, 1);
+        assert_eq!(r.profiled, 0);
+        assert!(
+            core.store
+                .context_clusters_of(std::slice::from_ref(&aid))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            later
+                .vectors
+                .context_query(&vec![0.1; CTX_DIM], 5, &Default::default())
+                .await
+                .unwrap()
+                .is_empty(),
+            "and the vector store was cleared too"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_old_event_with_no_bundle_still_carries_a_weekday_and_an_hour() {
+        // The cold start, which is not a backfill path: it is the ordinary
+        // sweep reading older rows. Device and network contribute nothing
+        // because an absent block is zeroed rather than defaulted.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        for w in 1..=6 {
+            core.store
+                .record_interaction(&aid, "opened", None, Some("alice"), friday(w))
+                .await
+                .unwrap();
+        }
+        let r = run(&core).await.unwrap();
+        assert_eq!(r.events, 6, "no context event, and they still count");
+        assert_eq!(r.clusters, 1);
+    }
+
+    #[tokio::test]
+    async fn two_people_get_two_profiles_on_one_artifact() {
+        // Slots are numbered per artifact and not per (scope, artifact): the
+        // multivector is one array on one point, so a slot numbered per scope
+        // would have two owners writing index 0.
+        let core = recommending_core(FRIDAY_SEVENTH).await;
+        let aid = seed_artifact(&core, "shared").await;
+        seed_six_fridays(&core, &aid).await;
+        for w in 1..=6 {
+            let at = friday(w) - 3 * 86_400;
+            core.store
+                .record_interaction(&aid, "opened", None, Some("bob"), at)
+                .await
+                .unwrap();
+        }
+
+        run(&core).await.unwrap();
+        let stored = core
+            .store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap();
+        let mine = &stored[&aid];
+        assert_eq!(mine.len(), 2, "one situation each");
+        let slots: Vec<i64> = mine.iter().map(|c| c.slot).collect();
+        assert_eq!(
+            slots,
+            vec![0, 1],
+            "numbered per artifact, without collision"
+        );
+        let mut scopes: Vec<&str> = mine.iter().filter_map(|c| c.scope.as_deref()).collect();
+        scopes.sort();
+        assert_eq!(scopes, vec!["alice", "bob"]);
+    }
+
+    #[tokio::test]
+    async fn the_sweep_does_not_run_when_the_faculty_is_off() {
+        let mut core = recommending_core(FRIDAY_SEVENTH).await;
+        core.recommend.enabled = false;
+        let aid = seed_artifact(&core, "recycling centre").await;
+        seed_six_fridays(&core, &aid).await;
+
+        let r = run(&core).await.unwrap();
+        assert_eq!(r.events, 0);
+        assert!(
+            core.store
+                .context_clusters_of(std::slice::from_ref(&aid))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn six_fridays_and_one_monday_leave_one_situation() {
+        // The shape the whole feature is for. The outlier is real and
+        // recorded; it is simply not yet a pattern, and `min_weight` is what
+        // says so. Without it, one accident is a habit.
+        let mut members: Vec<Member> = (0..6)
+            .map(|i| member(vec![1.0, 0.02 * i as f32], 1.0, 1_000 + i))
+            .collect();
+        members.push(member(vec![0.0, 1.0], 1.0, 2_000));
+
+        let out = agglomerate(&members, 0.82, 5, 2.0);
+        assert_eq!(out.len(), 1, "the Monday is below the threshold");
+        assert!((out[0].weight - 6.0).abs() < 1e-6);
+        assert_eq!(out[0].last_at, 1_005, "the most recent member's stamp");
+    }
+
+    #[test]
+    fn two_real_situations_are_two_clusters_not_their_mean() {
+        // The recycling centre looked up on Friday afternoons *and*
+        // occasionally on Monday mornings. A mean of them is a situation that
+        // never happened, and it would match neither.
+        let mut members: Vec<Member> = (0..4)
+            .map(|i| member(vec![1.0, 0.0], 1.0, 1_000 + i))
+            .collect();
+        members.extend((0..4).map(|i| member(vec![0.0, 1.0], 1.0, 2_000 + i)));
+
+        let out = agglomerate(&members, 0.82, 5, 2.0);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().any(|c| c.centroid[0] > 0.9));
+        assert!(out.iter().any(|c| c.centroid[1] > 0.9));
+    }
+
+    #[test]
+    fn the_same_input_clusters_the_same_way_twice() {
+        // One pass and no randomness, because otherwise it is not testable —
+        // and because a recommendation that changed its reason between two
+        // sweeps over identical data would be unaccountable.
+        let members: Vec<Member> = (0..12)
+            .map(|i| {
+                member(
+                    vec![(i % 3) as f32, ((i + 1) % 3) as f32, 1.0],
+                    1.0,
+                    1_000 + i,
+                )
+            })
+            .collect();
+        let a = agglomerate(&members, 0.82, 4, 0.0);
+        let b = agglomerate(&members, 0.82, 4, 0.0);
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(&b) {
+            assert_eq!(x.centroid, y.centroid);
+            assert_eq!(x.representative, y.representative);
+        }
+    }
+
+    #[test]
+    fn the_count_never_exceeds_the_cap() {
+        let members: Vec<Member> = (0..20)
+            .map(|i| {
+                let mut v = vec![0.0; 20];
+                v[i] = 1.0;
+                member(v, 1.0, 1_000 + i as i64)
+            })
+            .collect();
+        let out = agglomerate(&members, 0.99, 5, 0.0);
+        assert!(out.len() <= 5, "got {}", out.len());
+    }
+
+    #[test]
+    fn a_cluster_quotes_the_member_nearest_its_centre() {
+        // What the display shows is a real event that happened, not a
+        // reconstruction of the average of several.
+        let members = vec![
+            member(vec![1.0, 0.0], 1.0, 1_000),
+            member(vec![0.98, 0.2], 1.0, 1_001),
+            member(vec![0.99, 0.1], 1.0, 1_002),
+        ];
+        let out = agglomerate(&members, 0.5, 5, 0.0);
+        assert_eq!(out.len(), 1);
+        let rep: serde_json::Value = serde_json::from_str(&out[0].representative).unwrap();
+        assert!(rep["at"].is_i64(), "the stamp travels with the bundle");
+        assert!(rep["bundle"].is_object());
+        // And it is one of the members, not something assembled.
+        let at = rep["at"].as_i64().unwrap();
+        assert!(members.iter().any(|m| m.at == at));
+    }
+
+    #[test]
+    fn a_bundle_that_will_not_reparse_becomes_an_empty_one() {
+        // The row must always be valid JSON: the display reads it back, and a
+        // half-written bundle must not be able to break the page it explains.
+        let mut m = member(vec![1.0, 0.0], 3.0, 1_000);
+        m.bundle = "}{ not json".into();
+        let out = agglomerate(&[m], 0.5, 5, 0.0);
+        let rep: serde_json::Value = serde_json::from_str(&out[0].representative).unwrap();
+        assert_eq!(rep["bundle"], serde_json::json!({}));
+        assert_eq!(rep["at"], 1_000);
+    }
+
+    #[test]
+    fn heavier_members_pull_the_centroid_further() {
+        let members = vec![
+            member(vec![1.0, 0.0], 1.0, 1_000),
+            member(vec![0.9, 0.44], 9.0, 1_001),
+        ];
+        let out = agglomerate(&members, 0.5, 5, 0.0);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].centroid[1] > 0.3, "the heavy one dominates");
+    }
+
+    #[test]
+    fn a_weightless_member_is_skipped_entirely() {
+        // What the self-reinforcement guard rides on: at `self_weight = 0` a
+        // `recommended_open` arrives weighing nothing and must not open a
+        // cluster of its own either.
+        let members = vec![
+            member(vec![1.0, 0.0], 3.0, 1_000),
+            member(vec![0.0, 1.0], 0.0, 1_001),
+        ];
+        let out = agglomerate(&members, 0.82, 5, 0.0);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].centroid[0] > 0.9);
+    }
+
+    #[test]
+    fn nothing_in_means_nothing_out() {
+        assert!(agglomerate(&[], 0.82, 5, 2.0).is_empty());
+    }
+}

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -94,7 +94,7 @@ pub struct SweepReport {
 /// is stored; a coverage check that could not run is a line on the capture page
 /// that does not appear.
 pub async fn cover(core: &Core, corpus_id: &str) -> Result<usize> {
-    if !core.feedback.enabled {
+    if !core.learn.enabled {
         return Ok(0);
     }
     let mut open = core
@@ -443,7 +443,7 @@ mod tests {
     #[tokio::test]
     async fn a_capture_that_answers_a_gap_closes_it_and_says_which() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let v = vec![1.0, 0.0, 0.0, 0.0];
         let id = gap_search(&core, "how do I mount an E01", v.clone()).await;
         core.weak_below = 1.0;
@@ -473,7 +473,7 @@ mod tests {
     #[tokio::test]
     async fn a_capture_that_answers_nothing_closes_nothing() {
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let v = vec![1.0, 0.0, 0.0, 0.0];
         gap_search(&core, "how do I mount an E01", v.clone()).await;
         core.weak_below = 1.0;
@@ -503,7 +503,7 @@ mod tests {
         // `reconcile_stores_once` exists to repair, and `gap_coverage` carries
         // a foreign key onto it.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let dangling = vec![0.0, 1.0, 0.0, 0.0];
         let answerable = vec![1.0, 0.0, 0.0, 0.0];
         gap_search(&core, "what does a torn write look like", dangling.clone()).await;
@@ -554,7 +554,7 @@ mod tests {
         // Reversible, and by the cascade rather than by a second mechanism.
         // Nothing an automatic score decided overwrote what a person judged.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let v = vec![1.0, 0.0, 0.0, 0.0];
         let id = gap_search(&core, "how do I mount an E01", v.clone()).await;
         core.weak_below = 1.0;
@@ -584,7 +584,7 @@ mod tests {
         // capture, once per open gap.
         let (mut core, embedder) =
             crate::core::test_support::test_core_counting_embed_calls().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let v = vec![1.0, 0.0, 0.0, 0.0];
         gap_search(&core, "how do I mount an E01", v.clone()).await;
         core.weak_below = 1.0;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -307,7 +307,7 @@ async fn rearm_periodic(core: &Core, job: &Job) {
 /// the last half-hour's. The pursuit sweep keeps its own period as a floor, so
 /// this pulls it forward rather than being the only thing that runs it.
 async fn arm_successor(core: &Core, job: &Job) {
-    if job.stage != Stage::Associate || !core.pursuit.enabled {
+    if job.stage != Stage::Associate || !core.learn.enabled {
         return;
     }
     if let Err(e) = core
@@ -446,7 +446,7 @@ mod tests {
         // The question a system that describes itself as sleeping has to be
         // able to answer: what did the memory do while I was away.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.store
             .arm_periodic(
                 Stage::Associate,
@@ -476,7 +476,7 @@ mod tests {
         // No ticker holds the period any more: `run_after` is the cursor
         // recording when the sweep last ran, and it is already indexed.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.store
             .arm_periodic(
                 Stage::Associate,
@@ -516,7 +516,7 @@ mod tests {
         // leaves the row pending behind a backoff, which is the re-arming — so
         // what this asserts is that nothing closes it instead.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         // A pursuit sweep with no store behind it fails; what it fails on does
         // not matter, only that the row survives it.
         core.store
@@ -546,7 +546,7 @@ mod tests {
         // The gates live on the list now, so this is what "switched off" means
         // for a unit already in the queue: it runs once more and stops.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.store
             .arm_periodic(
                 Stage::Associate,
@@ -557,7 +557,7 @@ mod tests {
             .await
             .unwrap();
         let job = core.store.claim_job().await.unwrap().unwrap();
-        core.associate.enabled = false;
+        core.learn.enabled = false;
 
         run_claimed(&core, job).await.unwrap();
 
@@ -573,8 +573,7 @@ mod tests {
         // the last half-hour's. The pursuit sweep keeps its own period as a
         // floor; this is what pulls it forward.
         let mut core = test_core().await;
-        core.feedback.enabled = true;
-        core.pursuit.enabled = true;
+        core.learn.enabled = true;
         // Pursuit asleep on its own period, as it is for all but a moment of
         // every cycle.
         core.store

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,5 +1,6 @@
 pub mod associate;
 pub mod consolidate;
+pub mod context;
 pub mod dedupe;
 pub mod describe;
 pub mod embed;
@@ -114,7 +115,8 @@ async fn run_claimed(core: &Core, job: Job) -> Result<bool> {
             | Stage::Associate
             | Stage::Pursuit
             | Stage::Retention
-            | Stage::ArmDedupe,
+            | Stage::ArmDedupe
+            | Stage::Context,
             _,
         ) => run_accounted(core, job.stage).await,
     };
@@ -233,6 +235,7 @@ async fn run_accounted(core: &Core, stage: Stage) -> Result<()> {
         Stage::Consolidate => consolidate::run(core).await.and_then(detail),
         Stage::Associate => associate::run(core).await.and_then(detail),
         Stage::Retention => retention::run(core).await.and_then(detail),
+        Stage::Context => context::run(core).await.and_then(detail),
         Stage::Pursuit => pursuit::run(core)
             .await
             .and_then(|n| detail(serde_json::json!({ "pursuits": n }))),

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -277,7 +277,7 @@ mod tests {
     async fn earned_with_one_passage() -> (crate::core::Core, String, String) {
         let mut core = test_core().await;
         core.synthesis = SynthesisMode::Earned;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let out = core
             .ingest("a single verbatim passage", "web", None)
             .await
@@ -492,7 +492,7 @@ mod tests {
     ) {
         let mut core = test_core().await;
         core.synthesis = SynthesisMode::Earned;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let src = core
             .store
             .insert_corpus("l1\nl2\nl3\nl4\nl5\nl6", "web", None)

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -517,8 +517,16 @@ fn need_of(
             bump(id, 3.0);
             n.strong_engaged = true;
         }
-        let mine: Vec<&crate::store::pursuits::Interaction> =
-            attached[m].iter().map(|&k| &interactions[k]).collect();
+        let mine: Vec<&crate::store::pursuits::Interaction> = attached[m]
+            .iter()
+            .map(|&k| &interactions[k])
+            // What this base *offered* is not something a person did. Every
+            // kind that is not `dwell` or `pivoted` is weighed at 1.0 below, so
+            // without this every artifact the recommender ever guessed at would
+            // count as engaged — and `engaged`, a few lines down, would call a
+            // search followed by nothing a search that was followed.
+            .filter(|i| i.kind != "recommended_shown")
+            .collect();
         if !e.answered {
             for i in &mine {
                 if i.kind == "dwell" {
@@ -834,6 +842,44 @@ mod tests {
             .await
             .unwrap();
         id
+    }
+
+    #[tokio::test]
+    async fn an_offer_that_was_only_shown_is_not_engagement() {
+        // `recommended_shown` is the recommender's own guess, not something a
+        // person did. Every kind that is not `dwell` or `pivoted` is weighed at
+        // 1.0, so without an explicit exclusion every artifact the recommender
+        // ever guessed at would count as engaged — and a search followed by
+        // nothing at all would read as a search that was followed.
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        let t0 = now - 100;
+        search_event(
+            &core,
+            "recycling centre hours",
+            vec![1.0, 0.0],
+            &[&ids[0]],
+            t0,
+        )
+        .await;
+        core.store
+            .record_recommendation(
+                &ids[0],
+                "recommended_shown",
+                r#"{"rung":"pattern","slot":0}"#,
+                Some("me"),
+                t0 + 1,
+            )
+            .await
+            .unwrap();
+
+        run(&core).await.unwrap();
+        let pursuits = core.store.recent_pursuits(50).await.unwrap();
+        assert!(
+            pursuits.iter().all(|p| !p.sources.contains(&ids[0])),
+            "an offer nobody clicked is not a source: {pursuits:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -140,7 +140,7 @@ pub const PURSUIT_AFTER: &str = "pursuit.events_after";
 ///
 /// A ceiling rather than a budget: pursuits are swept every time the operator
 /// goes quiet, so nothing in ordinary use comes near it. What it stops is the
-/// first sweep after `pursuit.enabled` is turned on, where there is no cursor
+/// first sweep after `[learn]` is turned on, where there is no cursor
 /// and the window would otherwise open at the epoch. Recording is on by
 /// default, so that window holds every search the base has taken since it was
 /// installed — and the clustering below is quadratic in *memory* as well as
@@ -259,7 +259,7 @@ struct Ev {
 /// wait until the operator stopped. Local throughout — the only model call is
 /// the one `Generate` makes later, and only for a pursuit that earned it.
 pub async fn run(core: &Core) -> Result<usize> {
-    if !core.pursuit.enabled || !core.associating() {
+    if !core.associating() {
         return Ok(0);
     }
     let now = crate::store::now();
@@ -795,8 +795,7 @@ mod tests {
     async fn pursuing_core() -> crate::core::Core {
         let mut core = test_core().await;
         core.synthesis = crate::config::SynthesisMode::Earned;
-        core.feedback.enabled = true;
-        core.pursuit.enabled = true;
+        core.learn.enabled = true;
         core.pursuit.idle_secs = 10;
         core
     }

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -55,7 +55,7 @@ pub async fn run(core: &Core) -> Result<Report> {
         }
     }
 
-    if core.feedback.enabled {
+    if core.learn.enabled {
         match crate::jobs::gaps::sweep(core).await {
             Ok(r) => {
                 if r.named > 0 || r.removed > 0 {
@@ -155,7 +155,7 @@ mod tests {
         // own unit now, and it stays its own unit.
         let mut core = crate::core::test_support::test_core().await;
         core.consolidate.enabled = false;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.feedback.retain_days = 30;
         seed_old_event(&core).await;
 
@@ -176,7 +176,7 @@ mod tests {
         // into `sweep_runs` as `ok` with no counts — and the `failed` flag, the
         // stated reason that history exists, could never fire for this sweep.
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.feedback.retain_days = 30;
         // The expiry's table, taken out from under it.
         sqlx::query("DROP TABLE search_events")
@@ -206,7 +206,7 @@ mod tests {
     #[tokio::test]
     async fn the_unit_groups_the_gaps() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         // Two of them: one gap is not a group, and the sweep no longer spends a
         // naming call restating a single question.
         for q in ["mount an E01", "mounting E01 images"] {
@@ -247,7 +247,7 @@ mod tests {
         // reads the rows expiring removes, and naming a cluster around a search
         // deleted a second later is a call spent on nothing.
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         core.feedback.retain_days = 30;
         seed_old_event(&core).await;
 

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -22,6 +22,8 @@ pub struct Report {
     pub removed: usize,
     /// Situations dropped for being past `store::context::RETAIN_DAYS`.
     pub contexts: u64,
+    /// Interactions dropped for being past the same window.
+    pub interactions: u64,
 }
 
 pub async fn run(core: &Core) -> Result<Report> {
@@ -95,6 +97,28 @@ pub async fn run(core: &Core) -> Result<Report> {
         }
         Err(e) => {
             tracing::warn!(error = %e, "could not expire recorded situations");
+            failure.get_or_insert(e);
+        }
+    }
+
+    // Interactions ride the situations' window, not the query log's: the two
+    // are read as a pair by the context sweep, and one kept past the other
+    // profiles nothing. Behind no key for the same reason the line above is —
+    // an operator who turned the offer off still wants the rows it wrote while
+    // it was on to leave.
+    match core
+        .store
+        .expire_interactions(crate::store::context::RETAIN_DAYS)
+        .await
+    {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(dropped = n, "expired recorded interactions");
+            }
+            report.interactions = n;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "could not expire recorded interactions");
             failure.get_or_insert(e);
         }
     }

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -20,6 +20,8 @@ pub struct Report {
     pub clusters: usize,
     pub named: usize,
     pub removed: usize,
+    /// Situations dropped for being past `store::context::RETAIN_DAYS`.
+    pub contexts: u64,
 }
 
 pub async fn run(core: &Core) -> Result<Report> {
@@ -72,6 +74,28 @@ pub async fn run(core: &Core) -> Result<Report> {
                 tracing::warn!(error = %e, "could not group knowledge gaps");
                 failure.get_or_insert(e);
             }
+        }
+    }
+
+    // Its own window, and behind no key. A weekly pattern needs weeks, and
+    // `feedback.retain_days` defaults to keeping for ever but is an operator
+    // switch — an operator who shortens their query log is not asking the base
+    // to forget what Friday afternoon looks like. Runs whenever this unit runs,
+    // which is why `periodic_units` also arms it for `recommend.enabled`.
+    match core
+        .store
+        .expire_context_events(crate::store::context::RETAIN_DAYS)
+        .await
+    {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(dropped = n, "expired recorded situations");
+            }
+            report.contexts = n;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "could not expire recorded situations");
+            failure.get_or_insert(e);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,7 @@ mod startup_tests {
             pursuit: engram::config::PursuitConfig::default(),
             schedule: engram::config::ScheduleConfig::default(),
             sitting: engram::config::SittingConfig::default(),
+            recommend: engram::config::RecommendConfig::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ async fn main() -> anyhow::Result<()> {
         );
         if pairs == 0 {
             println!(
-                "no judged searches yet — set feedback.enabled, use the base, \
+                "no judged searches yet — set learn.enabled, use the base, \
                  then judge what it recorded at /ui/judge"
             );
         }
@@ -388,6 +388,7 @@ mod startup_tests {
                 }),
             },
             consolidate: ConsolidateConfig::default(),
+            learn: LearnConfig::default(),
             feedback: FeedbackConfig::default(),
             capture: CaptureConfig::default(),
             pacing: engram::config::PacingConfig::default(),

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -744,14 +744,18 @@ impl Store {
     /// The revision bump is what makes this safe to run while a worker is
     /// mid-batch on the same source: that worker's `mark_embedded` no longer
     /// matches, so it cannot clear the pending state this just set.
+    ///
+    /// `updated_at` is deliberately left alone. It answers whether the text on
+    /// screen is the text that was captured, and re-embedding changes no text —
+    /// a model change or a `--reindex` would otherwise stamp every artifact in
+    /// the corpus as edited today, which is the one thing the column is there
+    /// to deny.
     pub async fn reset_embed_state(&self, corpus_id: &str) -> Result<()> {
         sqlx::query(
             "UPDATE artifacts
-             SET embed_state = 'pending', embed_model = NULL, embed_rev = embed_rev + 1,
-                 updated_at = ?
+             SET embed_state = 'pending', embed_model = NULL, embed_rev = embed_rev + 1
              WHERE corpus_id = ?",
         )
-        .bind(super::now())
         .bind(corpus_id)
         .execute(&self.pool)
         .await?;
@@ -1463,6 +1467,33 @@ mod tests {
         s.insert_artifacts(&src.id, &[nc(0, "x")]).await.unwrap();
         s.delete_corpus(&src.id).await.unwrap();
         assert!(s.artifacts_for_corpus(&src.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn re_embedding_a_corpus_is_not_an_edit() {
+        // `updated_at` answers whether the text on screen is the text that was
+        // captured. Re-embedding changes no text — it is a model change or a
+        // `--reindex` — so stamping it here would mark every artifact in the
+        // corpus as edited today, which is the one thing the column exists to
+        // deny.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let c = s.insert_artifacts(&src.id, &[nc(0, "x")]).await.unwrap()[0].clone();
+
+        s.reset_embed_state(&src.id).await.unwrap();
+
+        let stamp: i64 = sqlx::query_scalar("SELECT updated_at FROM artifacts WHERE id = ?")
+            .bind(&c.id)
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(stamp, 0, "a re-embed reported itself as an edit");
+        let got = s.artifacts_for_corpus(&src.id).await.unwrap();
+        assert_eq!(
+            got[0].embed_state,
+            EmbedState::Pending,
+            "and it did re-queue"
+        );
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -747,9 +747,11 @@ impl Store {
     pub async fn reset_embed_state(&self, corpus_id: &str) -> Result<()> {
         sqlx::query(
             "UPDATE artifacts
-             SET embed_state = 'pending', embed_model = NULL, embed_rev = embed_rev + 1
+             SET embed_state = 'pending', embed_model = NULL, embed_rev = embed_rev + 1,
+                 updated_at = ?
              WHERE corpus_id = ?",
         )
+        .bind(super::now())
         .bind(corpus_id)
         .execute(&self.pool)
         .await?;
@@ -787,10 +789,11 @@ impl Store {
             sqlx::query(
                 "UPDATE artifacts
                  SET title = ?, embed_state = 'pending', embed_model = NULL,
-                     embed_rev = embed_rev + 1
+                     embed_rev = embed_rev + 1, updated_at = ?
                  WHERE id = ?",
             )
             .bind(title)
+            .bind(super::now())
             .bind(id)
             .execute(&self.pool)
             .await?,
@@ -802,10 +805,11 @@ impl Store {
             sqlx::query(
                 "UPDATE artifacts
                  SET text = ?, embed_state = 'pending', embed_model = NULL,
-                     embed_rev = embed_rev + 1
+                     embed_rev = embed_rev + 1, updated_at = ?
                  WHERE id = ?",
             )
             .bind(text)
+            .bind(super::now())
             .bind(id)
             .execute(&self.pool)
             .await?,
@@ -1459,6 +1463,37 @@ mod tests {
         s.insert_artifacts(&src.id, &[nc(0, "x")]).await.unwrap();
         s.delete_corpus(&src.id).await.unwrap();
         assert!(s.artifacts_for_corpus(&src.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn editing_an_artifact_stamps_when_it_changed() {
+        // The one question the base could not previously answer about itself.
+        // `created_at` says when it arrived and `last_verified_at` says when
+        // someone vouched for it; neither says whether the text on screen is
+        // the text that was captured.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let c = s
+            .insert_artifacts(&src.id, &[nc(0, "before")])
+            .await
+            .unwrap()
+            .remove(0);
+
+        let before: i64 = sqlx::query_scalar("SELECT updated_at FROM artifacts WHERE id = ?")
+            .bind(&c.id)
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert_eq!(before, 0, "a fresh row has never been edited");
+
+        s.update_artifact_text(&c.id, "after").await.unwrap();
+
+        let after: i64 = sqlx::query_scalar("SELECT updated_at FROM artifacts WHERE id = ?")
+            .bind(&c.id)
+            .fetch_one(&s.pool)
+            .await
+            .unwrap();
+        assert!(after > 0, "an edit says when it happened");
     }
 
     #[tokio::test]

--- a/src/store/context.rs
+++ b/src/store/context.rs
@@ -1,0 +1,416 @@
+//! What situation a page view happened in, and what the sweep made of them.
+//!
+//! Two tables with one rule between them: nothing here is joined by a stored
+//! id. A context event is matched to an open through `scope` and `at`, the way
+//! `interaction_events` is matched to a pursuit — so re-clustering never has to
+//! rewrite a row, and a sweep run under a new encoder starts from the raw
+//! bundles rather than from what the last one concluded.
+
+use super::{Store, now};
+use crate::error::Result;
+use crate::store::feedback::{blob_to_vec, vec_to_blob};
+use sqlx::Row;
+use std::collections::HashMap;
+
+/// How long a situation is kept.
+///
+/// Not `feedback.retain_days`, and not a setting. A weekly pattern needs weeks
+/// and a monthly one needs months, so the window this feature needs is not the
+/// window an operator sets for their query log — and it is longer than either
+/// default. Housekeeping about how long the base may remember a Friday
+/// afternoon is not a preference; it is what the feature costs to work at all.
+pub const RETAIN_DAYS: i64 = 400;
+
+/// One page view, as the browser described it.
+#[derive(Debug, Clone, Default)]
+pub struct ContextEvent {
+    pub id: i64,
+    pub scope: Option<String>,
+    pub at: i64,
+    /// The bundle as received, JSON.
+    pub bundle: String,
+    pub device_key: Option<String>,
+    pub local_hour: Option<i64>,
+    pub weekday: Option<i64>,
+    pub tz: Option<String>,
+}
+
+/// One learned situation, as SQLite holds it.
+#[derive(Debug, Clone)]
+pub struct StoredCluster {
+    pub scope: Option<String>,
+    pub artifact_id: String,
+    pub slot: i64,
+    pub centroid: Vec<f32>,
+    pub weight: f64,
+    pub last_at: i64,
+    pub encoder_version: i64,
+    pub representative: String,
+}
+
+impl Store {
+    /// Record one page view's situation. Returns the row's own id.
+    pub async fn record_context(&self, ev: &ContextEvent) -> Result<i64> {
+        let res = sqlx::query(
+            "INSERT INTO context_events
+                 (scope, at, bundle, device_key, local_hour, weekday, tz)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&ev.scope)
+        .bind(ev.at)
+        .bind(&ev.bundle)
+        .bind(&ev.device_key)
+        .bind(ev.local_hour)
+        .bind(ev.weekday)
+        .bind(&ev.tz)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.last_insert_rowid())
+    }
+
+    /// Every situation recorded at or after `since`, oldest first.
+    ///
+    /// Unbounded on purpose, and bounded in practice by `RETAIN_DAYS`: the one
+    /// caller is the sweep, which rebuilds every profile from the raw bundles
+    /// and therefore needs all of them. Paging it would mean holding a cursor
+    /// across a rebuild that is only correct when it sees the whole window.
+    pub async fn context_events_since(&self, since: i64) -> Result<Vec<ContextEvent>> {
+        let rows = sqlx::query(
+            "SELECT id, scope, at, bundle, device_key, local_hour, weekday, tz
+               FROM context_events
+              WHERE at >= ?
+              ORDER BY at, id",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| ContextEvent {
+                id: r.get("id"),
+                scope: r.get("scope"),
+                at: r.get("at"),
+                bundle: r.get("bundle"),
+                device_key: r.get("device_key"),
+                local_hour: r.get("local_hour"),
+                weekday: r.get("weekday"),
+                tz: r.get("tz"),
+            })
+            .collect())
+    }
+
+    /// Drop situations past keeping. See `RETAIN_DAYS`.
+    pub async fn expire_context_events(&self, retain_days: i64) -> Result<u64> {
+        let cutoff = now() - retain_days * 86_400;
+        Ok(sqlx::query("DELETE FROM context_events WHERE at < ?")
+            .bind(cutoff)
+            .execute(&self.pool)
+            .await?
+            .rows_affected())
+    }
+
+    /// Every artifact that currently has a profile.
+    ///
+    /// What the sweep needs in order to *clear* one: an artifact whose every
+    /// situation has decayed below `min_weight` produces no clusters this run,
+    /// so nothing in the run's own output names it, and without this its old
+    /// centroids would stand for ever — offering it on a pattern that stopped
+    /// months ago.
+    pub async fn artifacts_with_context_clusters(&self) -> Result<Vec<String>> {
+        Ok(
+            sqlx::query_scalar("SELECT DISTINCT artifact_id FROM context_clusters")
+                .fetch_all(&self.pool)
+                .await?,
+        )
+    }
+
+    /// Replace everything this artifact has learned, in one transaction.
+    ///
+    /// Wholesale, never merged. The sweep rebuilds a profile from the raw
+    /// bundles every run, so a merge would leave a slot from a previous run
+    /// standing beside fresh ones — and the multivector written from the fresh
+    /// ones would then not match the table the reason is read out of. An empty
+    /// list is a clear, which is what an artifact whose every cluster fell
+    /// below `min_weight` needs.
+    pub async fn replace_context_clusters(
+        &self,
+        artifact_id: &str,
+        clusters: &[StoredCluster],
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM context_clusters WHERE artifact_id = ?")
+            .bind(artifact_id)
+            .execute(&mut *tx)
+            .await?;
+        for c in clusters {
+            sqlx::query(
+                "INSERT INTO context_clusters
+                     (scope, artifact_id, slot, centroid, weight, last_at,
+                      encoder_version, representative)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&c.scope)
+            .bind(artifact_id)
+            .bind(c.slot)
+            .bind(vec_to_blob(&c.centroid))
+            .bind(c.weight)
+            .bind(c.last_at)
+            .bind(c.encoder_version)
+            .bind(&c.representative)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// What these artifacts have learned, keyed by artifact, in slot order.
+    /// Ids with no clusters are absent from the answer rather than present and
+    /// empty — the read path asks for the ten the vector store returned and
+    /// needs to know which of them it can say nothing about.
+    pub async fn context_clusters_of(
+        &self,
+        artifact_ids: &[String],
+    ) -> Result<HashMap<String, Vec<StoredCluster>>> {
+        if artifact_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        // Built by hand because sqlx has no list binding for SQLite, and
+        // `AssertSqlSafe` because the string is assembled here — the values are
+        // bound and never spliced, and only the placeholders are generated.
+        // Same shape as `artifacts_by_ids`.
+        let holes = std::iter::repeat_n("?", artifact_ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT scope, artifact_id, slot, centroid, weight, last_at,
+                    encoder_version, representative
+               FROM context_clusters
+              WHERE artifact_id IN ({holes})
+              ORDER BY artifact_id, slot"
+        )));
+        for id in artifact_ids {
+            q = q.bind(id);
+        }
+        let mut out: HashMap<String, Vec<StoredCluster>> = HashMap::new();
+        for r in q.fetch_all(&self.pool).await? {
+            let artifact_id: String = r.get("artifact_id");
+            out.entry(artifact_id.clone())
+                .or_default()
+                .push(StoredCluster {
+                    scope: r.get("scope"),
+                    artifact_id,
+                    slot: r.get("slot"),
+                    centroid: blob_to_vec(&r.get::<Vec<u8>, _>("centroid")),
+                    weight: r.get("weight"),
+                    last_at: r.get("last_at"),
+                    encoder_version: r.get("encoder_version"),
+                    representative: r.get("representative"),
+                });
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::artifacts::{CorpusSpan, NewArtifact};
+
+    fn event(scope: &str, at: i64) -> ContextEvent {
+        ContextEvent {
+            id: 0,
+            scope: Some(scope.into()),
+            at,
+            bundle: r#"{"tz":"Europe/Berlin"}"#.into(),
+            device_key: Some("phone".into()),
+            local_hour: Some(15),
+            weekday: Some(4),
+            tz: Some("Europe/Berlin".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_recorded_situation_comes_back_whole() {
+        let store = Store::memory().await.unwrap();
+        store.record_context(&event("alice", 1_000)).await.unwrap();
+
+        let out = store.context_events_since(0).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].scope.as_deref(), Some("alice"));
+        assert_eq!(out[0].bundle, r#"{"tz":"Europe/Berlin"}"#);
+        assert_eq!(out[0].weekday, Some(4));
+        assert!(out[0].id > 0, "the row's own id, not the argument's");
+    }
+
+    #[tokio::test]
+    async fn situations_come_back_oldest_first() {
+        let store = Store::memory().await.unwrap();
+        for at in [3_000, 1_000, 2_000] {
+            store.record_context(&event("alice", at)).await.unwrap();
+        }
+        let ats: Vec<i64> = store
+            .context_events_since(0)
+            .await
+            .unwrap()
+            .iter()
+            .map(|e| e.at)
+            .collect();
+        assert_eq!(ats, vec![1_000, 2_000, 3_000]);
+    }
+
+    #[tokio::test]
+    async fn expiry_uses_this_features_own_window() {
+        // Not `feedback.retain_days`: an operator who shortens their query log
+        // is not asking the base to forget what Friday afternoon looks like.
+        let store = Store::memory().await.unwrap();
+        let day = 86_400;
+        store
+            .record_context(&event("alice", now() - 500 * day))
+            .await
+            .unwrap();
+        store
+            .record_context(&event("alice", now() - 10 * day))
+            .await
+            .unwrap();
+
+        let dropped = store.expire_context_events(RETAIN_DAYS).await.unwrap();
+        assert_eq!(dropped, 1);
+        assert_eq!(store.context_events_since(0).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn clusters_are_replaced_wholesale_not_merged() {
+        // The sweep is a full rebuild per artifact. A write that merged would
+        // leave a slot from a previous encoder standing beside fresh ones, and
+        // the multivector written from them would not match the table.
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 3.0), cluster(&aid, 1, 2.0)])
+            .await
+            .unwrap();
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 9.0)])
+            .await
+            .unwrap();
+
+        let back = store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap();
+        let mine = &back[&aid];
+        assert_eq!(mine.len(), 1, "slot 1 is gone, not stale");
+        assert_eq!(mine[0].weight, 9.0);
+    }
+
+    #[tokio::test]
+    async fn an_empty_list_clears_the_profile() {
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 3.0)])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.artifacts_with_context_clusters().await.unwrap(),
+            vec![aid.clone()]
+        );
+
+        store.replace_context_clusters(&aid, &[]).await.unwrap();
+        assert!(
+            store
+                .artifacts_with_context_clusters()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_centroid_survives_the_round_trip() {
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+        let mut c = cluster(&aid, 0, 1.0);
+        c.centroid = vec![0.5, -0.25, 0.125];
+        store.replace_context_clusters(&aid, &[c]).await.unwrap();
+
+        let back = store
+            .context_clusters_of(std::slice::from_ref(&aid))
+            .await
+            .unwrap();
+        assert_eq!(back[&aid][0].centroid, vec![0.5, -0.25, 0.125]);
+    }
+
+    #[tokio::test]
+    async fn an_artifact_with_no_clusters_is_absent_rather_than_empty() {
+        // The read path asks for the ten ids the store returned and expects to
+        // learn which of them it knows nothing about.
+        let store = Store::memory().await.unwrap();
+        let back = store
+            .context_clusters_of(&["nobody".to_string()])
+            .await
+            .unwrap();
+        assert!(back.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleting_an_artifact_takes_its_situations_with_it() {
+        let store = Store::memory().await.unwrap();
+        let aid = seed_artifact(&store).await;
+        store
+            .replace_context_clusters(&aid, &[cluster(&aid, 0, 1.0)])
+            .await
+            .unwrap();
+
+        sqlx::query("DELETE FROM artifacts WHERE id = ?")
+            .bind(&aid)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let back = store.context_clusters_of(&[aid]).await.unwrap();
+        assert!(back.is_empty(), "ON DELETE CASCADE");
+    }
+
+    fn cluster(artifact_id: &str, slot: i64, weight: f64) -> StoredCluster {
+        StoredCluster {
+            scope: Some("alice".into()),
+            artifact_id: artifact_id.into(),
+            slot,
+            centroid: vec![1.0, 0.0],
+            weight,
+            last_at: 1_000,
+            encoder_version: 1,
+            representative: r#"{"at":1000,"bundle":{}}"#.into(),
+        }
+    }
+
+    /// A corpus and one artifact in it, because `context_clusters.artifact_id`
+    /// is a foreign key and SQLite enforces it.
+    async fn seed_artifact(store: &Store) -> String {
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        store
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: Some(CorpusSpan {
+                        start_line: 1,
+                        end_line: 2,
+                    }),
+                    caveats: vec![],
+                    title: Some("t".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id
+    }
+}

--- a/src/store/context.rs
+++ b/src/store/context.rs
@@ -43,6 +43,8 @@ pub struct StoredCluster {
     pub slot: i64,
     pub centroid: Vec<f32>,
     pub weight: f64,
+    /// How many events this was built from, undecayed. See the column comment.
+    pub events: i64,
     pub last_at: i64,
     pub encoder_version: i64,
     pub representative: String,
@@ -109,6 +111,29 @@ impl Store {
             .rows_affected())
     }
 
+    /// One active artifact, drawn at random.
+    ///
+    /// The bottom of the ladder, and deliberately *not* `resurface`. That one
+    /// answers "what has been forgotten" — older than thirty days and unshown
+    /// for thirty days — so on a base anyone has just started using it returns
+    /// nothing at all, which is the one moment this is for. It also stamps what
+    /// it draws as seen, which would quietly drain the pool the search page's
+    /// own resurfacing lives on.
+    ///
+    /// This asks a simpler question and has no side effect: something to look
+    /// at, while the base has nothing to say about the situation. Nothing is
+    /// claimed about it, and the page prints no reason beside it.
+    pub async fn random_artifact(&self) -> Result<Option<(String, Option<String>, String)>> {
+        let row = sqlx::query(
+            "SELECT id, title, text FROM artifacts
+              WHERE status = 'active' AND superseded_by IS NULL
+              ORDER BY RANDOM() LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| (r.get("id"), r.get("title"), r.get("text"))))
+    }
+
     /// Every artifact that currently has a profile.
     ///
     /// What the sweep needs in order to *clear* one: an artifact whose every
@@ -145,15 +170,16 @@ impl Store {
         for c in clusters {
             sqlx::query(
                 "INSERT INTO context_clusters
-                     (scope, artifact_id, slot, centroid, weight, last_at,
-                      encoder_version, representative)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                     (scope, artifact_id, slot, centroid, weight, events,
+                      last_at, encoder_version, representative)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&c.scope)
             .bind(artifact_id)
             .bind(c.slot)
             .bind(vec_to_blob(&c.centroid))
             .bind(c.weight)
+            .bind(c.events)
             .bind(c.last_at)
             .bind(c.encoder_version)
             .bind(&c.representative)
@@ -183,7 +209,7 @@ impl Store {
             .collect::<Vec<_>>()
             .join(",");
         let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
-            "SELECT scope, artifact_id, slot, centroid, weight, last_at,
+            "SELECT scope, artifact_id, slot, centroid, weight, events, last_at,
                     encoder_version, representative
                FROM context_clusters
               WHERE artifact_id IN ({holes})
@@ -203,6 +229,7 @@ impl Store {
                     slot: r.get("slot"),
                     centroid: blob_to_vec(&r.get::<Vec<u8>, _>("centroid")),
                     weight: r.get("weight"),
+                    events: r.get("events"),
                     last_at: r.get("last_at"),
                     encoder_version: r.get("encoder_version"),
                     representative: r.get("representative"),
@@ -381,6 +408,7 @@ mod tests {
             slot,
             centroid: vec![1.0, 0.0],
             weight,
+            events: 3,
             last_at: 1_000,
             encoder_version: 1,
             representative: r#"{"at":1000,"bundle":{}}"#.into(),

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -788,15 +788,74 @@ impl Store {
         let a: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM ask_events")
             .fetch_one(&self.pool)
             .await?;
-        let i: Option<i64> = sqlx::query_scalar("SELECT MAX(at) FROM interaction_events")
-            .fetch_one(&self.pool)
-            .await?;
+        // `recommended_shown` is excluded for the same reason the judge door is:
+        // it is not a session. That row is written on every page view — it is
+        // the base talking to itself, not a person doing something — so
+        // counting it keeps the base looking busy for as long as a tab is open,
+        // and the sweep that waits for quiet then never runs at all.
+        //
+        // `recommended_open` is not excluded. Taking the offer is a real act.
+        let i: Option<i64> = sqlx::query_scalar(
+            "SELECT MAX(at) FROM interaction_events WHERE kind <> 'recommended_shown'",
+        )
+        .fetch_one(&self.pool)
+        .await?;
         Ok([s, a, i].into_iter().flatten().max())
     }
 }
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn an_offer_nobody_asked_for_does_not_keep_the_base_looking_busy() {
+        // The pursuit sweep waits for quiet, and `recommended_shown` is written
+        // on every page view — the base talking to itself, not a person doing
+        // something. Counted, it would keep the base looking active for as long
+        // as a tab is open and the sweep would never run. This is the judge
+        // door's bug, one table over.
+        let store = Store::memory().await.unwrap();
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        let aid = store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "x".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id;
+
+        store
+            .record_interaction(&aid, "opened", None, Some("me"), 1_000)
+            .await
+            .unwrap();
+        store
+            .record_recommendation(&aid, "recommended_shown", "{}", Some("me"), 9_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.newest_event_at().await.unwrap(),
+            Some(1_000),
+            "the offer does not count as activity"
+        );
+
+        // Taking it does. That is a person doing something.
+        store
+            .record_recommendation(&aid, "recommended_open", "{}", Some("me"), 9_500)
+            .await
+            .unwrap();
+        assert_eq!(store.newest_event_at().await.unwrap(), Some(9_500));
+    }
     use super::*;
 
     fn ev(query: &str, door: Door) -> NewEvent {

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -64,13 +64,19 @@ pub enum Stage {
     /// arms judgements, it is not one — and local, since the call belongs to
     /// the units it arms.
     ArmDedupe,
+    /// The periodic context sweep: reads the interaction log, agglomerates the
+    /// situations each artifact was opened in, and writes the surviving
+    /// centroids to the vector store. Local work and no call — the whole point
+    /// of this faculty is that the learning is a sweep and the read is one
+    /// vector query.
+    Context,
 }
 
 impl Stage {
     /// Every stage there is. Written out rather than derived, and the compiler
     /// is no help here — a stage left out of this list is not an error, it is a
     /// stage the class backfill silently never sees.
-    pub const ALL: [Stage; 16] = [
+    pub const ALL: [Stage; 17] = [
         Stage::Synthesize,
         Stage::Enrich,
         Stage::SegmentWindow,
@@ -87,6 +93,7 @@ impl Stage {
         Stage::Generate,
         Stage::Retention,
         Stage::ArmDedupe,
+        Stage::Context,
     ];
 
     pub fn as_str(&self) -> &'static str {
@@ -107,6 +114,7 @@ impl Stage {
             Stage::Generate => "generate",
             Stage::Retention => "retention",
             Stage::ArmDedupe => "arm_dedupe",
+            Stage::Context => "context",
         }
     }
     /// Is someone waiting on this? `0` foreground, `1` background.
@@ -139,7 +147,8 @@ impl Stage {
             | Stage::Pursuit
             | Stage::Generate
             | Stage::Retention
-            | Stage::ArmDedupe => 1,
+            | Stage::ArmDedupe
+            | Stage::Context => 1,
         }
     }
 
@@ -161,6 +170,7 @@ impl Stage {
             "generate" => Some(Stage::Generate),
             "retention" => Some(Stage::Retention),
             "arm_dedupe" => Some(Stage::ArmDedupe),
+            "context" => Some(Stage::Context),
             _ => None,
         }
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,6 +2,7 @@ pub mod artifacts;
 pub mod asks;
 pub mod attachments;
 pub mod auth;
+pub mod context;
 pub mod corpora;
 pub mod feedback;
 pub mod gaps;

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -115,6 +115,38 @@ impl Store {
         Ok(())
     }
 
+    /// What this base offered, and whether it was taken.
+    ///
+    /// `kind` is `recommended_shown` or `recommended_open`. Both live in
+    /// `interaction_events` because both are things that happened after a page
+    /// rendered — but neither counts as an ordinary open: the context sweep
+    /// reads `recommended_open` at `recommend.self_weight` and ignores
+    /// `recommended_shown` entirely, and the pursuit sweep skips the latter too.
+    ///
+    /// `detail` carries the rung and the winning cluster as JSON, which is what
+    /// makes the Ops hit rate a breakdown rather than one number.
+    pub async fn record_recommendation(
+        &self,
+        artifact_id: &str,
+        kind: &str,
+        detail: &str,
+        scope: Option<&str>,
+        at: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO interaction_events (artifact_id, kind, detail, scope, at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(artifact_id)
+        .bind(kind)
+        .bind(detail)
+        .bind(scope)
+        .bind(at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Interactions with `from < at <= to`, oldest first.
     pub async fn interactions_between(&self, from: i64, to: i64) -> Result<Vec<Interaction>> {
         let rows = sqlx::query(

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -54,6 +54,14 @@ pub struct Pursuit {
     pub artifact_id: Option<String>,
 }
 
+/// Shown against clicked, for one rung of the ladder.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OfferRate {
+    pub rung: String,
+    pub shown: i64,
+    pub opened: i64,
+}
+
 fn row_to_pursuit(r: &sqlx::sqlite::SqliteRow) -> Pursuit {
     Pursuit {
         id: r.get("id"),
@@ -145,6 +153,38 @@ impl Store {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// What was offered and what was taken, by rung, since `since`.
+    ///
+    /// The only number that can later settle whether the block weights are
+    /// right. They are chosen, not measured, and fitting them before this data
+    /// exists would be guessing with extra steps — so this is the instrument,
+    /// and it goes on Ops, which is where mechanisms whose effect nobody can
+    /// otherwise see belong.
+    pub async fn offer_rates(&self, since: i64) -> Result<Vec<OfferRate>> {
+        let rows = sqlx::query(
+            "SELECT json_extract(detail, '$.rung') AS rung,
+                    SUM(kind = 'recommended_shown') AS shown,
+                    SUM(kind = 'recommended_open')  AS opened
+               FROM interaction_events
+              WHERE at >= ? AND kind IN ('recommended_shown', 'recommended_open')
+              GROUP BY rung
+              ORDER BY shown DESC, rung",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| OfferRate {
+                rung: r
+                    .get::<Option<String>, _>("rung")
+                    .unwrap_or_else(|| "unknown".into()),
+                shown: r.get("shown"),
+                opened: r.get("opened"),
+            })
+            .collect())
     }
 
     /// Interactions with `from < at <= to`, oldest first.

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -211,6 +211,28 @@ impl Store {
             .collect())
     }
 
+    /// Drop interactions past keeping.
+    ///
+    /// The table had no sweep at all, only the manual `purge_pursuits`, while
+    /// the situations it is read beside got `context::RETAIN_DAYS` from the
+    /// start. That was survivable while a row meant an open; it stopped being
+    /// so when the offer began writing a `recommended_shown` per page view, so
+    /// the table grew with browsing rather than with use — and the context
+    /// sweep reads the whole window into memory every six hours.
+    ///
+    /// The same window as the situations, and for the same reason: the sweep
+    /// pairs the two, and an interaction kept past the situation it happened in
+    /// profiles nothing. Nothing else reads further back — `offer_rates` asks
+    /// for a month, and the pursuit sweep works from a cursor.
+    pub async fn expire_interactions(&self, retain_days: i64) -> Result<u64> {
+        let cutoff = crate::store::now() - retain_days * 86_400;
+        Ok(sqlx::query("DELETE FROM interaction_events WHERE at < ?")
+            .bind(cutoff)
+            .execute(&self.pool)
+            .await?
+            .rows_affected())
+    }
+
     /// A new pursuit, `open`. Returns its id.
     ///
     /// Idempotent by identity rather than by insertion order: the id is the
@@ -361,6 +383,53 @@ mod tests {
         let got = s.interactions_between(0, 100).await.unwrap();
         assert_eq!(got[2].kind, "dwell");
         assert_eq!(got[2].detail.as_deref(), Some("45"));
+    }
+
+    #[tokio::test]
+    async fn interactions_past_the_window_are_dropped_and_the_rest_are_kept() {
+        // The table had no sweep of any kind. That was survivable while a row
+        // meant somebody opened something; it stopped being so when the offer
+        // began writing a `recommended_shown` per search-page view, because the
+        // context sweep reads the whole window into memory every six hours and
+        // the window had no end.
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let a = s
+            .insert_artifacts(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let now = crate::store::now();
+        let retain = crate::store::context::RETAIN_DAYS;
+        let old = now - (retain + 1) * 86_400;
+        let recent = now - 86_400;
+        s.record_interaction(&a, "opened", None, Some("u1"), old)
+            .await
+            .unwrap();
+        s.record_recommendation(&a, "recommended_shown", "{}", Some("u1"), old)
+            .await
+            .unwrap();
+        s.record_interaction(&a, "opened", None, Some("u1"), recent)
+            .await
+            .unwrap();
+
+        assert_eq!(s.expire_interactions(retain).await.unwrap(), 2);
+        let got = s.interactions_between(0, now + 1).await.unwrap();
+        assert_eq!(got.len(), 1, "{got:?}");
+        assert_eq!(got[0].at, recent);
     }
 
     #[tokio::test]

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -524,6 +524,11 @@ CREATE TABLE IF NOT EXISTS context_clusters (
   slot            INTEGER NOT NULL,
   centroid        BLOB NOT NULL,
   weight          REAL NOT NULL,
+  -- How many events this cluster was built from, undecayed. `weight` answers
+  -- "how much does this still count", which is the right question for ranking
+  -- and the wrong one for the line under the offer: nobody can read 1.9 and
+  -- know it means twice. This is what the wording says out loud.
+  events          INTEGER NOT NULL DEFAULT 0,
   last_at         INTEGER NOT NULL,
   -- What layout `centroid` was written under. A reader that does not recognise
   -- it skips the cluster rather than explaining a hit with the wrong blocks.

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -98,6 +98,12 @@ CREATE TABLE IF NOT EXISTS artifacts (
   -- Bumped on every edit. An embed job carries the revision it read, so a
   -- chunk edited mid-embed is not reported as indexed.
   embed_rev        INTEGER NOT NULL DEFAULT 0,
+  -- Bumped in the same UPDATE that bumps `embed_rev`. Unrelated to
+  -- recommendation, and the one question the base could not previously answer
+  -- about itself: when did this artifact last change. `created_at` answers when
+  -- it arrived, and `last_verified_at` answers when someone vouched for it;
+  -- neither says whether the text on screen is the text that was captured.
+  updated_at       INTEGER NOT NULL DEFAULT 0,
   -- Which window of the corpus produced it. Artifacts are replaced per
   -- window, so a retry of one window cannot disturb the others.
   segment_idx      INTEGER,

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -481,6 +481,61 @@ CREATE TABLE IF NOT EXISTS interaction_events (
 );
 CREATE INDEX IF NOT EXISTS idx_interactions_at ON interaction_events(at);
 
+-- ── The situation a page view happened in ────────────────────────────────────
+-- Joined to `search_events` and `interaction_events` through `scope` and `at`,
+-- never through a stored id — the same rule `interaction_events` states just
+-- above for pursuits. The clustering decides what belongs together, and
+-- re-clustering never has to rewrite these.
+CREATE TABLE IF NOT EXISTS context_events (
+  id          INTEGER PRIMARY KEY,
+  scope       TEXT,
+  at          INTEGER NOT NULL,
+  -- The whole bundle as received, including fields the encoder ignores. That
+  -- is what makes a new block cheap: a reindex plus a sweep, rather than the
+  -- loss of every situation recorded before it existed.
+  bundle      TEXT NOT NULL,
+  -- Hash over the stable fields only: platform, UA family, screen dimensions,
+  -- hardwareConcurrency, deviceMemory, language. Not canvas, WebGL or fonts —
+  -- those are what identify a device across a population, and here the
+  -- population is one authenticated person, so they are constant and say
+  -- nothing about *which situation* this is. They are also randomised per
+  -- session and origin by a hardened browser, so every day would look like a
+  -- new device.
+  device_key  TEXT,
+  -- Denormalised because the sweep reads them on every row.
+  local_hour  INTEGER,
+  weekday     INTEGER,
+  tz          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_context_scope_at ON context_events(scope, at);
+
+-- The situations one artifact is opened in, agglomerated. The centroids
+-- themselves live in the vector store as the `ctx` multivector; this is the
+-- bookkeeping, for two reasons: Qdrant holds numbers and cannot produce a
+-- reason, and this table survives a `--reindex` while the vectors are rewritten.
+CREATE TABLE IF NOT EXISTS context_clusters (
+  id              INTEGER PRIMARY KEY,
+  scope           TEXT,
+  artifact_id     TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  -- Position of this centroid within the point's `ctx` multivector. Unique per
+  -- artifact and NOT per (scope, artifact): the multivector is one array on one
+  -- point, shared by every scope that has opened this artifact, so a slot
+  -- numbered per scope would have two owners writing index 0.
+  slot            INTEGER NOT NULL,
+  centroid        BLOB NOT NULL,
+  weight          REAL NOT NULL,
+  last_at         INTEGER NOT NULL,
+  -- What layout `centroid` was written under. A reader that does not recognise
+  -- it skips the cluster rather than explaining a hit with the wrong blocks.
+  encoder_version INTEGER NOT NULL,
+  -- The member nearest the centroid, as `{"at": <unix>, "bundle": {…}}` — what
+  -- the display quotes. The stamp is carried with it because a bundle does not
+  -- contain one and the line says "like 08.08., 15:04".
+  representative  TEXT NOT NULL,
+  UNIQUE (artifact_id, slot)
+);
+CREATE INDEX IF NOT EXISTS idx_context_clusters_artifact ON context_clusters(artifact_id);
+
 -- A coherent thing that was wanted: its queries, and what came of it.
 CREATE TABLE IF NOT EXISTS pursuits (
   id           TEXT PRIMARY KEY,

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -11,12 +11,18 @@ use std::sync::RwLock;
 /// tested without running Qdrant.
 pub struct MemoryVectors {
     points: RwLock<HashMap<String, VectorPoint>>,
+    /// The `ctx` multivector per artifact, held apart from the point rather
+    /// than on it. A field on `VectorPoint` would put a context set in every
+    /// signature that carries a point — the embed job's, the reindex's — for
+    /// the sake of one caller that writes it and one that reads it.
+    ctx: RwLock<HashMap<String, Vec<Vec<f32>>>>,
 }
 
 impl MemoryVectors {
     pub fn new() -> Self {
         Self {
             points: RwLock::new(HashMap::new()),
+            ctx: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -398,17 +404,82 @@ impl VectorStore for MemoryVectors {
         Ok(hits)
     }
 
+    async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()> {
+        let mut w = self.ctx.write().unwrap();
+        if vectors.is_empty() {
+            w.remove(artifact_id);
+        } else {
+            w.insert(artifact_id.to_string(), vectors);
+        }
+        Ok(())
+    }
+
+    async fn context_query(
+        &self,
+        vector: &[f32],
+        limit: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>> {
+        let points = self.points.read().unwrap();
+        let ctx = self.ctx.read().unwrap();
+        let mut hits: Vec<SearchHit> = ctx
+            .iter()
+            // An artifact with a set but no point cannot be offered: there is
+            // no payload to render it from. That is the sweep having run
+            // against an artifact whose embedding has not, not an error.
+            .filter_map(|(id, set)| points.get(id).map(|p| (p, set)))
+            .filter(|(p, _)| {
+                let status = status_of(&p.payload);
+                (filter.include_superseded || status != ArtifactStatus::Superseded)
+                    && (filter.include_deprecated || status != ArtifactStatus::Deprecated)
+            })
+            .map(|(p, set)| SearchHit {
+                payload: p.payload.clone(),
+                // `max_sim`: the best of the artifact's situations, which is
+                // what makes a set worth more than a mean.
+                score: set
+                    .iter()
+                    .map(|c| cosine(vector, c))
+                    .fold(f32::NEG_INFINITY, f32::max),
+                // Not a query-to-document similarity, and calling it one would
+                // invite it into a ranking it has no business in.
+                similarity: None,
+            })
+            .collect();
+        // Ties break on the id, so a HashMap's iteration order never decides
+        // what is offered.
+        hits.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.payload.artifact_id.cmp(&b.payload.artifact_id))
+        });
+        hits.truncate(limit);
+        Ok(hits)
+    }
+
     async fn delete_artifacts(&self, artifact_ids: &[String]) -> Result<()> {
         let mut w = self.points.write().unwrap();
+        // The context set goes with the point. A set outliving its payload
+        // would keep answering `context_query` with an artifact that is gone.
+        let mut c = self.ctx.write().unwrap();
         for id in artifact_ids {
             w.remove(id);
+            c.remove(id);
         }
         Ok(())
     }
 
     async fn delete_by_corpus(&self, corpus_id: &str) -> Result<()> {
         let mut w = self.points.write().unwrap();
-        w.retain(|_, p| p.payload.corpus_id != corpus_id);
+        let mut c = self.ctx.write().unwrap();
+        w.retain(|id, p| {
+            let keep = p.payload.corpus_id != corpus_id;
+            if !keep {
+                c.remove(id);
+            }
+            keep
+        });
         Ok(())
     }
 
@@ -443,6 +514,170 @@ mod tests {
                 provenance: None,
             },
         }
+    }
+
+    /// Superseded and deprecated included, so a test asserting the ordinary
+    /// path is not silently asserting the filter instead.
+    fn wide() -> SearchFilter {
+        SearchFilter {
+            include_superseded: true,
+            include_deprecated: true,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn an_artifact_matches_on_its_nearest_situation_not_its_average() {
+        // Friday afternoon *and* Monday morning. Their mean is a situation that
+        // never happened, and a store that scored the mean would answer neither.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", "s1", vec![1.0, 1.0], &[], "procedure")])
+            .await
+            .unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0], vec![0.0, 1.0]])
+            .await
+            .unwrap();
+
+        let friday = v.context_query(&[1.0, 0.0], 5, &wide()).await.unwrap();
+        assert_eq!(friday.len(), 1);
+        assert!((friday[0].score - 1.0).abs() < 1e-5);
+
+        let monday = v.context_query(&[0.0, 1.0], 5, &wide()).await.unwrap();
+        assert!((monday[0].score - 1.0).abs() < 1e-5);
+    }
+
+    #[tokio::test]
+    async fn an_artifact_with_no_situations_is_not_a_candidate() {
+        // The candidate set is "anything ever opened", and that is expressed by
+        // the absence of a set rather than by a filter.
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("a", "s1", vec![1.0, 0.0], &[], "procedure"),
+            point("b", "s1", vec![1.0, 0.0], &[], "procedure"),
+        ])
+        .await
+        .unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+
+        let out = v.context_query(&[1.0, 0.0], 5, &wide()).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].payload.artifact_id, "a");
+    }
+
+    #[tokio::test]
+    async fn an_empty_write_removes_the_set_and_leaves_the_point() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", "s1", vec![1.0, 0.0], &[], "procedure")])
+            .await
+            .unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+        v.set_context_vectors("a", vec![]).await.unwrap();
+
+        assert!(
+            v.context_query(&[1.0, 0.0], 5, &wide())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(v.count().await.unwrap(), 1, "the point is still there");
+    }
+
+    #[tokio::test]
+    async fn a_hidden_artifact_is_never_offered() {
+        // The same rule search obeys: superseded and deprecated are out.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", "s1", vec![1.0, 0.0], &[], "procedure")])
+            .await
+            .unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+        v.set_lifecycle("a", ArtifactStatus::Superseded, Some("b"))
+            .await
+            .unwrap();
+
+        let out = v
+            .context_query(&[1.0, 0.0], 5, &SearchFilter::default())
+            .await
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn results_come_back_best_first_and_capped() {
+        let v = MemoryVectors::new();
+        v.upsert(vec![
+            point("near", "s1", vec![1.0, 0.0], &[], "procedure"),
+            point("far", "s1", vec![1.0, 0.0], &[], "procedure"),
+        ])
+        .await
+        .unwrap();
+        v.set_context_vectors("near", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+        v.set_context_vectors("far", vec![vec![0.2, 1.0]])
+            .await
+            .unwrap();
+
+        let out = v.context_query(&[1.0, 0.0], 1, &wide()).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].payload.artifact_id, "near");
+    }
+
+    #[tokio::test]
+    async fn a_set_on_an_artifact_with_no_point_is_not_an_error() {
+        // An artifact whose embedding never ran has nothing to attach a set to.
+        // The sweep must not fail over one.
+        let v = MemoryVectors::new();
+        v.set_context_vectors("nobody", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+        assert!(
+            v.context_query(&[1.0, 0.0], 5, &wide())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_an_artifact_takes_its_situations_with_it() {
+        // A set outliving its point would keep answering `context_query` with
+        // a payload that is gone.
+        let v = MemoryVectors::new();
+        v.upsert(vec![point("a", "s1", vec![1.0, 0.0], &[], "procedure")])
+            .await
+            .unwrap();
+        v.set_context_vectors("a", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+
+        v.delete_artifacts(&["a".to_string()]).await.unwrap();
+        assert!(
+            v.context_query(&[1.0, 0.0], 5, &wide())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // And the same when a whole corpus goes.
+        v.upsert(vec![point("b", "s2", vec![1.0, 0.0], &[], "procedure")])
+            .await
+            .unwrap();
+        v.set_context_vectors("b", vec![vec![1.0, 0.0]])
+            .await
+            .unwrap();
+        v.delete_by_corpus("s2").await.unwrap();
+        assert!(
+            v.context_query(&[1.0, 0.0], 5, &wide())
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -318,6 +318,42 @@ pub trait VectorStore: Send + Sync {
     /// no embedding call, because the query is a point that is already in the
     /// index. The artifact itself is never among its own neighbours.
     async fn neighbours(&self, artifact_id: &str, limit: usize) -> Result<Vec<SearchHit>>;
+    /// Replace this artifact's set of context centroids — the `ctx`
+    /// multivector, scored with `max_sim`.
+    ///
+    /// A **vector** write, never a point write. `upsert` replaces the whole
+    /// payload, and a writer that does not know when the artifact was last
+    /// shown would clear `last_seen_at` and `status` with it — which puts every
+    /// artifact the sweep hid straight back into search. See `qdrant.rs`'s
+    /// `upsert` for the same hazard stated where it bites.
+    ///
+    /// An empty `vectors` removes the set. That is the ordinary case for an
+    /// artifact whose every cluster has decayed below `min_weight`, not an
+    /// error, and it must leave the point and its dense vector alone.
+    ///
+    /// An artifact with no point is not a failure: its embedding may never have
+    /// run. There is nothing to attach a set to, and nothing to complain about.
+    async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()>;
+    /// The artifacts whose learned situations most resemble this one.
+    ///
+    /// `max_sim` over each artifact's set: an artifact matches if *any* of its
+    /// situations does, which is the whole reason the profile is a set rather
+    /// than a mean. A thing looked up on Friday afternoons and occasionally on
+    /// Monday mornings must match both, and their average is a situation that
+    /// never happened.
+    ///
+    /// Points carrying no set are absent from the answer, so the candidates are
+    /// "anything ever opened" without a filter saying so.
+    ///
+    /// `score` is the `max_sim`. `similarity` is `None`: this is not a query
+    /// vector against a document vector, and calling it a similarity would
+    /// invite it into a ranking it has no business in.
+    async fn context_query(
+        &self,
+        vector: &[f32],
+        limit: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>>;
     async fn delete_artifacts(&self, artifact_ids: &[String]) -> Result<()>;
     async fn delete_by_corpus(&self, corpus_id: &str) -> Result<()>;
     async fn count(&self) -> Result<u64>;

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -51,6 +51,12 @@ const READY_BACKOFF: Duration = Duration::from_millis(200);
 /// A chunk carrying this tag is boosted past the decay curve. A tag rather than
 /// a column: `PATCH /api/v1/artifacts/{id}` already edits tags without
 /// re-embedding, and the payload index that makes it filterable already exists.
+/// The context multivector: one element per learned situation, scored with
+/// `max_sim`. Not the multivector the roadmap cut — that was ColBERT-style
+/// late-interaction reranking, one reduced-width vector per *token* and
+/// thousands per artifact. This is two to five per artifact.
+pub const CTX: &str = "ctx";
+
 pub const PINNED_TAG: &str = "pinned";
 
 const SECONDS_PER_DAY: u64 = 86_400;
@@ -209,7 +215,19 @@ fn verified_payload(at: i64, reset_hits: bool) -> Value {
 /// The schema every generation is created with.
 fn collection_body(dim: usize) -> Value {
     json!({
-        "vectors": { DENSE: { "size": dim, "distance": "Cosine" } },
+        "vectors": {
+            DENSE: { "size": dim, "distance": "Cosine" },
+            CTX: {
+                "size": crate::core::context::CTX_DIM,
+                "distance": "Cosine",
+                "multivector_config": { "comparator": "max_sim" },
+                // No index, an exact scan. The candidates are only artifacts
+                // ever opened, at 53 dimensions, and an HNSW graph would be
+                // rebuilt on every sweep write to beat a scan it cannot beat at
+                // that size.
+                "hnsw_config": { "m": 0 },
+            },
+        },
         "sparse_vectors": { SPARSE: { "modifier": "idf" } },
     })
 }
@@ -312,6 +330,32 @@ fn dense_of(vector: &Value) -> Option<&Value> {
         Value::Object(m) => m.get(DENSE),
         _ => None,
     }
+}
+
+/// A stored point's context set, when it is still readable under the running
+/// encoder.
+///
+/// `None` covers three cases that a rebuild treats alike: no set at all, a
+/// pre-alias point with a single unnamed vector, and a set written under an
+/// older layout. The last is why the width is checked rather than trusted — a
+/// changed `BLOCKS` changes `CTX_DIM`, and copying the old numbers into the new
+/// space would give every artifact a profile assembled from the wrong blocks.
+/// Discarded, and the next sweep rebuilds from the raw bundles.
+fn ctx_of(vector: &Value) -> Option<Vec<Vec<f32>>> {
+    let set = vector.as_object()?.get(CTX)?.as_array()?;
+    if set.is_empty() {
+        return None;
+    }
+    set.iter()
+        .map(|e| {
+            let row: Vec<f32> = e
+                .as_array()?
+                .iter()
+                .map(|x| x.as_f64().map(|f| f as f32))
+                .collect::<Option<_>>()?;
+            (row.len() == crate::core::context::CTX_DIM).then_some(row)
+        })
+        .collect()
 }
 
 /// Every Qdrant response is wrapped in this. `result` is absent on failures,
@@ -854,6 +898,13 @@ impl QdrantVectors {
                 let mut vector = json!({ DENSE: dense });
                 if let Some(sp) = sparse_body(&sparse_of_payload(&p.payload)) {
                     vector[SPARSE] = sp;
+                }
+                // Copied when the dimension matches, skipped when it does not.
+                // No embedding call in either case — a context vector is
+                // assembled from a bundle, and the bundles are all still in
+                // `context_events`.
+                if let Some(set) = ctx_of(&p.vector) {
+                    vector[CTX] = json!(set);
                 }
                 batch.push(json!({
                     "id": p.id,
@@ -1732,6 +1783,66 @@ impl VectorStore for QdrantVectors {
         Ok(hits_of(res))
     }
 
+    async fn set_context_vectors(&self, artifact_id: &str, vectors: Vec<Vec<f32>>) -> Result<()> {
+        let id = point_uuid(artifact_id);
+        // `points/vectors`, never `upsert`. A point write replaces the entire
+        // payload — see the comment on `upsert` — and clearing `status` puts
+        // every artifact the sweep hid straight back into search, on every
+        // sweep run. This endpoint does not touch payload at all.
+        let (path, body) = match vectors.is_empty() {
+            true => (
+                format!(
+                    "/collections/{}/points/vectors/delete?wait=true",
+                    self.alias
+                ),
+                json!({ "points": [id], "vector": [CTX] }),
+            ),
+            false => (
+                format!("/collections/{}/points/vectors?wait=true", self.alias),
+                json!({ "points": [{ "id": id, "vector": { CTX: vectors } }] }),
+            ),
+        };
+        // Absent is not a failure, for the same reason `set_lifecycle` gives:
+        // an artifact whose embedding never ran has no point, and a sweep that
+        // errored on one would take the whole run down over an artifact that
+        // has nothing to attach a set to.
+        let _: Option<Value> = self
+            .call_absent_point_as_none(Method::POST, &path, Some(body))
+            .await?;
+        Ok(())
+    }
+
+    async fn context_query(
+        &self,
+        vector: &[f32],
+        limit: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>> {
+        let mut body = json!({
+            "query": vector,
+            "using": CTX,
+            "limit": limit,
+            "with_payload": true,
+        });
+        if let Some(f) = build_filter(filter) {
+            body["filter"] = f;
+        }
+        // No recency stage and no pinning over this. Those exist to reorder a
+        // ranked list of answers to a question; there is no question here, and
+        // an artifact captured today is not a better answer to "it is Friday
+        // afternoon" than one captured last year.
+        let res: QueryResult = self
+            .call(
+                Method::POST,
+                &format!("/collections/{}/points/query", self.alias),
+                Some(body),
+            )
+            .await?;
+        // `hits_of` leaves `similarity` unset, which is correct here: `max_sim`
+        // is not a query-to-document similarity.
+        Ok(hits_of(res))
+    }
+
     async fn delete_artifacts(&self, artifact_ids: &[String]) -> Result<()> {
         if artifact_ids.is_empty() {
             return Ok(());
@@ -1837,6 +1948,63 @@ impl VectorStore for QdrantVectors {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_collection_carries_a_context_multivector() {
+        let body = collection_body(768);
+        assert_eq!(body["vectors"][CTX]["size"], crate::core::context::CTX_DIM);
+        assert_eq!(body["vectors"][CTX]["distance"], "Cosine");
+        assert_eq!(
+            body["vectors"][CTX]["multivector_config"]["comparator"],
+            "max_sim"
+        );
+        // No HNSW, an exact scan. Right here rather than thrifty: the
+        // candidates are only artifacts ever opened — hundreds to a few
+        // thousand at 53 dimensions — and an index would be rebuilt on every
+        // sweep write to beat a scan it cannot beat at that size.
+        assert_eq!(body["vectors"][CTX]["hnsw_config"]["m"], 0);
+        // And nothing else moved.
+        assert_eq!(body["vectors"][DENSE]["size"], 768);
+        assert_eq!(body["sparse_vectors"][SPARSE]["modifier"], "idf");
+    }
+
+    #[test]
+    fn a_context_set_is_copied_by_a_rebuild_when_it_still_fits() {
+        let dim = crate::core::context::CTX_DIM;
+        let stored = json!({ DENSE: [1.0, 2.0], CTX: [vec![0.5; dim], vec![0.25; dim]] });
+        let copied = ctx_of(&stored).unwrap();
+        assert_eq!(copied.len(), 2);
+        assert_eq!(copied[0].len(), dim);
+    }
+
+    #[test]
+    fn a_context_set_from_an_older_layout_is_dropped_rather_than_copied() {
+        // A changed encoder layout changes CTX_DIM. The old sets are discarded
+        // and the next sweep rebuilds them from the raw bundles in
+        // `context_events` — which costs no embedding call either way.
+        let stored = json!({ DENSE: [1.0, 2.0], CTX: [[0.5, 0.5, 0.5]] });
+        assert!(ctx_of(&stored).is_none());
+    }
+
+    #[test]
+    fn a_point_with_no_context_set_reindexes_without_one() {
+        assert!(ctx_of(&json!({ DENSE: [1.0, 2.0] })).is_none());
+        // A pre-alias point with one unnamed vector.
+        assert!(ctx_of(&json!([1.0, 2.0])).is_none());
+        // And an empty set is the same as none, not a set of nothing.
+        assert!(ctx_of(&json!({ DENSE: [1.0], CTX: [] })).is_none());
+    }
+
+    #[test]
+    fn the_offer_excludes_hidden_artifacts_by_must_not() {
+        // `must_not` rather than a positive match, for the reason `build_filter`
+        // gives: a point carrying no `status` key at all reads as active, and a
+        // positive clause would drop every hand-written one.
+        let f = build_filter(&SearchFilter::default()).unwrap();
+        assert!(f.get("must").is_none());
+        let not = f["must_not"].as_array().unwrap();
+        assert_eq!(not.len(), 2);
+    }
 
     #[tokio::test]
     async fn neighbours_reports_an_unreachable_store_rather_than_no_neighbours() {

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1795,6 +1795,14 @@ impl VectorStore for QdrantVectors {
         // swallowed, so the sweep wrote its clusters to SQLite, reported `ok`,
         // and left the index with no `ctx` set at all. Nothing but running it
         // against a real Qdrant would have caught that.
+        //
+        // The bodies do not match either. The update names its vectors under
+        // `vector`, singular, mapped by name; the delete takes `vectors`,
+        // plural, a list of the names to drop. Writing the update's spelling
+        // into the delete leaves the required field missing, and Qdrant answers
+        // 400 rather than ignoring it — which took the whole sweep down on the
+        // ordinary path, since every artifact decayed below `min_weight` is
+        // cleared through here.
         let (method, path, body) = match vectors.is_empty() {
             true => (
                 Method::POST,
@@ -1802,7 +1810,7 @@ impl VectorStore for QdrantVectors {
                     "/collections/{}/points/vectors/delete?wait=true",
                     self.alias
                 ),
-                json!({ "points": [id], "vector": [CTX] }),
+                json!({ "points": [id], "vectors": [CTX] }),
             ),
             false => (
                 Method::PUT,
@@ -2361,6 +2369,39 @@ mod tests {
         })
         .await
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn clearing_a_context_set_names_the_vector_the_way_the_delete_takes_it() {
+        // The update and the delete do not spell it the same way, and the
+        // difference is not cosmetic: `vectors` is required on the delete, so
+        // sending the update's `vector` leaves it missing and Qdrant answers
+        // 400 rather than ignoring the field it does not know. That is the
+        // ordinary path — every artifact whose profile decayed below
+        // `min_weight` is cleared through here — so the whole sweep died on it
+        // and the stale centroids stayed in the index, still being offered.
+        use wiremock::matchers::{body_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let id = "0192abcd-0000-7000-8000-000000000000";
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/collections/engram/points/vectors/delete"))
+            .and(body_json(
+                json!({ "points": [point_uuid(id)], "vectors": [CTX] }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "status": "completed" }, "status": "ok"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        against(&server)
+            .await
+            .set_context_vectors(id, Vec::new())
+            .await
+            .expect("an empty set is a delete, and the delete takes `vectors`");
     }
 
     #[tokio::test]

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1789,8 +1789,15 @@ impl VectorStore for QdrantVectors {
         // payload — see the comment on `upsert` — and clearing `status` puts
         // every artifact the sweep hid straight back into search, on every
         // sweep run. This endpoint does not touch payload at all.
-        let (path, body) = match vectors.is_empty() {
+        // Update is PUT, delete is POST. Not symmetrical, and not a guess: the
+        // update was written as POST first, and Qdrant 1.19 answered 404 —
+        // which `call_absent_point_as_none` then read as "no such point" and
+        // swallowed, so the sweep wrote its clusters to SQLite, reported `ok`,
+        // and left the index with no `ctx` set at all. Nothing but running it
+        // against a real Qdrant would have caught that.
+        let (method, path, body) = match vectors.is_empty() {
             true => (
+                Method::POST,
                 format!(
                     "/collections/{}/points/vectors/delete?wait=true",
                     self.alias
@@ -1798,6 +1805,7 @@ impl VectorStore for QdrantVectors {
                 json!({ "points": [id], "vector": [CTX] }),
             ),
             false => (
+                Method::PUT,
                 format!("/collections/{}/points/vectors?wait=true", self.alias),
                 json!({ "points": [{ "id": id, "vector": { CTX: vectors } }] }),
             ),
@@ -1806,9 +1814,17 @@ impl VectorStore for QdrantVectors {
         // an artifact whose embedding never ran has no point, and a sweep that
         // errored on one would take the whole run down over an artifact that
         // has nothing to attach a set to.
-        let _: Option<Value> = self
-            .call_absent_point_as_none(Method::POST, &path, Some(body))
-            .await?;
+        //
+        // `missing_point_only` rather than the broader helper: that one accepts
+        // any 404 on a live collection, which is exactly how a wrong verb read
+        // as a missing point. Here only Qdrant actually saying so counts.
+        let (status, text) = self.send(method, &path, Some(body)).await?;
+        if status == reqwest::StatusCode::NOT_FOUND && text.contains("No point with id") {
+            return Ok(());
+        }
+        if !status.is_success() {
+            return Err(Error::Vector(format!("{path}: {}", text.trim())));
+        }
         Ok(())
     }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1671,7 +1671,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn an_extension_search_records_its_own_door() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let (app, token, core) = app_from_core(core).await;
 
         let res = app
@@ -1796,7 +1796,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn a_client_cannot_claim_a_door_that_would_launder_its_query() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let (app, token, core) = app_from_core(core).await;
 
         // `ask` and `judge` are never captured, so naming one would be a way

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -221,7 +221,7 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     let progress_pct = (stats.judged * 100 / FIRST_SWEEP_AT.max(1)).min(100);
     Ok(HtmlTemplate(JudgeTemplate {
         // Read off the stats already in hand rather than counted again.
-        judge_pending: st.core.feedback.enabled.then_some(stats.pending),
+        judge_pending: st.core.learn.enabled.then_some(stats.pending),
         ask_enabled: crate::web::state::ask_enabled(&st),
         recall: format!("{:.2}", stats.recall_at_10),
         mrr: format!("{:.2}", stats.mrr),

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -101,7 +101,7 @@ pub fn ask_enabled(st: &AppState) -> bool {
 /// `count(*)`; a failure returns `None`, since a broken badge is not a reason to
 /// fail the page it sits on.
 pub async fn judge_pending(st: &AppState) -> Option<i64> {
-    if !st.core.feedback.enabled {
+    if !st.core.learn.enabled {
         return None;
     }
     match st.core.store.pending_count().await {

--- a/src/web/templates/_context.html
+++ b/src/web/templates/_context.html
@@ -1,4 +1,9 @@
-{# A `div` rather than a `p` for the reason line: `details` and `pre` are flow
+{# The reason line is absent entirely on the random card. A card drawn at
+   random explains nothing, and printing a rung name beside it would be the
+   area claiming a reason it does not have — which is how this becomes
+   furniture within a fortnight.
+
+   A `div` rather than a `p` for the reason line: `details` and `pre` are flow
    content, and a `p` may only hold phrasing content — so a browser closes the
    paragraph before the `details` and leaves a stray empty one behind, which is
    not the DOM the stylesheet is written against.
@@ -22,6 +27,7 @@
 <div id="context-offer" class="offer">
 {% if let Some(o) = offer %}
   <a class="offer-title" href="/ui/artifacts/{{ o.id }}{{ o.rec }}">{{ o.title }}</a>
+  {% if !o.rung.is_empty() %}
   <div class="muted offer-why">{{ o.rung }}{% if !o.blocks.is_empty() %} · {{ o.blocks }}{% endif %}{% if !o.when.is_empty() %} · like {{ o.when }}{% endif %}
     {# `serde_json` over the raw bundle plus the contribution numbers, inside a
        `<details>`. No formatting code, and it satisfies "the parameters must be
@@ -33,5 +39,6 @@
       <pre class="mono">{{ o.detail }}</pre>
     </details>
   </div>
+  {% endif %}
 {% endif %}
 </div>

--- a/src/web/templates/_context.html
+++ b/src/web/templates/_context.html
@@ -1,0 +1,32 @@
+{# The area under the search box. Fetched rather than rendered because the
+   bundle originates in the browser and the server does not have it at first
+   render — `search_page` puts a placeholder here with reserved height, and this
+   replaces it.
+
+   Three parts, all cheap: the rung name, which is one of four fixed strings;
+   the blocks that decided it, which are `&'static str` labels sorted by
+   contribution; and the representative event's stamp, which is one date format.
+   No sentences are generated anywhere — a new block in the encoder brings its
+   own label and needs no template written for it. Generated prose per block was
+   the first draft and was cut, because it coupled every new dimension to a
+   sentence somebody had to keep in step with it.
+
+   The id is kept on the answer as well as on the placeholder: app.js removes
+   this area on the first keystroke, and it needs something to remove whichever
+   of the two is on screen when that happens. #}
+<div id="context-offer" class="offer">
+{% if let Some(o) = offer %}
+  <a class="offer-title" href="/ui/artifacts/{{ o.id }}{{ o.rec }}">{{ o.title }}</a>
+  <p class="muted offer-why">{{ o.rung }}{% if !o.blocks.is_empty() %} · {{ o.blocks }}{% endif %}{% if !o.when.is_empty() %} · like {{ o.when }}{% endif %}
+    {# `serde_json` over the raw bundle plus the contribution numbers, inside a
+       `<details>`. No formatting code, and it satisfies "the parameters must be
+       visible" completely: whoever wants to know exactly, expands it. It is
+       also the answer to what is being collected — inspectable rather than
+       promised. #}
+    <details class="offer-detail">
+      <summary>Details</summary>
+      <pre class="mono">{{ o.detail }}</pre>
+    </details>
+  </p>
+{% endif %}
+</div>

--- a/src/web/templates/_context.html
+++ b/src/web/templates/_context.html
@@ -1,4 +1,9 @@
-{# The area under the search box. Fetched rather than rendered because the
+{# A `div` rather than a `p` for the reason line: `details` and `pre` are flow
+   content, and a `p` may only hold phrasing content — so a browser closes the
+   paragraph before the `details` and leaves a stray empty one behind, which is
+   not the DOM the stylesheet is written against.
+
+   The area under the search box. Fetched rather than rendered because the
    bundle originates in the browser and the server does not have it at first
    render — `search_page` puts a placeholder here with reserved height, and this
    replaces it.
@@ -17,7 +22,7 @@
 <div id="context-offer" class="offer">
 {% if let Some(o) = offer %}
   <a class="offer-title" href="/ui/artifacts/{{ o.id }}{{ o.rec }}">{{ o.title }}</a>
-  <p class="muted offer-why">{{ o.rung }}{% if !o.blocks.is_empty() %} · {{ o.blocks }}{% endif %}{% if !o.when.is_empty() %} · like {{ o.when }}{% endif %}
+  <div class="muted offer-why">{{ o.rung }}{% if !o.blocks.is_empty() %} · {{ o.blocks }}{% endif %}{% if !o.when.is_empty() %} · like {{ o.when }}{% endif %}
     {# `serde_json` over the raw bundle plus the contribution numbers, inside a
        `<details>`. No formatting code, and it satisfies "the parameters must be
        visible" completely: whoever wants to know exactly, expands it. It is
@@ -27,6 +32,6 @@
       <summary>Details</summary>
       <pre class="mono">{{ o.detail }}</pre>
     </details>
-  </p>
+  </div>
 {% endif %}
 </div>

--- a/src/web/templates/ops.html
+++ b/src/web/templates/ops.html
@@ -65,6 +65,25 @@
 {% endif %}
 {% endif %}
 
+{# Shown against clicked, by rung. The one number that can settle whether the
+   weights the recommender rests on are right — they are chosen, not measured,
+   and until this has data, fitting them would be guessing with extra steps.
+   `[sitting] prime` has sat at `false` for months because nobody measured it;
+   this is here so the same thing does not happen twice. #}
+{% if !offer_rates.is_empty() %}
+<h3>What was offered</h3>
+<p class="muted">The last thirty days. A weekly pattern needs weeks, so a rate
+  measured over a day would be a number nobody could act on.</p>
+<table class="grid">
+  <thead><tr><th>Rung</th><th>Shown</th><th>Opened</th></tr></thead>
+  <tbody>
+  {% for r in offer_rates %}
+    <tr><td>{{ r.rung }}</td><td>{{ r.shown }}</td><td>{{ r.opened }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 {% if !merged.is_empty() %}
 <h3>Merged</h3>
 <p class="muted">

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -93,6 +93,20 @@
   {% endif %}
 </form>
 
+{# Reserved height, so the answer landing does not push the hint and the chips
+   down a page that has already been read. The offer is for the state "no intent
+   expressed yet" — app.js removes it on the first keystroke, and it does not
+   come back when the box is cleared: once there is an intent the offer is
+   wrong, and reappearing because someone corrected a typo is flicker. It
+   returns on the next page view.
+
+   Without JavaScript the area stays empty, which is the honest failure: the
+   bundle is the browser's to send. #}
+{% if recommend %}
+<div id="context-offer" class="offer" hx-post="/ui/context" hx-trigger="load"
+     hx-vals='js:{bundle: engramContext()}' hx-swap="outerHTML"></div>
+{% endif %}
+
 {# Taught once. A shortcut nobody is told about is a shortcut nobody uses, and
    a hint that cannot be dismissed is a banner. Hidden until app.js decides
    there is a keyboard to use it with. #}

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -101,8 +101,16 @@
    returns on the next page view.
 
    Without JavaScript the area stays empty, which is the honest failure: the
-   bundle is the browser's to send. #}
-{% if recommend %}
+   bundle is the browser's to send.
+
+   `q.is_empty()` as well as the switch, because "no intent expressed yet" is a
+   claim about the page and not about the switch. A deep link, a reload or a
+   back-navigation renders the box with its query restored and its results
+   below — app.js only removes the area on a *keystroke*, which never comes on
+   any of those, so the offer sat beside real results and wrote a
+   `recommended_shown` row per results page view, inflating the denominator of
+   the one hit rate this feature is measured by. #}
+{% if recommend && q.is_empty() %}
 <div id="context-offer" class="offer" hx-post="/ui/context" hx-trigger="load"
      hx-vals='js:{bundle: engramContext()}' hx-swap="outerHTML"></div>
 {% endif %}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1114,7 +1114,7 @@ async fn capture_page(
     // Read, never computed: the page shows what the sweep grouped and named,
     // and whatever has been judged since sits under itself until the next
     // pass. Nothing here embeds or calls a model.
-    let (gaps, loose) = if st.core.feedback.enabled {
+    let (gaps, loose) = if st.core.learn.enabled {
         let (rows, loose) = st
             .core
             .store
@@ -1375,10 +1375,15 @@ fn offer_view(o: crate::core::recommend::Offer) -> OfferView {
         // The rung rides on the link because that is the only place it still
         // exists: the offer was computed on a previous request, and Ops's
         // breakdown is a breakdown only if the click knows which rung it came
-        // from.
+        // from. Every rung, including the floor: the random card has no cluster
+        // and so no slot, and hanging the whole marker off `slot` left it
+        // linking like an ordinary result — its opens counted as opens, so its
+        // hit rate read zero for ever and the card it drew was fed back into
+        // the profile at full weight. `rec` is the slot when there is one;
+        // `rung` is always there.
         rec: match o.slot {
             Some(s) => format!("?rec={s}&rung={}", o.rung.as_str()),
-            None => String::new(),
+            None => format!("?rung={}", o.rung.as_str()),
         },
         id: o.artifact_id,
         title: o.title,
@@ -2523,11 +2528,11 @@ async fn settings(State(st): State<AppState>, _id: Identity) -> Result<Response>
         judge_pending: crate::web::state::judge_pending(&st).await,
         ask_enabled: crate::web::state::ask_enabled(&st),
         tokens: token_rows(&st).await?,
-        feedback: match st.core.feedback.enabled {
+        feedback: match st.core.learn.enabled {
             true => Some(st.core.store.feedback_stats().await?),
             false => None,
         },
-        asks: match st.core.feedback.enabled {
+        asks: match st.core.learn.enabled {
             true => Some(st.core.store.ask_stats().await?),
             false => None,
         },
@@ -2654,7 +2659,7 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             sources,
         });
     }
-    let pursuit_enabled = st.core.pursuit.enabled;
+    let pursuit_enabled = st.core.learn.enabled;
     let recent = match pursuit_enabled {
         true => st.core.store.recent_pursuits(50).await?,
         false => Vec::new(),
@@ -3543,9 +3548,9 @@ pub(crate) async fn build_artifact_detail(
         .collect();
     // Unreadable links are not a missing pane, for the same reason a missing
     // neighbour list is not: this layer can only ever add. And gated on
-    // `associating()`, not just `associate.enabled`: a base that learned
-    // links and then had the feature switched off must stop rendering them,
-    // the same as every other associative surface.
+    // And gated on `associating()`: a base that learned links and then had
+    // `[learn]` switched off must stop rendering them, the same as every other
+    // associative surface.
     let anchor = vec![c.id.clone()];
     let seen_together_links = if core.associating() {
         match core
@@ -3673,13 +3678,15 @@ struct ArtifactViewParams {
     /// a continuation — when the link came from another artifact's page.
     #[serde(default)]
     via: Option<String>,
-    /// The cluster slot this was offered under, when the link came from the
-    /// area under the search box.
+    /// The cluster slot this was offered under, when the offer rested on a
+    /// learned cluster. Absent on the floor of the ladder, which has none —
+    /// so this says which cluster, never whether the link came from an offer.
     #[serde(default)]
     rec: Option<i64>,
-    /// And the rung it was offered on. Carried on the link because the offer
-    /// was computed on a previous request and nothing server-side still holds
-    /// it — without it, every click lands in one bucket on Ops.
+    /// The rung it was offered on, and the thing that marks the link as an
+    /// offer's at all. Carried on the link because the offer was computed on a
+    /// previous request and nothing server-side still holds it — without it,
+    /// every click lands in one bucket on Ops.
     #[serde(default)]
     rung: Option<String>,
 }
@@ -3700,15 +3707,14 @@ async fn artifact_detail(
     // this came from the area under the search box, in which case it is written
     // under its own kind and *not* as an ordinary open. A `recommended_open`
     // counted as an open is the first lucky guess growing into a habit the
-    // system taught itself.
-    match p.rec {
-        Some(slot) => st.core.record_recommendation(
-            &cid,
-            "recommended_open",
-            p.rung.as_deref().unwrap_or("unknown"),
-            Some(slot),
-            Some(&id.subject),
-        ),
+    // system taught itself. Keyed on the rung and not on the slot: the floor of
+    // the ladder carries no slot, and it is the rung with no evidence behind it
+    // at all — the last one that should be teaching the profile.
+    match p.rung.as_deref() {
+        Some(rung) => {
+            st.core
+                .record_recommendation(&cid, "recommended_open", rung, p.rec, Some(&id.subject))
+        }
         None => st
             .core
             .record_interaction(&cid, p.via.as_deref(), Some(&id.subject)),
@@ -4747,7 +4753,7 @@ mod tests {
     /// changes the handle and not the app.
     async fn app_session_and_core_with_feedback() -> (axum::Router, String, crate::core::Core) {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let handle = core.clone();
         let (app, cookie) = app_with_cookie(core).await;
         (app, cookie, handle)
@@ -5163,6 +5169,7 @@ mod tests {
     async fn app_recommending() -> (axum::Router, String, crate::store::Store, String) {
         let mut core = crate::core::test_support::test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         let store = core.store.clone();
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let a = core
@@ -5232,6 +5239,7 @@ mod tests {
     async fn app_with_a_learned_situation() -> (axum::Router, String, String) {
         let mut core = crate::core::test_support::test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let aid = core
             .store
@@ -5294,7 +5302,7 @@ mod tests {
                     weight: 6.0,
                     events: 6,
                     last_at: at,
-                    encoder_version: crate::core::context::ENCODER_VERSION,
+                    encoder_version: crate::core::context::encoder_version(&core.recommend.weights),
                     representative: serde_json::json!({ "at": at, "bundle": bundle }).to_string(),
                 }],
             )
@@ -5316,6 +5324,7 @@ mod tests {
         // situations written down.
         let mut core = crate::core::test_support::test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         let store = core.store.clone();
         let background = core.background.clone();
         let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
@@ -5346,6 +5355,7 @@ mod tests {
     async fn a_bundle_the_browser_could_not_build_does_not_break_the_page() {
         let mut core = crate::core::test_support::test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         let store = core.store.clone();
         let background = core.background.clone();
         let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
@@ -5390,6 +5400,65 @@ mod tests {
         assert!(page.contains("engramContext()"));
         // The class the reserved height hangs off.
         assert!(page.contains(r#"class="offer""#));
+    }
+
+    #[tokio::test]
+    async fn the_offer_is_absent_from_a_page_that_already_carries_a_query() {
+        // The area is for the state "no intent expressed yet". A deep link, a
+        // reload or a back-navigation renders the box with its query restored
+        // and results below it — and app.js only removes the area on a
+        // *keystroke*, which never comes on any of those. Left ungated, the
+        // offer sat beside real results and wrote a `recommended_shown` row per
+        // results page view, inflating the denominator of the one hit rate this
+        // feature is measured by.
+        let (app, cookie, _store, _aid) = app_recommending().await;
+        let page = get(&app, "/ui/search?q=recycling", &cookie).await;
+        assert!(
+            !page.contains(r#"id="context-offer""#),
+            "an offer beside results: {page}"
+        );
+        // And it is back on the next fresh page view: dismissal is per view,
+        // not a state anything remembers.
+        let page = get(&app, "/ui/search", &cookie).await;
+        assert!(page.contains(r#"id="context-offer""#));
+    }
+
+    #[tokio::test]
+    async fn the_floor_of_the_ladder_is_clicked_like_an_offer_and_not_like_a_result() {
+        // The random card has no cluster and so no slot. Hanging the whole
+        // offer marker off the slot left it linking like an ordinary result:
+        // its opens counted as `opened`, so Ops read `random: shown N, opened
+        // 0` for ever — and random is the baseline the block weights would have
+        // to be fitted against. Worse, the open fed back into the profile at
+        // full weight, which is the self-reinforcement `self_weight = 0.0`
+        // exists to close, entered through the one rung with no evidence behind
+        // it at all.
+        let (app, cookie, store, aid) = app_recommending().await;
+        let body = crate::web::test_support::body_of(
+            app.clone()
+                .oneshot(form("/ui/context", &cookie, "bundle=%7B%7D"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(
+            body.contains(&format!("/ui/artifacts/{aid}?rung=random")),
+            "the card links like an ordinary result: {body}"
+        );
+
+        get(&app, &format!("/ui/artifacts/{aid}?rung=random"), &cookie).await;
+        drain().await;
+        // A shown and an open, and both of them on the random rung: that pair
+        // is the hit rate, and before this the second half could never be
+        // written.
+        let rows = store.interactions_between(0, i64::MAX).await.unwrap();
+        let kinds: Vec<&str> = rows.iter().map(|r| r.kind.as_str()).collect();
+        assert_eq!(kinds, vec!["recommended_shown", "recommended_open"]);
+        assert!(
+            rows.iter()
+                .all(|r| r.detail.as_deref().unwrap_or_default().contains("random")),
+            "Ops cannot tell which rung: {rows:?}"
+        );
     }
 
     #[tokio::test]
@@ -5464,10 +5533,10 @@ mod tests {
         // `self_weight` — which is zero.
         let mut core = crate::core::test_support::test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         // Both on, so an ordinary open *would* be recorded — otherwise this
         // test would pass on a base that records nothing at all.
-        core.pursuit.enabled = true;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let store = core.store.clone();
         let background = core.background.clone();
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
@@ -5521,6 +5590,7 @@ mod tests {
     async fn ops_shows_shown_against_clicked_by_rung() {
         let mut core = crate::core::test_support::test_core().await;
         core.recommend.enabled = true;
+        core.learn.enabled = true;
         let store = core.store.clone();
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let aid = core
@@ -5622,7 +5692,7 @@ mod tests {
     /// of them captured and waiting for a verdict.
     async fn app_recording_searches(pending: usize) -> (axum::Router, String) {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         for i in 0..pending {
             core.store
                 .record_search(
@@ -5951,7 +6021,7 @@ mod tests {
     #[tokio::test]
     async fn the_pane_lists_what_this_artifact_is_seen_together_with() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
         core.store
             .bump_link(
@@ -5978,7 +6048,7 @@ mod tests {
     #[tokio::test]
     async fn a_judged_link_shows_the_judges_line_instead_of_the_query() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let ids = artifacts(&core, &["alpha text", "something else entirely"]).await;
         core.store
             .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
@@ -6047,7 +6117,7 @@ mod tests {
         // The associative layer can only add. It is not a reason to refuse to
         // show an artifact beside its source.
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let ids = artifacts(&core, &["alpha text"]).await;
         sqlx::query("DROP TABLE artifact_links")
             .execute(&core.store.pool)
@@ -6063,7 +6133,7 @@ mod tests {
         // document needing each other is not" is the whole point of the flag —
         // pin it on the data the pane renders, not on a CSS class name.
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let ids = artifacts(&core, &["alpha text", "same corpus neighbour"]).await;
         let other_corpus = core.store.insert_corpus("y", "web", None).await.unwrap();
         let made = core
@@ -8186,7 +8256,7 @@ mod tests {
     /// capture through the page alone leaves nothing to retrieve.
     async fn ask_recorded() -> (axum::Router, String, crate::core::Core, String, String) {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let out = core
             .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
             .await
@@ -8544,7 +8614,7 @@ mod tests {
         // Coverage is closed silently — nothing asked the operator to confirm
         // it — so the queue row is the only place it is said.
         let mut c = crate::core::test_support::test_core().await;
-        c.feedback.enabled = true;
+        c.learn.enabled = true;
         let core = c.clone();
         let (app, cookie) = app_with_cookie(c).await;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
@@ -8705,7 +8775,7 @@ mod tests {
         // The default. Carrying ships on because it changes no order; this is
         // the part that does, and it waits for the harness.
         let mut c = crate::core::test_support::test_core().await;
-        c.feedback.enabled = true;
+        c.learn.enabled = true;
         assert!(!c.sitting.prime, "priming must ship off");
         let core = c.clone();
         let (app, cookie) = app_with_cookie(c).await;
@@ -8764,7 +8834,7 @@ mod tests {
         // loop that reinforces itself, which is the failure mode this whole
         // area is built to close.
         let mut c = crate::core::test_support::test_core().await;
-        c.feedback.enabled = true;
+        c.learn.enabled = true;
         let core = c.clone();
         let (app, cookie) = app_with_cookie(c).await;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
@@ -8816,7 +8886,7 @@ mod tests {
         // not the same claim, and an operator reading the list can tell them
         // apart.
         let mut c = crate::core::test_support::test_core().await;
-        c.feedback.enabled = true;
+        c.learn.enabled = true;
         // The fake embedder's vectors are not a semantic space, so the shipped
         // threshold would call everything weak. A line above what the
         // candidate below scores and below nothing else.
@@ -8902,8 +8972,7 @@ mod tests {
         // same, so counting the state pointed the operator at entries that
         // were not there.
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
-        core.pursuit.enabled = true;
+        core.learn.enabled = true;
         let handle = core.clone();
         let (app, cookie) = app_with_cookie(core).await;
         let core = handle;
@@ -9587,7 +9656,7 @@ mod tests {
     async fn app_session_and_core_with_an_embedded_base()
     -> (axum::Router, String, crate::core::Core) {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let out = core
             .ingest("alpha line\n\nbravo line\n\ncharlie line", "web", None)
             .await
@@ -10086,7 +10155,7 @@ mod tests {
     #[tokio::test]
     async fn an_empty_question_is_refused_without_being_parked() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let st = ask_state_over(core).await;
         let (app, cookie) = app_over(&st).await;
         let res = app
@@ -10445,8 +10514,7 @@ mod tests {
     #[tokio::test]
     async fn opening_from_another_artifacts_page_records_a_pivot() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
-        core.pursuit.enabled = true;
+        core.learn.enabled = true;
         let handle = core.clone();
         let (app, cookie) = app_with_cookie(core).await;
         let src = handle
@@ -10503,8 +10571,7 @@ mod tests {
     #[tokio::test]
     async fn a_generated_artifact_shows_its_cues_is_listed_on_ops_and_badged_in_the_rail() {
         let mut core = crate::core::test_support::test_core().await;
-        core.pursuit.enabled = true;
-        core.feedback.enabled = true;
+        core.learn.enabled = true;
         let handle = core.clone();
         let (app, cookie) = app_with_cookie(core).await;
         let src = handle
@@ -10585,8 +10652,7 @@ mod tests {
     #[tokio::test]
     async fn the_page_reports_how_long_an_artifact_was_open() {
         let mut core = crate::core::test_support::test_core().await;
-        core.feedback.enabled = true;
-        core.pursuit.enabled = true;
+        core.learn.enabled = true;
         let handle = core.clone();
         let (app, cookie) = app_with_cookie(core).await;
         let src = handle

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -631,6 +631,9 @@ struct SearchTemplate {
     /// What this sitting has been in. Absent on a cold sitting — an empty box
     /// saying "nothing yet" is worse than no box.
     sitting: Vec<SittingItem>,
+    /// Whether the area under the search box exists at all. See
+    /// `Core::recommends`.
+    recommend: bool,
 }
 
 #[derive(Template)]
@@ -1247,8 +1250,117 @@ async fn search_page(
         facets,
         category,
         sitting: sitting_rail(&st, &id).await,
+        recommend: st.core.recommends(),
     })
     .into_response())
+}
+
+/// One offer, flattened for the template. Every decision — which rung, which
+/// blocks, how the stamp reads — is made here, so the template holds no logic
+/// and a new block in the encoder changes no markup.
+#[derive(Default)]
+pub struct OfferView {
+    pub id: String,
+    pub title: String,
+    /// One of four fixed strings. See `Rung::line`.
+    pub rung: &'static str,
+    /// The blocks that decided it, joined. Empty on the lower two rungs.
+    pub blocks: String,
+    /// `08.08., 15:04`, or empty.
+    pub when: String,
+    /// `?rec=<slot>&rung=<rung>`, or empty — what tells `artifact_detail` this
+    /// open came from an offer, and which rung it was offered on.
+    pub rec: String,
+    /// The raw bundle and the contribution numbers, for the `<details>`.
+    pub detail: String,
+}
+
+#[derive(Template, Default)]
+#[template(path = "_context.html")]
+struct ContextTemplate {
+    offer: Option<OfferView>,
+}
+
+#[derive(serde::Deserialize)]
+struct ContextForm {
+    #[serde(default)]
+    bundle: String,
+}
+
+/// One endpoint, two jobs: it writes the situation and answers with the
+/// fragment. Recording happens even when nothing is recommended — a base that
+/// has learned nothing yet is exactly the one that most needs its situations
+/// written down.
+async fn context_offer(
+    State(st): State<AppState>,
+    id: Identity,
+    Form(f): Form<ContextForm>,
+) -> Result<Response> {
+    if !st.core.recommends() {
+        return Ok(HtmlTemplate(ContextTemplate::default()).into_response());
+    }
+    let bundle = crate::core::context::parse_bundle(&f.bundle);
+    st.core
+        .record_context_event(&f.bundle, &bundle, Some(&id.subject));
+
+    // A recommendation that cannot be computed is not worth a 500: the area is
+    // what it was yesterday, which is empty.
+    let offer = st
+        .core
+        .offer(Some(&id.subject), &bundle, id.session.as_deref())
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "could not build a recommendation");
+            None
+        });
+
+    if let Some(o) = &offer {
+        st.core.record_recommendation(
+            &o.artifact_id,
+            "recommended_shown",
+            o.rung.as_str(),
+            o.slot,
+            Some(&id.subject),
+        );
+    }
+    Ok(HtmlTemplate(ContextTemplate {
+        offer: offer.map(offer_view),
+    })
+    .into_response())
+}
+
+fn offer_view(o: crate::core::recommend::Offer) -> OfferView {
+    OfferView {
+        rung: o.rung.line(),
+        blocks: o.blocks.join(", "),
+        // The device's own reading of when this happened, in the zone it
+        // happened in. One date format, and the whole of the third part of the
+        // line.
+        when: o
+            .at
+            .map(|at| {
+                let t = crate::core::context::local_time(at, o.at_tz.as_deref(), None);
+                format!(
+                    "{:02}.{:02}., {:02}:{:02}",
+                    t.day,
+                    t.month,
+                    t.hour as u32,
+                    ((t.hour % 1.0) * 60.0).round() as u32
+                )
+            })
+            .unwrap_or_default(),
+        // The rung rides on the link because that is the only place it still
+        // exists: the offer was computed on a previous request, and Ops's
+        // breakdown is a breakdown only if the click knows which rung it came
+        // from.
+        rec: match o.slot {
+            Some(s) => format!("?rec={s}&rung={}", o.rung.as_str()),
+            None => String::new(),
+        },
+        id: o.artifact_id,
+        title: o.title,
+        detail: o.detail,
+    }
 }
 
 /// Append `value` to a facet row if the store did not report it. `count` is 0
@@ -3669,6 +3781,7 @@ pub fn ui_router() -> Router<AppState> {
         .route("/ui/capture", get(capture_page).post(capture_submit))
         .route("/ui/search", get(search_page))
         .route("/ui/search/results", get(search_results))
+        .route("/ui/context", post(context_offer))
         .route("/ui/queue", get(queue_fragment))
         // An installed PWA may still hold /ui/browse as its start URL, and a
         // bookmark outlives the page it pointed at.
@@ -4983,6 +5096,193 @@ mod tests {
         assert_eq!(
             core.store.get_corpus(&id).await.unwrap().status,
             CorpusStatus::Describing
+        );
+    }
+
+    /// A session with the recommender on, plus one artifact old enough and
+    /// unseen enough that `resurface` returns it.
+    async fn app_recommending() -> (axum::Router, String, crate::store::Store, String) {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let a = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "when the recycling centre is open".into(),
+                    corpus_span: None,
+                    title: Some("recycling centre".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0);
+        core.vectors
+            .upsert(vec![crate::vector::VectorPoint {
+                vector: vec![1.0; 8],
+                sparse: Default::default(),
+                payload: crate::vector::VectorPayload {
+                    artifact_id: a.id.clone(),
+                    corpus_id: src.id.clone(),
+                    text: a.text.clone(),
+                    title: Some("recycling centre".into()),
+                    category: None,
+                    tags: vec![],
+                    created_at: 0,
+                    last_seen_at: None,
+                    hit_count: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
+                    origin_corpora: vec![],
+                    provenance: None,
+                },
+            }])
+            .await
+            .unwrap();
+        let background = core.background.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        // Held so a test can drain the recording writes rather than sleep.
+        BACKGROUND.with(|b| *b.borrow_mut() = Some(background));
+        (app, cookie, store, a.id)
+    }
+
+    thread_local! {
+        static BACKGROUND: std::cell::RefCell<Option<std::sync::Arc<crate::core::background::Background>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    /// The recording writes run off the request path. Drain them rather than
+    /// sleeping and hoping.
+    async fn drain() {
+        let b = BACKGROUND.with(|b| b.borrow().clone());
+        if let Some(b) = b {
+            b.wait_idle().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn a_page_view_is_recorded_even_when_nothing_is_offered() {
+        // The endpoint has two jobs and does the first unconditionally. A base
+        // that has learned nothing yet is exactly the base that most needs its
+        // situations written down.
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let background = core.background.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                "/ui/context",
+                &cookie,
+                "bundle=%7B%22tz%22%3A%22Europe%2FBerlin%22%7D",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        background.wait_idle().await;
+
+        let rows = store.context_events_since(0).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].tz.as_deref(), Some("Europe/Berlin"));
+        assert!(rows[0].local_hour.is_some(), "denormalised for the sweep");
+        assert!(rows[0].weekday.is_some());
+        assert_eq!(rows[0].scope.as_deref(), Some("user-1"));
+        // Stored whole, including what the encoder does not read today.
+        assert!(rows[0].bundle.contains("Europe/Berlin"));
+    }
+
+    #[tokio::test]
+    async fn a_bundle_the_browser_could_not_build_does_not_break_the_page() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let background = core.background.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let res = app
+            .clone()
+            .oneshot(form("/ui/context", &cookie, "bundle=%7B%7Bnope"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "an empty bundle still works");
+        background.wait_idle().await;
+        assert_eq!(store.context_events_since(0).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn the_area_is_not_rendered_when_the_faculty_is_off() {
+        // One gate, in one place: no placeholder, no request, nothing recorded.
+        let core = crate::core::test_support::test_core().await;
+        let store = core.store.clone();
+        let background = core.background.clone();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        let page = get(&app, "/ui/search", &cookie).await;
+        assert!(!page.contains("/ui/context"), "no placeholder");
+
+        let res = app
+            .clone()
+            .oneshot(form("/ui/context", &cookie, "bundle=%7B%7D"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        background.wait_idle().await;
+        assert!(store.context_events_since(0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_placeholder_reserves_its_height_so_the_page_does_not_jump() {
+        let (app, cookie, _store, _aid) = app_recommending().await;
+        let page = get(&app, "/ui/search", &cookie).await;
+        assert!(page.contains(r#"id="context-offer""#));
+        assert!(page.contains(r#"hx-post="/ui/context""#));
+        assert!(page.contains("engramContext()"));
+        // The class the reserved height hangs off.
+        assert!(page.contains(r#"class="offer""#));
+    }
+
+    #[tokio::test]
+    async fn what_was_offered_is_written_down_with_its_rung() {
+        // Shown against clicked, broken down by rung, is a hit rate. It is the
+        // only number that can later settle whether the weights are right, and
+        // a recommender with no visible hit rate becomes `[sitting] prime`:
+        // a default nobody ever measured.
+        let (app, cookie, store, aid) = app_recommending().await;
+
+        let res = app
+            .clone()
+            .oneshot(form("/ui/context", &cookie, "bundle=%7B%7D"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = body_of(res).await;
+        assert!(body.contains("Not seen in a long time"), "{body}");
+        assert!(body.contains(&aid), "{body}");
+        // Nothing was matched, so nothing is named — the bottom rung does not
+        // borrow a pattern's wording.
+        assert!(!body.contains(" · weekday"), "{body}");
+        drain().await;
+
+        let rows = store.interactions_between(0, i64::MAX).await.unwrap();
+        let shown: Vec<_> = rows
+            .iter()
+            .filter(|r| r.kind == "recommended_shown")
+            .collect();
+        assert_eq!(shown.len(), 1);
+        assert!(
+            shown[0].detail.as_deref().unwrap().contains("forgotten"),
+            "{:?}",
+            shown[0].detail
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3710,11 +3710,23 @@ async fn artifact_detail(
     // system taught itself. Keyed on the rung and not on the slot: the floor of
     // the ladder carries no slot, and it is the rung with no evidence behind it
     // at all — the last one that should be teaching the profile.
-    match p.rung.as_deref() {
-        Some(rung) => {
-            st.core
-                .record_recommendation(&cid, "recommended_open", rung, p.rec, Some(&id.subject))
-        }
+    //
+    // The marker is checked against the ladder rather than taken as written:
+    // it arrives in a query string, and an unrecognised word would be recorded
+    // as the rung it claims and counted on Ops as a row of its own. A link
+    // carrying one is not an open under a rung, so it is an ordinary open.
+    match p
+        .rung
+        .as_deref()
+        .and_then(crate::core::recommend::Rung::parse)
+    {
+        Some(rung) => st.core.record_recommendation(
+            &cid,
+            "recommended_open",
+            rung.as_str(),
+            p.rec,
+            Some(&id.subject),
+        ),
         None => st
             .core
             .record_interaction(&cid, p.via.as_deref(), Some(&id.subject)),
@@ -5458,6 +5470,41 @@ mod tests {
             rows.iter()
                 .all(|r| r.detail.as_deref().unwrap_or_default().contains("random")),
             "Ops cannot tell which rung: {rows:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rung_the_ladder_does_not_have_is_an_ordinary_open() {
+        // The marker rides in the query string, so its value is whatever the
+        // viewer sends. Taken as written it went into the recorded row and from
+        // there into `offer_rates`' `GROUP BY rung`, which is to say anyone
+        // could add rows to the Ops breakdown by editing a URL — beside the
+        // four rungs that exist, in the one table the block weights would be
+        // fitted against.
+        let (app, cookie, store, aid) = app_recommending().await;
+        get(
+            &app,
+            &format!("/ui/artifacts/{aid}?rung=excellent"),
+            &cookie,
+        )
+        .await;
+        drain().await;
+
+        let rows = store.interactions_between(0, i64::MAX).await.unwrap();
+        let kinds: Vec<&str> = rows.iter().map(|r| r.kind.as_str()).collect();
+        assert_eq!(
+            kinds,
+            vec!["opened"],
+            "an invented rung was recorded as an offer: {rows:?}"
+        );
+        assert!(
+            store
+                .offer_rates(0)
+                .await
+                .unwrap()
+                .iter()
+                .all(|r| crate::core::recommend::Rung::parse(&r.rung).is_some()),
+            "Ops lists a rung the ladder does not have"
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -5293,6 +5293,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_reason_line_is_markup_a_browser_will_not_rearrange() {
+        // `details` and `pre` are flow content and a `p` may hold only phrasing
+        // content, so a `p` here is closed by the parser before the `details`
+        // and leaves a stray empty paragraph behind — a DOM the stylesheet is
+        // not written against, with the Details control on its own line.
+        let (app, cookie, _store, _aid) = app_recommending().await;
+        let body = crate::web::test_support::body_of(
+            app.clone()
+                .oneshot(form("/ui/context", &cookie, "bundle=%7B%7D"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(body.contains(r#"<div class="muted offer-why">"#), "{body}");
+        assert!(
+            !body.contains("<p class=\"muted offer-why\">"),
+            "the reason line must not be a paragraph: {body}"
+        );
+    }
+
+    #[tokio::test]
     async fn what_was_offered_is_written_down_with_its_rung() {
         // Shown against clicked, broken down by rung, is a hit rate. It is the
         // only number that can later settle whether the weights are right, and

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1267,8 +1267,11 @@ async fn search_page(
 pub struct OfferView {
     pub id: String,
     pub title: String,
-    /// One of four fixed strings. See `Rung::line`.
-    pub rung: &'static str,
+    /// What the line leads with. Fixed wording for the two established rungs;
+    /// for a thin one it is the count in words, because "Twice before" is the
+    /// honest thing to say about two occurrences and "Pattern" is not. Empty
+    /// on the random card, which claims nothing.
+    pub rung: String,
     /// The blocks that decided it, joined. Empty on the lower two rungs.
     pub blocks: String,
     /// `08.08., 15:04`, or empty.
@@ -1312,7 +1315,7 @@ async fn context_offer(
     // what it was yesterday, which is empty.
     let offer = st
         .core
-        .offer(Some(&id.subject), &bundle, id.session.as_deref())
+        .offer(Some(&id.subject), &bundle)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(error = %e, "could not build a recommendation");
@@ -1335,8 +1338,23 @@ async fn context_offer(
 }
 
 fn offer_view(o: crate::core::recommend::Offer) -> OfferView {
+    use crate::core::recommend::Rung;
     OfferView {
-        rung: o.rung.line(),
+        rung: match o.rung {
+            Rung::Pattern => "Pattern".to_string(),
+            Rung::Similar => "Similar to".to_string(),
+            // The count, in words a person reads. `weight` is the decayed
+            // number the ranking uses and nobody can read 1.9 and know it means
+            // twice — so the undecayed count is stored alongside it and said
+            // out loud here.
+            Rung::Tentative => match o.events {
+                0 | 1 => "Once before".to_string(),
+                2 => "Twice before".to_string(),
+                n => format!("{n} times before"),
+            },
+            // Nothing about the situation produced it, so nothing is claimed.
+            Rung::Random => String::new(),
+        },
         blocks: o.blocks.join(", "),
         // The device's own reading of when this happened, in the zone it
         // happened in. One date format, and the whole of the third part of the
@@ -5209,6 +5227,88 @@ mod tests {
         }
     }
 
+    /// The same base, plus one established situation matching the bundle the
+    /// tests post — so the reason line actually renders.
+    async fn app_with_a_learned_situation() -> (axum::Router, String, String) {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let aid = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "when the recycling centre is open".into(),
+                    corpus_span: None,
+                    title: Some("recycling centre".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id;
+        core.vectors
+            .upsert(vec![crate::vector::VectorPoint {
+                vector: vec![1.0; 8],
+                sparse: Default::default(),
+                payload: crate::vector::VectorPayload {
+                    artifact_id: aid.clone(),
+                    corpus_id: src.id.clone(),
+                    text: "when the recycling centre is open".into(),
+                    title: Some("recycling centre".into()),
+                    category: None,
+                    tags: vec![],
+                    created_at: 0,
+                    last_seen_at: None,
+                    hit_count: None,
+                    status: None,
+                    last_verified_at: None,
+                    superseded_by: None,
+                    origin_corpora: vec![],
+                    provenance: None,
+                },
+            }])
+            .await
+            .unwrap();
+
+        // The centroid is this very situation, so the offer lands on `Pattern`.
+        let at = crate::store::now();
+        let bundle = crate::core::context::Bundle {
+            tz: Some("Europe/Berlin".into()),
+            ..Default::default()
+        };
+        let v = crate::core::context::encode(at, Some("user-1"), &bundle, &core.recommend.weights);
+        core.store
+            .replace_context_clusters(
+                &aid,
+                &[crate::store::context::StoredCluster {
+                    scope: Some("user-1".into()),
+                    artifact_id: aid.clone(),
+                    slot: 0,
+                    centroid: v.clone(),
+                    weight: 6.0,
+                    events: 6,
+                    last_at: at,
+                    encoder_version: crate::core::context::ENCODER_VERSION,
+                    representative: serde_json::json!({ "at": at, "bundle": bundle }).to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+        core.vectors
+            .set_context_vectors(&aid, vec![v])
+            .await
+            .unwrap();
+
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        (app, cookie, aid)
+    }
+
     #[tokio::test]
     async fn a_page_view_is_recorded_even_when_nothing_is_offered() {
         // The endpoint has two jobs and does the first unconditionally. A base
@@ -5298,14 +5398,19 @@ mod tests {
         // content, so a `p` here is closed by the parser before the `details`
         // and leaves a stray empty paragraph behind — a DOM the stylesheet is
         // not written against, with the Details control on its own line.
-        let (app, cookie, _store, _aid) = app_recommending().await;
+        let (app, cookie, _aid) = app_with_a_learned_situation().await;
         let body = crate::web::test_support::body_of(
             app.clone()
-                .oneshot(form("/ui/context", &cookie, "bundle=%7B%7D"))
+                .oneshot(form(
+                    "/ui/context",
+                    &cookie,
+                    "bundle=%7B%22tz%22%3A%22Europe%2FBerlin%22%7D",
+                ))
                 .await
                 .unwrap(),
         )
         .await;
+        assert!(body.contains("Pattern"), "no reason line at all: {body}");
         assert!(body.contains(r#"<div class="muted offer-why">"#), "{body}");
         assert!(
             !body.contains("<p class=\"muted offer-why\">"),
@@ -5328,11 +5433,15 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
         let body = body_of(res).await;
-        assert!(body.contains("Not seen in a long time"), "{body}");
         assert!(body.contains(&aid), "{body}");
-        // Nothing was matched, so nothing is named — the bottom rung does not
-        // borrow a pattern's wording.
-        assert!(!body.contains(" · weekday"), "{body}");
+        // Nothing about the situation produced it, so nothing is claimed: no
+        // rung name, no blocks, no reason line at all. A card with a sentence
+        // under it would be the area borrowing authority it does not have.
+        assert!(
+            !body.contains("offer-why"),
+            "the card explains nothing: {body}"
+        );
+        assert!(!body.contains("Pattern"), "{body}");
         drain().await;
 
         let rows = store.interactions_between(0, i64::MAX).await.unwrap();
@@ -5342,7 +5451,7 @@ mod tests {
             .collect();
         assert_eq!(shown.len(), 1);
         assert!(
-            shown[0].detail.as_deref().unwrap().contains("forgotten"),
+            shown[0].detail.as_deref().unwrap().contains("random"),
             "{:?}",
             shown[0].detail
         );

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -891,6 +891,11 @@ struct OpsTemplate {
     /// could never give: whether this started yesterday or has been going
     /// wrong for a week.
     sweep_history: Vec<SweepRunRow>,
+    /// Shown against clicked, by rung. Empty when the offer is switched off, or
+    /// when it has been on and never had anything to say — either way there is
+    /// no table, because a heading over no rows is a claim that something is
+    /// being measured when nothing is.
+    offer_rates: Vec<crate::store::pursuits::OfferRate>,
 }
 
 #[derive(Template)]
@@ -2767,6 +2772,19 @@ async fn ops(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         last_day,
         last_day_failures,
         sweep_history,
+        // The last month rather than the last day: a weekly pattern needs
+        // weeks, so a hit rate measured over a day would be a number nobody
+        // could act on. Read like `vector_count` — a failure here must not
+        // blank the page you open when something is wrong.
+        offer_rates: match st.core.recommends() {
+            true => st
+                .core
+                .store
+                .offer_rates(crate::store::now() - 30 * 86_400)
+                .await
+                .unwrap_or_default(),
+            false => Vec::new(),
+        },
     })
     .into_response())
 }
@@ -3637,6 +3655,15 @@ struct ArtifactViewParams {
     /// a continuation — when the link came from another artifact's page.
     #[serde(default)]
     via: Option<String>,
+    /// The cluster slot this was offered under, when the link came from the
+    /// area under the search box.
+    #[serde(default)]
+    rec: Option<i64>,
+    /// And the rung it was offered on. Carried on the link because the offer
+    /// was computed on a previous request and nothing server-side still holds
+    /// it — without it, every click lands in one bucket on Ops.
+    #[serde(default)]
+    rung: Option<String>,
 }
 
 /// One route, two shapes. An htmx swap wants the pane's body; a pasted link
@@ -3651,9 +3678,23 @@ async fn artifact_detail(
     let d = build_artifact_detail(&st.core, &cid, &p.terms).await?;
     // Opening a chunk is the deliberate act that counts as remembering it.
     st.core.mark_artifact_seen(&cid);
-    // And the act the pursuit sweep reads: opened, or pivoted through.
-    st.core
-        .record_interaction(&cid, p.via.as_deref(), Some(&id.subject));
+    // And the act the pursuit sweep reads: opened, or pivoted through — unless
+    // this came from the area under the search box, in which case it is written
+    // under its own kind and *not* as an ordinary open. A `recommended_open`
+    // counted as an open is the first lucky guess growing into a habit the
+    // system taught itself.
+    match p.rec {
+        Some(slot) => st.core.record_recommendation(
+            &cid,
+            "recommended_open",
+            p.rung.as_deref().unwrap_or("unknown"),
+            Some(slot),
+            Some(&id.subject),
+        ),
+        None => st
+            .core
+            .record_interaction(&cid, p.via.as_deref(), Some(&id.subject)),
+    }
     // The live half of the same act. Written here rather than inside
     // `record_interaction` because this is where the session is known — and
     // that is the whole of what keeps the sitting at the web door.
@@ -5284,6 +5325,151 @@ mod tests {
             "{:?}",
             shown[0].detail
         );
+    }
+
+    #[tokio::test]
+    async fn taking_an_offer_is_not_an_ordinary_open() {
+        // Without this the profile reinforces itself. The row is written, and
+        // it is written under its own kind so the sweep can weigh it at
+        // `self_weight` — which is zero.
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        // Both on, so an ordinary open *would* be recorded — otherwise this
+        // test would pass on a base that records nothing at all.
+        core.pursuit.enabled = true;
+        core.feedback.enabled = true;
+        let store = core.store.clone();
+        let background = core.background.clone();
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let aid = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "opening hours".into(),
+                    corpus_span: None,
+                    title: Some("hours".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+
+        get(
+            &app,
+            &format!("/ui/artifacts/{aid}?rec=0&rung=pattern"),
+            &cookie,
+        )
+        .await;
+        background.wait_idle().await;
+
+        let rows = store.interactions_between(0, i64::MAX).await.unwrap();
+        let kinds: Vec<&str> = rows.iter().map(|r| r.kind.as_str()).collect();
+        assert_eq!(kinds, vec!["recommended_open"], "not an ordinary open");
+        assert!(
+            rows[0].detail.as_deref().unwrap().contains("pattern"),
+            "and it remembers which rung it was offered on: {:?}",
+            rows[0].detail
+        );
+
+        // And the ordinary path still records an ordinary open, so the branch
+        // above is a branch rather than a hole.
+        get(&app, &format!("/ui/artifacts/{aid}"), &cookie).await;
+        background.wait_idle().await;
+        let rows = store.interactions_between(0, i64::MAX).await.unwrap();
+        assert!(rows.iter().any(|r| r.kind == "opened"));
+    }
+
+    #[tokio::test]
+    async fn ops_shows_shown_against_clicked_by_rung() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.recommend.enabled = true;
+        let store = core.store.clone();
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let aid = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "opening hours".into(),
+                    corpus_span: None,
+                    title: Some("hours".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id;
+        let now = crate::store::now();
+        for _ in 0..4 {
+            store
+                .record_recommendation(
+                    &aid,
+                    "recommended_shown",
+                    r#"{"rung":"pattern"}"#,
+                    Some("me"),
+                    now,
+                )
+                .await
+                .unwrap();
+        }
+        store
+            .record_recommendation(
+                &aid,
+                "recommended_open",
+                r#"{"rung":"pattern"}"#,
+                Some("me"),
+                now,
+            )
+            .await
+            .unwrap();
+        store
+            .record_recommendation(
+                &aid,
+                "recommended_shown",
+                r#"{"rung":"forgotten"}"#,
+                Some("me"),
+                now,
+            )
+            .await
+            .unwrap();
+
+        let rates = store.offer_rates(0).await.unwrap();
+        assert_eq!(rates.len(), 2, "one row per rung: {rates:?}");
+        let pattern = rates.iter().find(|r| r.rung == "pattern").unwrap();
+        assert_eq!(pattern.shown, 4);
+        assert_eq!(pattern.opened, 1);
+        let forgotten = rates.iter().find(|r| r.rung == "forgotten").unwrap();
+        assert_eq!(forgotten.shown, 1);
+        assert_eq!(forgotten.opened, 0, "nobody took that one");
+
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let page = get(&app, "/ui/ops", &cookie).await;
+        assert!(page.contains("What was offered"), "no heading");
+        assert!(page.contains("pattern"), "no rung");
+        assert!(page.contains("forgotten"));
+    }
+
+    #[tokio::test]
+    async fn ops_says_nothing_about_offers_when_the_faculty_is_off() {
+        // A heading over no rows is a claim that something is being measured
+        // when nothing is.
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let page = get(&app, "/ui/ops", &cookie).await;
+        assert!(!page.contains("What was offered"));
     }
 
     async fn get(app: &axum::Router, uri: &str, cookie: &str) -> String {

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -384,6 +384,7 @@ fn sweep_label(stage: &str) -> &str {
         "generate" => "Answering gaps",
         "retention" => "Retention",
         "arm_dedupe" => "Arming dedupe",
+        "context" => "Learning situations",
         other => other,
     }
 }

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -541,6 +541,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         chunk_tokens: engram::config::DEFAULT_CHUNK_TOKENS,
         counter: Arc::new(engram::infer::budget::TokenCounter),
         background: Arc::new(engram::core::background::Background::default()),
+        clock: engram::core::context::Clock::System,
         query_cache: Arc::new(std::sync::Mutex::new(engram::core::QueryCache::new(
             engram::core::QUERY_CACHE_CAPACITY,
         ))),

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -548,10 +548,8 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         ))),
         consolidate: engram::config::ConsolidateConfig::default(),
         weak_below: 0.0,
-        feedback: engram::config::FeedbackConfig {
-            enabled: false,
-            ..Default::default()
-        },
+        learn: engram::config::LearnConfig { enabled: false },
+        feedback: engram::config::FeedbackConfig::default(),
         capture: engram::config::CaptureConfig::default(),
         associate: engram::config::AssociateConfig::default(),
         activation: engram::config::ActivationConfig::default(),

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -541,6 +541,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         chunk_tokens: engram::config::DEFAULT_CHUNK_TOKENS,
         counter: Arc::new(engram::infer::budget::TokenCounter),
         background: Arc::new(engram::core::background::Background::default()),
+        recommend: Default::default(),
         clock: engram::core::context::Clock::System,
         query_cache: Arc::new(std::sync::Mutex::new(engram::core::QueryCache::new(
             engram::core::QUERY_CACHE_CAPACITY,


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-21-context-recommendation-design.md`.

The area under the search box is empty, and the base already knows something
that could fill it. `search_events` and `interaction_events` have carried the
query, its scope and its timestamp all along; nothing read either for this
purpose, and nothing could — `created_at` is a bare Unix integer with no zone
attached, so "Friday at 15:00" was not a question the base could ask of its own
log.

So this is two things. A small one: give the application a working notion of
local time. A larger one: record the situation an interaction happened in, learn
which situations recur for which artifact, and offer that artifact before it is
asked for, with the reasons visible.

```
recycling centre opening hours
Pattern · weekday, hour, device · like 10.07., 21:54   [Details ▾]
```

**No model call and no embedding at read time.** One vector query per page view,
one exact scan over the profiled subset. The learning is a sweep; a counting
embedder in the tests asserts the read path spends nothing, rather than a
comment claiming it.

## How it works

A bundle collected in the browser on every page view — zone, local time,
viewport, device, locale, network, power, environment — recorded raw and whole.
A sweep agglomerates the situations each artifact was opened in into at most a
handful of decayed clusters. Each centroid becomes one element of a `ctx`
multivector on the artifact's existing Qdrant point, scored with `max_sim`. At
page load the current bundle is encoded and queried against it, and the winning
cluster is re-derived locally — Qdrant returns the maximum, not which element
produced it, and the display needs the element.

The encoder is eleven named blocks over 53 dimensions. **Each block is
normalised to length one and only then scaled by its weight**, so a block
contributes exactly its weight however many dimensions it uses — seven one-hot
slots for the weekday do not outweigh two for the hour because there are seven
of them. That is what turns weighting which would otherwise hide in the encoding
into numbers an operator can change, and it is also where the explanation comes
from: each block's contribution is computable at read time, so "weekday, hour,
device" is three lookups rather than three sentences somebody had to write.

Something is always shown, and the wording says what it rests on: **Pattern**,
**Similar to**, **Touched in this sitting**, **Not seen in a long time**. The
last rung *is* `resurface` and is deliberately not phrased like a pattern — the
distance between "Fridays around 15:00" and "not seen in a long time" is the
whole honesty of the feature.

## Three bugs the work found

**The scope-isolation hole.** The `scope` block was one-hot over eight buckets,
so any two people had a one-in-eight chance of sharing a slot — identical scope
blocks, and one person's Friday afternoon offered to another at a score of
1.0000001. `"alice"` and `"bob"` collided on the first test run. Fixed twice
over: the block is now a pseudo-random direction spread across all eight slots,
so two scopes are near-orthogonal rather than identical; and the read path cuts
foreign clusters **exactly**, since it already loads them to build the reason.
Near-orthogonal is still a probability, and this guarantee must not be one. The
test now tries twenty names instead of one, and a second test puts one person's
cluster alone in the index so the store is forced to return it and the read path
has to cut it anyway.

**`points/vectors` is PUT, not POST.** The design record said POST. Qdrant 1.19
answers 404, and `call_absent_point_as_none` read that as "no such point" and
swallowed it — so the sweep wrote its clusters to SQLite, reported `ok` in
`sweep_runs`, and left the index with no `ctx` set at all, with every test
green. Only running it against a real Qdrant surfaced this. The 404 handling on
that path is now narrowed to Qdrant actually saying the point is missing, so a
wrong URL cannot wear the same disguise again.

**`recommended_shown` counted as engagement.** `jobs::pursuit` weighs every kind
that is not `dwell` or `pivoted` at 1.0, so each artifact the recommender ever
guessed at would have become a pursuit source. Removing the filter makes the
test fail with the bug stated plainly: a search nobody clicked closes as
*"satisfied — one artifact engaged"*, with the offer as its source.

## Two deviations from the design record

**The rung is scored without the `scope` block.** At weight 10 against a total
under 5, counting it towards the rung would drag every same-scope score above
0.95 and leave `strong_at` and `weak_at` four hundredths apart. Qdrant's
`max_sim` over the full vector still decides *which* artifact is offered — that
is what the scope block is for; the scope-sliced score decides the rung. Two
questions, two scales. Measured against the shipped defaults:

| situation | score | rung |
|---|---|---|
| identical, and the same hour a week later | 1.00 | Pattern |
| eight minutes early, same phone | 0.9998 | Pattern |
| four hours later, wifi instead of cellular, landscape | 0.74 | Similar |
| Monday morning at a desktop | −0.12 | falls through |
| cold start, Friday vs Friday, no bundle at all | 1.00 | Pattern |

**`context_clusters.representative` stores `{"at", "bundle"}`.** The display
quotes the representative event's timestamp and a bundle carries none. Still one
`TEXT` column.

## Verified against a real Qdrant 1.19

Not only the in-memory store. The collection accepted the multivector as
designed (size 53, Cosine, `max_sim`, `m: 0` for an exact scan); the sweep
turned six seeded Fridays into one cluster of weight 4.18; the set landed on the
point beside an untouched 1024-wide dense vector; and **the payload survived the
write intact**, which is the one thing this must not break.

## What this does not touch

- **Ranking.** `src/core/search.rs` is unmodified. The recommendation is its own
  surface and disappears the moment a query exists.
- **Payload.** The sweep writes vectors through `points/vectors`, never
  `upsert`. Clearing `status` would put hidden artifacts back into search.
- **Read-time cost.** One vector query, no embedding, no model call.

## Measurement, so this does not become another unmeasured default

Shown against clicked, broken down by rung, over the last thirty days, on Ops.
The block weights are chosen, not measured, and this is the instrument that
would let them be fitted — fitting them before the data exists would be guessing
with extra steps. `[sitting] prime` has sat at `false` for months because nobody
measured it; a recommender with no visible hit rate becomes the same case.

## Configuration

Off by default. `[recommend]` is one gate and a table of numbers — `ROADMAP.md`
under `[Core Platform]` already objects to eight gates over one faculty, and
this does not add a ninth. A weekly pattern needs weeks, so shipping it on would
show the bottom rung for a fortnight and teach the operator to ignore the area.

## Deploying

**A Qdrant collection created before this branch carries no `ctx` named vector,
and the first sweep write to it will fail.** `--reindex` is the migration: it
creates a fresh generation from the new collection body and copies every dense
vector across, at no embedding cost. Run it before switching
`[recommend] enabled` on.

`artifacts` gains an `updated_at` column. Per `src/store/mod.rs`, adding a
column means recreating the database; the boot check names it rather than
failing later inside a request.

## Tests

1588 passing, up from 1507. `cargo clippy --all-targets` clean.

The guards were each verified to be load-bearing by breaking them and watching
the test fail — the self-reinforcement guard at `self_weight = 1.0`, the pursuit
exclusion with the filter removed, the config documentation with a weight
deleted, and the JS/Rust field agreement with a field renamed.

`the_browser_sends_exactly_the_fields_this_struct_reads` pins the one seam in
this feature with a compiler on neither side: the bundle is assembled in
`app.js` and parsed into `Bundle`, and a field renamed on one side is silently
`None` on the other — a block that quietly stops contributing, with nothing
failing anywhere.

## Not verified

The Chrome extension was not connected in this environment, so the
first-keystroke removal of the offer and the htmx race guard around it are
unexercised in a real browser. The server side of that path is tested; the
client side is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAowyLNDBp62wXfx9JNab
