### PR TITLE
Onboarding and wording polish: an empty base that teaches, and one word for a source

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -13,6 +13,9 @@
   // fetch had not landed yet, `/ui/context/seen` never went and a real
   // impression fell out of both halves of the hit rate.
   var VERB_SYNC = 'engram:verbsync';
+  // Fired on the box once the base has stopped being empty and the held
+  // state has been swapped in. See `syncHeld`.
+  var HELD_SYNC = 'engram:held';
 
   // Registering the worker is what makes the browser offer to install engram
   // rather than bookmark it. Guarded on both the API and a secure context,
@@ -203,10 +206,13 @@
   function askDriver() {
     var form = document.getElementById('box-form');
     if (!form) return;
-    // No model, no button, no driver. The server renders no Ask verb where
-    // `Core::asks` is false, and this is the other end of that.
-    var askBtn = form.querySelector('[data-verb="ask"]');
-    if (!askBtn) return;
+    // The press is delegated, rather than bound to the button found here.
+    // There are two states with no Ask verb in the page — an install with no
+    // model, and a base with nothing held — and only the second one ends: the
+    // verb arrives out-of-band on the first capture (see `syncHeld`), long
+    // after this runs, and a driver that had returned at this line left it
+    // dead. Nothing below fires until a press that reaches the button, so
+    // arming the driver where there is no model costs nothing.
     var box = form.querySelector('textarea[name="q"]');
     if (!box) return;
     var live = document.getElementById('ask-live');
@@ -462,7 +468,11 @@
       });
     }
 
-    askBtn.addEventListener('click', function (e) {
+    form.addEventListener('click', function (e) {
+      var askBtn = e.target.closest ? e.target.closest('[data-verb="ask"]') : null;
+      // `disabled` is checked as well as matched: a disabled button fires no
+      // click of its own, but it is inside a form that does.
+      if (!askBtn || askBtn.disabled) return;
       e.preventDefault();
       var q = box.value;
       if (!q.trim()) return;
@@ -576,6 +586,46 @@
     if (id === dwell.id) return;
     flushDwell();
     if (id) { dwell.id = id; dwell.since = Date.now(); }
+  }
+
+  // ── The end of the empty base ─────────────────────────────────────────────
+  //
+  // The workspace is rendered once. A capture posts to `/ui/capture` and swaps
+  // a receipt, and the rail refresh swaps `#results` — nothing else on the page
+  // moves. So the paste that ends an empty base left the whole page still
+  // arranged for one: no Ask verb, no shortcut row, a box hint introducing the
+  // application and a pane saying what will happen to the first capture, all
+  // of it describing a state the operator had just left, until a reload nobody
+  // had a reason to perform.
+  //
+  // `/ui/held` returns those four regions as out-of-band swaps, written from
+  // the same partials the page itself includes, so there is one author for
+  // what the held state says. The placeholders are not among them and ride the
+  // textarea instead — see the box's `HELD_SYNC` listener.
+  //
+  // Runs at most once: `data-held` is written before the request goes, so the
+  // second capture of a session asks for nothing.
+  function syncHeld() {
+    var form = document.getElementById('box-form');
+    if (!form || form.getAttribute('data-held') !== '0') return;
+    form.setAttribute('data-held', '1');
+    // `swap: "none"` because every region in the answer names its own target.
+    // A `target` is still required, and the form is the one element here that
+    // is certain to exist.
+    htmx.ajax('GET', '/ui/held', { target: form, swap: 'none' })
+      // A capture that stored and a page that failed to redress itself is
+      // still a capture that stored: the receipt stands, and the state is
+      // re-armed so the next one tries again rather than the page staying
+      // wrong for the session.
+      .catch(function () { form.setAttribute('data-held', '0'); })
+      .then(function () {
+        if (form.getAttribute('data-held') !== '1') return;
+        var box = form.querySelector('textarea[name="q"]');
+        if (box) box.dispatchEvent(new Event(HELD_SYNC, { bubbles: true }));
+        // The shortcut row arrived hidden, as it always does. This is what
+        // decides whether there is a keyboard to show it to.
+        keyHint();
+      });
   }
 
   // Shown until it is dismissed, then never again on this browser. Not shown
@@ -948,6 +998,15 @@
         : (narrow.matches ? short : wide);
     }
     narrow.addEventListener('change', fitPlaceholder);
+    // And the two sentences an empty base's box will use once something is
+    // held, carried on the element by the template. Read across here rather
+    // than swapped in with the rest of the held state: replacing a textarea
+    // takes the caret, the selection and anything typed since with it.
+    box.addEventListener(HELD_SYNC, function () {
+      wide = box.getAttribute('data-placeholder-held') || wide;
+      short = box.getAttribute('data-placeholder-held-narrow') || short;
+      fitPlaceholder();
+    });
     fitPlaceholder();
 
     sync();
@@ -1150,6 +1209,10 @@
             box.value = '';
             box.dispatchEvent(new Event(VERB_SYNC, { bubbles: true }));
             refreshRail();
+            // A photo or a PDF ends an empty base exactly as a paste does, and
+            // this path never goes near `/ui/capture` — without this the first
+            // capture of a phone-only base left the page arranged for nothing.
+            syncHeld();
           } else {
             // It never left. Put it back where it was, so the fix is a second
             // press rather than a second trip to the camera.
@@ -1272,6 +1335,9 @@
         box.value = '';
         box.dispatchEvent(new Event(VERB_SYNC, { bubbles: true }));
         refreshRail();
+        // The base may have just stopped being empty. Asked after the box is
+        // cleared, so the placeholder this uncovers is the one that lands.
+        syncHeld();
       });
     }
     verb.addEventListener('click', function (e) {

--- a/assets/css/40-workspace.css
+++ b/assets/css/40-workspace.css
@@ -847,3 +847,8 @@ body { overflow-x: hidden; }
 }
 .reasoning-box > .reasoning { max-height: 14rem; overflow-y: auto; }
 
+/* A full basis, so it takes a line of its own under the row rather than
+   competing with the verbs for one. Last in the DOM as well as last on screen:
+   placed earlier it would have wrapped the chips onto a third line, which
+   costs the row the density it is arranged for. */
+.attach-types { flex: 1 0 100%; margin: 0.25rem 0 0; }

--- a/assets/css/43-insights.css
+++ b/assets/css/43-insights.css
@@ -228,3 +228,24 @@
   color: var(--color-fg-secondary);
 }
 .measure-row .mono { color: var(--color-fg-primary); }
+
+/* The machine's own readout, closed. Everything above this line is about what
+   the base holds and can be acted on by whoever is reading; everything inside
+   is about the instance and is the same for every user of it. A rule and a
+   little air, because the boundary is the point — without them the summary
+   reads as one more heading in the list rather than as the lid on a different
+   kind of page.
+
+   The summary carries an <h2> so the heading level stays honest, which means
+   overriding its block display: a summary lays its marker out beside inline
+   content, and a block-level child pushes the text onto the next line and
+   leaves the triangle sitting on its own. */
+.machine {
+  margin-top: 2.5rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.75rem;
+}
+.machine > summary { cursor: pointer; color: var(--color-fg-secondary); }
+.machine > summary > h2 { display: inline; }
+.machine > summary::marker { color: var(--color-fg-muted); }
+.machine[open] > summary { margin-bottom: 0.5rem; }

--- a/assets/css/50-phone.css
+++ b/assets/css/50-phone.css
@@ -164,10 +164,15 @@
     /* Above the home indicator rather than under it. */
     padding-bottom: env(safe-area-inset-bottom);
   }
+  /* `min-width: 0` and no wrapping, because the row grew a fourth entry: a
+     flex item's floor is its content, so without this the widest label sets
+     everyone's width and a narrow phone breaks "Insights" over two lines,
+     which makes that one tab taller than the rest of the bar. */
   .tabbar a {
     position: relative;
-    flex: 1; display: flex; flex-direction: column; align-items: center;
-    justify-content: center; gap: 2px; min-height: 46px; text-decoration: none;
+    flex: 1; min-width: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 2px; min-height: 46px;
+    text-decoration: none; white-space: nowrap;
     font-size: var(--text-xs); color: var(--color-fg-muted);
   }
   /* Over the icon, not beside the label: the tab is 46px tall and a number

--- a/docs/superpowers/plans/2026-08-25-onboarding-polish.md
+++ b/docs/superpowers/plans/2026-08-25-onboarding-polish.md
@@ -1,0 +1,1342 @@
+# Onboarding and Wording Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an empty base teach a first-time user what engram is and what to do, close the captured-to-searchable blind spot, and settle the wording — before the application is opened to more than one person.
+
+**Architecture:** Every change is at the web door. One new boolean on the workspace template (`held`) carries the whole first-run story; everything else is template copy, one `<details>` on Insights, one include on the capture receipt, and a field on the settings template. No schema migrations, no new routes, no new persistence, no per-user state.
+
+**Tech Stack:** Rust, axum, askama templates (`src/web/templates/`), htmx plus one hand-written `assets/app.js`, layered CSS (`assets/css/00-…` through `50-phone.css`), SQLite via sqlx. Tests are inline `#[cfg(test)] mod tests` in the file under test, run with `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-onboarding-polish-design.md`
+
+## Global Constraints
+
+- **Branch:** `feat/onboarding-polish`, already created off `master` and already holding the spec commit. Do not branch again.
+- **Onboarding is a property of an empty base, not of a new user.** No welcome page, no tour, no scripted sequence, no per-user "has seen it" flag, no new table or column. If a task seems to want one, it is the wrong task.
+- **"Artifact" stays.** It is deliberate and defended in the comments. Do not rename it anywhere — not in templates, not in Rust, not in tests.
+- **Never change a URL, an API field name, or an MCP schema.** `/ui/corpora/…` and `/ui/artifacts/…` keep their paths. This is a copy change only.
+- **Never render the word `Untitled`,** and never render `Chunk N` as a title. Existing tests enforce this.
+- **Explanations are visible text, never a `title=` attribute.** A tooltip is unreachable on a touch screen. The established pattern is `_results.html`'s `rail-why`: the badge stays as the scannable form and one quiet sentence sits under it. `title=` may remain *in addition*, never *instead*.
+- **Comment style:** this codebase explains *why* in prose above the code and expects it. Match it. A template comment that only restates the markup is worse than none.
+- **Truncate by chars, never by bytes.** Slicing mid-codepoint panics; the corpus is largely German.
+- **Do not change:** the phone hiding the KIND chips (`50-phone.css`), the phone badge dropping its number (`layout.html`), Judge's rank numbers stopping at nine (`judge.rs`), or the IR vocabulary on the judge page itself (recall@10, MRR).
+- **Run `cargo fmt` before every commit.** The tree is formatted and the last commit on `master` was a formatting sweep.
+
+---
+
+### Task 1: An empty base does not offer what it cannot do
+
+On a base with nothing in it, searching returns nothing and asking returns an
+abstention. The box presently offers all three verbs anyway, names Capture last
+in its placeholder, and prints seven keyboard shortcuts for moving through a
+list with nothing in it.
+
+**Files:**
+- Modify: `src/web/workspace.rs` (add `held` to `WorkspaceTemplate`, set it in `base_template`)
+- Modify: `src/web/templates/workspace.html` (Ask button, placeholder, keyhint bar)
+- Test: `src/web/workspace.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Produces: `WorkspaceTemplate.held: bool` — true when the base holds at least one source. Read by Task 2's template changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `src/web/workspace.rs`. The module already
+has a `workspace(uri)` helper that boots the app and returns the rendered HTML;
+this test needs a second helper that seeds a capture first, because the
+interesting assertion is the *difference* between the two states.
+
+```rust
+    /// Two of the three verbs cannot work on a base with nothing in it, and a
+    /// list with nothing in it has nothing to move through. A disabled button
+    /// is a promise the page cannot keep and seven shortcuts are a wall; both
+    /// are absent until there is something for them to act on.
+    #[tokio::test]
+    async fn an_empty_base_offers_only_the_verb_that_can_work() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core.clone()).await;
+
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let empty = body_of(res).await;
+
+        assert!(
+            !empty.contains(r#"data-verb="ask""#),
+            "Ask can only abstain on an empty base, so the door is not there"
+        );
+        assert!(
+            !empty.contains(r#"class="keyhint""#),
+            "seven shortcuts for moving through a list with nothing in it"
+        );
+        assert!(
+            empty.contains("Paste anything worth keeping"),
+            "the placeholder names the one verb that can work"
+        );
+
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let held = body_of(res).await;
+
+        assert!(
+            held.contains(r#"data-verb="ask""#),
+            "one source is enough to have something to ask about"
+        );
+        assert!(
+            held.contains(r#"class="keyhint""#),
+            "and something to move through"
+        );
+        assert!(
+            held.contains("Describe the situation"),
+            "the placeholder goes back to naming all three verbs"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::workspace::tests::an_empty_base_offers_only_the_verb_that_can_work`
+Expected: FAIL — the empty render still contains `data-verb="ask"`.
+
+- [ ] **Step 3: Add the field to the template struct**
+
+In `src/web/workspace.rs`, add to `WorkspaceTemplate` immediately after `idle`:
+
+```rust
+    /// Whether the base holds anything at all.
+    ///
+    /// Onboarding here is a property of an empty base rather than of a new
+    /// user: no flag is stored, nothing is dismissed, and the same page serves
+    /// someone who has just arrived and someone who has just deleted
+    /// everything. Two of the three verbs cannot work with nothing held —
+    /// search returns nothing and ask can only abstain — so the page offers
+    /// the one that can, and the rest appears when there is something for it
+    /// to act on.
+    held: bool,
+```
+
+- [ ] **Step 4: Set it in `base_template`**
+
+In `base_template`, before the `Ok(WorkspaceTemplate { … })`:
+
+```rust
+    // The slimmest read there is, and the same one the idle rail takes. Asked
+    // unconditionally because the deep-link path renders no idle rail and
+    // still has to know: a search URL against an empty base is a page that
+    // must not offer Ask either.
+    let (corpora, _) = tenant.core.store.held_brief().await?;
+```
+
+and add `held: corpora > 0,` to the struct literal.
+
+- [ ] **Step 5: Hide Ask on an empty base**
+
+In `src/web/templates/workspace.html`, change the Ask button's guard:
+
+```html
+    {% if ask_enabled && held %}
+    <button class="btn btn-accent" type="button" data-verb="ask" disabled>Ask</button>
+    {% endif %}
+```
+
+- [ ] **Step 6: Swap the placeholder**
+
+Replace the `placeholder` and `data-placeholder-narrow` attributes on the
+`textarea` with a conditional pair. The long form names all three verbs; the
+empty-base form names the one that works.
+
+```html
+            placeholder="{% if held %}Describe the situation, ask a question, or paste anything worth keeping…{% else %}Paste anything worth keeping — a note, an article, a chunk of a chat.{% endif %}"
+            data-placeholder-narrow="{% if held %}Ask, search, or paste to keep…{% else %}Paste anything worth keeping…{% endif %}"
+```
+
+- [ ] **Step 7: Hide the keyboard hints on an empty base**
+
+Change the opening tag of the `keyhint` paragraph:
+
+```html
+{% if held %}
+<p class="keyhint" hidden>
+```
+
+and close the block with `{% endif %}` after its `</p>`.
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `cargo test --lib web::workspace::tests::an_empty_base_offers_only_the_verb_that_can_work`
+Expected: PASS
+
+- [ ] **Step 9: Run the whole web suite for regressions**
+
+Run: `cargo test --lib web::`
+Expected: PASS. If an existing test asserted `data-verb="ask"` against an
+unseeded core, seed it with `ingest_capture` as above rather than weakening the
+new guard.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cargo fmt
+git add src/web/workspace.rs src/web/templates/workspace.html
+git commit -m "feat: an empty base offers only the verb that can work"
+```
+
+---
+
+### Task 2: The empty base says what engram is, and that it is yours
+
+The tagline lives on `login.html`, which a user arriving through an identity
+provider never sees. Nothing on the workspace says what the application does,
+and nothing anywhere says the base is theirs alone — which is the exact
+hesitation a person has before pasting their own notes onto somebody else's
+server. The pane meanwhile gives an instruction that cannot be followed:
+"Search to see an artifact here", to a person with nothing to search.
+
+**Files:**
+- Modify: `src/web/templates/workspace.html` (box hint, pane idle text)
+- Test: `src/web/workspace.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `WorkspaceTemplate.held: bool` from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// An OIDC user never sees the login card, so the tagline and the privacy
+    /// boundary have to be said where the eye already is — under the box, not
+    /// on a settings page nobody opens before pasting.
+    #[tokio::test]
+    async fn an_empty_base_says_what_this_is_and_whose_it_is() {
+        let html = workspace("/ui").await;
+        assert!(
+            html.contains("finds it again by meaning"),
+            "what the application does, in one clause"
+        );
+        assert!(
+            html.contains("Nobody else can search it"),
+            "and the boundary, which is what a person wants before pasting \
+             their own notes onto someone else's server"
+        );
+        assert!(
+            !html.contains("Search to see an artifact here"),
+            "an instruction that cannot be followed on an empty base"
+        );
+        assert!(
+            html.contains("kept exactly as you wrote it"),
+            "the pane says what will happen to the first thing pasted"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::workspace::tests::an_empty_base_says_what_this_is_and_whose_it_is`
+Expected: FAIL — "finds it again by meaning" is not in the page.
+
+- [ ] **Step 3: Make the box hint conditional**
+
+Replace the `box-hint` paragraph in `src/web/templates/workspace.html`:
+
+```html
+  {# Two hints, because the two states need different sentences. With something
+     held, the useful thing to say is how to phrase a query — a whole sentence
+     embeds better than the two nouns from it a reader would otherwise type.
+     With nothing held there is no query to phrase, and the useful thing to say
+     is what this is and whose it is. The second half is not decoration: an
+     operator arriving through an identity provider never sees the login card,
+     so this is the only place the application introduces itself, and the
+     boundary is the question a person actually has before pasting their own
+     notes onto a server somebody else runs. #}
+  <p id="box-hint" class="muted hint">
+    {%- if held -%}
+    A sentence or a whole paragraph finds more than keywords do — paste what you
+    are looking at.
+    {%- else -%}
+    engram keeps what you paste in your own words and finds it again by meaning,
+    not by keywords. This base is yours: nobody else can search it.
+    {%- endif -%}
+  </p>
+```
+
+- [ ] **Step 4: Make the pane idle text conditional**
+
+Replace the `pane-idle` paragraph:
+
+```html
+    {# With something held this names where an artifact will appear. With
+       nothing held it named a search that cannot be run, which is an
+       instruction to do the one thing the page has just been arranged to
+       prevent. It says what will happen to the first paste instead. #}
+    <p id="pane-idle" class="muted">
+      {%- if held -%}
+      Search to see an artifact here, beside the lines it came from.
+      {%- else -%}
+      Whatever you paste is split into passages and embedded so it can be found
+      by meaning. The original is kept exactly as you wrote it, and every result
+      can be read beside it.
+      {%- endif -%}
+    </p>
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test --lib web::workspace::tests::an_empty_base_says_what_this_is_and_whose_it_is`
+Expected: PASS
+
+- [ ] **Step 6: Run the web suite**
+
+Run: `cargo test --lib web::`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/workspace.html src/web/workspace.rs
+git commit -m "feat: the empty base introduces itself and states the boundary"
+```
+
+---
+
+### Task 3: The capture receipt shows the work
+
+`_captured.html` answers a paste with one dead line — "Captured — view source"
+— while embedding runs as a background job. A person who immediately searches
+for what they just pasted gets nothing and concludes the application is broken.
+This is the most likely abandonment moment in the app.
+
+The fragment that answers it already exists. `_queue.html` reports per-source
+progress, polls itself every three seconds, stops polling when nothing is
+moving, and already listens for the `captured` event the box fires. It is
+rendered only on Insights, and `_captured.html`'s own comment records the cost:
+"nothing else on the workspace says the paste landed."
+
+**Files:**
+- Modify: `src/web/templates/_captured.html`
+- Test: `src/web/workspace.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: the existing `GET /ui/queue` route and `_queue.html` fragment. Neither changes.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// The gap between "captured" and "searchable" is a background job, and it
+    /// was invisible: a one-line receipt, then silence, then a search that
+    /// finds nothing. The queue fragment already reports the work and already
+    /// stops polling when it settles — it was only ever rendered on Insights.
+    #[tokio::test]
+    async fn the_capture_receipt_shows_the_work_that_is_still_running() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ui/capture")
+                    .header("cookie", &cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("text=LevelDB+tombstones+survive+compaction."))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            html.contains(r#"hx-get="/ui/queue""#),
+            "the receipt fetches the queue that reports the work"
+        );
+        assert!(
+            html.contains(r#"hx-trigger="load""#),
+            "on load, so the progress is there without a second press"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::workspace::tests::the_capture_receipt_shows_the_work_that_is_still_running`
+Expected: FAIL — the receipt contains no `hx-get`.
+
+- [ ] **Step 3: Include the queue on the receipt**
+
+In `src/web/templates/_captured.html`, add immediately after the existing
+`{% endif %}` that closes the duplicate/near-duplicate branch, so it renders on
+every path — a parked capture has a queue row too, and its row is the thing
+that says it is parked:
+
+```html
+{# The work the press started, reported by the fragment that already knows how.
+   The gap between a paste landing and that paste being searchable is a
+   background job, and it was invisible from here: this receipt, then silence,
+   then a search that finds nothing and reads as data loss. `_queue.html`
+   carries its own polling trigger and drops it the moment nothing is moving,
+   so an idle receipt costs one request and then none — the same contract it
+   already honours on Insights, which is why it is included rather than
+   reimplemented. #}
+<div hx-get="/ui/queue" hx-trigger="load" hx-swap="outerHTML"></div>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --lib web::workspace::tests::the_capture_receipt_shows_the_work_that_is_still_running`
+Expected: PASS
+
+- [ ] **Step 5: Check the receipt in the running app**
+
+Run: `cargo run -- serve` (or the project's usual invocation), sign in, paste a
+paragraph, and confirm the row appears under the receipt, shows a status, and
+stops updating once the capture settles. The polling stopping is the half a
+unit test cannot see.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/_captured.html src/web/workspace.rs
+git commit -m "feat: the capture receipt reports the work still running"
+```
+
+---
+
+### Task 4: Insights on an empty base is one line
+
+A new user opening Insights is shown Held 0, an empty Reach, a Retrieval panel
+explaining there is nothing to measure, and "0 artifacts, 0 embedded. No jobs
+queued." A page of zeros reads as a system with something wrong with it.
+
+**Files:**
+- Modify: `src/web/templates/insights.html`
+- Test: `src/web/insights.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `InsightsTemplate.held: crate::store::insights::Held`, which already carries `corpora` and `artifacts`.
+- **Not** the `held: bool` Task 1 adds to `WorkspaceTemplate`. Two different fields on two different structs that happen to share a name; this one predates the plan and is a struct, not a boolean. Do not unify them.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `src/web/insights.rs`, following the request
+pattern already used there.
+
+```rust
+    /// Five headings answered with a zero make a base with nothing wrong with
+    /// it look like a backlog — the same reasoning the housekeeping summary
+    /// already gives for collapsing its own empties into one sentence.
+    #[tokio::test]
+    async fn insights_over_an_empty_base_is_one_line_and_a_way_back() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/ui/insights")
+                    .header("cookie", &cookie)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = crate::web::test_support::body_of(res).await;
+        assert!(
+            html.contains("Nothing is held yet"),
+            "one honest line about an empty base"
+        );
+        assert!(
+            !html.contains("What this memory is like"),
+            "no measures over nothing"
+        );
+        assert!(
+            !html.contains("Housekeeping"),
+            "and no housekeeping over no work"
+        );
+        assert!(
+            html.contains(r#"href="/ui""#),
+            "and a way back to the one place there is anything to do"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::insights::tests::insights_over_an_empty_base_is_one_line_and_a_way_back`
+Expected: FAIL — the page still renders "What this memory is like".
+
+- [ ] **Step 3: Wrap the page**
+
+In `src/web/templates/insights.html`, immediately after `{% block content %}`,
+open the branch:
+
+```html
+{# A base with nothing in it has nothing to measure, nothing hidden, nothing
+   waiting and nothing retrying, and saying all four in a column of zeros makes
+   a healthy empty base read as a broken full one. The same argument the
+   housekeeping summary at the foot of this page already makes for itself,
+   applied to the page. #}
+{% if held.corpora == 0 %}
+<div class="empty">
+  <h2>Nothing is held yet</h2>
+  <p class="muted">This page measures what the base holds and lists what needs
+    you. Both wait on there being something in it.</p>
+  <p><a class="btn btn-ghost btn-sm" href="/ui">Back to the box</a></p>
+</div>
+{% else %}
+```
+
+and immediately before `{% endblock %}` at the foot of the file, close it:
+
+```html
+{% endif %}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --lib web::insights::tests::insights_over_an_empty_base_is_one_line_and_a_way_back`
+Expected: PASS
+
+- [ ] **Step 5: Run the insights suite for regressions**
+
+Run: `cargo test --lib web::insights::`
+Expected: PASS. Any existing test that asserts on Insights content must seed a
+capture first; several already do.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/insights.html src/web/insights.rs
+git commit -m "feat: insights over an empty base is one line, not a page of zeros"
+```
+
+---
+
+### Task 5: Insights halves in place
+
+Insights answers two different questions with one page: *what is in my memory
+and what needs me*, and *what is the machine doing*. The second is
+operator-grade — sweep history with stage identifiers, retrying jobs with target
+identifiers and raw error strings, offer rates by rung — and after #52 every
+user sees it.
+
+A disclosure achieves the separation outright. A new page would need a handler,
+a route, a link and an empty state of its own to achieve the same thing.
+
+**Files:**
+- Modify: `src/web/templates/insights.html`
+- Test: `src/web/insights.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// Two questions, one page: what is in my memory and what needs me, versus
+    /// what is the machine doing. The second is operator-grade — stage ids,
+    /// target ids, raw error strings — and every user sees this page now.
+    #[tokio::test]
+    async fn the_machines_own_readout_is_behind_a_disclosure() {
+        let core = crate::core::test_support::test_core().await;
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/ui/insights")
+                    .header("cookie", &cookie)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = crate::web::test_support::body_of(res).await;
+
+        let (above, inside) = html
+            .split_once(r#"<details class="machine">"#)
+            .expect("the disclosure exists");
+
+        assert!(
+            above.contains("What this memory is like"),
+            "what is held stays above the fold"
+        );
+        assert!(
+            !above.contains("Housekeeping"),
+            "the machine's own readout does not"
+        );
+        assert!(
+            inside.contains("Housekeeping"),
+            "it is inside the disclosure"
+        );
+        assert!(
+            !html.contains(r#"<details class="machine" open"#),
+            "and closed: nobody opened this page to read job counts"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::insights::tests::the_machines_own_readout_is_behind_a_disclosure`
+Expected: FAIL — panics on `expect("the disclosure exists")`.
+
+- [ ] **Step 3: Open the disclosure before the housekeeping heading**
+
+In `src/web/templates/insights.html`, replace the line `<h2>Housekeeping</h2>`
+with:
+
+```html
+{# Everything below is about the instance rather than about what is in it, and
+   it is the same readout for every user of it. Stage identifiers, target
+   identifiers and raw error strings are what an operator opens a page for and
+   what everybody else scrolls past, so the page states the memory above and
+   offers the machine here, closed. A disclosure rather than a second page: a
+   route would need a handler, a link and an empty state of its own to draw the
+   same line. #}
+<details class="machine">
+  <summary><h2>What the machine is doing</h2></summary>
+```
+
+- [ ] **Step 4: Close it after the last operator section**
+
+The sections that belong inside are, in file order: the housekeeping counts
+paragraph, "The last day" with its sweep-history table, "What was offered", and
+"Retrying". "Merged", "Generated", "Pursuits", "Hidden as stale", "Hidden as
+near-identical", "Worth a second look" and "Captures waiting on a decision" all
+stay above — they are about what is held and can be acted on by the person
+reading.
+
+Move the "Retrying" block and the "What was offered" block so they sit directly
+after the sweep-history block, then close the disclosure after "Retrying" and
+before the final "Nothing hidden, nothing waiting…" summary line:
+
+```html
+</details>
+```
+
+Leave the summary line outside the disclosure: it is a statement about what is
+held, and it must be visible without opening anything.
+
+- [ ] **Step 5: Style the disclosure**
+
+Append to `assets/css/40-pages.css` (or whichever layer already carries the
+Insights table styles — match the file the `.grid` rules live in):
+
+```css
+/* The machine's own readout. A summary that carries an <h2> so the heading
+   level is honest, with the marker aligned to it rather than to the text
+   baseline it would otherwise sit under. */
+.machine { margin-top: 2rem; border-top: 1px solid var(--color-rule); padding-top: 0.5rem; }
+.machine > summary { cursor: pointer; }
+.machine > summary > h2 { display: inline; }
+.machine > summary::marker { color: var(--color-muted); }
+```
+
+Check the variable names against the file you are editing and use whatever that
+layer already calls the rule colour and the muted colour.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test --lib web::insights::tests::the_machines_own_readout_is_behind_a_disclosure`
+Expected: PASS
+
+- [ ] **Step 7: Run the insights suite**
+
+Run: `cargo test --lib web::insights::`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/insights.html src/web/insights.rs assets/css/
+git commit -m "feat: the machine's own readout moves behind a disclosure"
+```
+
+---
+
+### Task 6: One word for a source
+
+The UI already uses two words for the same thing and switches between them
+without a rule: Insights says "from N sources", the idle rail says "sources",
+`corpus.html` says "this capture's wording", the URL says `corpora`. This picks
+the one already doing most of the work. It is a copy change: no URL, no API
+field, no Rust identifier, no test fixture name.
+
+`Mint` becomes `Create`, and two templates carry a stale cross-reference to a
+page that no longer exists.
+
+**Files:**
+- Modify: `src/web/templates/corpus.html`
+- Modify: `src/web/templates/insights.html`
+- Modify: `src/web/templates/settings.html`
+- Modify: `src/web/templates/extension.html`
+- Modify: `src/web/templates/pair.html`
+- Modify: `src/web/templates/_artifact_detail.html`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Find every user-visible occurrence**
+
+Run:
+
+```bash
+grep -rn "corpus\|corpora\|Corpus\|Corpora\|Mint\|Housekeeping" src/web/templates/
+```
+
+Sort the hits into three piles. **Change:** words rendered as visible text.
+**Leave:** anything inside `href=`, `hx-get=`, `hx-post=`, `action=`, or a
+`{{ }}` expression — those are URLs and Rust identifiers. **Leave:** anything
+inside a `{# … #}` comment, which is stripped before render and is the
+codebase's own record of its reasoning; a comment that says "corpus" is
+describing the type, not addressing the reader.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to the existing `mod tests` in `src/web/ui.rs`. Assert on the exact strings
+rather than on the bare word, because `/ui/corpora/` is a URL and must survive.
+
+```rust
+    /// Two words for one thing, switched between without a rule. This picks
+    /// the one already doing most of the work; the URLs keep theirs, because a
+    /// path is not addressed to the reader.
+    #[tokio::test]
+    async fn a_source_is_called_a_source_everywhere_a_person_reads_it() {
+        let core = crate::core::test_support::test_core().await;
+        // `ingest_capture` answers with an `IngestOutcome`; the corpus id is
+        // the field on it, not the value itself.
+        let id = core
+            .ingest_capture(crate::core::ingest::Capture::new(
+                "LevelDB tombstones survive compaction longer than the manual admits.",
+                "ui",
+            ))
+            .await
+            .unwrap()
+            .id;
+        let (app, cookie) = app_for(core).await;
+
+        let corpus = get(&app, &format!("/ui/corpora/{id}"), &cookie).await;
+        assert!(
+            !corpus.contains("Written from this corpus"),
+            "the page a person reads does not say corpus"
+        );
+        assert!(
+            corpus.contains("Written from this source"),
+            "it says source"
+        );
+        assert!(
+            corpus.contains("/ui/corpora/"),
+            "and the URL is untouched, because a path is not addressed to anyone"
+        );
+
+        let settings = get(&app, "/ui/settings", &cookie).await;
+        assert!(!settings.contains(">Mint<"), "Mint is a word about coins");
+        assert!(settings.contains(">Create<"), "the button says what it does");
+
+        let ext = get(&app, "/ui/extension", &cookie).await;
+        assert!(
+            !ext.contains("Housekeeping → API tokens"),
+            "Housekeeping is a heading on Insights; tokens are on Settings"
+        );
+        assert!(ext.contains("Settings → API tokens"), "named where they are");
+    }
+```
+
+Confirm the route for the extension page before running: it is registered in
+`src/web/extension.rs`. If it is `/extension/install` rather than
+`/ui/extension`, use that URI.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::a_source_is_called_a_source_everywhere_a_person_reads_it`
+Expected: FAIL
+
+- [ ] **Step 4: Make the replacements**
+
+Work the pile from Step 1. The visible-text changes are:
+
+- `corpus.html`: "Written from this corpus" → "Written from this source"; "this capture's wording" stays, it is already plain.
+- `insights.html`: any visible "corpora" → "sources".
+- `settings.html`: the `Mint` button label → `Create`; the placeholder "Token name, e.g. claude-code" stays.
+- `extension.html` and `pair.html`: "Housekeeping → API tokens" → "Settings → API tokens".
+- `_artifact_detail.html`: any visible "corpus" → "source".
+
+Do not touch `/ui/corpora/` in any attribute, and do not rename `corpus_label`,
+`CorpusTemplate`, `corpus_view.rs`, or any other Rust identifier.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test --lib web::ui::tests::a_source_is_called_a_source_everywhere_a_person_reads_it`
+Expected: PASS
+
+- [ ] **Step 6: Run the whole suite**
+
+Run: `cargo test --lib`
+Expected: PASS. Existing tests that assert on the old copy get their strings
+updated; that is the change landing, not a regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/ src/web/ui.rs
+git commit -m "feat: one word for a source, and two stale cross-references fixed"
+```
+
+---
+
+### Task 7: Judge is a task, not a role
+
+"Judge" in the navigation names a role rather than a task, and the badge invites
+a click into a page whose purpose is never stated. The page itself asks a real
+cognitive task — twenty unordered candidates, "which of these was the one you
+needed?" — with no statement of why it is worth doing.
+
+The duplicate-pair queue takes "decisions", so the two stop competing for the
+word "review".
+
+**Files:**
+- Modify: `src/web/templates/layout.html` (top row and tabbar labels)
+- Modify: `src/web/templates/judge.html` (the standing line)
+- Modify: `src/web/templates/_judge_card.html` (empty-queue copy)
+- Test: `src/web/judge.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `src/web/judge.rs`, matching the request
+pattern already in that module.
+
+```rust
+    /// The nav named a role. The page asks a real cognitive task and never
+    /// said why it was worth doing — and the number on Insights is exactly
+    /// what it is worth: recall@10 and MRR are read off these verdicts.
+    #[tokio::test]
+    async fn the_nav_names_the_task_and_the_page_says_why_it_matters() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = crate::web::test_support::app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/ui/judge")
+                    .header("cookie", &cookie)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = crate::web::test_support::body_of(res).await;
+        assert!(
+            html.contains("Review searches"),
+            "the nav names the task, not a role"
+        );
+        assert!(
+            html.contains("your own searches, coming back unlabelled"),
+            "and the page says what it is asking for"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::judge::tests::the_nav_names_the_task_and_the_page_says_why_it_matters`
+Expected: FAIL
+
+- [ ] **Step 3: Rename the nav entries**
+
+In `src/web/templates/layout.html`, the top row:
+
+```html
+      <a href="/ui/judge">Review searches{% if n > &0 %}
+        <span class="badge badge-accent">{{ n }}</span>{% endif %}</a>
+```
+
+and the tabbar, where the width is 52px and the shorter form is the only one
+that fits:
+
+```html
+    <a href="/ui/judge">
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M4 10.5l4 4 8-9"/></svg>Review{% if n > &0 %}
+      <span class="tab-dot" aria-label="{{ n }} waiting"></span>{% endif %}</a>
+```
+
+- [ ] **Step 4: Say what the page is asking for**
+
+In `src/web/templates/judge.html`, immediately after `{% block content %}` and
+before the `_judge_tune.html` include:
+
+```html
+{# What the page is for, said once and standing. The card asks a genuine
+   cognitive task — twenty unordered candidates and a question — and never
+   said why it was worth answering. The answer is the one number on Insights
+   that is not a proxy: recall@10 and MRR are read off exactly these verdicts,
+   which is why an unlabelled, shuffled pool is the only honest way to ask. #}
+<p class="muted hint">These are your own searches, coming back unlabelled and
+  shuffled. Saying which result you actually wanted is what turns the retrieval
+  figure on Insights into a measurement rather than a guess.</p>
+```
+
+- [ ] **Step 5: Say it on the empty queue too**
+
+In `src/web/templates/_judge_card.html`, the `{% when None %}` arm currently
+reads "Nothing to judge." Replace that paragraph:
+
+```html
+<p class="muted">Nothing to review — every recorded search has a verdict.
+  <a href="/ui">Back to the box.</a></p>
+```
+
+- [ ] **Step 6: Retire the collision on "review"**
+
+Run `grep -rn "review queue\|review" src/web/templates/` and change any visible
+text calling the duplicate-pair queue a "review queue" to "decisions". The
+Insights heading for it is already "Needs you" and stays.
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cargo test --lib web::judge::tests::the_nav_names_the_task_and_the_page_says_why_it_matters`
+Expected: PASS
+
+- [ ] **Step 8: Run the whole suite**
+
+Run: `cargo test --lib`
+Expected: PASS. Existing tests asserting the nav label `Judge` get updated.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/ src/web/judge.rs
+git commit -m "feat: the nav names the task, and the page says what it is for"
+```
+
+---
+
+### Task 8: Badges say in words what they mean
+
+The application has a precise private vocabulary that a new user does not
+share. Several terms already have the right treatment: `_results.html` puts the
+badge on the row as the scannable form and one quiet `rail-why` sentence under
+it. Others leave the whole meaning in a `title=` attribute, which no touch
+screen can reach.
+
+Terms in scope for a visible gloss: `superseded`, `deprecated`, `parked`,
+`model-written`, and the three icon-only buttons on the artifact pane.
+
+**Files:**
+- Modify: `src/web/templates/_artifact_detail.html`
+- Modify: `src/web/templates/corpus.html`
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// A tooltip is unreachable on a touch screen, and the terms that most
+    /// need explaining are the ones a phone meets first. The badge stays as
+    /// the scannable form; the sentence under it is what makes it readable —
+    /// the pattern `_results.html` already sets with `rail-why`.
+    #[tokio::test]
+    async fn the_icon_controls_say_in_words_what_they_do() {
+        let core = crate::core::test_support::test_core().await;
+        // `ingest_capture` answers with an `IngestOutcome`; the corpus id is
+        // the field on it, not the value itself.
+        let id = core
+            .ingest_capture(crate::core::ingest::Capture::new(
+                "LevelDB tombstones survive compaction longer than the manual admits.",
+                "ui",
+            ))
+            .await
+            .unwrap()
+            .id;
+        let (app, cookie) = app_for(core).await;
+        let html = get(&app, &format!("/ui/corpora/{id}"), &cookie).await;
+        assert!(
+            html.contains("Hiding keeps it and takes it out of results"),
+            "the hide control says what it does where a finger can read it"
+        );
+        assert!(
+            !html.contains(r#"title="Hide from results"#)
+                || html.contains("Hiding keeps it and takes it out of results"),
+            "a title may stay in addition, never instead"
+        );
+    }
+```
+
+Adjust the asserted page to whichever of the corpus page or the artifact pane
+actually renders the icon row; run `grep -n "btn-icon" src/web/templates/` to
+confirm before writing the URI.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::the_icon_controls_say_in_words_what_they_do`
+Expected: FAIL
+
+- [ ] **Step 3: Add the visible line under the icon row**
+
+In `src/web/templates/_artifact_detail.html`, under the row holding the three
+`btn-icon` controls:
+
+```html
+{# The row is three icons and the meaning of all three was in `title`
+   attributes, which a finger cannot reach. One line under them rather than
+   three labels beside them: the icons stay as the compact form, and the
+   sentence is what makes them legible the first time. `title` stays on each
+   button as well — it is what a pointer already reads. #}
+<p class="muted hint">Confirm marks it still accurate. Hiding keeps it and takes
+  it out of results, and can be undone. Deleting cannot.</p>
+```
+
+- [ ] **Step 4: Gloss the remaining badges**
+
+Run `grep -rn "superseded\|deprecated\|parked" src/web/templates/`. Wherever one
+of these appears as a badge or a heading with no adjacent plain sentence, add
+one, in the voice the surrounding page already uses:
+
+- superseded — "kept, but taken out of results because something near-identical won"
+- deprecated — "flagged stale and taken out of results; still stored and still readable"
+- parked — "stored, but nothing is spent on it until you decide"
+
+Where a heading already carries the explanation — Insights says "Hidden as
+near-identical" and "Still stored and still readable; kept out of results only"
+— leave it: the gloss is already there and a second one is noise.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test --lib web::ui::tests::the_icon_controls_say_in_words_what_they_do`
+Expected: PASS
+
+- [ ] **Step 6: Run the suite**
+
+Run: `cargo test --lib`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/ src/web/ui.rs
+git commit -m "feat: the vocabulary says itself in words, not in tooltips"
+```
+
+---
+
+### Task 9: Settings is reachable, and says whose base this is
+
+Settings is a quiet link at the foot of Insights, which is to say unreachable on
+a phone for anyone who does not already know where it is. And after #52 there is
+nowhere at all that says which account is looking at this base.
+
+Sign out stays in the top row: making it a two-click operation to gain a nav
+slot is the wrong trade. Settings joins it, and the tabbar.
+
+**Files:**
+- Modify: `src/web/templates/layout.html` (top row link, tabbar entry)
+- Modify: `src/web/templates/settings.html` (the account line)
+- Modify: `src/web/ui.rs` (`SettingsTemplate` gains `account`)
+- Modify: `assets/css/50-phone.css` (tabbar sizing for a fourth entry)
+- Test: `src/web/ui.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Produces: `SettingsTemplate.account: String` — the signed-in subject, or the email where the identity provider supplied one.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// After #52 every user has their own base, and nothing anywhere said
+    /// which account was looking at one. Settings is where account things
+    /// live; it was also the one page a phone could not reach.
+    #[tokio::test]
+    async fn settings_is_reachable_and_names_the_account() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_for(core).await;
+
+        let html = get(&app, "/ui", &cookie).await;
+        assert_eq!(
+            html.matches(r#"href="/ui/settings""#).count(),
+            2,
+            "the top row and the tabbar, so a phone can reach it too"
+        );
+
+        let settings = get(&app, "/ui/settings", &cookie).await;
+        assert!(
+            settings.contains("Signed in as"),
+            "and the page that holds account things says which account"
+        );
+        assert!(
+            settings.contains(crate::store::TEST_SUBJECT),
+            "named, not merely alluded to"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib web::ui::tests::settings_is_reachable_and_names_the_account`
+Expected: FAIL — the count is 0.
+
+- [ ] **Step 3: Add Settings to both navigation rows**
+
+In `src/web/templates/layout.html`, in the top row before the spacer:
+
+```html
+      <a href="/ui/settings">Settings</a>
+```
+
+and in the tabbar, after the Insights entry:
+
+```html
+    {# A fourth entry. Settings was a quiet link at the foot of Insights, which
+       is unreachable on a phone by anyone who does not already know it is
+       there — and after #52 it is where a person goes to see whose base this
+       is and to revoke what is reading it. #}
+    <a href="/ui/settings">
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="10" cy="10" r="2.5"/><path d="M10 3v2M10 15v2M3 10h2M15 10h2M5.4 5.4l1.4 1.4M13.2 13.2l1.4 1.4M14.6 5.4l-1.4 1.4M6.8 13.2l-1.4 1.4"/></svg>Settings</a>
+```
+
+- [ ] **Step 4: Make room for a fourth tab**
+
+In `assets/css/50-phone.css`, find the `.tabbar` rule. If it sizes entries by a
+fixed count, change it to distribute evenly:
+
+```css
+.tabbar a { flex: 1 1 0; min-width: 0; }
+```
+
+Open the page at 375px wide and confirm four labels fit without wrapping. If
+they do not, shorten "Settings" to a gear alone with an `aria-label`, rather
+than letting a label wrap.
+
+- [ ] **Step 5: Carry the account to the settings template**
+
+In `src/web/ui.rs`, add to `SettingsTemplate`:
+
+```rust
+    /// Who is looking at this base.
+    ///
+    /// Every user has held their own database and their own collection since
+    /// #52, and no page said so. The email where the identity provider gave
+    /// one, because that is the name a person recognises as theirs; the
+    /// subject otherwise, because a stable identifier beats no answer.
+    account: String,
+```
+
+and in the handler that builds it, alongside the existing `judge_pending`:
+
+```rust
+        account: identity
+            .email
+            .clone()
+            .unwrap_or_else(|| identity.subject.clone()),
+```
+
+Confirm the handler's extractor name — it may take a `Tenant` rather than an
+`Identity` directly; if so, read the identity from the tenant, and if the tenant
+does not carry one, add `identity: crate::auth::Identity` to the handler
+signature. The extractor is already implemented and every other authenticated
+handler can take it.
+
+- [ ] **Step 6: Say it on the page**
+
+In `src/web/templates/settings.html`, directly under the crumb:
+
+```html
+{# Said plainly, on the page where account things live. Every user has held
+   their own database and their own collection since #52; a person pasting
+   their own notes into a server somebody else runs has no way to know that
+   from anywhere else in the application. #}
+<p class="muted">Signed in as <span class="mono">{{ account }}</span>. This base
+  is yours alone — no other account can search it.</p>
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cargo test --lib web::ui::tests::settings_is_reachable_and_names_the_account`
+Expected: PASS
+
+- [ ] **Step 8: Run the suite**
+
+Run: `cargo test --lib`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/ src/web/ui.rs assets/css/
+git commit -m "feat: settings reaches the phone and names the account"
+```
+
+---
+
+### Task 10: A dead control says why, and a long confirmation gets shorter
+
+Capture and Ask disable themselves on an empty box and say nothing about it; a
+permanently dead button with no stated reason is indistinguishable from a broken
+one. The box never says that typing is already searching — the hint discusses
+phrasing, which is not the thing a first-time user does not know. Attach names
+its accepted types only in a `title`. And the feedback purge asks one forty-word
+question, which is a sentence nobody finishes before pressing a button.
+
+**Files:**
+- Modify: `src/web/templates/workspace.html` (verb buttons, Attach, the hint)
+- Modify: `src/web/templates/settings.html` (purge confirmation)
+- Test: `src/web/workspace.rs` (inline `mod tests`)
+
+**Interfaces:**
+- Consumes: `WorkspaceTemplate.held: bool` from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// A button that is dead on arrival and says nothing about why reads as a
+    /// broken application rather than as a control waiting for its input.
+    #[tokio::test]
+    async fn a_disabled_verb_says_what_it_is_waiting_for() {
+        let html = workspace("/ui").await;
+        assert!(
+            html.contains(r#"title="Type or attach something first""#),
+            "the disabled verb names what it wants"
+        );
+        assert!(
+            html.contains("A .txt file, a PDF"),
+            "and Attach names its types where a finger can read them, not only \
+             in a tooltip"
+        );
+    }
+
+    /// Results appear beside a person who pressed nothing. The old hint
+    /// explained how to phrase a query, which is true and is not the thing
+    /// they do not know.
+    #[tokio::test]
+    async fn the_box_says_that_typing_is_already_searching() {
+        let core = crate::core::test_support::test_core().await;
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(
+            html.contains("Typing searches"),
+            "the one thing a first-time user cannot deduce from the page"
+        );
+    }
+```
+
+- [ ] **Step 2: Run both tests to verify they fail**
+
+Run: `cargo test --lib web::workspace::tests::a_disabled_verb_says_what_it_is_waiting_for web::workspace::tests::the_box_says_that_typing_is_already_searching`
+Expected: FAIL, both.
+
+- [ ] **Step 3: Give the verbs a reason**
+
+In `src/web/templates/workspace.html`, add to both verb buttons:
+
+```html
+    {% if ask_enabled && held %}
+    <button class="btn btn-accent" type="button" data-verb="ask" disabled
+            title="Type or attach something first">Ask</button>
+    {% endif %}
+    <button class="btn" type="button" data-verb="capture" disabled
+            title="Type or attach something first">Capture</button>
+```
+
+app.js already clears `disabled` when the box has content; leaving the `title`
+in place is harmless and correct — it describes the disabled state, which is the
+only state that renders it.
+
+- [ ] **Step 4: Let Attach name its types visibly**
+
+Under the verb row, add a line that renders the same sentence the `title`
+carries, so it survives on a touch screen:
+
+```html
+    {# The accepted types, in the page rather than only on hover. The `title`
+       above stays for a pointer; this is the half a finger can read, and the
+       phone is where the camera path lives — the one door most likely to be
+       used by someone who has never seen this page on a desktop. #}
+    <span class="muted hint attach-types">{% if vision_enabled %}A .txt file, a PDF or an image{% else %}A .txt file or a PDF{% endif %} — or drop one anywhere on the page.</span>
+```
+
+- [ ] **Step 5: Say that typing searches**
+
+Extend the `held` branch of the `box-hint` paragraph from Task 2:
+
+```html
+    {%- if held -%}
+    Typing searches as you go. A sentence or a whole paragraph finds more than
+    keywords do — paste what you are looking at.
+    {%- else -%}
+```
+
+- [ ] **Step 6: Shorten the purge confirmation**
+
+In `src/web/templates/settings.html`, replace the `onsubmit` string:
+
+```html
+<form method="post" action="/ui/ops/feedback/purge"
+      onsubmit="return confirm('Delete every recorded search and question, and every verdict given on one? The judged ones cannot be recovered — they are what the retrieval figure is measured from.')">
+```
+
+- [ ] **Step 7: Run both tests to verify they pass**
+
+Run: `cargo test --lib web::workspace::tests::a_disabled_verb_says_what_it_is_waiting_for web::workspace::tests::the_box_says_that_typing_is_already_searching`
+Expected: PASS
+
+- [ ] **Step 8: Run the whole suite**
+
+Run: `cargo test --lib`
+Expected: PASS
+
+- [ ] **Step 9: Walk the app end to end**
+
+Run the server against a scratch database with nothing in it. Confirm, in order:
+the empty workspace offers Capture alone and says what engram is and whose the
+base is; a paste produces a receipt with a live queue row that stops moving when
+the work settles; the reloaded page now offers Ask and the shortcuts; searching
+for the paste in different words finds it; Insights shows the memory above and
+the machine behind a closed disclosure; Settings is reachable from the phone
+tabbar and names the account.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cargo fmt
+git add src/web/templates/ src/web/workspace.rs
+git commit -m "feat: dead controls say what they want, and the box admits it is searching"
+```

--- a/docs/superpowers/specs/2026-08-25-onboarding-polish-design.md
+++ b/docs/superpowers/specs/2026-08-25-onboarding-polish-design.md
@@ -1,0 +1,203 @@
+# Onboarding and wording polish
+
+**Status:** design, awaiting review
+**Date:** 2026-08-25
+
+## The situation
+
+After #52 every user gets their own database and their own collection. The
+application is about to be opened to more than one person for the first time,
+and there is no first-run experience of any kind in the tree — no `welcome`, no
+`onboard`, no seen-flag, nothing. A new user arrives through their identity
+provider, presses Continue, and lands on `/ui` with an empty base, a box
+offering three verbs, and one sentence in the rail.
+
+Two of those three verbs cannot work. Searching an empty base returns nothing;
+asking an empty base returns an abstention. The one verb that can work —
+Capture — is the one the placeholder mentions last.
+
+Nothing on that screen says what engram is. The tagline lives on `login.html`,
+which an OIDC user never sees. Nothing says the base is theirs alone, which is
+the exact hesitation a person has before pasting their own notes into a server
+somebody else runs.
+
+And once they do paste something, the receipt is a dead one-liner — "Captured —
+view source" — while embedding runs as a background job. A user who immediately
+searches for what they just pasted and gets nothing back concludes the thing is
+broken. That is the most likely abandonment moment in the application, and the
+fragment that would answer it already exists.
+
+## The principle
+
+Onboarding is a property of an empty base, not of a new user.
+
+No welcome page, no scripted sequence, no per-user "has seen it" flag. Each
+surface asks the state it can already see and renders accordingly. This is what
+`_rail_idle.html` already does, generalised to the rest of the app.
+
+The consequence worth having: the instruction cannot drift out of sync with
+reality, it serves someone who deleted everything just as well as someone new,
+and there is no stored flag to migrate, expire, or get wrong.
+
+## 1. First run, as rendered state
+
+### The workspace with nothing held (`corpora == 0`)
+
+**Ask is not rendered.** Not disabled — absent. A disabled button is a promise
+the page cannot keep, and Ask on an empty base can only abstain. It appears when
+there is something to ask about.
+
+**The placeholder names the one verb that works.** Today it names all three:
+"Describe the situation, ask a question, or paste anything worth keeping…". On
+an empty base it becomes "Paste anything worth keeping — a note, an article, a
+chunk of a chat.", with a narrow variant for the phone as the box already has.
+
+**The hint under the box carries what the login card says and an OIDC user never
+sees:** what engram does, and that this base is theirs alone. The privacy
+statement goes here rather than on Settings, because here is where the eye
+already is and there is where nobody looks before pasting.
+
+**The keyboard hint bar does not render.** Seven shortcuts for moving through a
+list that has nothing in it. It returns with the first source.
+
+**The pane stops giving an instruction that cannot be followed.** Today it says
+"Search to see an artifact here, beside the lines it came from" — to a person
+with nothing to search. It says instead what will happen to the first thing
+pasted: split into passages, embedded, the original kept and served back
+untouched.
+
+**The rail keeps its current sentence.** It is good copy; it simply stops being
+the only thing doing the job.
+
+### While a capture is being read
+
+`_captured.html` includes `_queue.html`, unchanged.
+
+The queue fragment already reports per-source progress — *segmenting 3/7*, the
+in-flight dot, *parked*, *failed* — already polls itself every three seconds,
+and already stops polling when nothing is moving, so an idle page in a
+background tab makes no requests. It listens for the `captured` event on `body`
+that the box already fires. It is presently rendered only on Insights, and
+`_captured.html`'s own comment records the cost of that: "nothing else on the
+workspace says the paste landed."
+
+The gap between *captured* and *searchable* stops being invisible, and it costs
+one include.
+
+### Insights with nothing held
+
+The page collapses to one honest line and a way back to the box. Today a new
+user is shown Held 0, an empty Reach, a Retrieval panel explaining there is
+nothing to measure, and "0 artifacts, 0 embedded. No jobs queued." — a page of
+zeros that reads as a system with something wrong with it.
+
+### Judge with an empty queue
+
+Keeps "Nothing to judge", and gains one sentence on what the page is for — these
+are your own searches, coming back unlabelled — so an empty visit still teaches
+rather than reading as a dead end.
+
+## 2. Naming and explanation
+
+**"Artifact" stays.** It is precise, deliberate, and defended in the comments.
+The problem it causes is not the word but the absence of a gloss, and a gloss is
+cheaper than a rename.
+
+**`corpus`/`corpora` becomes "source" in user-visible text.** This is not
+introducing a third word — it is picking one of two the UI already uses
+interchangeably for the same thing. Insights says "from N sources", the idle
+rail says "sources", `corpus.html` says "this capture's wording", and the URL
+says `corpora`. Roughly forty-five occurrences across the templates. URLs, API
+field names, MCP schemas and Rust internals are untouched.
+
+**Judge becomes "Review searches"** in the top row and "Review" on the tabbar.
+The present label names a role, not a task, and the badge invites a click into a
+page whose purpose is never stated. The duplicate-pair queue takes "decisions",
+so the two stop competing for the same word.
+
+**Mint becomes Create.**
+
+**`extension.html` and `pair.html` both say tokens appear "under Housekeeping →
+API tokens".** Housekeeping is a heading on Insights; tokens are on Settings.
+This is a stale cross-reference, not a matter of taste.
+
+**Every badge gets a visible plain-language line. Never a `title=`.** A tooltip
+is invisible on touch, and the terms that most need explaining are the ones a
+phone user meets first. `_results.html` already has the correct pattern in
+`rail-why`: the badge stays as the scannable form, and one quiet sentence under
+it says the thing in words. That pattern extends to `_artifact_detail.html`'s
+icon-only buttons, `corpus.html`, and the judge card.
+
+Terms in scope: loose, primed, model-written, "Relevance falls off here",
+superseded, deprecated, parked, sweep, rung, pursuit, gap, recall@10, MRR.
+
+## 3. Insights, halved in place
+
+Insights answers two different questions with one page: *what is in my memory and
+what needs me*, and *what is the machine doing*. The second is operator-grade —
+sweep history with stage identifiers, retrying jobs with target identifiers and
+raw error strings, offer rates by rung — and every user now sees it.
+
+The second half moves into a closed `<details>` at the foot of the page. Not a
+new route: a new page would need a handler, a template, a link, and its own
+empty state, to achieve a separation a disclosure achieves outright.
+
+Above the fold: Held, Reach, Retrieval, Needs you, Knowledge gaps, Merged,
+Generated, Hidden as stale, Hidden as near-identical, Worth a second look,
+Captures waiting on a decision.
+
+Inside the disclosure: Housekeeping counts, The last day and its sweep history,
+Retrying, What was offered.
+
+## 4. Interaction
+
+**Who you are appears in the top bar.** Sign out sits under it rather than at
+equal weight beside a theme toggle. The application has never needed this
+before; it does now.
+
+**Settings becomes reachable on the phone.** The tabbar has three entries and
+Settings is a quiet link at the foot of Insights, which is to say unreachable
+for anyone who does not already know where it is.
+
+**Capture and Ask say why they are disabled.** A permanently dead button with no
+stated reason is indistinguishable from a broken one.
+
+**The box says that typing searches.** The present hint discusses phrasing — "A
+sentence or a whole paragraph finds more than keywords do" — which is true and
+is not the thing a first-time user does not know. What they do not know is that
+the results appearing beside them are a search they did not press anything to
+run.
+
+**The judge card gets one line of motivation.** It asks a real cognitive task —
+twenty unordered candidates, "which of these was the one you needed?" — with no
+statement of why or what it is worth. These are the user's own searches, coming
+back unlabelled, and judging them is what makes the number on Insights mean
+anything at all.
+
+**The feedback-purge confirmation becomes two short sentences.** It is presently
+one forty-word question, which is a sentence nobody finishes reading before
+pressing a button.
+
+**Attach states its accepted types visibly**, rather than in a `title` nobody on
+a touch screen can reach.
+
+## Testing
+
+`src/web/ui.rs`, `src/web/workspace.rs` and `src/web/insights.rs` each carry an
+inline `#[cfg(test)] mod tests` that renders real structs through
+`askama::Template::render` and asserts over the HTML, with helpers in
+`test_support.rs`. That is the vehicle; no new test file.
+
+- An empty-base workspace renders no Ask button and no keyhint bar.
+- A workspace with sources held renders both.
+- The capture receipt renders the queue fragment.
+- Empty-base Insights renders the one line and none of the zero tables.
+- The operator tables render inside the disclosure and not above it.
+- No user-visible template renders "corpus", "corpora", "Mint", or
+  "Housekeeping →".
+
+## Out of scope
+
+Renaming "artifact". Any URL, API field, or MCP schema change. Replacing
+`window.confirm`. A welcome page, a tour, a seen-flag, or any per-user
+onboarding state.

--- a/src/web/insights.rs
+++ b/src/web/insights.rs
@@ -638,8 +638,41 @@ mod tests {
         // would hide both. What is noisy rather than absent goes behind the
         // disclosure at the foot instead.
         assert!(
-            html.contains("Housekeeping"),
+            html.contains("What the machine is doing"),
             "what the machine is doing is true of an empty base too"
+        );
+    }
+
+    /// Two questions, one page: what is in my memory and what needs me, versus
+    /// what is the machine doing. The second is operator-grade — stage ids,
+    /// target ids, raw error strings — and every user sees this page now.
+    #[tokio::test]
+    async fn the_machines_own_readout_is_behind_a_disclosure() {
+        let core = crate::core::test_support::test_core().await;
+        core.ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+        let html = insights(core).await;
+
+        let (above, inside) = html
+            .split_once(r#"<details class="machine">"#)
+            .expect("the disclosure exists");
+
+        assert!(
+            above.contains("What this memory is like"),
+            "what is held stays above the fold"
+        );
+        // The counts sentence rather than a heading: the section carries the
+        // disclosure's own name now, so the summary is the heading and the
+        // body is what it was always for.
+        assert!(
+            !above.contains("embedded."),
+            "the machine's own readout does not"
+        );
+        assert!(inside.contains("embedded."), "it is inside the disclosure");
+        assert!(
+            !html.contains(r#"<details class="machine" open"#),
+            "and closed: nobody opened this page to read job counts"
         );
     }
 

--- a/src/web/insights.rs
+++ b/src/web/insights.rs
@@ -643,6 +643,49 @@ mod tests {
         );
     }
 
+    /// A closed disclosure with a neutral summary is not a report. The sweep
+    /// failures and the last-error column are the only surfaces that say a
+    /// background pipeline has fallen over, and once they moved in here an
+    /// instance whose every embed job had failed for a week looked from the
+    /// fold exactly like one with nothing to say.
+    #[tokio::test]
+    async fn a_failing_pipeline_is_not_something_the_page_keeps_to_itself() {
+        let core = crate::core::test_support::test_core().await;
+        let quiet = insights(core).await;
+        assert!(
+            quiet.contains(r#"<details class="machine">"#),
+            "with nothing wrong the readout stays folded away: {quiet}"
+        );
+
+        let core = crate::core::test_support::test_core().await;
+        core.store
+            .record_sweep_run(
+                "consolidate",
+                crate::store::now(),
+                "failed",
+                r#"{"error":"the endpoint was down"}"#,
+            )
+            .await
+            .unwrap();
+        let html = insights(core).await;
+
+        assert!(
+            html.contains(r#"<details class="machine" open>"#),
+            "a failing sweep opens the readout that reports it: {html}"
+        );
+        let summary = html
+            .split_once(r#"<details class="machine" open>"#)
+            .expect("the disclosure exists")
+            .1
+            .split_once("</summary>")
+            .expect("and has a summary")
+            .0;
+        assert!(
+            summary.contains("1 failed"),
+            "and says so on the line that survives the fold: {summary}"
+        );
+    }
+
     /// Two questions, one page: what is in my memory and what needs me, versus
     /// what is the machine doing. The second is operator-grade — stage ids,
     /// target ids, raw error strings — and every user sees this page now.

--- a/src/web/insights.rs
+++ b/src/web/insights.rs
@@ -613,6 +613,36 @@ mod tests {
         body_of(res).await
     }
 
+    /// Five headings answered with a zero make a base with nothing wrong with
+    /// it look like a backlog — the same reasoning the housekeeping summary
+    /// already gives for collapsing its own empties into one sentence.
+    #[tokio::test]
+    async fn insights_over_an_empty_base_is_one_line_and_a_way_back() {
+        let core = crate::core::test_support::test_core().await;
+        let html = insights(core).await;
+        assert!(
+            html.contains("Nothing is held yet"),
+            "one honest line about an empty base: {html}"
+        );
+        assert!(
+            !html.contains("What this memory is like"),
+            "no measures over nothing"
+        );
+        assert!(
+            html.contains(r#"href="/ui""#),
+            "and a way back to the one place there is anything to do"
+        );
+        // Only the measures are gated. A gap is a question the base could not
+        // answer, which is exactly what an empty base produces, and the sweeps
+        // run whether or not anything was ever captured — a page-wide guard
+        // would hide both. What is noisy rather than absent goes behind the
+        // disclosure at the foot instead.
+        assert!(
+            html.contains("Housekeeping"),
+            "what the machine is doing is true of an empty base too"
+        );
+    }
+
     /// The measures read what the base already recorded.
     #[tokio::test]
     async fn the_measures_read_what_the_base_already_recorded() {
@@ -640,6 +670,13 @@ mod tests {
     async fn an_unjudged_base_says_so_rather_than_reporting_zero() {
         let mut core = crate::core::test_support::test_core().await;
         core.learn.enabled = true;
+        // Something held, because the measures are gated on that now: a base
+        // with nothing in it has nothing to measure at all, and the rule this
+        // test pins is the narrower one about a base that has content but no
+        // verdicts on it.
+        core.ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
         let html = insights(core).await;
         assert!(html.contains("Nothing judged yet"), "{html}");
         assert!(

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -927,6 +927,39 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
+    /// The nav named a role. The page asks a real cognitive task and never
+    /// said why it was worth doing — and the number on Insights is exactly
+    /// what it is worth: recall@10 and MRR are read off these verdicts.
+    #[tokio::test]
+    async fn the_nav_names_the_task_and_the_page_says_why_it_matters() {
+        // The entry exists only where searches are actually being recorded —
+        // an installation that records none has nothing to review and is
+        // offered no destination for it.
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/judge")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            html.contains("Review searches"),
+            "the nav names the task, not a role: {html}"
+        );
+        assert!(
+            html.contains("your own searches, coming back unlabelled"),
+            "and the page says what it is asking for: {html}"
+        );
+    }
+
     /// The gate, from the outside: a signed-in user without the grant.
     ///
     /// Eleven routes, because the grant covers the router and not a page —
@@ -2270,7 +2303,7 @@ mod tests {
         let (app, cookie, _core, _) = judge_app(0, &[]).await;
         let body = get(&app, "/ui/judge", &cookie).await;
         assert!(
-            body.to_lowercase().contains("nothing to judge"),
+            body.to_lowercase().contains("nothing to review"),
             "an empty queue must say so"
         );
     }

--- a/src/web/templates/_ask_verb.html
+++ b/src/web/templates/_ask_verb.html
@@ -1,0 +1,16 @@
+{# The Ask verb, in a slot that is always there.
+
+   Two callers: the workspace renders it inline, and `_held.html` swaps it in
+   out-of-band the moment the base stops being empty. The wrapper is what makes
+   the second one possible — htmx needs an element with this id already in the
+   page to swap against, and the button itself is absent on an empty base. #}
+<span id="ask-verb-slot"{% if oob %} hx-swap-oob="true"{% endif %}>
+  {%- if ask_enabled && held -%}
+  {# Carries the reason it is dead. app.js clears `disabled` the moment there
+     is something to act on, so the title only ever describes the state that
+     renders it — and a permanently grey button with no stated reason is
+     indistinguishable from a broken one. #}
+  <button class="btn btn-accent" type="button" data-verb="ask" disabled
+          title="Type or attach something first">Ask</button>
+  {%- endif -%}
+</span>

--- a/src/web/templates/_box_hint.html
+++ b/src/web/templates/_box_hint.html
@@ -1,0 +1,18 @@
+{# Two hints, because the two states need different sentences. With something
+   held, the useful thing to say is how to phrase a query — a whole sentence
+   embeds better than the two nouns from it a reader would otherwise type.
+   With nothing held there is no query to phrase, and the useful thing to say
+   is what this is and whose it is. The second half is not decoration: an
+   operator arriving through an identity provider never sees the login card,
+   so this is the only place the application introduces itself, and the
+   boundary is the question a person actually has before pasting their own
+   notes onto a server somebody else runs. #}
+<p id="box-hint" class="muted hint"{% if oob %} hx-swap-oob="true"{% endif %}>
+  {%- if held -%}
+  Typing searches as you go. A sentence or a whole paragraph finds more than
+  keywords do — paste what you are looking at.
+  {%- else -%}
+  engram keeps what you paste in your own words and finds it again by meaning,
+  not by keywords. This base is yours: nobody else can search it.
+  {%- endif -%}
+</p>

--- a/src/web/templates/_captured.html
+++ b/src/web/templates/_captured.html
@@ -29,3 +29,12 @@
 <p class="muted" role="status">Captured —
   <a href="/ui/corpora/{{ id }}">view source</a>.</p>
 {% endif %}
+{# The work the press started, reported by the fragment that already knows how.
+   The gap between a paste landing and that paste being searchable is a
+   background job, and it was invisible from here: this receipt, then silence,
+   then a search that finds nothing and reads as data loss. `_queue.html`
+   carries its own polling trigger and drops it the moment nothing is moving,
+   so an idle receipt costs one request and then none — the same contract it
+   already honours on Insights, which is why it is included rather than
+   reimplemented. #}
+<div hx-get="/ui/queue" hx-trigger="load" hx-swap="outerHTML"></div>

--- a/src/web/templates/_captured.html
+++ b/src/web/templates/_captured.html
@@ -37,4 +37,12 @@
    so an idle receipt costs one request and then none — the same contract it
    already honours on Insights, which is why it is included rather than
    reimplemented. #}
+{# And what the row under it means. The queue speaks in statuses — a badge
+   reading "segmenting 3/7" is exact and is the first thing a new reader meets,
+   with nothing anywhere saying what it is counting towards. Said here rather
+   than in the fragment because the fragment also serves Insights, where the
+   sentence would be a line of explanation nobody needed twice; and said in the
+   page rather than in a `title`, because the camera path is the phone's and a
+   phone has no hover. #}
+<p class="muted hint">Reading it now — searchable once it settles.</p>
 <div hx-get="/ui/queue" hx-trigger="load" hx-swap="outerHTML"></div>

--- a/src/web/templates/_captured.html
+++ b/src/web/templates/_captured.html
@@ -28,7 +28,6 @@
 {% else %}
 <p class="muted" role="status">Captured —
   <a href="/ui/corpora/{{ id }}">view source</a>.</p>
-{% endif %}
 {# The work the press started, reported by the fragment that already knows how.
    The gap between a paste landing and that paste being searchable is a
    background job, and it was invisible from here: this receipt, then silence,
@@ -46,3 +45,4 @@
    phone has no hover. #}
 <p class="muted hint">Reading it now — searchable once it settles.</p>
 <div hx-get="/ui/queue" hx-trigger="load" hx-swap="outerHTML"></div>
+{% endif %}

--- a/src/web/templates/_decide.html
+++ b/src/web/templates/_decide.html
@@ -61,13 +61,13 @@
        asking. #}
     <form method="post" action="/ui/ops/pairs/{{ p.id }}/supersede"
           data-keep="{{ p.a_title }}"
-          onsubmit="return confirm('Keep “' + this.dataset.keep + '” and hide the other? You can undo this from Housekeeping.')">
+          onsubmit="return confirm('Keep “' + this.dataset.keep + '” and hide the other? You can undo this from Insights.')">
       <input type="hidden" name="keep" value="{{ p.a_id }}">
       <button class="btn btn-sm {% if p.keeps_a %}btn-accent{% endif %}" type="submit">Keep “{{ p.a_title }}”</button>
     </form>
     <form method="post" action="/ui/ops/pairs/{{ p.id }}/supersede"
           data-keep="{{ p.b_title }}"
-          onsubmit="return confirm('Keep “' + this.dataset.keep + '” and hide the other? You can undo this from Housekeeping.')">
+          onsubmit="return confirm('Keep “' + this.dataset.keep + '” and hide the other? You can undo this from Insights.')">
       <input type="hidden" name="keep" value="{{ p.b_id }}">
       <button class="btn btn-sm {% if p.keeps_b %}btn-accent{% endif %}" type="submit">Keep “{{ p.b_title }}”</button>
     </form>
@@ -83,7 +83,7 @@
        syntax error fails open and retires both without asking. #}
     <form method="post" action="/ui/ops/pairs/{{ p.id }}/discard"
           data-a="{{ p.a_title }}" data-b="{{ p.b_title }}"
-          onsubmit="return confirm('Retire “' + this.dataset.a + '” and “' + this.dataset.b + '” from results? You can undo this from Housekeeping.')">
+          onsubmit="return confirm('Retire “' + this.dataset.a + '” and “' + this.dataset.b + '” from results? You can undo this from Insights.')">
       <button class="btn btn-sm {% if p.vacuous %}btn-accent{% endif %}" type="submit">Discard both</button>
     </form>
     <form method="post" action="/ui/ops/pairs/{{ p.id }}/dismiss">

--- a/src/web/templates/_held.html
+++ b/src/web/templates/_held.html
@@ -1,0 +1,21 @@
+{# Everything the workspace renders differently once the base stops being
+   empty, as out-of-band swaps.
+
+   The page is rendered once and never again: a capture posts to `/ui/capture`
+   and swaps a receipt, and the rail refresh swaps `#results`. Nothing else on
+   the page moves — so the first paste of a new base left the workspace still
+   arranged for an empty one, with no Ask verb, no shortcut row, and hints
+   describing a first capture that had already happened, until a manual reload.
+   These are the four regions that were wrong, fetched by app.js on the first
+   capture that stores and swapped where they stand.
+
+   The same partials the workspace itself includes, rendered with `held` true,
+   so the two cannot come to disagree about what the held state says.
+
+   The placeholders are not here: swapping the textarea would take the caret,
+   the selection and anything typed since with it, so app.js carries those two
+   sentences over from `data-placeholder-held*` instead. #}
+{% include "_ask_verb.html" %}
+{% include "_keyhint.html" %}
+{% include "_box_hint.html" %}
+{% include "_pane_idle.html" %}

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -147,5 +147,6 @@
 {# The figures outlive the queue: what has been judged is still worth reading
    when there is nothing left to judge. #}
 {% include "_judge_pulse.html" %}
-<p class="muted">Nothing to judge. <a href="/ui/search">Back to search.</a></p>
+<p class="muted">Nothing to review — every recorded search has a verdict.
+  <a href="/ui">Back to the box.</a></p>
 {% endmatch %}

--- a/src/web/templates/_keyhint.html
+++ b/src/web/templates/_keyhint.html
@@ -1,0 +1,18 @@
+{# Taught once. A shortcut nobody is told about is a shortcut nobody uses, and
+   a hint that cannot be dismissed is a banner. Hidden until app.js decides
+   there is a keyboard to use it with.
+
+   In a slot for the same reason as the Ask verb: on an empty base there are no
+   lists to move through and no verbs to chord, so there is nothing to teach
+   until the first capture lands. #}
+<span id="keyhint-slot"{% if oob %} hx-swap-oob="true"{% endif %}>
+  {%- if held %}
+  <p class="keyhint" hidden>
+    <kbd>/</kbd> box{% if ask_enabled %} <kbd>Ctrl</kbd><kbd>↵</kbd> ask{% endif %}
+    <kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>↵</kbd> keep
+    <kbd>↑</kbd><kbd>↓</kbd> move <kbd>↵</kbd> open
+    <kbd>s</kbd> hide source <kbd>r</kbd> reading
+    <button type="button" class="btn btn-ghost btn-sm" data-dismiss-hint>Got it</button>
+  </p>
+  {%- endif %}
+</span>

--- a/src/web/templates/_pane_idle.html
+++ b/src/web/templates/_pane_idle.html
@@ -1,0 +1,13 @@
+{# With something held this names where an artifact will appear. With nothing
+   held it named a search that cannot be run, which is an instruction to do the
+   one thing the page has just been arranged to prevent. It says what will
+   happen to the first paste instead. #}
+<p id="pane-idle" class="muted"{% if oob %} hx-swap-oob="true"{% endif %}>
+  {%- if held -%}
+  Search to see an artifact here, beside the lines it came from.
+  {%- else -%}
+  Whatever you paste is split into passages and embedded so it can be found
+  by meaning. The original is kept exactly as you wrote it, and every result
+  can be read beside it.
+  {%- endif -%}
+</p>

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -68,7 +68,7 @@
            — a neighbour, an association — does not carry one. Zero there means
            "not read", not "no sources", and the badge said the second. #}
         {% if r.origin_count > 0 %}
-        <span class="badge" title="A model wrote this, from {{ r.origin_count }} source corpus/corpora">model-written · {{ r.origin_count }}</span>
+        <span class="badge" title="A model wrote this, from {{ r.origin_count }} source{% if r.origin_count > 1 %}s{% endif %}">model-written · {{ r.origin_count }}</span>
         {% else %}
         <span class="badge" title="A model wrote this">model-written</span>
         {% endif %}

--- a/src/web/templates/corpus.html
+++ b/src/web/templates/corpus.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}Corpus — engram{% endblock %}
+{% block title %}Source — engram{% endblock %}
 {% block content %}
 <div class="row" style="margin-bottom:1rem">
   <span class="badge {{ badge }}">{{ status }}</span>
@@ -29,7 +29,7 @@
   </form>
   {% endif %}
   <form method="post" action="/ui/corpora/{{ id }}/delete" style="display:inline"
-        onsubmit="return confirm('Delete this corpus and all its artifacts?')">
+        onsubmit="return confirm('Delete this source and all its artifacts?')">
     <button class="btn btn-sm btn-danger" type="submit">Delete</button>
   </form>
 </div>
@@ -131,7 +131,7 @@
    joined back together, or a photo the vision model has not read yet. #}
 <div class="card">
   <div class="card-head">
-    <span class="card-title">{% if restored %}Restored artifacts{% else if image %}Transcription{% else %}Raw corpus{% endif %}</span>
+    <span class="card-title">{% if restored %}Restored artifacts{% else if image %}Transcription{% else %}Raw source{% endif %}</span>
   </div>
   {% if lines_empty %}
   {# Only a photo is waiting on the vision model. Any other capture with no
@@ -195,7 +195,7 @@
 {# A merged or synthesized artifact belongs to every corpus it drew from — its
    origins are its roots' corpora, derived from lineage, never stored — and
    this capture is one of them. #}
-<h3>Written from this corpus</h3>
+<h3>Written from this source</h3>
 <p class="muted">
   Model-written artifacts with a source here. Each lists what it was written
   from on its own page.

--- a/src/web/templates/extension.html
+++ b/src/web/templates/extension.html
@@ -52,7 +52,7 @@ alternative, and is not the default here.</p>
 more than one, and the one your browser uses is the one to type. Press
 <em>Pair</em>: Firefox or Chrome will ask for permission to reach that one
 host, and nothing else.</p>
-<p class="muted">The token appears under Housekeeping → API tokens as
+<p class="muted">The token appears under Settings → API tokens as
 “browser extension”, and can be revoked there. Revoking it puts the panel back
 to asking for an address rather than leaving it stuck.</p>
 {% endblock %}

--- a/src/web/templates/insights.html
+++ b/src/web/templates/insights.html
@@ -230,6 +230,12 @@
   since. A candidate list only — nothing here has been changed, and this never
   affects search ranking.
 </p>
+{# What the two icons in the last column do, said once over the column rather
+   than as a label on every row: fifty rows of two labelled buttons is a wall
+   of repeated words, which is why they are icons — but the meaning was in a
+   `title` on each, and a tooltip is unreachable on a touch screen. #}
+<p class="muted hint">The check confirms one is still accurate. The other hides
+  it from results, keeps it, and can be undone.</p>
 <table class="grid">
   <thead><tr><th>Artifact</th><th>Last verified</th><th></th></tr></thead>
   <tbody>

--- a/src/web/templates/insights.html
+++ b/src/web/templates/insights.html
@@ -59,7 +59,7 @@
     {# Nothing judged yet. A 0.00 here would read as a score rather than as an
        absence, which is the one thing this figure must never do. #}
     <p class="measure-sub">Nothing judged yet — {{ f.captured }} search{% if f.captured != 1 %}es{% endif %} recorded.
-      <a href="/ui/judge">Judge some</a> and the number appears.</p>
+      <a href="/ui/judge">Review some</a> and the number appears.</p>
     {% endif %}
     {% else %}
     <p class="measure-sub">Not recording searches, so there is nothing to measure.</p>
@@ -333,8 +333,16 @@
    offers the machine here, closed. A disclosure rather than a second page: a
    route would need a handler, a link and an empty state of its own to draw the
    same line. #}
-<details class="machine">
-  <summary><h2>What the machine is doing</h2></summary>
+{# Open, and said on the summary, when something in here is going wrong. The
+   sweep failures and the last-error column are the only surfaces that report a
+   background pipeline falling over, and behind a closed disclosure with a
+   neutral summary an instance whose every embed job has failed for a week
+   looks exactly like one with nothing to say. A count on the summary is the
+   smallest thing that survives the fold. #}
+<details class="machine"{% if last_day_failures > 0 || !retrying.is_empty() %} open{% endif %}>
+  <summary><h2>What the machine is doing</h2>{% if last_day_failures > 0 %}
+    <span class="flag">{{ last_day_failures }} failed</span>{% endif %}{% if !retrying.is_empty() %}
+    <span class="muted">{{ retrying.len() }} retrying</span>{% endif %}</summary>
 
 
 {# The counts as a sentence rather than as `done: 17`-style badges: this is a

--- a/src/web/templates/insights.html
+++ b/src/web/templates/insights.html
@@ -2,6 +2,20 @@
 {% block title %}Insights — engram{% endblock %}
 {% block regions %}regions-table{% endblock %}
 {% block content %}
+{# A base with nothing in it has nothing to measure, and three panels of
+   zeros make a healthy empty base read as a broken full one. Only the
+   measures: a gap is a question the base could not answer, which is exactly
+   what an empty base produces, and the sweeps and the queue run whether or not
+   anything has been captured — hiding the page would hide all of that. What is
+   noisy rather than absent lives behind the disclosure at the foot. #}
+{% if held.corpora == 0 %}
+<div class="empty">
+  <h2>Nothing is held yet</h2>
+  <p class="muted">This page measures what the base holds and lists what needs
+    you. The measures wait on there being something in it.</p>
+  <p><a class="btn btn-ghost btn-sm" href="/ui">Back to the box</a></p>
+</div>
+{% else %}
 {# ── What this memory is like ──────────────────────────────────────────────
    Aggregates over tables that already exist. Nothing here embeds anything or
    calls a model, which is what makes the page cheap enough to open whenever.
@@ -52,6 +66,7 @@
     {% endif %}
   </div>
 </div>
+{% endif %}
 
 {# Work waiting on a person, first: this is the only thing on the page that
    asks for anything. Everything below it is reference. #}

--- a/src/web/templates/insights.html
+++ b/src/web/templates/insights.html
@@ -96,88 +96,6 @@
   <a class="quiet-link" href="/ui/settings">Settings</a>
 </p>
 
-<h2>Housekeeping</h2>
-
-
-{# The counts as a sentence rather than as `done: 17`-style badges: this is a
-   page you open to reassure yourself, and a row of key-value chips reads as a
-   debug dump of something going wrong.
-
-   Every number says what it counts. "1523 done" sat beside "1236 artifacts"
-   and read as a count of artifacts — of which there cannot be more done than
-   there are — when it was a count of jobs. Same for the links: a bare "45
-   links, 0 named" says nothing about what is linked to what. #}
-<p class="muted">
-  {{ artifact_count }} artifacts, {{ vector_count }} embedded.
-  {% if job_counts.is_empty() %}No jobs queued.{% else %}
-  {% for j in job_counts %}{{ j.1 }} jobs {{ j.0 }}{% if !loop.last %}, {% endif %}{% endfor %}.
-  {% endif %}
-  {% if let Some(age) = oldest_pending_secs %}Oldest pending job {{ age }}s old.{% endif %}
-  {% if let Some(l) = links %}
-  {{ l.total }} links between artifacts, {{ l.related }} named, {{ l.judge_queue }} waiting on the judge.
-  {% endif %}
-</p>
-
-{# The last day, not "last night". Units that reschedule themselves on their
-   own periods do not line up into one cycle, and grouping them by an invented
-   cycle identity would be inventing it. The history under the summary is the
-   half a single overwritten line could never give: whether a sweep started
-   going wrong yesterday or has been going wrong for a week. #}
-{% if !last_day.is_empty() || last_day_failures > 0 || !sweep_history.is_empty() %}
-<h3>The last day</h3>
-<p class="muted">
-  {% if last_day.is_empty() %}The sweeps ran and found nothing to do.{% else %}
-  {% for c in last_day %}{{ c.n }} {{ c.what }}{% if !loop.last %}, {% endif %}{% endfor %}.
-  {% endif %}
-  {% if last_day_failures > 0 %}
-  {{ last_day_failures }} run{% if last_day_failures != 1 %}s{% endif %} failed.
-  {% endif %}
-</p>
-{% if !sweep_history.is_empty() %}
-<table class="grid">
-  <thead><tr><th>When</th><th>Sweep</th><th>Did</th><th>Took</th></tr></thead>
-  <tbody>
-  {% for r in sweep_history %}
-    <tr>
-      <td>{{ r.when }}</td>
-      <td title="{{ r.stage_id }}">{{ r.stage }}</td>
-      <td>
-        {% if !r.error.is_empty() %}
-        <span class="flag">failed</span>
-        <div class="muted row-sub">{{ r.error }}</div>
-        {% else if r.counts.is_empty() %}
-        <span class="muted">nothing to do</span>
-        {% else %}
-        {% for c in r.counts %}{{ c.n }} {{ c.what }}{% if !loop.last %}, {% endif %}{% endfor %}
-        {% endif %}
-      </td>
-      <td class="muted">{{ r.took }}</td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-{% endif %}
-{% endif %}
-
-{# Shown against clicked, by rung. The one number that can settle whether the
-   weights the recommender rests on are right — they are chosen, not measured,
-   and until this has data, fitting them would be guessing with extra steps.
-   `[sitting] prime` has sat at `false` for months because nobody measured it;
-   this is here so the same thing does not happen twice. #}
-{% if !offer_rates.is_empty() %}
-<h3>What was offered</h3>
-<p class="muted">The last thirty days. A weekly pattern needs weeks, so a rate
-  measured over a day would be a number nobody could act on.</p>
-<table class="grid">
-  <thead><tr><th>Rung</th><th>Shown</th><th>Opened</th></tr></thead>
-  <tbody>
-  {% for r in offer_rates %}
-    <tr><td>{{ r.rung }}</td><td>{{ r.shown }}</td><td>{{ r.opened }}</td></tr>
-  {% endfor %}
-  </tbody>
-</table>
-{% endif %}
-
 {% if !merged.is_empty() %}
 <h3>Merged</h3>
 <p class="muted">
@@ -402,6 +320,96 @@
 </table>
 {% endif %}
 
+{# Everything below is about the instance rather than about what is in it, and
+   it is the same readout for every user of it. Stage identifiers, target
+   identifiers and raw error strings are what an operator opens a page for and
+   what everybody else scrolls past, so the page states the memory above and
+   offers the machine here, closed. A disclosure rather than a second page: a
+   route would need a handler, a link and an empty state of its own to draw the
+   same line. #}
+<details class="machine">
+  <summary><h2>What the machine is doing</h2></summary>
+
+
+{# The counts as a sentence rather than as `done: 17`-style badges: this is a
+   page you open to reassure yourself, and a row of key-value chips reads as a
+   debug dump of something going wrong.
+
+   Every number says what it counts. "1523 done" sat beside "1236 artifacts"
+   and read as a count of artifacts — of which there cannot be more done than
+   there are — when it was a count of jobs. Same for the links: a bare "45
+   links, 0 named" says nothing about what is linked to what. #}
+<p class="muted">
+  {{ artifact_count }} artifacts, {{ vector_count }} embedded.
+  {% if job_counts.is_empty() %}No jobs queued.{% else %}
+  {% for j in job_counts %}{{ j.1 }} jobs {{ j.0 }}{% if !loop.last %}, {% endif %}{% endfor %}.
+  {% endif %}
+  {% if let Some(age) = oldest_pending_secs %}Oldest pending job {{ age }}s old.{% endif %}
+  {% if let Some(l) = links %}
+  {{ l.total }} links between artifacts, {{ l.related }} named, {{ l.judge_queue }} waiting on the judge.
+  {% endif %}
+</p>
+
+{# The last day, not "last night". Units that reschedule themselves on their
+   own periods do not line up into one cycle, and grouping them by an invented
+   cycle identity would be inventing it. The history under the summary is the
+   half a single overwritten line could never give: whether a sweep started
+   going wrong yesterday or has been going wrong for a week. #}
+{% if !last_day.is_empty() || last_day_failures > 0 || !sweep_history.is_empty() %}
+<h3>The last day</h3>
+<p class="muted">
+  {% if last_day.is_empty() %}The sweeps ran and found nothing to do.{% else %}
+  {% for c in last_day %}{{ c.n }} {{ c.what }}{% if !loop.last %}, {% endif %}{% endfor %}.
+  {% endif %}
+  {% if last_day_failures > 0 %}
+  {{ last_day_failures }} run{% if last_day_failures != 1 %}s{% endif %} failed.
+  {% endif %}
+</p>
+{% if !sweep_history.is_empty() %}
+<table class="grid">
+  <thead><tr><th>When</th><th>Sweep</th><th>Did</th><th>Took</th></tr></thead>
+  <tbody>
+  {% for r in sweep_history %}
+    <tr>
+      <td>{{ r.when }}</td>
+      <td title="{{ r.stage_id }}">{{ r.stage }}</td>
+      <td>
+        {% if !r.error.is_empty() %}
+        <span class="flag">failed</span>
+        <div class="muted row-sub">{{ r.error }}</div>
+        {% else if r.counts.is_empty() %}
+        <span class="muted">nothing to do</span>
+        {% else %}
+        {% for c in r.counts %}{{ c.n }} {{ c.what }}{% if !loop.last %}, {% endif %}{% endfor %}
+        {% endif %}
+      </td>
+      <td class="muted">{{ r.took }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endif %}
+
+{# Shown against clicked, by rung. The one number that can settle whether the
+   weights the recommender rests on are right — they are chosen, not measured,
+   and until this has data, fitting them would be guessing with extra steps.
+   `[sitting] prime` has sat at `false` for months because nobody measured it;
+   this is here so the same thing does not happen twice. #}
+{% if !offer_rates.is_empty() %}
+<h3>What was offered</h3>
+<p class="muted">The last thirty days. A weekly pattern needs weeks, so a rate
+  measured over a day would be a number nobody could act on.</p>
+<table class="grid">
+  <thead><tr><th>Rung</th><th>Shown</th><th>Opened</th></tr></thead>
+  <tbody>
+  {% for r in offer_rates %}
+    <tr><td>{{ r.rung }}</td><td>{{ r.shown }}</td><td>{{ r.opened }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 {% if !retrying.is_empty() %}
 <h3>Retrying</h3>
 <p class="muted">Work that hit something and is waiting to try again. Nothing here needs you.</p>
@@ -420,6 +428,8 @@
   </tbody>
 </table>
 {% endif %}
+</details>
+
 
 {# One sentence for everything that is empty. Five headings each answered
    "None." made a base with nothing wrong with it look like a backlog. #}

--- a/src/web/templates/judge.html
+++ b/src/web/templates/judge.html
@@ -2,6 +2,15 @@
 {% block title %}Judge — engram{% endblock %}
 {% block regions %}regions-judge{% endblock %}
 {% block content %}
+{# What the page is for, said once and standing. The card asks a genuine
+   cognitive task — twenty unordered candidates and a question — and never said
+   why it was worth answering. The answer is the one number on Insights that is
+   not a proxy: recall@10 and MRR are read off exactly these verdicts, which is
+   why an unlabelled, shuffled pool is the only honest way to ask. #}
+<p class="muted hint">These are your own searches, coming back unlabelled and
+  shuffled. Saying which result you actually wanted is what turns the retrieval
+  figure on Insights into a measurement rather than a guess.</p>
+
 {# Directly above the card: it is the one thing on this page that can be acted
    on, and it is what the bar inside the card is counting towards. #}
 {% include "_judge_tune.html" %}

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -70,6 +70,11 @@
          sit on Capture. A destination rather than a quiet link at the bottom
          of a page, because it is now the only other place there is. #}
       <a href="/ui/insights">Insights</a>
+      {# Where the account is, and where what reads this base over the API is
+         revoked. It was one quiet link at the foot of Insights, which is a
+         page you scroll — and on a phone that made it unreachable by anyone
+         who did not already know it was there. #}
+      <a href="/ui/settings">Settings</a>
       <span class="spacer"></span>
       {# The light palette has been in the stylesheet since the port and nobody
          has ever seen it, because it activated only on prefers-color-scheme.
@@ -112,6 +117,11 @@
     {% endif %}
     <a href="/ui/insights">
       <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M4 16V9M10 16V5M16 16v-4"/></svg>Insights</a>
+    {# A fourth entry. Since #52 this is where a person goes to see whose base
+       this is and to revoke what is reading it, and it was the one destination
+       the phone had no route to at all. #}
+    <a href="/ui/settings">
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="10" cy="10" r="2.5"/><path d="M10 3.5v2M10 14.5v2M3.5 10h2M14.5 10h2M5.6 5.6l1.4 1.4M13 13l1.4 1.4M14.4 5.6L13 7M7 13l-1.4 1.4"/></svg>Settings</a>
   </nav>
 </body>
 </html>

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -62,7 +62,7 @@
          screen that has to be visited often for the dataset to grow. The count
          is the whole invitation: an empty queue asks for nothing. #}
       {% if let Some(n) = judge_pending %}
-      <a href="/ui/judge">Judge{% if n > &0 %}
+      <a href="/ui/judge">Review searches{% if n > &0 %}
         <span class="badge badge-accent">{{ n }}</span>{% endif %}</a>
       {% endif %}
       {# What is true about this installation, and what needs a person: the
@@ -107,7 +107,7 @@
        count is not the point — that anything is waiting is. #}
     {% if let Some(n) = judge_pending %}
     <a href="/ui/judge">
-      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M4 10.5l4 4 8-9"/></svg>Judge{% if n > &0 %}
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M4 10.5l4 4 8-9"/></svg>Review{% if n > &0 %}
       <span class="tab-dot" aria-label="{{ n }} waiting"></span>{% endif %}</a>
     {% endif %}
     <a href="/ui/insights">

--- a/src/web/templates/pair.html
+++ b/src/web/templates/pair.html
@@ -12,7 +12,7 @@
   <input type="hidden" name="state" value="{{ state }}">
   <button class="btn btn-accent" type="submit">Pair</button>
 </form>
-<p class="muted">You can revoke it any time under Housekeeping → API tokens.</p>
+<p class="muted">You can revoke it any time under Settings → API tokens.</p>
 {% else %}
 {# This window belongs to the browser's auth flow, and it cannot be sent
    through sign-in and back: the login redirect carries no return path, so it

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -78,7 +78,7 @@ reading, and search from a panel beside it.</p>
    page for things that are true about the installation. #}
 <p class="muted">
   Searches are being recorded — {{ f.captured }} captured, {{ f.pending }} unjudged.
-  {% if f.pending > 0 %}<a href="/ui/judge">Judge them</a>{% endif %}
+  {% if f.pending > 0 %}<a href="/ui/judge">Review them</a>{% endif %}
 </p>
 {# Counted here beside the searches because one purge takes both. The judged
    count is what the button below destroys and what nothing can reproduce: a

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -92,7 +92,7 @@ reading, and search from a panel beside it.</p>
 {% when None %}
 {% endmatch %}
 <form method="post" action="/ui/ops/feedback/purge"
-      onsubmit="return confirm('Delete every captured search and every recorded question, with every verdict given on one, and every pursuit and what was opened? The judged questions cannot be recovered — they are what the ask harness is measured against.')">
+      onsubmit="return confirm('Delete every recorded search and question, and every verdict given on one? The judged ones cannot be recovered — they are what the retrieval figure is measured from.')">
   <button class="btn btn-sm btn-danger" type="submit">Delete all captured searches, questions and pursuits</button>
 </form>
 {% when None %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -5,7 +5,7 @@
 {# Everything true about this installation rather than about what is in it.
    The two were one page, which meant scrolling past every merge and every
    hidden artifact to revoke a token. Reachable from the same quiet line on
-   Housekeeping, and no more advertised than it is. #}
+   Insights, and no more advertised than it is. #}
 <p class="crumb"><a href="/ui">engram</a> › Settings</p>
 
 <h3>Browser extension</h3>
@@ -20,18 +20,18 @@ reading, and search from a panel beside it.</p>
 <form hx-post="/ui/ops/tokens" hx-target="#token-result" hx-swap="innerHTML"
       class="row" style="margin-bottom:1rem">
   <input class="input" name="name" placeholder="Token name, e.g. claude-code" style="max-width:20rem">
-  <button class="btn btn-accent" type="submit">Mint</button>
+  <button class="btn btn-accent" type="submit">Create</button>
 </form>
 
 {# Column headings over no rows is a table pretending to have some — the same
    thing the decide list names at its top: five headings answered with "None."
    made an empty base look like a backlog. #}
 {% if tokens.is_empty() %}
-<p class="muted">No tokens yet. Mint one to let Claude Code, Claude Desktop or
+<p class="muted">No tokens yet. Create one to let Claude Code, Claude Desktop or
   anything else on the API read and write this base without your session.</p>
 {% else %}
 <table class="grid">
-  <thead><tr><th>Name</th><th>Minted by</th><th>Created</th><th>Last used</th><th>State</th><th></th></tr></thead>
+  <thead><tr><th>Name</th><th>Created by</th><th>Created</th><th>Last used</th><th>State</th><th></th></tr></thead>
   <tbody>
   {% for t in tokens %}
     <tr>

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -8,6 +8,13 @@
    Insights, and no more advertised than it is. #}
 <p class="crumb"><a href="/ui">engram</a> › Settings</p>
 
+{# Said plainly, on the page where account things live. Every user has held
+   their own database and their own collection since #52, and no page said so
+   — which leaves the one question a person actually has before pasting their
+   own notes onto a server somebody else runs unanswered everywhere. #}
+<p class="muted">Signed in as <span class="mono">{{ account }}</span>. This base
+  is yours alone — no other account can search it.</p>
+
 <h3>Browser extension</h3>
 {# The extension mints its own token through /ui/pair, so it needs nothing from
    the form below. Listed here because this is where the tokens it creates show

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -43,7 +43,12 @@
    and a Judge-queue row for a paragraph nobody was looking for; /ui/ask?q=
    puts a question in it and got a search instead of the thing named on the
    door. Both now land filled and still, which is what a prefill is. #}
-<form id="box-form" hx-get="/ui/search/results" hx-target="#results" hx-swap="innerHTML"
+{# `data-held` is how app.js knows the page it is standing in was rendered for
+   an empty base, and so that the first capture that stores has to fetch
+   `/ui/held` and swap the four regions that are now wrong. Cleared to `1` once
+   that has happened, so a second capture fetches nothing. #}
+<form id="box-form" data-held="{% if held %}1{% else %}0{% endif %}"
+      hx-get="/ui/search/results" hx-target="#results" hx-swap="innerHTML"
       hx-sync="this:replace"
       hx-trigger="change from:#kind-chips,
                   input[!event.isComposing] changed delay:120ms from:textarea[name=q],
@@ -81,6 +86,15 @@
             aria-label="Search, ask, or capture"
             placeholder="{% if held %}Describe the situation, ask a question, or paste anything worth keeping…{% else %}Paste anything worth keeping — a note, an article, a chunk of a chat.{% endif %}"
             data-placeholder-narrow="{% if held %}Ask, search, or paste to keep…{% else %}Paste anything worth keeping…{% endif %}"
+            {%- if !held %}
+            {# The sentences this box will use once the base stops being empty,
+               carried on the element rather than swapped in. The rest of the
+               held state arrives out-of-band (see `_held.html`), but replacing
+               a textarea takes the caret, the selection and anything typed
+               since with it — so app.js reads these two across instead. #}
+            data-placeholder-held="Describe the situation, ask a question, or paste anything worth keeping…"
+            data-placeholder-held-narrow="Ask, search, or paste to keep…"
+            {%- endif %}
             aria-describedby="box-hint">{{ q }}</textarea>
 {# The file, when there is one. It used to be an always-open drop zone and a
      staged box under it — two places for one idea, on a page that grew a row as
@@ -124,11 +138,9 @@
     {# Both carry the reason they are dead. app.js clears `disabled` the moment
        there is something to act on, so the title only ever describes the state
        that renders it — and a permanently grey button with no stated reason is
-       indistinguishable from a broken one. #}
-    {% if ask_enabled && held %}
-    <button class="btn btn-accent" type="button" data-verb="ask" disabled
-            title="Type or attach something first">Ask</button>
-    {% endif %}
+       indistinguishable from a broken one. Ask is in a partial because it also
+       arrives out-of-band on the first capture; see `_held.html`. #}
+    {% include "_ask_verb.html" %}
     <button class="btn" type="button" data-verb="capture" disabled
             title="Type or attach something first">Capture</button>
     {# The invitation to a file, present from first paint. It lived inside the
@@ -192,24 +204,7 @@
        what it will accept itself, and the input keeps its `aria-label`. #}
     <span class="muted hint attach-types">{% if vision_enabled %}A .txt file, a PDF or an image{% else %}A .txt file or a PDF{% endif %} — or drop one anywhere on the page.</span>
   </div>
-  {# Two hints, because the two states need different sentences. With something
-     held, the useful thing to say is how to phrase a query — a whole sentence
-     embeds better than the two nouns from it a reader would otherwise type.
-     With nothing held there is no query to phrase, and the useful thing to say
-     is what this is and whose it is. The second half is not decoration: an
-     operator arriving through an identity provider never sees the login card,
-     so this is the only place the application introduces itself, and the
-     boundary is the question a person actually has before pasting their own
-     notes onto a server somebody else runs. #}
-  <p id="box-hint" class="muted hint">
-    {%- if held -%}
-    Typing searches as you go. A sentence or a whole paragraph finds more than
-    keywords do — paste what you are looking at.
-    {%- else -%}
-    engram keeps what you paste in your own words and finds it again by meaning,
-    not by keywords. This base is yours: nobody else can search it.
-    {%- endif -%}
-  </p>
+  {% include "_box_hint.html" %}
 </form>
 
 
@@ -253,18 +248,7 @@
      hx-vals='js:{bundle: engramContext()}' hx-swap="outerHTML"></div>
 {% endif %}
 
-{# Taught once. A shortcut nobody is told about is a shortcut nobody uses, and
-   a hint that cannot be dismissed is a banner. Hidden until app.js decides
-   there is a keyboard to use it with. #}
-{% if held %}
-<p class="keyhint" hidden>
-  <kbd>/</kbd> box{% if ask_enabled %} <kbd>Ctrl</kbd><kbd>↵</kbd> ask{% endif %}
-  <kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>↵</kbd> keep
-  <kbd>↑</kbd><kbd>↓</kbd> move <kbd>↵</kbd> open
-  <kbd>s</kbd> hide source <kbd>r</kbd> reading
-  <button type="button" class="btn btn-ghost btn-sm" data-dismiss-hint>Got it</button>
-</p>
-{% endif %}
+{% include "_keyhint.html" %}
 </div>
 
 {# The rail holds what the current act produced, and says which act that was.
@@ -332,19 +316,7 @@
      full reload. app.js clears the ask remnants when this fills, and clears
      this when an Ask starts, so the pane still shows one act at a time. #}
   <div id="pane-content">
-    {# With something held this names where an artifact will appear. With
-       nothing held it named a search that cannot be run, which is an
-       instruction to do the one thing the page has just been arranged to
-       prevent. It says what will happen to the first paste instead. #}
-    <p id="pane-idle" class="muted">
-      {%- if held -%}
-      Search to see an artifact here, beside the lines it came from.
-      {%- else -%}
-      Whatever you paste is split into passages and embedded so it can be found
-      by meaning. The original is kept exactly as you wrote it, and every result
-      can be read beside it.
-      {%- endif -%}
-    </p>
+    {% include "_pane_idle.html" %}
   </div>
 </div>
 {% endblock %}

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -79,8 +79,8 @@
      only thing left saying what the box is for. app.js swaps them. #}
   <textarea class="box" name="q" rows="1"
             aria-label="Search, ask, or capture"
-            placeholder="Describe the situation, ask a question, or paste anything worth keeping…"
-            data-placeholder-narrow="Ask, search, or paste to keep…"
+            placeholder="{% if held %}Describe the situation, ask a question, or paste anything worth keeping…{% else %}Paste anything worth keeping — a note, an article, a chunk of a chat.{% endif %}"
+            data-placeholder-narrow="{% if held %}Ask, search, or paste to keep…{% else %}Paste anything worth keeping…{% endif %}"
             aria-describedby="box-hint">{{ q }}</textarea>
 {# The file, when there is one. It used to be an always-open drop zone and a
      staged box under it — two places for one idea, on a page that grew a row as
@@ -121,7 +121,7 @@
      which a staged file disarms: the box is that file's note by then, and a
      note is not a question to spend a model call on. #}
   <div class="verbs">
-    {% if ask_enabled %}
+    {% if ask_enabled && held %}
     <button class="btn btn-accent" type="button" data-verb="ask" disabled>Ask</button>
     {% endif %}
     <button class="btn" type="button" data-verb="capture" disabled>Capture</button>
@@ -223,6 +223,7 @@
 {# Taught once. A shortcut nobody is told about is a shortcut nobody uses, and
    a hint that cannot be dismissed is a banner. Hidden until app.js decides
    there is a keyboard to use it with. #}
+{% if held %}
 <p class="keyhint" hidden>
   <kbd>/</kbd> box{% if ask_enabled %} <kbd>Ctrl</kbd><kbd>↵</kbd> ask{% endif %}
   <kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>↵</kbd> keep
@@ -230,6 +231,7 @@
   <kbd>s</kbd> hide source <kbd>r</kbd> reading
   <button type="button" class="btn btn-ghost btn-sm" data-dismiss-hint>Got it</button>
 </p>
+{% endif %}
 </div>
 
 {# The rail holds what the current act produced, and says which act that was.

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -121,10 +121,16 @@
      which a staged file disarms: the box is that file's note by then, and a
      note is not a question to spend a model call on. #}
   <div class="verbs">
+    {# Both carry the reason they are dead. app.js clears `disabled` the moment
+       there is something to act on, so the title only ever describes the state
+       that renders it — and a permanently grey button with no stated reason is
+       indistinguishable from a broken one. #}
     {% if ask_enabled && held %}
-    <button class="btn btn-accent" type="button" data-verb="ask" disabled>Ask</button>
+    <button class="btn btn-accent" type="button" data-verb="ask" disabled
+            title="Type or attach something first">Ask</button>
     {% endif %}
-    <button class="btn" type="button" data-verb="capture" disabled>Capture</button>
+    <button class="btn" type="button" data-verb="capture" disabled
+            title="Type or attach something first">Capture</button>
     {# The invitation to a file, present from first paint. It lived inside the
        staged box for four commits — a box hidden until a file was staged —
        so the only way to stage one was a drag nobody was told about. Built
@@ -174,6 +180,17 @@
       {% endfor %}
     </div>
     {% endif %}
+    {# The accepted types, in the page rather than only on the label's `title`,
+       which a pointer reads and nothing else does. Last in the row and given a
+       full basis by the stylesheet, so the buttons, the spacer and the chips
+       keep the one line they are laid out for and this sits under them.
+
+       It carries `hint`, which means the phone hides it along with the rest of
+       the prose in this bar. That is the bar's own rule and it is right: a
+       phone has about six hundred pixels of height and the results are what
+       they are for. Nothing is lost there — the picker a phone opens names
+       what it will accept itself, and the input keeps its `aria-label`. #}
+    <span class="muted hint attach-types">{% if vision_enabled %}A .txt file, a PDF or an image{% else %}A .txt file or a PDF{% endif %} — or drop one anywhere on the page.</span>
   </div>
   {# Two hints, because the two states need different sentences. With something
      held, the useful thing to say is how to phrase a query — a whole sentence
@@ -186,8 +203,8 @@
      notes onto a server somebody else runs. #}
   <p id="box-hint" class="muted hint">
     {%- if held -%}
-    A sentence or a whole paragraph finds more than keywords do — paste what you
-    are looking at.
+    Typing searches as you go. A sentence or a whole paragraph finds more than
+    keywords do — paste what you are looking at.
     {%- else -%}
     engram keeps what you paste in your own words and finds it again by meaning,
     not by keywords. This base is yours: nobody else can search it.

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -175,8 +175,24 @@
     </div>
     {% endif %}
   </div>
-  <p id="box-hint" class="muted hint">A sentence or a whole paragraph finds
-    more than keywords do — paste what you are looking at.</p>
+  {# Two hints, because the two states need different sentences. With something
+     held, the useful thing to say is how to phrase a query — a whole sentence
+     embeds better than the two nouns from it a reader would otherwise type.
+     With nothing held there is no query to phrase, and the useful thing to say
+     is what this is and whose it is. The second half is not decoration: an
+     operator arriving through an identity provider never sees the login card,
+     so this is the only place the application introduces itself, and the
+     boundary is the question a person actually has before pasting their own
+     notes onto a server somebody else runs. #}
+  <p id="box-hint" class="muted hint">
+    {%- if held -%}
+    A sentence or a whole paragraph finds more than keywords do — paste what you
+    are looking at.
+    {%- else -%}
+    engram keeps what you paste in your own words and finds it again by meaning,
+    not by keywords. This base is yours: nobody else can search it.
+    {%- endif -%}
+  </p>
 </form>
 
 
@@ -299,8 +315,19 @@
      full reload. app.js clears the ask remnants when this fills, and clears
      this when an Ask starts, so the pane still shows one act at a time. #}
   <div id="pane-content">
-    <p id="pane-idle" class="muted">Search to see an artifact here, beside the
-      lines it came from.</p>
+    {# With something held this names where an artifact will appear. With
+       nothing held it named a search that cannot be run, which is an
+       instruction to do the one thing the page has just been arranged to
+       prevent. It says what will happen to the first paste instead. #}
+    <p id="pane-idle" class="muted">
+      {%- if held -%}
+      Search to see an artifact here, beside the lines it came from.
+      {%- else -%}
+      Whatever you paste is split into passages and embedded so it can be found
+      by meaning. The original is kept exactly as you wrote it, and every result
+      can be read beside it.
+      {%- endif -%}
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -3736,6 +3736,29 @@ mod tests {
         (app, cookie)
     }
 
+    /// One source, so the base is not empty.
+    ///
+    /// The ask door only opens over a held base — with nothing stored it
+    /// redirects to the plain page, because the workspace renders no Ask verb
+    /// there and the door would be a question in a box with no way to send it.
+    /// Every test below that wants the ask *page* wants a base with something
+    /// in it first.
+    async fn hold_something(core: &crate::core::Core) {
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+    }
+
+    /// A session over a base holding one source. See `hold_something`.
+    async fn app_holding_something() -> (axum::Router, String) {
+        let (app, cookie, core) = app_session_and_core().await;
+        hold_something(&core).await;
+        (app, cookie)
+    }
+
     async fn app_session_and_core() -> (axum::Router, String, crate::core::Core) {
         let core = crate::core::test_support::test_core().await;
         let handle = core.clone();
@@ -3930,7 +3953,9 @@ mod tests {
     /// after was the one thing it did not do.
     #[tokio::test]
     async fn the_ask_door_fills_the_one_box_and_runs_nothing_on_arrival() {
-        let (app, cookie) = app_for(crate::core::test_support::test_core().await).await;
+        let core = crate::core::test_support::test_core().await;
+        hold_something(&core).await;
+        let (app, cookie) = app_for(core).await;
         let html = get(&app, "/ui/ask?q=why+did+the+reindex+fail", &cookie).await;
         assert!(
             html.contains("why did the reindex fail"),
@@ -5331,7 +5356,32 @@ mod tests {
                 .await
                 .unwrap();
         }
-        app_with_cookie(core).await
+        // Searches were recorded against something. Without a source the ask
+        // door redirects, and a test walking the nav across every page would
+        // be walking one that is not there.
+        let handle = core.clone();
+        let out = app_with_cookie(core).await;
+        hold_something(&handle).await;
+        out
+    }
+
+    /// One name for one destination. The nav entry, the tab and the empty
+    /// state were renamed together and two in-page links were left behind, so
+    /// "Judge some" on Insights and "Judge them" on Settings landed on a page
+    /// that called itself something else in all three of the places a reader
+    /// looks to confirm they arrived.
+    #[tokio::test]
+    async fn every_link_to_the_review_screen_calls_it_what_it_calls_itself() {
+        let (app, cookie) = app_recording_searches(3).await;
+        for page in ["/ui/insights", "/ui/settings", "/ui/judge"] {
+            let html = flat(&get(&app, page, &cookie).await);
+            for stale in ["Judge some", "Judge them", ">Judge<"] {
+                assert!(
+                    !html.contains(stale),
+                    "{page} still calls the review screen \"{stale}\""
+                );
+            }
+        }
     }
 
     #[tokio::test]
@@ -8700,7 +8750,8 @@ mod tests {
     async fn a_question_the_operator_arrived_with_is_never_overwritten() {
         // A gap's "ask again" is a question they chose. The sitting fills an
         // empty box and nothing else.
-        let (app, cookie, _core) = app_session_and_core().await;
+        let (app, cookie, core) = app_session_and_core().await;
+        hold_something(&core).await;
         get_body(&app, &cookie, "/ui/search/results?q=something%20else").await;
 
         let ask = get_body(&app, &cookie, "/ui/ask?q=the%20one%20I%20clicked").await;
@@ -9477,6 +9528,7 @@ mod tests {
         // Every one of them starts at the shell's left edge, which is what
         // stops the content column moving as you navigate.
         let (app, cookie, core) = app_session_and_core().await;
+        hold_something(&core).await;
 
         let search = get_body(&app, &cookie, "/ui/search").await;
         assert!(
@@ -9541,7 +9593,7 @@ mod tests {
 
     #[tokio::test]
     async fn the_ask_page_prefills_a_question_from_the_query_string() {
-        let (app, cookie) = app_with_session().await;
+        let (app, cookie) = app_holding_something().await;
         let page = get_body(&app, &cookie, "/ui/ask?q=mount+an+E01").await;
         // A textarea carries its value as content rather than as an
         // attribute, which is the one visible consequence of the box being a
@@ -9695,7 +9747,7 @@ mod tests {
             "the stamp is not a hash of the assets it stamps"
         );
 
-        let (app, cookie) = app_with_session().await;
+        let (app, cookie) = app_holding_something().await;
         let page = get_body(&app, &cookie, "/ui/ask").await;
         assert!(
             page.contains(&format!("/assets/app.js?v={want}")),
@@ -9864,7 +9916,7 @@ mod tests {
             "the driver looks up almost nothing, so this test checks almost nothing: {wanted:?}"
         );
 
-        let (app, cookie) = app_with_session().await;
+        let (app, cookie) = app_holding_something().await;
         let page = get_body(&app, &cookie, "/ui/ask").await;
         for id in wanted {
             assert!(

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -722,6 +722,13 @@ struct SettingsTemplate {
     /// only the searches let an operator clear their query log without knowing
     /// the judged questions went with it.
     asks: Option<crate::store::asks::AskStats>,
+    /// Who is looking at this base.
+    ///
+    /// Every user has held their own database and their own collection since
+    /// #52, and no page said so. The email where the identity provider gave
+    /// one, because that is the name a person recognises as theirs; the
+    /// subject otherwise, because a stable identifier beats no answer.
+    account: String,
 }
 
 pub struct SourceRow {
@@ -2177,6 +2184,11 @@ async fn settings(tenant: Tenant) -> Result<Response> {
             true => Some(tenant.core.store.ask_stats().await?),
             false => None,
         },
+        account: tenant
+            .user
+            .email
+            .clone()
+            .unwrap_or_else(|| tenant.user.subject.clone()),
     })
     .into_response())
 }
@@ -3062,6 +3074,7 @@ mod tests {
 
     fn settings_fixture(tokens: Vec<TokenRow>) -> String {
         askama::Template::render(&SettingsTemplate {
+            account: crate::store::TEST_SUBJECT.into(),
             judge_pending: None,
             tokens,
             feedback: None,
@@ -4282,6 +4295,31 @@ mod tests {
         assert!(
             ext.contains("Settings → API tokens"),
             "named where they are"
+        );
+    }
+
+    /// After #52 every user has their own base, and nothing anywhere said
+    /// which account was looking at one. Settings is where account things
+    /// live; it was also the one page a phone could not reach.
+    #[tokio::test]
+    async fn settings_is_reachable_and_names_the_account() {
+        let (app, cookie) = app_for(crate::core::test_support::test_core().await).await;
+
+        let html = get(&app, "/ui", &cookie).await;
+        assert_eq!(
+            html.matches(r#"href="/ui/settings""#).count(),
+            2,
+            "the top row and the tabbar, so a phone can reach it too: {html}"
+        );
+
+        let settings = get(&app, "/ui/settings", &cookie).await;
+        assert!(
+            settings.contains("Signed in as"),
+            "and the page that holds account things says which account"
+        );
+        assert!(
+            settings.contains(crate::store::TEST_SUBJECT),
+            "named, not merely alluded to"
         );
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -4234,6 +4234,57 @@ mod tests {
     /// Housekeeping is Insights now. The old door stays a door: it is in
     /// bookmarks, in the quiet link at the bottom of the page, and in at least
     /// one runbook — a 404 there is a broken promise, not a tidy-up.
+    /// Two words for one thing, switched between without a rule. This picks
+    /// the one already doing most of the work; the URLs keep theirs, because a
+    /// path is not addressed to the reader.
+    #[tokio::test]
+    async fn a_source_is_called_a_source_everywhere_a_person_reads_it() {
+        let core = crate::core::test_support::test_core().await;
+        // `ingest_capture` answers with an `IngestOutcome`; the corpus id is
+        // the field on it, not the value itself.
+        let id = core
+            .ingest_capture(crate::core::ingest::Capture::new(
+                "LevelDB tombstones survive compaction longer than the manual admits.",
+                "ui",
+            ))
+            .await
+            .unwrap()
+            .id;
+        let (app, cookie) = app_for(core).await;
+
+        let corpus = get(&app, &format!("/ui/corpora/{id}"), &cookie).await;
+        assert!(
+            !corpus.contains("Corpus — engram"),
+            "the page a person reads does not say corpus"
+        );
+        assert!(corpus.contains("Source — engram"), "it says source");
+        assert!(
+            !corpus.contains("Raw corpus"),
+            "nor in the card over the text itself"
+        );
+        assert!(
+            corpus.contains("/ui/corpora/"),
+            "and the URL is untouched, because a path is not addressed to anyone"
+        );
+
+        let settings = get(&app, "/ui/settings", &cookie).await;
+        assert!(!settings.contains(">Mint<"), "Mint is a word about coins");
+        assert!(
+            settings.contains(">Create<"),
+            "the button says what it does"
+        );
+
+        let ext = get(&app, "/extension/install", &cookie).await;
+        assert!(
+            !ext.contains("Housekeeping → API tokens"),
+            "Housekeeping is retired and tokens were never there anyway"
+        );
+        assert!(
+            ext.contains("Settings → API tokens"),
+            "named where they are"
+        );
+    }
+
     #[tokio::test]
     async fn housekeeping_moved_to_insights_and_the_old_door_still_opens() {
         let (app, cookie) = app_for(crate::core::test_support::test_core().await).await;
@@ -10335,7 +10386,7 @@ mod tests {
                 .await
                 .unwrap();
             let page = get_body(&app, &cookie, &format!("/ui/corpora/{}", c.id)).await;
-            assert!(page.contains("Written from this corpus"), "{page}");
+            assert!(page.contains("Written from this source"), "{page}");
             assert!(page.contains(&m.id), "{page}");
         }
     }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -4240,8 +4240,9 @@ mod tests {
 
         let html = get(&app, "/ui/insights", &cookie).await;
         assert!(
-            html.contains("Housekeeping"),
-            "the maintenance section is there"
+            html.contains("What the machine is doing"),
+            "the maintenance section is there, under the name that says what \
+             it holds rather than what a person might do about it"
         );
 
         let res = app

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -10185,7 +10185,17 @@ mod tests {
 
     #[tokio::test]
     async fn with_an_ask_model_the_verb_is_there() {
-        let (app, cookie) = app_with_session().await;
+        let (app, cookie, core) = app_session_and_core().await;
+        // Something held, because there are two conditions on the door now and
+        // this test is about the other one. An empty base hides Ask whatever
+        // the configuration says — it can only abstain — so without a capture
+        // here the assertion below would pass or fail for the wrong reason.
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
         let page = get_body(&app, &cookie, "/ui").await;
         // A button on the box, not a link in the nav. Ask stopped being a
         // place to go the moment the box learned to do it — but the rule the

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -5305,8 +5305,8 @@ mod tests {
         for page in ["/ui/search", "/ui/capture", "/ui/ask", "/ui/insights"] {
             let html = flat(&get(&app, page, &cookie).await);
             assert!(
-                html.contains(r#"<a href="/ui/judge">Judge"#),
-                "{page} offers no way to judge"
+                html.contains(r#"<a href="/ui/judge">Review searches"#),
+                "{page} offers no way to review searches"
             );
             assert!(
                 html.contains(r#"<span class="badge badge-accent">3</span>"#),
@@ -5322,7 +5322,7 @@ mod tests {
         // invitation to a screen that has no work on it.
         let (app, cookie) = app_recording_searches(0).await;
         let html = flat(&get(&app, "/ui/search", &cookie).await);
-        assert!(html.contains(r#"<a href="/ui/judge">Judge"#));
+        assert!(html.contains(r#"<a href="/ui/judge">Review searches"#));
         assert!(
             !html.contains(r#"badge-accent">0<"#),
             "an empty queue was badged"

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -133,6 +133,16 @@ struct WorkspaceTemplate {
     /// fragment is what the results endpoint returns when the box is emptied
     /// — one account of the idle state, however it is reached.
     idle: String,
+    /// Whether the base holds anything at all.
+    ///
+    /// Onboarding here is a property of an empty base rather than of a new
+    /// user: no flag is stored, nothing is dismissed, and the same page serves
+    /// someone who has just arrived and someone who has just deleted
+    /// everything. Two of the three verbs cannot work with nothing held —
+    /// search returns nothing and ask can only abstain — so the page offers
+    /// the one that can, and the rest appears when there is something for it
+    /// to act on.
+    held: bool,
 }
 
 /// Everything every door renders, before the door says what it opened for.
@@ -174,6 +184,11 @@ async fn base_template(
             .map_err(|e| crate::error::Error::Internal(e.to_string()))?,
         false => String::new(),
     };
+    // The slimmest read there is, and the same one the idle rail takes. Asked
+    // unconditionally because the deep-link path renders no idle rail and
+    // still has to know: a search URL against an empty base is a page that
+    // must not offer Ask either.
+    let (corpora, _) = tenant.core.store.held_brief().await?;
     Ok(WorkspaceTemplate {
         judge_pending: crate::web::state::judge_pending(tenant).await,
         ask_enabled: crate::web::state::ask_enabled(tenant),
@@ -188,6 +203,7 @@ async fn base_template(
         prefill_question: String::new(),
         open_with,
         idle,
+        held: corpora > 0,
     })
 }
 
@@ -740,6 +756,74 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK, "{uri}");
         body_of(res).await
+    }
+
+    /// Two of the three verbs cannot work on a base with nothing in it, and a
+    /// list with nothing in it has nothing to move through. A disabled button
+    /// is a promise the page cannot keep and seven shortcuts are a wall; both
+    /// are absent until there is something for them to act on.
+    #[tokio::test]
+    async fn an_empty_base_offers_only_the_verb_that_can_work() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core.clone()).await;
+
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let empty = body_of(res).await;
+
+        assert!(
+            !empty.contains(r#"data-verb="ask""#),
+            "Ask can only abstain on an empty base, so the door is not there"
+        );
+        assert!(
+            !empty.contains(r#"class="keyhint""#),
+            "seven shortcuts for moving through a list with nothing in it"
+        );
+        assert!(
+            empty.contains("Paste anything worth keeping"),
+            "the placeholder names the one verb that can work"
+        );
+
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let held = body_of(res).await;
+
+        assert!(
+            held.contains(r#"data-verb="ask""#),
+            "one source is enough to have something to ask about"
+        );
+        assert!(
+            held.contains(r#"class="keyhint""#),
+            "and something to move through"
+        );
+        assert!(
+            held.contains("Describe the situation"),
+            "the placeholder goes back to naming all three verbs"
+        );
     }
 
     fn answer_fixture(dropped: usize) -> String {

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -883,6 +883,33 @@ mod tests {
         );
     }
 
+    /// The receipt now shows the queue, and the queue speaks in statuses — a
+    /// row reading "segmenting 3/7" over a paste is the first thing a new
+    /// reader sees and the last thing they can interpret. A tooltip would not
+    /// reach them: the camera path is the phone's, and a phone has no hover.
+    #[tokio::test]
+    async fn the_receipt_says_what_the_work_below_it_means() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ui/capture")
+                    .header("cookie", &cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("text=LevelDB+tombstones+survive+compaction."))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(
+            html.contains("searchable once it settles"),
+            "the receipt says what the row under it is counting towards: {html}"
+        );
+    }
+
     fn answer_fixture(dropped: usize) -> String {
         askama::Template::render(&AnswerTemplate {
             answer: "<p>An answer.</p>".into(),

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -826,6 +826,31 @@ mod tests {
         );
     }
 
+    /// An OIDC user never sees the login card, so the tagline and the privacy
+    /// boundary have to be said where the eye already is — under the box, not
+    /// on a settings page nobody opens before pasting.
+    #[tokio::test]
+    async fn an_empty_base_says_what_this_is_and_whose_it_is() {
+        let html = workspace("/ui").await;
+        assert!(
+            html.contains("finds it again by meaning"),
+            "what the application does, in one clause"
+        );
+        assert!(
+            html.contains("nobody else can search it"),
+            "and the boundary, which is what a person wants before pasting \
+             their own notes onto someone else's server"
+        );
+        assert!(
+            !html.contains("Search to see an artifact here"),
+            "an instruction that cannot be followed on an empty base"
+        );
+        assert!(
+            html.contains("kept exactly as you wrote it"),
+            "the pane says what will happen to the first thing pasted"
+        );
+    }
+
     fn answer_fixture(dropped: usize) -> String {
         askama::Template::render(&AnswerTemplate {
             answer: "<p>An answer.</p>".into(),

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -851,6 +851,38 @@ mod tests {
         );
     }
 
+    /// The gap between "captured" and "searchable" is a background job, and it
+    /// was invisible: a one-line receipt, then silence, then a search that
+    /// finds nothing. The queue fragment already reports the work and already
+    /// stops polling when it settles — it was only ever rendered on Insights.
+    #[tokio::test]
+    async fn the_capture_receipt_shows_the_work_that_is_still_running() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ui/capture")
+                    .header("cookie", &cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("text=LevelDB+tombstones+survive+compaction."))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let html = body_of(res).await;
+        assert!(
+            html.contains(r#"hx-get="/ui/queue""#),
+            "the receipt fetches the queue that reports the work"
+        );
+        assert!(
+            html.contains(r#"hx-trigger="load""#),
+            "on load, so the progress is there without a second press"
+        );
+    }
+
     fn answer_fixture(dropped: usize) -> String {
         askama::Template::render(&AnswerTemplate {
             answer: "<p>An answer.</p>".into(),

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -42,6 +42,8 @@ pub fn routes() -> Router<AppState> {
         // The capture door. GET is the workspace with the box filled; POST is
         // what the button on it and the browser extension both send.
         .route("/ui/capture", get(capture_door).post(capture_submit))
+        // The held-state regions, out of band. See `held_regions`.
+        .route("/ui/held", get(held_regions))
         // The ask door, and the two-request stream behind it: the POST parks
         // the question and hands back an id, and an `EventSource` spends it.
         .route("/ui/ask", get(ask_door).post(ask_submit))
@@ -143,6 +145,49 @@ struct WorkspaceTemplate {
     /// the one that can, and the rest appears when there is something for it
     /// to act on.
     held: bool,
+    /// Always false here: the shared partials this page renders inline —
+    /// `_ask_verb.html`, `_keyhint.html`, `_box_hint.html`, `_pane_idle.html`
+    /// — mark themselves `hx-swap-oob` for the other caller, `HeldTemplate`,
+    /// which swaps the same four regions into a page already on screen.
+    oob: bool,
+}
+
+/// The four regions that read differently once the base stops being empty,
+/// rendered for an out-of-band swap into a workspace that is already open.
+///
+/// The page is built once. A capture posts to `/ui/capture` and swaps a
+/// receipt; the rail refresh swaps `#results`. Nothing else moves — so the
+/// paste that ends an empty base left the whole page still arranged for one,
+/// which is the state onboarding exists to leave. Fetched by app.js on the
+/// first capture that stores, and only that one.
+///
+/// The same partials the workspace includes, so the two accounts of what the
+/// held state says cannot drift apart.
+#[derive(Template)]
+#[template(path = "_held.html")]
+struct HeldTemplate {
+    ask_enabled: bool,
+    /// True by definition: this fragment exists only for the transition into
+    /// it. The field is here because the partials branch on it.
+    held: bool,
+    /// True by definition, for the same reason.
+    oob: bool,
+}
+
+/// Serves `HeldTemplate`, and only where something really is held: a page that
+/// asked for this before its capture stored would swap in an Ask verb over a
+/// base that still cannot answer.
+async fn held_regions(tenant: Tenant) -> Result<Response> {
+    let (corpora, _) = tenant.core.store.held_brief().await?;
+    if corpora == 0 {
+        return Err(crate::error::Error::NotFound);
+    }
+    Ok(HtmlTemplate(HeldTemplate {
+        ask_enabled: crate::web::state::ask_enabled(&tenant),
+        held: true,
+        oob: true,
+    })
+    .into_response())
 }
 
 /// Everything every door renders, before the door says what it opened for.
@@ -204,6 +249,7 @@ async fn base_template(
         open_with,
         idle,
         held: corpora > 0,
+        oob: false,
     })
 }
 
@@ -729,6 +775,19 @@ async fn ask_door(tenant: Tenant, Query(p): Query<AskPrefill>) -> Result<Respons
     if !tenant.core.asks() {
         return Err(crate::error::Error::NotFound);
     }
+    // Nothing held, no Ask button — `base_template` sets `held = false` and the
+    // template renders no `[data-verb="ask"]`, so this door used to answer 200
+    // with the question sitting in a box that has no way to send it and no
+    // word about why. Reachable: `_gaps.html` renders "ask again" from
+    // recorded searches, which outlive a purge of what they searched.
+    //
+    // Sent to the plain page rather than 404'd, because the question survives
+    // the redirect and search is the one verb an empty base can still honour.
+    let (corpora, _) = tenant.core.store.held_brief().await?;
+    if corpora == 0 {
+        let q: String = url::form_urlencoded::byte_serialize(p.q.as_bytes()).collect();
+        return Ok(axum::response::Redirect::to(&format!("/ui?q={q}")).into_response());
+    }
     let t = base_template(&tenant, p.q, String::new(), "ask").await?;
     Ok(HtmlTemplate(t).into_response())
 }
@@ -743,6 +802,34 @@ mod tests {
 
     async fn workspace(uri: &str) -> String {
         let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "{uri}");
+        body_of(res).await
+    }
+
+    /// The same, over a base holding one source.
+    ///
+    /// The ask door only opens where something is held: with nothing stored
+    /// the workspace renders no Ask verb, so the door redirects rather than
+    /// answer with a question in a box that has no way to send it.
+    async fn workspace_held(uri: &str) -> String {
+        let core = crate::core::test_support::test_core().await;
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
         let (app, cookie) = app_with_cookie(core).await;
         let res = app
             .oneshot(
@@ -907,6 +994,160 @@ mod tests {
         assert!(
             html.contains("searchable once it settles"),
             "the receipt says what the row under it is counting towards: {html}"
+        );
+    }
+
+    /// A capture that stored nothing must not promise that something is being
+    /// read. Both the "searchable once it settles" line and the queue it polls
+    /// sat outside the branch, so a duplicate said "nothing was processed a
+    /// second time" and then, in the next sentence, that it was being read —
+    /// over a queue row that would sit parked at zero artifacts forever.
+    #[tokio::test]
+    async fn a_receipt_for_a_paste_nothing_processed_promises_no_processing() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let post = |app: axum::Router, cookie: String| async move {
+            let res = app
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/ui/capture")
+                        .header("cookie", &cookie)
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .body(Body::from("text=LevelDB+tombstones+survive+compaction."))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+            body_of(res).await
+        };
+
+        let first = post(app.clone(), cookie.clone()).await;
+        assert!(
+            first.contains("searchable once it settles") && first.contains(r#"hx-get="/ui/queue""#),
+            "the ordinary path still reports the work it started: {first}"
+        );
+
+        let again = post(app, cookie).await;
+        assert!(
+            again.contains("nothing was processed a second time"),
+            "the second paste of the same text is a duplicate: {again}"
+        );
+        assert!(
+            !again.contains("searchable once it settles"),
+            "and a duplicate must not say it is being read: {again}"
+        );
+        assert!(
+            !again.contains(r#"hx-get="/ui/queue""#),
+            "nor poll a queue that will never move for it: {again}"
+        );
+    }
+
+    /// The page is rendered once. Nothing re-renders it after a capture — the
+    /// receipt swaps into the pane and the rail refreshes — so the paste that
+    /// ended an empty base left the whole workspace still arranged for one.
+    /// `/ui/held` is what app.js swaps over that.
+    #[tokio::test]
+    async fn the_first_capture_can_redress_a_page_built_for_an_empty_base() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core.clone()).await;
+
+        let empty = workspace("/ui").await;
+        assert!(
+            empty.contains(r#"data-held="0""#),
+            "the page says it was built for an empty base: {empty}"
+        );
+        assert!(
+            empty.contains(r#"data-placeholder-held="Describe the situation"#),
+            "and carries the sentence its box will use once something is held, \
+             because swapping a textarea would take the caret with it: {empty}"
+        );
+
+        // Nothing held, nothing to swap: an Ask verb over a base that cannot
+        // answer is the promise this whole state exists to avoid.
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/held")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/held")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let held = body_of(res).await;
+        for region in [
+            r#"id="ask-verb-slot""#,
+            r#"id="keyhint-slot""#,
+            r#"id="box-hint""#,
+            r#"id="pane-idle""#,
+        ] {
+            assert!(held.contains(region), "{region} is not in the swap: {held}");
+        }
+        assert_eq!(
+            held.matches(r#"hx-swap-oob="true""#).count(),
+            4,
+            "every region names its own target, or it lands nowhere: {held}"
+        );
+        assert!(
+            held.contains(r#"data-verb="ask""#) && held.contains(r#"class="keyhint""#),
+            "the two controls an empty base withholds: {held}"
+        );
+        assert!(
+            held.contains("Search to see an artifact here"),
+            "and the hints for the state it is now in: {held}"
+        );
+    }
+
+    /// A question in a box with no way to send it. `held = false` renders no
+    /// Ask verb, so this door used to answer 200 with the question prefilled,
+    /// no button, and no word about why — reachable from a gap's "ask again",
+    /// which outlives a purge of what it was asked about.
+    #[tokio::test]
+    async fn the_ask_door_over_an_empty_base_sends_the_question_somewhere_it_works() {
+        let core = crate::core::test_support::test_core().await;
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/ask?q=why+did+the+reindex+fail")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        let to = res.headers()["location"].to_str().unwrap().to_string();
+        assert!(
+            to.starts_with("/ui?q="),
+            "sent to the one verb an empty base can honour: {to}"
+        );
+        assert!(
+            to.contains("why") && to.contains("reindex"),
+            "with the question still in it: {to}"
         );
     }
 
@@ -1482,7 +1723,7 @@ mod tests {
     async fn an_ask_in_flight_offers_a_way_to_stop_it() {
         // Fifty seconds signalled by a small grey "thinking…" beside the
         // button, and nothing on the page to end it with.
-        let html = workspace("/ui/ask").await;
+        let html = workspace_held("/ui/ask").await;
         assert!(html.contains(r#"id="ask-stop""#), "{html}");
     }
 
@@ -1492,7 +1733,7 @@ mod tests {
         // seconds, restating the prompt's own constraints verbatim — "Answer
         // *only* using the provided knowledge-base excerpts" — above the empty
         // space where the answer was going to be.
-        let html = workspace("/ui/ask").await;
+        let html = workspace_held("/ui/ask").await;
         assert!(html.contains("ask-reasoning-box"), "{html}");
         assert!(
             !html.contains("<details open")

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -910,6 +910,55 @@ mod tests {
         );
     }
 
+    /// A button that is dead on arrival and says nothing about why reads as a
+    /// broken application rather than as a control waiting for its input.
+    #[tokio::test]
+    async fn a_disabled_verb_says_what_it_is_waiting_for() {
+        let html = workspace("/ui").await;
+        assert!(
+            html.contains(r#"title="Type or attach something first""#),
+            "the disabled verb names what it wants: {html}"
+        );
+        // The element, not the phrase: the same sentence is already on the
+        // label's `title`, so asserting the words alone would pass on a page
+        // where the only copy of them is the tooltip this exists to replace.
+        assert!(
+            html.contains(r#"class="muted hint attach-types""#),
+            "and Attach names its types where a finger can read them, not only \
+             in a tooltip: {html}"
+        );
+    }
+
+    /// Results appear beside a person who pressed nothing. The old hint
+    /// explained how to phrase a query, which is true and is not the thing
+    /// they do not know.
+    #[tokio::test]
+    async fn the_box_says_that_typing_is_already_searching() {
+        let core = crate::core::test_support::test_core().await;
+        core.ingest_capture(crate::core::ingest::Capture::new(
+            "LevelDB tombstones survive compaction longer than the manual admits.",
+            "ui",
+        ))
+        .await
+        .unwrap();
+        let (app, cookie) = app_with_cookie(core).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_of(res).await;
+        assert!(
+            html.contains("Typing searches"),
+            "the one thing a first-time user cannot deduce from the page: {html}"
+        );
+    }
+
     fn answer_fixture(dropped: usize) -> String {
         askama::Template::render(&AnswerTemplate {
             answer: "<p>An answer.</p>".into(),


### PR DESCRIPTION
The application is about to be opened to more than one person, and there was no
first-run experience of any kind in the tree — no `welcome`, no `onboard`, no
seen-flag, nothing. A user arriving through their identity provider pressed
Continue and landed on an empty base with a box offering three verbs, two of
which cannot work.

No new routes, no new persistence, no schema change, and no change to search,
capture, ask or the API. One boolean at the web door carries the whole first-run
story.

## Onboarding is a property of an empty base, not of a new user

No welcome page, no scripted sequence, no per-user flag. Each surface asks the
state it can already see, which is what `_rail_idle.html` has always done —
generalised to the rest of the app.

The consequence worth having: the instruction cannot drift out of sync with
reality, it serves someone who deleted everything as well as someone who has
just arrived, and there is no stored flag to migrate, expire, or get wrong.

With nothing held, **Ask is not rendered** — absent rather than greyed, because
on an empty base it can only abstain. The placeholder names the one verb that
works. The keyboard hints do not render: seven shortcuts for moving through a
list with nothing in it. The pane stops instructing a reader with nothing stored
to search for something, and says what will happen to their first paste instead.

The hint under the box carries what the login card says and an OIDC user never
sees — what engram does, and that the base is theirs alone. That second half is
not decoration. Every user has held their own database and their own collection
since #52 and no page said so, which leaves the one question a person actually
has before pasting their own notes onto a server somebody else runs unanswered
everywhere.

## The captured-to-searchable blind spot

A paste was answered by one line and then silence while embedding ran as a
background job. Someone who searched for what they had just pasted found nothing
and read it as data loss — the likeliest place in the app to lose a new reader.

`_captured.html`'s own comment already named the cause: the queue that used to
say so moved to Insights and nothing replaced it. It is included again rather
than reimplemented — `_queue.html` already reports per-source progress, already
carries its own polling trigger, and already drops it the moment nothing is
moving, so an idle receipt costs one request and then none.

## Wording

"Artifact" stays; it is precise and defended in the comments. The rest is
consistency and glossing, and no URL, API field or Rust identifier moves.

- **`corpus` → "source"** in visible text. Not a third word: the UI already used
  both and switched between them without a rule.
- **"Judge" → "Review searches".** The old label named a role, and the badge
  invited a click into a page whose purpose was never stated — while that page
  asked twenty unordered candidates and a question with no account of why it was
  worth answering. The account is short and true: recall@10 and MRR on Insights
  are read off exactly these verdicts.
- **`extension.html` and `pair.html`** both sent a reader to "Housekeeping → API
  tokens": a heading that no longer exists, for a table that lives on Settings
  and always did.
- **Explanations are visible text, never a `title=`** — a tooltip is unreachable
  on a touch screen. The receipt's new queue speaks in statuses ("segmenting
  3/7"), which is the first thing a new reader meets; and "Worth a second look"
  ends in two icons whose whole meaning was in a tooltip.

## Insights, halved in place

The page answered two questions at once: what is in my memory and what needs me,
versus what is the machine doing. The second is operator-grade — stage
identifiers, target identifiers, raw error strings — and every user sees it now.
It moves behind a closed `<details>`. A route would have needed a handler, a
link and an empty state of its own to draw a line a disclosure draws outright.

The measures are gated on the base holding anything: three panels of zeros make
a healthy empty base read as a broken full one. **Only** the measures — the plan
called for gating the whole page and the suite refused it, correctly. A
knowledge gap is a question the base could not answer, which is precisely what
an empty base produces, and the sweeps run whether or not anything was ever
captured.

## Also

- Who you are, on Settings — off the tenant, which already carries the user.
- Settings joins the top row and the tabbar. It was one quiet link at the foot
  of a page you scroll, which on a phone made it unreachable by anyone who did
  not already know it was there. Tabbar items gain `min-width: 0`, since a flex
  item's floor is its content and a fourth entry would otherwise break
  "Insights" over two lines.
- Disabled verbs carry the reason they are dead; the box admits that typing is
  already searching; Attach names its types in the page.
- The feedback purge asked one forty-word question, which is a sentence nobody
  finishes before pressing the button under it.

Sign out stays in the top bar — making it two clicks to buy a nav slot is the
wrong trade.

## Verification

1870 tests pass. Each of the ten commits is test-first with its own cycle.

Walked end to end against a scratch database and a scratch collection, which
caught what the unit tests structurally could not: the first walkthrough ran a
stale binary, because `cargo test` builds the lib and askama compiles templates
in. After a rebuild, the empty base renders no Ask and no keyhints with both new
sentences; one capture flips it to Ask, keyhints and "Typing searches"; the
receipt shows a live queue row; Insights renders the measures with the
disclosure closed; Settings reads "Signed in as dev"; the source page titles as
"Source — engram" with `/ui/corpora/` intact.

**Unrelated, found on the way:** the repo's `config.toml` is stale against this
tree — the binary refuses it with `missing configuration field
"infer.ask.tier"`. The format moved to `[infer.tiers.<name>]` with roles naming
a tier.

Spec: `docs/superpowers/specs/2026-08-25-onboarding-polish-design.md`
Plan: `docs/superpowers/plans/2026-08-25-onboarding-polish.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uc8DxdURehF54spN2ce9H
