### PR TITLE
feat(dedupe): a pair whose two sides both say nothing is answered, not filed

### DIFF
--- a/src/infer/prompt.rs
+++ b/src/infer/prompt.rs
@@ -180,6 +180,8 @@ pub const DEDUPE_SYSTEM: &str = r#"You compare knowledge artifacts that may be a
 
 First, if NEITHER states anything a reader could act on or be wrong about — a body that is only its own title or file path, a bare link, boilerplate, an outline with nothing under its headings — answer "vacuous" and stop. It must hold for both: one empty artifact beside a real one is not this.
 
+Answering "vacuous" retires both artifacts where it is found; nobody confirms it first. It is the only verdict here that takes two things away and puts nothing in their place, so it asks for certainty rather than suspicion: if you can name one thing either body states, the answer is not "vacuous". When you are unsure, answer "distinct" — two artifacts left in results cost a reader nothing.
+
 Real content merely not summarised is NOT vacuous, however raw or unstructured. A day of notes covering six subjects still states six things. Those are "distinct".
 
 Then decide whether they are about the same subject. Their titles say what each one is about, and the body may never repeat it — an artifact titled "FAT32 Specifications" can open with "32 Bit Clusternummern" and never name FAT32 again.
@@ -1114,9 +1116,12 @@ pub fn dedupe_schema() -> serde_json::Value {
                     {
                         "type": "object",
                         "properties": {
-                            // The three verdicts that write nothing and name
-                            // no side: they are one variant because they carry
-                            // one shape, not because they mean anything alike.
+                            // The three verdicts that name no side: they are
+                            // one variant because they carry one shape, not
+                            // because they mean anything alike. "distinct" and
+                            // "conflict" write nothing; "vacuous" retires both
+                            // artifacts where it is found, so this branch is
+                            // not the shape of the verdicts that touch nothing.
                             "relation": {
                                 "type": "string",
                                 "enum": ["distinct", "conflict", "vacuous"]

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -28,8 +28,11 @@
 //! tight — reference material degrades an answer when it goes, where refusing the
 //! call answers nothing at all.
 //!
-//! Four verdicts come back and only two touch an artifact. A value conflict is
-//! escalated to a person and never merged.
+//! Five verdicts come back and three touch an artifact: one is replaced by the
+//! other, the two are merged, or neither states anything and both are retired.
+//! Each is carried out where it is found, because deprecation and supersession
+//! are reversible and the undo is the review. A value conflict is the one the
+//! model is worst at, so it is escalated to a person and never merged.
 
 use crate::core::Core;
 use crate::error::{Error, Result};
@@ -369,10 +372,12 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
             tracing::info!("artifacts disagree; escalating rather than merging");
             settle(core, &s.pair, PairState::Contradiction, s.detail.as_deref()).await
         }
-        // Filed, not acted on. The card offers "Discard both" with this verdict
-        // as the accented recommendation, and the deprecation happens when a
-        // person presses it.
-        Relation::Vacuous => settle(core, &s.pair, PairState::Vacuous, s.detail.as_deref()).await,
+        // Acted on where it is found, like the two verdicts below it. Filing it
+        // as a recommendation left the one answer that clears a pair of empty
+        // artifacts waiting on a person holding no more evidence than the judge
+        // had — and unlike a merge, nothing here is rewritten: both sides are
+        // one press from active and still readable under `include_deprecated`.
+        Relation::Vacuous => discard_both(core, &s.pair, s.detail.as_deref()).await,
         Relation::Replaced => {
             let obsolete = s
                 .obsolete
@@ -436,6 +441,56 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
     }
 }
 
+/// Answer a pair by retiring both sides.
+///
+/// The queue's other answers each assume something. Keeping one side assumes
+/// one of them is worth keeping; Dismiss assumes the pair is a question not
+/// worth asking and leaves both in results. Neither fits two artifacts that
+/// state nothing — a body that is its own file path, an outline with nothing
+/// under it — which are alike for a reason that has no keeper.
+///
+/// Deprecation, not deletion, and through `core.deprecate` like every other
+/// hide in the app: this is the one answer here that retires *both* artifacts,
+/// so it is also the one that most needs the same undo as the rest.
+///
+/// Both callers of this — the judge's own `Relation::Vacuous` and the "Discard
+/// both" button — reach it through here rather than each writing the sequence,
+/// because the two orderings below are the whole of what makes it safe and
+/// neither is obvious from the outside.
+pub(crate) async fn discard_both(
+    core: &Core,
+    pair: &ArtifactPair,
+    detail: Option<&str>,
+) -> Result<()> {
+    // Both sides read before either is retired. A side already hidden in
+    // favour of another artifact — an applied supersede from a neighbouring
+    // pair does this, and on the job path it can land while this pair waits on
+    // its own model call — is one `core.deprecate` refuses. Deprecating in
+    // sequence therefore hid the first side and then failed on the second,
+    // leaving the pair answerable, half of it already gone, and unanswerable
+    // for good: every later attempt repeated the same refusal.
+    //
+    // A superseded artifact is out of results already, which is all a discard
+    // is asking for, so it is skipped rather than treated as an error.
+    let mut retire = Vec::new();
+    for id in [&pair.a_id, &pair.b_id] {
+        if core.store.get_artifact(id).await?.superseded_by.is_none() {
+            retire.push(id.clone());
+        }
+    }
+    // The side effects first and the pair settled after, the ordering the rest
+    // of `apply` documents: a failure part-way leaves the pair answerable
+    // rather than recorded as answered and never applied.
+    for id in &retire {
+        core.deprecate(id).await?;
+    }
+    // Settled the way an applied replacement settles, and carrying the judge's
+    // line rather than dropping it: it is the only record of why both sides
+    // were retired, and `set_pair_state` writes `detail` unconditionally, so
+    // `None` would null it.
+    settle(core, pair, PairState::Dismissed, detail).await
+}
+
 /// One pair, one verdict.
 async fn settle(
     core: &Core,
@@ -490,11 +545,18 @@ mod tests {
         assert_eq!(asker.calls(), 0, "the sweep called the ask model");
     }
 
-    /// Nothing a model says hides an artifact on its own. `PairState::Superseded`
-    /// already takes that stance about a proposed replacement, and a verdict
-    /// that would retire *both* sides has less claim to act unaided, not more.
+    /// A verdict that neither side states anything is acted on where it is
+    /// found, as `replaced` and `duplicate` already are. The queue's other
+    /// answers each assume something — keeping one side assumes one is worth
+    /// keeping, Dismiss assumes the question was not worth asking — and neither
+    /// fits two artifacts that say nothing. Filing it as a recommendation left
+    /// the one answer that clears them waiting on a person holding no more
+    /// evidence than the judge had.
+    ///
+    /// Deprecation, not deletion: both sides are one press from active and
+    /// still readable under `include_deprecated`. That undo is the review.
     #[tokio::test]
-    async fn a_vacuous_verdict_files_the_pair_and_hides_neither_side() {
+    async fn a_vacuous_verdict_retires_both_sides_without_waiting_for_an_operator() {
         let mut core = test_core().await;
         core.judge = Some(Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"vacuous","detail":"each body is its own file path"}"#.into(),
@@ -508,17 +570,67 @@ mod tests {
 
         run(&core, &pid.to_string()).await.unwrap();
 
-        assert_eq!(
-            core.store.get_pair(pid).await.unwrap().state,
-            PairState::Vacuous,
-            "the verdict was not filed as one a person can act on"
-        );
         for id in &ids {
-            assert!(
-                core.store.get_artifact(id).await.unwrap().in_results(),
-                "a vacuous verdict hid an artifact without anyone pressing anything"
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().status,
+                ArtifactStatus::Deprecated,
+                "a side of a vacuous pair was left in results"
             );
         }
+        let pair = core.store.get_pair(pid).await.unwrap();
+        assert_eq!(
+            pair.state,
+            PairState::Dismissed,
+            "an applied discard is still listed as awaiting confirmation"
+        );
+        assert_eq!(
+            pair.detail.as_deref(),
+            Some("each body is its own file path"),
+            "the only record of why both sides went was dropped"
+        );
+    }
+
+    /// `Core::deprecate` refuses an artifact already hidden in favour of
+    /// another, so retiring the two sides in sequence would hide the first and
+    /// then fail on the second — leaving the pair recorded as unanswered with
+    /// half of it already gone, and every later attempt repeating the same
+    /// error. A side already out of results is what a discard is asking for, so
+    /// it is skipped rather than treated as a failure.
+    ///
+    /// Against `discard_both` directly, because `run` settles a pair whose
+    /// member is already hidden before it ever reaches the judge. The window
+    /// this closes is the model call itself: a neighbouring pair's unit can
+    /// supersede a side while this one waits for its answer.
+    #[tokio::test]
+    async fn discarding_a_pair_skips_a_side_that_is_already_hidden() {
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("notes/a.md", [1.0, 0.0]),
+                ("notes/b.md", [0.99, 0.01]),
+                ("ext4 needs a journal to be enabled", [0.2, 0.98]),
+            ],
+        )
+        .await;
+        let pid = queue_pair(&core, &ids[0], &ids[1]).await;
+        core.supersede(&ids[0], &ids[2]).await.unwrap();
+        let pair = core.store.get_pair(pid).await.unwrap();
+
+        discard_both(&core, &pair, Some("each body is its own file path"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            core.store.get_artifact(&ids[1]).await.unwrap().status,
+            ArtifactStatus::Deprecated,
+            "the side that could be retired was not"
+        );
+        assert_eq!(
+            core.store.get_pair(pid).await.unwrap().state,
+            PairState::Dismissed,
+            "the pair was left answerable with half of it already gone"
+        );
     }
 
     async fn disagreeing(core: &Core) -> Vec<String> {

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -455,8 +455,8 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
 ///
 /// Both callers of this — the judge's own `Relation::Vacuous` and the "Discard
 /// both" button — reach it through here rather than each writing the sequence,
-/// because the two orderings below are the whole of what makes it safe and
-/// neither is obvious from the outside.
+/// because the orderings and the one refusal below are the whole of what makes
+/// it safe and none of them is obvious from the outside.
 pub(crate) async fn discard_both(
     core: &Core,
     pair: &ArtifactPair,
@@ -478,12 +478,58 @@ pub(crate) async fn discard_both(
             retire.push(id.clone());
         }
     }
+    // A side that other artifacts are hidden *behind* is not this pass's to
+    // retire. `core.deprecate` refuses a supersession loser and has no rule for
+    // a winner, so retiring one would leave `A -> W` with both ends out of
+    // results: the reader who opens A is sent to an artifact that answers
+    // nothing either, and no page can follow the hop.
+    //
+    // Nothing should reach here. A winner is an artifact a judgement already
+    // preferred to another, and a later call finding that same artifact states
+    // nothing contradicts the earlier one. So it is neither skipped nor
+    // absorbed: the pair goes to a person with the reason on it, and the log
+    // carries the ids, because a rule that fires when it cannot is worth
+    // hearing about rather than working around.
+    for id in &retire {
+        let hidden = core.store.artifacts_superseded_by(id).await?;
+        if !hidden.is_empty() {
+            tracing::warn!(
+                pair = pair.id,
+                winner = %id,
+                hidden = hidden.join(", "),
+                "refused to retire an artifact others are hidden behind"
+            );
+            return settle(
+                core,
+                pair,
+                PairState::Contradiction,
+                Some(
+                    "One of these is the current version of another artifact, so retiring \
+                     both would leave that one pointing at nothing. Resolve by hand.",
+                ),
+            )
+            .await;
+        }
+    }
     // The side effects first and the pair settled after, the ordering the rest
     // of `apply` documents: a failure part-way leaves the pair answerable
     // rather than recorded as answered and never applied.
     for id in &retire {
         core.deprecate(id).await?;
     }
+    // The one line that says this happened. `core.deprecate` logs an id apiece,
+    // byte-identical to an operator pressing the button, and the pair settles
+    // `Dismissed` — a state no queue lists. Without this, two artifacts leaving
+    // results unattended is a thing an operator can find no record of, and the
+    // judge's reason for it sits on a row nothing in the UI reads back.
+    tracing::info!(
+        pair = pair.id,
+        a = %pair.a_id,
+        b = %pair.b_id,
+        retired = retire.len(),
+        detail = detail.unwrap_or("none given"),
+        "retired both sides of a pair that states nothing"
+    );
     // Settled the way an applied replacement settles, and carrying the judge's
     // line rather than dropping it: it is the only record of why both sides
     // were retired, and `set_pair_state` writes `detail` unconditionally, so
@@ -630,6 +676,50 @@ mod tests {
             core.store.get_pair(pid).await.unwrap().state,
             PairState::Dismissed,
             "the pair was left answerable with half of it already gone"
+        );
+    }
+
+    /// The mirror of the case above, and the one `core.deprecate` has no rule
+    /// for: not a side that is hidden, but a side that others are hidden
+    /// *behind*. Retiring it would leave the artifacts pointing at it out of
+    /// results with a winner that is out of results too — the dead end
+    /// `Core::supersede` refuses to create from the other direction.
+    ///
+    /// It should not be reachable: a winner is an artifact some earlier
+    /// judgement preferred, so a later one calling it empty disagrees with
+    /// that. Which is why nothing is retired and nothing is skipped — the pair
+    /// goes to a person, who is the only one who can say which call was wrong.
+    #[tokio::test]
+    async fn discarding_a_pair_refuses_a_side_others_are_hidden_behind() {
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("notes/a.md", [1.0, 0.0]),
+                ("notes/b.md", [0.99, 0.01]),
+                ("ext4 needs a journal to be enabled", [0.2, 0.98]),
+            ],
+        )
+        .await;
+        let pid = queue_pair(&core, &ids[0], &ids[1]).await;
+        core.supersede(&ids[2], &ids[0]).await.unwrap();
+        let pair = core.store.get_pair(pid).await.unwrap();
+
+        discard_both(&core, &pair, Some("each body is its own file path"))
+            .await
+            .unwrap();
+
+        for id in &ids[..2] {
+            assert_eq!(
+                core.store.get_artifact(id).await.unwrap().status,
+                ArtifactStatus::Active,
+                "a side was retired out from under an artifact hidden behind it"
+            );
+        }
+        assert_eq!(
+            core.store.get_pair(pid).await.unwrap().state,
+            PairState::Contradiction,
+            "a discard nothing can carry out was recorded as carried out"
         );
     }
 
@@ -1360,11 +1450,18 @@ mod tests {
     async fn a_context_block_too_big_for_the_window_is_trimmed_not_refused() {
         // Context is reference material, so a window too small to hold it costs
         // the answer some quality — never the answer itself.
+        //
+        // The window is the system prompt plus room for the two members and
+        // the reply, and nothing more: it has to be too small for the source
+        // block and large enough for everything that is not trimmable, so it
+        // moves when `DEDUPE_SYSTEM` does. Left at a number chosen against an
+        // older, shorter prompt, this stopped testing the trim and started
+        // testing the refusal one paragraph later.
         let mut core = test_core().await;
         let judge = Arc::new(ScriptedCompleter::new(vec![
             r#"{"relation":"distinct","detail":"different subjects"}"#.into(),
         ]));
-        judge.set_context_tokens(1200);
+        judge.set_context_tokens(1600);
         core.judge = Some(judge.clone());
         let long = "verylongsourcetoken ".repeat(400);
         let ids = seed_titled(

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -72,9 +72,17 @@ pub enum PairState {
     /// rows left behind back in the queue.
     Oversized,
     /// The judge found that neither artifact states anything — two containers
-    /// rather than two claims. A recommendation to discard both, and nothing
-    /// more: like `Superseded`, an operator confirms it before anything is
-    /// hidden.
+    /// rather than two claims.
+    ///
+    /// Nothing files this any more. It was a recommendation an operator
+    /// confirmed, which left the one answer that clears a pair of empty
+    /// artifacts waiting on a person holding no more evidence than the judge
+    /// had; `jobs::dedupe::discard_both` now retires both sides where the
+    /// verdict is found and settles the pair `Dismissed`, as an applied
+    /// replacement does. Deprecation is reversible, so the undo is the review.
+    ///
+    /// The variant and everything that renders it stay for the rows an older
+    /// base filed, which are still waiting on that press.
     Vacuous,
 }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -663,9 +663,11 @@ async fn consolidation(
             .store
             .pairs_by_state(PairState::Superseded, 100)
             .await?,
-        // Judge-proposed discards awaiting the same confirmation, listed for
-        // the same reason: a pair the judge found vacuous is a recommendation
-        // it left behind, and without this key it is in no list here at all.
+        // Discards awaiting confirmation, listed for the same reason. Only ever
+        // rows an older base filed: a vacuous verdict is now carried out where
+        // it is found, so nothing new lands here. Emitted regardless — a client
+        // indexing this key breaks on a response that drops it, and the pairs
+        // already in that state are still waiting on the press.
         "discard_proposals": st
             .core
             .store

--- a/src/web/insights.rs
+++ b/src/web/insights.rs
@@ -56,6 +56,16 @@ async fn moved(_id: Identity) -> Response {
 /// page through.
 const TABLE_CAP: i64 = 25;
 
+/// The same, for the one table that is also an undo.
+///
+/// Deeper than the rest on purpose. A vacuous verdict retires two artifacts
+/// where it is found (`jobs::dedupe::discard_both`), and this list is where an
+/// operator finds them again — every search path in the UI passes
+/// `include_deprecated: false`, so a row that falls off the end is reachable
+/// only by a link someone would have to already have. The first sweep over a
+/// backlog can put hundreds here at once.
+const DEPRECATED_CAP: i64 = 50;
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/ui/insights", get(page))
@@ -178,10 +188,14 @@ struct InsightsTemplate {
     /// everything there is.
     more_merged: bool,
     more_superseded: bool,
+    more_deprecated: bool,
     /// `TABLE_CAP`, so the line that says how many rows are showing says the
     /// number the code actually truncated to. Written out twice in the
     /// template, it drifted from the constant the first time either moved.
     table_cap: i64,
+    /// `DEPRECATED_CAP`, for the same reason and for the one table that does
+    /// not share `TABLE_CAP`.
+    deprecated_cap: i64,
     deprecated: Vec<DeprecatedRow>,
     stale: Vec<StaleRow>,
     /// `None` when nothing is being learned, which renders nothing at all: a
@@ -453,10 +467,16 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
     let more_superseded = superseded.len() > TABLE_CAP as usize;
     superseded.truncate(TABLE_CAP as usize);
 
-    let deprecated = st
+    // One past the cap, as the two tables above do it: this is the undo for
+    // every artifact the judge retires unattended, so a list that stops
+    // without saying so reads as "these are all of them".
+    let mut deprecated: Vec<DeprecatedRow> = st
         .core
         .store
-        .artifacts_by_status(crate::store::artifacts::ArtifactStatus::Deprecated, 50)
+        .artifacts_by_status(
+            crate::store::artifacts::ArtifactStatus::Deprecated,
+            DEPRECATED_CAP + 1,
+        )
         .await?
         .into_iter()
         .map(|c| DeprecatedRow {
@@ -464,6 +484,8 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
             id: c.id,
         })
         .collect();
+    let more_deprecated = deprecated.len() > DEPRECATED_CAP as usize;
+    deprecated.truncate(DEPRECATED_CAP as usize);
 
     // Read-only candidates: nothing here has been changed, only listed.
     let stale = st
@@ -520,7 +542,9 @@ async fn page(State(st): State<AppState>, _id: Identity) -> Result<Response> {
         merged,
         more_merged,
         more_superseded,
+        more_deprecated,
         table_cap: TABLE_CAP,
+        deprecated_cap: DEPRECATED_CAP,
         deprecated,
         stale,
         job_counts: st.core.store.job_counts().await?,

--- a/src/web/templates/insights.html
+++ b/src/web/templates/insights.html
@@ -285,6 +285,9 @@
   {% endfor %}
   </tbody>
 </table>
+{% if more_deprecated %}
+<p class="muted">Showing the newest {{ deprecated_cap }} — the rest appear as these are cleared, and each is still at its own link.</p>
+{% endif %}
 {% endif %}
 
 {% if !stale.is_empty() %}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1908,9 +1908,11 @@ const PAIR_LIMIT: usize = 5;
 const PAIR_STATES: [crate::store::pairs::PairState; 4] = [
     crate::store::pairs::PairState::Contradiction,
     crate::store::pairs::PairState::Superseded,
-    // A judged recommendation like `Superseded`, and listed for the same
-    // reason: the judge proposing something is not the judge doing it, so the
-    // pair still has to reach the person who presses the button.
+    // Only ever rows an older base filed: a vacuous verdict is now carried
+    // out where it is found (`jobs::dedupe::discard_both`) and its pair
+    // settles `Dismissed`. Still listed, because those rows are a
+    // recommendation nobody has pressed yet, and without this key they are on
+    // no queue at all.
     crate::store::pairs::PairState::Vacuous,
     crate::store::pairs::PairState::Pending,
 ];

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2326,19 +2326,18 @@ async fn dismiss_pair_ui(
 
 /// Answer a pair by retiring both sides.
 ///
-/// The queue's other two answers each assume something. Keeping one side
-/// assumes one of them is worth keeping; Dismiss assumes the pair is a
-/// question not worth asking and leaves both in results. Neither fits two
-/// artifacts that state nothing — a body that is its own file path, an outline
-/// with nothing under it — which are alike for a reason that has no keeper.
+/// Offered on every card, because the judge is not the only reader who can
+/// tell: a pair it called a duplicate can still be two artifacts that say
+/// nothing. Where the judge *did* say so, `jobs::dedupe` has already carried
+/// this out and the pair never reaches the queue — so what this button answers
+/// is the pairs it ruled on differently, and the ones it was never asked
+/// about.
 ///
-/// Deprecation, not deletion, and through `core.deprecate` like every other
-/// hide in the app: this is the one action here that retires *both* artifacts,
-/// so it is also the one that most needs the same undo as the rest.
-///
-/// The side effects first and the pair settled after, the ordering
-/// `jobs::dedupe::apply` documents: a failure part-way leaves the pair
-/// answerable rather than recorded as answered and never applied.
+/// The retiring itself is `jobs::dedupe::discard_both`, shared with that path
+/// rather than restated here: the two orderings it documents — both sides read
+/// before either is retired, side effects before the pair is settled — are the
+/// whole of what makes the action safe, and a second copy of them is a second
+/// place for one of them to be dropped.
 async fn discard_pair_ui(
     State(st): State<AppState>,
     _id: Identity,
@@ -2346,43 +2345,8 @@ async fn discard_pair_ui(
     Form(back): Form<ReturnTo>,
 ) -> Result<Response> {
     let pair = st.core.store.get_pair(pid).await?;
-    // Both sides read before either is retired. A side already hidden in
-    // favour of another artifact — an applied supersede from a neighbouring
-    // pair in the same cluster does this, and nothing filters those rows off
-    // the page — is one `core.deprecate` refuses. Deprecating in sequence
-    // therefore hid the first side and then failed on the second, leaving the
-    // pair answerable, half of it already gone, and unanswerable for good:
-    // every later press repeated the same 400.
-    //
-    // A superseded artifact is out of results already, which is all this
-    // button is asking for, so it is skipped rather than treated as an error.
-    let mut retire = Vec::new();
-    for id in [&pair.a_id, &pair.b_id] {
-        if st
-            .core
-            .store
-            .get_artifact(id)
-            .await?
-            .superseded_by
-            .is_none()
-        {
-            retire.push(id.clone());
-        }
-    }
-    for id in &retire {
-        st.core.deprecate(id).await?;
-    }
-    // The judge's line carried through rather than dropped: it is the only
-    // record of why both sides were retired, and `set_pair_state` writes
-    // `detail` unconditionally, so `None` would null it.
-    st.core
-        .store
-        .set_pair_state(
-            pid,
-            crate::store::pairs::PairState::Dismissed,
-            pair.detail.as_deref(),
-        )
-        .await?;
+    let detail = pair.detail.clone();
+    crate::jobs::dedupe::discard_both(&st.core, &pair, detail.as_deref()).await?;
     Ok(Redirect::to(back.path()).into_response())
 }
 


### PR DESCRIPTION
Closes #43.

## The gap, as it actually stands

The issue asks for an opt-in auto-apply above a confidence bar, on the premise that "every dedupe verdict — `superseded` or `vacuous` — currently waits on a human." That premise turned out to be half stale. On `master` today:

| verdict | what happens |
|---|---|
| `replaced` | **already applied** — `core.supersede`, pair settled `Dismissed` |
| `duplicate` | **already applied** — merge written |
| `conflict` | → `Contradiction`, deliberately a person's call |
| `vacuous` | → `Vacuous`, **parked** |

`PairState::Superseded` has no writer left in the tree; only legacy rows parse into it. So `vacuous` was the last verdict in the queue still waiting on someone — and waiting on someone holding no more evidence than the judge had. With six hundred pairs behind it, that is a queue nobody drains.

## What this does

One branch in `jobs::dedupe::apply`:

```rust
Relation::Vacuous => discard_both(core, &s.pair, s.detail.as_deref()).await,
```

Both sides deprecated, pair settled `Dismissed` carrying the judge's line as the record of why — the way an applied replacement already closes.

## No confidence knob

The issue suggested gating on a score. `consolidate.auto_supersede`'s own comment records why that was removed the last time it was tried: embeddings barely distinguish negation. For `vacuous` a cosine bar is weaker still — it measures how alike two artefacts are, not how empty. Two bodies that are their own file paths sit at 0.99; an empty outline beside a bare link might sit at 0.88, and both are equally vacuous.

So the gate is the same one `replaced` and `duplicate` already pass through: none. Deprecation is not deletion — both artefacts are one press from active and still readable under `include_deprecated` — so the undo is the review, which is the stance `c1c2f63` took for duplicates.

## The extraction

The retiring is lifted out of the "Discard both" handler rather than written twice. Two orderings are the whole of what makes it safe and neither is obvious from outside:

- **Both sides read before either is retired.** `core.deprecate` refuses an artefact already hidden in favour of another, so a sequential retire hides side A, fails on B, and leaves the pair answerable with half of it gone — unanswerable for good, every later attempt repeating the same refusal. The job path needs this on its own account: a neighbouring pair's unit can supersede a side while this one waits on its model call.
- **Side effects before the pair is settled**, so a failure part-way leaves it answerable rather than recorded as answered and never applied.

## Nothing removed

`PairState::Vacuous` joins `Superseded` and `NearIdentical` as a variant nothing writes any more. The variant, `parse`, the `discard_proposals` API key and the card that renders it all stay wired for the rows an older base filed — those are still waiting on the press. "Discard both" also stays on every card regardless of verdict: the judge is not the only reader who can tell.

No config, no schema, no migration.

## Verification

- `cargo test` — 1717 lib + 5 integration, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt` applied

Two tests drive it. `a_vacuous_verdict_retires_both_sides_without_waiting_for_an_operator` replaces the one that asserted the old stance. `discarding_a_pair_skips_a_side_that_is_already_hidden` tests `discard_both` directly, because `run` settles a pair whose member is already hidden before it ever reaches the judge — the window this closes is the model call itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2XyfxJGoefvURp8oXPdi2