### PR TITLE
A judge card that fits the screen it is judged on

### DIFF
--- a/assets/css/20-layout.css
+++ b/assets/css/20-layout.css
@@ -90,6 +90,13 @@ body:has(.regions-rail-focus-source) > .shell > .regions { flex: 1; min-height: 
    anchor: the inner grid is never centred, only the shell is. */
 .regions-focus { grid-template-columns: minmax(0, 68rem); }
 .regions-focus > * { grid-column: 1 / -1; }
+/* The judge card is a working surface, not prose. Every line in it is bounded
+   by something other than the measure — the query is one line, each candidate
+   is clamped to two — so a reading column leaves half a wide window empty and
+   buys nothing for it, while the full table width would set snippet lines too
+   long to track back to their own left edge. Between the two. */
+.regions-judge { grid-template-columns: minmax(0, 86rem); }
+.regions-judge > * { grid-column: 1 / -1; }
 .regions-table { grid-template-columns: minmax(0, 1fr); }
 /* One column, centred in the window rather than anchored to its left edge.
    For the pages that are not part of the workspace and have nothing to line

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -1,95 +1,145 @@
 /* Judging. */
 
-/* ── Judging ─────────────────────────────────────────────────────────────── */
+/* ── The working surface ─────────────────────────────────────────────────────
+   One card, and it holds everything a judgement needs: the query, the figures
+   the judgement moves, the pool, and the three ways out. Nothing above it
+   except what a sweep has to offer, and nothing inside it scrolls except the
+   pool.
 
-/* One card at a time, wide enough to read a snippet without every line
-   wrapping. The options are buttons rather than links: they act, they do not
-   navigate. */
-.judge-header { max-width: 52rem; margin-bottom: 1.25rem; }
-/* Four figures and a spacer between them do not fit across a phone. They wrap
+   That last part is the whole arrangement. The figures used to be a block of
+   their own at the top of the page — a third of the screen of readout before
+   the first candidate — and under them sat twenty candidates at four lines
+   each, with the ways out of the question below all of them. The bar was three
+   pixels of a header nobody had to look at. Now the pool is the only thing with
+   a scrollbar, and it is bounded, so the question and its answers are always on
+   screen together. */
+
+/* ── The deck ───────────────────────────────────────────────────────────────
+   Two sheets behind the card, so a queue of fourteen is a depth and not only a
+   number. They are what moves forward when a card leaves: htmx holds the
+   outgoing content in the document for the length of the swap delay and marks
+   the target `htmx-swapping`, which is long enough for both to transition. */
+.judge-deck { position: relative; }
+.judge-ghost {
+  position: absolute; inset: 0; border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle); background: var(--color-bg-surface);
+  transform-origin: 50% 100%;
+  transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1), opacity 260ms;
+}
+.judge-ghost-2 { transform: translateY(-13px) scale(0.976); opacity: 0.45; }
+.judge-ghost-1 { transform: translateY(-6.5px) scale(0.988); opacity: 0.72; }
+#card.htmx-swapping .judge-ghost-2 { transform: translateY(-6.5px) scale(0.988); opacity: 0.72; }
+#card.htmx-swapping .judge-ghost-1 { transform: none; opacity: 1; }
+
+.judge-card {
+  position: relative; z-index: 1;
+  display: flex; flex-direction: column;
+  border: 1px solid var(--color-border); border-radius: var(--radius-md);
+  background: var(--color-bg-elevated); overflow: hidden;
+  transform-origin: 50% 130%;
+  transition: transform 220ms cubic-bezier(0.55, 0, 0.9, 0.4), opacity 190ms;
+}
+/* Away, and always in the same direction. A card that flew left for one answer
+   and right for another would be saying something about the answer, and this
+   card's whole discipline is that the interface says nothing about the answer
+   until after it is given. Down carries no verdict. */
+#card.htmx-swapping .judge-card {
+  transform: translateY(2.4rem) scale(0.94) rotate(0.45deg); opacity: 0;
+}
+@keyframes judge-enter {
+  from { transform: translateY(-9px) scale(0.985); opacity: 0.45; }
+  to { transform: none; opacity: 1; }
+}
+/* Only on a card a verdict brought in. On a plain fetch it would be the page
+   animating its own load. */
+.judge-card-enter { animation: judge-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) 1; }
+
+.judge-head { padding: 0.85rem 1.1rem 0.7rem; }
+.judge-meta { font-size: var(--text-xs); margin: 0; }
+.judge-query { font-size: var(--text-xl); font-weight: 500; margin: 0.25rem 0 0.8rem; line-height: 1.25; }
+.judge-ask { margin: 0.8rem 0 0; }
+.judge-ask .mono { font-size: var(--text-xs); color: var(--color-fg-muted); }
+
+/* ── The bar ─────────────────────────────────────────────────────────────────
+   An object with a height, under the query, where the work is.
+
+   Three things move on it, and all three are borrowed from the bars games put
+   experience and health in — for the reason those bars are built that way: a
+   quantity that only ever changes its endpoint is hard to notice changing at
+   all.
+
+   · The pale trail goes straight to the new value while the solid fill follows
+     late, so the ground just won reads as area rather than as a number that is
+     now different.
+   · The fill overshoots slightly and settles, so it arrives rather than stops.
+   · A sheen crosses once.
+
+   None of it responds to *what* was judged — only to the fact that something
+   was, which is `Pulse::delta` being non-empty. A bar that celebrated
+   confirmations would be teaching agreement with the ranker it exists to
+   measure, and the flash line above the card already says the informative
+   thing, quietly, in the opposite direction. */
+.judge-live { margin: 0; }
+.judge-xp {
+  position: relative; height: 14px; border-radius: 7px;
+  background: var(--color-bg-active); border: 1px solid var(--color-border-subtle);
+  overflow: hidden;
+}
+.judge-xp > span { position: absolute; inset: 0; border-radius: 7px; }
+.judge-xp-trail { width: var(--to); background: var(--color-accent-muted); }
+.judge-xp-fill {
+  width: var(--to);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-accent) 82%, white) 0%,
+    var(--color-accent) 55%,
+    color-mix(in srgb, var(--color-accent) 84%, black) 100%);
+}
+/* Notches, so the bar is a distance rather than a percentage: ten of them,
+   because the two counts it spans are always round numbers of judgements. */
+.judge-xp-notches {
+  pointer-events: none; opacity: 0.45;
+  background-image: repeating-linear-gradient(
+    90deg, transparent 0 calc(10% - 1px), var(--color-bg-base) calc(10% - 1px) 10%);
+}
+.judge-xp-sheen { pointer-events: none; transform: translateX(-110%); }
+
+@keyframes judge-xp-fill { from { width: var(--from); } to { width: var(--to); } }
+@keyframes judge-xp-sheen { to { transform: translateX(110%); } }
+@keyframes judge-xp-pulse {
+  0% { box-shadow: 0 0 0 0 var(--color-accent-muted); }
+  35% { box-shadow: 0 0 0 5px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+/* `backwards`, so the fill holds where it started for the length of its delay
+   instead of standing at the new value until the animation begins — which is
+   the delay the trail is visible in, and so the whole effect. */
+.judge-xp-moved .judge-xp-fill {
+  animation: judge-xp-fill 620ms 180ms cubic-bezier(0.34, 1.4, 0.64, 1) backwards;
+}
+.judge-xp-moved .judge-xp-sheen { animation: judge-xp-sheen 850ms 200ms ease-out 1; }
+/* Once, and then still. A bar that pulsed continuously would be asking for
+   attention on a page whose actual work is reading. */
+.judge-xp-moved { animation: judge-xp-pulse 700ms ease-out 1; }
+
+.judge-xp-read { margin: 0.45rem 0 0; font-size: var(--text-base); }
+.judge-xp-read b { font-weight: 500; font-size: var(--text-lg); }
+.judge-live .hint { margin: 0.25rem 0 0; }
+/* Four counts, two figures and a delta do not fit across a phone. They wrap
    rather than run off the side — the row is a readout, and a readout that has
    to be scrolled sideways is not one. */
-.judge-header .row { flex-wrap: wrap; }
-.judge-card { max-width: 52rem; }
-.judge-query { font-size: var(--text-lg); font-weight: 500; margin: 0.25rem 0 0.75rem; }
-.judge-options {
-  list-style: none; margin: 0 0 1rem; padding: 0;
-  display: flex; flex-direction: column; gap: 0.375rem;
+.judge-figures {
+  margin: 0.4rem 0 0; font-size: var(--text-sm);
+  display: flex; flex-wrap: wrap; gap: 0 0.4rem;
 }
-.judge-option {
-  display: grid; grid-template-columns: 1.5rem minmax(0, 1fr); gap: 0.125rem 0.5rem;
-  width: 100%; text-align: left; padding: 0.5rem 0.625rem; cursor: pointer;
-  border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm);
-  background: var(--color-bg-elevated); color: inherit; font: inherit;
-}
-.judge-option:hover { background: var(--color-bg-hover); }
-.judge-option:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
-/* `anywhere`, because a snippet is a slice of whatever was captured: a URL, a
-   hash, a German compound. `minmax(0, 1fr)` above stops such a word widening
-   the column; this is what stops it spilling out of the one it is in. */
-.judge-title { font-weight: 500; overflow-wrap: anywhere; }
-/* Still legible, plainly not choosable: the pool is shown at full length so the
-   operator can see what the search returned, and a candidate the benchmark
-   cannot hold is greyed rather than dropped. */
-.judge-option-unusable {
-  cursor: not-allowed; opacity: 0.55; background: transparent;
-  border-style: dashed;
-}
-.judge-option-unusable:hover { background: transparent; }
-.judge-option-unusable .judge-title { font-weight: 400; text-decoration: line-through; }
-.judge-key { font-family: var(--font-mono); color: var(--color-fg-muted); font-size: var(--text-sm); }
-.judge-snippet {
-  grid-column: 2; color: var(--color-fg-secondary); font-size: var(--text-base);
-  overflow-wrap: anywhere;
-}
-/* Reading a candidate before confirming it. Indented under its option and
-   quiet, because the snippet answers most of the time and this is the second
-   question, not the first. Capped and scrollable so a long artifact cannot
-   push the other options off the screen. */
-.judge-peek { margin: 0.125rem 0 0 2.125rem; font-size: var(--text-sm); }
-.judge-peek > summary {
-  cursor: pointer; color: var(--color-fg-muted); padding: 0.125rem 0;
-  width: fit-content;
-}
-.judge-peek > summary:hover { color: var(--color-fg-secondary); }
-/* `overflow`, not `overflow-y`: the capped height was the only thing being
-   thought about, and a wide markdown table or an unwrapped code block inside a
-   peek pushed the page instead of scrolling inside the box that caps it. */
-.judge-full { max-height: 22rem; overflow: auto; margin-top: 0.25rem; }
-.judge-full .md { font-size: var(--text-base); }
-/* Sticky, because the three answers sat below every candidate: twenty-three
-   cards at `feedback.candidates` of twenty, and the way out of the question
-   was a scroll past all of them. The shortcuts always worked from anywhere;
-   the bar is what says so. Its own background, or the cards scroll through
-   it. */
-.judge-outs {
-  position: sticky; bottom: 0; z-index: 1;
-  flex-wrap: wrap; row-gap: 0.375rem;
-  margin-bottom: 0; padding: 0.6rem 0;
-  background: var(--color-bg-base);
-  border-top: 1px solid var(--color-border-subtle);
-}
-.judge-undo { margin-left: 0.5rem; }
+.judge-figures [title] { cursor: help; }
 
-/* Read from the ranks the searches actually gave, so it moves on every
-   verdict. It is the measurement, not a score standing in for one. */
-.progress { height: 4px; background: var(--color-bg-active); border-radius: 2px; overflow: hidden; }
-.progress span { display: block; height: 100%; background: var(--color-accent); }
-
-/* The moment after a verdict.
- *
- * Only the figures already on the page respond: the MRR lights once, the delta
- * rises beside it and goes, the bar brightens as it grows. Nothing here reacts
- * to *which* verdict was given — what is being acknowledged is that the work
- * moved, never that the ranker was agreed with. The flash line above the card
- * says what was learned, and it is loudest where the ranking did worst.
- *
- * Every rule is one-shot and cheap, and all of it is skipped for anyone who
- * asked not to be moved. */
-.judge-live { max-width: 52rem; }
+/* The moment after a verdict, on the two figures themselves: the MRR lights
+   once and the delta rises beside it and goes. Both are one-shot and cheap, and
+   all of it is skipped for anyone who asked not to be moved. */
 @keyframes judge-tick {
-  0%   { background: transparent; }
-  20%  { background: color-mix(in srgb, var(--color-accent) 28%, transparent); }
+  0% { background: transparent; }
+  20% { background: color-mix(in srgb, var(--color-accent) 28%, transparent); }
   100% { background: transparent; }
 }
 .judge-tick {
@@ -98,24 +148,142 @@
   padding: 0 0.2rem; margin: 0 -0.2rem;
 }
 @keyframes judge-delta {
-  0%   { opacity: 0; transform: translateY(0.35rem); }
-  18%  { opacity: 1; transform: none; }
-  70%  { opacity: 1; }
+  0% { opacity: 0; transform: translateY(0.35rem); }
+  18% { opacity: 1; transform: none; }
+  70% { opacity: 1; }
   100% { opacity: 0; }
 }
 /* `forwards`, so it ends invisible rather than snapping back for the moment
    before the next swap replaces it. */
 .judge-delta { color: var(--color-accent); animation: judge-delta 2.4s ease-out 1 forwards; }
-@keyframes judge-grow { from { filter: brightness(1.7); } to { filter: none; } }
-.judge-grow { animation: judge-grow 0.7s ease-out 1; }
-@media (prefers-reduced-motion: reduce) {
-  .judge-tick, .judge-delta, .judge-grow { animation: none; }
-  .judge-delta { opacity: 1; }
+
+/* ── The pool ────────────────────────────────────────────────────────────────
+   Bounded and scrolling, and the only thing on the card that does either. All
+   of it is in there: a shortened pool is what would make a verdict mean
+   something it doesn't, and a scrollbar is not a shortening. What the bound
+   buys is that the question above and the three ways out below are on screen
+   at the same time — which the sticky action bar used to approximate, because
+   the page it sat on was twenty-three cards tall. */
+.judge-pool {
+  flex: 1; min-height: 0; max-height: 56vh; overflow: auto;
+  margin: 0 1.1rem; background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm);
 }
+.judge-options {
+  list-style: none; margin: 0; padding: 0.4rem;
+  display: flex; flex-direction: column; gap: 0.35rem;
+}
+/* Three cells: the option, the handle beside it, and the full text under both.
+   The handle is a grid item rather than the last line of the option because a
+   button inside a button is neither valid nor clickable, and it must never be
+   possible to fire a verdict by reaching for something to read. */
+.judge-options > li {
+  display: grid; grid-template-columns: minmax(0, 1fr) auto;
+  border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm);
+  background: var(--color-bg-elevated);
+}
+.judge-options > li:has(.judge-option:hover),
+.judge-options > li:has(.judge-option:focus-visible) { border-color: var(--color-accent-muted); }
+.judge-option {
+  display: grid; grid-template-columns: 1.6rem minmax(0, 1fr); gap: 0.15rem 0.55rem;
+  width: 100%; text-align: left; padding: 0.6rem 0.3rem 0.6rem 0.7rem;
+  border: 0; border-radius: var(--radius-sm); background: transparent;
+  color: inherit; font: inherit; cursor: pointer;
+}
+.judge-option:hover { background: var(--color-bg-hover); }
+.judge-option:focus-visible { outline: 2px solid var(--color-accent); outline-offset: -2px; }
+.judge-key {
+  grid-row: 1 / span 2;
+  font-family: var(--font-mono); color: var(--color-fg-muted); font-size: var(--text-sm);
+}
+/* `anywhere`, because a snippet is a slice of whatever was captured: a URL, a
+   hash, a German compound. `minmax(0, 1fr)` above stops such a word widening
+   the column; this is what stops it spilling out of the one it is in. */
+.judge-title { font-weight: 500; overflow-wrap: anywhere; }
+/* Two lines, which is what the old card gave a snippet as well. The clamp is
+   what makes twenty candidates a predictable height instead of a variable one:
+   the snippet is 140 characters and wraps to two lines or three depending on
+   where the words fall, and a pool that changes height by a third from card to
+   card is one the eye has to re-find its place in every time. */
+.judge-snippet {
+  grid-column: 2; color: var(--color-fg-secondary); font-size: var(--text-base);
+  line-height: 1.5; overflow-wrap: anywhere;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+/* Still legible, plainly not choosable: the pool is shown at full length so the
+   operator can see what the search returned, and a candidate the benchmark
+   cannot hold is greyed rather than dropped. */
+.judge-dead { opacity: 0.5; background: transparent; border-style: dashed; }
+.judge-option-unusable { cursor: not-allowed; }
+.judge-option-unusable:hover { background: transparent; }
+.judge-option-unusable .judge-title { font-weight: 400; text-decoration: line-through; }
+
+/* Reading a candidate before confirming it. The handle sits in the row: twenty
+   candidates meant twenty lines that each said "Read it in full" and nothing
+   else, which was the most expensive thing on the old card by a wide margin. */
+.judge-peek { display: flex; }
+.judge-peek > summary {
+  display: flex; align-items: center; justify-content: center;
+  width: 2rem; height: 100%; cursor: pointer; list-style: none;
+  color: var(--color-fg-muted); border-left: 1px solid var(--color-border-subtle);
+}
+.judge-peek > summary::-webkit-details-marker { display: none; }
+.judge-peek > summary::after {
+  content: ""; width: 0.42rem; height: 0.42rem;
+  border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor;
+  transform: translateY(-0.12rem) rotate(45deg); transition: transform 160ms ease;
+}
+.judge-peek > summary:hover { color: var(--color-fg-primary); background: var(--color-bg-hover); }
+.judge-peek[open] > summary::after { transform: translateY(0.06rem) rotate(-135deg); }
+/* Under both cells rather than inside the disclosure, so it can have the width
+   of the row while the handle keeps its own column. htmx swaps into it by
+   `next`, which is exactly the relationship the grid gives them. */
+.judge-full {
+  grid-column: 1 / -1; display: none;
+  padding: 0.2rem 0.9rem 0.7rem 2.9rem;
+  border-top: 1px solid var(--color-border-subtle);
+  /* `overflow`, not `overflow-y`: the capped height was the only thing being
+     thought about, and a wide markdown table or an unwrapped code block inside
+     a peek pushed the row instead of scrolling inside the box that caps it. */
+  max-height: 18rem; overflow: auto;
+  font-size: var(--text-base); color: var(--color-fg-secondary);
+}
+.judge-options > li:has(> .judge-peek[open]) > .judge-full { display: block; }
+.judge-full .md { font-size: var(--text-base); }
+
+/* Inside the card and after the pool, so they are on screen whatever the pool
+   is scrolled to. They used to be sticky, which was the same intent paid for
+   differently: the page was twenty-three cards tall and the way out of the
+   question was a scroll past all of them. */
+.judge-outs {
+  flex-wrap: wrap; row-gap: 0.375rem;
+  margin: 0.7rem 0 0; padding: 0.55rem 1.1rem;
+  border-top: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-surface);
+}
+.judge-undo { margin-left: 0.5rem; }
+
+/* ── The line after a verdict ────────────────────────────────────────────────
+   The one place on the page that speaks about the judgement, and the emphasis
+   runs opposite to intuition: the better the ranking did, the quieter the line.
+   A rank-one confirmation teaches almost nothing, and an interface that cheers
+   for it is training its operator to agree with whatever was already on top.
+   The tier is decided in `judge::tier`; this is only what each one weighs. */
+.judge-flash {
+  margin: 0 0 0.7rem; padding: 0.3rem 0 0.3rem 0.75rem;
+  font-size: var(--text-base); color: var(--color-fg-secondary);
+}
+.judge-flash-common { opacity: 0.6; }
+.judge-flash-plain { color: var(--color-fg-secondary); }
+/* A find, or a hit the search had buried. The only accent on the page. */
+.judge-flash-rare { color: var(--color-fg-primary); box-shadow: inset 3px 0 0 var(--color-accent); }
+.judge-flash-gap { color: var(--color-fg-primary); box-shadow: inset 3px 0 0 var(--color-warning); }
+.judge-flash-quiet { color: var(--color-fg-muted); }
+
 /* What the sweeps have to say. Accent-bordered because the recommendation is
    the only thing on this page that can be acted on; absent entirely — not
    greyed, not empty — until a sweep has actually run. */
-.judge-tune { max-width: 52rem; margin-bottom: 1rem; }
+.judge-tune { margin-bottom: 0.9rem; }
 .judge-tune-rec {
   border: 1px solid var(--color-accent); border-radius: var(--radius-sm);
   padding: 0.5rem 0.75rem;
@@ -129,7 +297,10 @@
 .judge-tune li { overflow-wrap: anywhere; }
 .judge-tune-history { font-size: var(--text-sm); }
 
-.misses { max-width: 52rem; margin-top: 1.25rem; }
+/* Below the card: references to fall back on between judgements, not things to
+   read before starting one. */
+.judge-asks { margin: 1rem 0 0; font-size: var(--text-sm); }
+.misses { margin-top: 0.75rem; }
 .misses ul { margin: 0.5rem 0 0; padding-left: 1.25rem; font-size: var(--text-sm); }
 /* A query is whatever someone typed, in a monospace list with no spaces to
    break at. It wraps rather than setting the width of the page. */
@@ -139,8 +310,23 @@
 .exif-all { margin-top: 0.75rem; font-size: var(--text-sm); }
 .exif-all summary { cursor: pointer; }
 .exif-all table { margin-top: 0.5rem; }
-/* The line after a verdict. Quiet by design — its job is to say what was just
-   learned, not to congratulate. */
-.judge-flash { margin: 0 0 1rem; font-size: var(--text-base); color: var(--color-fg-secondary); }
 .judge-assign .input { max-width: 32rem; }
 
+/* Every rule above is one-shot and cheap, and all of it is skipped for anyone
+   who asked not to be moved. The bar still shows where it stands; it simply
+   arrives there. */
+@media (prefers-reduced-motion: reduce) {
+  .judge-ghost, .judge-card, .judge-peek > summary::after { transition: none; }
+  .judge-card-enter, .judge-tick, .judge-delta,
+  .judge-xp-moved, .judge-xp-moved .judge-xp-fill,
+  .judge-xp-moved .judge-xp-sheen { animation: none; }
+  .judge-delta { opacity: 1; }
+  #card.htmx-swapping .judge-card { transform: none; opacity: 1; }
+}
+
+/* On a short window the pool gives back first: the card has a floor of its own
+   in the head and the action row, and 56vh of pool under a 200px head is a card
+   taller than a laptop screen. */
+@media (height <= 800px) {
+  .judge-pool { max-height: 44vh; }
+}

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -60,6 +60,11 @@ pub struct Pulse {
     pub target: i64,
     /// How far along the stretch between the two, not how far along the count.
     pub pct: i64,
+    /// Where the bar stood before this verdict. A swapped element is a new
+    /// element with no previous width to transition away from, so the previous
+    /// width is sent and the fill is animated between the two. Equal to `pct`
+    /// wherever nothing moved, which is what makes the animation a no-op there.
+    pub pct_prev: i64,
     /// What that target buys, in the words for a first sweep or a later one.
     pub label: &'static str,
     pub recall: String,
@@ -85,11 +90,9 @@ struct JudgeTemplate {
     /// this page too, so the badge falls as the queue is worked down rather
     /// than standing at whatever it read on arrival.
     judge_pending: Option<i64>,
-    /// Always `Some` here. `Option` because the partial is shared with the
-    /// card fragment, where a plain fetch carries none.
+    /// Always `Some` here. `Option` because the partial is shared with the card
+    /// fragment, which draws nothing where there is no card to hang it under.
     pulse: Option<Pulse>,
-    /// False on the page itself: it is drawing the header, not replacing one.
-    pulse_oob: bool,
     /// What the sweeps have to say. Always `Some` here; `Option` because the
     /// partial is shared with the card fragment and the apply answer.
     tune: Option<TuneView>,
@@ -112,12 +115,11 @@ struct CardTemplate {
     /// What the judgement just before this one revealed. `None` on a plain
     /// fetch of the next card.
     flash: Option<Flash>,
-    /// The header, shipped beside the card so it moves with the work. `None`
-    /// where nothing was judged: an animation on a plain fetch would be the
-    /// page congratulating itself for a page load.
+    /// The figures, drawn inside the card so they move with the work. Always
+    /// `Some` from every route: they are part of what a verdict replaces now,
+    /// not a second region kept in step with it. What tells a verdict from a
+    /// plain fetch is `Pulse::delta`, which every animation on them keys on.
     pulse: Option<Pulse>,
-    /// True here: the header this replaces is already on the page.
-    pulse_oob: bool,
     /// A sweep runs off the request path, so the page that paid for it was
     /// already sent. The next verdict is the first chance to report one.
     tune: Option<TuneView>,
@@ -126,6 +128,8 @@ struct CardTemplate {
 
 pub struct Flash {
     pub line: String,
+    /// How loudly to say it, as a class suffix. See `tier`.
+    pub tier: &'static str,
     /// `MRR 0.54 → 0.57`, so the figure the work is measured by visibly moves
     /// as the work is done.
     pub delta: String,
@@ -150,6 +154,28 @@ pub fn diagnosis(rank: Option<i64>, verdict: Verdict) -> &'static str {
         }
         (Verdict::Hit, Some(r)) if r > 0 => "there, but far down. These are what move the MRR.",
         (Verdict::Hit, _) => "found as expected.",
+    }
+}
+
+/// How much weight the flash line is given, as a class suffix.
+///
+/// The same split `diagnosis` makes, spent on emphasis rather than wording, and
+/// running the same way: quietest where the ranking did best. A rank-one
+/// confirmation is greyed towards invisible and a hit the ranking buried gets
+/// the only accent on the page. It has to run this way round — an interface
+/// that lit up for confirmations would be teaching its operator that agreeing
+/// with the top result is the good outcome, and the top result is the thing
+/// under examination.
+pub fn tier(rank: Option<i64>, verdict: Verdict) -> &'static str {
+    match (verdict, rank) {
+        (Verdict::Gap, _) => "gap",
+        (Verdict::Discard, _) => "quiet",
+        // A find, and a hit below what the search actually showed: the two
+        // cases the wider pool exists to make recordable at all.
+        (Verdict::Hit, None) => "rare",
+        (Verdict::Hit, Some(r)) if r >= 10 => "rare",
+        (Verdict::Hit, Some(r)) if r > 0 => "plain",
+        (Verdict::Hit, _) => "common",
     }
 }
 
@@ -252,7 +278,7 @@ async fn next_pending_card(st: &AppState) -> Result<Option<Card>> {
 /// judgement buys is a measurement, and after the first one the distance is to
 /// the next re-sweep. Read from the last run rather than counted, so the two
 /// always agree about when it is due.
-async fn pulse_of(st: &AppState, stats: &Stats, delta: String) -> Result<Pulse> {
+async fn pulse_of(st: &AppState, stats: &Stats, delta: String, prev: i64) -> Result<Pulse> {
     let tune = &st.core.feedback.tune;
     let (floor, label) = match st.core.store.latest_eval_run().await? {
         None => (0, "until the first sweep"),
@@ -271,9 +297,11 @@ async fn pulse_of(st: &AppState, stats: &Stats, delta: String) -> Result<Pulse> 
     // 95% and then 96%, and the one visual the header is built around stopped
     // saying anything.
     let span = (target - floor).max(1);
+    let along = |n: i64| ((n - floor).max(0) * 100 / span).min(100);
     Ok(Pulse {
         judged: stats.judged,
-        pct: ((stats.judged - floor).max(0) * 100 / span).min(100),
+        pct: along(stats.judged),
+        pct_prev: along(prev),
         floor,
         target,
         label,
@@ -304,8 +332,7 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     Ok(HtmlTemplate(JudgeTemplate {
         // Read off the stats already in hand rather than counted again.
         judge_pending: st.core.learn.enabled.then_some(stats.pending),
-        pulse: Some(pulse_of(&st, &stats, String::new()).await?),
-        pulse_oob: false,
+        pulse: Some(pulse_of(&st, &stats, String::new(), stats.judged).await?),
         tune: Some(tune_view(&st, "").await?),
         tune_oob: false,
         misses,
@@ -316,13 +343,18 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     .into_response())
 }
 
+/// The next card, with nothing to say about the last one.
+///
+/// The figures ride inside the card, so they are always rendered — leaving them
+/// out would blank the bar rather than leave it alone. What is left out is the
+/// movement: `delta` is empty, and every animation on this fragment keys on it.
 async fn next_card(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     use axum::response::IntoResponse;
+    let stats = st.core.store.feedback_stats().await?;
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(&st).await?,
         flash: None,
-        pulse: None,
-        pulse_oob: true,
+        pulse: Some(pulse_of(&st, &stats, String::new(), stats.judged).await?),
         tune: None,
         tune_oob: true,
     })
@@ -335,8 +367,9 @@ async fn next_card(State(st): State<AppState>, _id: Identity) -> Result<Response
 /// this judgement actually caused rather than a figure recomputed later.
 async fn card_after(
     st: &AppState,
-    before: f64,
-    line: &'static str,
+    before: Stats,
+    rank: Option<i64>,
+    verdict: Verdict,
     judged: &str,
 ) -> Result<Response> {
     use axum::response::IntoResponse;
@@ -346,10 +379,15 @@ async fn card_after(
     // operator must not wait on a grid of searches, and a sweep that fails
     // must not fail the verdict that paid for it.
     crate::eval::sweep::maybe_spawn(&st.core);
-    let moved = after - before;
-    // Under half a point the figure on screen does not change, and a tick
-    // pointing at an unchanged number is an animation about nothing.
-    let delta = if moved.abs() < 0.005 {
+    let moved = after - before.mrr;
+    // Three places rather than two, and no floor under it. Half a point was the
+    // threshold, on the reasoning that a smaller move leaves the figure on
+    // screen unchanged. But one verdict can shift the MRR by at most 1/n, so
+    // the tick fell silent in exact proportion to how much work had been done:
+    // the one number this page is worked towards stopped acknowledging the work
+    // precisely where the work started to add up. Shown at the precision the
+    // movement actually has instead, and shown whenever there was one.
+    let delta = if moved == 0.0 {
         String::new()
     } else if moved > 0.0 {
         format!("▲ +{moved:.2}")
@@ -359,12 +397,12 @@ async fn card_after(
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(st).await?,
         flash: Some(Flash {
-            line: line.to_string(),
-            delta: format!("MRR {before:.2} → {after:.2}"),
+            line: diagnosis(rank, verdict).to_string(),
+            tier: tier(rank, verdict),
+            delta: format!("MRR {:.2} → {after:.2}", before.mrr),
             undo: Some(judged.to_string()),
         }),
-        pulse: Some(pulse_of(st, &stats, delta).await?),
-        pulse_oob: true,
+        pulse: Some(pulse_of(st, &stats, delta, before.judged).await?),
         tune: Some(tune_view(st, "").await?),
         tune_oob: true,
     })
@@ -383,16 +421,20 @@ async fn card_again(st: &AppState, event_id: &str, line: &str) -> Result<Respons
         Some(event) => Some(card_for(st, event).await?),
         None => next_pending_card(st).await?,
     };
+    let stats = st.core.store.feedback_stats().await?;
     Ok(HtmlTemplate(CardTemplate {
         card,
         flash: Some(Flash {
             line: line.to_string(),
+            // A correction, not a verdict: said plainly, with none of the
+            // weight a judgement carries.
+            tier: "quiet",
             delta: String::new(),
             undo: None,
         }),
-        // Nothing was recorded, so no figure moved.
-        pulse: None,
-        pulse_oob: true,
+        // Nothing was recorded, so the figures are rendered where they stand and
+        // `delta` is empty, which is what every animation on them keys on.
+        pulse: Some(pulse_of(st, &stats, String::new(), stats.judged).await?),
         tune: None,
         tune_oob: true,
     })
@@ -444,13 +486,15 @@ async fn undo(
         // is a better answer than an error page.
         None => next_pending_card(&st).await?,
     };
+    let stats = st.core.store.feedback_stats().await?;
     Ok(HtmlTemplate(CardTemplate {
         card,
         flash: None,
-        // An undo moves the figures back, and the operator is looking at the
-        // header while it happens.
-        pulse: Some(pulse_of(&st, &st.core.store.feedback_stats().await?, String::new()).await?),
-        pulse_oob: true,
+        // An undo moves the figures back, and the operator is looking straight
+        // at them while it happens. No delta, though: the tick and the bar's
+        // travel are how the page acknowledges work, and taking a judgement
+        // back is not some of it.
+        pulse: Some(pulse_of(&st, &stats, String::new(), stats.judged).await?),
         tune: None,
         tune_oob: true,
     })
@@ -502,9 +546,9 @@ async fn hit(
         .store
         .rank_in_event(&event_id, &f.artifact_id)
         .await?;
-    let before = st.core.store.feedback_stats().await?.mrr;
+    let before = st.core.store.feedback_stats().await?;
     st.core.store.judge_hit(&event_id, &f.artifact_id).await?;
-    card_after(&st, before, diagnosis(rank, Verdict::Hit), &event_id).await
+    card_after(&st, before, rank, Verdict::Hit, &event_id).await
 }
 
 async fn gap(
@@ -512,9 +556,9 @@ async fn gap(
     _id: Identity,
     Path(event_id): Path<String>,
 ) -> Result<Response> {
-    let before = st.core.store.feedback_stats().await?.mrr;
+    let before = st.core.store.feedback_stats().await?;
     st.core.store.judge(&event_id, Verdict::Gap).await?;
-    card_after(&st, before, diagnosis(None, Verdict::Gap), &event_id).await
+    card_after(&st, before, None, Verdict::Gap, &event_id).await
 }
 
 async fn discard(
@@ -522,9 +566,9 @@ async fn discard(
     _id: Identity,
     Path(event_id): Path<String>,
 ) -> Result<Response> {
-    let before = st.core.store.feedback_stats().await?.mrr;
+    let before = st.core.store.feedback_stats().await?;
     st.core.store.judge(&event_id, Verdict::Discard).await?;
-    card_after(&st, before, diagnosis(None, Verdict::Discard), &event_id).await
+    card_after(&st, before, None, Verdict::Discard, &event_id).await
 }
 
 async fn skip(
@@ -1077,13 +1121,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_way_out_of_the_question_is_never_inside_the_scrolling_part() {
+        // The pool is the only thing on the card with a scrollbar, and the three
+        // answers are outside it. That is the whole of why they stay put — it
+        // used to be `position: sticky` fighting a page twenty-three cards tall.
+        let (app, cookie, _core, _) = judge_app(20, &[]).await;
+        let body = get(&app, "/ui/judge/next", &cookie).await;
+        let pool_ends = body.find("</ol>").expect("no pool");
+        let outs = body.find("judge-outs").expect("no way out of the question");
+        assert!(
+            outs > pool_ends,
+            "the answers are inside the box that scrolls: {body}"
+        );
+        assert_eq!(
+            body.matches("judge-pool").count(),
+            1,
+            "more than one thing on the card scrolls: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reading_a_candidate_costs_no_line_of_its_own() {
+        // Twenty candidates meant twenty lines that said "Read it in full" and
+        // nothing else — a whole row each, to repeat the same six words. The
+        // handle is in the row now, and what it opens lands in the sibling
+        // beneath so it can span the row without moving the handle out of its
+        // column.
+        let (app, cookie, _core, _) = judge_app(20, &[]).await;
+        let body = get(&app, "/ui/judge/next", &cookie).await;
+        assert!(
+            !body.contains(">Read it in full<"),
+            "the handle is still a line of prose per candidate: {body}"
+        );
+        assert!(
+            body.contains(r#"hx-target="next .judge-full""#),
+            "the full text is not fetched into the row it belongs to: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_bar_carries_where_it_moved_from_as_well_as_where_it_is() {
+        // A swapped element is a new element: it has no previous width to
+        // transition away from, so a bar rendered by the server can only be
+        // animated between two values it was told. Without the first one it
+        // jumps, which is the thing it exists not to do.
+        let (app, cookie, core, ids) = judge_app(2, &[]).await;
+        let event = core.store.next_pending().await.unwrap().unwrap();
+        let card = {
+            let res = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("/ui/judge/{}/hit", event.id))
+                        .method("POST")
+                        .header("cookie", &cookie)
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .body(Body::from(format!("artifact_id={}", ids[0])))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            body_of(res).await
+        };
+        assert!(card.contains("--from:"), "no starting position: {card}");
+        assert!(card.contains("--to:"), "no finishing position: {card}");
+        assert!(
+            card.contains("judge-xp-moved"),
+            "a verdict left the bar still: {card}"
+        );
+
+        // And a plain fetch does not: an animation there is the page
+        // acknowledging its own load.
+        let plain = get(&app, "/ui/judge/next", &cookie).await;
+        assert!(
+            !plain.contains("judge-xp-moved"),
+            "the bar animates on a fetch that judged nothing: {plain}"
+        );
+    }
+
+    #[tokio::test]
     async fn the_card_shows_no_ranks_and_no_scores() {
         // Both are the ranker's opinion, which is exactly what must not be
         // heard while judging.
+        //
+        // Read off the pool rather than the whole fragment. The figures ride in
+        // the card now, and one of them is the mean reciprocal *rank* — an
+        // aggregate over judgements already given, which says nothing about the
+        // candidates on this card and is the number the work is aimed at. What
+        // must stay clean is the list itself.
         let (app, cookie, _core, _) = judge_app(3, &[]).await;
         let body = get(&app, "/ui/judge/next", &cookie).await;
-        assert!(!body.contains("rank"), "a rank leaked into the card");
-        assert!(!body.contains("score"), "a score leaked into the card");
+        let pool = body
+            .split_once(r#"<div class="judge-pool">"#)
+            .and_then(|(_, rest)| rest.split_once("</ol>"))
+            .map(|(pool, _)| pool)
+            .unwrap_or_else(|| panic!("no pool on the card: {body}"));
+        assert!(
+            !pool.contains("rank"),
+            "a rank leaked into the pool: {pool}"
+        );
+        assert!(
+            !pool.contains("score"),
+            "a score leaked into the pool: {pool}"
+        );
     }
 
     #[tokio::test]
@@ -1354,12 +1494,23 @@ mod tests {
         // Inverted on purpose. A first-position hit is the least informative
         // card of the day; making it the most celebrated would breed agreement
         // with whatever the ranker already thought.
-        use super::diagnosis;
+        use super::{diagnosis, tier};
         use crate::store::feedback::Verdict;
         assert_eq!(diagnosis(Some(0), Verdict::Hit), "found as expected.");
         assert!(diagnosis(Some(13), Verdict::Hit).contains("wrong"));
         assert!(diagnosis(None, Verdict::Hit).contains("find"));
         assert!(diagnosis(None, Verdict::Gap).contains("hole"));
+
+        // The same split, said again in weight rather than in words: a
+        // confirmation of what was already on top is greyed towards invisible,
+        // and the two cases the wider pool exists for get the only accent on
+        // the page. Held here rather than left to the stylesheet — which
+        // verdict is the quiet one is a claim about what judging is for.
+        assert_eq!(tier(Some(0), Verdict::Hit), "common");
+        assert_eq!(tier(Some(13), Verdict::Hit), "rare");
+        assert_eq!(tier(None, Verdict::Hit), "rare");
+        assert_eq!(tier(None, Verdict::Gap), "gap");
+        assert_eq!(tier(None, Verdict::Discard), "quiet");
     }
 
     #[tokio::test]
@@ -1780,7 +1931,7 @@ mod tests {
 
         let body = get(&app, "/ui/judge", &cookie).await;
         assert!(
-            body.contains("width:0%"),
+            body.contains("--to:0%"),
             "the stretch to the next sweep has not started: {body}"
         );
         assert!(
@@ -1809,7 +1960,7 @@ mod tests {
         core.store.judge_hit(&id, &ids[0]).await.unwrap();
 
         let body = get(&app, "/ui/judge", &cookie).await;
-        assert!(body.contains("width:10%"), "{body}");
+        assert!(body.contains("--to:10%"), "{body}");
     }
 
     /// A sweep in the store, recorded as having run at `judged`.

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -1,23 +1,22 @@
-{# The header, shipped with the card so the figures move as the queue is worked
-   down. Nothing when nothing was judged.
+{# The tuning strip, shipped with the card so a sweep that finished off the
+   request path is reported at the first opportunity.
 
-   Only where they are going out of band, which is only from the fragment
-   routes. The page draws both itself, outside `#card`, and including them
-   unconditionally rendered a second `judge-live` and a second `judge-tune`
-   inside it: the whole recommendation twice, and an Apply button whose swap
-   landed on the first copy while the second went on offering what had just
-   been taken. #}
-{% if pulse_oob %}{% include "_judge_pulse.html" %}{% endif %}
+   Only where it is going out of band, which is only from the fragment routes.
+   The page draws it itself, outside `#card`, and including it unconditionally
+   rendered a second `judge-tune` inside: the whole recommendation twice, and an
+   Apply button whose swap landed on the first copy while the second went on
+   offering what had just been taken. #}
 {% if tune_oob %}{% include "_judge_tune.html" %}{% endif %}
 {% match flash %}
 {% when Some with (f) %}
 {# What the last verdict revealed. Loudest where the ranking did worst: a
    first-position confirmation is the least informative card of the day, and
-   celebrating it would breed agreement rather than judgement. #}
+   celebrating it would breed agreement rather than judgement. The tier classes
+   are what carry that difference now — see `Flash::tier`. #}
 {# Undo sits on the flash because that is where the operator is already looking
    when they realise the digit was wrong. A mislabelled pair is worse than no
    pair: it is scored against the ranker as though it were true. #}
-<p class="judge-flash">{{ f.line }} <span class="mono muted">{{ f.delta }}</span>
+<p class="judge-flash judge-flash-{{ f.tier }}">{{ f.line }} <span class="mono muted">{{ f.delta }}</span>
   {% if let Some(undo_id) = f.undo %}
   <button class="btn btn-ghost btn-sm judge-undo" hx-post="/ui/judge/{{ undo_id }}/undo"
           hx-target="#card" hx-swap="innerHTML">Undo <kbd>U</kbd></button>
@@ -27,85 +26,126 @@
 {% endmatch %}
 {% match card %}
 {% when Some with (c) %}
-<article class="judge-card" data-judge-id="{{ c.id }}">
-  <p class="muted mono">{{ c.when }} · {{ c.door }}</p>
-  <h2 class="judge-query">{{ c.query }}</h2>
-  <p class="muted hint">Which of these was the one you needed?</p>
-  {# Numbered for the keyboard only. The order is a hash of the event id, so it
-     carries no information about how the search ranked them — seeing that would
-     turn judging into agreeing. #}
-  <ol class="judge-options">
-    {% for o in c.choices %}
-    <li>
-      {# Deprecated and superseded artifacts stay in the pool at full length so
-         the operator sees what the search actually returned, but they are
-         disabled: `hit` would refuse them, and a refusal arriving after the
-         keystroke re-renders an identical card with nothing to show which
-         option was the bad one. Said here instead, before the choice. #}
-      <button class="judge-option{% if !o.usable %} judge-option-unusable{% endif %}"
-              {% if o.usable %}
-              hx-post="/ui/judge/{{ c.id }}/hit"
-              hx-vals='{"artifact_id": "{{ o.artifact_id }}"}'
-              hx-target="#card" hx-swap="innerHTML"
-              {% else %}disabled{% endif %}>
-        {# Only the first nine choosable options carry a number. The shortcut is
-           a single digit and `feedback.candidates` is 20 by default, so a badge
-           on the tenth would advertise a key that does nothing; a badge on a
-           disabled one would advertise a key that refuses. The column stays
-           either way so the titles line up. #}
-        <span class="judge-key">{% if let Some(k) = o.key %}{{ k }}{% endif %}</span>
-        {# No heading where there is no name. A verbatim passage has no title
-           by design, and a list of "Untitled" is a column of a word that says
-           nothing where a name would say something — the same reasoning
-           `render_hit` states for the search rail. The snippet below carries
-           the row. #}
-        {% if !o.title.is_empty() %}<span class="judge-title">{{ o.title }}</span>{% endif %}
-        {% if o.usable %}
-        <span class="judge-snippet">{{ o.snippet }}</span>
-        {% else %}
-        <span class="judge-snippet muted">deprecated or superseded — the benchmark can't hold
-          this one, so it can't be the answer</span>
-        {% endif %}
+{# The deck. Two sheets behind the card make the queue a depth rather than a
+   number, and they are the thing that moves forward when a card leaves — which
+   is why they are drawn here and not by the card: they have to still be in the
+   document while the outgoing card is animating off it. #}
+<div class="judge-deck">
+  {% if let Some(p) = pulse %}{% if p.pending > 1 %}
+  <span class="judge-ghost judge-ghost-2" aria-hidden="true"></span>
+  <span class="judge-ghost judge-ghost-1" aria-hidden="true"></span>
+  {% endif %}{% endif %}
+  {# `judge-card-enter` only where a verdict brought this one in. On a plain
+     fetch it would be the page animating its own load. #}
+  <article class="judge-card{% if flash.is_some() %} judge-card-enter{% endif %}"
+           data-judge-id="{{ c.id }}">
+    <div class="judge-head">
+      <p class="judge-meta mono muted">{{ c.when }} · {{ c.door }}</p>
+      <h2 class="judge-query">{{ c.query }}</h2>
+      {% include "_judge_pulse.html" %}
+      <p class="muted hint judge-ask">Which of these was the one you needed?
+        <span class="mono">— {{ c.choices.len() }} candidates, unordered</span></p>
+    </div>
+
+    {# The pool is the only thing on this card that scrolls, and it is bounded
+       so the question and the three ways out of it are always both on screen.
+       The whole pool is in it: shortening the list is what would make a verdict
+       mean something it doesn't, and a scroll inside a box is not a shortening.
+       This is what the sticky action bar used to work around — twenty-three
+       cards' worth of page, with the way out at the bottom of it. #}
+    <div class="judge-pool">
+      {# Numbered for the keyboard only. The order is a hash of the event id, so
+         it carries no information about how the search ranked them — seeing
+         that would turn judging into agreeing. #}
+      <ol class="judge-options">
+        {% for o in c.choices %}
+        {# Deprecated and superseded artifacts stay in the pool at full length so
+           the operator sees what the search actually returned, but they are
+           disabled: `hit` would refuse them, and a refusal arriving after the
+           keystroke re-renders an identical card with nothing to show which
+           option was the bad one. Said here instead, before the choice. #}
+        <li{% if !o.usable %} class="judge-dead"{% endif %}>
+          <button class="judge-option{% if !o.usable %} judge-option-unusable{% endif %}"
+                  {% if o.usable %}
+                  hx-post="/ui/judge/{{ c.id }}/hit"
+                  hx-vals='{"artifact_id": "{{ o.artifact_id }}"}'
+                  hx-target="#card" hx-swap="innerHTML swap:220ms"
+                  {% else %}disabled{% endif %}>
+            {# Only the first nine choosable options carry a number. The shortcut
+               is a single digit and `feedback.candidates` is 20 by default, so a
+               badge on the tenth would advertise a key that does nothing; a badge
+               on a disabled one would advertise a key that refuses. The column
+               stays either way so the titles line up. #}
+            <span class="judge-key">{% if let Some(k) = o.key %}{{ k }}{% endif %}</span>
+            {# No heading where there is no name. A verbatim passage has no title
+               by design, and a list of "Untitled" is a column of a word that says
+               nothing where a name would say something — the same reasoning
+               `render_hit` states for the search rail. The snippet below carries
+               the row. #}
+            {% if !o.title.is_empty() %}<span class="judge-title">{{ o.title }}</span>{% endif %}
+            {% if o.usable %}
+            <span class="judge-snippet">{{ o.snippet }}</span>
+            {% else %}
+            <span class="judge-snippet muted">deprecated or superseded — the benchmark can't hold
+              this one, so it can't be the answer</span>
+            {% endif %}
+          </button>
+          {% if o.usable %}
+          {# A hundred and forty characters is enough to recognise an artifact and
+             not enough to be sure of one, and the click after it is a line in the
+             dataset. Fetched on first open and kept: reading two candidates and
+             comparing them is exactly the case this exists for.
+
+             The handle sits in the row instead of on a line of its own beneath
+             it. Twenty candidates meant twenty "Read it in full" lines, which was
+             the single most expensive thing on the old card — a whole row each,
+             to say the same six words twenty times.
+
+             Outside the option rather than inside it — a button within a button
+             is neither valid nor clickable — so opening this can never fire a
+             verdict. The text lands in the sibling below rather than inside the
+             disclosure, so it can span the row while the handle stays in its
+             column. #}
+          <details class="judge-peek" hx-get="/ui/judge/read/{{ o.artifact_id }}"
+                   hx-trigger="toggle once" hx-target="next .judge-full"
+                   hx-swap="innerHTML">
+            <summary title="Read it in full" aria-label="Read it in full"></summary>
+          </details>
+          <div class="judge-full"><span class="muted">loading…</span></div>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ol>
+    </div>
+
+    {# `data-key` is what the shortcut binds to. By position it bound to whatever
+       button happened to sit at that index, and the assign screen's row is a
+       different row: N there was an immediate gap verdict. #}
+    <div class="row judge-outs">
+      {# Not a verdict yet: it opens the search for what should have answered.
+         Only if nothing there fits does it become a gap. #}
+      <button class="btn btn-ghost btn-sm" data-key="n"
+              hx-get="/ui/judge/{{ c.id }}/assign"
+              hx-target="#card" hx-swap="innerHTML">
+        None of these <kbd>N</kbd>
       </button>
-      {# A hundred and forty characters is enough to recognise an artifact and
-         not enough to be sure of one, and the click after it is a line in the
-         dataset. Fetched on first open and kept: reading two candidates and
-         comparing them is exactly the case this exists for. Outside the
-         option rather than inside it — a button within a button is neither
-         valid nor clickable — so opening this can never fire a verdict. #}
-      <details class="judge-peek" hx-get="/ui/judge/read/{{ o.artifact_id }}"
-               hx-trigger="toggle once" hx-target="find .judge-full"
-               hx-swap="innerHTML">
-        <summary>Read it in full</summary>
-        <div class="judge-full"><span class="muted">loading…</span></div>
-      </details>
-    </li>
-    {% endfor %}
-  </ol>
-  {# `data-key` is what the shortcut binds to. By position it bound to whatever
-     button happened to sit at that index, and the assign screen's row is a
-     different row: N there was an immediate gap verdict. #}
-  <div class="row judge-outs">
-    {# Not a verdict yet: it opens the search for what should have answered.
-       Only if nothing there fits does it become a gap. #}
-    <button class="btn btn-ghost btn-sm" data-key="n"
-            hx-get="/ui/judge/{{ c.id }}/assign"
-            hx-target="#card" hx-swap="innerHTML">
-      None of these <kbd>N</kbd>
-    </button>
-    <button class="btn btn-ghost btn-sm" data-key="s"
-            hx-post="/ui/judge/{{ c.id }}/skip"
-            hx-target="#card" hx-swap="innerHTML">
-      Can't remember <kbd>S</kbd>
-    </button>
-    <span class="spacer"></span>
-    <button class="btn btn-ghost btn-sm" data-key="x"
-            hx-post="/ui/judge/{{ c.id }}/discard"
-            hx-target="#card" hx-swap="innerHTML">
-      Not a real search <kbd>X</kbd>
-    </button>
-  </div>
-</article>
+      <button class="btn btn-ghost btn-sm" data-key="s"
+              hx-post="/ui/judge/{{ c.id }}/skip"
+              hx-target="#card" hx-swap="innerHTML swap:220ms">
+        Can't remember <kbd>S</kbd>
+      </button>
+      <span class="spacer"></span>
+      <button class="btn btn-ghost btn-sm" data-key="x"
+              hx-post="/ui/judge/{{ c.id }}/discard"
+              hx-target="#card" hx-swap="innerHTML swap:220ms">
+        Not a real search <kbd>X</kbd>
+      </button>
+    </div>
+  </article>
+</div>
 {% when None %}
+{# The figures outlive the queue: what has been judged is still worth reading
+   when there is nothing left to judge. #}
+{% include "_judge_pulse.html" %}
 <p class="muted">Nothing to judge. <a href="/ui/search">Back to search.</a></p>
 {% endmatch %}

--- a/src/web/templates/_judge_pulse.html
+++ b/src/web/templates/_judge_pulse.html
@@ -1,40 +1,63 @@
-{# The header's live half, rendered twice: once by the page, once beside the
-   card a verdict returns. Out of band the second time, because the header sits
-   outside the swapped region and would otherwise stand at whatever it read on
-   arrival while the queue was worked down.
+{# The live figures, now inside the card rather than above it.
 
-   Nothing here reacts to *which* verdict was given. What animates is progress
+   They used to be a block of their own at the top of the page, swapped out of
+   band on every verdict. That cost the top third of the screen before a single
+   candidate was readable, and it needed the out-of-band machinery only because
+   it sat outside the region a verdict replaces. Inside the card there is one
+   copy, swapped with everything else, and no `hx-swap-oob` left to keep in
+   step.
+
+   Nothing here reacts to *which* verdict was given. What moves is progress
    towards the next sweep — the work — never agreement with the ranker. The
    flash line above the card is where a judgement is spoken about, and its
    loudness runs the other way on purpose. #}
 {% if let Some(p) = pulse %}
-<div id="judge-live" class="judge-live"{% if pulse_oob %} hx-swap-oob="true"{% endif %}>
-  <div class="row">
-    <span class="mono">{{ p.judged }} judged</span>
-    <span class="spacer"></span>
-    {# The two figures carried no explanation at all: an operator who had not
-       read docs/evaluation.md was working towards numbers nobody had named. #}
-    <span class="mono" title="Of the answers you have confirmed, the share the ranking put in its top ten.">recall@10 {{ p.recall }}</span>
-    <span class="mono{% if !p.delta.is_empty() %} judge-tick{% endif %}"
-          title="Mean reciprocal rank: 1.00 means every confirmed answer came first. An answer search never returned counts as zero.">MRR {{ p.mrr }}</span>
-    {% if !p.delta.is_empty() %}<span class="mono judge-delta">{{ p.delta }}</span>{% endif %}
-    <span class="spacer"></span>
-    <span class="mono muted">{{ p.recent }} in the last 24h · {{ p.pending }} waiting</span>
-  </div>
-  <div class="progress" role="progressbar" aria-valuenow="{{ p.judged }}"
+<div id="judge-live" class="judge-live">
+  {# The bar is an object with a height, not the edge of one.
+
+     `--from` and `--to` are what let it move at all on a server-rendered swap:
+     the element that arrives is a new one, with no previous width to transition
+     away from, so the previous width is sent alongside the current one and the
+     fill is animated between the two. The pale trail goes straight to `--to`,
+     so for the length of the fill's delay the ground just won reads as area
+     rather than as a different endpoint. The notches are what make it a
+     distance instead of a percentage. #}
+  <div class="judge-xp{% if !p.delta.is_empty() %} judge-xp-moved{% endif %}"
+       style="--from:{{ p.pct_prev }}%;--to:{{ p.pct }}%"
+       role="progressbar" aria-valuenow="{{ p.judged }}"
        aria-valuemin="{{ p.floor }}" aria-valuemax="{{ p.target }}">
-    <span style="width:{{ p.pct }}%"{% if pulse_oob %} class="judge-grow"{% endif %}></span>
+    <span class="judge-xp-trail"></span>
+    <span class="judge-xp-fill"></span>
+    <span class="judge-xp-notches"></span>
+    <span class="judge-xp-sheen"></span>
   </div>
-  {# What the bar is progress *towards*. It counted to fifty and promised
+  <p class="judge-xp-read mono">
+    <b>{{ p.judged }}</b> / {{ p.target }} {{ p.label }}
+  </p>
+  {# Said in full only while it has never happened. After the first sweep the
+     operator has seen what one produces — a recommendation on this very page —
+     and a sentence explaining it every time is a sentence between them and the
+     candidates. Before it, nobody has: the bar counted to fifty and promised
      nothing, so reaching it looked like nothing happening. #}
-  <p class="muted hint">{{ p.judged }} / {{ p.target }} {{ p.label }} — a sweep
-    tries other ranking settings over everything you have judged, and offers
-    the ones that score better.</p>
-  <p class="muted mono">
+  {% if p.floor == 0 %}
+  <p class="muted hint">A sweep tries other ranking settings over everything you
+    have judged, and offers the ones that score better.</p>
+  {% endif %}
+  {# The two figures carried no explanation at all: an operator who had not read
+     docs/evaluation.md was working towards numbers nobody had named. #}
+  <p class="judge-figures mono muted">
+    <span title="Of the answers you have confirmed, the share the ranking put in its top ten.">recall@10 {{ p.recall }}</span>
+    ·
+    <span class="{% if !p.delta.is_empty() %}judge-tick{% endif %}"
+          title="Mean reciprocal rank: 1.00 means every confirmed answer came first. An answer search never returned counts as zero.">MRR {{ p.mrr }}</span>
+    {% if !p.delta.is_empty() %}<span class="judge-delta">{{ p.delta }}</span>{% endif %}
+    ·
     <span title="A confirmed answer that search had returned.">{{ p.hits }} hits</span> ·
     <span title="A confirmed answer search never returned. The only evidence that ranking, rather than the base, was at fault.">{{ p.finds }} finds</span> ·
     <span title="Nothing in the base could have answered it.">{{ p.gaps }} gaps</span> ·
-    <span title="Not a real search.">{{ p.discards }} discarded</span>
+    <span title="Not a real search.">{{ p.discards }} discarded</span> ·
+    <span>{{ p.recent }} in the last 24h</span> ·
+    <span>{{ p.pending }} waiting</span>
   </p>
 </div>
 {% endif %}

--- a/src/web/templates/judge.html
+++ b/src/web/templates/judge.html
@@ -1,27 +1,27 @@
 {% extends "layout.html" %}
 {% block title %}Judge — engram{% endblock %}
+{% block regions %}regions-judge{% endblock %}
 {% block content %}
-{# The header is the real measurement, not a score standing in for one: both
-   figures are read from the ranks the searches actually gave, so every verdict
-   moves the number it is measured by. #}
-<div class="judge-header">
-  {% include "_judge_pulse.html" %}
-  {% if asks.asked > 0 %}
-  <p class="muted mono">
-    {{ asks.judged }} of {{ asks.asked }} questions judged ·
-    {{ asks.right }} right · {{ asks.wrong }} wrong · {{ asks.nothing_here }} nothing here
-  </p>
-  {% endif %}
-</div>
-
-{# Directly under the figures it would move: it is the one thing on this page
-   that can be acted on, and it is what the progress bar is counting towards. #}
+{# Directly above the card: it is the one thing on this page that can be acted
+   on, and it is what the bar inside the card is counting towards. #}
 {% include "_judge_tune.html" %}
 
+{# The whole working surface. The figures used to stand above this in a block of
+   their own — a third of the screen of readout before the first candidate — and
+   they are inside the card now, under the query, where the bar they belong to
+   can be seen moving as the queue is worked down. #}
 <div id="card">{% include "_judge_card.html" %}</div>
 
-{# Below the card, folded. It is a reference to fall back on between
-   judgements, not something to read before starting one. #}
+{# Below the card. Both of these are references to fall back on between
+   judgements rather than things to read before starting one, and the questions
+   are a different queue from the searches — it is the ask page that moves them,
+   not this one. #}
+{% if asks.asked > 0 %}
+<p class="judge-asks muted mono">
+  {{ asks.judged }} of {{ asks.asked }} questions judged ·
+  {{ asks.right }} right · {{ asks.wrong }} wrong · {{ asks.nothing_here }} nothing here
+</p>
+{% endif %}
 {% if !misses.is_empty() %}
 <details class="misses">
   <summary class="muted">{{ misses.len() }} queries the ranking got wrong</summary>

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3237,17 +3237,23 @@ mod tests {
     fn the_judges_own_answers_stay_with_the_question() {
         // The three ways out sat below every candidate — twenty at
         // `feedback.candidates`' default — so answering "None of these" meant
-        // scrolling past all of them first. The bar is sticky in CSS; what
-        // this holds is that it is one element, in one place, for the rule to
-        // key on.
+        // scrolling past all of them first. A sticky bar was the first answer to
+        // that. The bound on the pool is the second and the better one: the card
+        // is the only thing on the page, the pool is the only thing inside it
+        // with a scrollbar, and the question and its answers are on screen
+        // together whatever the pool is scrolled to.
+        //
+        // The bound is the load-bearing part, so it is what this holds — along
+        // with the action row being outside the box that scrolls, which is the
+        // whole of why it stays put.
         let css = include_str!("../../assets/css/42-judge.css");
         assert!(
-            css.contains(".judge-outs {") && css.contains("position: sticky"),
-            "the action bar is not sticky"
+            css.contains(".judge-pool {") && css.contains("max-height: 56vh"),
+            "the pool is unbounded, so the card is as tall as the pool"
         );
         assert!(
-            css.contains("background: var(--color-bg-base)"),
-            "a sticky bar with no background is one the cards scroll through"
+            css.contains("overflow: auto"),
+            "a bounded pool that does not scroll is a shortened pool"
         );
     }
 


### PR DESCRIPTION
Judging was a scroll. The figures took a block of their own at the top — a third of the screen of readout before the first candidate — and under them sat twenty candidates at four lines each, because every one carried a "Read it in full" line of its own beneath it. The three ways out were below all of that, held in place by a sticky bar that existed only because the page was twenty-three cards tall.

One card now holds all of it: the query, the figures the verdict moves, the pool, and the answers. Nothing inside it scrolls except the pool, and the pool is bounded, so the question and its answers are on screen together whatever it is scrolled to. The whole pool is still in there — shortening it is what would make a verdict mean something it doesn't, and a scrollbar is not a shortening.

The bar is an object with a height instead of the edge of a header nobody had to look at. It carries where it moved from as well as where it is, because a swapped element has no previous width to travel from: the pale trail goes straight to the new value and the fill follows late, so the ground just won reads as area rather than as a number that is now different. None of that responds to *what* was judged, only that something was. The flash line remains the one place that speaks about the judgement, and `tier` now gives it weight to match the wording `diagnosis` already chose — quietest where the ranking did best.

### Three things go with it

- **`pulse_oob` is gone.** The figures sat outside the region a verdict replaces and had to be dragged along out of band; inside the card they are simply part of what is swapped.
- **The MRR ticker no longer waits for half a point.** One verdict moves the MRR by at most 1/n, so the threshold silenced the tick in exact proportion to how much work had been done — the number this page is aimed at stopped acknowledging the work precisely where the work started to add up.
- **The empty `#judge-tune` no longer reserves a strip** for a sweep with nothing to say, and the card takes a working measure rather than a reading one.

### What is unchanged

The pool stays shuffled, unranked and unscored. The wider-than-shown pool, the precondition on "none of these", the visible-but-disabled artifacts and the uncaptured assign search are all as they were. No data model, no schema, no route, no config key; `feedback.candidates` is still 20.

### Tests

`cargo fmt`, `clippy` clean, full suite green (1716 + 4 + 1 passed, 0 failed). Three new tests: the way out is never inside the scrolling part, reading a candidate costs no line of its own, and the bar carries both positions.

Two tests changed rather than were fixed. One held the action bar sticky, which was the old answer to the same question; it now holds that the pool is bounded and that the answers are outside the box that scrolls. The other swept the whole fragment for the word "rank" — the figures ride in the card now and one of them is the mean reciprocal rank, so it reads the pool, which is where the ranker's opinion actually must not appear.

**Not verified in a browser.** The rendered markup and CSS were checked statically; the fly-away, the keyboard and the in-row disclosure need a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2XyfxJGoefvURp8oXPdi2