### PR TITLE
feat(search): the keystroke gets vector order, the pause gets the reranker

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1308,6 +1308,112 @@
     });
     }
 
+  // ── The refining pass ─────────────────────────────────────────────────────
+  //
+  // Typing gets vector order at embedding speed; the reranker's opinion is
+  // asked for afterwards, once the box has been quiet long enough to mean the
+  // query is settled. The reranked fragment then replaces the list and the
+  // rows glide to their new places, so the reordering reads as a refinement
+  // happening in front of you rather than as the list twitching.
+  //
+  // Armed only by `data-rerank` on the form, which the server renders only
+  // where a reranker actually serves search: without it a second request
+  // could only buy the same order back, and the tick beside the count would
+  // be claiming a confirmation that never took place.
+
+  // Was this swap the refining pass? Read off the request rather than kept in
+  // a flag, so the fast handler below and the driver cannot disagree about
+  // which swap they are looking at.
+  function wasRefine(e) {
+    var cfg = e.detail && e.detail.requestConfig;
+    return !!(cfg && cfg.parameters && cfg.parameters.rerank === 'true');
+  }
+
+  function refinePass() {
+    var form = document.getElementById('box-form');
+    if (!form || form.getAttribute('data-rerank') !== 'true') return;
+    var box = form.querySelector('textarea[name="q"]');
+    if (!box) return;
+    // Long enough past the 120ms debounce to mean "settled", short enough
+    // that the refinement still reads as part of the same answer.
+    var QUIET_MS = 500;
+    var timer = null;
+    // Where each row stood when the refine was fired, keyed by href — taken
+    // just before the request, spent by the animation, and good for exactly
+    // one swap.
+    var from = null;
+
+    function cancel() {
+      if (timer) { clearTimeout(timer); timer = null; }
+    }
+
+    function fire() {
+      timer = null;
+      var q = box.value.trim();
+      // The same two guards the endpoint applies: an empty box is the idle
+      // rail, and a pasted chapter is a capture, not a query.
+      if (!q || q.length > 2000) return;
+      var values = { q: q, rerank: 'true' };
+      var chip = form.querySelector('input[name="category"]:checked');
+      if (chip && chip.value) values.category = chip.value;
+      from = {};
+      document.querySelectorAll('#results .rail-item').forEach(function (el) {
+        from[el.getAttribute('href')] = el.getBoundingClientRect().top;
+      });
+      // `source: form` so this request stands in the form's own sync queue:
+      // a keystroke's search replaces an in-flight refine exactly as it
+      // replaces an older keystroke's search, and the list shown is always
+      // the answer to the last thing typed.
+      htmx.ajax('GET', '/ui/search/results', {
+        source: form, target: '#results', swap: 'innerHTML', values: values
+      });
+    }
+
+    function glide() {
+      var was = from;
+      from = null;
+      if (!was) return;
+      if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      document.querySelectorAll('#results .rail-item').forEach(function (el) {
+        var top = was[el.getAttribute('href')];
+        if (top === undefined) {
+          // A row the fast pass never showed: promoted from the candidate
+          // pool. Nowhere to glide from, so it arrives instead.
+          el.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 300, easing: 'ease-out' });
+          return;
+        }
+        var delta = top - el.getBoundingClientRect().top;
+        if (!delta) return;
+        el.animate(
+          [{ transform: 'translateY(' + delta + 'px)' }, { transform: 'none' }],
+          { duration: 300, easing: 'ease-in-out' }
+        );
+      });
+    }
+
+    // A keystroke inside the debounce window: the pending refine belongs to a
+    // query that is no longer what the box says.
+    box.addEventListener('input', cancel);
+    // Any request from the form — a keystroke's search, a chip, the refine
+    // itself — retires the pending timer; the fast swap landing below is what
+    // arms a new one.
+    document.body.addEventListener('htmx:beforeRequest', function (e) {
+      if (e.detail && e.detail.elt === form) cancel();
+    });
+    document.body.addEventListener('htmx:afterSwap', function (e) {
+      if (e.target.id !== 'results') return;
+      if (wasRefine(e)) {
+        glide();
+      } else {
+        // Never re-armed off a refine swap: that loop would turn one settled
+        // query into a rerank call every half second forever.
+        cancel();
+        from = null;
+        timer = setTimeout(fire, QUIET_MS);
+      }
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
     enhance(document.body);
     themeToggle();
@@ -1319,6 +1425,7 @@
     railBack();
     captureVerb();
     askDriver();
+    refinePass();
     trackDwell();
     window.addEventListener('pagehide', flushDwell);
     document.addEventListener('visibilitychange', function () {
@@ -1374,7 +1481,12 @@
       // `#results` rather than `#rail`: the list is its own element inside the
       // rail now, so that what a search replaces is the results and not the
       // sitting beside them.
-      if (e.target.id === 'results') {
+      //
+      // Not for the refining pass: it lands over a list the operator may
+      // already be reading, and the whole point of the glide is that the rows
+      // move under a still eye. Resetting the scroll would trade that for a
+      // jump.
+      if (e.target.id === 'results' && !wasRefine(e)) {
         if (ws) ws.classList.remove('has-selection', 'answering');
         // Back to the top of the answer. Nothing moved the scroll on a swap,
         // and the two layouts strand it in different places for the same

--- a/assets/app.js
+++ b/assets/app.js
@@ -1407,10 +1407,10 @@
       // question, so its fragment is replayed rather than bought twice.
       // Replayed only over an identical row set: a capture landing
       // mid-sitting changes what there is to rank, and a stored answer must
-      // never hide a row the fast pass just showed.
-      // Sorted, because the two lists hold the same rows in different orders:
-      // the screen shows vector order and the stored answer shows the
-      // reranker's.
+      // never hide a row the fast pass just showed. Both sides of the
+      // comparison are fast-pass sets — this one and the one captured when
+      // the stored refine fired — sorted into set order, because what is
+      // being asked is "same rows", not "same order".
       if (refined && refined.key === key && refined.hrefs === hrefs.slice().sort().join('\n')) {
         var target = document.getElementById('results');
         if (target) {
@@ -1428,7 +1428,12 @@
         }
         return;
       }
-      pending = key;
+      // The row set the refine is answering over is the one on screen *now*:
+      // the reranker reorders (and promotes into) what the fast pass matched,
+      // so its fragment can show rows this list does not. Valid replay is
+      // "same query over the same fast-pass rows", which only this moment
+      // knows — captured here, promoted into `refined` when the swap lands.
+      pending = { key: key, hrefs: hrefs.slice().sort().join('\n') };
       // `source: form` so this request stands in the form's own sync queue:
       // a keystroke's search replaces an in-flight refine exactly as it
       // replaces an older keystroke's search, and the list shown is always
@@ -1462,13 +1467,29 @@
     }
 
     // A keystroke inside the debounce window: the pending refine belongs to a
-    // query that is no longer what the box says.
-    box.addEventListener('input', cancel);
+    // query that is no longer what the box says. Composition events are
+    // skipped to mirror the form's own trigger filter
+    // (`input[!event.isComposing]`): a browser whose final IME event still
+    // says composing fires no search off it, and a cancel with no request
+    // behind it would leave the pass disarmed on a settled query. The
+    // composition itself disarms once, below, when it starts.
+    box.addEventListener('input', function (e) {
+      if (e.isComposing) return;
+      cancel();
+    });
+    box.addEventListener('compositionstart', cancel);
     // Any request from the form — a keystroke's search, a chip, the refine
     // itself — retires the pending timer; the fast swap landing below is what
-    // arms a new one.
+    // arms a new one. And any mutation from anywhere — an edit saved in the
+    // detail pane, a deprecate, a delete — retires the stored answer: its
+    // fragment carries titles and snippets as they stood when it was bought,
+    // and a pane-only edit changes those without touching the row set the
+    // replay guard checks.
     document.body.addEventListener('htmx:beforeRequest', function (e) {
-      if (e.detail && e.detail.elt === form) cancel();
+      if (!e.detail) return;
+      if (e.detail.elt === form) cancel();
+      var cfg = e.detail.requestConfig;
+      if (cfg && cfg.verb && String(cfg.verb).toLowerCase() !== 'get') refined = null;
     });
     document.body.addEventListener('htmx:afterSwap', function (e) {
       if (e.target.id !== 'results') return;
@@ -1479,17 +1500,17 @@
         // nothing about what is open.
         markOpenRow();
         // Kept to be replayed the next time this exact query settles over
-        // this exact row set — see `fire`.
+        // this exact row set — see `fire`. The row set stored is the
+        // fast-pass one `fire` captured, not the fragment's: the reranker
+        // may have promoted rows the fast list never showed, and a replay
+        // guard built from those would miss every time the rerank did
+        // anything at all.
         var target = document.getElementById('results');
         if (pending && target) {
-          var hrefs = [];
-          target.querySelectorAll('.rail-item').forEach(function (r) {
-            hrefs.push(r.getAttribute('href'));
-          });
           var head = document.getElementById('rail-head');
           refined = {
-            key: pending,
-            hrefs: hrefs.sort().join('\n'),
+            key: pending.key,
+            hrefs: pending.hrefs,
             html: target.innerHTML,
             head: head ? head.innerHTML : null
           };
@@ -1497,6 +1518,10 @@
         pending = null;
         glide();
       } else {
+        // The same repaint hazard as the refine branch: a typing swap also
+        // renders every row unselected, and the open artifact's highlight
+        // must survive it.
+        markOpenRow();
         // Never re-armed off a refine swap: that loop would turn one settled
         // query into a rerank call every half second forever.
         cancel();
@@ -1531,6 +1556,13 @@
     // here instead, and it names the page so signing in comes back to it.
     document.body.addEventListener('htmx:responseError', function (e) {
       if (!e.detail || !e.detail.xhr) return;
+      // Not for the refining pass: nobody asked for that request, and the
+      // vector-order list it would improve is already on screen and being
+      // read. A transient failure half a second after the operator stopped
+      // typing must not replace their results with an error box — and an
+      // expired session must not navigate them to a login mid-read; the next
+      // thing they actually do will land here and redirect with intent.
+      if (wasRefine(e)) return;
       if (e.detail.xhr.status === 401) {
         var here = window.location.pathname + window.location.search;
         window.location.assign('/auth/login?go=' + encodeURIComponent(here));
@@ -1546,6 +1578,9 @@
     // reading left is that the base has nothing.
     document.body.addEventListener('htmx:sendError', function (e) {
       if (!e.detail) return;
+      // Same exemption as above: a refine that never reached the server
+      // leaves the list it was refining alone.
+      if (wasRefine(e)) return;
       failedSwap(e.detail.target, null);
     });
     document.body.addEventListener('htmx:afterSwap', function (e) {

--- a/assets/app.js
+++ b/assets/app.js
@@ -1326,7 +1326,23 @@
   // which swap they are looking at.
   function wasRefine(e) {
     var cfg = e.detail && e.detail.requestConfig;
-    return !!(cfg && cfg.parameters && cfg.parameters.rerank === 'true');
+    // The pre-filter set: `parameters` is only what survived `hx-params`, so
+    // an allowlist edit there would silently turn every refine swap back into
+    // a typing swap — and the typing branch re-arms the timer, which is the
+    // loop that never stops.
+    var params = cfg && (cfg.unfilteredParameters || cfg.parameters);
+    return !!(params && params.rerank === 'true');
+  }
+
+  // The rail's selected row, recomputed from the URL. Run after any swap that
+  // repaints the list while an artifact is open: the fragment renders every
+  // row `aria-selected="false"`, and the open artifact's highlight must
+  // survive a repaint it had nothing to do with.
+  function markOpenRow() {
+    var open = window.location.pathname;
+    document.querySelectorAll('.rail-item').forEach(function (el) {
+      el.setAttribute('aria-selected', el.getAttribute('href') === open ? 'true' : 'false');
+    });
   }
 
   function refinePass() {
@@ -1342,9 +1358,26 @@
     // just before the request, spent by the animation, and good for exactly
     // one swap.
     var from = null;
+    // The last refined answer, kept to be replayed: `key` is the query and
+    // chip it answered, `hrefs` the row set it is valid over, `html` and
+    // `head` the fragment and the count line it painted.
+    var refined = null;
+    // The key of the refine in flight, promoted into `refined` when its swap
+    // lands.
+    var pending = null;
 
     function cancel() {
       if (timer) { clearTimeout(timer); timer = null; }
+    }
+
+    // Positions are taken relative to the list itself rather than the
+    // viewport: the rail is its own scroll box on a wide screen and the
+    // window scrolls on a narrow one, and a refine can land seconds after it
+    // fired. Viewport coordinates captured before a scroll would make every
+    // unmoved row lurch by exactly the scroll distance.
+    function resultsTop() {
+      var el = document.getElementById('results');
+      return el ? el.getBoundingClientRect().top : 0;
     }
 
     function fire() {
@@ -1356,10 +1389,46 @@
       var values = { q: q, rerank: 'true' };
       var chip = form.querySelector('input[name="category"]:checked');
       if (chip && chip.value) values.category = chip.value;
+      var rows = document.querySelectorAll('#results .rail-item');
+      // Nothing to refine: the server skips the rerank call over an empty
+      // answer, so the request would buy a guaranteed-identical fragment.
+      if (!rows.length) return;
+      var key = q + '\u0000' + (values.category || '');
+      var origin = resultsTop();
+      var hrefs = [];
       from = {};
-      document.querySelectorAll('#results .rail-item').forEach(function (el) {
-        from[el.getAttribute('href')] = el.getBoundingClientRect().top;
+      rows.forEach(function (el) {
+        var href = el.getAttribute('href');
+        hrefs.push(href);
+        from[href] = el.getBoundingClientRect().top - origin;
       });
+      // The same query, settled again over the same rows — a type-and-undo,
+      // a chip toggled back. The reranker already answered this exact
+      // question, so its fragment is replayed rather than bought twice.
+      // Replayed only over an identical row set: a capture landing
+      // mid-sitting changes what there is to rank, and a stored answer must
+      // never hide a row the fast pass just showed.
+      // Sorted, because the two lists hold the same rows in different orders:
+      // the screen shows vector order and the stored answer shows the
+      // reranker's.
+      if (refined && refined.key === key && refined.hrefs === hrefs.slice().sort().join('\n')) {
+        var target = document.getElementById('results');
+        if (target) {
+          target.innerHTML = refined.html;
+          var head = document.getElementById('rail-head');
+          if (head && refined.head) head.innerHTML = refined.head;
+          // By hand, so none of the htmx swap machinery ran: the new rows
+          // need their hx- attributes wired, the same enhancements a real
+          // swap gets, and the selection recomputed.
+          htmx.process(target);
+          enhance(target);
+          markOpenRow();
+          trackDwell();
+          glide();
+        }
+        return;
+      }
+      pending = key;
       // `source: form` so this request stands in the form's own sync queue:
       // a keystroke's search replaces an in-flight refine exactly as it
       // replaces an older keystroke's search, and the list shown is always
@@ -1374,6 +1443,7 @@
       from = null;
       if (!was) return;
       if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      var origin = resultsTop();
       document.querySelectorAll('#results .rail-item').forEach(function (el) {
         var top = was[el.getAttribute('href')];
         if (top === undefined) {
@@ -1382,7 +1452,7 @@
           el.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 300, easing: 'ease-out' });
           return;
         }
-        var delta = top - el.getBoundingClientRect().top;
+        var delta = top - (el.getBoundingClientRect().top - origin);
         if (!delta) return;
         el.animate(
           [{ transform: 'translateY(' + delta + 'px)' }, { transform: 'none' }],
@@ -1403,6 +1473,28 @@
     document.body.addEventListener('htmx:afterSwap', function (e) {
       if (e.target.id !== 'results') return;
       if (wasRefine(e)) {
+        // The fragment renders every row unselected, and this swap can land
+        // over a list whose open artifact was clicked during the quiet
+        // window; the highlight must not vanish under a repaint that changed
+        // nothing about what is open.
+        markOpenRow();
+        // Kept to be replayed the next time this exact query settles over
+        // this exact row set — see `fire`.
+        var target = document.getElementById('results');
+        if (pending && target) {
+          var hrefs = [];
+          target.querySelectorAll('.rail-item').forEach(function (r) {
+            hrefs.push(r.getAttribute('href'));
+          });
+          var head = document.getElementById('rail-head');
+          refined = {
+            key: pending,
+            hrefs: hrefs.sort().join('\n'),
+            html: target.innerHTML,
+            head: head ? head.innerHTML : null
+          };
+        }
+        pending = null;
         glide();
       } else {
         // Never re-armed off a refine swap: that loop would turn one settled
@@ -1531,10 +1623,7 @@
           var el = document.getElementById(id);
           if (el) el.textContent = '';
         });
-        var open = window.location.pathname;
-        document.querySelectorAll('.rail-item').forEach(function (el) {
-          el.setAttribute('aria-selected', el.getAttribute('href') === open ? 'true' : 'false');
-        });
+        markOpenRow();
       }
     });
   });

--- a/assets/css/40-workspace.css
+++ b/assets/css/40-workspace.css
@@ -247,6 +247,19 @@ body { overflow-x: hidden; }
   font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.04em;
   color: var(--color-fg-muted); flex: 0 0 auto;
 }
+/* The refining pass landed: the reranker confirmed this order. A step quieter
+   than the count it hangs off — it is a footnote to the number, not a second
+   heading — and it fades in with the glide so the word and the movement read
+   as one event. */
+.refined-tick {
+  color: var(--color-fg-faint, var(--color-fg-muted));
+  text-transform: none; letter-spacing: normal;
+  animation: refined-in 300ms ease-out;
+}
+@keyframes refined-in { from { opacity: 0; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .refined-tick { animation: none; }
+}
 
 /* ── The rail before anything is asked ───────────────────────────────────
    The idle state is designed, not left over: the base introduces itself under

--- a/config.example.toml
+++ b/config.example.toml
@@ -273,6 +273,14 @@ tier = "deep"
 # base_url = "http://localhost:8001"
 # model = "bge-reranker-v2-m3"
 # style = "tei"
+#
+# Where the reranker is consulted. Both places unless narrowed. Typing in the
+# web UI never waits on it either way: keystrokes come back in vector order at
+# embedding speed, and the reranked order lands as a visible refinement once
+# the query settles. `apply = ["ask"]` is the opt-out for search entirely —
+# for a rerank endpoint slow or billed enough that only a deliberate question
+# should spend it.
+# apply = ["ask", "search"]
 
 # Reading captured images. Optional and disabled by default: with this block
 # absent the image door is closed and the capture page offers text only.

--- a/extension/shared/panel.js
+++ b/extension/shared/panel.js
@@ -289,11 +289,19 @@ function hint(message) {
 }
 
 let searchTimer;
+// The settled pass, the same contract as the web UI's workspace: the
+// keystroke's search answers in vector order, and once the operator stops
+// typing the same question is asked once more with `rerank=true`. On a
+// deployment whose scope covers search that buys the reranked order; on one
+// without, the server answers in the same vector order and the identical
+// list is left untouched below.
+let refineTimer;
 
 box.addEventListener('input', () => {
   fit();
   reflectVerbs();
   clearTimeout(searchTimer);
+  clearTimeout(refineTimer);
   // Debounced, because this is search-as-you-type and every keystroke would
   // otherwise be an embedding call on the deployment.
   searchTimer = setTimeout(runSearch, 200);
@@ -406,10 +414,40 @@ async function runSearch() {
       return;
     }
     renderHits(hits, $('results'));
+    // Long enough past the 200ms debounce to mean "settled", short enough
+    // that the refinement still reads as part of the same answer — the same
+    // quiet window the web UI waits.
+    clearTimeout(refineTimer);
+    refineTimer = setTimeout(() => refineSearch(q, mine, hits), 500);
   } catch (e) {
     if (mine !== turn) return;
     await fail(e);
   }
+}
+
+/// The settled query, asked once more with the reranker on. Unattended, so it
+/// is held to less than a search: a failure keeps the vector-order list
+/// already on screen and says nothing, and an answer that arrives after
+/// anything else took the pane — a keystroke, an ask, back — is dropped.
+async function refineSearch(q, owner, fast) {
+  if (owner !== turn) return;
+  let hits;
+  try {
+    hits = await engramApi.call(
+      '/api/v1/search?door=extension&rerank=true&q=' + encodeURIComponent(q));
+  } catch (e) {
+    return;
+  }
+  if (owner !== turn) return;
+  // The same rows in the same order — a deployment that does not rerank
+  // search, or one whose reranker agreed with the vector order. Nothing to
+  // repaint, and no reason to rebuild nodes under a reading operator.
+  if (
+    hits.length === fast.length &&
+    hits.every((h, i) => h.artifact_id === fast[i].artifact_id)
+  ) return;
+  clearResults();
+  renderHits(hits, $('results'));
 }
 
 // An ask runs for as long as the model takes — `infer.ask.timeout_secs`
@@ -438,8 +476,11 @@ $('ask').addEventListener('click', async () => {
   // the document — an answer that streams into nowhere. Disarmed before the
   // await below rather than after it, or the 200ms can elapse while pairing is
   // read from storage and the search that fires takes the higher turn, whose
-  // `abandonAsk` aborts the ask this click just asked for.
+  // `abandonAsk` aborts the ask this click just asked for. The refine armed
+  // by that search's own hits is disarmed with it — its turn-guard would
+  // drop the answer anyway, but there is no reason to put it on the wire.
   clearTimeout(searchTimer);
+  clearTimeout(refineTimer);
 
   if (!(await requirePaired())) return;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1431,6 +1431,32 @@ pub struct RerankRole {
     pub style: RerankStyle,
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+    /// Where the reranker is consulted. Both places unless narrowed: whoever
+    /// configured the endpoint wants it working, and `apply = ["ask"]` is the
+    /// opt-out for search, where the rerank call is latency a typing operator
+    /// would otherwise wait on.
+    #[serde(default = "default_rerank_apply")]
+    pub apply: Vec<RerankApply>,
+}
+
+impl RerankRole {
+    pub fn applies_to(&self, place: RerankApply) -> bool {
+        self.apply.contains(&place)
+    }
+}
+
+fn default_rerank_apply() -> Vec<RerankApply> {
+    vec![RerankApply::Ask, RerankApply::Search]
+}
+
+/// A place the reranker can be consulted. `Ask` is retrieval behind a
+/// question; `Search` is every ranked list a caller sees directly — the UI
+/// rail, the API, MCP, the extension, and the judging view.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RerankApply {
+    Ask,
+    Search,
 }
 
 /// The vision model that reads a captured image into text. Optional: absent
@@ -2459,6 +2485,28 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
         assert!(
             cfg.infer.rerank.is_none(),
             "rerank must default to disabled"
+        );
+    }
+
+    #[test]
+    fn rerank_applies_everywhere_unless_narrowed() {
+        // A configured reranker is used for both ask and search unless `apply`
+        // names fewer places: whoever set up the endpoint wants it working,
+        // and the narrowing is the opt-out for search's latency.
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let rerank = "\n[infer.rerank]\nbase_url = \"http://localhost:8081\"\nmodel = \"bge-reranker-v2-m3\"\nstyle = \"tei\"\n";
+        let p = write(&dir, &format!("{MINIMAL}{rerank}"));
+        let role = Config::load(Some(&p)).unwrap().infer.rerank.unwrap();
+        assert!(role.applies_to(RerankApply::Ask));
+        assert!(role.applies_to(RerankApply::Search));
+
+        let p = write(&dir, &format!("{MINIMAL}{rerank}apply = [\"ask\"]\n"));
+        let role = Config::load(Some(&p)).unwrap().infer.rerank.unwrap();
+        assert!(role.applies_to(RerankApply::Ask));
+        assert!(
+            !role.applies_to(RerankApply::Search),
+            "apply = [\"ask\"] must switch the reranker off for search"
         );
     }
 

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -512,6 +512,9 @@ impl Core {
                     mark: deliberate,
                     include_deprecated: false,
                     include_superseded: false,
+                    // Whether ask reranks is the scope's decision, not this
+                    // call's: nobody is typing here.
+                    rerank: true,
                 },
                 None,
                 // Deliberately not captured: the right answer to a question is

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -372,7 +372,7 @@ impl Core {
 pub mod test_support {
     use super::*;
     use crate::infer::fake::{
-        FakeCompleter, FakeDescriber, FakeEmbedder, FakeReranker, FakeSynthesizer,
+        FailingReranker, FakeCompleter, FakeDescriber, FakeEmbedder, FakeReranker, FakeSynthesizer,
     };
     use crate::vector::memory::MemoryVectors;
 
@@ -388,6 +388,16 @@ pub mod test_support {
         let reranker = Arc::new(FakeReranker::default());
         let core = build(Arc::new(FakeSynthesizer::default()), Some(reranker.clone())).await;
         (core, reranker)
+    }
+
+    /// A core whose reranker errors on every call — the endpoint outage or
+    /// cold start a deployment actually sees.
+    pub async fn test_core_with_failing_reranker() -> Core {
+        build(
+            Arc::new(FakeSynthesizer::default()),
+            Some(Arc::new(FailingReranker)),
+        )
+        .await
     }
 
     /// A core plus a handle on its embedder, for asserting how many times the

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -342,16 +342,26 @@ impl Core {
         self.completer.is_some()
     }
 
+    /// Does a reranker serve `place` at all? One is configured and the scope
+    /// covers it. The one spelling of that question: a guard added here — a
+    /// health check, a kill switch, a new scope — holds for every door.
+    fn reranks(&self, place: crate::config::RerankApply) -> bool {
+        self.reranker.is_some() && self.rerank_apply.contains(&place)
+    }
+
     /// Does a reranker serve the search path? `false` means the UI never fires
     /// a refining pass and never claims one happened: with no reranker — or
     /// one scoped to ask alone — a `rerank=true` request answers in vector
     /// order, and saying "refined" over it would assert a confirmation that
     /// never took place.
     pub fn reranks_search(&self) -> bool {
-        self.reranker.is_some()
-            && self
-                .rerank_apply
-                .contains(&crate::config::RerankApply::Search)
+        self.reranks(crate::config::RerankApply::Search)
+    }
+
+    /// Does a reranker serve the ask path? The retrieval behind an answer is
+    /// ordered by it before the citations are chosen.
+    pub fn reranks_ask(&self) -> bool {
+        self.reranks(crate::config::RerankApply::Ask)
     }
 
     /// Is the area under the search box filled? `false` means the placeholder

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -79,6 +79,10 @@ pub struct Core {
     pub synthesizer: Option<Arc<dyn Synthesizer>>,
     pub embedder: Arc<dyn Embedder>,
     pub reranker: Option<Arc<dyn Reranker>>,
+    /// Where the configured reranker is consulted — `[infer.rerank].apply`.
+    /// Meaningless without a reranker; both places when one is configured
+    /// without narrowing.
+    pub rerank_apply: Vec<crate::config::RerankApply>,
     /// `None` when `[infer.ask]` is not configured: no ask page, no ask tool.
     pub completer: Option<Arc<dyn Completer>>,
     /// The model that rules on duplicate pairs. Separate from `completer`
@@ -219,6 +223,12 @@ impl Core {
                 .rerank
                 .as_ref()
                 .map(|r| Arc::new(HttpReranker::new(r)) as Arc<dyn Reranker>),
+            rerank_apply: cfg
+                .infer
+                .rerank
+                .as_ref()
+                .map(|r| r.apply.clone())
+                .unwrap_or_default(),
             completer: cfg
                 .infer
                 .ask
@@ -332,6 +342,18 @@ impl Core {
         self.completer.is_some()
     }
 
+    /// Does a reranker serve the search path? `false` means the UI never fires
+    /// a refining pass and never claims one happened: with no reranker — or
+    /// one scoped to ask alone — a `rerank=true` request answers in vector
+    /// order, and saying "refined" over it would assert a confirmation that
+    /// never took place.
+    pub fn reranks_search(&self) -> bool {
+        self.reranker.is_some()
+            && self
+                .rerank_apply
+                .contains(&crate::config::RerankApply::Search)
+    }
+
     /// Is the area under the search box filled? `false` means the placeholder
     /// is not rendered, the endpoint records nothing, and the sweep does not
     /// run — one question, asked in one place.
@@ -408,6 +430,11 @@ pub mod test_support {
             synthesizer: Some(synthesizer),
             embedder: Arc::new(FakeEmbedder::new(TEST_DIM)),
             reranker,
+            // The shipped default: a configured reranker serves both places.
+            rerank_apply: vec![
+                crate::config::RerankApply::Ask,
+                crate::config::RerankApply::Search,
+            ],
             completer: Some(Arc::new(FakeCompleter::default())),
             judge: Some(Arc::new(FakeCompleter::default())),
             link_judge: Some(Arc::new(FakeCompleter::default())),
@@ -637,6 +664,10 @@ mod tests {
             api_key: None,
             style: crate::config::RerankStyle::Tei,
             timeout_secs: 60,
+            apply: vec![
+                crate::config::RerankApply::Ask,
+                crate::config::RerankApply::Search,
+            ],
         });
         let core = Core::from_config(&cfg, vectors, store);
         assert!(core.reranker.is_some());

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -71,6 +71,11 @@ enum Lane<'a> {
 pub struct SearchTiming {
     pub embed_ms: u128,
     pub total_ms: u128,
+    /// Whether a rerank call actually ran and came back. The UI's claim
+    /// ("Order confirmed by the reranker") is derived from this and never
+    /// from what the request asked for: a rerank that failed or was skipped
+    /// answered in vector order, and the honest fragment stays silent.
+    pub reranked: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -989,13 +994,16 @@ impl Core {
         // collapses every door but `Ask` into "search" — the judging view, the
         // API, MCP and the extension all show the operator a ranked list, and
         // `apply = ["ask"]` means none of them wait on a rerank call.
-        let reranking = self.reranker.is_some()
-            && query.rerank
+        let reranking = query.rerank
             && match door {
-                Door::Ask => self.rerank_apply.contains(&crate::config::RerankApply::Ask),
-                _ => self
-                    .rerank_apply
-                    .contains(&crate::config::RerankApply::Search),
+                Door::Ask => {
+                    self.reranker.is_some()
+                        && self.rerank_apply.contains(&crate::config::RerankApply::Ask)
+                }
+                // The same predicate that arms the UI's refining pass: written
+                // once, so the form can never advertise a refine this search
+                // would not run.
+                _ => self.reranks_search(),
             };
 
         // Over-fetch whenever something downstream narrows the list: both the
@@ -1064,6 +1072,7 @@ impl Core {
             })
             .collect();
 
+        let mut reranked = false;
         if let Some(reranker) = &self.reranker
             && reranking
             && !results.is_empty()
@@ -1082,6 +1091,7 @@ impl Core {
             };
             match reranker.rerank(&query.q, &docs, top_n).await {
                 Ok(order) => {
+                    reranked = true;
                     results = order
                         .into_iter()
                         .filter_map(|(idx, score)| {
@@ -1231,6 +1241,7 @@ impl Core {
             SearchTiming {
                 embed_ms,
                 total_ms: started.elapsed().as_millis(),
+                reranked,
             },
         ))
     }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -38,6 +38,20 @@ pub struct SearchQuery {
     /// Include superseded artifacts, excluded by default.
     #[serde(default)]
     pub include_superseded: bool,
+    /// Whether this request wants the reranker consulted, where the scope
+    /// allows it at all (`Core::rerank_apply`).
+    ///
+    /// True by default: an API or MCP call is one deliberate question and
+    /// wants the best order engram can produce. The UI's typing path passes
+    /// false — a keystroke must come back at embedding speed — and asks again
+    /// with true once the operator stops typing, which is the refining pass
+    /// that reorders the rail.
+    #[serde(default = "default_rerank")]
+    pub rerank: bool,
+}
+
+fn default_rerank() -> bool {
+    true
 }
 
 /// The gate's claim for one search, held for as long as the search runs.
@@ -970,9 +984,23 @@ impl Core {
             // the coverage check's question, not a searcher's.
             corpus_id: None,
         };
+        // Whether the reranker runs on *this* search: one is configured, the
+        // scope covers this door, and the query did not opt out. The scope
+        // collapses every door but `Ask` into "search" — the judging view, the
+        // API, MCP and the extension all show the operator a ranked list, and
+        // `apply = ["ask"]` means none of them wait on a rerank call.
+        let reranking = self.reranker.is_some()
+            && query.rerank
+            && match door {
+                Door::Ask => self.rerank_apply.contains(&crate::config::RerankApply::Ask),
+                _ => self
+                    .rerank_apply
+                    .contains(&crate::config::RerankApply::Search),
+            };
+
         // Over-fetch whenever something downstream narrows the list: both the
         // per-source cap and the reranker can only discard what they are given.
-        let candidates = if cap.is_some() || self.reranker.is_some() {
+        let candidates = if cap.is_some() || reranking {
             limit * CANDIDATE_MULTIPLIER
         } else {
             limit
@@ -1037,6 +1065,7 @@ impl Core {
             .collect();
 
         if let Some(reranker) = &self.reranker
+            && reranking
             && !results.is_empty()
         {
             let docs: Vec<String> = results.iter().map(|r| r.text.clone()).collect();
@@ -1335,6 +1364,7 @@ mod tests {
             // The default for these tests is the deliberate search the API and
             // MCP make; the incremental case is exercised explicitly below.
             mark: true,
+            rerank: true,
             include_deprecated: false,
             include_superseded: false,
         }
@@ -1686,6 +1716,58 @@ mod tests {
              could only reorder the answer it was already given",
             reranker.docs_seen(),
             query.limit
+        );
+    }
+
+    #[tokio::test]
+    async fn a_scope_of_ask_keeps_the_reranker_out_of_search() {
+        // `apply = ["ask"]` is the opt-out for search latency: a configured
+        // reranker must then never be consulted on the search path, whatever
+        // the query asks for.
+        let (mut core, reranker) =
+            crate::core::test_support::test_core_counting_reranked_docs().await;
+        core.rerank_apply = vec![crate::config::RerankApply::Ask];
+        seed_from(
+            &core,
+            "one",
+            &[("alpha", "c", &[][..]), ("beta", "c", &[][..])],
+        )
+        .await;
+
+        core.search(&q("anything"), Door::Ui).await.unwrap();
+        assert_eq!(
+            reranker.docs_seen(),
+            0,
+            "the reranker was consulted on a search it is scoped out of"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_incremental_query_skips_the_reranker() {
+        // The typing fast path: a query that says `rerank: false` gets vector
+        // order immediately, and the refining pass asks again with `true`.
+        let (core, reranker) = crate::core::test_support::test_core_counting_reranked_docs().await;
+        seed_from(
+            &core,
+            "one",
+            &[("alpha", "c", &[][..]), ("beta", "c", &[][..])],
+        )
+        .await;
+
+        let mut query = q("anything");
+        query.rerank = false;
+        core.search(&query, Door::Ui).await.unwrap();
+        assert_eq!(
+            reranker.docs_seen(),
+            0,
+            "a rerank:false query still reached the reranker"
+        );
+
+        query.rerank = true;
+        core.search(&query, Door::Ui).await.unwrap();
+        assert!(
+            reranker.docs_seen() > 0,
+            "the refining pass must consult the reranker"
         );
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -996,10 +996,7 @@ impl Core {
         // `apply = ["ask"]` means none of them wait on a rerank call.
         let reranking = query.rerank
             && match door {
-                Door::Ask => {
-                    self.reranker.is_some()
-                        && self.rerank_apply.contains(&crate::config::RerankApply::Ask)
-                }
+                Door::Ask => self.reranks_ask(),
                 // The same predicate that arms the UI's refining pass: written
                 // once, so the form can never advertise a refine this search
                 // would not run.

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -115,6 +115,9 @@ async fn rank_of(core: &Core, pair: &Pair, params: RankingParams) -> Result<Opti
         // Resurfacing reads `last_seen_at`, and a scored run is not someone
         // reading their notes.
         mark: false,
+        // The sweep measures the pipeline as configured, reranker included;
+        // the scope alone decides whether one runs.
+        rerank: true,
         include_deprecated: false,
         include_superseded: false,
     };
@@ -376,6 +379,7 @@ mod tests {
             mark: false,
             include_deprecated: false,
             include_superseded: false,
+            rerank: true,
         };
         core.search_with_ranking(&q, params, Door::Judge)
             .await

--- a/src/infer/fake.rs
+++ b/src/infer/fake.rs
@@ -483,6 +483,27 @@ impl Reranker for FakeReranker {
     }
 }
 
+/// A reranker whose endpoint is down: every call errors. What the caller does
+/// next — vector order, and no claim of refinement — is the behavior under
+/// test.
+#[derive(Default)]
+pub struct FailingReranker;
+
+#[async_trait]
+impl Reranker for FailingReranker {
+    async fn rerank(
+        &self,
+        _query: &str,
+        _docs: &[String],
+        _top_n: usize,
+    ) -> Result<Vec<(usize, f32)>> {
+        Err(Error::Inference {
+            role: "rerank",
+            detail: "endpoint is down".into(),
+        })
+    }
+}
+
 /// Answers with `reply`, or — with `None` — with the user prompt it was
 /// handed. What `ask` puts in front of the model is the whole of what the
 /// model can use, and echoing it makes the prompt the thing under test.

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -1904,6 +1904,10 @@ mod tests {
                 api_key: None,
                 style,
                 timeout_secs: crate::config::DEFAULT_TIMEOUT_SECS,
+                apply: vec![
+                    crate::config::RerankApply::Ask,
+                    crate::config::RerankApply::Search,
+                ],
             };
             let batch: Vec<String> = (0..docs).map(|i| format!("d{i}")).collect();
             let out = HttpReranker::new(&cfg)

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,9 @@ async fn startup_checks(core: &Core, cfg: &Config) -> Result<()> {
     embed_recipe_check(core, cfg).await?;
     if let Some(r) = &cfg.infer.rerank {
         engram::infer::openai::probe("rerank", &r.base_url, r.api_key.as_deref()).await;
+        if !r.applies_to(engram::config::RerankApply::Search) {
+            tracing::info!("rerank scoped to ask; search returns vector order");
+        }
     } else {
         tracing::info!("rerank not configured; search returns vector order");
     }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -159,6 +159,7 @@ impl PkdbTools {
             mark: true,
             include_deprecated: false,
             include_superseded: false,
+            rerank: true,
         };
         match self
             .core
@@ -418,6 +419,7 @@ mod tests {
                         mark: true,
                         include_deprecated: false,
                         include_superseded: false,
+                        rerank: true,
                     },
                     crate::store::feedback::Door::Ui,
                 )

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -758,9 +758,11 @@ async fn search(
         mark: !typing,
         include_deprecated: q.include_deprecated,
         include_superseded: q.include_superseded,
-        // Deliberate calls want the best order by default; `rerank=false`
-        // is a typing client's opt-out, the same one the web UI takes.
-        rerank: q.rerank.unwrap_or(true),
+        // Deliberate calls want the best order by default; a typing door
+        // opts out the way the web UI's keystrokes do, and gets its answer
+        // at vector-order speed. An explicit `rerank` still overrides either
+        // way.
+        rerank: q.rerank.unwrap_or(!typing),
     };
     // Coalescing folds a keystroke into the query it was an early spelling of,
     // and it folds only within one scope — so a box that types has to say who
@@ -1807,6 +1809,63 @@ pub(crate) mod tests {
         assert_eq!(
             stamped, 0,
             "typing in the panel must not stamp last_seen_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_panel_keystroke_does_not_wait_on_the_reranker() {
+        // The panel is the same search-as-you-type box as the web UI's, and
+        // the comment on `search` says it takes the same opt-outs. The web UI
+        // answers keystrokes in vector order and refines on the pause; a
+        // debounced panel prefix must not pay a synchronous rerank round trip
+        // either.
+        let (core, reranker) = crate::core::test_support::test_core_counting_reranked_docs().await;
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "the loop device is what makes this work".into(),
+                    corpus_span: None,
+                    title: Some("loop".into()),
+                    category: Some("reference".into()),
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        for c in &made {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        let (app, token, _core) = app_from_core(core).await;
+
+        let res = app
+            .clone()
+            .oneshot(get("/api/v1/search?q=loop&door=extension", Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            reranker.docs_seen(),
+            0,
+            "a typing door's keystroke must answer in vector order, not wait \
+             on a rerank call"
+        );
+
+        // A deliberate API call is one question asked on purpose, and it
+        // still gets the best order by default.
+        let res = app
+            .oneshot(get("/api/v1/search?q=loop", Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(
+            reranker.docs_seen() > 0,
+            "a deliberate API search still reranks by default"
         );
     }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -714,6 +714,9 @@ pub struct SearchParams {
     /// Which client is asking. Only `extension` is honoured; see
     /// `Door::from_client`.
     pub door: Option<String>,
+    /// `false` skips the reranker for this call — the typing opt-out.
+    /// Absent means true: one deliberate question wants the best order.
+    pub rerank: Option<bool>,
 }
 
 async fn search(
@@ -755,6 +758,9 @@ async fn search(
         mark: !typing,
         include_deprecated: q.include_deprecated,
         include_superseded: q.include_superseded,
+        // Deliberate calls want the best order by default; `rerank=false`
+        // is a typing client's opt-out, the same one the web UI takes.
+        rerank: q.rerank.unwrap_or(true),
     };
     // Coalescing folds a keystroke into the query it was an early spelling of,
     // and it folds only within one scope — so a box that types has to say who

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -664,6 +664,8 @@ async fn assign_results(
             mark: false,
             include_deprecated: false,
             include_superseded: false,
+            // One deliberate lookup; the scope decides whether it reranks.
+            rerank: true,
         };
         // The one search in the application that must never be captured: it is
         // composed in full knowledge of the answer, which is the contamination

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -11,7 +11,7 @@
      is outside the swapped target, so the fragment that fills the list is also
      what names it and the two cannot disagree. #}
   <div class="rail-act" hx-swap-oob="innerHTML:#rail-head">
-    <span class="result-count">{{ results.len() }} result{% if results.len() != 1 %}s{% endif %}</span>
+    <span class="result-count">{{ results.len() }} result{% if results.len() != 1 %}s{% endif %}{% if reranked %} <span class="refined-tick" title="Order confirmed by the reranker">· refined</span>{% endif %}</span>
   </div>
   {# Said once, above the list, rather than repeated on every card: when the
      whole answer is loose the useful statement is about the search, not about

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -49,7 +49,7 @@
                   input[!event.isComposing] changed delay:120ms from:textarea[name=q],
                   submit{% if !q.is_empty() && open_with.is_empty() %},
                   load{% endif %}"
-      hx-params="q,category"
+      hx-params="q,category,rerank"
       hx-indicator="#search-spinner"{% if search_reranks %} data-rerank="true"{% endif %}>
   {# A textarea from the first keystroke to the last. It grows to a ten-line
      cap and then scrolls inside itself; it never switches element type, and it
@@ -90,8 +90,8 @@
      something is waiting, so the workspace costs nothing to a search.
 
      The file goes multipart to the API endpoint, never with the GET form it
-     happens to sit inside: `hx-params` on the form names `q` and `category`
-     and nothing else rides a search.
+     happens to sit inside: `hx-params` on the form names `q`, `category` and
+     the refining pass's `rerank` flag, and nothing else rides a search.
 
      A photo taken on a phone used to upload the instant the camera handed it
      back: nothing had been pressed and the note underneath was unfillable by

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -50,7 +50,7 @@
                   submit{% if !q.is_empty() && open_with.is_empty() %},
                   load{% endif %}"
       hx-params="q,category"
-      hx-indicator="#search-spinner">
+      hx-indicator="#search-spinner"{% if search_reranks %} data-rerank="true"{% endif %}>
   {# A textarea from the first keystroke to the last. It grows to a ten-line
      cap and then scrolls inside itself; it never switches element type, and it
      never infers a verb from a length or a newline. What decides which of the

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -473,6 +473,10 @@ struct ResultsTemplate {
     all_weak: bool,
     /// The query's indexable terms, for client-side highlighting.
     terms: String,
+    /// This fragment is the refining pass — the reranker confirmed the order.
+    /// The tick beside the count is what makes the reordering legible as a
+    /// refinement rather than a glitch.
+    reranked: bool,
 }
 
 /// The rail before anything is asked: the base introducing itself.
@@ -1024,6 +1028,11 @@ pub(crate) struct UiSearchParams {
     pub(crate) tags: Option<String>,
     #[serde(default)]
     pub(crate) category: Option<String>,
+    /// The refining pass. Absent on every keystroke — typing gets vector
+    /// order at embedding speed — and `true` on the request app.js fires once
+    /// the operator stops, whose answer reorders the rail it just painted.
+    #[serde(default)]
+    pub(crate) rerank: bool,
 }
 
 /// Function words carry no signal and appear in every chunk, so highlighting
@@ -1114,6 +1123,7 @@ pub(crate) async fn search_results(
                 mark: false,
                 include_deprecated: false,
                 include_superseded: false,
+                rerank: p.rerank,
             },
             cap,
             // Scoped to the operator, because coalescing folds a keystroke into
@@ -1152,6 +1162,7 @@ pub(crate) async fn search_results(
         results,
         associated,
         terms,
+        reranked: p.rerank && st.core.reranks_search(),
     })
     .into_response();
     // Measured as before, reported where a browser already knows to show it.
@@ -3452,6 +3463,7 @@ mod tests {
                     mark: false,
                     include_deprecated: false,
                     include_superseded: false,
+                    rerank: true,
                 },
                 crate::store::feedback::Door::Ui,
             )
@@ -5918,6 +5930,7 @@ mod tests {
             associated: vec![],
             all_weak: true,
             terms: String::new(),
+            reranked: false,
         })
         .unwrap();
         assert!(html.contains("Nothing matches closely"), "{html}");
@@ -6015,6 +6028,7 @@ mod tests {
             associated: vec![render_hit(0, hit(None, Some("a")), &titles)],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         })
         .unwrap();
         assert!(!html.contains("Untitled"), "{html}");
@@ -6059,6 +6073,7 @@ mod tests {
             associated: vec![],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         }
         .render()
         .unwrap();
@@ -6080,6 +6095,7 @@ mod tests {
             associated: vec![],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         }
         .render()
         .unwrap();
@@ -6101,6 +6117,7 @@ mod tests {
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         };
         let body = template.render().unwrap();
         assert!(body.contains("Recalled by association"), "{body}");
@@ -6116,10 +6133,40 @@ mod tests {
             )],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         };
         let body = judged.render().unwrap();
         assert!(body.contains("the tool and its errors"), "{body}");
         assert!(!body.contains("seen together with"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn a_reranked_fragment_says_it_was_refined() {
+        // The refining pass visibly reorders the rail; the tick beside the
+        // count is what says the movement was the reranker rather than a
+        // glitch. The fast pass must not carry it: it is claiming an order
+        // the reranker never confirmed.
+        let refined = ResultsTemplate {
+            results: vec![rendered(Some("Mounting E01 images"), None)],
+            associated: vec![],
+            all_weak: false,
+            terms: String::new(),
+            reranked: true,
+        }
+        .render()
+        .unwrap();
+        assert!(refined.contains("refined"), "{refined}");
+
+        let fast = ResultsTemplate {
+            results: vec![rendered(Some("Mounting E01 images"), None)],
+            associated: vec![],
+            all_weak: false,
+            terms: String::new(),
+            reranked: false,
+        }
+        .render()
+        .unwrap();
+        assert!(!fast.contains("refined"), "{fast}");
     }
 
     #[tokio::test]
@@ -6169,6 +6216,7 @@ mod tests {
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: true,
             terms: String::new(),
+            reranked: false,
         };
         let body = weak_with_association.render().unwrap();
         assert!(
@@ -6181,6 +6229,7 @@ mod tests {
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         };
         let body = good_with_association.render().unwrap();
         assert!(
@@ -6418,6 +6467,7 @@ mod tests {
             associated: vec![],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         }
         .render()
         .unwrap();
@@ -6434,6 +6484,7 @@ mod tests {
             associated: vec![],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         }
         .render()
         .unwrap();
@@ -6452,6 +6503,7 @@ mod tests {
             associated: vec![],
             all_weak: false,
             terms: String::new(),
+            reranked: false,
         }
         .render()
         .unwrap();
@@ -6688,6 +6740,42 @@ mod tests {
         assert_eq!(res.status(), StatusCode::OK);
         let html = body_of(res).await;
         assert!(!html.contains("<html"), "results must be a fragment");
+    }
+
+    #[tokio::test]
+    async fn a_box_with_no_search_reranker_never_claims_refinement() {
+        // The tick says "the reranker confirmed this order". With no reranker
+        // wired — or one scoped to ask alone — a `rerank=true` request still
+        // answers, but the claim must not appear: it would be asserting a
+        // confirmation that never happened.
+        let (app, cookie, core) = app_session_and_core().await;
+        app.clone()
+            .oneshot(form("/ui/capture", &cookie, "text=mounting+an+image"))
+            .await
+            .unwrap();
+        while crate::jobs::run_one(&core).await.unwrap() {}
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/search/results?q=mounting&rerank=true")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            html.contains("result-count"),
+            "the fragment must actually carry results for this test to mean \
+             anything: {html}"
+        );
+        assert!(
+            !html.contains("refined"),
+            "a box with no search reranker claimed a refinement: {html}"
+        );
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1162,7 +1162,10 @@ pub(crate) async fn search_results(
         results,
         associated,
         terms,
-        reranked: p.rerank && st.core.reranks_search(),
+        // From the search's outcome, not from the request's intent: a rerank
+        // that failed or was skipped answered in vector order, and the tick
+        // would assert a confirmation that never took place.
+        reranked: t.reranked,
     })
     .into_response();
     // Measured as before, reported where a browser already knows to show it.
@@ -6778,6 +6781,103 @@ mod tests {
         );
     }
 
+    /// The tick's title is "Order confirmed by the reranker", so it has to be
+    /// derived from what the rerank call did — not from what the request asked
+    /// for. A reranker that is configured but down degrades to vector order
+    /// with a warning, and the fragment must degrade its claim with it.
+    #[tokio::test]
+    async fn a_fragment_whose_rerank_failed_never_claims_refinement() {
+        let core = crate::core::test_support::test_core_with_failing_reranker().await;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        app.clone()
+            .oneshot(form("/ui/capture", &cookie, "text=mounting+an+image"))
+            .await
+            .unwrap();
+        while crate::jobs::run_one(&handle).await.unwrap() {}
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/search/results?q=mounting&rerank=true")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            html.contains("result-count"),
+            "the fragment must actually carry results for this test to mean \
+             anything: {html}"
+        );
+        assert!(
+            !html.contains("refined"),
+            "the rerank call failed, so the order is vector order and the \
+             fragment must not claim the reranker confirmed it: {html}"
+        );
+    }
+
+    /// The same claim over nothing: the server skips the rerank call for an
+    /// empty result set, so "0 results · refined" would be a confirmation of
+    /// an order that was never sent anywhere.
+    #[tokio::test]
+    async fn an_empty_result_set_never_claims_refinement() {
+        let (core, _reranker) = crate::core::test_support::test_core_counting_reranked_docs().await;
+        let (app, cookie) = app_with_cookie(core).await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/search/results?q=nothing+matches+this&rerank=true")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            !html.contains("refined"),
+            "no rerank call was made for an empty answer, so nothing was \
+             confirmed: {html}"
+        );
+    }
+
+    /// The positive half, end to end: a working reranker asked for by the
+    /// request is what earns the tick.
+    #[tokio::test]
+    async fn a_rerank_that_actually_ran_earns_the_refined_tick() {
+        let (core, _reranker) = crate::core::test_support::test_core_counting_reranked_docs().await;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        app.clone()
+            .oneshot(form("/ui/capture", &cookie, "text=mounting+an+image"))
+            .await
+            .unwrap();
+        while crate::jobs::run_one(&handle).await.unwrap() {}
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/search/results?q=mounting&rerank=true")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            html.contains("refined"),
+            "the reranker ran and confirmed the order; the tick is earned: {html}"
+        );
+    }
+
     #[tokio::test]
     async fn rendered_chunk_html_is_sanitized() {
         let (app, cookie) = app_with_session().await;
@@ -8789,10 +8889,11 @@ mod tests {
         );
 
         // The box's own form is a GET that searches on every keystroke. The
-        // staged file sits inside it, so the serialisation is pinned to the two
+        // staged file sits inside it, so the serialisation is pinned to the
         // fields the search actually takes — without this, every keystroke
-        // carries a filename into the query string.
-        assert!(page.contains(r#"hx-params="q,category""#), "{page}");
+        // carries a filename into the query string. `rerank` is on the list
+        // for the refining pass, whose own flag rides this form's GET.
+        assert!(page.contains(r#"hx-params="q,category,rerank""#), "{page}");
     }
 
     #[tokio::test]

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -798,6 +798,12 @@ mod tests {
             html.contains(r#"data-rerank="true""#),
             "a reranker serving search is what arms the refining pass"
         );
+        assert!(
+            html.contains(r#"hx-params="q,category,rerank""#),
+            "hx-params is the allowlist for what rides a search GET; without \
+             `rerank` on it the refining pass's own flag is filtered off the \
+             wire and the server only ever runs the fast path"
+        );
     }
 
     /// The refining pass, pinned at the seams that keep it honest: it arms
@@ -821,6 +827,13 @@ mod tests {
             js.contains("wasRefine"),
             "a refine swap must be told apart from a typing swap, or the \
              refine reschedules off its own landing and never stops"
+        );
+        assert!(
+            js.contains("unfilteredParameters"),
+            "wasRefine must read the pre-filter parameter set: `parameters` \
+             is what survived hx-params, so an allowlist edit there would \
+             silently turn every refine swap back into a typing swap — and \
+             the refine reschedules off its own landing forever"
         );
     }
 

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -75,6 +75,11 @@ struct WorkspaceTemplate {
     /// Whether the image door is open, i.e. `[infer.vision]` is configured.
     /// Off, the control offers text only rather than a picker that fails.
     vision_enabled: bool,
+    /// Whether a reranker serves the search path — `Core::reranks_search`.
+    /// Rendered onto the form as `data-rerank`, which is what arms app.js's
+    /// refining pass: without it no second request fires, ever, because it
+    /// could only buy the same order back.
+    search_reranks: bool,
     /// Whether capture spends a synthesis call per segment, i.e. `eager`.
     ///
     /// At `earned` and `off` it spends none: the text is embedded as written,
@@ -177,6 +182,7 @@ async fn base_template(
         category,
         recommend: st.core.recommends(),
         vision_enabled: st.core.describer.is_some(),
+        search_reranks: st.core.reranks_search(),
         eager: st.core.synthesis == crate::config::SynthesisMode::Eager,
         prefill_ask: String::new(),
         prefill_question: String::new(),
@@ -760,6 +766,62 @@ mod tests {
             verdict_bar: String::new(),
         })
         .unwrap()
+    }
+
+    /// The refining pass is a second request per settled query, and app.js
+    /// decides whether to fire it by reading the form. A box with no search
+    /// reranker must not advertise one: every pause would buy a second search
+    /// that answers in the same order, and the rail would claim "refined" over
+    /// an order nothing confirmed.
+    #[tokio::test]
+    async fn the_form_says_whether_a_refining_pass_is_worth_firing() {
+        let html = workspace("/ui").await;
+        assert!(
+            !html.contains("data-rerank"),
+            "no reranker, so the form must not advertise a refining pass"
+        );
+
+        let (core, _reranker) = crate::core::test_support::test_core_counting_reranked_docs().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(
+            html.contains(r#"data-rerank="true""#),
+            "a reranker serving search is what arms the refining pass"
+        );
+    }
+
+    /// The refining pass, pinned at the seams that keep it honest: it arms
+    /// only off the form's `data-rerank`, it fires `rerank=true` rather than
+    /// re-running the fast search, and it never schedules itself off its own
+    /// swap — which is the loop that would turn one settled query into a
+    /// rerank call every half second forever.
+    #[test]
+    fn the_refining_pass_is_armed_by_the_form_and_never_by_itself() {
+        let js = crate::web::assets::Assets::get("app.js").expect("app.js is embedded");
+        let js = String::from_utf8(js.data.into_owned()).unwrap();
+        assert!(
+            js.contains("data-rerank"),
+            "the driver reads the form's flag; without it no refine ever fires"
+        );
+        assert!(
+            js.contains("rerank: 'true'"),
+            "the refining request asks for the reranked order by name"
+        );
+        assert!(
+            js.contains("wasRefine"),
+            "a refine swap must be told apart from a typing swap, or the \
+             refine reschedules off its own landing and never stops"
+        );
     }
 
     /// Three destinations, because there are three places. Capture and Ask

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -124,6 +124,9 @@ async fn evaluate_retrieval() {
             mark: false,
             include_deprecated: false,
             include_superseded: false,
+            // The harness measures the configured pipeline; with no reranker
+            // wired this is inert either way.
+            rerank: true,
         };
         let (results, _) = core
             .search_with(&q, cap, engram::store::feedback::Door::Ui)
@@ -498,6 +501,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         synthesizer: Some(Arc::new(engram::infer::fake::FakeSynthesizer::default())),
         embedder: Arc::new(engram::infer::fake::FakeEmbedder::new(8)),
         reranker: None,
+        rerank_apply: vec![],
         completer: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
         judge: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
         link_judge: Some(Arc::new(engram::infer::fake::FakeCompleter::default())),
@@ -559,6 +563,7 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         mark: false,
         include_deprecated: false,
         include_superseded: false,
+        rerank: true,
     };
     let (results, _) = core
         .search_with(&q, None, engram::store::feedback::Door::Judge)


### PR DESCRIPTION
## What

A configured reranker used to stand in front of every debounced keystroke — the one synchronous model call on the typing path, on the door where latency is felt most. This PR splits search into two phases and makes the reranker's reach configurable.

- **Typing stays instant.** Keystrokes answer in vector order at embedding speed; the reranker is never on the incremental path.
- **The pause refines.** Once the box is quiet for 500ms, app.js fires a second request with `rerank=true`. The reranked fragment swaps in, rows glide to their new positions (FLIP via the Web Animations API, keyed by artifact; promoted rows fade in; `prefers-reduced-motion` disables the movement), and the count line shows a quiet "· refined" tick — the reordering reads as a refinement, not a glitch.
- **Scope is configurable.** `[infer.rerank].apply = ["ask", "search"]` (the default, matching previous behavior) says where the reranker is consulted; `["ask"]` keeps it off the search path entirely, for an endpoint slow or billed enough that only a deliberate question should spend it.
- **Per-request opt-out.** `SearchQuery.rerank` carries the request half: API/MCP/ask/judge default to true, `GET /api/v1/search?rerank=false` is there for any typing client.

## Honesty guards

- The form advertises the refining pass (`data-rerank`) only where `Core::reranks_search()` is true — no reranker serving search means no second request, ever.
- The fragment claims "refined" only when a reranker actually served the request, never over an order nothing confirmed.
- The refine joins the form's `hx-sync` queue (a keystroke always wins), never resets scroll, and never re-arms off its own swap.

## Testing

Built test-first. New tests cover: `apply` parsing and its default, door scoping (`apply = ["ask"]` keeps the reranker out of a UI search), the `rerank: false` fast path, the refined tick's rendering and its absence without a search reranker, the form flag, and the JS driver's honesty seams. Full suite: 1727 lib tests + integration targets green, clippy clean.

The glide animation itself is pinned by static asserts but has not had a visual pass in a live browser yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nyCoyriWHSUsHzWCZh7Ae