### PR TITLE
Engagement at the API door, and a citation as use

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,13 +96,13 @@ written, a seam that moves ranking waits.
 
 ## [What counts as use]
 
-Everything plastic in the base is downstream of one question, and it has one
-answer today: use means the web UI. `jobs::context` clusters `interactions`
-rows into the `ctx` vectors the recommendation rests on; `associate` replays the
-search log; `promote` reads an activation that only moves at a bump. All three
-are fed through a single production caller, and the first two items below are
-about widening that. Nothing else on this list is worth as much per line
-changed.
+Everything plastic in the base is downstream of one question. `jobs::context`
+clusters `interactions` rows into the `ctx` vectors the recommendation rests on;
+`associate` replays the search log; `promote` reads an activation that only
+moves at a bump. Use now means the web UI **and the API door**: asking for one
+artifact by id is the same deliberate act the detail pane records, and it says
+so in `get_artifact`. What `/mcp` counts as use is answered, and the answer is
+nothing beyond what it already does — see below.
 
 Built, and worth keeping the reasons for: Hebbian links from co-retrieval,
 decaying activation per artifact, bounded priming and one-hop association in the
@@ -118,40 +118,28 @@ web session (`src/core/sitting.rs`), expiring at `pursuit.idle_secs` so that the
 live definition and the reconstructed one agree by construction. It joins the
 doors and never writes activation, and there is a test saying so.
 
-- **Every door counts as engagement.** Retrieval is recorded everywhere:
-  `core::search` bumps activation whether the query came from the rail, the API
-  or `/mcp`, and `Origin` (`src/store/feedback.rs:77`) already carries the door,
-  the subject and — for the web — the session. Engagement is not.
-  `mark_artifact_seen` and `record_interaction` have exactly one production
-  caller between them, the dwell route at `src/web/ui.rs:3766`. An artifact a
-  Claude Code session read all afternoon is never opened, never promoted, never
-  part of a pursuit, and never a situation anybody learns from.
+And engagement at more than one door. `GET /api/v1/artifacts/{id}` is an open:
+it marks the artifact seen and records the interaction, with no `via` — the API
+has no navigation to have pivoted through — and no session, because a bearer
+token is not a conversation. A citation is an engagement: `ask_citations.used`
+already separated what an answer was shown from what it used, and the artifacts
+it used now bump `activation.cited` and are checked for promotion at the bump
+(`Core::mark_artifacts_cited`). It deliberately does not stamp `last_seen_at`
+the way an open does — the stale review list exists to put artifacts nobody has
+verified in front of a person, and a model citing one is not a person having
+looked at it.
 
-  The doors are not symmetrical, and that is where the actual work is.
-  `GET /api/v1/artifacts/{id}` is an open and can say so in one line. `/mcp` has
-  no open at all: its tools are search, ask and ingest, and a search returns the
-  whole artifact, so the read *is* the result. Counting every returned artifact
-  as engagement would only relearn what association already learns from display.
-  The honest signal at that door is the citation, which is why the next item is
-  half of this one.
-
-  **Worth:** the anticipating half of the application stops being blind at two
-  doors out of three. Today an operator who works through `/mcp` teaches the
-  offer ladder, promotion and pursuits precisely nothing, and the base's picture
-  of what is used is a picture of the web UI.
-  **Cost:** one line in the API artifact route, the citation bump below, and a
-  recorded decision about what MCP counts as use. **One commit.** No harness: it
-  changes what is learned, not how a fixed input is ranked, and no corpus in
-  this repository contains real multi-door use anyway.
-
-- **A citation is an engagement.** `ask_citations` already stores what the model
-  was shown and what it used (`src/store/asks.rs:153`, column `used`). An
-  artifact the model cited was used, and it bumps nothing.
-  **Worth:** closes the `/mcp` half of the item above with the one signal that
-  door honestly has, and retires the pursuit sweep's promotion call under Core
-  Platform — an ask-cited artifact is the only case that call still covers.
-  **Cost:** one call where the ask is recorded, minus `maybe_promote` in
-  `jobs/pursuit.rs` and the test pinning it. **One commit.**
+**What `/mcp` counts as use: nothing, and that is the decision rather than an
+omission.** Its search already bumps activation like every other door. It has no
+open at all — a search returns the whole artifact, so the read *is* the result —
+and counting every returned artifact as engagement would only relearn what
+association already learns from display. The honest signal at that door is the
+citation, and citations are recorded only where the question is: `record_ask`
+stays at the web door, because a question is personal data of the same kind as a
+query and API and MCP callers asked for the smallest footprint. So the bump
+rides with the recording rather than around it, and there is a test pinning
+that. Widening it means widening what is *recorded* first, which is a different
+decision from this one.
 
 - **Co-citation is a stronger link than co-display.** `associate` learns its
   Hebbian links by replaying the search log: two artifacts shown in one result
@@ -538,18 +526,6 @@ that would otherwise have left the page disabled for good.
   On the list because scripted capture and export are the two things a shell is
   genuinely better at.
   **Cost:** a binary over the existing API. **A branch.** Near the bottom.
-
-- **The pursuit sweep's promotion call, which almost never has anything to do.**
-  A one-engaged-artifact pursuit calls `maybe_promote`, but every engagement
-  already calls it at the bump, and the sweep only runs once the sitting has been
-  idle for `idle_secs` — so it re-checks the same artifact against a *more*
-  decayed activation than the live call saw, and can only ever decline where that
-  one declined. The single case it covers is an artifact engaged solely by an ask
-  citation.
-  **Worth:** one fewer call that cannot do anything, and one fewer thing to
-  explain.
-  **Cost:** free — **A citation is an engagement** above removes the last case
-  and this deletes itself with it. Not a separate item so much as a consequence.
 
 - **DOCX, EPUB, XLSX and the rest.** `docling` is in the tree and already reads
   them; only a door and a `kind` are missing. Deliberately out of PDF capture.

--- a/config.example.toml
+++ b/config.example.toml
@@ -463,13 +463,18 @@ half_life_days = 14
 retrieved = 1.0
 opened = 0.5
 confirmed = 3.0
+# Cited by an answer /ask wrote. A model's use of an artifact, not a person's,
+# which is why it weighs what an open weighs and not what a confirmation does:
+# nothing here verified that the answer was right. Only the web door records
+# which artifacts an answer used, so only the web door raises this.
+cited = 0.5
 
 # ── Promotion ────────────────────────────────────────────────────────────────
 # At synthesis = "earned", when a passage has earned its window a synthesis
 # call. Read against [activation]: baseline 1.0 at capture, so 4.0 is one
 # confirmation after a retrieval and an open, or about three engaged openings.
-# Checked only when a passage is opened or confirmed — never when it merely
-# appears in results — and the window's new artifacts inherit the access the
+# Checked only when a passage is opened, confirmed or cited by an answer —
+# never when it merely appears in results — and the window's new artifacts inherit the access the
 # passages earned.
 [promote]
 activation_above = 4.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -277,6 +277,10 @@ pub struct ActivationConfig {
     pub opened: f64,
     /// Judged the answer to a real question. The strong signal.
     pub confirmed: f64,
+    /// Cited by an answer. A model's use of an artifact, not a person's, which
+    /// is why it weighs what an open weighs rather than what a confirmation
+    /// does: nothing here verified that the answer was right.
+    pub cited: f64,
 }
 
 impl Default for ActivationConfig {
@@ -286,6 +290,7 @@ impl Default for ActivationConfig {
             retrieved: 1.0,
             opened: 0.5,
             confirmed: 3.0,
+            cited: 0.5,
         }
     }
 }

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -917,6 +917,17 @@ impl Core {
                     .collect()
             },
         };
+        // The same distinction, read the other way: what the answer used was
+        // engaged, and that is the one signal a question honestly gives about
+        // an artifact. Off the recording path's success — an insert that fails
+        // does not unmake the use.
+        self.mark_artifacts_cited(
+            ask.citations
+                .iter()
+                .filter(|c| c.used)
+                .map(|c| c.artifact_id.clone())
+                .collect(),
+        );
         match self.store.record_ask(ask).await {
             Ok(id) => response.event_id = Some(id),
             Err(e) => tracing::warn!(error = %e, "could not record the question"),
@@ -2095,6 +2106,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn only_the_artifacts_an_answer_cited_are_engaged_by_it() {
+        // `used` already separates shown from used, and an artifact the model
+        // cited was used. Every excerpt that merely fit the window is not — the
+        // association layer already learns from display.
+        let mut core = test_core().await;
+        core.learn.enabled = true;
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some("the answer rests on this [1]".into()),
+        }));
+        seed(&core, 3, 4).await;
+
+        let out = core.ask(&req("chunk"), Door::Ui.by("me")).await.unwrap();
+        core.background.wait_idle().await;
+
+        assert!(out.citations.len() > 1, "need a shown-but-uncited one");
+        let ids: Vec<String> = out
+            .citations
+            .iter()
+            .map(|c| c.artifact_id.clone())
+            .collect();
+        // Every excerpt was retrieved by the same searches, so they share a
+        // baseline and the only difference left between them is the citation.
+        let act = core.store.activation_of(&ids).await.unwrap();
+        let of = |id: &String| act.get(id).map(|(a, _)| *a).unwrap_or(0.0);
+        let uncited = of(&ids[1]);
+        for id in &ids[2..] {
+            assert_eq!(of(id), uncited, "the excerpts did not share a baseline");
+        }
+        assert!(
+            (of(&ids[0]) - uncited - core.activation.cited).abs() < 1e-6,
+            "cited {} against uncited {uncited}, expected a lift of {}",
+            of(&ids[0]),
+            core.activation.cited
+        );
+    }
+
+    #[tokio::test]
     async fn an_api_or_mcp_ask_is_never_recorded() {
         let mut core = test_core().await;
         core.learn.enabled = true;
@@ -2104,6 +2152,39 @@ mod tests {
             assert!(out.event_id.is_none(), "{door:?} recorded a question");
         }
         assert_eq!(core.store.ask_stats().await.unwrap().asked, 0);
+    }
+
+    #[tokio::test]
+    async fn an_mcp_or_api_ask_engages_nothing_by_citing_it() {
+        // The recorded decision about what `/mcp` counts as use: nothing. Its
+        // search already bumps activation like every other door, and counting
+        // what it returned as engagement on top would only relearn what
+        // association learns from display. The citation is the one honest
+        // signal a question gives, and it is only recorded at the web door —
+        // so the bump rides with the recording rather than around it.
+        let mut core = test_core().await;
+        core.learn.enabled = true;
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some("the answer rests on this [1]".into()),
+        }));
+        seed(&core, 3, 4).await;
+
+        for door in [Door::Api, Door::Mcp] {
+            let out = core.ask(&req("chunk"), door).await.unwrap();
+            core.background.wait_idle().await;
+            let ids: Vec<String> = out
+                .citations
+                .iter()
+                .map(|c| c.artifact_id.clone())
+                .collect();
+            let act = core.store.activation_of(&ids).await.unwrap();
+            let of = |id: &String| act.get(id).map(|(a, _)| *a).unwrap_or(0.0);
+            assert_eq!(
+                of(&ids[0]),
+                of(&ids[1]),
+                "{door:?} engaged what its answer cited"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -538,6 +538,33 @@ impl Core {
         }
     }
 
+    /// An answer cited this artifact, so the model drew on it. `ask_citations`
+    /// has said which those were since it was written; nothing read it as use.
+    ///
+    /// Deliberately not `mark_artifact_seen`: that stamps `last_seen_at`, and
+    /// the stale review list exists to put artifacts nobody has verified in
+    /// front of a person. A model citing one is not a person having looked at
+    /// it, so stamping would quietly remove it from the list that was trying
+    /// to get it looked at. What a citation is, is an engagement — the one kind
+    /// of bump that can promote.
+    pub fn mark_artifacts_cited(&self, ids: Vec<String>) {
+        if ids.is_empty() || !self.associating() {
+            return;
+        }
+        let core = self.clone();
+        let (delta, half_life) = (self.activation.cited, self.activation.half_life_days);
+        let at = now_secs();
+        self.background.spawn(async move {
+            if let Err(e) = core.store.bump_activation(&ids, delta, half_life, at).await {
+                tracing::warn!(error = %e, "could not raise activation for a citation");
+                return;
+            }
+            if let Err(e) = crate::jobs::promote::maybe_promote(&core, &ids, at).await {
+                tracing::warn!(error = %e, "could not check the promotion threshold");
+            }
+        });
+    }
+
     /// What happened after the list rendered: this artifact was opened, or
     /// reached from `via` — a neighbour, an association, a continuation. The
     /// pursuit sweep attaches it to a search by time and scope; nothing here

--- a/src/jobs/promote.rs
+++ b/src/jobs/promote.rs
@@ -291,6 +291,61 @@ mod tests {
         (core, out.id, p)
     }
 
+    /// The live half of what the pursuit sweep used to re-check hours later.
+    ///
+    /// A citation is the one signal `/ask` honestly gives about an artifact,
+    /// and it arrives at the bump — against an activation that has not decayed
+    /// yet, which is the whole reason the sweep's copy of this check could only
+    /// ever decline where this one declined.
+    #[tokio::test]
+    async fn an_artifact_an_answer_cited_can_promote_its_window() {
+        let (mut core, corpus, p) = earned_with_one_passage().await;
+        core.completer = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some("the answer rests on this [1]".into()),
+        }));
+        crate::jobs::embed::run(&core, &p).await.unwrap();
+        // The searches an ask runs bump retrieval too, and enough of it to
+        // carry a passage over the line on its own — which would leave this
+        // test passing with the citation deleted. Retrieval is silenced so
+        // that the only thing left that can move activation is the citation.
+        core.activation.retrieved = 0.0;
+        let now = crate::store::now();
+        // Just under the line, so the citation is what carries it over.
+        core.store
+            .bump_activation(
+                std::slice::from_ref(&p),
+                core.promote.activation_above - core.activation.cited + 0.1,
+                core.activation.half_life_days,
+                now,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Verbatim),
+            "the window was already promoted before the question"
+        );
+
+        core.ask(
+            &crate::core::ask::AskRequest {
+                q: "verbatim passage".into(),
+                limit: None,
+                tags: vec![],
+                category: None,
+            },
+            crate::store::feedback::Door::Ui.by("me"),
+        )
+        .await
+        .unwrap();
+        core.background.wait_idle().await;
+
+        assert_eq!(
+            core.store.segment_state(&corpus, 0).await.unwrap(),
+            Some(SegmentState::Pending),
+            "the citation engaged the artifact but armed nothing"
+        );
+    }
+
     fn unit(corpus: &str) -> String {
         crate::jobs::window::unit_target(corpus, 0)
     }

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -182,8 +182,6 @@ pub struct Need {
 pub enum Decision {
     Satisfied(String),
     Unsatisfied(String),
-    /// One engaged artifact: its window, not a generation.
-    Promote(String),
     Generate,
 }
 
@@ -191,9 +189,6 @@ pub enum Decision {
 /// hit was engaged, the question was rephrased and rephrased, the last search
 /// was walked away from, the model declined to answer.
 ///
-/// Read twice — once here, once by the caller of a `Promote`, which has to say
-/// whether the need was met after finding out what the promotion did — and so
-/// it lives in one place rather than being spelled out in both.
 pub fn unsatisfied(n: &Need) -> bool {
     !n.strong_engaged || n.refined >= 2 || n.abandoned || n.abstained
 }
@@ -206,9 +201,6 @@ pub fn decide(n: &Need, min_sources: usize, min_engagement: f64) -> Decision {
     let total: f64 = n.engagement.iter().map(|(_, w)| *w).sum();
     let unsatisfied = unsatisfied(n);
     if n.engagement.len() < min_sources {
-        if n.engagement.len() == 1 {
-            return Decision::Promote(n.engagement[0].0.clone());
-        }
         return if unsatisfied {
             // Above the shipped `min_sources = 2` this is reachable with
             // artifacts engaged, and "nothing engaged" would then be a lie.
@@ -414,29 +406,6 @@ pub async fn run(core: &Core) -> Result<usize> {
                 core.store
                     .close_pursuit(&pid, "unsatisfied", &why, now)
                     .await?;
-            }
-            Decision::Promote(id) => {
-                // Promoted first, then closed: the reason is a statement about
-                // what happened, and every guard in `maybe_promote` can
-                // decline silently. A promotion case that armed nothing did
-                // nothing at all for this need, so it is only `satisfied` when
-                // nothing said otherwise — one open at the end of three
-                // rephrasings is not a need that was met.
-                let armed =
-                    crate::jobs::promote::maybe_promote(core, std::slice::from_ref(&id), now)
-                        .await?;
-                let (state, why) = match (armed > 0, unsatisfied(&need)) {
-                    (true, _) => (
-                        "satisfied",
-                        "one artifact engaged: its window is being re-read",
-                    ),
-                    (false, false) => ("satisfied", "one artifact engaged and searching stopped"),
-                    (false, true) => (
-                        "unsatisfied",
-                        "one artifact engaged, not enough to write from",
-                    ),
-                };
-                core.store.close_pursuit(&pid, state, why, now).await?;
             }
             Decision::Generate => {
                 // Nothing to arm without a generator. `run_claimed` would drop
@@ -741,10 +710,12 @@ mod tests {
         let mut n = need(&[("a", 5.0), ("b", 5.0)]);
         n.answered = true;
         assert!(matches!(decide(&n, 2, 3.0), Decision::Satisfied(_)));
-        // One engaged artifact: promotion, not generation.
+        // One engaged artifact is below `min_sources` like any other shortfall.
+        // It used to be a promotion case of its own; the engagement that made
+        // it one now promotes at the bump, hours before this sweep runs.
         assert_eq!(
             decide(&need(&[("a", 9.0)]), 2, 3.0),
-            Decision::Promote("a".into())
+            Decision::Satisfied("nothing to assemble".into())
         );
         // Three strong opens in a row, then stopped: reading, not assembling.
         assert!(matches!(
@@ -1278,7 +1249,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn one_engaged_artifact_is_a_promotion_case() {
+    async fn one_engaged_artifact_after_refining_closes_unsatisfied() {
         let core = pursuing_core().await;
         let out = core
             .ingest("a verbatim passage", "web", None)
@@ -1291,50 +1262,12 @@ mod tests {
             .id
             .clone();
         let now = crate::store::now();
-        // Enough activation that the promotion check passes when the sweep asks.
-        core.store
-            .bump_activation(std::slice::from_ref(&p), 5.0, 14.0, now)
-            .await
-            .unwrap();
-        search_event(&core, "that passage", vec![1.0, 0.0], &[&p], now - 100).await;
-        core.store
-            .record_interaction(&p, "opened", None, Some("me"), now - 99)
-            .await
-            .unwrap();
-        run(&core).await.unwrap();
-        assert_eq!(
-            core.store.segment_state(&out.id, 0).await.unwrap(),
-            Some(crate::store::segments::SegmentState::Pending),
-            "the window was not promoted"
-        );
-        // And the row says what was done, not which branch was taken.
-        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
-        assert_eq!(p.state, "satisfied", "{p:?}");
-        assert!(
-            p.reason.as_deref().unwrap_or_default().contains("re-read"),
-            "{p:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_promotion_that_armed_nothing_after_refining_closes_unsatisfied() {
-        let core = pursuing_core().await;
-        let out = core
-            .ingest("a verbatim passage", "web", None)
-            .await
-            .unwrap();
-        crate::jobs::passages::capture_verbatim(&core, &out.id)
-            .await
-            .unwrap();
-        let p = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
-            .id
-            .clone();
-        let now = crate::store::now();
-        // No activation: the promotion check will decline, so nothing at all
-        // happens for this need — and three phrasings of one question with a
-        // single open at the end is the shape of a need that went unmet.
-        // Inside one sitting: further apart than `idle_secs` and these would
-        // be three pursuits, not one need asked three ways.
+        // Three phrasings of one question with a single open at the end is the
+        // shape of a need that went unmet. Nothing the sweep does can help it:
+        // one engaged artifact is below `min_sources`, and the sweep no longer
+        // has a promotion of its own to try. Inside one sitting — further apart
+        // than `idle_secs` and these would be three pursuits, not one need
+        // asked three ways.
         search_event(&core, "where is it stored", vec![1.0, 0.0], &[&p], now - 40).await;
         search_event(&core, "where is it kept", vec![1.0, 0.0], &[&p], now - 36).await;
         search_event(&core, "storage location", vec![1.0, 0.0], &[&p], now - 32).await;

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -803,10 +803,18 @@ async fn resurface(
 
 async fn get_artifact(
     State(st): State<AppState>,
-    _id: Identity,
+    id: Identity,
     Path(cid): Path<String>,
 ) -> Result<Json<crate::store::artifacts::Chunk>> {
-    Ok(Json(st.core.store.get_artifact(&cid).await?))
+    let chunk = st.core.store.get_artifact(&cid).await?;
+    // Asking for one artifact by id is the same deliberate act the detail pane
+    // records, and it is the whole of what this door can honestly say: there
+    // is no navigation to have pivoted through, so no `via`, and no session to
+    // belong to, because a bearer token is not a conversation. Written after
+    // the read succeeds — a 404 engaged nothing.
+    st.core.mark_artifact_seen(&cid);
+    st.core.record_interaction(&cid, None, Some(&id.subject));
+    Ok(Json(chunk))
 }
 
 async fn patch_artifact(
@@ -1158,6 +1166,45 @@ pub(crate) mod tests {
                 "the report dropped `{key}`: {body}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn reading_an_artifact_over_the_api_is_an_open() {
+        // The API door was the one place a read left no trace at all: an agent
+        // could work through `GET /artifacts/{id}` all afternoon and teach the
+        // offer ladder, promotion and pursuits precisely nothing.
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let out = core
+            .ingest("a verbatim passage", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::passages::capture_verbatim(&core, &out.id)
+            .await
+            .unwrap();
+        let a = core.store.artifacts_for_corpus(&out.id).await.unwrap()[0]
+            .id
+            .clone();
+        let (app, token, core) = app_from_core(core).await;
+
+        let res = app
+            .oneshot(get(&format!("/api/v1/artifacts/{a}"), Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        core.background.wait_idle().await;
+        let got = core
+            .store
+            .interactions_between(0, crate::store::now() + 1)
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 1, "the API read was not recorded: {got:?}");
+        assert_eq!(got[0].artifact_id, a);
+        assert_eq!(got[0].kind, "opened");
+        // The API has no navigation to pivot through and no session to belong
+        // to: a bearer token is not a conversation.
+        assert_eq!(got[0].via, None);
     }
 
     fn get(uri: &str, token: Option<&str>) -> Request<Body> {


### PR DESCRIPTION
Two roadmap items from **[What counts as use]**, which are really one piece of work: `mark_artifact_seen` and `record_interaction` had exactly one production caller between them, so everything plastic in the base — the offer ladder, promotion, pursuits, `jobs::context` — was learning from the web UI and nothing else.

## The API door is an open

`GET /api/v1/artifacts/{id}` marks the artifact seen and records the interaction, after the read succeeds. No `via` (the API has no navigation to have pivoted through) and no session (a bearer token is not a conversation, and that absence is what keeps the live sitting at the web door).

## A citation is an engagement

`ask_citations.used` has separated what an answer was *shown* from what it *used* since it was written, and nothing read it as use. `Core::mark_artifacts_cited` now bumps `activation.cited` for the artifacts an answer cited and checks them for promotion at the bump.

New config key `[activation] cited = 0.5` — what an open weighs, not what a confirmation does: a model citing an artifact did not verify the answer was right. For the same reason it does **not** stamp `last_seen_at` the way an open does. The stale review list exists to put artifacts nobody has verified in front of a person; stamping would quietly remove one from the list that was trying to get it looked at.

## The recorded decision: `/mcp` counts as nothing beyond what it already does

Its search bumps activation like every other door. It has no open at all — a search returns the whole artifact, so the read *is* the result — and counting every returned artifact as engagement would only relearn what association already learns from display. The honest signal there is the citation, and citations are recorded only where the question is: `record_ask` stays at the web door because a question is personal data of the same kind as a query. So the bump rides with the recording rather than around it, and a test pins that. Widening it means widening what is *recorded* first, which is a different decision.

## The pursuit sweep's promotion call deletes itself

It ran only once the sitting had been idle for `idle_secs`, re-checking one artifact against a *more* decayed activation than the live call saw — so it could only ever decline where that one declined. Its single remaining case was an artifact engaged solely by a citation, which now promotes at the bump.

`Decision::Promote` goes with it: with nothing to promote, the branch only chose between the same two closes the below-`min_sources` branch already makes. Net −89/+9 in `jobs/pursuit.rs`.

## Tests

1638 pass (was 1635): +4 new, −1 superseded. `cargo clippy --all-targets` and `cargo fmt --check` clean.

| Test | Evidence |
|---|---|
| `reading_an_artifact_over_the_api_is_an_open` | Watched it fail on an empty interactions table |
| `only_the_artifacts_an_answer_cited_are_engaged_by_it` | Differential against the shared retrieval baseline; watched it fail at "cited 2 against uncited 2" |
| `an_mcp_or_api_ask_engages_nothing_by_citing_it` | Would have passed immediately, so mutation-checked: hoisting the bump above the door gate makes it fail |
| `an_artifact_an_answer_cited_can_promote_its_window` | Replaces `one_engaged_artifact_is_a_promotion_case`. First passed for a weak reason (retrieval bumps alone crossed the threshold), so `activation.retrieved` is silenced to isolate the citation; confirmed the bump's removal makes it fail |

**No harness run.** Neither change moves how a fixed input is ranked — only what is learned from use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EkeVRBEiEg31XRXyY29j8