### PR TITLE
Judgements that buy their own tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
+ "toml_edit",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -5788,6 +5789,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5795,6 +5809,12 @@ checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,11 @@ encoding_rs = "0.8.35"
 docling = { version = "=1.14.0", default-features = false, features = ["pdf-text"] }
 
 url = "2"
+# Rewriting config.toml in place when a tuning recommendation is applied.
+# `config` reads the file and cannot write it; a serialize-and-overwrite would
+# return the operator's commented file as a machine's, so the edit is made to
+# the parsed document and every byte around it is kept.
+toml_edit = "0.25.13"
 schemars = "1.2.2"
 # Decoding, orientation and the downscaled preview of a captured image. Only
 # the three formats a phone or a browser actually hands over.

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -75,6 +75,43 @@
    verdict. It is the measurement, not a score standing in for one. */
 .progress { height: 4px; background: var(--color-bg-active); border-radius: 2px; overflow: hidden; }
 .progress span { display: block; height: 100%; background: var(--color-accent); }
+
+/* The moment after a verdict.
+ *
+ * Only the figures already on the page respond: the MRR lights once, the delta
+ * rises beside it and goes, the bar brightens as it grows. Nothing here reacts
+ * to *which* verdict was given — what is being acknowledged is that the work
+ * moved, never that the ranker was agreed with. The flash line above the card
+ * says what was learned, and it is loudest where the ranking did worst.
+ *
+ * Every rule is one-shot and cheap, and all of it is skipped for anyone who
+ * asked not to be moved. */
+.judge-live { max-width: 52rem; }
+@keyframes judge-tick {
+  0%   { background: transparent; }
+  20%  { background: color-mix(in srgb, var(--color-accent) 28%, transparent); }
+  100% { background: transparent; }
+}
+.judge-tick {
+  animation: judge-tick 0.9s ease-out 1;
+  border-radius: var(--radius-sm);
+  padding: 0 0.2rem; margin: 0 -0.2rem;
+}
+@keyframes judge-delta {
+  0%   { opacity: 0; transform: translateY(0.35rem); }
+  18%  { opacity: 1; transform: none; }
+  70%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+/* `forwards`, so it ends invisible rather than snapping back for the moment
+   before the next swap replaces it. */
+.judge-delta { color: var(--color-accent); animation: judge-delta 2.4s ease-out 1 forwards; }
+@keyframes judge-grow { from { filter: brightness(1.7); } to { filter: none; } }
+.judge-grow { animation: judge-grow 0.7s ease-out 1; }
+@media (prefers-reduced-motion: reduce) {
+  .judge-tick, .judge-delta, .judge-grow { animation: none; }
+  .judge-delta { opacity: 1; }
+}
 .misses { max-width: 52rem; margin-bottom: 1.25rem; }
 .misses ul { margin: 0.5rem 0 0; padding-left: 1.25rem; font-size: var(--text-sm); }
 /* A query is whatever someone typed, in a monospace list with no spaces to

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -112,7 +112,24 @@
   .judge-tick, .judge-delta, .judge-grow { animation: none; }
   .judge-delta { opacity: 1; }
 }
-.misses { max-width: 52rem; margin-bottom: 1.25rem; }
+/* What the sweeps have to say. Accent-bordered because the recommendation is
+   the only thing on this page that can be acted on; absent entirely — not
+   greyed, not empty — until a sweep has actually run. */
+.judge-tune { max-width: 52rem; margin-bottom: 1rem; }
+.judge-tune-rec {
+  border: 1px solid var(--color-accent); border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+}
+.judge-tune-rec > .row { margin-bottom: 0; flex-wrap: wrap; row-gap: 0.375rem; }
+.judge-tune-rec details, .judge-tune-history { margin-top: 0.375rem; }
+.judge-tune summary { cursor: pointer; }
+.judge-tune ul { margin: 0.5rem 0 0; padding-left: 1.25rem; font-size: var(--text-sm); }
+/* A query is whatever someone typed: it wraps rather than setting the width of
+   the page, the same as the miss list below. */
+.judge-tune li { overflow-wrap: anywhere; }
+.judge-tune-history { font-size: var(--text-sm); }
+
+.misses { max-width: 52rem; margin-top: 1.25rem; }
 .misses ul { margin: 0.5rem 0 0; padding-left: 1.25rem; font-size: var(--text-sm); }
 /* A query is whatever someone typed, in a monospace list with no spaces to
    break at. It wraps rather than setting the width of the page. */

--- a/config.example.toml
+++ b/config.example.toml
@@ -39,6 +39,11 @@ recency_half_life_days = 180
 # Extra score for an artifact tagged `pinned`, so a decision you made beats the
 # decay curve.
 pinned_boost = 0.15
+# Chunks one document may contribute to a result list, so a long document
+# cannot fill it. 0 lets one document supply every result. This and
+# recency_weight above are the two knobs the tuning sweep measures, and
+# applying its recommendation rewrites them here — see [feedback.tune].
+per_source_cap = 3
 
 # ── Inference roles ─────────────────────────────────────────────────────────
 # Three independent roles. They may all point at one server, or at three
@@ -422,6 +427,17 @@ retain_days = 0
 # How often retention is enforced. A window measured in days does not need
 # checking more often than this, and the sweep is a single DELETE.
 sweep_hours = 6
+
+# What judged searches are spent on: a background sweep of recency_weight and
+# per_source_cap over every judged pair, which recommends a better setting when
+# it finds one worth the name. See docs/evaluation.md.
+[feedback.tune]
+# Judgements before the first sweep. A floor, not a target: with ten pairs
+# recall@10 moves in ten-point steps, and a sweep under that recommends the
+# quirks of ten queries as confidently as a real improvement.
+min_judgements = 50
+# Further verdicts before the sweep is run again.
+resweep_after = 10
 
 # Links learned from co-retrieval, and a decaying accessibility per artifact.
 # Both are learned from use and neither touches what is stored: the trace is

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -175,6 +175,17 @@ per-source cap over every judged pair, against the live index. It needs no
 export, no frozen corpus and no re-embedding: both knobs only reorder what
 retrieval already returned, so a whole grid is seconds of vector reads. Like
 the assign search, it reads and never records — `Door::Judge`, `mark: false`.
+It asks the whole grid about one query before moving to the next, so each query
+is embedded once however many pairs there are, and it takes the background lane
+rather than the interactive one: nobody is waiting on a replay of questions
+that were already answered, and thousands of searches on the fast lane would
+hold every worker off for the length of the run.
+
+Its two figures are a **replay**, not the header's. The counter at the top of
+`/ui/judge` is recall@10 and MRR over the positions the searches actually gave;
+a sweep's are those searches run again, now, under each setting, through a door
+that leaves priming out. Both are honest and neither substitutes for the other
+— read `MRR 0.50 → 0.60` against itself, never against the number above it.
 
 A candidate is offered only when **at least two pairs are net better and
 neither aggregate is worse**. That floor is the whole safety of running it
@@ -183,11 +194,14 @@ and an aggregate delta alone cannot tell one from a real improvement. Ties keep
 the current values.
 
 The recommendation appears on `/ui/judge` with the pairs that moved, and
-applying it rewrites `config.toml` in place — comments intact — and swaps the
-running parameters in one step. Every sweep is recorded in `eval_runs` with the
-settings that produced it, recommended or not, which is section 4's rule about
-never writing a number without its configuration, made structural rather than
-asked for.
+applying it rewrites `config.toml` — beside the file and renamed over it, so a
+crash mid-write leaves the operator's file as it was — and swaps the running
+parameters in one step. Only the newest sweep's recommendation stands: a later
+sweep looked at the same pairs over more evidence, so whatever it says, it says
+last, including when what it says is nothing. Every sweep is recorded in
+`eval_runs` with the settings that produced it, recommended or not, which is
+section 4's rule about never writing a number without its configuration, made
+structural rather than asked for.
 
 What this does **not** replace: the harness below stays the instrument for
 everything a runtime sweep cannot reach — the embedding model and its

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -135,10 +135,10 @@ anything.** Keep the whole line when you write a result down.
 
 | Knob | Variable | What it moves | Watch |
 |---|---|---|---|
-| Recency weight | `ENGRAM__VECTOR__RECENCY_WEIGHT` | How much age counts against a hit. `0.0` turns it off. Fused ranks sit between ~0.1 and 1.0, so the default breaks near-ties without overturning a clear match. | MRR |
+| Recency weight *(swept at runtime — see 4½)* | `ENGRAM__VECTOR__RECENCY_WEIGHT` | How much age counts against a hit. `0.0` turns it off. Fused ranks sit between ~0.1 and 1.0, so the default breaks near-ties without overturning a clear match. | MRR |
 | Recency half-life | `ENGRAM__VECTOR__RECENCY_HALF_LIFE_DAYS` | Age at which a hit has lost half that boost. | MRR |
 | Pinned boost | `ENGRAM__VECTOR__PINNED_BOOST` | Extra score for a `pinned` tag, so a decision you made beats the decay curve. | MRR |
-| Per-source cap | `ENGRAM_EVAL_CAP` (a number, or `none`) | Chunks one document may contribute. Default 3; `none` lets one document fill the list. Raising it usually lifts recall and costs diversity. | recall@10 |
+| Per-source cap *(swept at runtime — see 4½)* | `ENGRAM_EVAL_CAP` here, `[vector] per_source_cap` in the server | Chunks one document may contribute. Default 3; `none` (`0` in the file) lets one document fill the list. Raising it usually lifts recall and costs diversity. | recall@10 |
 | Reranker | `[infer.rerank]` present or absent in `config.toml` | A cross-encoder over the candidate pool. The settings line reports `rerank on/off`. | MRR first, recall second |
 | Embedding model | `ENGRAM__INFER__EMBED__MODEL` (+ `DIM`) | The whole retrieval geometry. Needs `--reindex` against a real base; the harness reindexes its own collection anyway. | both |
 | Embed templates | `ENGRAM__INFER__EMBED__QUERY_TEMPLATE`, `..._DOCUMENT_TEMPLATE` | The envelope each side is embedded in. Asymmetric models care a great deal. | both |
@@ -163,6 +163,37 @@ excerpts, and `dropped` on the answer says how many).
 5. Write the numbers into the commit message that moves the default. That is
    what the rule at the top asks for, and a commit that changes ranking without
    them is the thing this whole apparatus exists to prevent.
+
+---
+
+## 4½. Tuning at runtime
+
+The two cheap knobs tune themselves. Once fifty judgements exist
+(`feedback.tune.min_judgements`), every tenth further verdict
+(`feedback.tune.resweep_after`) re-runs a background sweep of recency weight ×
+per-source cap over every judged pair, against the live index. It needs no
+export, no frozen corpus and no re-embedding: both knobs only reorder what
+retrieval already returned, so a whole grid is seconds of vector reads. Like
+the assign search, it reads and never records — `Door::Judge`, `mark: false`.
+
+A candidate is offered only when **at least two pairs are net better and
+neither aggregate is worse**. That floor is the whole safety of running it
+automatically: on fifty pairs a single flipped pair is two points of recall,
+and an aggregate delta alone cannot tell one from a real improvement. Ties keep
+the current values.
+
+The recommendation appears on `/ui/judge` with the pairs that moved, and
+applying it rewrites `config.toml` in place — comments intact — and swaps the
+running parameters in one step. Every sweep is recorded in `eval_runs` with the
+settings that produced it, recommended or not, which is section 4's rule about
+never writing a number without its configuration, made structural rather than
+asked for.
+
+What this does **not** replace: the harness below stays the instrument for
+everything a runtime sweep cannot reach — the embedding model and its
+templates (they change the vector geometry, not the order over it), priming,
+pinning, the ask side, and any number that has to be comparable across months
+rather than against today's other candidates.
 
 ---
 
@@ -199,4 +230,6 @@ to run *something* and call the question answered.
 | `src/eval/metrics.rs` | `recall_at`, `mrr`, and the ask metrics. |
 | `src/eval/export.rs` | `--export-eval`. |
 | `src/eval/claims.rs` | Literal extraction and claim support. |
-| `/ui/judge` | Where pairs come from. Its counter is not a stand-in for the measurement — it *is* recall@10 and MRR over the positions those searches actually gave. |
+| `src/eval/sweep.rs` | The runtime sweep: the grid, the gate, and the job a verdict starts. See 4½. |
+| `src/store/eval_runs.rs` | Every sweep, with the settings that produced it and whether it was applied. |
+| `/ui/judge` | Where pairs come from, and where a sweep reports. Its counter is not a stand-in for the measurement — it *is* recall@10 and MRR over the positions those searches actually gave. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,6 +154,7 @@ pub struct FeedbackConfig {
     /// `retain_days` is the only thing it enforces: a window measured in days
     /// does not need checking more than a few times a day.
     pub sweep_hours: u64,
+    pub tune: TuneConfig,
 }
 
 impl Default for FeedbackConfig {
@@ -163,6 +164,30 @@ impl Default for FeedbackConfig {
             coalesce_secs: 15,
             retain_days: 0,
             sweep_hours: 6,
+            tune: TuneConfig::default(),
+        }
+    }
+}
+
+/// When judgements are spent on a parameter sweep, and how often.
+///
+/// The floor is statistical rather than cautious: with ten pairs recall@10
+/// moves in ten-point steps, so a sweep under it recommends the quirks of ten
+/// queries with the same confidence as a real improvement. Below
+/// `min_judgements` nothing runs; after that a sweep re-runs once
+/// `resweep_after` further verdicts have been given.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct TuneConfig {
+    pub min_judgements: i64,
+    pub resweep_after: i64,
+}
+
+impl Default for TuneConfig {
+    fn default() -> Self {
+        Self {
+            min_judgements: 50,
+            resweep_after: 10,
         }
     }
 }
@@ -625,9 +650,20 @@ pub struct VectorConfig {
     /// labelling off.
     #[serde(default = "default_weak_below")]
     pub weak_below: f32,
+    /// Chunks one document may contribute to a result list. `0` lets a single
+    /// document fill it.
+    ///
+    /// A setting rather than the constant it was, because the tuning sweep
+    /// measures it and applying a recommendation writes it back here — the
+    /// file stays the one place the running configuration can be read.
+    #[serde(default = "default_per_source_cap")]
+    pub per_source_cap: usize,
 }
 fn default_recency_weight() -> f32 {
     0.05
+}
+fn default_per_source_cap() -> usize {
+    crate::core::search::MAX_PER_CORPUS
 }
 fn default_recency_half_life_days() -> u32 {
     180
@@ -2139,6 +2175,29 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = write(&dir, &format!("{MINIMAL}\n[feedback]\ncandidates = 5\n"));
         assert_eq!(Config::load(Some(&p)).unwrap().feedback.candidates, 5);
+    }
+
+    #[test]
+    fn tune_defaults_and_file_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, MINIMAL);
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert_eq!(cfg.feedback.tune.min_judgements, 50);
+        assert_eq!(cfg.feedback.tune.resweep_after, 10);
+        assert_eq!(cfg.vector.per_source_cap, 3);
+
+        let tuned = MINIMAL.replace(
+            "collection = \"chunks\"",
+            "collection = \"chunks\"\nper_source_cap = 0",
+        );
+        let p = write(
+            &dir,
+            &format!("{tuned}\n[feedback.tune]\nmin_judgements = 20\nresweep_after = 5\n"),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert_eq!(cfg.feedback.tune.min_judgements, 20);
+        assert_eq!(cfg.feedback.tune.resweep_after, 5);
+        assert_eq!(cfg.vector.per_source_cap, 0);
     }
 
     fn write(dir: &tempfile::TempDir, body: &str) -> std::path::PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1584,6 +1584,29 @@ pub enum ConfigError {
     Invalid(String),
 }
 
+/// Write the two runtime-tunable keys back into the file they came from.
+///
+/// An edit to the parsed document rather than a re-serialisation of the whole
+/// configuration: every comment, every blank line and every key this does not
+/// name comes back byte for byte. A file is where an operator explains their
+/// own choices to themselves, and handing it back as a machine's would cost
+/// more than the setting is worth.
+///
+/// A missing file is refused rather than created. The apply path promises that
+/// memory and disk agree, and a configuration invented by the server is one
+/// nobody wrote.
+pub fn write_ranking(path: &Path, p: &crate::core::ranking::RankingParams) -> std::io::Result<()> {
+    let text = std::fs::read_to_string(path)?;
+    let mut doc: toml_edit::DocumentMut = text.parse().map_err(std::io::Error::other)?;
+    // Three decimals is the whole resolution the grid has. Widened to f64
+    // verbatim, 0.05 writes as 0.05000000074505806 — the file claiming a
+    // precision the sweep never measured.
+    let weight = (f64::from(p.recency_weight) * 1000.0).round() / 1000.0;
+    doc["vector"]["recency_weight"] = toml_edit::value(weight);
+    doc["vector"]["per_source_cap"] = toml_edit::value(p.per_source_cap.map_or(0, |n| n as i64));
+    std::fs::write(path, doc.to_string())
+}
+
 impl Config {
     pub fn load(path: Option<&Path>) -> Result<Config, ConfigError> {
         let mut builder = config::Config::builder();
@@ -2175,6 +2198,64 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = write(&dir, &format!("{MINIMAL}\n[feedback]\ncandidates = 5\n"));
         assert_eq!(Config::load(Some(&p)).unwrap().feedback.candidates, 5);
+    }
+
+    #[test]
+    fn applying_a_recommendation_edits_the_file_and_leaves_the_rest_of_it_alone() {
+        // The file is the operator's, not the server's: a rewrite that dropped
+        // their comments would be a worse answer than refusing to write at all.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            &dir,
+            "# the note I left myself\n\
+             [vector]\n\
+             url = \"http://localhost:6333\"   # and this one\n\
+             recency_weight = 0.05\n\
+             pinned_boost = 0.15\n",
+        );
+        let params = crate::core::ranking::RankingParams {
+            recency_weight: 0.1,
+            per_source_cap: None,
+        };
+        write_ranking(&p, &params).unwrap();
+
+        let out = std::fs::read_to_string(&p).unwrap();
+        assert!(out.contains("# the note I left myself"), "{out}");
+        assert!(out.contains("# and this one"), "{out}");
+        assert!(out.contains("pinned_boost = 0.15"), "{out}");
+        assert!(out.contains("recency_weight = 0.1"), "{out}");
+        assert!(out.contains("per_source_cap = 0"), "no cap is written as 0");
+    }
+
+    #[test]
+    fn a_config_that_is_not_there_is_refused_rather_than_invented() {
+        // A server that writes a configuration nobody wrote is a server with
+        // two authors, and the apply path promises the file and memory agree.
+        let dir = tempfile::tempdir().unwrap();
+        let params = crate::core::ranking::RankingParams {
+            recency_weight: 0.1,
+            per_source_cap: Some(2),
+        };
+        assert!(write_ranking(&dir.path().join("absent.toml"), &params).is_err());
+    }
+
+    #[test]
+    fn a_swept_weight_is_written_at_the_grids_resolution() {
+        // f32 to f64 verbatim writes 0.05000000074505806, which is the file
+        // saying a precision the sweep never had.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, "[vector]\nrecency_weight = 0.15\n");
+        write_ranking(
+            &p,
+            &crate::core::ranking::RankingParams {
+                recency_weight: 0.05,
+                per_source_cap: Some(3),
+            },
+        )
+        .unwrap();
+        let out = std::fs::read_to_string(&p).unwrap();
+        assert!(out.contains("recency_weight = 0.05"), "{out}");
+        assert!(out.contains("per_source_cap = 3"), "{out}");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1607,6 +1607,31 @@ pub fn write_ranking(path: &Path, p: &crate::core::ranking::RankingParams) -> st
     write_beside_and_rename(path, &doc.to_string())
 }
 
+/// Whichever of the two swept keys the environment is currently setting.
+///
+/// `load` layers `ENGRAM__*` *after* the file, so an operator who set one of
+/// these where the server starts gets that value back on the next boot whatever
+/// was just written — while the tuning history goes on naming settings that
+/// stopped being in force at the restart. The write is still the right thing to
+/// do and the running server does use the new values; what cannot be promised
+/// is that they survive. Saying so is the whole of what is available from here:
+/// the environment belongs to whoever starts the process, and this is a page
+/// with a button on it, not an installer.
+pub fn ranking_keys_in_env() -> Vec<String> {
+    // Read back rather than assumed, and matched without case, because the
+    // config crate lowercases before it compares and an operator's compose file
+    // is under no obligation to shout.
+    std::env::vars_os()
+        .filter_map(|(k, _)| k.into_string().ok())
+        .filter(|k| {
+            matches!(
+                k.to_ascii_uppercase().as_str(),
+                "ENGRAM__VECTOR__RECENCY_WEIGHT" | "ENGRAM__VECTOR__PER_SOURCE_CAP"
+            )
+        })
+        .collect()
+}
+
 /// Replace `path` with `body` in one step, or leave it exactly as it was.
 ///
 /// `fs::write` truncates and then writes. A crash or a full disk in between
@@ -1619,6 +1644,33 @@ pub fn write_ranking(path: &Path, p: &crate::core::ranking::RankingParams) -> st
 /// and it carries the original's permissions: a config file holding a password
 /// hash or a client secret must not come back world-readable because it was
 /// rewritten.
+/// The temporary file, born with no permissions to spare.
+///
+/// `File::create` opens at `0666 & ~umask` — 0644 on an ordinary host — and
+/// widening it first to narrow it a line later leaves a window in which anyone
+/// on the box may open it. The bytes land after that, but a descriptor is
+/// checked when it is opened and not when it is read, so the window is enough
+/// to walk away with a password hash. The mode is set by the same call that
+/// makes the file, and the copy of the original's permissions still follows:
+/// this decides what the file may never have been, that decides what it ends up
+/// as. Truncating rather than `create_new`, so a `.tmp` left behind by an
+/// earlier crash does not wedge every write after it.
+#[cfg(unix)]
+fn create_private(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .mode(0o600)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn create_private(path: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::File::create(path)
+}
+
 fn write_beside_and_rename(path: &Path, body: &str) -> std::io::Result<()> {
     use std::io::Write;
     let mut name = path.file_name().unwrap_or_default().to_os_string();
@@ -1626,7 +1678,7 @@ fn write_beside_and_rename(path: &Path, body: &str) -> std::io::Result<()> {
     let tmp = path.with_file_name(name);
 
     let written = (|| -> std::io::Result<()> {
-        let mut f = std::fs::File::create(&tmp)?;
+        let mut f = create_private(&tmp)?;
         #[cfg(unix)]
         f.set_permissions(std::fs::metadata(path)?.permissions())?;
         f.write_all(body.as_bytes())?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1604,7 +1604,42 @@ pub fn write_ranking(path: &Path, p: &crate::core::ranking::RankingParams) -> st
     let weight = (f64::from(p.recency_weight) * 1000.0).round() / 1000.0;
     doc["vector"]["recency_weight"] = toml_edit::value(weight);
     doc["vector"]["per_source_cap"] = toml_edit::value(p.per_source_cap.map_or(0, |n| n as i64));
-    std::fs::write(path, doc.to_string())
+    write_beside_and_rename(path, &doc.to_string())
+}
+
+/// Replace `path` with `body` in one step, or leave it exactly as it was.
+///
+/// `fs::write` truncates and then writes. A crash or a full disk in between
+/// leaves the operator holding a half-written configuration — and since a
+/// configuration that will not parse is refused rather than ignored, a server
+/// that will not start. The file this function exists to preserve byte for
+/// byte would be destroyed by the one failure it is most likely to meet.
+///
+/// The temporary file is a sibling so the rename stays within one filesystem,
+/// and it carries the original's permissions: a config file holding a password
+/// hash or a client secret must not come back world-readable because it was
+/// rewritten.
+fn write_beside_and_rename(path: &Path, body: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".tmp");
+    let tmp = path.with_file_name(name);
+
+    let written = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp)?;
+        #[cfg(unix)]
+        f.set_permissions(std::fs::metadata(path)?.permissions())?;
+        f.write_all(body.as_bytes())?;
+        // Before the rename, not after it: a rename that reaches the disk ahead
+        // of the bytes it points at is the same lost file by a slower route.
+        f.sync_all()
+    })();
+    if let Err(e) = written.and_then(|()| std::fs::rename(&tmp, path)) {
+        // Nothing was touched, so the only thing to undo is the temporary file.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
 }
 
 impl Config {
@@ -2225,6 +2260,42 @@ mod tests {
         assert!(out.contains("pinned_boost = 0.15"), "{out}");
         assert!(out.contains("recency_weight = 0.1"), "{out}");
         assert!(out.contains("per_source_cap = 0"), "no cap is written as 0");
+    }
+
+    #[test]
+    fn applying_leaves_no_half_written_file_and_no_widened_permissions() {
+        // `fs::write` truncates and then writes. A crash or a full disk in
+        // between left the operator with an empty configuration and a server
+        // that refuses to start on the next boot — the one file this whole
+        // `toml_edit` approach exists to preserve. Written beside and renamed
+        // over, so it is either the old file or the new one.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, "[vector]\nrecency_weight = 0.05\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let params = crate::core::ranking::RankingParams {
+            recency_weight: 0.1,
+            per_source_cap: Some(2),
+        };
+        write_ranking(&p, &params).unwrap();
+
+        let left: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(left.len(), 1, "a temporary file was left behind: {left:?}");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&p).unwrap().permissions().mode() & 0o777,
+                0o600,
+                "a file that may hold a password hash came back readable to everyone"
+            );
+        }
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod gaps;
 pub mod image;
 pub mod ingest;
 pub mod pdf;
+pub mod ranking;
 pub mod recommend;
 pub mod search;
 pub mod sitting;
@@ -185,6 +186,13 @@ pub struct Core {
     /// `image::MAX_CONCURRENT_DECODES`; shared by every clone, because a
     /// per-clone permit would bound nothing.
     pub decodes: Arc<tokio::sync::Semaphore>,
+    /// The two scoring knobs a tuning sweep may move. Shared by every clone,
+    /// like the background queue: applying a recommendation has to change the
+    /// search the next request runs, not the one this handler holds.
+    pub ranking: Arc<std::sync::RwLock<crate::core::ranking::RankingParams>>,
+    /// Whether a sweep is in flight, so a run of verdicts starts one and not
+    /// one each.
+    pub tuning: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Core {
@@ -240,6 +248,10 @@ impl Core {
             clock: crate::core::context::Clock::System,
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: cfg.consolidate.clone(),
+            ranking: Arc::new(std::sync::RwLock::new(
+                crate::core::ranking::RankingParams::from_vector(&cfg.vector),
+            )),
+            tuning: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             weak_below: cfg.vector.weak_below,
             learn: cfg.learn.clone(),
             feedback: cfg.feedback.clone(),
@@ -416,6 +428,16 @@ pub mod test_support {
             clock: crate::core::context::Clock::System,
             query_cache: Arc::new(std::sync::Mutex::new(QueryCache::new(QUERY_CACHE_CAPACITY))),
             consolidate: crate::config::ConsolidateConfig::default(),
+            // The shipped cap, so a test ranks what the binary ranks; recency
+            // off, because the fake embedder's ordering is the only thing a
+            // search test can assert against and an age boost over it is noise.
+            ranking: Arc::new(std::sync::RwLock::new(
+                crate::core::ranking::RankingParams {
+                    recency_weight: 0.0,
+                    per_source_cap: Some(crate::core::search::MAX_PER_CORPUS),
+                },
+            )),
+            tuning: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             // The fake embedder's vectors are not a semantic space, so a
             // realistic threshold would mark arbitrary results weak and every
             // search test would be asserting against noise. Tests that care

--- a/src/core/ranking.rs
+++ b/src/core/ranking.rs
@@ -1,0 +1,63 @@
+//! The scoring knobs a sweep may move while the server runs.
+//!
+//! Everything else that shapes ranking is read once at startup and threaded
+//! down. These two are different: the tuning sweep ranks the same judged pairs
+//! under a grid of them in one pass, and applying its recommendation has to
+//! change the search the *next* request runs. So they live behind
+//! `Core::ranking` rather than being copied into the places that use them.
+
+use crate::config::VectorConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RankingParams {
+    pub recency_weight: f32,
+    /// Chunks one document may contribute. `None` lets a single document fill
+    /// the whole list — which is what `ask` wants, and what the sweep offers as
+    /// one of its candidates.
+    pub per_source_cap: Option<usize>,
+}
+
+impl RankingParams {
+    pub fn from_vector(cfg: &VectorConfig) -> Self {
+        Self {
+            recency_weight: cfg.recency_weight,
+            // `0` is how a file says "no cap": a setting cannot hold `None`,
+            // and a cap of zero would otherwise mean a search that returns
+            // nothing at all.
+            per_source_cap: match cfg.per_source_cap {
+                0 => None,
+                n => Some(n),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vector_config(per_source_cap: usize) -> VectorConfig {
+        VectorConfig {
+            url: String::new(),
+            collection: String::new(),
+            api_key: None,
+            recency_weight: 0.05,
+            recency_half_life_days: 180,
+            pinned_boost: 0.15,
+            weak_below: 0.35,
+            per_source_cap,
+        }
+    }
+
+    #[test]
+    fn a_cap_of_zero_is_no_cap_rather_than_a_search_that_returns_nothing() {
+        assert_eq!(
+            RankingParams::from_vector(&vector_config(0)).per_source_cap,
+            None
+        );
+        assert_eq!(
+            RankingParams::from_vector(&vector_config(3)).per_source_cap,
+            Some(3)
+        );
+    }
+}

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -819,10 +819,8 @@ impl Core {
         query: &SearchQuery,
         origin: impl Into<Origin>,
     ) -> Result<Vec<SearchResult>> {
-        Ok(self
-            .search_with(query, Some(MAX_PER_CORPUS), origin.into())
-            .await?
-            .0)
+        let cap = self.ranking.read().expect("ranking lock").per_source_cap;
+        Ok(self.search_with(query, cap, origin.into()).await?.0)
     }
 
     /// The embedding of `q`, if a search just made it. `search_with` caches the
@@ -846,7 +844,38 @@ impl Core {
         cap: Option<usize>,
         origin: impl Into<Origin>,
     ) -> Result<(Vec<SearchResult>, SearchTiming)> {
-        let origin = origin.into();
+        let weight = self.ranking.read().expect("ranking lock").recency_weight;
+        self.search_inner(query, cap, weight, origin.into()).await
+    }
+
+    /// `search_with`, with every runtime-tunable knob chosen by the caller.
+    ///
+    /// What the tuning sweep ranks its candidates through, so measurement and
+    /// the live path are one pipeline rather than two that can drift: a sweep
+    /// scoring a subtly different search would recommend settings for a program
+    /// nobody runs.
+    pub async fn search_with_ranking(
+        &self,
+        query: &SearchQuery,
+        params: crate::core::ranking::RankingParams,
+        origin: impl Into<Origin>,
+    ) -> Result<(Vec<SearchResult>, SearchTiming)> {
+        self.search_inner(
+            query,
+            params.per_source_cap,
+            params.recency_weight,
+            origin.into(),
+        )
+        .await
+    }
+
+    async fn search_inner(
+        &self,
+        query: &SearchQuery,
+        cap: Option<usize>,
+        recency_weight: f32,
+        origin: Origin,
+    ) -> Result<(Vec<SearchResult>, SearchTiming)> {
         let door = origin.door;
         if query.q.trim().is_empty() {
             return Err(Error::Validation("query is empty".into()));
@@ -922,7 +951,7 @@ impl Core {
         let sparse = crate::vector::sparse::encode_query(query.q.trim());
         let hits = self
             .vectors
-            .search(&vector, &sparse, candidates, &filter)
+            .search_weighted(&vector, &sparse, candidates, &filter, recency_weight)
             .await?;
 
         // Cap before reranking, in vector order, so what leads per source is
@@ -2439,6 +2468,61 @@ mod tests {
         assert_eq!(
             pool, 12,
             "the configured pool was cut back to the over-fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_live_cap_is_read_per_search_rather_than_compiled_in() {
+        // What makes applying a tuning recommendation mean anything: the cap
+        // was a constant, so a recommendation to change it could only ever
+        // have been advice. Every ordinary search reads it here now.
+        //
+        // The cap is visible in the order rather than the length: it displaces
+        // a document's later chunks behind other sources instead of dropping
+        // them. Two sources, one matching the query verbatim, is the smallest
+        // arrangement where that is observable.
+        let core = test_core().await;
+        // Untitled and identical within a source, so the three chunks of one
+        // document embed identically and tie: which source leads is then hash
+        // noise, and what the assertions read is only whether a source may
+        // hold two places at once.
+        for (raw, text) in [
+            ("raw one", "the image will not mount"),
+            ("raw two", "unrelated words"),
+        ] {
+            let src = core.store.insert_corpus(raw, "web", None).await.unwrap();
+            let new: Vec<NewArtifact> = (0..3)
+                .map(|i| NewArtifact {
+                    ordinal: i,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                })
+                .collect();
+            for c in core.store.insert_artifacts(&src.id, &new).await.unwrap() {
+                crate::jobs::embed::run(&core, &c.id).await.unwrap();
+            }
+        }
+
+        let mut query = q("the image will not mount");
+        query.limit = 6;
+
+        core.ranking.write().unwrap().per_source_cap = None;
+        let uncapped = core.search(&query, Door::Judge).await.unwrap();
+        assert_eq!(
+            uncapped[0].text, uncapped[1].text,
+            "uncapped, one document supplies the head of the list"
+        );
+
+        core.ranking.write().unwrap().per_source_cap = Some(1);
+        let capped = core.search(&query, Door::Judge).await.unwrap();
+        assert_ne!(
+            capped[0].text, capped[1].text,
+            "a cap of one must let the other source take the second place"
         );
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -40,6 +40,18 @@ pub struct SearchQuery {
     pub include_superseded: bool,
 }
 
+/// The gate's claim for one search, held for as long as the search runs.
+///
+/// Two shapes because the two lanes are two different things: a lease is a
+/// count that others yield to, a permit is a turn that waits for them. Held in
+/// one binding so the choice is made once, at the top, and released at the same
+/// place either way.
+/// Both are held and never read: what a lane does, it does on the way out.
+enum Lane<'a> {
+    Interactive(#[allow(dead_code)] crate::infer::gate::InteractiveLease),
+    Background(#[allow(dead_code)] crate::infer::gate::BackgroundPermit<'a>),
+}
+
 /// What a search cost, for the faint line under the rail.
 #[derive(Debug, Clone, Copy)]
 pub struct SearchTiming {
@@ -845,7 +857,8 @@ impl Core {
         origin: impl Into<Origin>,
     ) -> Result<(Vec<SearchResult>, SearchTiming)> {
         let weight = self.ranking.read().expect("ranking lock").recency_weight;
-        self.search_inner(query, cap, weight, origin.into()).await
+        self.search_inner(query, cap, weight, origin.into(), true)
+            .await
     }
 
     /// `search_with`, with every runtime-tunable knob chosen by the caller.
@@ -854,6 +867,11 @@ impl Core {
     /// the live path are one pipeline rather than two that can drift: a sweep
     /// scoring a subtly different search would recommend settings for a program
     /// nobody runs.
+    ///
+    /// The one thing it does differently is the lane. Nobody is waiting on a
+    /// replay of questions that were already answered, and a sweep is thousands
+    /// of searches: on the interactive lane it holds every background worker off
+    /// for the length of the run.
     pub async fn search_with_ranking(
         &self,
         query: &SearchQuery,
@@ -865,16 +883,20 @@ impl Core {
             params.per_source_cap,
             params.recency_weight,
             origin.into(),
+            false,
         )
         .await
     }
 
+    /// `waited_on` is whether a person is on the other end of this search. It
+    /// chooses the lane and nothing else: the pipeline is the same either way.
     async fn search_inner(
         &self,
         query: &SearchQuery,
         cap: Option<usize>,
         recency_weight: f32,
         origin: Origin,
+        waited_on: bool,
     ) -> Result<(Vec<SearchResult>, SearchTiming)> {
         let door = origin.door;
         if query.q.trim().is_empty() {
@@ -892,7 +914,16 @@ impl Core {
         // lands, and the query then waits out twenty to seventy seconds of it.
         // `ask` takes one too and holds it across this; the lane is a count, so
         // nesting is what it is built for.
-        let _lane = self.gate.interactive();
+        //
+        // Unless nobody is waiting: a sweep is twenty-one searches per judged
+        // pair and hundreds of pairs, so on this lane it is not a query in
+        // front of a worker but a wall in front of every worker, for as long as
+        // the run lasts. It takes the background turn instead — behind whoever
+        // is actually waiting, and never alongside a generation.
+        let _lane = match waited_on {
+            true => Lane::Interactive(self.gate.interactive()),
+            false => Lane::Background(self.gate.background_light().await),
+        };
 
         let started = std::time::Instant::now();
         // Prefixes repeat constantly inside one search and whole queries repeat

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -16,6 +16,7 @@
 pub mod claims;
 pub mod export;
 pub mod metrics;
+pub mod sweep;
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -133,6 +133,36 @@ pub fn load_pairs(dir: &Path) -> Result<Vec<EvalPair>> {
     serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
 }
 
+/// The artifact ids that satisfy a grade naming `expected`: itself, plus
+/// whatever superseded it.
+///
+/// A graded pair names the artifact that answered the query. When consolidation
+/// merges it into another, or supersedes it in favour of one that plainly
+/// replaced it, the knowledge is in the survivor and search returns that. The
+/// grade is still satisfied; only the id changed.
+///
+/// Bounded rather than trusted to terminate. Chains should not exist — a merge
+/// re-points what it hides, precisely so no reader lands on a hidden winner —
+/// but a sweep that hangs on a cycle in the data is worse than one that stops
+/// looking after a few hops.
+pub async fn satisfied_by(core: &crate::core::Core, expected: &str) -> Vec<String> {
+    let mut out = vec![expected.to_string()];
+    let mut cursor = expected.to_string();
+    for _ in 0..8 {
+        match core.store.get_artifact(&cursor).await {
+            Ok(c) => match c.superseded_by {
+                Some(next) => {
+                    out.push(next.clone());
+                    cursor = next;
+                }
+                None => break,
+            },
+            Err(_) => break,
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -253,6 +253,198 @@ async fn sweep_if_due(core: &Core) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::feedback::{Door, NewEvent, Verdict};
+
+    const QUERY: &str = "the image will not mount";
+
+    /// Two sources of three identical, untitled chunks each, and the order the
+    /// uncapped ranking gives them.
+    ///
+    /// Identical within a source so the three tie and the cap is the only
+    /// thing that can separate them; the order is read back rather than
+    /// assumed, because which source leads is a property of the fake
+    /// embedder's hashes and nothing this is testing.
+    async fn seeded() -> (crate::core::Core, Vec<String>) {
+        let core = crate::core::test_support::test_core().await;
+        for (raw, text) in [("raw one", QUERY), ("raw two", "unrelated words")] {
+            let src = core.store.insert_corpus(raw, "web", None).await.unwrap();
+            let new: Vec<crate::store::artifacts::NewArtifact> = (0..3)
+                .map(|i| crate::store::artifacts::NewArtifact {
+                    ordinal: i,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                })
+                .collect();
+            for c in core.store.insert_artifacts(&src.id, &new).await.unwrap() {
+                crate::jobs::embed::run(&core, &c.id).await.unwrap();
+            }
+        }
+        // The baseline this sweep is measured against: one source may fill the
+        // whole list, so a cap is the improvement available to be found.
+        core.ranking.write().unwrap().per_source_cap = None;
+        let order = ranks_order(&core).await;
+        (core, order)
+    }
+
+    async fn ranks_order(core: &crate::core::Core) -> Vec<String> {
+        let params = *core.ranking.read().unwrap();
+        let q = crate::core::search::SearchQuery {
+            q: QUERY.into(),
+            limit: LIMIT,
+            tags: vec![],
+            category: None,
+            mark: false,
+            include_deprecated: false,
+            include_superseded: false,
+        };
+        core.search_with_ranking(&q, params, Door::Judge)
+            .await
+            .unwrap()
+            .0
+            .into_iter()
+            .map(|r| r.artifact_id)
+            .collect()
+    }
+
+    /// One judged search naming `expect` as its answer.
+    async fn judge(core: &crate::core::Core, expect: &str) {
+        let id = core
+            .store
+            .record_search(
+                NewEvent {
+                    query: QUERY.into(),
+                    door: Door::Ui,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![0.1, 0.2],
+                    embed_model: "fake".into(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                // Folding off: these are the same query on purpose, and two
+                // pairs are what the gate needs.
+                0,
+            )
+            .await
+            .unwrap();
+        core.store.judge_hit(&id, expect).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_candidate_that_lifts_two_pairs_is_recorded_as_a_recommendation() {
+        let (core, order) = seeded().await;
+        // The second source's first two chunks: buried behind the leading
+        // source uncapped, promoted the moment a cap displaces its tail.
+        judge(&core, &order[3]).await;
+        judge(&core, &order[4]).await;
+
+        run_sweep(&core).await.unwrap();
+
+        let run = core.store.latest_eval_run().await.unwrap().unwrap();
+        assert_eq!(run.pairs_used, 2);
+        assert_eq!(run.pairs_skipped, 0);
+        assert!(run.recommended, "a strictly better candidate was refused");
+        assert!(
+            run.best_params.per_source_cap.is_some(),
+            "the improvement here is a cap, and the run must name it"
+        );
+        assert!(run.best_mrr > run.base_mrr);
+        assert_eq!(
+            run.diff.len(),
+            2,
+            "both pairs moved, and the diff is what a person reads"
+        );
+        assert!(
+            run.diff.iter().all(|d| d.new < d.base),
+            "a recommended run's diff must show the pairs climbing"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_with_nothing_better_records_the_silence() {
+        // Pairs already answered at the top of the list. Nothing can lift them
+        // and a cap can only push the second one down, so the gate refuses
+        // everything — and the run is still written, so the page can say so.
+        let (core, order) = seeded().await;
+        judge(&core, &order[0]).await;
+        judge(&core, &order[1]).await;
+
+        run_sweep(&core).await.unwrap();
+
+        let run = core.store.latest_eval_run().await.unwrap().unwrap();
+        assert!(!run.recommended);
+        assert_eq!(run.base_params, run.best_params);
+        assert!(run.diff.is_empty(), "nothing changed, so nothing moved");
+        assert!(core.store.open_recommendation().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_pair_whose_artifact_is_gone_is_counted_rather_than_scored() {
+        // Housekeeping, not a ranking result. Scored as a miss it would look
+        // like a ranking failure forever; raised it would stop every later
+        // sweep over one deletion.
+        let (core, order) = seeded().await;
+        judge(&core, &order[3]).await;
+        judge(&core, "deleted-since").await;
+
+        run_sweep(&core).await.unwrap();
+
+        let run = core.store.latest_eval_run().await.unwrap().unwrap();
+        assert_eq!((run.pairs_used, run.pairs_skipped), (1, 1));
+    }
+
+    #[tokio::test]
+    async fn verdicts_that_name_no_answer_leave_nothing_to_sweep() {
+        // Gaps and discards count towards the floor but are not pairs. With
+        // only those, there is nothing to rank and no run to record.
+        let (core, _) = seeded().await;
+        let id = core
+            .store
+            .record_search(
+                NewEvent {
+                    query: QUERY.into(),
+                    door: Door::Ui,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![0.1, 0.2],
+                    embed_model: "fake".into(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        core.store.judge(&id, Verdict::Gap).await.unwrap();
+
+        run_sweep(&core).await.unwrap();
+        assert!(core.store.latest_eval_run().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_sweep_leaves_no_trace_in_what_it_measures() {
+        // It replays queries in full knowledge of their answers. Recorded,
+        // those would be captured searches nobody made, waiting to be judged.
+        let (mut core, order) = seeded().await;
+        core.learn.enabled = true;
+        judge(&core, &order[3]).await;
+        judge(&core, &order[4]).await;
+        let before = core.store.feedback_stats().await.unwrap().captured;
+
+        run_sweep(&core).await.unwrap();
+        core.background.wait_idle().await;
+
+        assert_eq!(
+            core.store.feedback_stats().await.unwrap().captured,
+            before,
+            "the sweep's own searches became data"
+        );
+    }
 
     #[test]
     fn the_gate_needs_two_net_better_pairs_and_no_aggregate_loss() {

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -1,0 +1,296 @@
+//! The background parameter sweep judgements pay for.
+//!
+//! The cargo harness freezes a corpus because its numbers must be comparable
+//! across months. A recommendation asks a smaller question: what would *these*
+//! pairs score under other settings, right now, against the base as it stands.
+//! Baseline and candidates run in one pass over one index, so nothing needs
+//! freezing and nothing needs re-embedding — the query cache means each
+//! distinct query is embedded once and every candidate re-ranks the same
+//! vectors.
+//!
+//! It reads the live index and only reads it. `Door::Judge` and `mark: false`
+//! are the same discipline the judge page's assign search follows, for the same
+//! reason: a sweep is not someone reading their notes, and its queries are
+//! replayed in full knowledge of their answers.
+
+use crate::core::Core;
+use crate::core::ranking::RankingParams;
+use crate::error::Result;
+use crate::eval::metrics::{mrr, recall_at};
+use crate::store::eval_runs::{DiffRow, NewEvalRun};
+
+/// The `k` in recall@k, and the depth a rank is looked for in. The judge
+/// page's own figure is recall@10; a sweep reporting recall@20 beside it would
+/// be two numbers with one name.
+const LIMIT: usize = 10;
+
+/// The grid's axes. Both are scoring knobs — they reorder what retrieval
+/// already returned — which is what makes a sweep cheap enough to run on a
+/// verdict. The knobs that change the vector geometry (the embedding model and
+/// its templates) cannot be swept at runtime at all, and stay with the cargo
+/// harness.
+const RECENCY: [f32; 5] = [0.0, 0.05, 0.1, 0.15, 0.25];
+const CAPS: [Option<usize>; 4] = [Some(2), Some(3), Some(5), None];
+
+/// Every combination, with the running configuration always among them: it is
+/// the baseline everything else is measured against.
+pub fn grid(current: RankingParams) -> Vec<RankingParams> {
+    let mut out = Vec::with_capacity(RECENCY.len() * CAPS.len() + 1);
+    for &recency_weight in &RECENCY {
+        for &per_source_cap in &CAPS {
+            out.push(RankingParams {
+                recency_weight,
+                per_source_cap,
+            });
+        }
+    }
+    if !out.contains(&current) {
+        out.push(current);
+    }
+    out
+}
+
+/// Whether `cand` placed a pair better than `base` did. A miss loses to any
+/// rank; two misses are equal.
+fn better(cand: Option<usize>, base: Option<usize>) -> bool {
+    match (cand, base) {
+        (Some(c), Some(b)) => c < b,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+/// The gate, and the reason the whole feature is safe to run automatically.
+///
+/// An aggregate delta can be a single flipped pair wearing a percentage: on
+/// fifty pairs one is two points of recall. Requiring two *net* better pairs
+/// is what a change has to look like before it is worth a person's attention,
+/// and refusing any candidate that costs either aggregate keeps a trade the
+/// operator did not ask for from being presented as an improvement. Ties keep
+/// the current values, always: a knob that moves nothing should keep its
+/// default.
+pub fn recommend(base: &[Option<usize>], cand: &[Option<usize>]) -> bool {
+    let improved = base
+        .iter()
+        .zip(cand)
+        .filter(|(b, c)| better(**c, **b))
+        .count() as i64;
+    let worsened = base
+        .iter()
+        .zip(cand)
+        .filter(|(b, c)| better(**b, **c))
+        .count() as i64;
+    improved - worsened >= 2
+        && recall_at(cand, LIMIT) >= recall_at(base, LIMIT)
+        && mrr(cand) >= mrr(base)
+}
+
+/// One judged pair, with every id that satisfies it already resolved.
+type Pair = (String, Vec<String>);
+
+/// Rank every pair under one configuration.
+async fn ranks_for(
+    core: &Core,
+    pairs: &[Pair],
+    params: RankingParams,
+) -> Result<Vec<Option<usize>>> {
+    let mut ranks = Vec::with_capacity(pairs.len());
+    for (query, satisfies) in pairs {
+        let q = crate::core::search::SearchQuery {
+            q: query.clone(),
+            limit: LIMIT,
+            tags: vec![],
+            category: None,
+            // Resurfacing reads `last_seen_at`, and a scored run is not
+            // someone reading their notes.
+            mark: false,
+            include_deprecated: false,
+            include_superseded: false,
+        };
+        let (results, _) = core
+            .search_with_ranking(&q, params, crate::store::feedback::Door::Judge)
+            .await?;
+        ranks.push(
+            results
+                .iter()
+                .position(|r| satisfies.iter().any(|id| id == &r.artifact_id)),
+        );
+    }
+    Ok(ranks)
+}
+
+/// The pairs a sweep can actually replay, and how many it had to leave out.
+async fn pairs_to_replay(core: &Core) -> Result<(Vec<Pair>, i64)> {
+    let mut pairs = Vec::new();
+    let mut skipped = 0;
+    for p in core.store.judged_pairs().await? {
+        // A deleted artifact is housekeeping, not a ranking result. Scored as
+        // a miss it would look like a ranking failure for as long as the pair
+        // exists; raised as an error it would stop every future sweep over one
+        // deletion.
+        match core.store.get_artifact(&p.expect).await {
+            Ok(_) => {
+                let satisfies = crate::eval::satisfied_by(core, &p.expect).await;
+                pairs.push((p.query, satisfies));
+            }
+            Err(crate::error::Error::NotFound) => skipped += 1,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok((pairs, skipped))
+}
+
+/// Rank the judged pairs under the whole grid and record what was found.
+///
+/// Runs whatever the thresholds say — `maybe_spawn` is what decides whether it
+/// is due. Callable directly, which is what the tests do.
+pub async fn run_sweep(core: &Core) -> Result<()> {
+    let (pairs, skipped) = pairs_to_replay(core).await?;
+    if pairs.is_empty() {
+        return Ok(());
+    }
+    let judged = core.store.feedback_stats().await?.judged;
+    let current = *core.ranking.read().expect("ranking lock");
+
+    let base = ranks_for(core, &pairs, current).await?;
+    let mut best: Option<(RankingParams, Vec<Option<usize>>)> = None;
+    for cand in grid(current) {
+        if cand == current {
+            continue;
+        }
+        let ranks = ranks_for(core, &pairs, cand).await?;
+        if !recommend(&base, &ranks) {
+            continue;
+        }
+        // MRR first, recall as the tie-break: the gate has already refused
+        // anything that costs either, so this only chooses among improvements.
+        let beats = best.as_ref().is_none_or(|(_, b)| {
+            mrr(&ranks) > mrr(b)
+                || (mrr(&ranks) == mrr(b) && recall_at(&ranks, LIMIT) > recall_at(b, LIMIT))
+        });
+        if beats {
+            best = Some((cand, ranks));
+        }
+    }
+
+    let (winner, winning_ranks, recommended) = match best {
+        Some((p, r)) => (p, r, true),
+        // A quiet sweep still records itself: without the row a page can only
+        // say nothing, which reads as "no sweep has ever run".
+        None => (current, base.clone(), false),
+    };
+    let diff: Vec<DiffRow> = pairs
+        .iter()
+        .zip(base.iter().zip(&winning_ranks))
+        .filter(|(_, (b, n))| b != n)
+        .map(|((query, _), (b, n))| DiffRow {
+            // The query names its own row, as it does in the harness's miss
+            // list. No artifact text is written here.
+            query: query.chars().take(48).collect(),
+            base: *b,
+            new: *n,
+        })
+        .collect();
+
+    core.store
+        .record_eval_run(&NewEvalRun {
+            judged_count: judged,
+            pairs_used: pairs.len() as i64,
+            pairs_skipped: skipped,
+            base: current.into(),
+            base_recall: recall_at(&base, LIMIT),
+            base_mrr: mrr(&base),
+            best: winner.into(),
+            best_recall: recall_at(&winning_ranks, LIMIT),
+            best_mrr: mrr(&winning_ranks),
+            diff,
+            recommended,
+        })
+        .await?;
+    Ok(())
+}
+
+/// Run a sweep if the judgements have paid for one.
+///
+/// Called after every verdict, off the request path: the verdict must not wait
+/// on a grid of searches, and a sweep that fails must not fail the verdict.
+pub fn maybe_spawn(core: &Core) {
+    if !core.learn.enabled {
+        return;
+    }
+    let core = core.clone();
+    core.background.clone().spawn(async move {
+        use std::sync::atomic::Ordering;
+        // A run of verdicts is one sweep, not one each. Released on the way
+        // out whatever happened, including the early returns below.
+        if core.tuning.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        if let Err(e) = sweep_if_due(&core).await {
+            tracing::warn!(error = %e, "tuning sweep failed");
+        }
+        core.tuning.store(false, Ordering::SeqCst);
+    });
+}
+
+async fn sweep_if_due(core: &Core) -> Result<()> {
+    let tune = &core.feedback.tune;
+    let judged = core.store.feedback_stats().await?.judged;
+    if judged < tune.min_judgements {
+        return Ok(());
+    }
+    // Paced by judgements rather than by the clock: what makes a sweep worth
+    // repeating is new evidence, and nothing else about the base changes what
+    // these two knobs do.
+    if let Some(last) = core.store.latest_eval_run().await?
+        && judged - last.judged_count < tune.resweep_after
+    {
+        return Ok(());
+    }
+    run_sweep(core).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_gate_needs_two_net_better_pairs_and_no_aggregate_loss() {
+        let base = vec![Some(5), Some(7), None, Some(0)];
+        assert!(
+            recommend(&base, &[Some(1), Some(2), None, Some(0)]),
+            "two pairs climbed and none fell"
+        );
+        assert!(
+            !recommend(&base, &[Some(1), Some(7), None, Some(0)]),
+            "one pair is noise wearing a percentage"
+        );
+        assert!(
+            !recommend(&base, &[Some(1), Some(2), None, None]),
+            "two climbed but one was lost: net one"
+        );
+        assert!(!recommend(&base, &base), "a tie keeps the current values");
+        assert!(
+            !recommend(&base, &[Some(0), Some(0), None, Some(3)]),
+            "two climbed and one fell out of the head: MRR must not pay for it"
+        );
+    }
+
+    #[test]
+    fn the_grid_always_contains_the_configuration_it_is_measured_against() {
+        let shipped = RankingParams {
+            recency_weight: 0.05,
+            per_source_cap: Some(3),
+        };
+        assert!(grid(shipped).contains(&shipped));
+        assert_eq!(grid(shipped).len(), RECENCY.len() * CAPS.len());
+
+        // A hand-set value nobody would have guessed is still the baseline.
+        let odd = RankingParams {
+            recency_weight: 0.07,
+            per_source_cap: Some(4),
+        };
+        assert!(grid(odd).contains(&odd));
+        assert_eq!(grid(odd).len(), RECENCY.len() * CAPS.len() + 1);
+    }
+}

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -88,33 +88,47 @@ pub fn recommend(base: &[Option<usize>], cand: &[Option<usize>]) -> bool {
 /// One judged pair, with every id that satisfies it already resolved.
 type Pair = (String, Vec<String>);
 
-/// Rank every pair under one configuration.
-async fn ranks_for(
+/// Where one configuration put the answer to one pair. `None` past `LIMIT`.
+async fn rank_of(core: &Core, pair: &Pair, params: RankingParams) -> Result<Option<usize>> {
+    let (query, satisfies) = pair;
+    let q = crate::core::search::SearchQuery {
+        q: query.clone(),
+        limit: LIMIT,
+        tags: vec![],
+        category: None,
+        // Resurfacing reads `last_seen_at`, and a scored run is not someone
+        // reading their notes.
+        mark: false,
+        include_deprecated: false,
+        include_superseded: false,
+    };
+    let (results, _) = core
+        .search_with_ranking(&q, params, crate::store::feedback::Door::Judge)
+        .await?;
+    Ok(results
+        .iter()
+        .position(|r| satisfies.iter().any(|id| id == &r.artifact_id)))
+}
+
+/// Every pair under every configuration, one row per configuration.
+///
+/// Query-major, and that is the whole point of the function. A pass per
+/// configuration walks the same queries in the same order twenty-one times,
+/// which is the one access pattern an insertion-ordered cache of
+/// `QUERY_CACHE_CAPACITY` entries can never serve: past that many distinct
+/// judged queries the hit rate was zero and every search in the grid embedded
+/// its query again. Asking all twenty-one questions about one query before
+/// moving to the next embeds it once, however many pairs there are.
+async fn ranks_over_grid(
     core: &Core,
     pairs: &[Pair],
-    params: RankingParams,
-) -> Result<Vec<Option<usize>>> {
-    let mut ranks = Vec::with_capacity(pairs.len());
-    for (query, satisfies) in pairs {
-        let q = crate::core::search::SearchQuery {
-            q: query.clone(),
-            limit: LIMIT,
-            tags: vec![],
-            category: None,
-            // Resurfacing reads `last_seen_at`, and a scored run is not
-            // someone reading their notes.
-            mark: false,
-            include_deprecated: false,
-            include_superseded: false,
-        };
-        let (results, _) = core
-            .search_with_ranking(&q, params, crate::store::feedback::Door::Judge)
-            .await?;
-        ranks.push(
-            results
-                .iter()
-                .position(|r| satisfies.iter().any(|id| id == &r.artifact_id)),
-        );
+    grid: &[RankingParams],
+) -> Result<Vec<Vec<Option<usize>>>> {
+    let mut ranks = vec![Vec::with_capacity(pairs.len()); grid.len()];
+    for pair in pairs {
+        for (row, params) in ranks.iter_mut().zip(grid) {
+            row.push(rank_of(core, pair, *params).await?);
+        }
     }
     Ok(ranks)
 }
@@ -152,36 +166,42 @@ pub async fn run_sweep(core: &Core) -> Result<()> {
     let judged = core.store.feedback_stats().await?.judged;
     let current = *core.ranking.read().expect("ranking lock");
 
-    let base = ranks_for(core, &pairs, current).await?;
-    let mut best: Option<(RankingParams, Vec<Option<usize>>)> = None;
-    for cand in grid(current) {
-        if cand == current {
-            continue;
-        }
-        let ranks = ranks_for(core, &pairs, cand).await?;
-        if !recommend(&base, &ranks) {
+    let grid = grid(current);
+    let ranks = ranks_over_grid(core, &pairs, &grid).await?;
+    // `grid` always contains the running configuration — that is what makes it
+    // the baseline everything else is measured against.
+    let base_at = grid
+        .iter()
+        .position(|p| *p == current)
+        .expect("the grid carries the running configuration");
+    let base = &ranks[base_at];
+
+    let mut best: Option<usize> = None;
+    for cand in (0..grid.len()).filter(|i| *i != base_at) {
+        if !recommend(base, &ranks[cand]) {
             continue;
         }
         // MRR first, recall as the tie-break: the gate has already refused
         // anything that costs either, so this only chooses among improvements.
-        let beats = best.as_ref().is_none_or(|(_, b)| {
-            mrr(&ranks) > mrr(b)
-                || (mrr(&ranks) == mrr(b) && recall_at(&ranks, LIMIT) > recall_at(b, LIMIT))
+        let beats = best.is_none_or(|b| {
+            mrr(&ranks[cand]) > mrr(&ranks[b])
+                || (mrr(&ranks[cand]) == mrr(&ranks[b])
+                    && recall_at(&ranks[cand], LIMIT) > recall_at(&ranks[b], LIMIT))
         });
         if beats {
-            best = Some((cand, ranks));
+            best = Some(cand);
         }
     }
 
     let (winner, winning_ranks, recommended) = match best {
-        Some((p, r)) => (p, r, true),
+        Some(i) => (grid[i], &ranks[i], true),
         // A quiet sweep still records itself: without the row a page can only
         // say nothing, which reads as "no sweep has ever run".
-        None => (current, base.clone(), false),
+        None => (current, base, false),
     };
     let diff: Vec<DiffRow> = pairs
         .iter()
-        .zip(base.iter().zip(&winning_ranks))
+        .zip(base.iter().zip(winning_ranks))
         .filter(|(_, (b, n))| b != n)
         .map(|((query, _), (b, n))| DiffRow {
             // The query names its own row, as it does in the harness's miss
@@ -198,11 +218,11 @@ pub async fn run_sweep(core: &Core) -> Result<()> {
             pairs_used: pairs.len() as i64,
             pairs_skipped: skipped,
             base: current.into(),
-            base_recall: recall_at(&base, LIMIT),
-            base_mrr: mrr(&base),
+            base_recall: recall_at(base, LIMIT),
+            base_mrr: mrr(base),
             best: winner.into(),
-            best_recall: recall_at(&winning_ranks, LIMIT),
-            best_mrr: mrr(&winning_ranks),
+            best_recall: recall_at(winning_ranks, LIMIT),
+            best_mrr: mrr(winning_ranks),
             diff,
             recommended,
         })
@@ -220,17 +240,40 @@ pub fn maybe_spawn(core: &Core) {
     }
     let core = core.clone();
     core.background.clone().spawn(async move {
-        use std::sync::atomic::Ordering;
-        // A run of verdicts is one sweep, not one each. Released on the way
-        // out whatever happened, including the early returns below.
-        if core.tuning.swap(true, Ordering::SeqCst) {
+        // A run of verdicts is one sweep, not one each.
+        let Some(_claim) = Sweeping::claim(&core) else {
             return;
-        }
+        };
         if let Err(e) = sweep_if_due(&core).await {
             tracing::warn!(error = %e, "tuning sweep failed");
         }
-        core.tuning.store(false, Ordering::SeqCst);
     });
+}
+
+/// The claim on `core.tuning`, released on the way out whatever happened.
+///
+/// It used to be a `store(false)` at the end of the task, which a panic
+/// skipped: a poisoned `ranking` lock or an unwrap anywhere under the search
+/// path left the flag standing at true, and every later sweep then returned at
+/// the first line for the lifetime of the process — silently, since a sweep
+/// that declines to start says nothing. `Background::spawn` is a bare
+/// `tokio::spawn` and catches nothing on its own.
+struct Sweeping(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl Sweeping {
+    fn claim(core: &Core) -> Option<Self> {
+        use std::sync::atomic::Ordering;
+        match core.tuning.swap(true, Ordering::SeqCst) {
+            true => None,
+            false => Some(Self(core.tuning.clone())),
+        }
+    }
+}
+
+impl Drop for Sweeping {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 async fn sweep_if_due(core: &Core) -> Result<()> {
@@ -381,6 +424,29 @@ mod tests {
         assert_eq!(run.base_params, run.best_params);
         assert!(run.diff.is_empty(), "nothing changed, so nothing moved");
         assert!(core.store.open_recommendation().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_panics_does_not_disable_every_later_one() {
+        // The flag used to be cleared at the end of the task body, which a
+        // panic skipped — a poisoned `ranking` lock, an unwrap anywhere under
+        // the search path — and `Background::spawn` is a bare `tokio::spawn`,
+        // so nothing caught it. Every later sweep then returned at its first
+        // line for the lifetime of the process, and said nothing about it.
+        let core = crate::core::test_support::test_core().await;
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let died = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _claim = Sweeping::claim(&core).expect("the first claim is free");
+            panic!("a poisoned lock under the search path");
+        }));
+        std::panic::set_hook(hook);
+
+        assert!(died.is_err());
+        assert!(
+            Sweeping::claim(&core).is_some(),
+            "the claim outlived the panic that dropped it"
+        );
     }
 
     #[tokio::test]

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -85,6 +85,22 @@ pub fn recommend(base: &[Option<usize>], cand: &[Option<usize>]) -> bool {
         && mrr(cand) >= mrr(base)
 }
 
+/// How many knobs a candidate moves off the running configuration.
+///
+/// The last tie-break, and the reason it has to exist: `grid` is walked
+/// recency-major from `RECENCY[0] = 0.0`, so among candidates whose rank
+/// vectors are identical — the ordinary case, since most judged pairs carry no
+/// recency signal at all — the lowest index wins, and that index is recency
+/// zero. A cap change would then arrive with "recency 0.05 → 0.00" attached to
+/// it, measured by nothing, and applying it would switch recency weighting off
+/// on the strength of a result about caps. `recommend` already promises a knob
+/// that moves nothing keeps its value; this is that promise held among the
+/// candidates rather than only against the base.
+fn moved(cand: RankingParams, current: RankingParams) -> usize {
+    usize::from(cand.recency_weight != current.recency_weight)
+        + usize::from(cand.per_source_cap != current.per_source_cap)
+}
+
 /// One judged pair, with every id that satisfies it already resolved.
 type Pair = (String, Vec<String>);
 
@@ -181,12 +197,14 @@ pub async fn run_sweep(core: &Core) -> Result<()> {
         if !recommend(base, &ranks[cand]) {
             continue;
         }
-        // MRR first, recall as the tie-break: the gate has already refused
-        // anything that costs either, so this only chooses among improvements.
+        // MRR first, then recall: the gate has already refused anything that
+        // costs either, so this only chooses among improvements. Then the
+        // fewest knobs moved, which is what keeps a candidate the measurements
+        // cannot tell apart from claiming credit for the axis it changed.
         let beats = best.is_none_or(|b| {
-            mrr(&ranks[cand]) > mrr(&ranks[b])
-                || (mrr(&ranks[cand]) == mrr(&ranks[b])
-                    && recall_at(&ranks[cand], LIMIT) > recall_at(&ranks[b], LIMIT))
+            let score = |i: usize| (mrr(&ranks[i]), recall_at(&ranks[i], LIMIT));
+            score(cand) > score(b)
+                || (score(cand) == score(b) && moved(grid[cand], current) < moved(grid[b], current))
         });
         if beats {
             best = Some(cand);
@@ -211,6 +229,20 @@ pub async fn run_sweep(core: &Core) -> Result<()> {
             new: *n,
         })
         .collect();
+
+    // An apply can land in the minutes this takes: `Sweeping` keeps two sweeps
+    // apart and nothing else, and `tune_apply` takes the write lock without
+    // asking anyone. The row would name a base that is no longer in force and a
+    // winner measured against it — and being the newest, it would be the
+    // recommendation the page then offers, walking the ranking back off what
+    // the operator just applied. That is the failure "only the newest sweep's
+    // recommendation stands" was written to prevent, arriving by the other
+    // door. A sweep whose baseline moved under it has measured nothing worth
+    // recording; the next verdict pays for one against the settings now running.
+    if *core.ranking.read().expect("ranking lock") != current {
+        tracing::info!("ranking changed while the sweep ran; its results were discarded");
+        return Ok(());
+    }
 
     core.store
         .record_eval_run(&NewEvalRun {
@@ -409,6 +441,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_cap_result_does_not_arrive_wearing_a_recency_change() {
+        // The grid is walked recency-major from 0.0, so among candidates whose
+        // rank vectors are identical the lowest index wins — and these pairs
+        // are all the same age, so recency separates nothing. Untie-broken, the
+        // recommendation reads "recency 0.05 → 0.00" beside the cap that
+        // actually earned it, and applying it switches recency weighting off on
+        // the strength of a result about caps.
+        let (core, order) = seeded().await;
+        core.ranking.write().unwrap().recency_weight = 0.05;
+        judge(&core, &order[3]).await;
+        judge(&core, &order[4]).await;
+
+        run_sweep(&core).await.unwrap();
+
+        let run = core.store.latest_eval_run().await.unwrap().unwrap();
+        assert!(run.recommended, "the cap improvement was refused");
+        assert!(
+            run.best_params.per_source_cap.is_some(),
+            "the cap is what this sweep measured"
+        );
+        assert_eq!(
+            run.best_params.recency_weight, 0.05,
+            "the sweep moved a knob nothing it measured had an opinion about"
+        );
+    }
+
+    #[tokio::test]
     async fn a_sweep_with_nothing_better_records_the_silence() {
         // Pairs already answered at the top of the list. Nothing can lift them
         // and a cap can only push the second one down, so the gate refuses
@@ -424,6 +483,60 @@ mod tests {
         assert_eq!(run.base_params, run.best_params);
         assert!(run.diff.is_empty(), "nothing changed, so nothing moved");
         assert!(core.store.open_recommendation().await.unwrap().is_none());
+    }
+
+    /// An apply landing mid-sweep, at a point the sweep cannot miss.
+    ///
+    /// Wall-clock racing would be the honest shape of this and a coin-toss as a
+    /// test. The reranker runs inside every search in the grid — always after
+    /// the baseline has been snapshotted, never before — so hanging the write
+    /// off the first call puts it exactly where `tune_apply`'s would land, on
+    /// every run.
+    struct ApplyOnFirstSearch(std::sync::Arc<std::sync::RwLock<RankingParams>>);
+
+    #[async_trait::async_trait]
+    impl crate::infer::Reranker for ApplyOnFirstSearch {
+        async fn rerank(
+            &self,
+            _query: &str,
+            docs: &[String],
+            top_n: usize,
+        ) -> Result<Vec<(usize, f32)>> {
+            self.0.write().expect("ranking lock").per_source_cap = Some(2);
+            // Scores descending, so the order search already had comes back
+            // unchanged: this is here to write, not to rank.
+            Ok((0..docs.len().min(top_n))
+                .map(|i| (i, 1.0 - i as f32 / 100.0))
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_sweep_whose_baseline_was_applied_out_from_under_it_records_nothing() {
+        // The operator judging is the operator clicking Apply, and a sweep over
+        // real pairs runs for minutes. Recorded anyway, the row would be the
+        // newest — so the page would offer a winner measured against settings
+        // that are no longer running, and taking it would undo the apply that
+        // raced it.
+        let (mut core, order) = seeded().await;
+        judge(&core, &order[3]).await;
+        judge(&core, &order[4]).await;
+        let base = *core.ranking.read().unwrap();
+        core.reranker = Some(std::sync::Arc::new(ApplyOnFirstSearch(
+            core.ranking.clone(),
+        )));
+
+        run_sweep(&core).await.unwrap();
+
+        assert_ne!(
+            base,
+            *core.ranking.read().unwrap(),
+            "the apply never landed"
+        );
+        assert!(
+            core.store.latest_eval_run().await.unwrap().is_none(),
+            "a sweep measured against a baseline that is gone was written down anyway"
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,6 +332,7 @@ mod startup_tests {
                 recency_half_life_days: 180,
                 pinned_boost: 0.15,
                 weak_below: 0.35,
+                per_source_cap: 3,
             },
             infer: InferConfig {
                 synthesis: engram::config::SynthesisMode::Eager,

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,13 @@ async fn main() -> anyhow::Result<()> {
             pending: engram::auth::oidc::PendingStore::new(),
             secure_cookies,
         }),
+        // The path `Config::load` was given, or the name it looks for when it
+        // was given none.
+        config_path: Arc::new(
+            args.config
+                .clone()
+                .unwrap_or_else(|| std::path::PathBuf::from("config.toml")),
+        ),
         ask_handoff: Default::default(),
     };
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -379,6 +379,7 @@ mod tests {
                 pending: crate::auth::oidc::PendingStore::new(),
                 secure_cookies: false,
             }),
+            config_path: std::sync::Arc::new(crate::web::test_support::scratch_config()),
             ask_handoff: Default::default(),
         };
         let res = crate::web::router(state)

--- a/src/store/eval_runs.rs
+++ b/src/store/eval_runs.rs
@@ -1,0 +1,274 @@
+//! What a tuning sweep found, kept.
+//!
+//! The judge page's recall and MRR are read from the ranks the searches
+//! actually gave, which is the measurement of the ranking that produced them.
+//! A sweep asks the other question — what *these* pairs would score under
+//! other settings — and the answer is only worth anything beside the settings
+//! that produced it. Hence a row per sweep rather than a number on a page.
+
+use super::{Store, new_id, now};
+use crate::error::{Error, Result};
+use sqlx::Row;
+
+/// The runtime-tunable knobs, as stored. Mirrors
+/// `core::ranking::RankingParams`; separate because what is written to a
+/// database outlives the shape a running program happens to hold it in.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RunParams {
+    pub recency_weight: f32,
+    pub per_source_cap: Option<usize>,
+}
+
+impl From<crate::core::ranking::RankingParams> for RunParams {
+    fn from(p: crate::core::ranking::RankingParams) -> Self {
+        Self {
+            recency_weight: p.recency_weight,
+            per_source_cap: p.per_source_cap,
+        }
+    }
+}
+
+impl From<RunParams> for crate::core::ranking::RankingParams {
+    fn from(p: RunParams) -> Self {
+        Self {
+            recency_weight: p.recency_weight,
+            per_source_cap: p.per_source_cap,
+        }
+    }
+}
+
+/// One pair that moved, named by the leading characters of its own query.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiffRow {
+    pub query: String,
+    /// `None` means the answer was not in the first ten at all.
+    pub base: Option<usize>,
+    pub new: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewEvalRun {
+    pub judged_count: i64,
+    pub pairs_used: i64,
+    pub pairs_skipped: i64,
+    pub base: RunParams,
+    pub base_recall: f64,
+    pub base_mrr: f64,
+    pub best: RunParams,
+    pub best_recall: f64,
+    pub best_mrr: f64,
+    pub diff: Vec<DiffRow>,
+    pub recommended: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvalRun {
+    pub id: String,
+    pub created_at: i64,
+    pub judged_count: i64,
+    pub pairs_used: i64,
+    pub pairs_skipped: i64,
+    pub base_params: RunParams,
+    pub base_recall: f64,
+    pub base_mrr: f64,
+    pub best_params: RunParams,
+    pub best_recall: f64,
+    pub best_mrr: f64,
+    pub diff: Vec<DiffRow>,
+    pub recommended: bool,
+    pub applied_at: Option<i64>,
+}
+
+impl Store {
+    pub async fn record_eval_run(&self, run: &NewEvalRun) -> Result<String> {
+        let id = new_id();
+        sqlx::query(
+            "INSERT INTO eval_runs
+               (id, created_at, judged_count, pairs_used, pairs_skipped,
+                base_params, base_recall, base_mrr,
+                best_params, best_recall, best_mrr,
+                diff, recommended)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(now())
+        .bind(run.judged_count)
+        .bind(run.pairs_used)
+        .bind(run.pairs_skipped)
+        .bind(json(&run.base)?)
+        .bind(run.base_recall)
+        .bind(run.base_mrr)
+        .bind(json(&run.best)?)
+        .bind(run.best_recall)
+        .bind(run.best_mrr)
+        .bind(json(&run.diff)?)
+        .bind(run.recommended as i64)
+        .execute(&self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    /// The most recent sweep, recommended or not. What paces the next one.
+    pub async fn latest_eval_run(&self) -> Result<Option<EvalRun>> {
+        let row = sqlx::query("SELECT * FROM eval_runs ORDER BY created_at DESC, id DESC LIMIT 1")
+            .fetch_optional(&self.pool)
+            .await?;
+        row.map(hydrate).transpose()
+    }
+
+    /// The recommendation waiting for an answer, if there is one.
+    ///
+    /// Only the newest: an older recommendation was measured against a
+    /// configuration that may since have changed, and offering two at once
+    /// would invite applying the stale one.
+    pub async fn open_recommendation(&self) -> Result<Option<EvalRun>> {
+        let row = sqlx::query(
+            "SELECT * FROM eval_runs WHERE recommended = 1 AND applied_at IS NULL
+             ORDER BY created_at DESC, id DESC LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(hydrate).transpose()
+    }
+
+    pub async fn eval_run(&self, id: &str) -> Result<Option<EvalRun>> {
+        let row = sqlx::query("SELECT * FROM eval_runs WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+        row.map(hydrate).transpose()
+    }
+
+    /// Stamp a run as applied. `false` if it was already, which is how a
+    /// double-submitted apply is refused rather than counted twice.
+    pub async fn mark_eval_run_applied(&self, id: &str) -> Result<bool> {
+        let res =
+            sqlx::query("UPDATE eval_runs SET applied_at = ? WHERE id = ? AND applied_at IS NULL")
+                .bind(now())
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// What has actually been changed, newest first. The provenance a commit
+    /// message used to carry.
+    pub async fn applied_eval_runs(&self, limit: i64) -> Result<Vec<EvalRun>> {
+        sqlx::query(
+            "SELECT * FROM eval_runs WHERE applied_at IS NOT NULL
+             ORDER BY applied_at DESC, id DESC LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?
+        .into_iter()
+        .map(hydrate)
+        .collect()
+    }
+}
+
+/// A row this binary cannot read is a broken row, not an empty one: a sweep
+/// silently rehydrated with default settings would recommend against a
+/// baseline nobody ever ran.
+fn parse<T: serde::de::DeserializeOwned>(raw: &str) -> Result<T> {
+    serde_json::from_str(raw).map_err(|e| Error::Store(format!("eval_runs: {e}")))
+}
+
+fn json<T: serde::Serialize>(v: &T) -> Result<String> {
+    serde_json::to_string(v).map_err(|e| Error::Store(format!("eval_runs: {e}")))
+}
+
+fn hydrate(row: sqlx::sqlite::SqliteRow) -> Result<EvalRun> {
+    Ok(EvalRun {
+        id: row.get("id"),
+        created_at: row.get("created_at"),
+        judged_count: row.get("judged_count"),
+        pairs_used: row.get("pairs_used"),
+        pairs_skipped: row.get("pairs_skipped"),
+        base_params: parse(row.get("base_params"))?,
+        base_recall: row.get("base_recall"),
+        base_mrr: row.get("base_mrr"),
+        best_params: parse(row.get("best_params"))?,
+        best_recall: row.get("best_recall"),
+        best_mrr: row.get("best_mrr"),
+        diff: parse(row.get("diff"))?,
+        recommended: row.get::<i64, _>("recommended") == 1,
+        applied_at: row.get("applied_at"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(recommended: bool) -> NewEvalRun {
+        let base = RunParams {
+            recency_weight: 0.05,
+            per_source_cap: Some(3),
+        };
+        let best = if recommended {
+            RunParams {
+                recency_weight: 0.1,
+                per_source_cap: None,
+            }
+        } else {
+            base
+        };
+        NewEvalRun {
+            judged_count: 50,
+            pairs_used: 12,
+            pairs_skipped: 1,
+            base,
+            base_recall: 0.70,
+            base_mrr: 0.50,
+            best,
+            best_recall: if recommended { 0.80 } else { 0.70 },
+            best_mrr: if recommended { 0.60 } else { 0.50 },
+            diff: vec![DiffRow {
+                query: "the image will not mount".into(),
+                base: None,
+                new: Some(2),
+            }],
+            recommended,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_recommendation_is_open_until_applied_and_applies_once() {
+        let store = Store::memory().await.unwrap();
+        let id = store.record_eval_run(&sample(true)).await.unwrap();
+        assert_eq!(
+            store.open_recommendation().await.unwrap().map(|r| r.id),
+            Some(id.clone())
+        );
+
+        assert!(store.mark_eval_run_applied(&id).await.unwrap());
+        assert!(
+            store.open_recommendation().await.unwrap().is_none(),
+            "an applied recommendation must stop being offered"
+        );
+        assert!(
+            !store.mark_eval_run_applied(&id).await.unwrap(),
+            "a replayed apply must be refused rather than stamped twice"
+        );
+
+        let applied = store.applied_eval_runs(10).await.unwrap();
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].best_params.per_source_cap, None);
+        assert_eq!(applied[0].diff.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_quiet_sweep_is_recorded_but_never_recommended() {
+        // The silence has to be explainable: without the row, a page can only
+        // say nothing at all, which reads as "no sweep has ever run".
+        let store = Store::memory().await.unwrap();
+        store.record_eval_run(&sample(false)).await.unwrap();
+        assert!(store.open_recommendation().await.unwrap().is_none());
+
+        let latest = store.latest_eval_run().await.unwrap().unwrap();
+        assert!(!latest.recommended);
+        assert_eq!(latest.base_params, latest.best_params);
+        assert_eq!(latest.pairs_skipped, 1);
+    }
+}

--- a/src/store/eval_runs.rs
+++ b/src/store/eval_runs.rs
@@ -118,17 +118,18 @@ impl Store {
 
     /// The recommendation waiting for an answer, if there is one.
     ///
-    /// Only the newest: an older recommendation was measured against a
-    /// configuration that may since have changed, and offering two at once
-    /// would invite applying the stale one.
+    /// The latest run, and only if that run is itself an open recommendation.
+    /// Selecting the newest *recommended* row instead left every older one
+    /// alive behind it: a sweep recommends X, a later sweep over more evidence
+    /// recommends Y, the operator applies Y — and X, measured against a
+    /// baseline that is no longer in force and already refused by the newer
+    /// evidence, was offered again on the next render. A sweep is the last
+    /// word on what these pairs say, including when what it says is nothing.
     pub async fn open_recommendation(&self) -> Result<Option<EvalRun>> {
-        let row = sqlx::query(
-            "SELECT * FROM eval_runs WHERE recommended = 1 AND applied_at IS NULL
-             ORDER BY created_at DESC, id DESC LIMIT 1",
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-        row.map(hydrate).transpose()
+        Ok(self
+            .latest_eval_run()
+            .await?
+            .filter(|r| r.recommended && r.applied_at.is_none()))
     }
 
     pub async fn eval_run(&self, id: &str) -> Result<Option<EvalRun>> {
@@ -256,6 +257,40 @@ mod tests {
         assert_eq!(applied.len(), 1);
         assert_eq!(applied[0].best_params.per_source_cap, None);
         assert_eq!(applied[0].diff.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_later_sweep_retires_the_recommendation_before_it() {
+        // The stale one used to outlive the fresh one. A sweep recommends X,
+        // more judgements arrive, a second sweep recommends Y, the operator
+        // takes Y — and X came back on the next render, measured against a
+        // baseline no longer in force and already refused by the newer
+        // evidence. Applying it would have walked the ranking backwards.
+        let store = Store::memory().await.unwrap();
+        let old = store.record_eval_run(&sample(true)).await.unwrap();
+        let new = store.record_eval_run(&sample(true)).await.unwrap();
+        assert_eq!(
+            store.open_recommendation().await.unwrap().map(|r| r.id),
+            Some(new.clone())
+        );
+
+        assert!(store.mark_eval_run_applied(&new).await.unwrap());
+        assert!(
+            store.open_recommendation().await.unwrap().is_none(),
+            "the sweep before the applied one was offered again"
+        );
+        // The row is not rewritten — it recorded what it found, and that stays
+        // true. It is simply no longer the last word.
+        let old = store.eval_run(&old).await.unwrap().unwrap();
+        assert!(old.recommended && old.applied_at.is_none());
+
+        // A sweep that found nothing is just as much the last word: it looked
+        // at the same pairs, over more of them, and refused what the one before
+        // it had offered.
+        let quiet = Store::memory().await.unwrap();
+        quiet.record_eval_run(&sample(true)).await.unwrap();
+        quiet.record_eval_run(&sample(false)).await.unwrap();
+        assert!(quiet.open_recommendation().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -411,6 +411,13 @@ pub struct Miss {
     pub rank: Option<i64>,
 }
 
+/// A query and the artifact a person said answered it.
+#[derive(Debug, Clone)]
+pub struct JudgedPair {
+    pub query: String,
+    pub expect: String,
+}
+
 impl Store {
     /// The next event to judge: never-skipped first, newest first within that.
     ///
@@ -663,6 +670,38 @@ impl Store {
             rank: r.get("rank"),
         })
         .collect())
+    }
+
+    /// Every judgement that names an answer: the dataset a tuning sweep
+    /// replays, and the same rows `--export-eval` freezes into `pairs.json`.
+    ///
+    /// Gaps and discards are verdicts but not pairs — neither names an
+    /// artifact, so replaying one would be a query the ranking can only fail.
+    pub async fn judged_pairs(&self) -> Result<Vec<JudgedPair>> {
+        Ok(sqlx::query(
+            "SELECT query, expect_id FROM search_events
+             WHERE verdict = 'hit' AND expect_id IS NOT NULL
+             ORDER BY created_at, id",
+        )
+        .fetch_all(&self.pool)
+        .await?
+        .iter()
+        .map(|r| JudgedPair {
+            query: r.get("query"),
+            expect: r.get("expect_id"),
+        })
+        .collect())
+    }
+
+    /// Verdicts given since `since`. What the day's counter on the judge page
+    /// reads, so it counts the work done rather than the pairs produced.
+    pub async fn judged_since(&self, since: i64) -> Result<i64> {
+        Ok(
+            sqlx::query_scalar("SELECT count(*) FROM search_events WHERE judged_at >= ?")
+                .bind(since)
+                .fetch_one(&self.pool)
+                .await?,
+        )
     }
 
     /// Drop captured *unjudged* searches older than the window. `0` keeps them
@@ -1390,6 +1429,34 @@ mod tests {
         assert!((s.recall_at_10 - 1.0).abs() < 1e-9);
         // 1/1 and 1/3, averaged.
         assert!((s.mrr - (1.0 + 1.0 / 3.0) / 2.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn the_judged_pairs_are_the_answers_and_only_the_answers() {
+        // What a sweep replays. A gap and a discard are verdicts, and they
+        // count towards the judgement floor, but neither names an artifact:
+        // replayed as a pair, one would be a query the ranking can only fail.
+        let store = Store::memory().await.unwrap();
+        let hit = seed(&store, "the image will not mount", &["a", "b"]).await;
+        store.judge_hit(&hit, "a").await.unwrap();
+        let gap = seed(&store, "nothing about this", &["c"]).await;
+        store.judge(&gap, Verdict::Gap).await.unwrap();
+        let junk = seed(&store, "asdf", &["d"]).await;
+        store.judge(&junk, Verdict::Discard).await.unwrap();
+        seed(&store, "still waiting", &["e"]).await;
+
+        let pairs = store.judged_pairs().await.unwrap();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].query, "the image will not mount");
+        assert_eq!(pairs[0].expect, "a");
+
+        // The day's counter reads verdicts, not pairs: judging is the work
+        // being paced, and a gap is judging.
+        assert_eq!(store.judged_since(0).await.unwrap(), 3);
+        assert_eq!(
+            store.judged_since(crate::store::now() + 60).await.unwrap(),
+            0
+        );
     }
 
     #[tokio::test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -4,6 +4,7 @@ pub mod attachments;
 pub mod auth;
 pub mod context;
 pub mod corpora;
+pub mod eval_runs;
 pub mod feedback;
 pub mod gaps;
 pub mod insights;

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -350,6 +350,40 @@ CREATE TABLE IF NOT EXISTS search_candidates (
   PRIMARY KEY (event_id, rank)
 );
 
+-- ── Tuning sweeps ────────────────────────────────────────────────────────────
+-- One row per background sweep over the judged pairs: what the running
+-- configuration scored, the best the grid found, and whether the gate let that
+-- become a recommendation. A number recorded without the configuration that
+-- produced it cannot be compared against anything, so the settings are stored
+-- beside the figures rather than left to a commit message to remember.
+--
+-- `diff` holds query prefixes and ranks. No artifact text is written here, for
+-- the same reason the harness never prints any.
+CREATE TABLE IF NOT EXISTS eval_runs (
+  id            TEXT PRIMARY KEY,
+  created_at    INTEGER NOT NULL,
+  -- Verdicts given when this ran: what the next sweep measures its distance
+  -- from, so a re-sweep is paced by new judgements rather than by the clock.
+  judged_count  INTEGER NOT NULL,
+  pairs_used    INTEGER NOT NULL,
+  -- Pairs whose artifact is gone. Housekeeping, not a ranking result, and
+  -- counted rather than scored as a miss.
+  pairs_skipped INTEGER NOT NULL,
+  base_params   TEXT NOT NULL,
+  base_recall   REAL NOT NULL,
+  base_mrr      REAL NOT NULL,
+  -- Equal to the baseline when nothing passed the gate, which is what a quiet
+  -- sweep is: recorded, so the silence can be explained.
+  best_params   TEXT NOT NULL,
+  best_recall   REAL NOT NULL,
+  best_mrr      REAL NOT NULL,
+  diff          TEXT NOT NULL,
+  recommended   INTEGER NOT NULL,
+  applied_at    INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_eval_runs_open
+  ON eval_runs(recommended, applied_at, created_at DESC);
+
 -- ── Ask feedback ─────────────────────────────────────────────────────────────
 -- A question asked on the page, the answer it got and the excerpts the model
 -- was shown — so a verdict given later can be scored against exactly what

--- a/src/vector/memory.rs
+++ b/src/vector/memory.rs
@@ -705,6 +705,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_weighted_search_is_the_same_search_where_nothing_weighs_age() {
+        // The default implementation ignores the weight, and this store is
+        // what the tuning sweep's tests rank through: a sweep that silently
+        // scored every candidate identically would still pass its own gate.
+        let v = MemoryVectors::new();
+        v.ensure_collection(3).await.unwrap();
+        v.upsert(vec![
+            point("near", "s1", vec![1.0, 0.0, 0.0], &["a"], "procedure"),
+            point("far", "s1", vec![0.0, 0.0, 1.0], &["a"], "procedure"),
+        ])
+        .await
+        .unwrap();
+
+        let plain = v
+            .search(&[1.0, 0.0, 0.0], &Default::default(), 10, &wide())
+            .await
+            .unwrap();
+        let weighted = v
+            .search_weighted(&[1.0, 0.0, 0.0], &Default::default(), 10, &wide(), 0.9)
+            .await
+            .unwrap();
+        assert_eq!(
+            plain
+                .iter()
+                .map(|h| &h.payload.artifact_id)
+                .collect::<Vec<_>>(),
+            weighted
+                .iter()
+                .map(|h| &h.payload.artifact_id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
     async fn limit_is_respected() {
         let v = MemoryVectors::new();
         v.ensure_collection(3).await.unwrap();

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -269,6 +269,24 @@ pub trait VectorStore: Send + Sync {
         limit: usize,
         filter: &SearchFilter,
     ) -> Result<Vec<SearchHit>>;
+    /// `search`, with the recency weight chosen per call rather than fixed
+    /// when the store was connected.
+    ///
+    /// The default ignores it and delegates: only a store that applies recency
+    /// at all has anything to vary, and the tuning sweep is the one caller that
+    /// needs to — it ranks the same pairs under several weights in one pass, so
+    /// the knob cannot live in the connection.
+    async fn search_weighted(
+        &self,
+        vector: &[f32],
+        sparse: &sparse::SparseVector,
+        limit: usize,
+        filter: &SearchFilter,
+        recency_weight: f32,
+    ) -> Result<Vec<SearchHit>> {
+        let _ = recency_weight;
+        self.search(vector, sparse, limit, filter).await
+    }
     /// Record that these chunks were just shown. Merged into the stored
     /// payload, never written as a whole one. `last_seen_at` is stamped for
     /// every target; `hit_count` only for the ones marked `counts_as_hit`.

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -1533,12 +1533,26 @@ impl VectorStore for QdrantVectors {
             .collect())
     }
 
+    /// Under the weight this store was connected with, which is the configured
+    /// one until a tuning sweep applies another.
     async fn search(
         &self,
         vector: &[f32],
         sparse: &SparseVector,
         limit: usize,
         filter: &SearchFilter,
+    ) -> Result<Vec<SearchHit>> {
+        self.search_weighted(vector, sparse, limit, filter, self.recency_weight)
+            .await
+    }
+
+    async fn search_weighted(
+        &self,
+        vector: &[f32],
+        sparse: &SparseVector,
+        limit: usize,
+        filter: &SearchFilter,
+        recency_weight: f32,
     ) -> Result<Vec<SearchHit>> {
         let f = build_filter(filter);
 
@@ -1582,7 +1596,7 @@ impl VectorStore for QdrantVectors {
         // Recency and pinning are applied as a final scoring stage over
         // whatever retrieval returned, so they reorder results without
         // changing which ones were retrieved.
-        if self.recency_weight > 0.0 || self.pinned_boost > 0.0 {
+        if recency_weight > 0.0 || self.pinned_boost > 0.0 {
             let mut prefetch = std::mem::replace(&mut body, Value::Null);
             // The payload is fetched once, by the outer stage. Asking the
             // prefetch for it too would carry every candidate's full text
@@ -1595,7 +1609,7 @@ impl VectorStore for QdrantVectors {
                 "query": scoring_formula(
                     now_secs(),
                     self.recency_half_life_days as u64 * SECONDS_PER_DAY,
-                    self.recency_weight,
+                    recency_weight,
                     self.pinned_boost,
                 ),
                 "limit": limit,

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -2047,6 +2047,7 @@ mod tests {
             recency_half_life_days: 180,
             pinned_boost: 0.15,
             weak_below: 0.35,
+            per_source_cap: 3,
         })
         .await
         .unwrap();
@@ -2366,6 +2367,7 @@ mod tests {
             recency_half_life_days: 180,
             pinned_boost: 0.15,
             weak_below: 0.35,
+            per_source_cap: 3,
         })
         .await
         .unwrap()

--- a/src/web/auth_routes.rs
+++ b/src/web/auth_routes.rs
@@ -444,6 +444,7 @@ mod tests {
                 pending: crate::auth::oidc::PendingStore::new(),
                 secure_cookies: true,
             }),
+            config_path: std::sync::Arc::new(crate::web::test_support::scratch_config()),
             ask_handoff: Default::default(),
         };
         let res = crate::web::router(state)

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -53,6 +53,33 @@ pub struct Card {
     pub choices: Vec<Choice>,
 }
 
+/// The header's live half: what is true right now, and what just moved.
+///
+/// One struct rather than a dozen template fields because it is rendered
+/// twice — once in the page, once out of band beside the next card — and two
+/// copies of the same dozen fields would drift.
+pub struct Pulse {
+    pub judged: i64,
+    /// The judgement count the next sweep runs at.
+    pub target: i64,
+    pub pct: i64,
+    /// What that target buys, in the words for a first sweep or a later one.
+    pub label: &'static str,
+    pub recall: String,
+    pub mrr: String,
+    /// `▲ +0.01`, or empty where nothing was judged. What the tick renders on.
+    pub delta: String,
+    /// Verdicts in the last 24 hours. Not "today": the zone that would define
+    /// a midnight belongs to the client, never to the server — see
+    /// `core::context::local_time` — and a window needs no zone at all.
+    pub recent: i64,
+    pub pending: i64,
+    pub hits: i64,
+    pub finds: i64,
+    pub gaps: i64,
+    pub discards: i64,
+}
+
 #[derive(Template)]
 #[template(path = "judge.html")]
 struct JudgeTemplate {
@@ -61,11 +88,11 @@ struct JudgeTemplate {
     /// this page too, so the badge falls as the queue is worked down rather
     /// than standing at whatever it read on arrival.
     judge_pending: Option<i64>,
-    stats: Stats,
-    recall: String,
-    mrr: String,
-    target: i64,
-    progress_pct: i64,
+    /// Always `Some` here. `Option` because the partial is shared with the
+    /// card fragment, where a plain fetch carries none.
+    pulse: Option<Pulse>,
+    /// False on the page itself: it is drawing the header, not replacing one.
+    pulse_oob: bool,
     misses: Vec<crate::store::feedback::Miss>,
     /// Questions asked and judged, beside the searches. Read from the same
     /// database and moved by every verdict on the ask page.
@@ -84,6 +111,12 @@ struct CardTemplate {
     /// What the judgement just before this one revealed. `None` on a plain
     /// fetch of the next card.
     flash: Option<Flash>,
+    /// The header, shipped beside the card so it moves with the work. `None`
+    /// where nothing was judged: an animation on a plain fetch would be the
+    /// page congratulating itself for a page load.
+    pulse: Option<Pulse>,
+    /// True here: the header this replaces is already on the page.
+    pulse_oob: bool,
 }
 
 pub struct Flash {
@@ -208,6 +241,45 @@ async fn next_pending_card(st: &AppState) -> Result<Option<Card>> {
     }
 }
 
+/// What the header shows, and what — if anything — just moved.
+///
+/// The target is the next sweep rather than a fixed milestone: what a
+/// judgement buys is a measurement, and after the first one the distance is to
+/// the next re-sweep. Read from the last run rather than counted, so the two
+/// always agree about when it is due.
+async fn pulse_of(st: &AppState, stats: &Stats, delta: String) -> Result<Pulse> {
+    let tune = &st.core.feedback.tune;
+    let (target, label) = match st.core.store.latest_eval_run().await? {
+        None => (tune.min_judgements, "until the first sweep"),
+        Some(last) => (
+            last.judged_count + tune.resweep_after,
+            "until the next sweep",
+        ),
+    };
+    // A target already passed would draw a bar over 100% and a hint counting
+    // backwards; it happens whenever a sweep is queued but has not run yet.
+    let target = target.max(stats.judged).max(1);
+    Ok(Pulse {
+        judged: stats.judged,
+        pct: (stats.judged * 100 / target).min(100),
+        target,
+        label,
+        recall: format!("{:.2}", stats.recall_at_10),
+        mrr: format!("{:.2}", stats.mrr),
+        delta,
+        recent: st
+            .core
+            .store
+            .judged_since(crate::store::now() - 86_400)
+            .await?,
+        pending: stats.pending,
+        hits: stats.hits,
+        finds: stats.finds,
+        gaps: stats.gaps,
+        discards: stats.discards,
+    })
+}
+
 async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     use axum::response::IntoResponse;
     let stats = st.core.store.feedback_stats().await?;
@@ -216,15 +288,11 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     } else {
         vec![]
     };
-    let progress_pct = (stats.judged * 100 / FIRST_SWEEP_AT.max(1)).min(100);
     Ok(HtmlTemplate(JudgeTemplate {
         // Read off the stats already in hand rather than counted again.
         judge_pending: st.core.learn.enabled.then_some(stats.pending),
-        recall: format!("{:.2}", stats.recall_at_10),
-        mrr: format!("{:.2}", stats.mrr),
-        target: FIRST_SWEEP_AT,
-        progress_pct,
-        stats,
+        pulse: Some(pulse_of(&st, &stats, String::new()).await?),
+        pulse_oob: false,
         misses,
         asks: st.core.store.ask_stats().await?,
         card: next_pending_card(&st).await?,
@@ -238,6 +306,8 @@ async fn next_card(State(st): State<AppState>, _id: Identity) -> Result<Response
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(&st).await?,
         flash: None,
+        pulse: None,
+        pulse_oob: true,
     })
     .into_response())
 }
@@ -253,11 +323,22 @@ async fn card_after(
     judged: &str,
 ) -> Result<Response> {
     use axum::response::IntoResponse;
-    let after = st.core.store.feedback_stats().await?.mrr;
+    let stats = st.core.store.feedback_stats().await?;
+    let after = stats.mrr;
     // A verdict is what buys the next measurement. Off the request path: the
     // operator must not wait on a grid of searches, and a sweep that fails
     // must not fail the verdict that paid for it.
     crate::eval::sweep::maybe_spawn(&st.core);
+    let moved = after - before;
+    // Under half a point the figure on screen does not change, and a tick
+    // pointing at an unchanged number is an animation about nothing.
+    let delta = if moved.abs() < 0.005 {
+        String::new()
+    } else if moved > 0.0 {
+        format!("▲ +{moved:.2}")
+    } else {
+        format!("▼ −{:.2}", moved.abs())
+    };
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(st).await?,
         flash: Some(Flash {
@@ -265,6 +346,8 @@ async fn card_after(
             delta: format!("MRR {before:.2} → {after:.2}"),
             undo: Some(judged.to_string()),
         }),
+        pulse: Some(pulse_of(st, &stats, delta).await?),
+        pulse_oob: true,
     })
     .into_response())
 }
@@ -288,6 +371,9 @@ async fn card_again(st: &AppState, event_id: &str, line: &str) -> Result<Respons
             delta: String::new(),
             undo: None,
         }),
+        // Nothing was recorded, so no figure moved.
+        pulse: None,
+        pulse_oob: true,
     })
     .into_response())
 }
@@ -337,7 +423,15 @@ async fn undo(
         // is a better answer than an error page.
         None => next_pending_card(&st).await?,
     };
-    Ok(HtmlTemplate(CardTemplate { card, flash: None }).into_response())
+    Ok(HtmlTemplate(CardTemplate {
+        card,
+        flash: None,
+        // An undo moves the figures back, and the operator is looking at the
+        // header while it happens.
+        pulse: Some(pulse_of(&st, &st.core.store.feedback_stats().await?, String::new()).await?),
+        pulse_oob: true,
+    })
+    .into_response())
 }
 
 #[derive(serde::Deserialize)]
@@ -1381,6 +1475,63 @@ mod tests {
             "stamped a change that was never made"
         );
         assert!(core.store.open_recommendation().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn the_header_explains_the_numbers_it_shows() {
+        // They were shown bare: an operator who had not read docs/evaluation.md
+        // was asked to work towards two figures nobody had told them the
+        // meaning of, and towards a target that named no reward.
+        let (app, cookie, _core, _) = judge_app(2, &[]).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains("Mean reciprocal rank"), "MRR unexplained");
+        assert!(body.contains("top ten"), "recall@10 unexplained");
+        assert!(
+            body.contains("tries other ranking settings"),
+            "the progress bar must say what it is progress towards"
+        );
+        assert!(body.contains("until the first sweep"));
+        assert!(body.contains("last 24h"), "the day's work is not counted");
+    }
+
+    #[tokio::test]
+    async fn a_verdict_ships_the_header_beside_the_next_card() {
+        // The header lives outside the swapped region, so without this it
+        // stood at whatever it read on arrival while the queue was worked
+        // down — the one figure the work is measured by, frozen.
+        let (app, cookie, core, ids) = judge_app(2, &[]).await;
+        let event = core.store.next_pending().await.unwrap().unwrap();
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/ui/judge/{}/hit", event.id))
+                    .method("POST")
+                    .header("cookie", &cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(format!("artifact_id={}", ids[0])))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_of(res).await;
+
+        assert!(body.contains(r#"id="judge-live""#), "no header shipped");
+        assert!(body.contains("hx-swap-oob"), "the header would not land");
+        assert!(
+            body.contains("judge-tick"),
+            "the figure that moved must show that it moved"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_card_fetched_without_a_verdict_animates_nothing() {
+        // Nothing was judged, so nothing moved. An animation here would be the
+        // page congratulating itself for a page load.
+        let (app, cookie, _core, _) = judge_app(2, &[]).await;
+        let body = get(&app, "/ui/judge/next", &cookie).await;
+        assert!(!body.contains("hx-swap-oob"), "{body}");
+        assert!(!body.contains("judge-tick"), "{body}");
     }
 
     #[tokio::test]

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -93,6 +93,10 @@ struct JudgeTemplate {
     pulse: Option<Pulse>,
     /// False on the page itself: it is drawing the header, not replacing one.
     pulse_oob: bool,
+    /// What the sweeps have to say. Always `Some` here; `Option` because the
+    /// partial is shared with the card fragment and the apply answer.
+    tune: Option<TuneView>,
+    tune_oob: bool,
     misses: Vec<crate::store::feedback::Miss>,
     /// Questions asked and judged, beside the searches. Read from the same
     /// database and moved by every verdict on the ask page.
@@ -117,6 +121,10 @@ struct CardTemplate {
     pulse: Option<Pulse>,
     /// True here: the header this replaces is already on the page.
     pulse_oob: bool,
+    /// A sweep runs off the request path, so the page that paid for it was
+    /// already sent. The next verdict is the first chance to report one.
+    tune: Option<TuneView>,
+    tune_oob: bool,
 }
 
 pub struct Flash {
@@ -293,6 +301,8 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         judge_pending: st.core.learn.enabled.then_some(stats.pending),
         pulse: Some(pulse_of(&st, &stats, String::new()).await?),
         pulse_oob: false,
+        tune: Some(tune_view(&st, "").await?),
+        tune_oob: false,
         misses,
         asks: st.core.store.ask_stats().await?,
         card: next_pending_card(&st).await?,
@@ -308,6 +318,8 @@ async fn next_card(State(st): State<AppState>, _id: Identity) -> Result<Response
         flash: None,
         pulse: None,
         pulse_oob: true,
+        tune: None,
+        tune_oob: true,
     })
     .into_response())
 }
@@ -348,6 +360,8 @@ async fn card_after(
         }),
         pulse: Some(pulse_of(st, &stats, delta).await?),
         pulse_oob: true,
+        tune: Some(tune_view(st, "").await?),
+        tune_oob: true,
     })
     .into_response())
 }
@@ -374,6 +388,8 @@ async fn card_again(st: &AppState, event_id: &str, line: &str) -> Result<Respons
         // Nothing was recorded, so no figure moved.
         pulse: None,
         pulse_oob: true,
+        tune: None,
+        tune_oob: true,
     })
     .into_response())
 }
@@ -430,6 +446,8 @@ async fn undo(
         // header while it happens.
         pulse: Some(pulse_of(&st, &st.core.store.feedback_stats().await?, String::new()).await?),
         pulse_oob: true,
+        tune: None,
+        tune_oob: true,
     })
     .into_response())
 }
@@ -634,13 +652,121 @@ async fn assign_results(
     .into_response())
 }
 
+// ── What the sweeps have to say ─────────────────────────────────────────────
+
+/// A recommendation, ready to read and to take.
+pub struct Rec {
+    pub id: String,
+    /// What would change and what it buys, in one line.
+    pub line: String,
+    /// The pairs that move under it. Mandatory, never folded away: an
+    /// aggregate says something moved, and only this says what.
+    pub diff: Vec<String>,
+}
+
+pub struct TuneView {
+    pub rec: Option<Rec>,
+    /// Why there is nothing to offer, when a sweep has run and found nothing.
+    /// Empty before the first sweep, where the honest answer is silence.
+    pub quiet: String,
+    pub applied: Vec<String>,
+    /// What the press just before this one did.
+    pub flash: String,
+}
+
+#[derive(Template)]
+#[template(path = "_judge_tune.html")]
+struct TuneTemplate {
+    tune: Option<TuneView>,
+    tune_oob: bool,
+}
+
+fn cap_str(c: Option<usize>) -> String {
+    c.map_or("none".to_string(), |n| n.to_string())
+}
+
+/// One line naming what changes and what it is worth.
+///
+/// Every figure is read off the run rather than recomputed: a number and the
+/// settings that produced it travel together, which is the whole of what the
+/// `eval_runs` row is for.
+fn describe(run: &crate::store::eval_runs::EvalRun) -> String {
+    format!(
+        "recency {:.2} → {:.2}, cap {} → {} · MRR {:.2} → {:.2}, recall@10 {:.2} → {:.2}, \
+         over {} pairs",
+        run.base_params.recency_weight,
+        run.best_params.recency_weight,
+        cap_str(run.base_params.per_source_cap),
+        cap_str(run.best_params.per_source_cap),
+        run.base_mrr,
+        run.best_mrr,
+        run.base_recall,
+        run.best_recall,
+        run.pairs_used,
+    )
+}
+
+fn rank_str(r: Option<usize>) -> String {
+    r.map_or("not in the first ten".to_string(), |i| {
+        format!("position {}", i + 1)
+    })
+}
+
+async fn tune_view(st: &AppState, flash: &str) -> Result<TuneView> {
+    let rec = st.core.store.open_recommendation().await?.map(|run| Rec {
+        line: describe(&run),
+        diff: run
+            .diff
+            .iter()
+            .map(|d| format!("{} — {} → {}", d.query, rank_str(d.base), rank_str(d.new)))
+            .collect(),
+        id: run.id,
+    });
+    // Only where a sweep has actually run and come back empty. Before the
+    // first one there is nothing to explain, and a line explaining nothing is
+    // one more thing on a page that has enough.
+    let quiet = match (&rec, st.core.store.latest_eval_run().await?) {
+        (None, Some(last)) if !last.recommended => format!(
+            "last sweep {}: no improvement found over {} pairs.",
+            ago(last.created_at),
+            last.pairs_used
+        ),
+        _ => String::new(),
+    };
+    let applied = st
+        .core
+        .store
+        .applied_eval_runs(10)
+        .await?
+        .iter()
+        .map(|r| {
+            format!(
+                "{} — {}",
+                ago(r.applied_at.unwrap_or(r.created_at)),
+                describe(r)
+            )
+        })
+        .collect();
+    Ok(TuneView {
+        rec,
+        quiet,
+        applied,
+        flash: flash.to_string(),
+    })
+}
+
 // ── Taking a recommendation live ────────────────────────────────────────────
 
 /// The tuning block, redrawn, with a line about what just happened.
 async fn tune_fragment(st: &AppState, line: &str) -> Result<Response> {
     use axum::response::IntoResponse;
-    let _ = st;
-    Ok(axum::response::Html(format!("<div id=\"judge-tune\">{line}</div>")).into_response())
+    Ok(HtmlTemplate(TuneTemplate {
+        tune: Some(tune_view(st, line).await?),
+        // Answering the button inside the block itself, which htmx swaps by
+        // target rather than by id.
+        tune_oob: false,
+    })
+    .into_response())
 }
 
 /// Apply the open recommendation: the file first, then the running parameters,
@@ -1532,6 +1658,106 @@ mod tests {
         let body = get(&app, "/ui/judge/next", &cookie).await;
         assert!(!body.contains("hx-swap-oob"), "{body}");
         assert!(!body.contains("judge-tick"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn an_open_recommendation_is_offered_with_the_pairs_that_moved() {
+        let (app, cookie, _core, run, _) = tune_app(true).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains(&format!("/ui/judge/tune/{run}/apply")));
+        assert!(body.contains("recency"), "the line must name what changes");
+        assert!(body.contains("cap"), "both knobs are named");
+        assert!(body.contains("MRR 0.50 → 0.60"), "{body}");
+        assert!(
+            body.contains("what changes"),
+            "the diff is the part that decides it, not an extra"
+        );
+        assert!(
+            body.contains("the image will not mount"),
+            "the moved pair is named by its own query"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_found_nothing_says_so_rather_than_going_quiet() {
+        // Silence reads as "no sweep has ever run", which is a different fact
+        // and the wrong one.
+        let (app, cookie, _core, _, _) = tune_app(false).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains("no improvement found"), "{body}");
+        assert!(!body.contains("/apply"), "nothing to apply was offered");
+    }
+
+    #[tokio::test]
+    async fn before_any_sweep_the_block_says_nothing_at_all() {
+        let (app, cookie, _core, _) = judge_app(2, &[]).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(!body.contains("no improvement found"));
+        assert!(!body.contains("/apply"));
+        assert!(!body.contains("tuning history"));
+    }
+
+    #[tokio::test]
+    async fn an_applied_change_stands_in_the_history_with_its_numbers() {
+        // The provenance rule, made structural: a number without the settings
+        // that produced it cannot be compared against anything.
+        let (app, cookie, _core, run, _) = tune_app(true).await;
+        post(&app, &format!("/ui/judge/tune/{run}/apply"), &cookie, "").await;
+
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains("tuning history"), "{body}");
+        assert!(body.contains("MRR 0.50 → 0.60"), "{body}");
+        assert!(body.contains("cap 3 → none"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn applying_answers_with_the_block_it_replaces() {
+        // htmx swaps `#judge-tune` by id: a reply that is not that block would
+        // leave the recommendation on screen after it was taken.
+        let (app, cookie, _core, run, _) = tune_app(true).await;
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/ui/judge/tune/{run}/apply"))
+                    .method("POST")
+                    .header("cookie", &cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_of(res).await;
+        assert!(body.contains(r#"id="judge-tune""#), "{body}");
+        assert!(body.contains("applied"), "{body}");
+        assert!(!body.contains("/apply"), "it is still offering itself");
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_finished_in_the_background_surfaces_on_the_next_verdict() {
+        // It runs off the request path, so the page that paid for it has
+        // already been sent. The next verdict is the first chance to say so.
+        let (app, cookie, core, ids) = judge_app_tuned(2, &[], Some(1)).await;
+        let event = core.store.next_pending().await.unwrap().unwrap();
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/ui/judge/{}/hit", event.id))
+                    .method("POST")
+                    .header("cookie", &cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(format!("artifact_id={}", ids[0])))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_of(res).await;
+        assert!(
+            body.contains(r#"id="judge-tune""#),
+            "the verdict carried no tuning block: {body}"
+        );
     }
 
     #[tokio::test]

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -20,13 +20,6 @@ use axum::extract::{Path, State};
 use axum::response::Response;
 use axum::routing::{get, post};
 
-/// Judgements before the first parameter sweep can say anything.
-///
-/// Below this a proposal is noise: half a dozen queries cannot separate a real
-/// improvement from the quirks of half a dozen queries. The tuning plan replaces
-/// this constant with `feedback.tune.min_judgements`.
-pub const FIRST_SWEEP_AT: i64 = 50;
-
 /// Judgements before the miss list is worth opening.
 const MISS_LIST_AT: i64 = 10;
 
@@ -1437,14 +1430,14 @@ mod tests {
         // under the same grid give the same answer, at the cost of a grid of
         // searches per verdict.
         let (app, cookie, core, ids) = judge_app_tuned(3, &[], Some(1)).await;
-        for i in 0..2 {
+        for id in ids.iter().take(2) {
             let event = core.store.next_pending().await.unwrap();
             let Some(event) = event else { break };
             post(
                 &app,
                 &format!("/ui/judge/{}/hit", event.id),
                 &cookie,
-                &format!("artifact_id={}", ids[i]),
+                &format!("artifact_id={id}"),
             )
             .await;
             core.background.wait_idle().await;

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -836,7 +836,21 @@ async fn tune_apply(
     // would have read "nothing happened" about a server that is now running
     // settings its history does not mention.
     match st.core.store.mark_eval_run_applied(&run_id).await {
-        Ok(true) => tune_fragment(&st, "applied — the next search runs with these settings.").await,
+        // The environment is layered over the file, so where one of these keys
+        // is set the write is real and the restart undoes it. Said now, beside
+        // the button, rather than discovered months later as a history claiming
+        // settings the server stopped running at its last boot.
+        Ok(true) => {
+            let line = match crate::config::ranking_keys_in_env().as_slice() {
+                [] => "applied — the next search runs with these settings.".to_string(),
+                keys => format!(
+                    "applied — the next search runs with these settings, but {} is set in the \
+                     environment and will overrule the file at the next restart.",
+                    keys.join(" and ")
+                ),
+            };
+            tune_fragment(&st, &line).await
+        }
         Ok(false) => {
             tune_fragment(
                 &st,

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -53,8 +53,12 @@ pub struct Card {
 /// copies of the same dozen fields would drift.
 pub struct Pulse {
     pub judged: i64,
+    /// The judgement count the last sweep ran at, and so where this stretch of
+    /// the bar starts. Zero before the first one.
+    pub floor: i64,
     /// The judgement count the next sweep runs at.
     pub target: i64,
+    /// How far along the stretch between the two, not how far along the count.
     pub pct: i64,
     /// What that target buys, in the words for a first sweep or a later one.
     pub label: &'static str,
@@ -250,19 +254,27 @@ async fn next_pending_card(st: &AppState) -> Result<Option<Card>> {
 /// always agree about when it is due.
 async fn pulse_of(st: &AppState, stats: &Stats, delta: String) -> Result<Pulse> {
     let tune = &st.core.feedback.tune;
-    let (target, label) = match st.core.store.latest_eval_run().await? {
-        None => (tune.min_judgements, "until the first sweep"),
-        Some(last) => (
-            last.judged_count + tune.resweep_after,
-            "until the next sweep",
-        ),
+    let (floor, label) = match st.core.store.latest_eval_run().await? {
+        None => (0, "until the first sweep"),
+        Some(last) => (last.judged_count, "until the next sweep"),
+    };
+    let target = match floor {
+        0 => tune.min_judgements,
+        n => n + tune.resweep_after,
     };
     // A target already passed would draw a bar over 100% and a hint counting
     // backwards; it happens whenever a sweep is queued but has not run yet.
     let target = target.max(stats.judged).max(1);
+    // Against the last sweep rather than against zero. Measured from zero the
+    // bar reads the share of all judgements ever given that have been swept —
+    // which after the first sweep is always nearly all of them, so it stood at
+    // 95% and then 96%, and the one visual the header is built around stopped
+    // saying anything.
+    let span = (target - floor).max(1);
     Ok(Pulse {
         judged: stats.judged,
-        pct: (stats.judged * 100 / target).min(100),
+        pct: ((stats.judged - floor).max(0) * 100 / span).min(100),
+        floor,
         target,
         label,
         recall: format!("{:.2}", stats.recall_at_10),
@@ -683,19 +695,26 @@ fn cap_str(c: Option<usize>) -> String {
 /// Every figure is read off the run rather than recomputed: a number and the
 /// settings that produced it travel together, which is the whole of what the
 /// `eval_runs` row is for.
+///
+/// "Replayed over N pairs" leads the figures rather than trailing them. They
+/// used to end the line, which put `MRR 0.50 → 0.60` immediately under the
+/// header's own MRR with nothing between them — two numbers of one name, one
+/// read from the ranks the searches actually gave and one from a replay of
+/// those searches through a door that skips priming. Neither is wrong; they
+/// are not the same quantity, and side by side they invited being read as one.
 fn describe(run: &crate::store::eval_runs::EvalRun) -> String {
     format!(
-        "recency {:.2} → {:.2}, cap {} → {} · MRR {:.2} → {:.2}, recall@10 {:.2} → {:.2}, \
-         over {} pairs",
+        "recency {:.2} → {:.2}, cap {} → {} · replayed over {} pairs: \
+         MRR {:.2} → {:.2}, recall@10 {:.2} → {:.2}",
         run.base_params.recency_weight,
         run.best_params.recency_weight,
         cap_str(run.base_params.per_source_cap),
         cap_str(run.best_params.per_source_cap),
+        run.pairs_used,
         run.base_mrr,
         run.best_mrr,
         run.base_recall,
         run.best_recall,
-        run.pairs_used,
     )
 }
 
@@ -777,9 +796,13 @@ async fn tune_apply(
     let Some(run) = st.core.store.eval_run(&run_id).await? else {
         return Err(crate::error::Error::NotFound);
     };
-    // A recommendation that was already taken, or a run that never was one:
-    // both arrive from a stale page, and neither is a reason to write anything.
-    if !run.recommended || run.applied_at.is_some() {
+    // A recommendation that was already taken, a run that never was one, or
+    // one a later sweep has since spoken over: all three arrive from a page
+    // left open, and none is a reason to write anything. Asked of the store
+    // rather than of this row, so what the button may take is exactly what the
+    // page may offer.
+    let open = st.core.store.open_recommendation().await?;
+    if open.as_ref().is_none_or(|o| o.id != run.id) {
         return tune_fragment(
             &st,
             "that sweep is not an open recommendation — nothing was changed.",
@@ -803,8 +826,34 @@ async fn tune_apply(
         .await;
     }
     *st.core.ranking.write().expect("ranking lock") = params;
-    st.core.store.mark_eval_run_applied(&run_id).await?;
-    tune_fragment(&st, "applied — the next search runs with these settings.").await
+    // The stamp is what closes the recommendation, so its answer is the one
+    // thing here that must not be dropped. `false` is the second press of the
+    // same button arriving while the first was still in flight: same run, same
+    // parameters, so the file and the running settings say what this press
+    // would have written anyway — but only one press gets to report a change.
+    // An error is worse than either, and raising it would have answered a 500
+    // to a request that did change the file and the parameters: the operator
+    // would have read "nothing happened" about a server that is now running
+    // settings its history does not mention.
+    match st.core.store.mark_eval_run_applied(&run_id).await {
+        Ok(true) => tune_fragment(&st, "applied — the next search runs with these settings.").await,
+        Ok(false) => {
+            tune_fragment(
+                &st,
+                "that sweep had already been applied — nothing changed.",
+            )
+            .await
+        }
+        Err(e) => {
+            tracing::error!(error = %e, run = %run_id, "applied run not stamped");
+            tune_fragment(
+                &st,
+                "these settings are live and written to config.toml, but the run could not be \
+                 recorded as applied — it may be offered again.",
+            )
+            .await
+        }
+    }
 }
 
 pub fn judge_router() -> Router<AppState> {
@@ -1669,6 +1718,108 @@ mod tests {
             body.contains("the image will not mount"),
             "the moved pair is named by its own query"
         );
+    }
+
+    #[tokio::test]
+    async fn the_page_draws_one_header_and_one_recommendation() {
+        // Both partials are shipped beside the card a verdict returns, and the
+        // page draws both itself. Included unconditionally they rendered a
+        // second time inside `#card`: the whole recommendation twice, and the
+        // lower Apply button swapping the upper copy — so the one the operator
+        // pressed stayed on screen, still offering what had just been taken.
+        let (app, cookie, _core, _run, _) = tune_app(true).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert_eq!(body.matches(r#"id="judge-live""#).count(), 1, "{body}");
+        assert_eq!(body.matches(r#"id="judge-tune""#).count(), 1, "{body}");
+        assert_eq!(body.matches("/apply").count(), 1, "two Apply buttons");
+    }
+
+    #[tokio::test]
+    async fn the_sweeps_figures_are_named_as_a_replay_rather_than_the_headers() {
+        // The line carries an MRR and a recall@10, and so does the header a few
+        // lines above it. Same names, different measurements: one is the ranks
+        // the searches gave, the other is those searches run again under each
+        // setting. Printed bare they read as one quantity moving.
+        let (app, cookie, _core, _run, _) = tune_app(true).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains("replayed over 12 pairs"), "{body}");
+        assert!(body.contains("from the replay"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn the_bar_counts_from_the_last_sweep_rather_than_from_zero() {
+        // Measured from zero it reads the share of every judgement ever given
+        // that has been swept — which after the first sweep is nearly all of
+        // them. It stood at 95%, then 96%, then 98%, and the one visual the
+        // header is built around stopped conveying anything.
+        let (app, cookie, core, ids) = judge_app(2, &[]).await;
+        let event = core.store.next_pending().await.unwrap().unwrap();
+        post(
+            &app,
+            &format!("/ui/judge/{}/hit", event.id),
+            &cookie,
+            &format!("artifact_id={}", ids[0]),
+        )
+        .await;
+        let swept_at = core.store.feedback_stats().await.unwrap().judged;
+        record_run_at(&core, swept_at).await;
+
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(
+            body.contains("width:0%"),
+            "the stretch to the next sweep has not started: {body}"
+        );
+        assert!(
+            body.contains(&format!(r#"aria-valuemin="{swept_at}""#)),
+            "the bar starts where the last sweep did: {body}"
+        );
+
+        // One further verdict is one tenth of the ten the next sweep waits for.
+        let id = core
+            .store
+            .record_search(
+                NewEvent {
+                    query: "a second question entirely".into(),
+                    door: Door::Ui,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![0.1, 0.2],
+                    embed_model: "fake".into(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        core.store.judge_hit(&id, &ids[0]).await.unwrap();
+
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains("width:10%"), "{body}");
+    }
+
+    /// A sweep in the store, recorded as having run at `judged`.
+    async fn record_run_at(core: &crate::core::Core, judged: i64) {
+        let params = crate::store::eval_runs::RunParams {
+            recency_weight: 0.05,
+            per_source_cap: Some(3),
+        };
+        core.store
+            .record_eval_run(&crate::store::eval_runs::NewEvalRun {
+                judged_count: judged,
+                pairs_used: 1,
+                pairs_skipped: 0,
+                base: params,
+                base_recall: 0.70,
+                base_mrr: 0.50,
+                best: params,
+                best_recall: 0.70,
+                best_mrr: 0.50,
+                diff: vec![],
+                recommended: false,
+            })
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -254,6 +254,10 @@ async fn card_after(
 ) -> Result<Response> {
     use axum::response::IntoResponse;
     let after = st.core.store.feedback_stats().await?.mrr;
+    // A verdict is what buys the next measurement. Off the request path: the
+    // operator must not wait on a grid of searches, and a sweep that fails
+    // must not fail the verdict that paid for it.
+    crate::eval::sweep::maybe_spawn(&st.core);
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(st).await?,
         flash: Some(Flash {
@@ -579,7 +583,24 @@ mod tests {
         real: usize,
         phantom: &[&str],
     ) -> (axum::Router, String, crate::core::Core, Vec<String>) {
-        let core = crate::core::test_support::test_core().await;
+        // Learning off and the shipped floor: the ordinary judging tests are
+        // never within reach of a sweep and never wait on one.
+        judge_app_tuned(real, phantom, None).await
+    }
+
+    /// `judge_app`, with tuning live and the judgement floor low enough that a
+    /// test can cross it.
+    async fn judge_app_tuned(
+        real: usize,
+        phantom: &[&str],
+        floor: Option<i64>,
+    ) -> (axum::Router, String, crate::core::Core, Vec<String>) {
+        let mut core = crate::core::test_support::test_core().await;
+        if let Some(n) = floor {
+            core.feedback.tune.min_judgements = n;
+            core.learn.enabled = true;
+        }
+        let core = core;
         let src = core
             .store
             .insert_corpus("raw for judging", "web", None)
@@ -1095,6 +1116,70 @@ mod tests {
         let body = body_of(res).await;
         assert!(body.contains("a find"), "the flash did not name it a find");
         assert_eq!(core.store.feedback_stats().await.unwrap().finds, 1);
+    }
+
+    #[tokio::test]
+    async fn a_verdict_past_the_floor_pays_for_a_sweep() {
+        // The loop the whole feature is: a verdict is what buys the next
+        // measurement, so the check rides on the verdict rather than a timer.
+        let (app, cookie, core, ids) = judge_app_tuned(2, &[], Some(1)).await;
+        let event = core.store.next_pending().await.unwrap().unwrap();
+        post(
+            &app,
+            &format!("/ui/judge/{}/hit", event.id),
+            &cookie,
+            &format!("artifact_id={}", ids[0]),
+        )
+        .await;
+        core.background.wait_idle().await;
+
+        let run = core.store.latest_eval_run().await.unwrap();
+        assert!(run.is_some(), "the floor was crossed and no sweep ran");
+        assert_eq!(run.unwrap().pairs_used, 1);
+    }
+
+    #[tokio::test]
+    async fn under_the_floor_a_verdict_buys_nothing() {
+        // Below it a sweep would recommend the quirks of a handful of queries
+        // as confidently as a real improvement.
+        let (app, cookie, core, ids) = judge_app_tuned(2, &[], Some(50)).await;
+        let event = core.store.next_pending().await.unwrap().unwrap();
+        post(
+            &app,
+            &format!("/ui/judge/{}/hit", event.id),
+            &cookie,
+            &format!("artifact_id={}", ids[0]),
+        )
+        .await;
+        core.background.wait_idle().await;
+
+        assert!(core.store.latest_eval_run().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_second_sweep_waits_for_new_judgements_rather_than_the_clock() {
+        // What makes a re-sweep worth running is new evidence: the same pairs
+        // under the same grid give the same answer, at the cost of a grid of
+        // searches per verdict.
+        let (app, cookie, core, ids) = judge_app_tuned(3, &[], Some(1)).await;
+        for i in 0..2 {
+            let event = core.store.next_pending().await.unwrap();
+            let Some(event) = event else { break };
+            post(
+                &app,
+                &format!("/ui/judge/{}/hit", event.id),
+                &cookie,
+                &format!("artifact_id={}", ids[i]),
+            )
+            .await;
+            core.background.wait_idle().await;
+        }
+
+        let runs: i64 = sqlx::query_scalar("SELECT count(*) FROM eval_runs")
+            .fetch_one(&core.store.pool)
+            .await
+            .unwrap();
+        assert_eq!(runs, 1, "one judgement is not ten");
     }
 
     #[tokio::test]

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -540,9 +540,64 @@ async fn assign_results(
     .into_response())
 }
 
+// ── Taking a recommendation live ────────────────────────────────────────────
+
+/// The tuning block, redrawn, with a line about what just happened.
+async fn tune_fragment(st: &AppState, line: &str) -> Result<Response> {
+    use axum::response::IntoResponse;
+    let _ = st;
+    Ok(axum::response::Html(format!("<div id=\"judge-tune\">{line}</div>")).into_response())
+}
+
+/// Apply the open recommendation: the file first, then the running parameters,
+/// then the stamp.
+///
+/// The order is the guarantee. A hot swap the file does not carry would vanish
+/// on the next restart, leaving the tuning history claiming a change that is no
+/// longer in force — and the file is the one place an operator can read what
+/// their server is doing.
+async fn tune_apply(
+    State(st): State<AppState>,
+    _id: Identity,
+    Path(run_id): Path<String>,
+) -> Result<Response> {
+    let Some(run) = st.core.store.eval_run(&run_id).await? else {
+        return Err(crate::error::Error::NotFound);
+    };
+    // A recommendation that was already taken, or a run that never was one:
+    // both arrive from a stale page, and neither is a reason to write anything.
+    if !run.recommended || run.applied_at.is_some() {
+        return tune_fragment(
+            &st,
+            "that sweep is not an open recommendation — nothing was changed.",
+        )
+        .await;
+    }
+
+    let params: crate::core::ranking::RankingParams = run.best_params.into();
+    if let Err(e) = crate::config::write_ranking(&st.config_path, &params) {
+        // Said here rather than raised: a read-only config file is an ordinary
+        // thing to find out about, and the operator is looking at the button
+        // they just pressed. Nothing was swapped and nothing was stamped, so
+        // the recommendation stays open and can be applied once the file can
+        // be written.
+        tracing::warn!(error = %e, path = %st.config_path.display(), "config.toml not written");
+        return tune_fragment(
+            &st,
+            "config.toml could not be written, so nothing was applied. \
+             The recommendation is still here.",
+        )
+        .await;
+    }
+    *st.core.ranking.write().expect("ranking lock") = params;
+    st.core.store.mark_eval_run_applied(&run_id).await?;
+    tune_fragment(&st, "applied — the next search runs with these settings.").await
+}
+
 pub fn judge_router() -> Router<AppState> {
     Router::new()
         .route("/ui/judge", get(page))
+        .route("/ui/judge/tune/{run_id}/apply", post(tune_apply))
         .route("/ui/judge/next", get(next_card))
         .route("/ui/judge/{id}/hit", post(hit))
         .route("/ui/judge/{id}/gap", post(gap))
@@ -1180,6 +1235,152 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(runs, 1, "one judgement is not ten");
+    }
+
+    /// An app whose store already holds one recommendation, plus the path to
+    /// the configuration file that app would rewrite.
+    async fn tune_app(
+        recommended: bool,
+    ) -> (
+        axum::Router,
+        String,
+        crate::core::Core,
+        String,
+        std::path::PathBuf,
+    ) {
+        let core = crate::core::test_support::test_core().await;
+        let base = crate::store::eval_runs::RunParams {
+            recency_weight: 0.05,
+            per_source_cap: Some(3),
+        };
+        let best = if recommended {
+            crate::store::eval_runs::RunParams {
+                recency_weight: 0.1,
+                per_source_cap: None,
+            }
+        } else {
+            base
+        };
+        let run = core
+            .store
+            .record_eval_run(&crate::store::eval_runs::NewEvalRun {
+                judged_count: 50,
+                pairs_used: 12,
+                pairs_skipped: 0,
+                base,
+                base_recall: 0.70,
+                base_mrr: 0.50,
+                best,
+                best_recall: 0.80,
+                best_mrr: 0.60,
+                diff: vec![crate::store::eval_runs::DiffRow {
+                    query: "the image will not mount".into(),
+                    base: Some(5),
+                    new: Some(1),
+                }],
+                recommended,
+            })
+            .await
+            .unwrap();
+        let handle = core.clone();
+        let (app, cookie, state) = crate::web::test_support::app_with_state(core).await;
+        let path = state.config_path.as_ref().clone();
+        (app, cookie, handle, run, path)
+    }
+
+    #[tokio::test]
+    async fn applying_writes_the_file_swaps_the_parameters_and_stamps_the_run() {
+        // All three or none: a swap the file does not carry vanishes on
+        // restart, and a stamp without either is a history of things that did
+        // not happen.
+        let (app, cookie, core, run, path) = tune_app(true).await;
+        let status = post(&app, &format!("/ui/judge/tune/{run}/apply"), &cookie, "").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let live = *core.ranking.read().unwrap();
+        assert_eq!(live.recency_weight, 0.1);
+        assert_eq!(live.per_source_cap, None);
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("recency_weight = 0.1"), "{written}");
+        assert!(written.contains("per_source_cap = 0"), "{written}");
+        assert!(
+            written.contains("# a comment the apply path must not eat"),
+            "the operator's file came back as a machine's: {written}"
+        );
+
+        assert!(
+            core.store
+                .eval_run(&run)
+                .await
+                .unwrap()
+                .unwrap()
+                .applied_at
+                .is_some()
+        );
+        assert!(core.store.open_recommendation().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_run_that_is_not_an_open_recommendation_changes_nothing() {
+        // Both arrive from a page left open: one was never a recommendation,
+        // the other has already been taken.
+        for second_press in [false, true] {
+            let (app, cookie, core, run, path) = tune_app(second_press).await;
+            let before = std::fs::read_to_string(&path).unwrap();
+            if second_press {
+                assert_eq!(
+                    post(&app, &format!("/ui/judge/tune/{run}/apply"), &cookie, "").await,
+                    StatusCode::OK
+                );
+            }
+            let live_before = *core.ranking.read().unwrap();
+
+            let status = post(&app, &format!("/ui/judge/tune/{run}/apply"), &cookie, "").await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "a stale press is an answer, not a 500"
+            );
+            assert_eq!(*core.ranking.read().unwrap(), live_before);
+            if !second_press {
+                assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_run_that_does_not_exist_is_a_404() {
+        let (app, cookie, _core, _, _) = tune_app(true).await;
+        assert_eq!(
+            post(&app, "/ui/judge/tune/no-such-run/apply", &cookie, "").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unwritable_config_leaves_the_running_parameters_alone() {
+        // The whole apply or none of it. The recommendation stays open, so it
+        // can be taken once the file can be written.
+        let (app, cookie, core, run, path) = tune_app(true).await;
+        std::fs::remove_file(&path).unwrap();
+        let before = *core.ranking.read().unwrap();
+
+        let status = post(&app, &format!("/ui/judge/tune/{run}/apply"), &cookie, "").await;
+        assert_eq!(status, StatusCode::OK, "the operator is told, not 500'd");
+
+        assert_eq!(*core.ranking.read().unwrap(), before, "swapped anyway");
+        assert!(
+            core.store
+                .eval_run(&run)
+                .await
+                .unwrap()
+                .unwrap()
+                .applied_at
+                .is_none(),
+            "stamped a change that was never made"
+        );
+        assert!(core.store.open_recommendation().await.unwrap().is_some());
     }
 
     #[tokio::test]

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -24,6 +24,12 @@ pub struct AuthContext {
 pub struct AppState {
     pub core: Core,
     pub auth: Arc<AuthContext>,
+    /// The configuration file this server was started with.
+    ///
+    /// Held because applying a tuning recommendation writes it: the running
+    /// parameters and the file have to agree, or a restart would quietly undo
+    /// a change the tuning history says was made.
+    pub config_path: Arc<std::path::PathBuf>,
     /// Questions parked between the POST that creates them and the GET that
     /// streams them.
     ///

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -1,6 +1,7 @@
 {# The header, shipped with the card so the figures move as the queue is worked
    down. Nothing when nothing was judged. #}
 {% include "_judge_pulse.html" %}
+{% include "_judge_tune.html" %}
 {% match flash %}
 {% when Some with (f) %}
 {# What the last verdict revealed. Loudest where the ranking did worst: a

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -1,3 +1,6 @@
+{# The header, shipped with the card so the figures move as the queue is worked
+   down. Nothing when nothing was judged. #}
+{% include "_judge_pulse.html" %}
 {% match flash %}
 {% when Some with (f) %}
 {# What the last verdict revealed. Loudest where the ranking did worst: a

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -1,7 +1,14 @@
 {# The header, shipped with the card so the figures move as the queue is worked
-   down. Nothing when nothing was judged. #}
-{% include "_judge_pulse.html" %}
-{% include "_judge_tune.html" %}
+   down. Nothing when nothing was judged.
+
+   Only where they are going out of band, which is only from the fragment
+   routes. The page draws both itself, outside `#card`, and including them
+   unconditionally rendered a second `judge-live` and a second `judge-tune`
+   inside it: the whole recommendation twice, and an Apply button whose swap
+   landed on the first copy while the second went on offering what had just
+   been taken. #}
+{% if pulse_oob %}{% include "_judge_pulse.html" %}{% endif %}
+{% if tune_oob %}{% include "_judge_tune.html" %}{% endif %}
 {% match flash %}
 {% when Some with (f) %}
 {# What the last verdict revealed. Loudest where the ranking did worst: a

--- a/src/web/templates/_judge_pulse.html
+++ b/src/web/templates/_judge_pulse.html
@@ -1,0 +1,40 @@
+{# The header's live half, rendered twice: once by the page, once beside the
+   card a verdict returns. Out of band the second time, because the header sits
+   outside the swapped region and would otherwise stand at whatever it read on
+   arrival while the queue was worked down.
+
+   Nothing here reacts to *which* verdict was given. What animates is progress
+   towards the next sweep — the work — never agreement with the ranker. The
+   flash line above the card is where a judgement is spoken about, and its
+   loudness runs the other way on purpose. #}
+{% if let Some(p) = pulse %}
+<div id="judge-live" class="judge-live"{% if pulse_oob %} hx-swap-oob="true"{% endif %}>
+  <div class="row">
+    <span class="mono">{{ p.judged }} judged</span>
+    <span class="spacer"></span>
+    {# The two figures carried no explanation at all: an operator who had not
+       read docs/evaluation.md was working towards numbers nobody had named. #}
+    <span class="mono" title="Of the answers you have confirmed, the share the ranking put in its top ten.">recall@10 {{ p.recall }}</span>
+    <span class="mono{% if !p.delta.is_empty() %} judge-tick{% endif %}"
+          title="Mean reciprocal rank: 1.00 means every confirmed answer came first. An answer search never returned counts as zero.">MRR {{ p.mrr }}</span>
+    {% if !p.delta.is_empty() %}<span class="mono judge-delta">{{ p.delta }}</span>{% endif %}
+    <span class="spacer"></span>
+    <span class="mono muted">{{ p.recent }} in the last 24h · {{ p.pending }} waiting</span>
+  </div>
+  <div class="progress" role="progressbar" aria-valuenow="{{ p.judged }}"
+       aria-valuemin="0" aria-valuemax="{{ p.target }}">
+    <span style="width:{{ p.pct }}%"{% if pulse_oob %} class="judge-grow"{% endif %}></span>
+  </div>
+  {# What the bar is progress *towards*. It counted to fifty and promised
+     nothing, so reaching it looked like nothing happening. #}
+  <p class="muted hint">{{ p.judged }} / {{ p.target }} {{ p.label }} — a sweep
+    tries other ranking settings over everything you have judged, and offers
+    the ones that score better.</p>
+  <p class="muted mono">
+    <span title="A confirmed answer that search had returned.">{{ p.hits }} hits</span> ·
+    <span title="A confirmed answer search never returned. The only evidence that ranking, rather than the base, was at fault.">{{ p.finds }} finds</span> ·
+    <span title="Nothing in the base could have answered it.">{{ p.gaps }} gaps</span> ·
+    <span title="Not a real search.">{{ p.discards }} discarded</span>
+  </p>
+</div>
+{% endif %}

--- a/src/web/templates/_judge_pulse.html
+++ b/src/web/templates/_judge_pulse.html
@@ -22,7 +22,7 @@
     <span class="mono muted">{{ p.recent }} in the last 24h · {{ p.pending }} waiting</span>
   </div>
   <div class="progress" role="progressbar" aria-valuenow="{{ p.judged }}"
-       aria-valuemin="0" aria-valuemax="{{ p.target }}">
+       aria-valuemin="{{ p.floor }}" aria-valuemax="{{ p.target }}">
     <span style="width:{{ p.pct }}%"{% if pulse_oob %} class="judge-grow"{% endif %}></span>
   </div>
   {# What the bar is progress *towards*. It counted to fifty and promised

--- a/src/web/templates/_judge_tune.html
+++ b/src/web/templates/_judge_tune.html
@@ -1,0 +1,43 @@
+{# What the sweeps have to say, in three states: an offer, an explained
+   silence, or nothing at all.
+
+   Rendered in the page, beside the card a verdict returns (a sweep runs off
+   the request path, so the next verdict is the first chance to report one),
+   and as its own answer to the apply button. #}
+{% if let Some(t) = tune %}
+<div id="judge-tune" class="judge-tune"{% if tune_oob %} hx-swap-oob="true"{% endif %}>
+  {% if !t.flash.is_empty() %}<p class="judge-flash">{{ t.flash }}</p>{% endif %}
+  {% match t.rec %}
+  {% when Some with (r) %}
+  <div class="judge-tune-rec">
+    <p class="row">
+      <span>{{ r.line }}</span>
+      <span class="spacer"></span>
+      <button class="btn btn-sm" hx-post="/ui/judge/tune/{{ r.id }}/apply"
+              hx-target="#judge-tune" hx-swap="outerHTML">Apply</button>
+    </p>
+    {# Open by choice, not by default: the aggregate is the claim and this is
+       the evidence, and the evidence is what a knob change has to be judged
+       on. Folded so it does not push the card off the screen. #}
+    <details>
+      <summary class="muted">what changes</summary>
+      <ul class="mono">
+        {% for d in r.diff %}<li>{{ d }}</li>{% endfor %}
+      </ul>
+    </details>
+  </div>
+  {% when None %}
+  {% if !t.quiet.is_empty() %}<p class="muted hint">{{ t.quiet }}</p>{% endif %}
+  {% endmatch %}
+  {% if !t.applied.is_empty() %}
+  {# Where the numbers behind a change live now. They used to live in a commit
+     message, which is no help to whoever is looking at this page. #}
+  <details class="judge-tune-history">
+    <summary class="muted">tuning history ({{ t.applied.len() }})</summary>
+    <ul class="mono">
+      {% for a in t.applied %}<li>{{ a }}</li>{% endfor %}
+    </ul>
+  </details>
+  {% endif %}
+</div>
+{% endif %}

--- a/src/web/templates/_judge_tune.html
+++ b/src/web/templates/_judge_tune.html
@@ -16,6 +16,15 @@
       <button class="btn btn-sm" hx-post="/ui/judge/tune/{{ r.id }}/apply"
               hx-target="#judge-tune" hx-swap="outerHTML">Apply</button>
     </p>
+    {# Said once, next to the figures it is about. The line above carries an
+       MRR and a recall@10, and so does the header a few lines up: same names,
+       different measurements — one is the ranks the searches actually gave,
+       the other is those searches run again under each setting, on the door
+       that leaves the association step out. Comparing the two would be reading
+       a difference in method as a difference in result. #}
+    <p class="muted hint">Both figures are from the replay, measured against
+      each other. The header's are from the searches themselves — a different
+      count, not a later one.</p>
     {# Open by choice, not by default: the aggregate is the claim and this is
        the evidence, and the evidence is what a knob change has to be judged
        on. Folded so it does not push the card off the screen. #}

--- a/src/web/templates/judge.html
+++ b/src/web/templates/judge.html
@@ -5,21 +5,7 @@
    figures are read from the ranks the searches actually gave, so every verdict
    moves the number it is measured by. #}
 <div class="judge-header">
-  <div class="row">
-    <span class="mono">{{ stats.judged }} judged</span>
-    <span class="spacer"></span>
-    <span class="mono">recall@10 {{ recall }}</span>
-    <span class="mono">MRR {{ mrr }}</span>
-  </div>
-  <div class="progress" role="progressbar" aria-valuenow="{{ stats.judged }}"
-       aria-valuemin="0" aria-valuemax="{{ target }}">
-    <span style="width:{{ progress_pct }}%"></span>
-  </div>
-  <p class="muted hint">{{ stats.judged }} / {{ target }} until the first sweep</p>
-  <p class="muted mono">
-    {{ stats.hits }} hits · {{ stats.finds }} finds · {{ stats.gaps }} gaps ·
-    {{ stats.discards }} discarded
-  </p>
+  {% include "_judge_pulse.html" %}
   {% if asks.asked > 0 %}
   <p class="muted mono">
     {{ asks.judged }} of {{ asks.asked }} questions judged ·

--- a/src/web/templates/judge.html
+++ b/src/web/templates/judge.html
@@ -14,6 +14,14 @@
   {% endif %}
 </div>
 
+{# Directly under the figures it would move: it is the one thing on this page
+   that can be acted on, and it is what the progress bar is counting towards. #}
+{% include "_judge_tune.html" %}
+
+<div id="card">{% include "_judge_card.html" %}</div>
+
+{# Below the card, folded. It is a reference to fall back on between
+   judgements, not something to read before starting one. #}
 {% if !misses.is_empty() %}
 <details class="misses">
   <summary class="muted">{{ misses.len() }} queries the ranking got wrong</summary>
@@ -29,6 +37,4 @@
   </ul>
 </details>
 {% endif %}
-
-<div id="card">{% include "_judge_card.html" %}</div>
 {% endblock %}

--- a/src/web/test_support.rs
+++ b/src/web/test_support.rs
@@ -17,18 +17,63 @@ pub fn router(core: Core, local: Option<crate::config::LocalConfig>) -> axum::Ro
             pending: crate::auth::oidc::PendingStore::new(),
             secure_cookies: false,
         }),
+        config_path: std::sync::Arc::new(scratch_config()),
         ask_handoff: Default::default(),
     })
 }
 
+/// A `config.toml` of its own per app under test.
+///
+/// The apply path writes the file the server was started with, so two tests
+/// sharing one would be asserting against whichever ran last. One directory
+/// for the whole test binary, one file per app in it.
+pub(crate) fn scratch_config() -> std::path::PathBuf {
+    static DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    let dir = DIR.get_or_init(|| tempfile::tempdir().expect("scratch config dir"));
+    let path = dir.path().join(format!("{}.toml", crate::store::new_id()));
+    std::fs::write(
+        &path,
+        "# a comment the apply path must not eat\n\
+         [vector]\n\
+         recency_weight = 0.05\n\
+         per_source_cap = 3\n",
+    )
+    .expect("scratch config");
+    path
+}
+
 /// A router over `core` plus a browser session cookie for `user-1`.
 pub async fn app_with_cookie(core: Core) -> (axum::Router, String) {
+    let (app, cookie, _) = app_with_state(core).await;
+    (app, cookie)
+}
+
+/// `app_with_cookie`, plus the state behind it — what a test needs when it has
+/// to read something a handler wrote outside the database, such as the
+/// configuration file the apply path rewrites.
+pub async fn app_with_state(core: Core) -> (axum::Router, String, crate::web::state::AppState) {
     let cid = crate::store::new_id();
     core.store
         .insert_session(&cid, "user-1", None, 3600)
         .await
         .unwrap();
-    (router(core, None), format!("engram_session={cid}"))
+    let state = crate::web::state::AppState {
+        core,
+        auth: std::sync::Arc::new(crate::web::state::AuthContext {
+            mode: crate::config::AuthMode::Local,
+            local: None,
+            oidc: None,
+            pending: crate::auth::oidc::PendingStore::new(),
+            secure_cookies: false,
+        }),
+        config_path: std::sync::Arc::new(scratch_config()),
+        ask_handoff: Default::default(),
+    };
+    (
+        crate::web::router(state.clone()),
+        format!("engram_session={cid}"),
+        state,
+    )
 }
 
 /// A router over `core` plus a bearer token for `user-1`.

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -9875,6 +9875,7 @@ mod tests {
                 pending: crate::auth::oidc::PendingStore::new(),
                 secure_cookies: false,
             }),
+            config_path: std::sync::Arc::new(crate::web::test_support::scratch_config()),
             ask_handoff: Default::default(),
         }
     }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1099,6 +1099,9 @@ pub(crate) async fn search_results(
             st.core.pursuit.idle_secs as i64,
         );
     }
+    // Read into a local: a lock guard living inside the call expression would
+    // still be held across the await, and a future holding one is not `Send`.
+    let cap = st.core.ranking.read().expect("ranking lock").per_source_cap;
     let (hits, t) = st
         .core
         .search_with(
@@ -1112,7 +1115,7 @@ pub(crate) async fn search_results(
                 include_deprecated: false,
                 include_superseded: false,
             },
-            Some(crate::core::search::MAX_PER_CORPUS),
+            cap,
             // Scoped to the operator, because coalescing folds a keystroke into
             // the query it was an early spelling of, and two people typing at
             // once are not spelling the same thing.

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -547,6 +547,15 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
             engram::core::QUERY_CACHE_CAPACITY,
         ))),
         consolidate: engram::config::ConsolidateConfig::default(),
+        // The harness measures the shipped cap; recency is off because the
+        // fake embedder's ordering is the only thing this asserts against.
+        ranking: Arc::new(std::sync::RwLock::new(
+            engram::core::ranking::RankingParams {
+                recency_weight: 0.0,
+                per_source_cap: Some(engram::core::search::MAX_PER_CORPUS),
+            },
+        )),
+        tuning: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         weak_below: 0.0,
         learn: engram::config::LearnConfig { enabled: false },
         feedback: engram::config::FeedbackConfig::default(),

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -139,7 +139,7 @@ async fn evaluate_retrieval() {
         // scoring only the original would report a retrieval regression that is
         // really a bookkeeping change — and the one number that says whether
         // merging helps would be unreadable exactly when it matters.
-        let satisfies = resolve_expected(&core, expect).await;
+        let satisfies = engram::eval::satisfied_by(&core, expect).await;
         let rank = results
             .iter()
             .position(|r| satisfies.iter().any(|id| id == &r.artifact_id));
@@ -241,7 +241,7 @@ async fn evaluate_ask() {
                 let stored = translated
                     .get(e)
                     .expect("questions.json names an artifact not in artifacts.json");
-                carriers.push(resolve_expected(&core, stored).await);
+                carriers.push(engram::eval::satisfied_by(&core, stored).await);
             }
             let cited: Vec<String> = out
                 .citations
@@ -352,36 +352,6 @@ async fn evaluate_ask() {
     }
     println!();
     vectors.drop_collection().await.unwrap();
-}
-
-/// The artifact ids that satisfy a grade naming `expected`: itself, plus
-/// whatever superseded it.
-///
-/// A graded pair names the artifact that answered the query. When consolidation
-/// merges it into another, or supersedes it in favour of one that plainly
-/// replaced it, the knowledge is in the survivor and search returns that. The
-/// grade is still satisfied; only the id changed.
-///
-/// Bounded rather than trusted to terminate. Chains should not exist — a merge
-/// re-points what it hides, precisely so no reader lands on a hidden winner —
-/// but a harness that hangs on a cycle in the data is worse than one that stops
-/// looking after a few hops.
-async fn resolve_expected(core: &Core, expected: &str) -> Vec<String> {
-    let mut out = vec![expected.to_string()];
-    let mut cursor = expected.to_string();
-    for _ in 0..8 {
-        match core.store.get_artifact(&cursor).await {
-            Ok(c) => match c.superseded_by {
-                Some(next) => {
-                    out.push(next.clone());
-                    cursor = next;
-                }
-                None => break,
-            },
-            Err(_) => break,
-        }
-    }
-    out
 }
 
 /// Load the frozen artifacts and embed them, reporting the id each one was
@@ -625,7 +595,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         .unwrap();
     core.supersede(expect, &merged.id).await.unwrap();
 
-    let satisfies = resolve_expected(&core, expect).await;
+    let satisfies = engram::eval::satisfied_by(&core, expect).await;
     assert!(
         satisfies.contains(&merged.id),
         "a grade against a merged-away artifact no longer resolves: {satisfies:?}"

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -23,6 +23,7 @@ fn cfg(collection: &str) -> VectorConfig {
         recency_half_life_days: 180,
         pinned_boost: 0.15,
         weak_below: 0.35,
+        per_source_cap: 3,
     }
 }
 


### PR DESCRIPTION
Judging produced the only ground truth this system has about its own ranking,
and at runtime that truth led nowhere: the numbers it earned were spent only by
someone who knew to leave the UI, export a corpus and run an `#[ignore]`d
benchmark. This closes the loop inside the running server.

## What happens now

Once fifty judgements exist (`feedback.tune.min_judgements`), every tenth
further verdict re-runs a background sweep of recency weight × per-source cap
over every judged pair. A recommendation appears on `/ui/judge` with the pairs
that moved; one click rewrites `config.toml` and the running parameters.

The sweep needs **no snapshot and no re-embedding**. The cargo harness freezes a
corpus because its numbers must be comparable across months; a recommendation
compares candidates against each other in one pass over one index, so it reads
the live index and only reads it — `Door::Judge`, `mark: false`, never captured,
the same discipline the assign search follows. Both knobs only reorder what
retrieval already returned, so a twenty-point grid is seconds of vector reads.

## The gate

A candidate is offered only when **at least two pairs are net better and neither
aggregate is worse**. That floor is the whole safety of running this
automatically: on fifty pairs a single flipped pair is two points of recall, and
an aggregate delta alone cannot tell one from a real improvement. Ties keep the
current values. A sweep that finds nothing is still recorded, so the page can
explain its silence rather than look like it never ran.

## The judge page

Layout and interaction were designed against mockups before implementation.

- The header became a cockpit that **explains its own numbers** — recall@10 and
  MRR stood bare, and the progress bar counted to fifty while naming no reward.
  It now counts towards the next sweep and says what a sweep is.
- After each verdict the header ships out of band beside the next card: the MRR
  ticks once, a delta rises and fades, the bar brightens as it grows. Nothing
  reacts to *which* verdict was given — what is acknowledged is that the work
  moved, never agreement with the ranker. `diagnosis` and its inverted loudness
  are untouched, and `prefers-reduced-motion` turns all of it off.
- The recommendation sits under the header with its miss diff **mandatory, not
  optional**: an aggregate says something moved, only the diff says what.

## Structural notes

- `RankingParams` moves into `Core` behind a lock; the live path reads it and
  `search_with_ranking` takes it explicitly, so measurement and the live search
  are one pipeline rather than two that can drift.
- Applying writes the file **first**, then swaps, then stamps. A swap the file
  does not carry would vanish on restart while the history claimed otherwise.
  `toml_edit` keeps every comment; a missing file is refused rather than
  invented. An unwritable file leaves the recommendation open and says so.
- `eval_runs` records every sweep with the settings that produced it —
  section 4's rule about never writing a number without its configuration, made
  structural rather than asked for.
- `FIRST_SWEEP_AT` retires into `feedback.tune.min_judgements`, which is what
  its own comment promised.

`tests/eval.rs` is untouched except for reusing `satisfied_by`, which moved into
the library. It remains the instrument for everything a runtime sweep cannot
reach: embedding models and templates, priming, pinning, the ask side, and any
number that must be comparable across months.

## Verification

1710 tests pass, `cargo clippy --all-targets -- -D warnings` is clean. New
coverage includes the gate's arithmetic, the grid, a sweep that recommends, one
that stays quiet, a deleted pair counted rather than scored, the sweep leaving
no trace in what it measures, the apply path's three failure modes, and the
header animating only where something was judged.

Spec: `docs/superpowers/specs/2026-08-23-tuning-sweep-design.md`
Plan: `docs/superpowers/plans/2026-08-23-tuning-sweep.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vfp4KKXShw7pmNEuHnteb6
