### PR TITLE
The note a file carries, and the box it is typed into

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -245,19 +245,31 @@
     }
 
     // One act in flight. From the press of Ask until the answer lands, the box
-    // and both verbs are disabled and only Stop is live.
+    // is read-only, both verbs are disabled and only Stop is live.
     //
-    // Disabling the box is what disables search-while-type: a disabled input
-    // fires no `keyup`, so the form's `hx-trigger` goes quiet on its own —
-    // there is no second mechanism and no flag to keep in sync with this one.
+    // Read-only rather than disabled, which is what it was. `disabled` is the
+    // one state that also makes text unselectable and hands focus back to the
+    // body, so the question being answered could not be copied out of the box
+    // holding it — while the CSS went to the trouble of keeping that text
+    // legible, on the grounds that a box someone is waiting on is still a box
+    // someone is reading. Read-only keeps the caret, the selection and the
+    // focus, and silences search-while-type just as completely: nothing can be
+    // typed or pasted into it, so no `input` is fired and the form's
+    // `hx-trigger` goes quiet on its own — there is no second mechanism and no
+    // flag to keep in sync with this one.
+    //
+    // The one thing `disabled` did that this does not is drop `q` from the
+    // serialization. That was never what kept a stray request honest anyway;
+    // `configRequest` below is, and it cancels every request this form makes
+    // while the ask owns it.
     //
     // The re-enable lives in `stop()` and nowhere else, because every exit
     // already runs through it: the answer completing, the Stop button, and the
     // transport error that `fail()` funnels into it. That last one is the
     // reason it cannot live on the `done` handler — a dropped connection would
-    // leave the box disabled forever, with no way back but a reload.
+    // leave the box read-only forever, with no way back but a reload.
     function setBusy(busy) {
-      box.disabled = busy;
+      box.readOnly = busy;
       form.setAttribute('aria-busy', busy ? 'true' : 'false');
       var vs = form.querySelectorAll('[data-verb]');
       for (var i = 0; i < vs.length; i++) vs[i].disabled = busy;
@@ -284,13 +296,15 @@
       }, 1000);
     }
 
-    // No search leaves this form while an ask owns the page. Disabling the
-    // box silences its `keyup`, but not a debounce timer that armed just
-    // before Ask was pressed, and not the "← results" anchor firing
-    // `submit` — and a disabled control serializes nothing, so either one
-    // sent `q` empty and swapped the idle rail over the citations the answer
-    // was being written from. `configRequest` is cancelable and is the one
-    // gate every htmx request from this form passes through.
+    // No search leaves this form while an ask owns the page. A read-only box
+    // fires no `input`, but that silences neither a debounce timer that armed
+    // just before Ask was pressed nor the "← results" anchor firing `submit`,
+    // and either one swapped the idle rail over the citations the answer was
+    // being written from. It matters more since the box stopped being
+    // `disabled`: `q` now serializes while the ask runs, so a request that got
+    // out would search for the question instead of sending it empty — a live
+    // rail either way. `configRequest` is cancelable and is the one gate every
+    // htmx request from this form passes through.
     form.addEventListener('htmx:configRequest', function (e) {
       if (form.getAttribute('aria-busy') === 'true') e.preventDefault();
     });
@@ -835,7 +849,10 @@
       for (var i = 0; i < buttons.length; i++) {
         buttons[i].disabled = buttons[i].getAttribute('data-verb') === 'capture'
           ? !(hasText || hasFile)
-          : !hasText;
+          // A staged file has made the box that file's note. Asking a note is
+          // not a thing to do, and the answer would land beside a file the
+          // question was never about.
+          : (!hasText || hasFile);
       }
     }
 
@@ -846,15 +863,87 @@
     // This is not the box changing shape on its own in the sense the panel
     // rules out: it never becomes a different control, and it never decides
     // what the words in it are for. It only stops hiding them.
+    //
+    // The padding and the border have to be added back, and leaving them out
+    // was worth two pixels of permanent scroll. `.box` is `border-box`, so the
+    // height set here is the outside of the element, while `scrollHeight` is
+    // the inside — content and padding, never the 1px border on each edge. The
+    // box therefore ended two pixels shorter than the text it was measured
+    // from, every time, and with `overflow-y: auto` above it that is a live
+    // scrollbar on a box that has nothing to scroll. The cap is the other half
+    // of the same mistake: ten lines of text plus the padding they sit in, or
+    // the tenth line is the one the padding eats.
     var CAP = 10;
     function grow() {
       box.style.height = 'auto';
-      var line = parseFloat(getComputedStyle(box).lineHeight) || 20;
-      box.style.height = Math.min(box.scrollHeight, line * CAP) + 'px';
+      var css = getComputedStyle(box);
+      var line = parseFloat(css.lineHeight) || 20;
+      var pad = parseFloat(css.paddingTop) + parseFloat(css.paddingBottom);
+      var border = box.offsetHeight - box.clientHeight;
+      box.style.height =
+        Math.min(box.scrollHeight - pad, line * CAP) + pad + border + 'px';
     }
 
     box.addEventListener('input', function () { sync(); grow(); });
-    box.addEventListener(VERB_SYNC, function () { sync(); grow(); });
+    box.addEventListener(VERB_SYNC, function () { sync(); grow(); fitPlaceholder(); });
+
+    // The height is a measurement of wrapped text, and text re-wraps whenever
+    // the box changes width. Bound to `input` alone it was only ever correct
+    // for the width the last keystroke was typed at: narrow the window, or turn
+    // a phone, and a paragraph that grew to four lines is still four lines tall
+    // with six lines in it — clipped, scrolling, and no key coming to fix it.
+    window.addEventListener('resize', grow);
+    // Inter loads with `font-display: swap`, so the first measurement is of the
+    // fallback face and the swap re-wraps everything under a height nothing
+    // will recompute — the box is not typed into before it is read.
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(grow);
+
+    // The two verbs, without a pointer. This is not the box inferring one from
+    // a newline — the rule it is built on and keeps: Enter puts in a line
+    // break here and always will. The chord is a second, deliberate gesture,
+    // the same act as the button and no more ambiguous, and without it the one
+    // hand that reached the box with `/` had no way back out of it.
+    //
+    // Routed through the button rather than the handler behind it, so that
+    // everything the button already knows goes on being true: an empty box or
+    // an ask in flight leaves it disabled, and a disabled verb does nothing
+    // here either. Where the install has no Ask, there is no button and the
+    // unshifted chord is simply not a key.
+    box.addEventListener('keydown', function (e) {
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey) || e.altKey) return;
+      var verb = form.querySelector(
+        '[data-verb="' + (e.shiftKey ? 'capture' : 'ask') + '"]');
+      if (!verb || verb.disabled) return;
+      e.preventDefault();
+      verb.click();
+    });
+
+    // The long placeholder names all three verbs, which is what the box needs
+    // said and what the phone has no room for: one row at that width clips it
+    // around the thirtieth character, and the hint that would have carried the
+    // rest is `display: none` there. Read off the element rather than branched
+    // on in the template, because app.js is one file for every installation —
+    // the same reason `data-eager` exists below. Bound to the query, not read
+    // once, so a rotation is not a sentence that stays cut in half.
+    var narrow = window.matchMedia('(max-width: 40rem)');
+    var wide = box.placeholder;
+    var short = box.getAttribute('data-placeholder-narrow') || wide;
+    // And a third, for when the box is not a query box at all: a staged file
+    // makes it that file's note. Asked here rather than written from
+    // `stage()`, because this function owns the placeholder and re-runs on
+    // every rotation — set from outside, the note's prompt would survive until
+    // the first turn of the phone and then be replaced by a search hint over
+    // an annotation half typed. Short enough for either width.
+    var NOTE_HINT = 'What is it, why keep it?';
+    function fitPlaceholder() {
+      var stagedEl = document.getElementById('staged');
+      box.placeholder = stagedEl && !stagedEl.hidden
+        ? NOTE_HINT
+        : (narrow.matches ? short : wide);
+    }
+    narrow.addEventListener('change', fitPlaceholder);
+    fitPlaceholder();
+
     sync();
     grow();
   }
@@ -890,18 +979,29 @@
 
     var drop = document.getElementById('drop');
     var picker = drop && drop.querySelector('input[type=file]');
-    var noteBox = document.querySelector('input[name="note"]');
     // Same reason as EAGER: read off the picker the server rendered, which
     // names `image/*` only where `[infer.vision]` is configured.
     var VISION = !!picker && (picker.getAttribute('accept') || '').indexOf('image/*') >= 0;
 
     // ── What is waiting to be sent ────────────────────────────────────────
     // A file arriving is not a capture. It is held here until Capture is
-    // pressed, so the note beside it can be written and the wrong photo can be
-    // removed — on a phone the camera hands the picture back the moment it is
-    // taken, and uploading on arrival meant the operator never got a say.
+    // pressed, so the note can be written into the box above it and the wrong
+    // photo can be removed — on a phone the camera hands the picture back the
+    // moment it is taken, and uploading on arrival meant the operator never
+    // got a say.
     var staged = null, stagedUrl = null;
     var stagedBox = document.getElementById('staged');
+
+    // The box is that file's note while one is staged, and typing an
+    // annotation into a live search box is an embedding call, an activation
+    // bump and a Judge-queue row per phrase — for text nobody asked as a
+    // question. Cancelling the form's own requests rather than rewriting its
+    // `hx-trigger`: the trigger is the template's to say, and this holds
+    // whatever it says. Capture does not go through the form, and Ask is
+    // disabled in `boxVerbs` while a file waits.
+    form.addEventListener('htmx:beforeRequest', function (e) {
+      if (staged) e.preventDefault();
+    });
     var stagedName = document.getElementById('staged-name');
     var stagedThumb = document.getElementById('staged-thumb');
     var stagedClear = document.getElementById('staged-clear');
@@ -928,11 +1028,14 @@
     }
 
     // `restore` is the failed upload coming back: the same file, already
-    // described, and no reason to reach for the note a second time.
-    // Where a capture answers. One press can be two captures — a staged file
-    // and the text above it — and both used to write this node whole: whichever
-    // request landed last wiped the other's line, an upload's error included.
-    // A line each, cleared once per press.
+    // described, and no reason to take the caret off the note a second time.
+    //
+    // Where a capture answers. A press was once two captures — a staged file
+    // and the text above it, which is now that file's note — and both wrote
+    // this node whole: whichever request landed last wiped the other's line,
+    // an upload's error included. A line each, cleared once per press. One
+    // press writes one line now, and the appending swap below is what keeps
+    // that true rather than what makes it necessary.
     function receipt() {
       var host = document.getElementById('capture-result');
       var slot = document.createElement('p');
@@ -973,15 +1076,13 @@
       // paste box and the search box already follow. On a phone this would
       // throw the software keyboard over the thumbnail the operator is
       // checking, which is the picture they just took.
-      if (noteBox && !restore && window.matchMedia('(hover: hover)').matches) {
-        noteBox.focus();
-      }
+      if (!restore && window.matchMedia('(hover: hover)').matches) box.focus();
       // A file over an empty box is still something Capture can act on. See
       // `sync` in boxVerbs, which listens for this.
       box.dispatchEvent(new Event(VERB_SYNC, { bubbles: true }));
     }
 
-    function send(file) {
+    function send(file, note) {
       if (!file) return;
       var isImage = file.type.indexOf('image/') === 0;
       // By name as well as by type: a drop from some file managers carries no
@@ -997,7 +1098,7 @@
       // sends and pressing Capture looked like it had done nothing.
       result.textContent = 'Sending…';
       var payload = new FormData();
-      if (noteBox && noteBox.value.trim()) payload.append('note', noteBox.value.trim());
+      if (note) payload.append('note', note);
       // The fallback name matters: a PDF that arrived unnamed and went up as
       // `paste.txt` would be refused by the very door it belongs to.
       var fallbackName = isImage ? 'photo.jpg' : (isPdf ? 'capture.pdf' : 'paste.txt');
@@ -1026,7 +1127,10 @@
                : 'Captured.')
             : (pair[1].error || 'Upload failed.');
           if (pair[0]) {
-            if (noteBox) noteBox.value = '';
+            // The note went in with the file. The box is a search box again
+            // and holding the words it sent is not that.
+            box.value = '';
+            box.dispatchEvent(new Event(VERB_SYNC, { bubbles: true }));
             refreshRail();
           } else {
             // It never left. Put it back where it was, so the fix is a second
@@ -1155,12 +1259,22 @@
     verb.addEventListener('click', function (e) {
       e.preventDefault();
       clearReceipts();
-      var file = null;
-      if (staged) { file = staged; unstage(); }
-      // Never both in flight. They write the same node, and a failed swap
-      // empties it — so the upload's line is written last, or a text capture
-      // that fails takes the photo's receipt down with it.
-      postText().then(function () { if (file) send(file); });
+      // A staged file is one capture, annotated — never two. The box is read
+      // here, at press time, which is what makes the order the file and the
+      // words arrived in stop mattering: nothing moved when the file was
+      // staged, and nothing moves now but this read.
+      //
+      // `from_ask` needs no guard: `postText` is its only sender, and a staged
+      // file no longer reaches it. A whole model answer turned into a caption
+      // on somebody's PDF is not what that provenance claims.
+      if (staged) {
+        var file = staged;
+        var note = box.value.trim();
+        unstage();
+        send(file, note);
+        return;
+      }
+      postText();
     });
     // A pasted screenshot goes the same way as a dropped one — unless the
     // paste is on its way somewhere that takes text. A clipboard from Sheets,
@@ -1360,8 +1474,10 @@
       // The box is a textarea, and has been since the three pages became one.
       // `select()` because `/` means "start a new query", not "append to the
       // last one" — the same as it always did.
+      // `readOnly` while an ask is in flight, and focusing it then would put a
+      // caret in a box that cannot take the query `/` promised to start.
       var q = document.querySelector('textarea[name="q"]');
-      if (q && !q.disabled) { e.preventDefault(); q.focus(); q.select(); }
+      if (q && !q.readOnly) { e.preventDefault(); q.focus(); q.select(); }
       return;
     }
     if (e.key === 'Escape') {

--- a/assets/app.js
+++ b/assets/app.js
@@ -990,6 +990,12 @@
     // moment it is taken, and uploading on arrival meant the operator never
     // got a say.
     var staged = null, stagedUrl = null;
+    // Set from the press until the upload answers. `staged` is cleared before
+    // the file is sent, and a debounce armed by the last word of the note
+    // fires after that — a search for the annotation, which is the one thing
+    // the guard below exists to prevent. The box is not cleared early instead:
+    // a capture that fails keeps its note for the second press.
+    var sending = false;
     var stagedBox = document.getElementById('staged');
 
     // The box is that file's note while one is staged, and typing an
@@ -1000,7 +1006,7 @@
     // whatever it says. Capture does not go through the form, and Ask is
     // disabled in `boxVerbs` while a file waits.
     form.addEventListener('htmx:beforeRequest', function (e) {
-      if (staged) e.preventDefault();
+      if (staged || sending) e.preventDefault();
     });
     var stagedName = document.getElementById('staged-name');
     var stagedThumb = document.getElementById('staged-thumb');
@@ -1118,6 +1124,12 @@
         })
         .catch(function () { return [false, { error: 'engram is unreachable.' }]; })
         .then(function (pair) {
+          // Lifted before the branches: `refreshRail` below submits the form,
+          // and a guard still standing would cancel the very refresh the
+          // capture was made for. Any debounce armed while the note was being
+          // typed has long since tried to fire and been cancelled — it was
+          // 120ms behind the press, and this is a round trip later.
+          sending = false;
           // The server's reason, verbatim. A generic "upload failed" would
           // hide what actually goes wrong here: wrong type, wrong encoding,
           // an image door that is closed.
@@ -1270,6 +1282,7 @@
       if (staged) {
         var file = staged;
         var note = box.value.trim();
+        sending = true;
         unstage();
         send(file, note);
         return;

--- a/assets/css/00-tokens.css
+++ b/assets/css/00-tokens.css
@@ -6,11 +6,11 @@
    frontend/src/components/ui/), converted from Tailwind @theme to plain CSS.
    Visualization palette and density toggle deliberately not carried. */
 
-@font-face { font-family: "Inter"; font-weight: 400; font-display: swap;
+@font-face { font-family: Inter; font-weight: 400; font-display: swap;
   src: url("/assets/fonts/inter-400.woff2") format("woff2"); }
-@font-face { font-family: "Inter"; font-weight: 500; font-display: swap;
+@font-face { font-family: Inter; font-weight: 500; font-display: swap;
   src: url("/assets/fonts/inter-500.woff2") format("woff2"); }
-@font-face { font-family: "Inter"; font-weight: 600; font-display: swap;
+@font-face { font-family: Inter; font-weight: 600; font-display: swap;
   src: url("/assets/fonts/inter-600.woff2") format("woff2"); }
 @font-face { font-family: "JetBrains Mono"; font-weight: 400; font-display: swap;
   src: url("/assets/fonts/jetbrains-mono-400.woff2") format("woff2"); }
@@ -31,21 +31,18 @@
 
   --radius-sm: 3px;
   --radius-md: 6px;
-  --radius-lg: 10px;
-}
 
-:root {
+  /* …and the light half of the palette, on the same bare `:root`. One block,
+     because two `:root` blocks in a row are one block written twice. */
   --color-bg-base: #f8f6f1;
   --color-bg-surface: #f2f0ea;
   --color-bg-elevated: #ffffff;
-  --color-bg-overlay: #ffffff;
   --color-bg-hover: #ece9e2;
   --color-bg-active: #e2ded3;
 
   --color-fg-primary: #2d2d2d;
   --color-fg-secondary: #5a5a5a;
   --color-fg-muted: #7a7a72;
-  --color-fg-disabled: #b8b5ac;
 
   --color-border: #ddd8cc;
   --color-border-strong: #c9c3b4;
@@ -59,11 +56,6 @@
   --color-danger: #b3382c;  --color-danger-dim: rgba(179, 56, 44, 0.1);
   --color-warning: #9a6a1a; --color-warning-dim: rgba(154, 106, 26, 0.1);
   --color-success: #2f7a4f; --color-success-dim: rgba(47, 122, 79, 0.1);
-  --color-info: #3d6f99;    --color-info-dim: rgba(61, 111, 153, 0.1);
-
-  --shadow-sm: 0 1px 2px rgba(45, 45, 45, 0.08);
-  --shadow-md: 0 4px 12px rgba(45, 45, 45, 0.1);
-  --shadow-lg: 0 12px 32px rgba(45, 45, 45, 0.14);
 
   color-scheme: light;
 }
@@ -84,14 +76,12 @@
     --color-bg-base: #0e1015;
     --color-bg-surface: #14171d;
     --color-bg-elevated: #1b1e26;
-    --color-bg-overlay: #22252f;
     --color-bg-hover: #262a34;
     --color-bg-active: #2d3140;
 
     --color-fg-primary: #e2e4ec;
     --color-fg-secondary: #8b8fa8;
     --color-fg-muted: #7d82a0;
-    --color-fg-disabled: #3a3d50;
 
     --color-border: #232636;
     --color-border-strong: #2e3244;
@@ -105,11 +95,6 @@
     --color-danger: #e05252;  --color-danger-dim: rgba(224, 82, 82, 0.15);
     --color-warning: #e8a839; --color-warning-dim: rgba(232, 168, 57, 0.15);
     --color-success: #4caf7d; --color-success-dim: rgba(76, 175, 125, 0.15);
-    --color-info: #5e9ed6;    --color-info-dim: rgba(94, 158, 214, 0.15);
-
-    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.5);
-    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
-    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.8);
 
     color-scheme: dark;
   }
@@ -119,14 +104,12 @@
     --color-bg-base: #0e1015;
     --color-bg-surface: #14171d;
     --color-bg-elevated: #1b1e26;
-    --color-bg-overlay: #22252f;
     --color-bg-hover: #262a34;
     --color-bg-active: #2d3140;
 
     --color-fg-primary: #e2e4ec;
     --color-fg-secondary: #8b8fa8;
     --color-fg-muted: #7d82a0;
-    --color-fg-disabled: #3a3d50;
 
     --color-border: #232636;
     --color-border-strong: #2e3244;
@@ -140,11 +123,6 @@
     --color-danger: #e05252;  --color-danger-dim: rgba(224, 82, 82, 0.15);
     --color-warning: #e8a839; --color-warning-dim: rgba(232, 168, 57, 0.15);
     --color-success: #4caf7d; --color-success-dim: rgba(76, 175, 125, 0.15);
-    --color-info: #5e9ed6;    --color-info-dim: rgba(94, 158, 214, 0.15);
-
-    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.5);
-    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
-    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.8);
 
     color-scheme: dark;
 }

--- a/assets/css/20-layout.css
+++ b/assets/css/20-layout.css
@@ -22,6 +22,22 @@
   padding: 0 1rem 4rem;
 }
 
+.regions {
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+  grid-template-columns: [rail] 22rem [focus] minmax(0, 1fr);
+}
+
+/* A grid child defaults to `min-width: auto`, which resolves to min-content:
+   one unwrappable line of source widens its column instead of scrolling inside
+   it, and takes the document's width with it. */
+.regions > * { min-width: 0; }
+
+.region-bar { grid-column: 1 / -1; }
+.region-rail { grid-column: rail; }
+.region-focus { grid-column: focus; }
+
 /* The three-up workspace fills the window instead of ending wherever its
    tallest pane happens to stop. `.shell` takes the space under the top row and
    hands it to the region grid, which is what lets one height reach all three
@@ -51,32 +67,16 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
    content and the window's bottom meant nothing. This is the pin, and it needs
    a definite height to divide.
 
-   62rem is `@container shell (max-width: 60rem)` written as a media query, and
+   62rem is `@container shell (width <= 60rem)` written as a media query, and
    the arithmetic is exact rather than approximate: `.shell` is `min(110rem,
    100vw)` wide less its own `1rem` of padding on each side, so a 60rem
    container is a 62rem viewport. It has to be a media query — `body` is
    outside the container it would have to ask about. */
-@media (min-width: 62rem) {
+@media (width >= 62rem) {
   body:has(.regions-rail-focus-source) { height: 100dvh; overflow: hidden; }
   /* The foot under a page that ends. This one ends at the window. */
   body:has(.regions-rail-focus-source) > .shell { padding-bottom: 1rem; }
 }
-
-.regions {
-  display: grid;
-  gap: 1rem;
-  align-items: start;
-  grid-template-columns: [rail] 22rem [focus] minmax(0, 1fr);
-}
-
-/* A grid child defaults to `min-width: auto`, which resolves to min-content:
-   one unwrappable line of source widens its column instead of scrolling inside
-   it, and takes the document's width with it. */
-.regions > * { min-width: 0; }
-
-.region-bar { grid-column: 1 / -1; }
-.region-rail { grid-column: rail; }
-.region-focus { grid-column: focus; }
 
 /* One region. Two of them, and the difference is what the region holds rather
    than how wide the page fancies being — which is the distinction the three
@@ -98,27 +98,6 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
 .regions-center > * { grid-column: 1 / -1; }
 .regions-table > * { grid-column: 1 / -1; }
 
-/* Two regions: what the page is for, and what it has already done with it.
-   Prose keeps its measure on the left — a paste box and an answer are both
-   prose — and the aside takes what is left of the window.
-
-   This exists because the prose pages were leaving that remainder empty. At
-   1690px a 68rem column anchored left is six hundred pixels of nothing beside
-   it, and every one of those pages had a second thing already on it, stacked
-   underneath or folded into a scroller: Capture's Recent, Ask's excerpts. The
-   width was never the problem. Not using it was.
-
-   The aside has a floor rather than `minmax(0, 1fr)`, because an `fr` track
-   takes what is left after a 68rem column and what is left can be nothing. At
-   an 81rem shell — a maximised laptop window — that left a 3rem gutter holding
-   the Recent list: every title truncated to one letter, the timestamp column
-   wider than the name beside it. Under the floor the reading column gives way
-   instead, which is the one that has room to. */
-.regions-focus-aside {
-  grid-template-columns: [focus] minmax(0, 68rem) [aside] minmax(24rem, 1fr);
-}
-.region-aside { grid-column: aside; }
-
 /* An artifact and where it came from, as one `.split` in a single full-width
    region. Not prose and not a table: the split decides its own two columns,
    and this is the same pair the search pane renders — so it gets the same
@@ -133,7 +112,7 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
    that split having room to be two columns instead of two stacked halves.
 
    So the rail gives some back rather than the grid growing a column. */
-@container shell (min-width: 90rem) {
+@container shell (width >= 90rem) {
   .regions-rail-focus-source { grid-template-columns: [rail] 19rem [focus] minmax(0, 1fr); }
 }
 
@@ -151,9 +130,12 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
    written into the column beside it.
 
    Inside a container query because of what it is: a claim about how to divide
-   two columns, which is nonsense where there is only one. Three `:not()`s
-   outrank the single class the one-up block below sets `grid-template-columns`
-   with, and specificity does not care that the two rules answer different
+   two columns, which is nonsense where there is only one. Chained rather than
+   `:not(.has-selection, .answering)`: the chain counts both classes and the
+   list counts one, and the three classes are what outrank the `.regions.reading`
+   track list in 40-workspace.css, which is a later file at equal weight. The
+   chain also outranks the single class the one-up block below sets
+   `grid-template-columns` with, and specificity does not care that the two rules answer different
    widths — so an idle narrow screen kept this two-column track list, and the
    pane it left beside a 40rem rail was twelve pixels wide. Bounded here rather
    than fought there: the one-up block says what one column is, and this says
@@ -167,7 +149,7 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
 /* One-up: one region, the rest a navigation away. This is the phone, and it is
    equally a half-width desktop window — which is the whole reason it is a
    container query and not a device breakpoint. */
-@container shell (max-width: 60rem) {
+@container shell (width <= 60rem) {
   .regions { grid-template-columns: minmax(0, 1fr); }
   .regions > * { grid-column: 1 / -1; }
   .regions.has-selection .region-rail { display: none; }

--- a/assets/css/30-components.css
+++ b/assets/css/30-components.css
@@ -31,8 +31,6 @@
   color: var(--color-fg-secondary);
   transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
 }
-.btn-icon:hover { background: var(--color-bg-hover); color: var(--color-fg-primary); }
-.btn-icon svg { width: 16px; height: 16px; display: block; }
 /* An icon with a word beside it stops being a square. The square is right for
    a control that repeats down a list — the delete on a rail row, "not related"
    — where the row already says what it acts on. It is wrong for the three that
@@ -42,21 +40,23 @@
   width: auto; padding: 0 0.75rem; gap: 0.375rem;
   font-size: var(--text-xs); font-weight: 500;
 }
+.btn-icon:hover { background: var(--color-bg-hover); color: var(--color-fg-primary); }
+.btn-icon svg { width: 16px; height: 16px; display: block; }
 .btn-icon-danger:hover {
   background: var(--color-danger); border-color: var(--color-danger); color: #fff;
 }
 
-.input, .textarea, .select {
+.input, .textarea {
   width: 100%; font-size: var(--text-base); font-family: inherit;
   color: var(--color-fg-primary); background: var(--color-bg-elevated);
   border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm);
   padding: 0 0.75rem; transition: border-color 120ms ease;
 }
-.input, .select { height: 36px; }
+.input { height: 36px; }
 .textarea { padding: 0.625rem 0.75rem; min-height: 12rem; resize: vertical;
             font-family: var(--font-mono); line-height: 1.6; }
 .input::placeholder, .textarea::placeholder { color: var(--color-fg-muted); }
-.input:focus, .textarea:focus, .select:focus { outline: none; border-color: var(--color-accent); }
+.input:focus, .textarea:focus { outline: none; border-color: var(--color-accent); }
 
 /* `nowrap`, because a badge is a label rather than a paragraph: "100% covered"
    broke across two lines inside its own border and made every table row a
@@ -162,17 +162,13 @@ nav.top a.brand img { display: block; }
 
 /* ── Filter chips ────────────────────────────────────────────────────────── */
 
+/* Composes `.label` for the type; keeps only what is about its place in the
+   row of verbs the one taxonomy rides in. */
+.facet-label { flex: none; width: 2.5rem; padding-top: 3px; }
+
 /* A radio styled as a chip. The input is the state — checked, focusable,
    reachable by keyboard, submitted with the form — and is hidden only from
    sight, so none of that is reimplemented in script. */
-.facets { display: flex; flex-direction: column; gap: 0.375rem; margin-top: 0.625rem; }
-.facets .chips { margin-top: 0; }
-/* Each row says what it narrows by. The label sits on the baseline of the first
-   chip rather than above the row, so two rows cost two lines, not four. */
-.facet-row { display: flex; gap: 0.5rem; align-items: baseline; }
-/* Composes `.label` for the type; keeps only what is about its place in the
-   row. */
-.facet-label { flex: none; width: 2.5rem; padding-top: 3px; }
 .chip { display: inline-flex; cursor: pointer; }
 .chip input {
   position: absolute; width: 1px; height: 1px; margin: -1px;
@@ -274,8 +270,8 @@ mark { background: var(--color-accent-dim); color: inherit; border-radius: 2px; 
      fade is gone by the time the last line arrives rather than lifting the
      instant anything is scrolled. */
   @keyframes scroll-edge {
-    from, 88% { --edge: 2.5rem; }
-    to        { --edge: 0px; }
+    0%, 88% { --edge: 2.5rem; }
+    100%    { --edge: 0px; }
   }
 
   /* No `prefers-reduced-motion` carve-out, deliberately. Nothing here moves on

--- a/assets/css/40-workspace.css
+++ b/assets/css/40-workspace.css
@@ -13,14 +13,18 @@
 /* The source column takes the larger share: it holds the source's own lines,
    while the artifact beside it is prose that reads better narrow. */
 .split { display: grid; grid-template-columns: 1fr 1.2fr; gap: 0.75rem; align-items: start; }
-@media (max-width: 60rem) { .split { grid-template-columns: 1fr; } }
+/* 62rem rather than 60rem: this has to be a media query — `.shell` stops being
+   a container under 40rem — and 62rem of viewport is the 60rem of container
+   that every `@container shell` block beside it asks about. At 60rem the split
+   stayed two columns for the two rem in which the regions had already gone
+   one-up. */
+@media (width <= 62rem) { .split { grid-template-columns: 1fr; } }
 
 /* A grid child defaults to `min-width: auto`, which resolves to min-content:
    one unwrappable line of source then widens the column instead of scrolling
    inside `.raw`, and takes the document's width with it. `.pane` had this; its
    siblings did not, so the source pane escaped to the right at every width. */
 .split > *, .rail-head { min-width: 0; }
-.raw { max-width: 100%; }
 /* Titles and snippets are prose, not source: they break rather than push. */
 .rail-title, .rail-snippet, .card-title { overflow-wrap: anywhere; }
 /* A backstop. If something new overflows, it scrolls in its own box rather
@@ -54,6 +58,9 @@ body { overflow-x: hidden; }
 .raw {
   background: var(--color-bg-elevated); border: 1px solid var(--color-border);
   border-radius: var(--radius-md); overflow: auto; max-height: min(60vh, 45rem);
+  /* Part of the overflow backstop above: without it one unwrappable line of
+     source widens the column rather than scrolling inside this box. */
+  max-width: 100%;
 }
 .raw table { border-collapse: collapse; width: 100%; font-family: var(--font-mono); font-size: var(--text-sm); }
 /* Wrapped, with the continuation hanging under its own line rather than under
@@ -71,16 +78,22 @@ body { overflow-x: hidden; }
 }
 /* The line numbers stay put while the code scrolls under them; a line number
    that scrolls out of view makes the column useless for finding a line. */
-.raw td.ln { position: sticky; left: 0; background: var(--color-bg-elevated); z-index: 1; }
-.raw tr.in td.ln { background: var(--color-accent-dim); }
 .raw td.ln {
+  position: sticky; left: 0; background: var(--color-bg-elevated); z-index: 1;
   width: 3.5rem; text-align: right; color: var(--color-fg-muted); user-select: none;
   border-right: 1px solid var(--color-border-subtle); font-variant-numeric: tabular-nums;
   /* The hanging indent belongs to the source lines, not to their numbers. */
   padding: 1px 0.5rem; text-indent: 0;
 }
+/* The lines the artifact was written from, and their numbers with them. The
+   tint says these are the ones; a bar down their edge says where the run starts
+   and stops, which a background shared with the row above it does not — and it
+   survives a glance from across the pane. */
 .raw tr.in td { background: var(--color-accent-dim); }
-.raw tr.in td.ln { color: var(--color-accent); }
+.raw tr.in td.ln {
+  background: var(--color-accent-dim); color: var(--color-accent);
+  box-shadow: inset 2px 0 0 var(--color-accent);
+}
 
 .flag {
   display: flex; gap: 0.625rem; align-items: flex-start;
@@ -127,8 +140,14 @@ body { overflow-x: hidden; }
 }
 /* A box someone is waiting on is still a box someone is reading. The UA greys
    disabled text towards the background, which says "broken" where this means
-   "busy" — the question you asked stays worth reading while you wait for it. */
-.box:disabled {
+   "busy" — the question you asked stays worth reading while you wait for it.
+
+   `[readonly]` rather than `:disabled`, and app.js now sets that attribute
+   instead: `disabled` was undoing this rule's whole point one level below the
+   colour, because disabled text cannot be selected and cannot be copied. The
+   question was legible and untouchable, in the one box on the page it could
+   have been edited back out of. */
+.box[readonly] {
   color: var(--color-fg-secondary); opacity: 1; cursor: wait;
   background: var(--color-bg-surface);
 }
@@ -151,7 +170,6 @@ body { overflow-x: hidden; }
    this the Stop button is on screen from first paint, offering to stop an ask
    nobody has started. */
 .btn[hidden] { display: none; }
-.facet-label { flex: 0 0 auto; }
 
 /* The grid itself lives in 20-layout.css now: the rail beside the artifact is
    the region model rather than a layout this one page invented, and the
@@ -209,7 +227,6 @@ body { overflow-x: hidden; }
   font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.04em;
   color: var(--color-fg-muted);
 }
-.rail-why { font-size: var(--text-sm); color: var(--color-fg-muted); margin-top: 0.25rem; }
 /* Recalled by association, not ranked against the query — so it must not
    borrow the shape of something that was. The rule and the heading above said
    so already, and the identical card underneath them said otherwise. */
@@ -307,7 +324,7 @@ body { overflow-x: hidden; }
 .lineage { list-style: none; margin: 0 0 0.75rem; padding: 0; }
 .lin {
   display: flex; gap: 0.4rem; padding: 0.4rem 0;
-  padding-left: calc(var(--d) * 1.25rem);
+  padding-left: calc(var(--d, 0) * 1.25rem);
   border-bottom: 1px solid var(--color-border-subtle);
 }
 .lin:last-child { border-bottom: 0; }
@@ -335,9 +352,6 @@ body { overflow-x: hidden; }
 /* The fallback for a source there is nothing to band. */
 .raw-flat { margin: 0; padding: 0.5rem 0.75rem; white-space: pre-wrap;
             overflow-wrap: anywhere; font-family: var(--font-mono); font-size: var(--text-sm); }
-
-/* One column on a narrow screen: the source first, then what came of it. */
-@media (max-width: 60rem) { .band { grid-template-columns: 1fr; } }
 
 /* What tells two rows with one title apart: when it was written, and how it
    opens. Quiet, because it is a disambiguator and not a second title. */
@@ -468,7 +482,7 @@ body { overflow-x: hidden; }
    the width the narrowed rail had just given up. What `r` frees goes to focus
    entire, which is what "gives the width to the artifact and its source"
    means. */
-@container shell (min-width: 90rem) {
+@container shell (width >= 90rem) {
   .regions.reading {
     grid-template-columns: [rail] 3.25rem [focus] minmax(0, 1fr);
   }
@@ -508,11 +522,6 @@ body { overflow-x: hidden; }
 
 /* ── The source pane ─────────────────────────────────────────────────────── */
 
-/* The tint says these lines are the ones. A bar down their edge says where the
-   run starts and stops, which a background shared with the row above it does
-   not — and it survives a glance from across the pane. */
-.raw tr.in td.ln { box-shadow: inset 2px 0 0 var(--color-accent); }
-
 /* A fold is a rule with a count, not a gap. "Something was left out here" is
    what empty space fails to say. Indented past the gutter, so the line-number
    column stays a column. */
@@ -540,7 +549,7 @@ body { overflow-x: hidden; }
 
    The floor is what stops a long neighbour list from squeezing the artifact to
    a sliver; past it the column scrolls as a whole. */
-@container shell (min-width: 60rem) {
+@container shell (width >= 60rem) {
   .split > :first-child {
     display: flex; flex-direction: column; overflow-y: auto;
     max-height: min(60vh, 45rem);
@@ -598,7 +607,7 @@ body { overflow-x: hidden; }
    Only where all three regions are on screen. One-up is a page you scroll, and
    pinning the single visible region to the viewport there would put the
    results list in a box the size of the window it already fills. */
-@container shell (min-width: 60rem) {
+@container shell (width >= 60rem) {
   .regions-rail-focus-source { grid-template-rows: auto minmax(0, 1fr); }
   .regions-rail-focus-source > .region-rail,
   .regions-rail-focus-source > .region-focus { align-self: stretch; min-height: 0; }

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -24,6 +24,10 @@
 }
 .judge-option:hover { background: var(--color-bg-hover); }
 .judge-option:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+/* `anywhere`, because a snippet is a slice of whatever was captured: a URL, a
+   hash, a German compound. `minmax(0, 1fr)` above stops such a word widening
+   the column; this is what stops it spilling out of the one it is in. */
+.judge-title { font-weight: 500; overflow-wrap: anywhere; }
 /* Still legible, plainly not choosable: the pool is shown at full length so the
    operator can see what the search returned, and a candidate the benchmark
    cannot hold is greyed rather than dropped. */
@@ -34,10 +38,6 @@
 .judge-option-unusable:hover { background: transparent; }
 .judge-option-unusable .judge-title { font-weight: 400; text-decoration: line-through; }
 .judge-key { font-family: var(--font-mono); color: var(--color-fg-muted); font-size: var(--text-sm); }
-/* `anywhere`, because a snippet is a slice of whatever was captured: a URL, a
-   hash, a German compound. `minmax(0, 1fr)` above stops such a word widening
-   the column; this is what stops it spilling out of the one it is in. */
-.judge-title { font-weight: 500; overflow-wrap: anywhere; }
 .judge-snippet {
   grid-column: 2; color: var(--color-fg-secondary); font-size: var(--text-base);
   overflow-wrap: anywhere;

--- a/assets/css/43-insights.css
+++ b/assets/css/43-insights.css
@@ -109,7 +109,7 @@
    anyone reads. Same reasoning as `.qtime { display: none }` on a phone,
    applied to the width rather than to the device: the aside is this narrow on
    a laptop too. */
-@container queue (max-width: 30rem) {
+@container queue (width <= 30rem) {
   .qname { flex: 1 0 100%; }
   .qmeta {
     margin-left: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;
@@ -173,7 +173,7 @@
   display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 0.5rem;
 }
 .decide-sides p { margin: 0.25rem 0 0; font-size: var(--text-sm); color: var(--color-fg-secondary); }
-@container shell (max-width: 60rem) {
+@container shell (width <= 60rem) {
   .decide-sides { grid-template-columns: 1fr; }
 }
 /* The holes, grouped and named by the sweep. */

--- a/assets/css/44-corpus.css
+++ b/assets/css/44-corpus.css
@@ -9,6 +9,13 @@
    source. */
 .bands { display: flex; flex-direction: column; gap: 0.75rem; }
 .band { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; align-items: start; }
+/* One column on a narrow screen: the source first, then what came of it. Here
+   rather than in 40-workspace.css, where it used to be and never applied: both
+   selectors are a single class, a media query adds no specificity of its own,
+   and this file concatenates after that one — so the two-column rule above won
+   at every width, including a phone. 62rem is the media-query spelling of the
+   60rem container the rest of the layout asks about. */
+@media (width <= 62rem) { .band { grid-template-columns: 1fr; } }
 .band > * { min-width: 0; }
 .band-src {
   background: var(--color-bg-elevated); border: 1px solid var(--color-border);

--- a/assets/css/50-phone.css
+++ b/assets/css/50-phone.css
@@ -23,7 +23,7 @@
    one. A media query here would be off by the shell's own padding, which is
    a narrow band of window widths where the list disappears and nothing on the
    page brings it back — the very bug this block exists to prevent. */
-@container shell (max-width: 60rem) {
+@container shell (width <= 60rem) {
   .back {
     display: inline-flex; align-items: center; gap: 0.375rem; min-height: 44px;
     margin: 0 0 0.25rem -0.5rem; padding: 0 0.5rem; border-radius: var(--radius-sm);
@@ -33,7 +33,7 @@
   .back:hover { background: var(--color-bg-hover); color: var(--color-fg-primary); }
 }
 
-@media (max-width: 40rem) {
+@media (width <= 40rem) {
   /* ── No container here ────────────────────────────────────────────────
      `container-type: inline-size` computes to `contain: layout style
      inline-size`, and layout containment makes `.shell` the containing block
@@ -43,11 +43,20 @@
      viewport: it scrolled away with the results, which is the opposite of
      what putting it under the thumb is for.
 
-     Dropping the container costs nothing at this width. Both `@container
-     shell (max-width: 60rem)` blocks are unconditionally true on a screen
-     this narrow, so they are restated below as plain rules; the three
-     `min-width: 60rem`/`90rem` blocks never applied here in the first place.
-     Above 40rem the shell is a container again and the queries do the work.
+     Dropping the container costs nothing at this width. Every `@container
+     shell (width <= 60rem)` block is unconditionally true on a screen this
+     narrow, so all of them are restated below as plain rules — `.regions` from
+     20-layout.css, `.decide-sides` from 43-insights.css, and `.back` at the top
+     of this file. The wide-side blocks, `width > 60rem` and `width >= 60rem`
+     and `>= 90rem`, never applied here in the first place. Above 40rem the
+     shell is a container again and the queries do the work.
+
+     Listed by name rather than counted, because a count is what went wrong:
+     this said "both" while there were three, and the one it did not name was
+     `.decide-sides` — so Housekeeping's two sides sat as two prose columns on a
+     390px screen, the one width at which the query that says otherwise cannot
+     fire. A new `width <= 60rem` block anywhere in the sheet belongs in this
+     list and in the rules below.
 
      `container-type: normal` is on `.shell` below, with the rest of what this
      width does to it. The restated rules sit after `.regions-focus` in source
@@ -57,6 +66,7 @@
   .regions > * { grid-column: 1 / -1; }
   .regions.has-selection .region-rail { display: none; }
   .regions.answering .region-rail { order: 1; }
+  .decide-sides { grid-template-columns: 1fr; }
   .back {
     display: inline-flex; align-items: center; gap: 0.375rem; min-height: 44px;
     margin: 0 0 0.25rem -0.5rem; padding: 0 0.5rem; border-radius: var(--radius-sm);
@@ -131,7 +141,6 @@
      goes on the first keystroke, like everywhere else, and the bar shrinks back
      to the box and the verbs. */
   .regions-rail-focus-source .region-bar .hint,
-  .regions-rail-focus-source .region-bar .facets,
   .regions-rail-focus-source .region-bar .chips,
   .regions-rail-focus-source .region-bar .facet-label,
   .regions-rail-focus-source .region-bar .keyhint,
@@ -175,8 +184,8 @@
      `.box` belongs in this list above all: it is the one control on the phone
      that is always there and always focused, and it is not a `.textarea` —
      it has a rule of its own, so it was not covered by this one. */
-  .box, .input, .textarea, .select { font-size: 1rem; }
-  .input, .select { height: 44px; }
+  .box, .input, .textarea { font-size: 1rem; }
+  .input { height: 44px; }
 
   /* Targets a thumb can hit. */
   /* :not(:has(span)) — a labelled control still needs room for its word;
@@ -184,7 +193,6 @@
   .btn-icon:not(:has(span)) { width: 44px; height: 44px; }
   .btn-icon:has(span) { height: 44px; }
   .chip > span { padding: 8px 12px; font-size: var(--text-sm); }
-  .facet-row { align-items: center; }
 
   /* No scroller inside a scroller: the page is the only thing that scrolls. */
   .rail, .raw { max-height: none; }

--- a/config.example.toml
+++ b/config.example.toml
@@ -614,11 +614,19 @@ prime = false
 # One gap in front of every inference call, whatever its role. The roles share
 # one GPU, so a per-role cooldown could not bound total load.
 [pacing]
-# Minimum seconds between the end of one background call and the start of the
-# next, and only one background call runs at a time however many workers are
+# Minimum seconds between the end of one background generation and the start of
+# the next, and only one background call runs at a time however many workers are
 # configured, so this is the gap between calls rather than per worker. Zero
 # disables pacing. A question asked through `ask` ignores it: someone is
 # waiting, and the pacer is there to protect the GPU from batch work.
+#
+# Embedding ignores it as well, for the opposite reason. It still takes its
+# turn — a batch never runs alongside a generation, which is what actually
+# bounds a shared GPU — but it serves no gap and starts none. The gap is sized
+# against a generation; an encoder answering a batch of 32 in about a second is
+# not one, and pacing it spends nearly the whole budget on the one role that
+# needs no protecting. At `synthesis = "earned"`, where capture generates
+# nothing at all, that was most of what this setting did.
 cooldown_secs = 0
 
 [capture]

--- a/docs/superpowers/plans/2026-08-23-file-annotation.md
+++ b/docs/superpowers/plans/2026-08-23-file-annotation.md
@@ -1,0 +1,706 @@
+# The box is the file's annotation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A staged file turns the workspace's one box into that file's annotation, and that annotation becomes a searchable artifact instead of unfindable metadata.
+
+**Architecture:** Three doors (`ingest_capture`, `ingest_pdf`, `ingest_image`) gain one shared helper that writes the note as an artifact on the file's own corpus — `corpus_span: None`, `segment_idx: None`, so it claims no line of the document and `renumber_artifacts` sorts it to ordinal 0 unaided. The 2000-character cap stops truncating storage and moves into the vision prompt, the only place unboundedness costs anything. On the front end the dedicated note input is deleted and `assets/app.js` reads the box at press time, so attach-then-type and type-then-attach are the same act.
+
+**Tech Stack:** Rust, `sqlx`/SQLite, `tokio`, Askama templates, vanilla ES5-style JS + htmx.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-file-annotation-design.md`
+
+## Global Constraints
+
+- **No new endpoint, no new table, no new model call.** The note is embedded by the corpus-level Embed job the capture already arms.
+- **The three upload doors' wire format is unchanged.** `note` stays an optional multipart field (`src/web/api.rs:364,470`).
+- **A duplicate capture writes nothing.** The note artifact is written only on `Insertion::Created` — never on `Insertion::Existing`.
+- **Comments in this codebase say *why*, in prose, at the density of the surrounding file.** Match it. Do not add narration to code that does not need it.
+- **`assets/app.js` is ES5-flavoured**: `var`, `function`, no arrow functions, no `const`/`let`, no template literals.
+- **Tests are `#[tokio::test]` inside `mod tests` in the same file as the code.**
+- Build with `cargo build`; if memory is tight use `./build-lowmem.sh`.
+
+---
+
+### Task 1: A note becomes an artifact on the file's corpus
+
+**Files:**
+- Modify: `src/core/ingest.rs` — add helper, call from three doors, tests
+
+**Already imported** in `src/core/ingest.rs`'s `mod tests` (`:1140-1150`) — do not re-import: `Capture`, `ImageCapture`, `MAX_NOTE_CHARS`, `PdfCapture`, `test_core`, `Stage`, `CorpusStatus`, and the `a_pdf_fixture()` / `a_seeded_png()` helpers.
+
+**Interfaces:**
+- Consumes: `Store::insert_artifacts(&str, &[NewArtifact]) -> Result<Vec<Chunk>>` (defaults to `Provenance::Captured`, `src/store/artifacts.rs:453`); `Store::rearm_idle_seq(Stage, &str, &str, i64)` (`src/store/jobs.rs:340`)
+- Produces: `Core::attach_note_artifact(&self, corpus_id: &str, note: Option<&str>) -> Result<()>` — private to `ingest.rs`, called by all three doors
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `src/core/ingest.rs`:
+
+```rust
+    /// The sentence most worth searching on must be an artifact, not a
+    /// caption. Embedding runs over artifact chunks and never over metadata,
+    /// so a note that stays in `metadata["note"]` cannot be found at all.
+    #[tokio::test]
+    async fn a_note_on_a_pdf_becomes_a_span_less_artifact_on_its_corpus() {
+        let core = test_core().await;
+        let out = core
+            .ingest_pdf(PdfCapture {
+                bytes: a_pdf_fixture(),
+                filename: Some("lease.pdf".into()),
+                title_hint: None,
+                note: Some("  scan of the Reinhardt lease, break clause is p.3  ".into()),
+            })
+            .await
+            .unwrap();
+
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert_eq!(all.len(), 1, "the note, and nothing extracted yet");
+        let n = &all[0];
+        assert_eq!(n.text, "scan of the Reinhardt lease, break clause is p.3");
+        assert_eq!(
+            n.corpus_span, None,
+            "the note is about the file, not a line of it"
+        );
+        assert_eq!(n.segment_idx, None, "it belongs to no window");
+        assert_eq!(n.ordinal, 0);
+        assert_eq!(n.provenance, crate::store::artifacts::Provenance::Captured);
+        assert_eq!(n.title, None);
+    }
+
+    /// One helper, three doors, so a fourth cannot forget it.
+    #[tokio::test]
+    async fn every_door_that_takes_a_note_writes_it_as_an_artifact() {
+        let describer = std::sync::Arc::new(crate::infer::fake::FakeDescriber::default());
+        let core = crate::core::test_support::test_core_with_describer(describer).await;
+
+        let img = core
+            .ingest_image(ImageCapture {
+                bytes: a_seeded_png(11),
+                filename: Some("IMG_9.png".into()),
+                title_hint: None,
+                note: Some("front of the router".into()),
+            })
+            .await
+            .unwrap();
+        let a = core.store.artifacts_for_corpus(&img.id).await.unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].text, "front of the router");
+
+        let txt = core
+            .ingest_capture(Capture::new("the file's own text", "upload").with_note(
+                Some("from the printer".into()),
+            ))
+            .await
+            .unwrap();
+        let a = core.store.artifacts_for_corpus(&txt.id).await.unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].text, "from the printer");
+    }
+
+    #[tokio::test]
+    async fn a_capture_with_no_usable_note_writes_no_artifact() {
+        let core = test_core().await;
+        let none = core
+            .ingest_capture(Capture::new("text one", "upload"))
+            .await
+            .unwrap();
+        assert!(
+            core.store.artifacts_for_corpus(&none.id).await.unwrap().is_empty()
+        );
+
+        let blank = core
+            .ingest_capture(Capture::new("text two", "upload").with_note(Some("   ".into())))
+            .await
+            .unwrap();
+        assert!(
+            core.store.artifacts_for_corpus(&blank.id).await.unwrap().is_empty(),
+            "whitespace is not an annotation"
+        );
+    }
+
+    /// A scan with no text layer parks as `failed` and never reaches `settle`,
+    /// which is what normally arms the embed. Without arming it here, the one
+    /// thing a person typed about an unreadable document waits forever.
+    #[tokio::test]
+    async fn a_note_arms_the_embed_so_a_parked_capture_still_becomes_findable() {
+        let core = test_core().await;
+        let out = core
+            .ingest_pdf(PdfCapture {
+                bytes: a_pdf_fixture(),
+                filename: Some("scan.pdf".into()),
+                title_hint: None,
+                note: Some("the survey nobody can OCR".into()),
+            })
+            .await
+            .unwrap();
+
+        let pending = core
+            .store
+            .pending_artifacts_for_corpus(&out.id)
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 1, "the note is waiting for a vector");
+        assert!(
+            core.store
+                .live_job(Stage::Embed, &out.id)
+                .await
+                .unwrap(),
+            "a corpus embed job must be armed by the capture itself"
+        );
+    }
+
+    /// Re-uploading the same file must not stack a second note on it.
+    #[tokio::test]
+    async fn a_duplicate_upload_writes_no_second_note() {
+        let core = test_core().await;
+        let bytes = a_pdf_fixture();
+        let first = core
+            .ingest_pdf(PdfCapture {
+                bytes: bytes.clone(),
+                filename: Some("plan.pdf".into()),
+                title_hint: None,
+                note: Some("the quarterly plan".into()),
+            })
+            .await
+            .unwrap();
+        let again = core
+            .ingest_pdf(PdfCapture {
+                bytes,
+                filename: Some("plan.pdf".into()),
+                title_hint: None,
+                note: Some("a second thought about it".into()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.id, again.id);
+        assert!(again.duplicate);
+        assert_eq!(
+            core.store.artifacts_for_corpus(&first.id).await.unwrap().len(),
+            1
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib core::ingest::tests::a_note -- --nocapture`
+Expected: FAIL — `artifacts_for_corpus` returns an empty vector, so the length assertions trip.
+
+- [ ] **Step 3: Write the helper**
+
+Add to the `impl Core` block in `src/core/ingest.rs`, directly after `park_or_queue` (which ends at `ingest.rs:297`):
+
+```rust
+    /// The operator's sentence about a file, written where it can be found.
+    ///
+    /// Embedding runs over artifact chunks and never over metadata, so a note
+    /// left in `metadata["note"]` is invisible to search — on a PDF or a text
+    /// upload absolutely, and on a photograph only as whatever the vision
+    /// model happened to echo. This is the same words as their own artifact.
+    ///
+    /// `corpus_span: None` is the point: the note is *about* the file and is
+    /// no line *of* it, so it claims no span and nothing tries to read it
+    /// beside lines it did not come from. `segment_idx: None` puts it ahead of
+    /// every window in `renumber_artifacts`, which orders by
+    /// `COALESCE(segment_idx, 0), ordinal, rowid` — so it settles at ordinal 0
+    /// with no help from either artifact writer.
+    ///
+    /// The embed is armed here rather than left to `settle`. A scan with no
+    /// text layer parks as `failed` and never reaches settling, and that is
+    /// exactly the capture whose note is the only text anyone will ever have.
+    async fn attach_note_artifact(&self, corpus_id: &str, note: Option<&str>) -> Result<()> {
+        let Some(text) = note.map(str::trim).filter(|n| !n.is_empty()) else {
+            return Ok(());
+        };
+        self.store
+            .insert_artifacts(
+                corpus_id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    // A heading is something a document gave. This had none.
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await?;
+        self.store
+            .rearm_idle_seq(Stage::Embed, "corpus", corpus_id, 0)
+            .await?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Call it from the text door**
+
+In `ingest_capture`, replace the `Ok(IngestOutcome { ... })` at `src/core/ingest.rs:262-267` with:
+
+```rust
+        self.attach_note_artifact(&src.id, c.metadata["note"].as_str())
+            .await?;
+
+        Ok(IngestOutcome {
+            id: src.id,
+            status: src.status,
+            duplicate: false,
+            near_duplicate: near,
+        })
+```
+
+`c` is borrowed, never destructured, in `ingest_capture` (`src/core/ingest.rs:193-196`), so it is still in scope here. Do not call `clean_note` again — `with_note` (`src/core/ingest.rs:125`) already trimmed the value now sitting in `metadata`.
+
+- [ ] **Step 5: Call it from the PDF door**
+
+In `ingest_pdf`, `note` is moved into `clean_note` at `src/core/ingest.rs:334`. Keep a copy before that, and write the artifact only on the created branch. Replace `src/core/ingest.rs:333-366` with:
+
+```rust
+        let note = clean_note(note);
+        if let Some(n) = &note {
+            metadata["note"] = serde_json::json!(n);
+        }
+
+        let inserted = self
+            .store
+            .insert_attached_corpus(
+                &hash,
+                ORIGIN_PDF,
+                title_hint.as_deref(),
+                &metadata,
+                crate::store::corpora::Reading::EXTRACTION,
+                &crate::store::attachments::NewFile {
+                    kind: "pdf",
+                    mime: "application/pdf",
+                    filename: filename.as_deref(),
+                    bytes: &bytes,
+                    preview: &[],
+                    width: None,
+                    height: None,
+                },
+            )
+            .await?;
+        Ok(match inserted {
+            // A file already in the base keeps the note it was captured with.
+            // Stacking a second one per re-upload is how a corpus grows a pile
+            // of near-identical captions nobody wrote twice on purpose.
+            Insertion::Existing(c) => IngestOutcome::existing(&c),
+            Insertion::Created(c) => {
+                self.attach_note_artifact(&c.id, note.as_deref()).await?;
+                IngestOutcome {
+                    id: c.id,
+                    status: c.status,
+                    duplicate: false,
+                    near_duplicate: None,
+                }
+            }
+        })
+```
+
+- [ ] **Step 6: Call it from the image door**
+
+In `ingest_image`, the same shape. `note` is consumed by `clean_note` at `src/core/ingest.rs:417`; hold the cleaned value, and after the `Insertion::Created(src) => src` match resolves (`src/core/ingest.rs:433-449`) add the call before the `Ok(...)`:
+
+```rust
+        let note = clean_note(note);
+        if let Some(n) = &note {
+            metadata["note"] = serde_json::Value::String(n.clone());
+        }
+```
+
+and after the `tracing::info!` at `src/core/ingest.rs:450-455`:
+
+```rust
+        self.attach_note_artifact(&src.id, note.as_deref()).await?;
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cargo test --lib core::ingest`
+Expected: PASS, including the pre-existing note tests at `ingest.rs:1157`, `2222` and `2296`.
+
+- [ ] **Step 8: Prove the ordinal claim against the real passage writer**
+
+The whole design rests on `renumber_artifacts` ordering by `COALESCE(segment_idx, 0), ordinal, rowid` (`src/store/artifacts.rs:918`). Add to `mod tests` in `src/jobs/passages.rs`:
+
+```rust
+    /// The note is written at capture and the passages arrive later, each
+    /// numbered from 0 within its own window. Renumbering has to put the note
+    /// first and push the document down by one — with no change to this
+    /// writer, which is the whole reason the note carries no `segment_idx`.
+    #[tokio::test]
+    async fn a_note_sorts_ahead_of_the_document_it_annotates() {
+        // `passages.rs`'s `mod tests` (`:221-224`) imports neither of these.
+        let core = crate::core::test_support::test_core().await;
+        let out = core
+            .ingest_capture(
+                crate::core::ingest::Capture::new(
+                    "# Heading\n\nThe body of the uploaded document.",
+                    "upload",
+                )
+                .with_note(Some("printout from the hallway scanner".into())),
+            )
+            .await
+            .unwrap();
+
+        capture_verbatim(&core, &out.id).await.unwrap();
+
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert!(all.len() >= 2, "the note and at least one passage");
+        assert_eq!(all[0].text, "printout from the hallway scanner");
+        assert_eq!(all[0].ordinal, 0);
+        assert_eq!(all[0].corpus_span, None);
+        assert_eq!(all[1].ordinal, 1, "ordinals stay continuous");
+        assert!(
+            all[1].corpus_span.is_some(),
+            "a passage still anchors to its lines"
+        );
+    }
+```
+
+- [ ] **Step 9: Run it**
+
+Run: `cargo test --lib jobs::passages::tests::a_note_sorts_ahead`
+Expected: PASS with no production change. If it fails, the design's central assumption is wrong — stop and report rather than editing the renumberer.
+
+Note: no separate retrieval test is needed. `seed_from` (`src/core/search.rs:1148-1166`) already builds every search-suite fixture with `corpus_span: None` and `segment_idx: None`, so span-less artifacts being fully retrievable is proven by the existing suite.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/core/ingest.rs src/jobs/passages.rs
+git commit -m "feat(ingest): the note a person typed becomes something they can find
+
+Embedding runs over artifact chunks, so a note in metadata was
+invisible to search: on a PDF or a text upload entirely, on a photo
+only as whatever the vision model echoed back. It is now an artifact
+on the file's own corpus, span-less because it is about the file and
+is no line of it.
+
+renumber_artifacts orders by COALESCE(segment_idx, 0), ordinal, rowid,
+so a segment-less note written at capture settles at ordinal 0 with no
+change to either artifact writer. The embed is armed at ingest rather
+than left to settle, so a scan that parks as failed still makes the
+one sentence anybody typed about it findable."
+```
+
+---
+
+### Task 2: The cap stops truncating storage and bounds the prompt instead
+
+**Files:**
+- Modify: `src/core/ingest.rs:24-36` — `MAX_NOTE_CHARS` doc, `clean_note`
+- Modify: `src/core/ingest.rs:2296` — the existing cap test
+- Modify: `src/infer/prompt.rs:1310-1317` — `describe_context`
+
+**Interfaces:**
+- Consumes: `crate::core::ingest::MAX_NOTE_CHARS` (already `pub`)
+- Produces: nothing new. `clean_note` keeps its signature `fn clean_note(note: Option<String>) -> Option<String>`; `describe_context(&serde_json::Value) -> String` keeps its.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/infer/prompt.rs`, inside `mod tests`:
+
+```rust
+    /// The note leads the vision prompt, so an unbounded one would swamp the
+    /// description or overrun the call. This is now the only place the cap
+    /// still earns its keep — nothing stored is truncated any more.
+    #[test]
+    fn describe_context_bounds_the_note_it_spends_on_a_model_call() {
+        let long = "x".repeat(crate::core::ingest::MAX_NOTE_CHARS + 500);
+        let m = serde_json::json!({ "note": long });
+        let ctx = describe_context(&m);
+        let kept = ctx
+            .lines()
+            .next()
+            .unwrap()
+            .trim_start_matches("Context from the person who captured this: ");
+        assert_eq!(kept.chars().count(), crate::core::ingest::MAX_NOTE_CHARS);
+    }
+```
+
+In `src/core/ingest.rs`, replace the existing `a_note_is_capped_and_a_blank_one_is_dropped` (`ingest.rs:2296`) with:
+
+```rust
+    /// A note is no longer truncated on the way into storage. It is an
+    /// artifact like any other, and `embed::run_with_limit` splits an oversize
+    /// chunk into siblings — so length is the embedder's problem, not a
+    /// silent amputation at the door.
+    #[tokio::test]
+    async fn a_long_note_is_stored_whole_and_a_blank_one_is_dropped() {
+        let core = test_core().await;
+        let long = "x".repeat(MAX_NOTE_CHARS + 50);
+        let out = core
+            .ingest_capture(Capture::new("some text", "upload").with_note(Some(long.clone())))
+            .await
+            .unwrap();
+        let src = core.store.get_corpus(&out.id).await.unwrap();
+        assert_eq!(src.metadata["note"].as_str().unwrap(), long);
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert_eq!(all[0].text, long, "the artifact keeps every character");
+
+        let out = core
+            .ingest_capture(Capture::new("other text", "upload").with_note(Some("   ".into())))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .get_corpus(&out.id)
+                .await
+                .unwrap()
+                .metadata
+                .get("note")
+                .is_none()
+        );
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib infer::prompt::tests::describe_context_bounds core::ingest::tests::a_long_note`
+Expected: FAIL — the prompt test sees `MAX_NOTE_CHARS + 500` characters (nothing truncates yet in the prompt); the ingest test sees `MAX_NOTE_CHARS` where it wants the full string.
+
+- [ ] **Step 3: Stop truncating storage**
+
+Replace `src/core/ingest.rs:24-36` with:
+
+```rust
+/// Longest note spent on a vision call. Context, not a document: the note is
+/// the lead line of the describe prompt, and an unbounded one swamps the
+/// description or overruns the request.
+///
+/// It bounds that copy and nothing else. A note is stored whole — it is an
+/// artifact like any other text, and `jobs::embed` cuts an oversize chunk into
+/// siblings rather than losing the tail of it. Truncating on the way in was a
+/// silent amputation with no receipt anywhere.
+pub const MAX_NOTE_CHARS: usize = 2000;
+
+/// The user's context for a capture, cleaned: trimmed, `None` when there is
+/// nothing in it.
+fn clean_note(note: Option<String>) -> Option<String> {
+    let n = note?.trim().to_string();
+    if n.is_empty() {
+        return None;
+    }
+    Some(n)
+}
+```
+
+- [ ] **Step 4: Bound the prompt**
+
+Replace `src/infer/prompt.rs:1312-1317` with:
+
+```rust
+    if let Some(note) = metadata["note"].as_str().filter(|n| !n.trim().is_empty()) {
+        // The stored note is whole; this copy is the one that costs tokens.
+        let n = note.trim();
+        lines.push(format!(
+            "Context from the person who captured this: {}",
+            n.chars()
+                .take(crate::core::ingest::MAX_NOTE_CHARS)
+                .collect::<String>()
+        ));
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib core::ingest infer::prompt`
+Expected: PASS. `describe_context_leads_with_the_note_then_the_facts_and_omits_what_is_absent` (`prompt.rs:2261`) must still pass — the note still leads.
+
+- [ ] **Step 6: Run the whole suite**
+
+Run: `cargo test`
+Expected: PASS. Anything asserting a truncated stored note is now wrong and should be updated to assert the whole note; anything asserting the vision prompt is bounded is now right.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/ingest.rs src/infer/prompt.rs
+git commit -m "fix(ingest): bound the note where it costs, not where it is kept
+
+MAX_NOTE_CHARS truncated on the way into metadata, silently and with no
+receipt. Now that a note is an artifact, length is the embedder's
+problem — jobs::embed cuts an oversize chunk into siblings — so nothing
+stored is cut.
+
+The one place unboundedness still costs something is the vision prompt,
+where the note is the lead line. The cap moves there and bounds only
+the copy spent on the call."
+```
+
+---
+
+### Task 3: The box becomes the note, and one press is one capture
+
+**Files:**
+- Modify: `src/web/templates/workspace.html:74-86` — delete the note input from the staged box
+- Modify: `assets/app.js` — `boxVerbs` sync (`:826-839`), `captureVerb` stage/unstage/send/click (`:893-1037`, `:1153-1163`)
+
+**Interfaces:**
+- Consumes: `VERB_SYNC` (the synthetic event `boxVerbs` listens for), `refreshRail()`, `receipt()`, `clearReceipts()` — all already in `captureVerb`'s scope
+- Produces: `send(file, note)` — the second parameter is new; `stage`/`unstage` keep their signatures
+
+- [ ] **Step 1: Delete the note input**
+
+In `src/web/templates/workspace.html`, remove the comment and the input at lines 77-83 (the `{# Context for the file… #}` block and `<input class="input" type="text" name="note" …>`), leaving the staged box as thumbnail, name and Remove. Replace the comment above the staged box (`workspace.html:74-76`, ending `…is the photo. #}`) with a sentence saying where the note went:
+
+```
+     The note is not in here any more. A file makes the box below this one the
+     file's annotation — one place to type, whichever order the two arrive in.
+     Two boxes on screen and no rule saying which one the words in front of you
+     belong to is the thing this replaced. #}
+```
+
+- [ ] **Step 2: Disarm Ask while a file is staged**
+
+In `boxVerbs`'s `sync` (`assets/app.js:832-839`), replace the loop with:
+
+```js
+      var hasText = !!box.value.trim();
+      var stagedEl = document.getElementById('staged');
+      var hasFile = !!(stagedEl && !stagedEl.hidden);
+      for (var i = 0; i < buttons.length; i++) {
+        buttons[i].disabled = buttons[i].getAttribute('data-verb') === 'capture'
+          ? !(hasText || hasFile)
+          // A staged file has made the box that file's note. Asking a note is
+          // not a thing to do, and the answer would land beside a file the
+          // question was never about.
+          : (!hasText || hasFile);
+      }
+```
+
+- [ ] **Step 3: Make the box go quiet**
+
+In `captureVerb`, replace the `noteBox` lookup (`assets/app.js:893`) with the placeholder the box wears while it is a note, and add the guard. Put this beside the `staged` declarations at `assets/app.js:903-908`:
+
+```js
+    // What the box says when it is annotating a file rather than searching.
+    var SEARCH_HINT = box.getAttribute('placeholder');
+    var NOTE_HINT = 'What is it, why keep it?';
+
+    // Typing an annotation into a live search box is an embedding call, an
+    // activation bump and a Judge-queue row per phrase, for text nobody asked
+    // as a question. The form's own requests are cancelled while a file waits;
+    // Capture does not go through the form, and Ask is disabled above.
+    form.addEventListener('htmx:beforeRequest', function (e) {
+      if (staged) e.preventDefault();
+    });
+```
+
+- [ ] **Step 4: Swap the placeholder on stage and restore it on unstage**
+
+In `stage` (`assets/app.js:948-980`), replace the focus block at `:976-978` with:
+
+```js
+      box.setAttribute('placeholder', NOTE_HINT);
+      // Only where a pointer says there is a hardware keyboard — the rule the
+      // box already follows. On a phone this would throw the software keyboard
+      // over the thumbnail the operator is checking, which is the picture they
+      // just took.
+      if (!restore && window.matchMedia('(hover: hover)').matches) box.focus();
+```
+
+In `unstage` (`assets/app.js:909-926`), before the `VERB_SYNC` dispatch at `:925`:
+
+```js
+      // The box is a search box again, with whatever was typed still in it:
+      // Remove is the way out and must never be the thing that eats it.
+      box.setAttribute('placeholder', SEARCH_HINT);
+```
+
+- [ ] **Step 5: Send the box as the note**
+
+In `send`, change the signature and the two `noteBox` reads. Replace `assets/app.js:983` and `:1000`:
+
+```js
+    function send(file, note) {
+```
+
+```js
+      if (note) payload.append('note', note);
+```
+
+and in the success branch (`assets/app.js:1029-1030`), replace `if (noteBox) noteBox.value = '';` with:
+
+```js
+            box.value = '';
+            box.dispatchEvent(new Event(VERB_SYNC, { bubbles: true }));
+            refreshRail();
+```
+
+removing the now-duplicated `refreshRail()` on the line below it. The failure branch is unchanged: `stage(file, true)` puts the file back, and the note is still in the box because nothing cleared it.
+
+- [ ] **Step 6: One press, one capture**
+
+Replace the click handler at `assets/app.js:1153-1163` with:
+
+```js
+    verb.addEventListener('click', function (e) {
+      e.preventDefault();
+      clearReceipts();
+      // A staged file is one capture, annotated — never two. The box is read
+      // here, at press time, which is what makes the order the file and the
+      // words arrived in stop mattering.
+      if (staged) {
+        var file = staged;
+        var note = box.value.trim();
+        unstage();
+        send(file, note);
+        return;
+      }
+      postText();
+    });
+```
+
+- [ ] **Step 7: Drop `from_ask` when a file is staged**
+
+No code change is needed — `postText()` is the only sender of `from_ask` and it is no longer reached with a file staged. Confirm by reading `assets/app.js:1110-1134`: `from_ask` is read inside `postText` only. Note this in the commit rather than adding a guard for a path that cannot be taken.
+
+- [ ] **Step 8: Build and run the app**
+
+Run: `cargo build && cargo run`
+Then walk both orders in a browser at `/ui`:
+
+1. Type "scan of the lease, break clause p.3" → results appear as you type. Attach a PDF → results stop updating, placeholder reads "What is it, why keep it?", **Ask** dims, **Capture** stays armed, text untouched. Press Capture → one receipt, one artifact.
+2. Attach the PDF first → box is already quiet. Type the same sentence → no requests fire (check the network panel). Press Capture → the same single annotated artifact.
+3. Attach, type, then press **Remove** → the text is still there, the placeholder is back, **Ask** re-arms, and typing searches again.
+4. With no file: type and press Capture → unchanged from today.
+5. Search for a phrase from the note → the note comes back, pointing at the file.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/web/templates/workspace.html assets/app.js
+git commit -m "feat(capture): a staged file makes the box that file's note
+
+Text plus a file ran two captures from one press, with two boxes to
+type in and no rule saying which words belonged to which. Now a staged
+file makes the one box the file's annotation: one press, one capture,
+and the box is read at press time so type-then-attach and
+attach-then-type reach the same place.
+
+The box goes quiet while a file waits — no search on keystroke, Ask
+disarmed, placeholder swapped. An annotation typed into a live search
+box is an embedding call, an activation bump and a Judge row per
+phrase, for text nobody asked as a question. Remove gives all of it
+back with the text untouched.
+
+from_ask needs no guard: postText is its only sender and a staged file
+no longer reaches it."
+```
+
+---
+
+## Final verification
+
+- [ ] `cargo test` passes.
+- [ ] `cargo clippy --all-targets` is clean of new warnings.
+- [ ] The five browser walks in Task 3 Step 8 all behave as written.
+- [ ] `git log --oneline -3` shows the three commits.
+- [ ] Spec §9 "deleting the file takes the note" needs no task: the note is an
+      artifact on the file's corpus like any other, and corpus deletion already
+      removes them. No new code path, so no new test.

--- a/docs/superpowers/specs/2026-08-23-file-annotation-design.md
+++ b/docs/superpowers/specs/2026-08-23-file-annotation-design.md
@@ -1,7 +1,7 @@
 # The box is the file's annotation, and an annotation is findable — Design
 
 Date: 2026-08-23
-Status: draft
+Status: implemented (2026-08-23) — §3 corrected during implementation; see “What changed” at the end
 Touches `src/core/ingest.rs`, `src/infer/prompt.rs`, `assets/app.js`,
 `src/web/templates/workspace.html`.
 No new endpoint, no new table, no new model call, no change to any of the three
@@ -59,7 +59,7 @@ One artifact, written at capture time, on the file's own corpus:
 | Field | Value | Why |
 |---|---|---|
 | `corpus_id` | the file's | The note points at the file; deleting the file takes it |
-| `provenance` | `Captured` | A person typed it. Not `Passage`: it is no slice of the document |
+| `provenance` | `Note` | A new variant. See “What changed” — `Captured` did not survive implementation |
 | `corpus_span` | `None` | **The load-bearing choice.** See below |
 | `segment_idx` | `None` | It belongs to no window |
 | `ordinal` | `0` | Renumbered to 0 anyway; see below |
@@ -77,7 +77,7 @@ invariant — every artifact reads beside the lines it came from — only ever
 covered artifacts that *claim* a span. A span-less artifact claims none, and is
 honest: it is about the file, not from it.
 
-**Ordinals need no change at all.** `renumber_artifacts` orders by
+**Ordinals need no change at all.** (This held.) `renumber_artifacts` orders by
 `COALESCE(segment_idx, 0), ordinal, rowid` (`artifacts.rs:918`). The note has
 `segment_idx = None` → sorts as segment 0; `ordinal = 0`; and it was inserted
 before any passage, so its `rowid` is lowest. It lands at ordinal 0, first in
@@ -255,3 +255,47 @@ Front end: exercised by hand — the automated suite does not drive `app.js`.
   goes with it.
 - **A photo still waits for Capture.** The camera handing back a file stages it;
   it does not upload.
+
+
+---
+
+## 10. What changed during implementation
+
+Two things this spec asserted did not survive contact. Both were found by the
+tests it asked for, and both are now in the code.
+
+**`segment_idx: None` was not a free marker.** The column already means
+something for a window-less row: *debris from an older segmentation*.
+`artifact_ids_for_segment` (`src/store/artifacts.rs:884`) matches
+`segment_idx = ? OR segment_idx IS NULL` deliberately, so the sweep before a
+window rewrite would have deleted the note — and, worse, `passages.rs:159`
+read window 0 as already written and **skipped every passage**. A file
+captured with an annotation was never chunked at all. A sentinel index instead
+of `NULL` fails the other way: `upsert_segments`
+(`src/store/segments.rs:115-121`) refuses to segment a corpus any artifact owns
+a window in. Provenance could not distinguish it either —
+`write_segment_artifacts` writes through `insert_artifacts`, whose default is
+`Captured`.
+
+So there is a fourth `Provenance`: `Note`. The distinction lives in the field
+that means *what kind of row is this*, and the two queries above exclude it.
+`renumber_artifacts` needed no change — that half of §3 held exactly as
+written.
+
+**`settle_corpus` read "nothing left to embed" as "finished".** That is only
+true for a source whose windows have been written: `synthesize::finish` sets
+`embedding` *before* arming the job. §3 arms the note's embed at the door
+instead, so the note embedding alone would have found nothing else pending and
+reported a PDF `ready` before it was extracted — and walked a parked `failed`
+scan forward to `ready` on the way past. It now returns early unless the corpus
+is `embedding` or `partial`. The bug was latent before this work: nothing could
+arm an embed outside that window, so nothing could reach it.
+
+**Two effects accepted rather than fixed.** A note is `in_results()`, so it is
+eligible for dedupe and merge like any other captured text — two identical
+notes on two files can consolidate. And `Provenance::parse` maps an unknown
+string to `Captured`, so a `note` row read by an older binary is swept as
+debris: this is forward-safe, not rollback-safe.
+
+**One §7 sketch was wrong about the DOM.** The staged file sits *below* the
+box, not above it. Nothing was moved; the mockup drew it the other way round.

--- a/docs/superpowers/specs/2026-08-23-file-annotation-design.md
+++ b/docs/superpowers/specs/2026-08-23-file-annotation-design.md
@@ -1,0 +1,257 @@
+# The box is the file's annotation, and an annotation is findable — Design
+
+Date: 2026-08-23
+Status: draft
+Touches `src/core/ingest.rs`, `src/infer/prompt.rs`, `assets/app.js`,
+`src/web/templates/workspace.html`.
+No new endpoint, no new table, no new model call, no change to any of the three
+upload doors' wire format.
+See §9 for what it is not allowed to break.
+
+## 1. Why
+
+Two problems that turn out to be one.
+
+**The workspace does not say what text plus a file means.** Type into the box,
+attach a PDF, press Capture, and `assets/app.js:1159-1163` runs two captures:
+`postText()` stores the box as its own text artifact, then `send(file)` uploads
+the file with the *separate* `input[name=note]` (`workspace.html:81`) as its
+annotation. One press, two artifacts, two places to type, and no way to tell
+from the page which of the two boxes the words in front of you belong to.
+
+**A note is not findable.** Embedding runs over artifact chunks — title and
+text, `src/jobs/embed.rs:18-50`. `metadata["note"]` is in neither. So:
+
+| Door | Where the note goes | Retrievable? |
+|---|---|---|
+| Image | vision prompt (`prompt.rs:1312`) → description → chunks | Only as the model's paraphrase, never the operator's words |
+| PDF | `metadata["note"]`, and no model in the path | **No** |
+| `.txt` upload | `metadata["note"]` | **No** |
+
+The sentence most worth searching on — *"scan of the Reinhardt lease, the break
+clause is p.3"* — is the one sentence engram cannot find, on exactly the
+captures whose extracted text is least likely to contain the operator's words
+for it. A scanned PDF with no text layer parks as `failed` and keeps nothing
+searchable at all, though somebody sat and typed what it was.
+
+Fixing the first without the second is a regression: it would demote text that
+today becomes a searchable artifact into a caption that never can be.
+
+## 2. What is built
+
+1. **A staged file makes the box the file's note.** The dedicated note input is
+   removed. One press, one capture: the file, annotated with what is in the box.
+2. **Order-independence falls out.** Nothing moves at attach time; the box's
+   value is read at press time. Type-then-attach and attach-then-type reach the
+   same single annotated file.
+3. **While a file is staged the box goes quiet** — no search on keystroke, Ask
+   disarmed, placeholder swapped. Removing the file restores it, with the text
+   still in it.
+4. **A note becomes a real artifact** on the file's corpus: embedded, searchable
+   in the operator's own words, anchored to no line of the document.
+5. **The 2000-character cap moves to the only place it earns its keep** — the
+   vision prompt. A note is no longer truncated on the way into storage.
+
+## 3. The note as an artifact
+
+One artifact, written at capture time, on the file's own corpus:
+
+| Field | Value | Why |
+|---|---|---|
+| `corpus_id` | the file's | The note points at the file; deleting the file takes it |
+| `provenance` | `Captured` | A person typed it. Not `Passage`: it is no slice of the document |
+| `corpus_span` | `None` | **The load-bearing choice.** See below |
+| `segment_idx` | `None` | It belongs to no window |
+| `ordinal` | `0` | Renumbered to 0 anyway; see below |
+| `text` | the note, trimmed | Uncapped |
+| `title` | `None` | A heading is something the document gave; this had none |
+
+`corpus_span` is already `Option<CorpusSpan>` (`artifacts.rs:135,217`), and the
+production readers already treat it as optional — `lineage.rs:102` carries it
+through as an `Option`, `ask/mod.rs:647` short-circuits on `?`. Every
+`.expect("every artifact keeps a span")` in the tree is inside a `#[cfg(test)]`
+module (`synthesize.rs:1154,1294`, all past the `mod tests` at line 304).
+
+So the note does **not** get spliced into the document's text. The anchoring
+invariant — every artifact reads beside the lines it came from — only ever
+covered artifacts that *claim* a span. A span-less artifact claims none, and is
+honest: it is about the file, not from it.
+
+**Ordinals need no change at all.** `renumber_artifacts` orders by
+`COALESCE(segment_idx, 0), ordinal, rowid` (`artifacts.rs:918`). The note has
+`segment_idx = None` → sorts as segment 0; `ordinal = 0`; and it was inserted
+before any passage, so its `rowid` is lowest. It lands at ordinal 0, first in
+reading order, and the document's passages renumber after it. Neither
+`passages.rs:169` nor `window.rs:537` changes, and neither does the renumberer.
+
+**Length needs no cap.** `embed.rs:99-131` splits an oversized chunk into
+siblings — on its own estimate before the call, and again on the endpoint's
+refusal. A long note becomes several chunks, the way a long paste already does.
+
+**A parked capture keeps its note.** The artifact is written at ingest, not
+after extraction, and ingest explicitly arms
+`rearm_idle_seq(Stage::Embed, "corpus", corpus_id, 0)` — the same corpus-level
+embed job `synthesize.rs:191` uses. A scan that `extract::park_failed` marks
+`Failed` has never reached `settle`, so without that arming its note would sit
+`pending` forever. With it, the one thing anybody typed about an unreadable
+scan is searchable.
+
+### Where it is written
+
+One private helper in `ingest.rs`, called from all three doors after the corpus
+row exists: `ingest_capture` (the `.txt` upload, via `with_note`, `ingest.rs:125`),
+`ingest_pdf` (`ingest.rs:334`) and `ingest_image` (`ingest.rs:417`). One place,
+so a fourth door cannot forget it.
+
+`metadata["note"]` stays exactly where it is and keeps its job: the corpus page
+reads it, and `describe_context` builds the vision prompt from it. It is now a
+second copy of text that also lives in an artifact. That is the cheaper of the
+two options — the alternative is teaching the corpus page and the describe job
+to go find an artifact, which is coupling bought for nothing.
+
+## 4. Where the cap goes
+
+`MAX_NOTE_CHARS = 2000` currently truncates on the way into `metadata`
+(`clean_note`, `ingest.rs:35`) — silently, with no receipt. It exists because a
+note is "context, not a document".
+
+That reason is now only true in one place: the vision prompt, where the note is
+the *lead line* (`prompt.rs:1312-1316`) and an unbounded note would swamp the
+description or overrun the call. Everywhere else the note is an artifact like
+any other, and artifacts are not truncated.
+
+So the cap moves into `describe_context`, which truncates the copy it puts in
+the prompt. `clean_note` keeps the trim and the empty→`None`, and drops the
+`.take(MAX_NOTE_CHARS)`. Nothing stored is truncated any more; the only bounded
+copy is the one that is spent on a model call.
+
+## 5. The box, when a file is staged
+
+The dedicated note input is deleted from `workspace.html`. The box takes its
+job:
+
+| | Box empty, no file | File staged |
+|---|---|---|
+| Typing | searches (`keyup changed delay:120ms`) | nothing — no request, no embedding, no Judge row |
+| Placeholder | "Describe the situation, ask a question…" | "What is it, why keep it?" |
+| **Ask** | armed when the box has text | disabled |
+| **Capture** | armed when the box has text | armed by the file alone |
+
+The quiet is the point: an annotation typed into a live search box is an
+embedding call, an activation bump and a Judge-queue row per phrase, for text
+nobody asked as a question.
+
+Going quiet is one attribute. The form's `hx-trigger` names
+`keyup ... from:textarea[name=q]`; staging removes the box's search triggers and
+unstaging restores them, alongside the `hidden` toggles `stage`/`unstage`
+already do (`app.js:908-970`).
+
+**Removing the file restores everything**, with the text untouched in the box —
+Remove is the way out, and it must never be the thing that eats what you wrote.
+On unstage the box's triggers come back and a search fires for whatever is in
+it, so the rail matches the box again.
+
+## 6. One press, one capture
+
+`app.js:1159-1163` becomes: if a file is staged, send the file with
+`note = box.value.trim()` and do **not** call `postText()`. With nothing staged,
+`postText()` as today.
+
+On a capture that stored, the box is cleared and the staged file released —
+the same `stored` verdict on `htmx:afterRequest` that `postText` already uses
+(`app.js:1120-1128`), so a failed upload leaves both the file and the words in
+place. Two receipts collapse to one, and the `swap: 'beforeend'` that existed
+to keep two receipts from overwriting each other is no longer load-bearing —
+it stays, harmlessly, because a press can no longer produce two.
+
+**`from_ask` is not sent with a file.** `/ui/capture?from_ask=` fills the box
+with a whole model answer; attaching a file to that turns the answer into a
+caption on somebody's PDF, and `origin = "ask"` is a claim about a text capture.
+The `kept-from` node is removed on a stored capture as it is today.
+
+## 7. What the operator sees
+
+Before, two boxes and no rule:
+
+```
+┌──────────────────────────────────┐
+│ ...whatever I typed up here...   │  ← searched, and captured as its own artifact
+└──────────────────────────────────┘
+┌──────────────────────────────────┐
+│ [thumb] scan.pdf  38 KB          │
+│ Note for the file (optional)…    │  ← and here too?
+│                         [Remove] │
+└──────────────────────────────────┘
+        [ Ask ]  [ Capture ]  [ Attach ]
+```
+
+After, one box whose job the file decides:
+
+```
+┌──────────────────────────────────┐
+│ [thumb] scan.pdf  38 KB [Remove] │
+└──────────────────────────────────┘
+┌──────────────────────────────────┐
+│ What is it, why keep it?         │
+│ scan of the Reinhardt lease,     │
+│ break clause is p.3              │
+└──────────────────────────────────┘
+        [ Ask ]  [ Capture ]  [ Attach ]
+         dimmed    armed
+```
+
+Press Capture: one PDF, annotated. Search "break clause lease" next month and
+that sentence comes back, pointing at the scan.
+
+## 8. Testing
+
+Ingest (`src/core/ingest.rs`):
+- a note on a PDF capture writes one span-less artifact on that corpus, ordinal
+  0, provenance `captured`
+- the same for an image and for a `.txt` upload — one helper, three doors
+- a capture with no note writes no artifact
+- a whitespace-only note writes no artifact and no `metadata["note"]`
+- a note longer than 2000 chars is stored whole, in both metadata and artifact
+- the note artifact is `pending` and a corpus Embed job is armed
+
+Ordering (`src/store/artifacts.rs` or `src/jobs/passages.rs`):
+- after passages land and `renumber_artifacts` runs, the note is ordinal 0 and
+  the document's first passage is ordinal 1
+
+Parked capture (`src/jobs/extract.rs`):
+- a PDF that `park_failed` marks `Failed` still has its note artifact, and it
+  still reaches `embedded`
+
+Prompt (`src/infer/prompt.rs`):
+- `describe_context` truncates a 5000-char note to `MAX_NOTE_CHARS`
+- the note still leads, ahead of the capture facts (the existing test at
+  `prompt.rs:2261` must keep passing)
+
+Retrieval (`src/core/search.rs`):
+- a search for the note's wording returns the note artifact, and it carries the
+  file's `corpus_id`
+
+Front end: exercised by hand — the automated suite does not drive `app.js`.
+§9 is the checklist.
+
+## 9. What it must not break
+
+- **Order-independence.** Type→attach→Capture and attach→type→Capture give the
+  same single annotated file. Nothing may move text at attach time.
+- **Remove gives the text back.** Unstaging restores the box's search triggers,
+  the placeholder, Ask, and leaves the typed text exactly as it was.
+- **A failed capture keeps everything.** No box cleared, no file released,
+  unless the `htmx:afterRequest` verdict says stored.
+- **A capture with no file behaves exactly as today** — search on keystroke,
+  Ask armed, `from_ask` carried, box cleared on success.
+- **The three upload doors' wire format is unchanged.** `note` is still an
+  optional multipart field on `/api/v1` (`api.rs:364,470`); the API and MCP
+  callers gain searchable notes without changing a line.
+- **The image path still reads the note before the pixels.** `describe_context`
+  keeps the note as its first line.
+- **No new model call.** The note is embedded by the corpus Embed job that the
+  capture already arms; at `synthesis = "off"` and `"earned"` nothing else runs.
+- **Deleting the file takes the note.** It is an artifact on that corpus and
+  goes with it.
+- **A photo still waits for Capture.** The camera handing back a file stages it;
+  it does not upload.

--- a/extension/shared/panel.css
+++ b/extension/shared/panel.css
@@ -8,19 +8,25 @@
  * which is most of what read as "an extension somebody wrote for engram"
  * rather than as engram.
  *
- * Only the tokens the panel actually names are carried. The rest — elevated
- * and overlay surfaces, the warning and info roles, three shadow steps — has
- * no reader here, and a token nothing reads is a second copy of a decision waiting
- * to fall out of step with the first. */
+ * Only the tokens the panel actually names are carried. The rest — the surfaces,
+ * roles, type steps and the mono face that 350 pixels of one column never asks
+ * for — has no reader here, and a token nothing reads is a second copy of a
+ * decision waiting to fall out of step with the first. The app has since applied
+ * the same rule to itself and dropped its overlay surface, its info role and its
+ * shadow scale, none of which it read either.
+ *
+ * `--fg-disabled` is the one token going the other way: the panel's placeholder
+ * text and its disabled button read it, and the app, which does not, no longer
+ * defines it. The value here is the light palette's, unchanged. */
 
 /* Bundled rather than fetched. The deployment serves these at
  * `/assets/fonts/`, but a panel that reaches for them over the network draws
  * in the fallback face on every cold open, announces to that origin each time
  * the panel is opened, and renders in system-ui entirely when engram is
  * unreachable — which is exactly the moment the panel is being read. */
-@font-face { font-family: "Inter"; font-weight: 400; font-display: swap;
+@font-face { font-family: Inter; font-weight: 400; font-display: swap;
   src: url("inter-400.woff2") format("woff2"); }
-@font-face { font-family: "Inter"; font-weight: 500; font-display: swap;
+@font-face { font-family: Inter; font-weight: 500; font-display: swap;
   src: url("inter-500.woff2") format("woff2"); }
 
 :root {
@@ -31,7 +37,6 @@
   --text-base: 0.875rem;
   --text-md: 0.9375rem;
 
-  --radius-sm: 3px;
   --radius-md: 6px;
 
   --bg-base: #f8f6f1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,18 +79,29 @@ impl Default for CaptureConfig {
     }
 }
 
-/// Pacing for every inference call, not just synthesis.
+/// Pacing for every generating inference call, not just synthesis.
 ///
 /// The roles share one GPU, so a per-role gap could not bound total load: three
 /// roles each honouring their own cooldown still interleave into unbroken work.
 /// One gap in front of all of them is the only version of this setting that
 /// means what it says.
+///
+/// Generating is the word that carries the exception. Embedding takes its turn
+/// like everything else — one call at a time is what bounds the GPU — but it
+/// neither serves the gap nor starts one, because the gap is measured against
+/// a generation and an encoder is not one. Pacing a batch that answers in a
+/// second behind thirty seconds of silence spends almost the whole budget on
+/// the one role that needs no protecting; at `synthesis = "earned"`, where
+/// capture generates nothing, that was most of what the setting did.
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct PacingConfig {
-    /// Minimum seconds between the end of one background call and the start of
-    /// the next. Zero disables pacing. `ask` ignores it: a person is waiting,
-    /// and the pacer exists to protect the GPU from batch work, not from them.
+    /// Minimum seconds between the end of one background generation and the
+    /// start of the next. Zero disables pacing. `ask` ignores it: a person is
+    /// waiting, and the pacer exists to protect the GPU from batch work, not
+    /// from them. Embedding ignores it too, for the opposite reason — it is
+    /// batch work the gap was never sized against. See `InferenceGate::
+    /// background_light`.
     pub cooldown_secs: u64,
 }
 

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -2691,7 +2691,11 @@ mod tests {
         core.reprocess(&out.id, Stage::Extract).await.unwrap();
 
         let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
-        assert_eq!(all.len(), 1, "the reprocess deleted the operator's own note");
+        assert_eq!(
+            all.len(),
+            1,
+            "the reprocess deleted the operator's own note"
+        );
         assert_eq!(all[0].text, "break clause is p.3");
         assert_eq!(
             core.store

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -21,18 +21,25 @@ pub const ORIGIN_WEB: &str = "web";
 /// is the whole of what the keep-this-answer door concedes, and a bare literal
 /// in one handler is not where a distinction that load-bearing should live.
 pub const ORIGIN_ASK: &str = "ask";
-/// Longest note kept. Context, not a document: someone wanting to say more
-/// than this has a paste box.
+/// Longest note spent on a vision call. Context, not a document: the note is
+/// the lead line of the describe prompt, and an unbounded one swamps the
+/// description or overruns the request.
+///
+/// It bounds that copy and nothing else. A note is stored whole — it is an
+/// artifact like any other text, and `jobs::embed` cuts an oversize chunk into
+/// siblings rather than losing the tail of it. Truncating on the way in was a
+/// silent amputation with no receipt anywhere: the operator saw a note go in
+/// and had no way to learn that most of it had not.
 pub const MAX_NOTE_CHARS: usize = 2000;
 
-/// The user's context for a capture, cleaned: trimmed, capped, `None` when
-/// there is nothing in it.
+/// The user's context for a capture, cleaned: trimmed, `None` when there is
+/// nothing in it.
 fn clean_note(note: Option<String>) -> Option<String> {
     let n = note?.trim().to_string();
     if n.is_empty() {
         return None;
     }
-    Some(n.chars().take(MAX_NOTE_CHARS).collect())
+    Some(n)
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -2354,16 +2361,22 @@ mod tests {
         assert!(core.store.list_corpora(10, 0).await.unwrap().is_empty());
     }
 
+    /// A note is no longer truncated on the way into storage. It is an
+    /// artifact like any other, and `embed::run_with_limit` splits an oversize
+    /// chunk into siblings — so length is the embedder's problem, not a silent
+    /// amputation at the door.
     #[tokio::test]
-    async fn a_note_is_capped_and_a_blank_one_is_dropped() {
-        let core = crate::core::test_support::test_core().await;
+    async fn a_long_note_is_stored_whole_and_a_blank_one_is_dropped() {
+        let core = test_core().await;
         let long = "x".repeat(MAX_NOTE_CHARS + 50);
         let out = core
-            .ingest_capture(Capture::new("some text", "upload").with_note(Some(long)))
+            .ingest_capture(Capture::new("some text", "upload").with_note(Some(long.clone())))
             .await
             .unwrap();
         let src = core.store.get_corpus(&out.id).await.unwrap();
-        assert_eq!(src.metadata["note"].as_str().unwrap().len(), MAX_NOTE_CHARS);
+        assert_eq!(src.metadata["note"].as_str().unwrap(), long);
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert_eq!(all[0].text, long, "the artifact keeps every character");
 
         let out = core
             .ingest_capture(Capture::new("other text", "upload").with_note(Some("   ".into())))

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -267,7 +267,7 @@ impl Core {
         }
 
         self.attach_note_artifact(&src.id, c.metadata["note"].as_str())
-            .await?;
+            .await;
 
         Ok(IngestOutcome {
             id: src.id,
@@ -329,7 +329,19 @@ impl Core {
     /// The embed is armed here rather than left to `settle`. A scan with no
     /// text layer parks as `failed` and never reaches settling, and that is
     /// exactly the capture whose note is the only text anyone will ever have.
-    async fn attach_note_artifact(&self, corpus_id: &str, note: Option<&str>) -> Result<()> {
+    /// By the time this runs the corpus row is committed and its stages are
+    /// queued, so a store failure here is not a failed capture and must not be
+    /// reported as one: the browser would put the file back for a retry, the
+    /// retry would find the hash already stored and answer `duplicate` — which
+    /// correctly writes no note — and the operator would end up with the file
+    /// in the base and the note nowhere.
+    async fn attach_note_artifact(&self, corpus_id: &str, note: Option<&str>) {
+        if let Err(e) = self.write_note_artifact(corpus_id, note).await {
+            tracing::error!(corpus_id, error = %e, "capture stored, but its note was not");
+        }
+    }
+
+    async fn write_note_artifact(&self, corpus_id: &str, note: Option<&str>) -> Result<()> {
         let Some(text) = note.map(str::trim).filter(|n| !n.is_empty()) else {
             return Ok(());
         };
@@ -421,7 +433,7 @@ impl Core {
             // of near-identical captions nobody wrote twice on purpose.
             Insertion::Existing(c) => IngestOutcome::existing(&c),
             Insertion::Created(c) => {
-                self.attach_note_artifact(&c.id, note.as_deref()).await?;
+                self.attach_note_artifact(&c.id, note.as_deref()).await;
                 IngestOutcome {
                     id: c.id,
                     status: c.status,
@@ -521,7 +533,7 @@ impl Core {
             mime = prepared.mime,
             "image captured; queued for reading"
         );
-        self.attach_note_artifact(&src.id, note.as_deref()).await?;
+        self.attach_note_artifact(&src.id, note.as_deref()).await;
         Ok(IngestOutcome {
             id: src.id,
             status: CorpusStatus::Describing,
@@ -1024,10 +1036,25 @@ impl Core {
     async fn forget_derived_work(&self, id: &str) -> Result<()> {
         // Re-segmenting replaces every chunk, so the old vectors and rows go
         // first.
+        //
+        // Except the note, which is not derived work: nothing a rerun does can
+        // produce the sentence a person typed about the document, so deleting
+        // it here would make it unsearchable for good while the caption on the
+        // page went on claiming otherwise. Its vector went with the corpus, so
+        // it is put back in line for a new one — armed here rather than left to
+        // `settle`, for the same reason the door arms it: a re-read that parks
+        // as `failed` never reaches settling.
         self.vectors.delete_by_corpus(id).await?;
         for c in self.store.artifacts_for_corpus(id).await? {
+            if c.provenance == crate::store::artifacts::Provenance::Note {
+                continue;
+            }
             self.store.delete_artifact(&c.id).await?;
         }
+        self.store.reset_embed_state(id).await?;
+        self.store
+            .rearm_idle_seq(Stage::Embed, "corpus", id, 0)
+            .await?;
         // The window rows are the segment job's memory of what it has already
         // done. Leaving them behind means the rerun finds every window `done`,
         // segments nothing, and lands on a source with no chunks at all.
@@ -2634,6 +2661,46 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    /// A note is not derived work. A reprocess replaces everything the pipeline
+    /// made from the document; the sentence a person typed about it is the one
+    /// thing in the corpus no rerun can produce again.
+    #[tokio::test]
+    async fn a_reprocess_keeps_the_note_and_queues_it_for_a_fresh_vector() {
+        let core = test_core().await;
+        let out = core
+            .ingest_pdf(PdfCapture {
+                bytes: a_pdf_fixture(),
+                filename: Some("lease.pdf".into()),
+                title_hint: None,
+                note: Some("break clause is p.3".into()),
+            })
+            .await
+            .unwrap();
+        let before = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        let note = &before[0];
+        assert!(
+            core.store
+                .mark_embedded(&note.id, "bge-m3", note.embed_rev)
+                .await
+                .unwrap()
+        );
+
+        core.reprocess(&out.id, Stage::Extract).await.unwrap();
+
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert_eq!(all.len(), 1, "the reprocess deleted the operator's own note");
+        assert_eq!(all[0].text, "break clause is p.3");
+        assert_eq!(
+            core.store
+                .pending_artifacts_for_corpus(&out.id)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "its vector went with the corpus; the note has to be embedded again"
         );
     }
 }

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -259,6 +259,9 @@ impl Core {
             None => tracing::info!(corpus_id = %src.id, origin, bytes = text.len(), "ingested"),
         }
 
+        self.attach_note_artifact(&src.id, c.metadata["note"].as_str())
+            .await?;
+
         Ok(IngestOutcome {
             id: src.id,
             status: src.status,
@@ -293,6 +296,56 @@ impl Core {
                 "looks like an existing corpus; parked for review"
             );
         }
+        Ok(())
+    }
+
+    /// The operator's sentence about a file, written where it can be found.
+    ///
+    /// Embedding runs over artifact chunks and never over metadata, so a note
+    /// left in `metadata["note"]` is invisible to search — on a PDF or a text
+    /// upload absolutely, and on a photograph only as whatever the vision
+    /// model happened to echo back.
+    ///
+    /// `corpus_span: None` is the point: the note is *about* the file and is no
+    /// line *of* it, so it claims no span and nothing tries to read it beside
+    /// lines it did not come from. `segment_idx: None` puts it ahead of every
+    /// window in `renumber_artifacts`, which orders by
+    /// `COALESCE(segment_idx, 0), ordinal, rowid` — so it settles at ordinal 0
+    /// with no help from either artifact writer.
+    ///
+    /// `Provenance::Note` is what keeps that survivable. A window-less row
+    /// otherwise reads as debris from an older segmentation, and the two
+    /// queries that sweep such rows would have deleted the note — or, with a
+    /// sentinel index instead, counted it as a window this corpus already owns
+    /// and refused to segment the document at all.
+    ///
+    /// The embed is armed here rather than left to `settle`. A scan with no
+    /// text layer parks as `failed` and never reaches settling, and that is
+    /// exactly the capture whose note is the only text anyone will ever have.
+    async fn attach_note_artifact(&self, corpus_id: &str, note: Option<&str>) -> Result<()> {
+        let Some(text) = note.map(str::trim).filter(|n| !n.is_empty()) else {
+            return Ok(());
+        };
+        self.store
+            .insert_artifacts_with_provenance(
+                corpus_id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    // A heading is something a document gave. This had none.
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+                crate::store::artifacts::Provenance::Note,
+            )
+            .await?;
+        self.store
+            .rearm_idle_seq(Stage::Embed, "corpus", corpus_id, 0)
+            .await?;
         Ok(())
     }
 
@@ -331,7 +384,8 @@ impl Core {
             file["name"] = serde_json::Value::String(n.to_string());
         }
         let mut metadata = serde_json::json!({ "file": file });
-        if let Some(n) = clean_note(note) {
+        let note = clean_note(note);
+        if let Some(n) = &note {
             metadata["note"] = serde_json::json!(n);
         }
 
@@ -355,13 +409,19 @@ impl Core {
             )
             .await?;
         Ok(match inserted {
+            // A file already in the base keeps the note it was captured with.
+            // Stacking a second one per re-upload is how a corpus grows a pile
+            // of near-identical captions nobody wrote twice on purpose.
             Insertion::Existing(c) => IngestOutcome::existing(&c),
-            Insertion::Created(c) => IngestOutcome {
-                id: c.id,
-                status: c.status,
-                duplicate: false,
-                near_duplicate: None,
-            },
+            Insertion::Created(c) => {
+                self.attach_note_artifact(&c.id, note.as_deref()).await?;
+                IngestOutcome {
+                    id: c.id,
+                    status: c.status,
+                    duplicate: false,
+                    near_duplicate: None,
+                }
+            }
         })
     }
 
@@ -414,8 +474,9 @@ impl Core {
         if prepared.exif.as_object().is_some_and(|o| !o.is_empty()) {
             metadata["exif"] = prepared.exif.clone();
         }
-        if let Some(n) = clean_note(note) {
-            metadata["note"] = serde_json::Value::String(n);
+        let note = clean_note(note);
+        if let Some(n) = &note {
+            metadata["note"] = serde_json::Value::String(n.clone());
         }
         // A filename is a file fact, not a name: `photo.jpg` and `image.png`
         // are what a camera and a clipboard call everything. Seeding the title
@@ -453,6 +514,7 @@ impl Core {
             mime = prepared.mime,
             "image captured; queued for reading"
         );
+        self.attach_note_artifact(&src.id, note.as_deref()).await?;
         Ok(IngestOutcome {
             id: src.id,
             status: CorpusStatus::Describing,
@@ -2406,6 +2468,159 @@ mod tests {
         assert_eq!(
             core.store.segment_state(&src.id, 0).await.unwrap(),
             Some(crate::store::segments::SegmentState::Verbatim)
+        );
+    }
+
+    /// The sentence most worth searching on must be an artifact, not a
+    /// caption. Embedding runs over artifact chunks and never over metadata,
+    /// so a note that stays in `metadata["note"]` cannot be found at all.
+    #[tokio::test]
+    async fn a_note_on_a_pdf_becomes_a_span_less_artifact_on_its_corpus() {
+        let core = test_core().await;
+        let out = core
+            .ingest_pdf(PdfCapture {
+                bytes: a_pdf_fixture(),
+                filename: Some("lease.pdf".into()),
+                title_hint: None,
+                note: Some("  scan of the Reinhardt lease, break clause is p.3  ".into()),
+            })
+            .await
+            .unwrap();
+
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert_eq!(all.len(), 1, "the note, and nothing extracted yet");
+        let n = &all[0];
+        assert_eq!(n.text, "scan of the Reinhardt lease, break clause is p.3");
+        assert_eq!(
+            n.corpus_span, None,
+            "the note is about the file, not a line of it"
+        );
+        assert_eq!(n.segment_idx, None, "it belongs to no window");
+        assert_eq!(n.ordinal, 0);
+        assert_eq!(n.provenance, crate::store::artifacts::Provenance::Note);
+        assert_eq!(n.title, None);
+    }
+
+    /// One helper, three doors, so a fourth cannot forget it.
+    #[tokio::test]
+    async fn every_door_that_takes_a_note_writes_it_as_an_artifact() {
+        let describer = std::sync::Arc::new(crate::infer::fake::FakeDescriber::default());
+        let core = crate::core::test_support::test_core_with_describer(describer).await;
+
+        let img = core
+            .ingest_image(ImageCapture {
+                bytes: a_seeded_png(11),
+                filename: Some("IMG_9.png".into()),
+                title_hint: None,
+                note: Some("front of the router".into()),
+            })
+            .await
+            .unwrap();
+        let a = core.store.artifacts_for_corpus(&img.id).await.unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].text, "front of the router");
+
+        let txt = core
+            .ingest_capture(
+                Capture::new("the file's own text", "upload")
+                    .with_note(Some("from the printer".into())),
+            )
+            .await
+            .unwrap();
+        let a = core.store.artifacts_for_corpus(&txt.id).await.unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].text, "from the printer");
+    }
+
+    #[tokio::test]
+    async fn a_capture_with_no_usable_note_writes_no_artifact() {
+        let core = test_core().await;
+        let none = core
+            .ingest_capture(Capture::new("text one", "upload"))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .artifacts_for_corpus(&none.id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let blank = core
+            .ingest_capture(Capture::new("text two", "upload").with_note(Some("   ".into())))
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .artifacts_for_corpus(&blank.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "whitespace is not an annotation"
+        );
+    }
+
+    /// A scan with no text layer parks as `failed` and never reaches `settle`,
+    /// which is what normally arms the embed. Without arming it here, the one
+    /// thing a person typed about an unreadable document waits forever.
+    #[tokio::test]
+    async fn a_note_arms_the_embed_so_a_parked_capture_still_becomes_findable() {
+        let core = test_core().await;
+        let out = core
+            .ingest_pdf(PdfCapture {
+                bytes: a_pdf_fixture(),
+                filename: Some("scan.pdf".into()),
+                title_hint: None,
+                note: Some("the survey nobody can OCR".into()),
+            })
+            .await
+            .unwrap();
+
+        let pending = core
+            .store
+            .pending_artifacts_for_corpus(&out.id)
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 1, "the note is waiting for a vector");
+        assert!(
+            core.store.live_job(Stage::Embed, &out.id).await.unwrap(),
+            "a corpus embed job must be armed by the capture itself"
+        );
+    }
+
+    /// Re-uploading the same file must not stack a second note on it.
+    #[tokio::test]
+    async fn a_duplicate_upload_writes_no_second_note() {
+        let core = test_core().await;
+        let bytes = a_pdf_fixture();
+        let first = core
+            .ingest_pdf(PdfCapture {
+                bytes: bytes.clone(),
+                filename: Some("plan.pdf".into()),
+                title_hint: None,
+                note: Some("the quarterly plan".into()),
+            })
+            .await
+            .unwrap();
+        let again = core
+            .ingest_pdf(PdfCapture {
+                bytes,
+                filename: Some("plan.pdf".into()),
+                title_hint: None,
+                note: Some("a second thought about it".into()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.id, again.id);
+        assert!(again.duplicate);
+        assert_eq!(
+            core.store
+                .artifacts_for_corpus(&first.id)
+                .await
+                .unwrap()
+                .len(),
+            1
         );
     }
 }

--- a/src/infer/gate.rs
+++ b/src/infer/gate.rs
@@ -60,6 +60,37 @@ impl InferenceGate {
     /// Returns the right to make one background inference call, once one may
     /// start. Hold the permit for the duration of the call.
     pub async fn background(&self) -> BackgroundPermit<'_> {
+        self.acquire(true).await
+    }
+
+    /// The same turn, without the cooldown on either side of it.
+    ///
+    /// For a call whose cost is not what the gap was configured against.
+    /// Embedding is the case it exists for: a 300M encoder answering a batch
+    /// in about a second, against the seconds-to-minutes of a generation on
+    /// the tier beside it. Serving thirty seconds in front of that call is the
+    /// pacer spending almost all of its budget on the one role that needs no
+    /// protecting — and at `synthesis = "earned"`, where nothing generates at
+    /// capture, that is most of what the pacer does.
+    ///
+    /// It still takes the turn, so a batch never runs alongside a generation:
+    /// they share a GPU, and one at a time is the part of the gate that bounds
+    /// load rather than merely spaces it. It still yields to an interactive
+    /// lease, because a person waiting on `ask` outranks a batch either way.
+    /// And it does not stamp `last_finished` on the way out: a call that never
+    /// earned the gap must not impose it on the next one.
+    pub async fn background_light(&self) -> BackgroundPermit<'_> {
+        self.acquire(false).await
+    }
+
+    /// The turn, then the wait, then the permit.
+    ///
+    /// `paced` is whether this call serves the cooldown before it and starts
+    /// one after it. The two travel together on purpose: a call exempt from
+    /// the gap it would otherwise wait out has not occupied the GPU in the way
+    /// the gap is measured against, so it has nothing to make the next caller
+    /// wait for.
+    async fn acquire(&self, paced: bool) -> BackgroundPermit<'_> {
         // The turn is taken before the wait rather than after it, so whoever
         // holds it re-reads the cooldown once the call ahead has finished.
         // Checking first and taking the turn afterwards would let every waiter
@@ -87,6 +118,11 @@ impl InferenceGate {
                 if st.interactive > 0 {
                     resumed.as_mut().enable();
                     None
+                } else if !paced {
+                    // Nothing to serve. The turn is already held, and yielding
+                    // to the lease above is the whole of what a light call waits
+                    // for.
+                    break;
                 } else {
                     let now = Instant::now();
                     match st.last_finished.map(|t| t + self.cooldown) {
@@ -105,6 +141,7 @@ impl InferenceGate {
         BackgroundPermit {
             gate: self,
             _turn: turn,
+            paced,
         }
     }
 
@@ -129,6 +166,9 @@ impl InferenceGate {
 pub struct BackgroundPermit<'a> {
     gate: &'a InferenceGate,
     _turn: SemaphorePermit<'a>,
+    /// Whether this call starts a cooldown when it ends. False for a light
+    /// call, which served none going in.
+    paced: bool,
 }
 
 impl BackgroundPermit<'_> {
@@ -136,7 +176,9 @@ impl BackgroundPermit<'_> {
     /// passes on at the moment the call ended rather than whenever the caller
     /// got around to saying so.
     pub fn finished(self) {
-        self.gate.call_finished();
+        if self.paced {
+            self.gate.call_finished();
+        }
     }
 }
 
@@ -278,6 +320,70 @@ mod tests {
         let released = tokio::time::Instant::now();
         let acquired = second.await.unwrap();
         assert_eq!(acquired - released, Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_light_call_does_not_serve_the_cooldown() {
+        // Embedding is a 300M encoder next to a 9B generation. It takes its
+        // turn, but the gap in front of the heavy calls is not its to serve.
+        let g = gate(600);
+        g.call_finished();
+        let started = tokio::time::Instant::now();
+        g.background_light().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_light_call_does_not_start_a_cooldown_behind_it() {
+        // A call that never earned the gap must not impose it either: an embed
+        // batch between two generations would otherwise push the next one out.
+        let g = gate(600);
+        let permit = g.background_light().await;
+        permit.finished();
+        let started = tokio::time::Instant::now();
+        g.background().await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_light_call_still_takes_its_turn() {
+        // Exempt from the gap, not from the one-at-a-time. The batch and the
+        // generation share a GPU, and that is the half of the gate that bounds
+        // load rather than spacing it.
+        let g = gate(0);
+        let heavy = g.background().await;
+
+        let g2 = Arc::clone(&g);
+        let light = tokio::spawn(async move {
+            g2.background_light().await;
+        });
+        tokio::time::advance(Duration::from_secs(3600)).await;
+        assert!(
+            !light.is_finished(),
+            "an embed batch ran alongside a generation"
+        );
+
+        heavy.finished();
+        light.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_light_call_still_yields_to_someone_waiting_on_ask() {
+        let g = gate(0);
+        let lease = g.interactive();
+        let g2 = Arc::clone(&g);
+        let light = tokio::spawn(async move {
+            g2.background_light().await;
+        });
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        assert!(
+            !light.is_finished(),
+            "an embed batch ran while an ask was in flight"
+        );
+
+        drop(lease);
+        light.await.unwrap();
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -1310,9 +1310,14 @@ Rules:
 pub fn describe_context(metadata: &serde_json::Value) -> String {
     let mut lines: Vec<String> = Vec::new();
     if let Some(note) = metadata["note"].as_str().filter(|n| !n.trim().is_empty()) {
+        // The stored note is whole; this is the copy that costs tokens, and it
+        // leads the prompt — so it is the one place a long one does damage.
         lines.push(format!(
             "Context from the person who captured this: {}",
             note.trim()
+                .chars()
+                .take(crate::core::ingest::MAX_NOTE_CHARS)
+                .collect::<String>()
         ));
     }
     let mut facts: Vec<String> = Vec::new();
@@ -2255,6 +2260,22 @@ mod tests {
         let p = repair_prompt("{bad", "expected value at line 1");
         assert!(p.contains("expected value at line 1"));
         assert!(p.contains("{bad"));
+    }
+
+    /// The note leads the vision prompt, so an unbounded one would swamp the
+    /// description or overrun the call. This is now the only place the cap
+    /// still earns its keep — nothing stored is truncated any more.
+    #[test]
+    fn describe_context_bounds_the_note_it_spends_on_a_model_call() {
+        let long = "x".repeat(crate::core::ingest::MAX_NOTE_CHARS + 500);
+        let m = serde_json::json!({ "note": long });
+        let ctx = describe_context(&m);
+        let kept = ctx
+            .lines()
+            .next()
+            .unwrap()
+            .trim_start_matches("Context from the person who captured this: ");
+        assert_eq!(kept.chars().count(), crate::core::ingest::MAX_NOTE_CHARS);
     }
 
     #[test]

--- a/src/jobs/describe.rs
+++ b/src/jobs/describe.rs
@@ -135,6 +135,16 @@ mod tests {
             d.last_context()
         );
         assert!(d.last_context().contains("p.png"));
+        // The note captured with the photo is armed for embedding at the door,
+        // so it sits ahead of the synthesis in the queue. Both are queued; the
+        // hand-off this test is about is the second one.
+        let embed = core
+            .store
+            .claim_job()
+            .await
+            .unwrap()
+            .expect("the note's embed");
+        assert_eq!(embed.stage, Stage::Embed);
         let next = core
             .store
             .claim_job()

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -905,12 +905,27 @@ async fn upsert_with_current_lifecycle(core: &Core, mut points: Vec<VectorPoint>
 /// Advance the parent source once no chunk is still pending: `ready` if every
 /// chunk embedded, `partial` if any gave up.
 pub async fn settle_corpus(core: &Core, corpus_id: &str) -> Result<()> {
+    // "Nothing left to embed" only means "finished" for a source whose windows
+    // have already been written: `finish` sets `embedding` — or `partial` —
+    // before it arms the job, so those two are the states this reads. Every
+    // other one means the document has not been read yet, and an empty pending
+    // count says nothing about it.
+    //
+    // A capture's note is armed for embedding at the door, long before any of
+    // that. Without this guard the note embedding on its own would find
+    // nothing else pending and report a PDF `ready` that had not been
+    // extracted, or walk a parked `failed` scan forward to `ready` on the way
+    // past.
+    let was = core.store.get_corpus(corpus_id).await?.status;
+    if !matches!(was, CorpusStatus::Embedding | CorpusStatus::Partial) {
+        return Ok(());
+    }
     if core.store.pending_embed_count(corpus_id).await? > 0 {
         return Ok(());
     }
     let status = if core.store.failed_embed_count(corpus_id).await? > 0 {
         CorpusStatus::Partial
-    } else if core.store.get_corpus(corpus_id).await?.status == CorpusStatus::Partial {
+    } else if was == CorpusStatus::Partial {
         // A source with a window the model refused is already partial. Its
         // chunks embedding cleanly does not fill the hole those lines left,
         // and reporting `ready` would hide it.

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -102,9 +102,12 @@ pub async fn run_with_limit(core: &Core, artifact_id: &str, limit: usize) -> Res
         return split_oversize(core, &chunk, limit, false).await;
     }
 
-    // Paced like every other inference call. `split_into_artifact_jobs` can
-    // leave hundreds of these behind for one document.
-    let permit = core.gate.background().await;
+    // Takes its turn like every other inference call, and serves no cooldown:
+    // `background_light` is what an encoder gets. `split_into_artifact_jobs`
+    // can leave hundreds of these behind for one document, and at thirty
+    // seconds apiece that was hours of gap in front of a call that answers in
+    // about a second.
+    let permit = core.gate.background_light().await;
     let outcome = embed_batch(core, std::slice::from_ref(&chunk)).await;
     permit.finished();
     match outcome {
@@ -184,7 +187,7 @@ pub async fn run_corpus_with_limit(core: &Core, corpus_id: &str, limit: usize) -
         return settle_corpus(core, corpus_id).await;
     }
 
-    let permit = core.gate.background().await;
+    let permit = core.gate.background_light().await;
     let outcome = embed_batch(core, &batch[..take]).await;
     permit.finished();
     match outcome {
@@ -431,7 +434,7 @@ async fn split_oversize(core: &Core, chunk: &Chunk, limit: usize, hard: bool) ->
         splittable,
         "oversize chunk has no split available; embedding as-is"
     );
-    let permit = core.gate.background().await;
+    let permit = core.gate.background_light().await;
     let embedded = core
         .embedder
         .embed_documents(std::slice::from_ref(&doc_of(chunk)))
@@ -534,7 +537,7 @@ async fn embed_head(core: &Core, chunk: &Chunk, limit: usize) -> Result<()> {
         title: chunk.title.clone(),
         text: head,
     };
-    let permit = core.gate.background().await;
+    let permit = core.gate.background_light().await;
     let embedded = core
         .embedder
         .embed_documents(std::slice::from_ref(&input))
@@ -1810,6 +1813,50 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(seq, 1, "the re-armed batch stayed at the front");
+    }
+
+    #[tokio::test]
+    async fn an_embed_batch_does_not_serve_the_generation_cooldown() {
+        // The gap is configured against a generation. Serving it in front of a
+        // 300M encoder spends the pacer's whole budget on the one role that
+        // needs no protecting — and at `synthesis = "earned"` that is most of
+        // what it does.
+        //
+        // Real time rather than a paused clock: the measured section is a job
+        // that talks to the store, and an auto-advancing clock times sqlx's
+        // pool acquire out instead of measuring anything. Thirty seconds of
+        // cooldown against a sub-second budget is a wide enough margin that no
+        // scheduling noise can blur the two answers.
+        let mut core = crate::core::test_support::test_core().await;
+        core.gate = std::sync::Arc::new(crate::infer::gate::InferenceGate::new(
+            std::time::Duration::from_secs(30),
+        ));
+        let (src, _ids) = seed(&core, &["one", "two"]).await;
+        // A generation has just ended, so a paced call would serve the gap.
+        core.gate.call_finished();
+
+        let started = std::time::Instant::now();
+        run_corpus(&core, &src).await.unwrap();
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "the embed job served a generation's cooldown: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_embed_batch_does_not_hold_the_next_generation_off() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.gate = std::sync::Arc::new(crate::infer::gate::InferenceGate::new(
+            std::time::Duration::from_secs(600),
+        ));
+        let (src, _ids) = seed(&core, &["one", "two"]).await;
+        run_corpus(&core, &src).await.unwrap();
+
+        tokio::time::pause();
+        let started = tokio::time::Instant::now();
+        core.gate.background().await;
+        assert_eq!(started.elapsed(), std::time::Duration::ZERO);
     }
 
     async fn seed(core: &crate::core::Core, texts: &[&str]) -> (String, Vec<String>) {

--- a/src/jobs/passages.rs
+++ b/src/jobs/passages.rs
@@ -452,4 +452,36 @@ mod tests {
                 .unwrap()
         );
     }
+
+    /// The note is written at capture and the passages arrive later, each
+    /// numbered from 0 within its own window. Renumbering has to put the note
+    /// first and push the document down by one — with no change to this
+    /// writer, which is the whole reason the note carries no `segment_idx`.
+    #[tokio::test]
+    async fn a_note_sorts_ahead_of_the_document_it_annotates() {
+        let core = crate::core::test_support::test_core().await;
+        let out = core
+            .ingest_capture(
+                crate::core::ingest::Capture::new(
+                    "# Heading\n\nThe body of the uploaded document.",
+                    "upload",
+                )
+                .with_note(Some("printout from the hallway scanner".into())),
+            )
+            .await
+            .unwrap();
+
+        capture_verbatim(&core, &out.id).await.unwrap();
+
+        let all = core.store.artifacts_for_corpus(&out.id).await.unwrap();
+        assert!(all.len() >= 2, "the note and at least one passage");
+        assert_eq!(all[0].text, "printout from the hallway scanner");
+        assert_eq!(all[0].ordinal, 0);
+        assert_eq!(all[0].corpus_span, None);
+        assert_eq!(all[1].ordinal, 1, "ordinals stay continuous");
+        assert!(
+            all[1].corpus_span.is_some(),
+            "a passage still anchors to its lines"
+        );
+    }
 }

--- a/src/jobs/synthesize.rs
+++ b/src/jobs/synthesize.rs
@@ -2,6 +2,7 @@ use crate::core::Core;
 use crate::error::Result;
 use crate::infer::budget::segment_tokens;
 use crate::infer::split::split_into_segments;
+use crate::store::artifacts::Provenance;
 use crate::store::corpora::CorpusStatus;
 use crate::store::jobs::Stage;
 use crate::store::segments::SegmentState;
@@ -120,13 +121,17 @@ pub async fn recompute_coverage(core: &Core, corpus_id: &str) -> Result<f64> {
         .collect();
 
     // A corpus segmented before per-segment windows existed has no ranges to
-    // group by; measure it as one.
+    // group by; measure it as one. The note is left out here as the per-window
+    // branch above leaves it out: it was not made from the source, so a note
+    // that quotes the document would report its lines as covered by an artifact
+    // that does not exist.
     let made = if made.is_empty() {
         vec![(
             1,
             src.raw_text.lines().count() as i64,
             chunks
                 .iter()
+                .filter(|c| c.provenance != Provenance::Note)
                 .map(|c| c.text.as_str())
                 .collect::<Vec<_>>()
                 .join("\n"),
@@ -150,7 +155,12 @@ pub async fn finish(core: &Core, corpus_id: &str) -> Result<()> {
         .iter()
         .any(|w| !matches!(w.state, SegmentState::Done | SegmentState::Verbatim));
     let chunks = core.store.artifacts_for_corpus(corpus_id).await?;
-    if chunks.is_empty() {
+    // The note does not count towards having read anything: it is the
+    // operator's own sentence, attached at the door before a word of the
+    // document was looked at. Counting it leaves a scan that yielded nothing
+    // measuring near-zero coverage and settling `ready` — a document reported
+    // as read when none of it was.
+    if chunks.iter().all(|c| c.provenance == Provenance::Note) {
         core.store
             .set_corpus_status(corpus_id, CorpusStatus::Failed)
             .await?;
@@ -1355,6 +1365,86 @@ Then run sync.";
         assert_eq!(
             rows[0].provenance,
             crate::store::artifacts::Provenance::Passage
+        );
+    }
+
+    /// A note is the operator's own sentence, not something read out of the
+    /// document. Counting it as a chunk tells a person a scan was read when
+    /// nothing of it was.
+    #[tokio::test]
+    async fn a_document_that_produced_only_its_note_still_parks_as_failed() {
+        let core = test_core().await;
+        let out = core
+            .ingest_capture(
+                crate::core::ingest::Capture::new("a page nothing could be made of", "upload")
+                    .with_note(Some("the survey nobody can OCR".into())),
+            )
+            .await
+            .unwrap();
+        plan(&core, &out.id).await.unwrap();
+        sqlx::query("UPDATE segments SET state = 'done' WHERE corpus_id = ?")
+            .bind(&out.id)
+            .execute(&core.store.pool)
+            .await
+            .unwrap();
+
+        finish(&core, &out.id).await.unwrap();
+
+        assert_eq!(
+            core.store.get_corpus(&out.id).await.unwrap().status,
+            CorpusStatus::Failed,
+            "a corpus holding nothing but its note was reported as read"
+        );
+    }
+
+    /// A corpus segmented before per-window segments existed is measured as one
+    /// window over all its chunks. The note is not one of them: it was not made
+    /// from the source, and one that quotes the document reports lines as
+    /// covered that no artifact holds.
+    #[tokio::test]
+    async fn the_windowless_coverage_fallback_does_not_count_the_note() {
+        let core = test_core().await;
+        let src = core
+            .store
+            .insert_corpus(
+                "quarterly revenue projections attached\nthe Reinhardt lease expires November",
+                "web",
+                None,
+            )
+            .await
+            .unwrap();
+        let new = |text: &str| crate::store::artifacts::NewArtifact {
+            ordinal: 0,
+            text: text.to_string(),
+            corpus_span: None,
+            title: None,
+            category: None,
+            tags: vec![],
+            segment_idx: None,
+            caveats: vec![],
+        };
+        core.store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[new("quarterly revenue projections attached")],
+                crate::store::artifacts::Provenance::Captured,
+            )
+            .await
+            .unwrap();
+        core.store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[new("the Reinhardt lease expires November")],
+                crate::store::artifacts::Provenance::Note,
+            )
+            .await
+            .unwrap();
+
+        let cov = recompute_coverage(&core, &src.id).await.unwrap();
+
+        assert_eq!(
+            cov, 0.5,
+            "the note was measured as if it had been read out of the document"
         );
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -264,7 +264,11 @@ fn service_config(
 ) -> rmcp::transport::streamable_http_server::StreamableHttpServerConfig {
     use rmcp::transport::streamable_http_server::StreamableHttpServerConfig;
 
-    let mut hosts = vec!["localhost".to_string(), "127.0.0.1".to_string(), "::1".to_string()];
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
     if let Some(host) = public_host {
         hosts.push(host);
     }

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -81,6 +81,11 @@ pub enum Provenance {
     Captured,
     Merged,
     Synthesized,
+    /// What a person typed about a file when they captured it. Source text
+    /// like `Captured`, but owned by no window: it is *about* the document and
+    /// is no line *of* it, so the two queries that treat a window-less row as
+    /// debris from an older segmentation must leave it alone.
+    Note,
 }
 
 impl Provenance {
@@ -90,6 +95,7 @@ impl Provenance {
             Provenance::Captured => "captured",
             Provenance::Merged => "merged",
             Provenance::Synthesized => "synthesized",
+            Provenance::Note => "note",
         }
     }
     pub fn parse(s: &str) -> Provenance {
@@ -97,6 +103,7 @@ impl Provenance {
             "passage" => Provenance::Passage,
             "merged" => Provenance::Merged,
             "synthesized" => Provenance::Synthesized,
+            "note" => Provenance::Note,
             _ => Provenance::Captured,
         }
     }
@@ -876,13 +883,19 @@ impl Store {
     /// the new segmentation beside the old one instead of replacing it. They
     /// are swept by whichever window writes first, and there are none left by
     /// the second.
+    ///
+    /// Except a `note`, which is window-less because it belongs to no window
+    /// and not because it is left over from an older split. Sweeping it made
+    /// the first window see the corpus as already written and skip every
+    /// passage, so a captured file with an annotation was never chunked at
+    /// all.
     pub async fn artifact_ids_for_segment(
         &self,
         corpus_id: &str,
         segment_idx: i64,
     ) -> Result<Vec<String>> {
         let rows = sqlx::query(
-            "SELECT id FROM artifacts WHERE corpus_id = ?
+            "SELECT id FROM artifacts WHERE corpus_id = ? AND provenance != 'note'
                AND (segment_idx = ? OR segment_idx IS NULL)
              ORDER BY ordinal",
         )

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -137,7 +137,8 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_provenance ON artifacts(provenance);
 
 -- ── Lineage ──────────────────────────────────────────────────────────────────
 -- What a merged artifact is made of, as resolved captured roots rather than as
--- parent edges. `root_id` always names a `provenance = 'captured'` artifact, so
+-- parent edges. `root_id` always names source text — `captured` or `note`, the
+-- test in `roots_of` being `!is_model_written()` rather than one literal — so
 -- a re-merge reads the leaves in one query and is never written from text a
 -- model produced — which is what keeps information loss one generation deep
 -- however many times a group is merged. That sentence is about *merging*: a

--- a/src/store/segments.rs
+++ b/src/store/segments.rs
@@ -112,8 +112,12 @@ impl Store {
         // the split move out from under it. A window that produced no chunks is
         // why the state is still consulted: it owns nothing and has still
         // finished.
+        // A `note` is excluded for the same reason the sweep excludes it: it
+        // owns no window, so counting it here would refuse to segment every
+        // document that arrived with an annotation.
         let owned: i64 = sqlx::query_scalar(
-            "SELECT count(*) FROM artifacts WHERE corpus_id = ? AND segment_idx IS NOT NULL",
+            "SELECT count(*) FROM artifacts
+              WHERE corpus_id = ? AND provenance != 'note' AND segment_idx IS NOT NULL",
         )
         .bind(corpus_id)
         .fetch_one(&mut *tx)

--- a/src/web/lineage_view.rs
+++ b/src/web/lineage_view.rs
@@ -300,6 +300,7 @@ impl Walk<'_> {
                 crate::store::artifacts::Provenance::Synthesized => "synthesized",
                 crate::store::artifacts::Provenance::Passage => "passage",
                 crate::store::artifacts::Provenance::Captured => "captured",
+                crate::store::artifacts::Provenance::Note => "note",
             },
             when: crate::web::ui::fmt_time(c.created_at),
             created_at: c.created_at,

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -4,13 +4,28 @@
 {% block content %}
 <div class="region-bar">
 {# One form around the box and the chips, so a chip carries the query with it
-   and the query carries the chips. `change` fires for the chips, `keyup` only
+   and the query carries the chips. `change` fires for the chips, `input` only
    for the box: a radio does not need a debounce and the box does. `change` is
    scoped to the chip row because it bubbles, and the box fires its own on blur
    — which is fired by the very click that opens a result, so an unscoped
    `change` replaced the list out from under the pointer and the first click on
    a result did nothing at all. The selector has to be one word: htmx reads
    `from:` up to the first space. `submit` is listed so htmx cancels it.
+
+   `input` rather than `keyup`, and that is the difference between a box that
+   searches and one that only sometimes does. A paste made with the mouse — the
+   context menu, the middle button, the phone's own bubble — fires no key at
+   all, and with `change` scoped away to the chips for the reason above there
+   was nothing left to notice it: the box grew, the verbs lit up, and the rail
+   under a pasted paragraph did not move. On a page whose placeholder ends
+   "paste anything worth keeping", that was the hole. `input` also covers text
+   dropped into the box and an autofill, and like `keyup changed` it stays
+   quiet for a key that changed no text.
+
+   `[!event.isComposing]` because `input` fires for every keystroke inside an
+   IME composition too, and a Japanese or Chinese query would embed each
+   half-formed romaji fragment on the way to the word. The filter waits for the
+   commit, which fires an `input` of its own with the flag already cleared.
 
    120ms rather than 250. A quarter second is a pause you can feel between a
    phrase and its answer, and the query path is the same work either way: one
@@ -31,7 +46,7 @@
 <form id="box-form" hx-get="/ui/search/results" hx-target="#results" hx-swap="innerHTML"
       hx-sync="this:replace"
       hx-trigger="change from:#kind-chips,
-                  keyup changed delay:120ms from:textarea[name=q],
+                  input[!event.isComposing] changed delay:120ms from:textarea[name=q],
                   submit{% if !q.is_empty() && open_with.is_empty() %},
                   load{% endif %}"
       hx-params="q,category"
@@ -48,9 +63,24 @@
      The placeholder names all three verbs because the box does all three. A
      query is embedded whole, so a sentence carries more signal than the two
      nouns from it a reader would otherwise type — and the hint below survives
-     the first keystroke, which the placeholder does not. #}
+     the first keystroke, which the placeholder does not.
+
+     `aria-label` as well, because a placeholder is not a name: a screen reader
+     is free to ignore it as one, and it is gone by the second keystroke. The
+     one control this whole page is built around announced itself as an
+     unlabelled text field. Not a visible `<label>`, which the chips above earn
+     because "All" says nothing on its own — here the placeholder is the label,
+     in the place a label would have gone, and a word over the box would only
+     name it twice.
+
+     `data-placeholder-narrow` is the same sentence for a box one row tall on a
+     phone, where the long one is clipped around its thirtieth character — and
+     where the hint below is `display: none`, so that clipped placeholder is the
+     only thing left saying what the box is for. app.js swaps them. #}
   <textarea class="box" name="q" rows="1"
+            aria-label="Search, ask, or capture"
             placeholder="Describe the situation, ask a question, or paste anything worth keeping…"
+            data-placeholder-narrow="Ask, search, or paste to keep…"
             aria-describedby="box-hint">{{ q }}</textarea>
 {# The file, when there is one. It used to be an always-open drop zone and a
      staged box under it — two places for one idea, on a page that grew a row as
@@ -70,22 +100,26 @@
      needed.
 
      The thumbnail is for the camera above all: on a phone the only thing that
-     says which photo this is, is the photo. #}
+     says which photo this is, is the photo.
+
+     The note used to be a second text field, in here. Two boxes on screen and
+     no rule saying which one the words in front of you belonged to: a press
+     with both filled ran two captures, the typing as its own artifact and the
+     file annotated with the other field. A staged file now makes the box above
+     that file's note — one place to type, and the box is read when Capture is
+     pressed, so it does not matter whether the file or the words arrived
+     first. #}
   <div id="staged" class="staged" hidden>
     <img id="staged-thumb" alt="" hidden>
     <span id="staged-name" class="mono" hidden></span>
-    {# Context for the file: a sentence about what it is. Sent with it, then
-       cleared. For an image the vision model reads it too. Inside the staged box
-       because it is about the staged file and nothing else — on its own row it
-       was a permanent empty field on a page that mostly never sees a file. #}
-    <input class="input" type="text" name="note" maxlength="2000"
-           placeholder="Note for the file (optional) — what is it, why keep it?">
     <button class="btn btn-ghost btn-sm" type="button" id="staged-clear">Remove</button>
   </div>
   {# The two verbs that need a button. Typing is the third and needs none: it
      is the trigger on the form above. Both are disabled while the box is
      empty, because neither has anything to act on — except Capture, which a
-     staged file re-arms on its own: the file is something to act on. #}
+     staged file re-arms on its own: the file is something to act on, and Ask,
+     which a staged file disarms: the box is that file's note by then, and a
+     note is not a question to spend a model call on. #}
   <div class="verbs">
     {% if ask_enabled %}
     <button class="btn btn-accent" type="button" data-verb="ask" disabled>Ask</button>
@@ -190,7 +224,9 @@
    a hint that cannot be dismissed is a banner. Hidden until app.js decides
    there is a keyboard to use it with. #}
 <p class="keyhint" hidden>
-  <kbd>/</kbd> box <kbd>↑</kbd><kbd>↓</kbd> move <kbd>↵</kbd> open
+  <kbd>/</kbd> box{% if ask_enabled %} <kbd>Ctrl</kbd><kbd>↵</kbd> ask{% endif %}
+  <kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>↵</kbd> keep
+  <kbd>↑</kbd><kbd>↓</kbd> move <kbd>↵</kbd> open
   <kbd>s</kbd> hide source <kbd>r</kbd> reading
   <button type="button" class="btn btn-ghost btn-sm" data-dismiss-hint>Got it</button>
 </p>
@@ -205,8 +241,15 @@
      div *children* (`hx-swap-oob="innerHTML:…"` discards the wrapper), so a
      class on the wrapper never survived a swap and the heading rendered
      without the rule the row is designed around. Hidden while empty, or the
-     rule would hang alone over the rail before anything filled it. #}
-  <div id="rail-head" class="rail-act"></div>
+     rule would hang alone over the rail before anything filled it.
+
+     `aria-live` because the rail is replaced under a box that keeps its focus:
+     twelve results, or none, arriving in silence for anyone who is not looking
+     at the screen. This slot is the only part of the rail that survives every
+     swap — the fragments hand it children — so it is the only stable live
+     region here, and what it already holds is exactly the announcement wanted:
+     "12 results", or "This memory" when the box is emptied. #}
+  <div id="rail-head" class="rail-act" aria-live="polite"></div>
   {# Idle is a state the rail renders, not an absence: with an empty box the
      base introduces itself here (see `_rail_idle.html`), and the same
      fragment comes back from the results endpoint when the box is emptied.

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3974,10 +3974,6 @@ mod tests {
         let (app, cookie) = app_for(crate::core::test_support::test_core().await).await;
         let html = get(&app, "/ui", &cookie).await;
         assert!(html.contains("image/*"), "the picker accepts images");
-        assert!(
-            html.contains(r#"name="note""#),
-            "the context field is there"
-        );
 
         let (app, cookie) =
             app_for(crate::core::test_support::test_core_without_vision().await).await;
@@ -4014,6 +4010,70 @@ mod tests {
         assert!(
             trigger_of(&html).contains("load"),
             "and the results are fetched on load: {html}"
+        );
+    }
+
+    /// Typing is the third verb, and `input` is what it fires. It was `keyup`,
+    /// which a paste made with the mouse — the context menu, the middle button,
+    /// the phone's own bubble — does not fire at all; and the box's `change` is
+    /// scoped away to the chip row on purpose, because it also fires on the
+    /// blur of the very click that opens a result. So nothing was left to
+    /// notice a pasted paragraph: the box grew, the verbs lit up, and the rail
+    /// under it did not move. On a page whose placeholder ends "paste anything
+    /// worth keeping", that is the hole this test exists to keep shut.
+    ///
+    /// The filter is the other half. `input` fires for every keystroke inside
+    /// an IME composition, so without it a Japanese or Chinese query embedded
+    /// each half-formed romaji fragment on the way to the word.
+    #[tokio::test]
+    async fn a_paste_searches_because_typing_is_an_input_event() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_for(core.clone()).await;
+        let html = get(&app, "/ui/search", &cookie).await;
+        let trigger = trigger_of(&html);
+
+        assert!(
+            trigger.contains("input[!event.isComposing] changed delay:120ms from:textarea[name=q]"),
+            "the box does not search on `input`: {trigger}"
+        );
+        assert!(
+            !trigger.contains("keyup"),
+            "`keyup` is back, and a mouse paste searches for nothing: {trigger}"
+        );
+    }
+
+    /// What the box says it is, to something that is not looking at it.
+    ///
+    /// A placeholder is not a name — a screen reader may ignore it as one, and
+    /// it is gone by the second keystroke — so the one control the page is
+    /// built around announced itself as an unlabelled text field. And the rail
+    /// is replaced under a box that keeps its focus, so twelve results, or
+    /// none, arrived in silence; `#rail-head` is the only part of it that
+    /// survives every swap, and what it already holds is the announcement.
+    #[tokio::test]
+    async fn the_box_has_a_name_and_the_rail_says_what_it_found() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_for(core.clone()).await;
+        let html = get(&app, "/ui/search", &cookie).await;
+
+        assert!(
+            html.contains(r#"aria-label="Search, ask, or capture""#),
+            "the box has no accessible name: {html}"
+        );
+        // The long sentence names all three verbs and the phone has no room
+        // for it: one row at that width clips it, and the hint that would have
+        // carried the rest is `display: none` there.
+        assert!(
+            html.contains("data-placeholder-narrow="),
+            "nothing says what the box is for on a phone: {html}"
+        );
+        let head = html
+            .split(r#"id="rail-head""#)
+            .nth(1)
+            .expect("the rail's heading");
+        assert!(
+            head.split('>').next().unwrap().contains(r#"aria-live="polite""#),
+            "a search announces nothing: {head}"
         );
     }
 
@@ -4214,7 +4274,6 @@ mod tests {
         let (app, cookie) = app_for(crate::core::test_support::test_core().await).await;
         let html = get(&app, "/ui/capture", &cookie).await;
         assert!(html.contains("image/*"), "picker accepts images");
-        assert!(html.contains("name=\"note\""), "the context field is there");
 
         let (app, cookie) =
             app_for(crate::core::test_support::test_core_without_vision().await).await;
@@ -8426,35 +8485,33 @@ mod tests {
         let (app, cookie) = app_with_session().await;
         let page = get_body(&app, &cookie, "/ui/capture").await;
 
-        let note = page
-            .find(r#"name="note""#)
-            .expect("the note input is on the page");
+        // There is one field now. A staged file makes the box that file's
+        // note, which is what took the second one away: two boxes on screen
+        // and no rule saying which one the words in front of you belong to.
+        assert!(
+            !page.contains(r#"name="note""#),
+            "the note is the box, not a field of its own: {page}"
+        );
+        let box_at = page
+            .find(r#"name="q""#)
+            .expect("the one box is on the page");
+        let staged = page
+            .find(r#"id="staged""#)
+            .expect("a file waits to be sent rather than going on arrival");
         // The verb, not the nav link of the same name above it.
         let button = page
             .find(r#"data-verb="capture""#)
             .expect("the capture verb is there");
         assert!(
-            note < button,
-            "the note field must precede the button that sends it: {page}"
+            box_at < button && staged < button,
+            "the button must come after everything it sends: {page}"
         );
 
         // The box's own form is a GET that searches on every keystroke. The
-        // staged file and its note sit inside it now, so the serialisation is
-        // pinned to the two fields the search actually takes — without this,
-        // every keystroke carries a filename and a note into the query string.
+        // staged file sits inside it, so the serialisation is pinned to the two
+        // fields the search actually takes — without this, every keystroke
+        // carries a filename into the query string.
         assert!(page.contains(r#"hx-params="q,category""#), "{page}");
-
-        // The order the work happens in: the file arrives and is held, the note
-        // says what it is, the button sends both. A photo taken on a phone used
-        // to upload the instant the camera handed it back, which put the note
-        // after the send and made it unfillable.
-        let staged = page
-            .find(r#"id="staged""#)
-            .expect("a file waits to be sent rather than going on arrival");
-        assert!(
-            staged < note,
-            "what is waiting must sit above the note describing it: {page}"
-        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -4072,7 +4072,10 @@ mod tests {
             .nth(1)
             .expect("the rail's heading");
         assert!(
-            head.split('>').next().unwrap().contains(r#"aria-live="polite""#),
+            head.split('>')
+                .next()
+                .unwrap()
+                .contains(r#"aria-live="polite""#),
             "a search announces nothing: {head}"
         );
     }

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -890,26 +890,32 @@ mod tests {
         );
     }
 
-    /// One press can be two captures — a staged file and the text above it —
-    /// and both answer in `#capture-result`. They used to be started together
-    /// and write it whole, so whichever request landed last wiped the other's
-    /// line: with text over a photo the text's receipt vanished, and an upload
-    /// that failed had its reason overwritten by a success beside it.
+    /// A press was once two captures — a staged file and the text above it —
+    /// and both answered in `#capture-result`, so whichever request landed
+    /// last wiped the other's line. The text above a file is that file's note
+    /// now, so one press is one capture and writes one receipt. What is
+    /// guarded here is that it stayed one: a second sender reaching this node
+    /// is the bug the appending swap was added for.
     #[test]
-    fn a_file_and_text_in_one_press_each_keep_their_receipt() {
+    fn a_press_with_a_file_is_one_capture_carrying_the_box_as_its_note() {
         let js = crate::web::assets::Assets::get("app.js").expect("app.js is embedded");
         let js = String::from_utf8(js.data.into_owned()).unwrap();
         assert!(
-            js.contains("postText().then(function () { if (file) send(file); })"),
-            "the two acts are sequenced, not raced"
+            js.contains("send(file, note);"),
+            "the file goes with the box's text as its note"
         );
         assert!(
-            js.contains("swap: 'beforeend'"),
-            "the text capture appends its line rather than replacing the node"
+            !js.contains("if (file) send(file)"),
+            "and not beside a second capture of those same words"
+        );
+        assert!(
+            js.contains("var note = box.value.trim();"),
+            "read at press time, so the order the file and the words arrived \
+             in does not matter"
         );
         assert!(
             js.contains("function clearReceipts()"),
-            "and the node is cleared once per press instead"
+            "the node is cleared once per press"
         );
     }
 
@@ -978,15 +984,22 @@ mod tests {
         assert!(!js.contains("cmdk"), "and so did everything it looked up");
     }
 
-    /// One act in flight. Pressing Ask disables the box, and disabling the box
-    /// is what disables search-while-type: a disabled input fires no `keyup`,
-    /// so the form's `hx-trigger` goes quiet with no second mechanism and no
-    /// flag to keep in sync.
+    /// One act in flight. Pressing Ask makes the box read-only, and that is
+    /// what disables search-while-type: nothing can be typed or pasted into a
+    /// read-only box, so it fires no `input` and the form's `hx-trigger` goes
+    /// quiet with no second mechanism and no flag to keep in sync.
+    ///
+    /// Read-only and not `disabled`, which is what it was. `disabled` also
+    /// makes text unselectable and hands focus back to the body, so the
+    /// question being answered could not be copied out of the box holding it —
+    /// while `.box[readonly]` in the CSS goes to the trouble of keeping that
+    /// text legible, on the grounds that a box someone is waiting on is still
+    /// a box someone is reading.
     ///
     /// The re-enable belongs in `stop()` and nowhere else. Every exit already
     /// runs through it — the answer completing, the Stop button, and the
     /// transport error that `fail()` funnels into it. Put it on the `done`
-    /// handler instead and a dropped connection leaves the box disabled
+    /// handler instead and a dropped connection leaves the box read-only
     /// forever, with no way back but a reload.
     #[test]
     fn the_ask_disables_the_surface_and_only_stop_gives_it_back() {
@@ -1009,8 +1022,13 @@ mod tests {
             .1;
         let busy = &busy[..busy.find("\n    }").expect("setBusy() does not end")];
         assert!(
-            busy.contains("box.disabled"),
-            "setBusy does not disable the box, so typing still searches: {busy}"
+            busy.contains("box.readOnly"),
+            "setBusy does not silence the box, so typing still searches: {busy}"
+        );
+        assert!(
+            !busy.contains("box.disabled"),
+            "the box is disabled again, and the question cannot be selected \
+             out of it while it is being answered: {busy}"
         );
 
         // The other half: nothing else may re-enable it. A second caller is a
@@ -1019,6 +1037,78 @@ mod tests {
             js.matches("setBusy(false)").count(),
             1,
             "setBusy(false) is called from more than one place"
+        );
+    }
+
+    /// Both verbs, without a pointer. `/` reaches the box and nothing reached
+    /// back out of it: a hand that never left the keys had to find the mouse
+    /// to press the button it had just finished typing into.
+    ///
+    /// This is not the box inferring a verb from a newline, which is the rule
+    /// it is built on — Enter puts in a line break here and always will. The
+    /// chord is a second deliberate gesture, the same act as the button.
+    ///
+    /// Routed through the button and not the handler behind it, so everything
+    /// the button already knows stays true: an empty box or an ask in flight
+    /// leaves it disabled, and a disabled verb does nothing here either. Where
+    /// the install has no Ask there is no button, and the unshifted chord is
+    /// simply not a key.
+    #[test]
+    fn the_two_verbs_are_reachable_from_the_keys() {
+        let js = crate::web::assets::Assets::get("app.js").expect("app.js is embedded");
+        let js = String::from_utf8(js.data.into_owned()).unwrap();
+
+        let chord = js
+            .split_once("if (e.key !== 'Enter'")
+            .expect("nothing commits the box from the keyboard")
+            .1;
+        let chord = &chord[..chord.find("\n    });").expect("the handler does not end")];
+        assert!(
+            chord.contains("e.shiftKey ? 'capture' : 'ask'"),
+            "the chord does not pick a verb: {chord}"
+        );
+        assert!(
+            chord.contains("verb.disabled") && chord.contains("verb.click()"),
+            "the chord goes around the button instead of pressing it: {chord}"
+        );
+    }
+
+    /// The box is `border-box` and `scrollHeight` is not: it measures the
+    /// content and the padding, never the 1px border on each edge. Set the
+    /// height straight from it and the box ends two pixels shorter than the
+    /// text it was measured from, every time — which with `overflow-y: auto`
+    /// is a live scrollbar on a box that has nothing to scroll. The cap is the
+    /// same mistake: ten lines of text *plus* the padding they sit in, or the
+    /// tenth line is the one the padding eats.
+    ///
+    /// And the height is a measurement of wrapped text, so it is wrong the
+    /// moment the box changes width. Bound to `input` alone it was only ever
+    /// correct at the width the last keystroke was typed at.
+    #[test]
+    fn the_box_measures_its_own_padding_and_remeasures_on_a_resize() {
+        let js = crate::web::assets::Assets::get("app.js").expect("app.js is embedded");
+        let js = String::from_utf8(js.data.into_owned()).unwrap();
+
+        let grow = js
+            .split_once("function grow() {")
+            .expect("the box does not size itself")
+            .1;
+        let grow = &grow[..grow.find("\n    }").expect("grow() does not end")];
+        assert!(
+            grow.contains("box.offsetHeight - box.clientHeight"),
+            "grow() does not add the border back: {grow}"
+        );
+        assert!(
+            grow.contains("+ pad + border"),
+            "grow() sets a height that is not the box's own outside: {grow}"
+        );
+        assert!(
+            js.contains("window.addEventListener('resize', grow)"),
+            "a re-wrap at a new width leaves the height where the last keystroke put it"
+        );
+        assert!(
+            js.contains("document.fonts.ready.then(grow)"),
+            "the first measurement is of the fallback face, and nothing recomputes it"
         );
     }
 

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -939,11 +939,13 @@ mod tests {
             .split_once(":not(.has-selection):not(.answering)")
             .expect("the idle 40rem rail is not held while an answer is being written")
             .0;
-        // Bounded to the widths that have two columns. Three `:not()`s outrank
-        // the single class the one-up block sets its track list with, and
-        // specificity does not care that the two rules answer different widths
-        // — unbounded, this two-column rule won on a narrow screen too, and
-        // left the pane beside a 40rem rail twelve pixels wide.
+        // Bounded to the widths that have two columns. The two chained
+        // `:not()`s outrank the single class the one-up block sets its track
+        // list with — chained rather than `:not(.has-selection, .answering)`,
+        // which would count one class and not two — and specificity does not
+        // care that the two rules answer different widths: unbounded, this
+        // two-column rule won on a narrow screen too, and left the pane beside
+        // a 40rem rail twelve pixels wide.
         assert!(
             idle.rsplit_once("@container")
                 .is_some_and(|(_, open)| open.trim_start().starts_with("shell (width > 60rem)")),


### PR DESCRIPTION
Two things landed on this branch: the note a person types about a file becomes
something they can find, and the box they type it into got the pass it was
overdue.

## The note

A note used to live in metadata, and embedding runs over artifact chunks — so
it was invisible to search on a PDF or a text upload entirely, and on a photo
only as whatever the vision model echoed back. It is an artifact now, on the
file's own corpus, span-less because it is about the file and is no line of it.

It needed a provenance of its own. A window-less row already meant "debris from
an older segmentation" in two places, and one of them made a captured file with
an annotation skip every passage. `Provenance::Note` says what the row is in the
field that means what a row is. `settle_corpus` needed a guard for the same
reason: it read "nothing left to embed" as "finished", which is only true for a
source whose windows have been written.

`MAX_NOTE_CHARS` moved off the way into storage — where it truncated silently,
with no receipt — and onto the vision prompt, which is the one place the length
still costs anything.

Text plus a file used to run two captures from one press, with two boxes and no
rule saying which words belonged to which. A staged file now makes the one box
that file's annotation: one press, one capture, read at press time, so
type-then-attach and attach-then-type reach the same place. The box goes quiet
while a file waits — an annotation typed into a live search box is an embedding
call, an activation bump and a Judge row per phrase, for text nobody asked as a
question.

## The box

Eight findings from an audit of the one control the workspace is built around.
Each is verified in a real browser against a fake engram, not only asserted in
source.

- **A paste made with the mouse never searched.** The trigger was `keyup`, which
  the context menu, the middle button and the phone's own bubble do not fire —
  and the box's `change` is scoped away to the chip row on purpose, because it
  also fires on the blur of the very click that opens a result. So nothing was
  left to notice a pasted paragraph: the box grew, the verbs lit up, and the
  rail did not move. It is `input` now, filtered on `[!event.isComposing]` so an
  IME composition no longer embeds each half-formed romaji fragment on the way
  to the word.
- **The busy box could not be read.** `disabled` is the one state that also
  makes text unselectable and hands focus back to the body, so the question
  being answered could not be copied out of the box holding it — while the CSS
  went to the trouble of keeping that text legible. It is `readonly` now: same
  silence, and the caret, the selection and the focus all survive.
- **The box had no accessible name**, and the rail announced nothing. An
  `aria-label`, and `aria-live` on `#rail-head` — the only part of the rail that
  survives every swap, and already holding "12 results".
- **Neither verb was reachable from the keys.** `/` reached the box and nothing
  reached back out of it. `Ctrl+↵` asks and `Ctrl+⇧+↵` keeps, routed through the
  buttons so a disabled verb stays disabled. Plain Enter still puts in a line
  break: the chord is a second deliberate gesture, not a verb inferred from a
  newline.
- **`grow()` was two pixels short.** The box is `border-box` and `scrollHeight`
  is not, so the height was always two pixels under the text it was measured
  from — a live scrollbar on a box with nothing to scroll. The cap had the same
  bug in reverse: ten lines of text *plus* the padding they sit in.
- **`grow()` never re-ran on a resize**, so the height was only ever correct at
  the width the last keystroke was typed at. Bound to `resize` and to
  `document.fonts.ready`, since Inter swaps in under a height nothing recomputed.
- **The placeholder was clipped on a phone** at about its thirtieth character,
  at the one width where the hint below it is `display: none` — so nothing said
  what the box was for. A shorter sentence swaps in under the breakpoint.

Also on the way past: a static pass over the stylesheets found two rules that
never applied, one declared twice, a collapse boundary two rem off what the
layout documents, and eight tokens nothing read.

## Verification

`cargo test` — 1656 pass, 0 fail. The box's four browser-only behaviours were
driven in headless Chrome: a paste fires the search and a composition does not;
`readonly` keeps focus and selection while no search leaks; one line measures
with zero scroll residue and the cap lands exactly on ten lines plus padding and
border; a reflow at a new width re-measures with no keystroke.
