### PR TITLE
audit: the two quick-xml advisories, with the argument that they cannot fire

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,6 +27,46 @@ ignore = [
   #   * engram starts using `private_key_jwt` client authentication, or signs
   #     anything with RSA. Then the advisory becomes live and must be fixed.
   "RUSTSEC-2023-0071",
+
+  # RUSTSEC-2026-0194 — quadratic duplicate-attribute check in `quick-xml`.
+  # RUSTSEC-2026-0195 — unbounded namespace allocation in `quick-xml`'s
+  # `NsReader`.
+  # Both reached via: engram -> docling 1.14.0 -> calamine 0.26.1 -> quick-xml
+  # 0.31.0. Both are CPU/memory exhaustion on a thread parsing untrusted XML.
+  #
+  # Not reachable in this codebase. `quick-xml` appears twice in `Cargo.lock`:
+  # docling's own direct dependency is already 0.41.0, which is the patched
+  # version. The 0.31.0 copy belongs to `calamine`, which docling uses for
+  # exactly three things — its `.xls`, `.xlsx` and `.xlsb` backends
+  # (`src/backend/xls.rs`, `src/backend/xlsx.rs`). Nothing else in docling
+  # names it.
+  #
+  # engram never reaches those backends. `src/core/pdf.rs` is the only place
+  # docling is named at all, and it builds its source with
+  # `SourceDocument::from_bytes(.., docling::InputFormat::Pdf, ..)`.
+  # `from_bytes` stores the format it is handed without detection, and
+  # docling's converter dispatches on `match source.format`, so the
+  # spreadsheet arms are dead for us. Its one content-sniffing path
+  # (`sniff_xml`) applies only to `Md`- and `Xml`-typed sources and can return
+  # only the four XML formats — never a spreadsheet.
+  #
+  # No fix is available short of a fork. docling requires `calamine = "0.26"`,
+  # 0.26.1 is the newest release in that range, and every calamine that moved
+  # to a patched `quick-xml` is a later incompatible major (0.36.1 at the time
+  # of writing). A `[patch.crates-io]` entry would still have to satisfy
+  # `^0.26`, so it would mean maintaining a fork of a spreadsheet reader whose
+  # code this application never executes.
+  #
+  # Re-review if any of the following becomes true:
+  #   * docling ships a release whose `calamine` requirement admits a patched
+  #     `quick-xml`, at which point both entries should be deleted rather than
+  #     carried forward.
+  #   * engram passes docling any `InputFormat` other than `Pdf`, or starts
+  #     using `SourceDocument::from_path`, which picks the format from the
+  #     file extension and can therefore select a spreadsheet backend. Then
+  #     both advisories become live and must be fixed.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]
 
 # Informational advisories still surface in the log. `paste` (via tokenizers) is

--- a/src/core/pdf.rs
+++ b/src/core/pdf.rs
@@ -222,6 +222,34 @@ fn is_markdown_structure(text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    /// The reachability argument in `.cargo/audit.toml` rests on this file.
+    ///
+    /// Two `quick-xml` advisories are ignored there — RUSTSEC-2026-0194 and
+    /// -0195 — because the vulnerable copy belongs to `calamine`, which docling
+    /// reaches only from its spreadsheet backends, and this application asks
+    /// docling for exactly one format. `from_path` would pick the format from a
+    /// file extension and could therefore select one of those backends; the
+    /// declared `InputFormat::Pdf` cannot.
+    ///
+    /// If this fails, do not adjust it: the two entries in `.cargo/audit.toml`
+    /// have stopped being true and the advisories are live.
+    #[test]
+    fn docling_is_only_ever_asked_for_a_pdf() {
+        let src = include_str!("pdf.rs");
+        let body = &src[..src.find("mod tests").expect("the test module")];
+        assert_eq!(
+            body.matches("InputFormat::").count(),
+            1,
+            "one input format is named, and it decides which docling backends exist for us"
+        );
+        assert!(body.contains("docling::InputFormat::Pdf"), "and it is Pdf");
+        assert!(
+            !body.contains("from_path"),
+            "`from_path` detects the format from the extension, which can select \
+             a spreadsheet backend — see `.cargo/audit.toml`"
+        );
+    }
+
     use super::*;
 
     // Both fixtures were generated, not written by hand:


### PR DESCRIPTION
`cargo audit` has been failing on master since RUSTSEC-2026-0194 and -0195 landed. Both are against `quick-xml` 0.31.0; both are denial of service on a thread parsing untrusted XML.

`quick-xml` appears twice in `Cargo.lock`. docling's own direct dependency is 0.41.0, the patched version. The 0.31.0 copy comes from `calamine`, which docling uses only for its `.xls`, `.xlsx` and `.xlsb` backends — and this application never reaches those:

- `src/core/pdf.rs` is the only place docling is named.
- It builds its source with `docling::InputFormat::Pdf`, and `from_bytes` stores the format it is handed without detection.
- docling's converter dispatches on `match source.format`, so the spreadsheet arms are dead here.
- Its one content-sniffing path (`sniff_xml`) applies to `Md`- and `Xml`-typed sources and can only return an XML format.

No fix is available short of a fork. docling requires `calamine = "0.26"`, 0.26.1 is the newest release in that range, and every calamine that moved to a patched `quick-xml` is a later incompatible major (0.36.1 today). A `[patch.crates-io]` entry would also have to satisfy `^0.26`, so it would mean maintaining a fork of a spreadsheet reader whose code never executes here.

Both ids are therefore ignored in `.cargo/audit.toml`, one at a time and with the reachability argument written out, as that file requires of every entry — including the conditions under which the entries must be deleted.

The argument rests on a single file, so `pdf.rs` gains a test that fails if this application ever names a second `InputFormat` or reaches for `from_path`, which picks a backend from a file extension and could pick a spreadsheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)