### PR TITLE
The document continues, and the plan's holes are kept

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,10 @@ as a paste the operator approves; one bounded round of planned retrieval behind
 `[infer.ask] plan`, fanning out to a search per uncovered subject; named model
 tiers, so a role picks a model by what the call is worth; judged questions with
 a second harness — citation recall, abstention, faithfulness by literals and by
-claim check; knowledge gaps grouped and named on the capture page; a
+claim check; knowledge gaps grouped and named on the capture page, the fifth
+kind of them the subjects a plan named and the base could not cover; what a
+hit's document does next, said on the rail and read in the pane, which appends
+the passages that follow one click at a time; a
 recommendation under the search box, learned from the situations an artifact
 was opened in — the browser's time zone and local time, the device, the
 viewport, the network and the power state, clustered per artifact and stored as
@@ -334,6 +337,21 @@ generation. And nothing is written to memory without a person: the
 keep-this-answer link prefills the capture box and saves nothing, so the trace
 records that a model wrote the text and what it was written from.
 
+Built: **the plan's uncovered subjects are gaps of their own**, a fifth
+`GapKind` beside the four the capture page already had. A subject whose fan-out
+search came back with every ranked candidate under `weak_below` is a hole the
+base named itself, for a question a person asked, out of a call that was
+already paid for. Weakness rather than emptiness, and deliberately the same
+threshold `Unmatched` reads — one definition of "nothing near this", at a
+second door. What makes it a kind rather than a second reading of `Unmatched`
+is the text: a subject a model named to describe a hole, where `Unmatched`
+carries a query somebody typed. Badged *planned*, and only at the web door,
+because a subject is derived from a question and `record_ask` already draws
+that line. Only the ranked hits are read — a neighbour reached sideways is
+structure, not a match. The cost was not the "one commit" this file estimated:
+it wanted a table, because planned rounds deliberately write nothing to the
+search log.
+
 Model tiers are built: named tiers under `[infer.tiers.*]`, each chat role
 pointing at one, resolved at parse time into the same concrete role structs the
 completers already took. The planning call runs on the efficient tier while the
@@ -342,17 +360,6 @@ too (`2026-08-17-ask-harness-design.md`): verdicts with carriers,
 `questions.json` in the export, `evaluate_ask` measuring citation recall,
 abstention accuracy and faithfulness by literals and by claim check, and
 "nothing here" surfaced as a knowledge gap.
-
-- **The plan's uncovered subjects are gap candidates.** When `[infer.ask] plan`
-  names the subjects the excerpts miss, it has said out loud what the base does
-  not hold, in the model's own words, one bounded round per question. Today each
-  becomes a search and is then thrown away. A subject whose fan-out search came
-  back with nothing is a knowledge gap that cost nothing to find.
-  **Worth:** gaps from a call already paid for, and the most specific ones on
-  the queue — a named subject beats "this search scored low".
-  **Cost:** keep what the plan already computed and write it as a fifth
-  `GapKind` (`src/store/gaps.rs:10`), with the same coverage and dismissal paths
-  the other four use. **One commit.**
 
 - **Whether the planning call earns itself, and whether packing to the cliff
   helps with no reranker configured.** A search's own fused scores are smooth
@@ -388,19 +395,29 @@ abstention accuracy and faithfulness by literals and by claim check, and
 What ask learns at write time, search inherits. Ask verdicts join judged
 searches as access cues under **access reconsolidation** above. The cliff is
 built (`search::cliff`, `src/core/search.rs:256`) and ask packs to it. The items
-here are search's own, and all but the first move ranking.
+here are search's own, and every one of them moves ranking.
 
-- **Continues in.** A hit whose neighbour in its corpus (adjacent ordinal) is
-  also above the cliff says so, and one click reads on. The answer to a
-  situation is often the paragraph after the one that matched. Most of the
-  machinery arrived with ask's sideways reach: `Store::adjacent_artifacts`
-  exists (`src/store/artifacts.rs:660`), and `ask/retrieve.rs` already decides
-  which hits are reliable enough to reach from. What is left is the presentation
-  — saying so on the rail, and the click.
-  **Worth:** the paragraph after the match stops being something the operator
-  has to go and find. Highest worth-per-line in this section, and the only item
-  here that needs no measurement.
-  **Cost:** a badge on the rail and a route behind the click. **One commit.**
+Built: **continues in**, and it turned out to be two things rather than one. On
+the rail a hit says what its document does next — *continues in #2* where the
+next passage itself placed, *continues in the next passage* where it did not,
+never both. In the pane the document actually continues: opening a passage
+appends the one after it, and a control appends the next as often as it is
+clicked, until the document ends and the control becomes the way into the
+document. The source column grows with the run, recomputed rather than
+appended so the lines between two adjacent passages are not printed twice.
+
+Two things it did not become. Not an inline expansion on the rail — the rail is
+a `listbox` whose rows are options, and a disclosure inside an option breaks
+the arrow keys as well as the ARIA. And not a semantic chain: adjacent passages
+are additionally similar through their shared heading (see **Server-side
+grouping** below), so such a chain ends where the formatting changes rather
+than where the meaning does, and a pane whose length is a computed judgement
+cannot tell the reader whether it stopped because the document ended or because
+a number was not met. The run length rides in the link, so the reader is the
+stopping rule. Cross-corpus was considered and belongs elsewhere: `ordinal` is
+a per-corpus sequence, so there is no reading order to continue into, and what
+a near artifact in another document is — a neighbour — the pane already shows
+as *Related* and *Seen together*.
 
 - **Server-side grouping — a prerequisite, not a nice-to-have.** The per-corpus
   cap is applied client-side over a candidate pool three times the limit; a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -261,15 +261,28 @@ the write-time half of the same question and carries an instrument of its own.
   commit of its own carrying both numbers in its message. It moves that way or
   it does not move.
 
-- **Dropping the `scope` block.** At weight 10 against a total under 5, that
-  block is what keeps one person's situations from being ranked first for
-  another. The read path cuts foreign clusters exactly, so the block is a
-  ranking aid rather than the guarantee — but it stays until each user has their
-  own collection.
-  **Worth:** none for a single operator. It is a correctness item for the day
-  tenancy exists, and nothing else about the encoder changes with it.
-  **Cost:** one weight to 0. **One commit**, blocked on **Multi-user tenancy**
-  below.
+- **Dropping the `scope` block.** *(unblocked)* At weight 10 against a total
+  under 5, that block is what kept one person's situations from being ranked
+  first for another while everyone shared a collection. Everyone no longer does:
+  each user has their own database and their own Qdrant collection, and the read
+  path cuts foreign clusters exactly on top of that (`recommend.rs:177`), which
+  was always the guarantee. Inside one collection every cluster now carries the
+  same subject, so the block is a constant: the same direction of magnitude 10
+  in every stored vector and in the query, ordering nothing and — under
+  cosine — compressing the differences the seven blocks that *do* describe the
+  situation are able to make. `context_score` already slices it off, so the
+  gate never read it; only the ranking still carries it.
+  **Worth:** the full cosine stops being dominated by a block that decides
+  nothing, so the two numbers behind an offer are read on the same evidence.
+  Small in itself, and the honest precondition for fitting weights to history —
+  a fit over a mostly-constant block is a fit over noise.
+  **Cost:** not one weight after all. The weights are the encoder version
+  (`core::context::encoder_version`), so changing one retires every stored
+  cluster: they are skipped rather than explained with the wrong blocks, and the
+  offer falls to its `Random` floor until `jobs::context` has re-clustered. That
+  is correct behaviour and it is still a cost, and it argues for spending it
+  before the shown/clicked history is long enough to be worth keeping.
+  **One commit**, plus one sweep before the offer speaks again.
 
 - **Speculative synthesis.** Promotion is retrospective: a window is rewritten
   once its passages have earned it. The prospective half is to spend an idle
@@ -514,6 +527,23 @@ keep in step — and every one of the three exits re-enables through the one
 `stop()` the stream already funnelled them into, including the transport error
 that would otherwise have left the page disabled for good.
 
+Built: **multi-user tenancy**, and not in the shape this file predicted (spec
+`2026-08-24-multi-user-tenancy-design.md`). It was listed here as
+de-prioritised and payload-partitioned; it shipped as a database and a Qdrant
+collection per user, with the job queue and one worker pool staying
+instance-wide. The split follows what is actually scarce: files and collections
+are cheap and get divided, the embed and synthesize endpoints are one GPU and
+stay shared, and the queue is where the two planes meet, which is why the
+tenant lives in the queue rather than in a registry beside it. Isolation is
+structural — there is no tenant filter to forget, because no tenant filter
+exists. Identity comes with it: the provider is the gate, and the local account
+store engram used to keep for a single operator is gone.
+
+Two items above are downstream of that. **Dropping the `scope` block** is
+unblocked and now has a cost worth naming. **OAuth 2.1 for `/mcp`** stopped
+being administrative — with a collection per user, a bearer token is what
+decides whose base a call reads.
+
 - **One dial instead of eight gates.** Three are gone: `[learn]` is now the
   single switch over recording, association and pursuits, and the sections below
   it keep their thresholds and no switch of their own. What is left is the half
@@ -573,18 +603,15 @@ that would otherwise have left the page disabled for good.
   **Cost:** a snapshot call, a file copy, a restore path that checks the two
   agree. **A branch.**
 
-- **OAuth 2.1 for `/mcp`.** OIDC login for the web UI is built; the MCP surface
-  still authenticates on its own terms.
-  **Worth:** one identity model instead of two — and `/mcp` is about to become
-  the door that teaches the base, which makes "who is this" load-bearing rather
-  than administrative.
+- **OAuth 2.1 for `/mcp`.** The web UI's identity is the provider's now, and
+  the local one it used to keep is gone. `/mcp` still authenticates on its own
+  terms: a bearer token, checked against `api_tokens`, with nothing but the
+  protected-resource host taken from the OIDC config.
+  **Worth:** one identity model instead of two, and it is no longer only
+  administrative. With a database and a collection per user, a token is what
+  decides *whose* base a call reads — an answer the web door now gets from the
+  provider and the MCP door still gets from a row.
   **Cost:** the MCP surface moved onto the existing OIDC path. **A branch.**
-
-- **Multi-user tenancy.** *(de-prioritised)* Payload-partitioned rather than a
-  collection per user. Single-operator use is the design point.
-  **Worth:** none for the design point. It unblocks **Dropping the `scope`
-  block** and nothing else.
-  **Cost:** **a project**, and it stays de-prioritised.
 
 - `clippy` is not run locally in every environment; CI is the only gate.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -601,9 +601,20 @@ self_weight = 0.0
 # weight however many dimensions it uses — seven one-hot slots for the weekday
 # do not outweigh two for the hour because there are seven of them.
 [recommend.weights]
-# Interim, and load-bearing: every person shares one collection today, so this
-# is what keeps one person's situations from being offered to another. It goes
-# to 0 when each user has their own collection.
+# Interim, and no longer load-bearing. This kept one person's situations from
+# being ranked first for another back when everyone shared one collection; each
+# user now has their own database and their own collection, and the read path
+# cuts foreign clusters by an exact match on top of that, which was always the
+# guarantee. Inside one collection every cluster carries the same subject, so
+# this block is the same direction in every stored vector and in the query: it
+# orders nothing, and under cosine it flattens the differences the blocks below
+# can make. `strong_at`/`weak_at` never saw it — the gate slices it off — so
+# only the ranking still carries it.
+#
+# It stays at 10.0 for one reason: the weights *are* the encoder version, so
+# changing this retires every cluster already learnt and the offer falls back
+# to a random card until the next context sweep has rebuilt them. Set it to 0
+# when you would rather pay that sweep than keep the distortion.
 scope = 10.0
 # The hour, as an angle — 23:30 and 00:30 are an hour apart, and 14:55 against a
 # 15:00 pattern costs almost nothing.

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -26,6 +26,14 @@ pub struct AskRequest {
 
 /// What one retrieval round produced.
 struct Round {
+    /// The query this round ran. Round one carries the question as it was
+    /// asked; a planned round carries the subject the model named.
+    ///
+    /// Held on the round rather than zipped alongside it, because `fan_out`
+    /// drops a round that failed — a list of queries and a list of rounds stop
+    /// lining up the moment one endpoint times out, and the thing that would
+    /// then be mislabelled is a claim about what the base does not hold.
+    query: String,
     /// Above the cliff, with whatever was reached sideways appended.
     hits: Vec<SearchResult>,
     /// How many of `hits` are ranked. Everything after them was reached.
@@ -160,7 +168,9 @@ impl Core {
                 // question that retrieved nothing.
                 yield AskEvent::Retrieved { round: 1, retrieved: 0, shown: 0, dropped: 0, cliff_at: None };
                 yield AskEvent::Citations(vec![]);
-                let response = core.record_ask(&req, &origin, response).await?;
+                // Nothing was planned — this returns before the plan runs — so
+                // there are no uncovered subjects to record.
+                let response = core.record_ask(&req, &origin, response, &[]).await?;
                 yield AskEvent::Done(Box::new(response));
                 return;
             }
@@ -202,7 +212,9 @@ impl Core {
                     cliff_at: first.cliff_at,
                 };
                 yield AskEvent::Citations(vec![]);
-                let response = core.record_ask(&req, &origin, response).await?;
+                // Nothing was planned — this returns before the plan runs — so
+                // there are no uncovered subjects to record.
+                let response = core.record_ask(&req, &origin, response, &[]).await?;
                 yield AskEvent::Done(Box::new(response));
                 return;
             }
@@ -229,6 +241,9 @@ impl Core {
             // `needed_queries` returns empty the moment no planning model is
             // wired, so with the feature off this costs one `Option` check and
             // no call at all.
+            // The subjects the plan named that nothing came back for. Empty
+            // with planning off, and empty when the plan named nothing.
+            let mut uncovered: Vec<String> = Vec::new();
             let queries = plan::needed_queries(&core, &req.q, &blocks[..kept]).await;
             if !queries.is_empty() {
                 yield AskEvent::Needs(queries.clone());
@@ -238,6 +253,10 @@ impl Core {
                 // charge the reader one embedding round trip per subject for no
                 // reason. `PLAN_MAX_QUERIES` caps the plan and so caps this.
                 let extra = core.fan_out(&req, &queries).await;
+                // Read before the rounds are merged away. A subject the base
+                // held nothing near is a hole it just named itself, and after
+                // the merge there is no round left to ask.
+                uncovered = plan::uncovered(&extra);
 
                 // Round one's hits are the first part, so round-robin starts
                 // with the question as it was actually asked.
@@ -411,7 +430,7 @@ impl Core {
             };
             // Recorded here rather than by either door, so one ask is one row
             // however it was asked. The harness reads these.
-            let response = core.record_ask(&req, &origin, response).await?;
+            let response = core.record_ask(&req, &origin, response, &uncovered).await?;
             yield AskEvent::Done(Box::new(response));
         }
     }
@@ -547,6 +566,7 @@ impl Core {
         self.reach_sideways(&mut hits, cliff_at).await;
 
         Ok(Round {
+            query: q.to_string(),
             hits,
             ranked,
             retrieved,
@@ -883,6 +903,7 @@ impl Core {
         req: &AskRequest,
         origin: &Origin,
         mut response: AskResponse,
+        uncovered: &[String],
     ) -> Result<AskResponse> {
         if !(self.learn.enabled && origin.door == Door::Ui) {
             return Ok(response);
@@ -932,7 +953,31 @@ impl Core {
                 .collect(),
         );
         match self.store.record_ask(ask).await {
-            Ok(id) => response.event_id = Some(id),
+            Ok(id) => {
+                // The subjects the plan named and the base could not cover,
+                // written as gaps of their own. They hang off the question,
+                // so this runs only where the question was recorded — the
+                // same door, in the same breath, and never for an ask whose
+                // insert failed and has no row to hang from.
+                //
+                // The vector costs nothing: the fan-out embedded each subject
+                // in order to search for it, and the query cache still holds
+                // what it embedded. A subject whose vector has fallen out of
+                // the cache is stored without one and skipped by every reader
+                // here — the fact that it was named is still worth more than
+                // the row is worth refusing.
+                for subject in uncovered {
+                    let vec = self.cached_query_vector(subject).unwrap_or_default();
+                    if let Err(e) = self
+                        .store
+                        .record_uncovered_subject(&id, subject, &vec, self.embedder.model())
+                        .await
+                    {
+                        tracing::warn!(error = %e, subject, "could not record an uncovered subject");
+                    }
+                }
+                response.event_id = Some(id);
+            }
             Err(e) => tracing::warn!(error = %e, "could not record the question"),
         }
         Ok(response)
@@ -1189,6 +1234,57 @@ mod tests {
             model.calls(),
             1,
             "a plan that plans again is a third round waiting to happen"
+        );
+    }
+
+    /// The plan says out loud what the base does not hold, in the model's own
+    /// words, for a question a person asked in earnest — and the call was
+    /// already paid for. The subject that came back with nothing becomes a gap
+    /// rather than being discarded with the round.
+    #[tokio::test]
+    async fn a_planned_subject_the_base_could_not_cover_becomes_a_gap() {
+        let (mut core, _) = core_with_planner(Some(r#"{"need": ["mounting an E01"]}"#)).await;
+        core.learn.enabled = true;
+        // A base where nothing matches closely. Cosine tops out at 1, so every
+        // candidate is under this — which is the situation the kind exists for,
+        // stated as a threshold rather than hoped for from a fake embedder.
+        core.weak_below = 1.0;
+        core.ask(&req("chunk"), Door::Ui.by("me")).await.unwrap();
+
+        let gaps = core
+            .store
+            .open_gap_refs(core.embedder.model(), core.weak_below)
+            .await
+            .unwrap();
+        let subjects: Vec<&str> = gaps
+            .iter()
+            .filter(|g| g.kind == crate::store::gaps::GapKind::Subject)
+            .map(|g| g.text.as_str())
+            .collect();
+        assert_eq!(subjects, vec!["mounting an E01"]);
+    }
+
+    /// The same rule `record_ask` already draws, and for the same reason: a
+    /// subject is derived from a question, a question is personal data of the
+    /// same kind as a query, and API and MCP callers asked for the smallest
+    /// footprint. The bump rides with the recording rather than around it.
+    #[tokio::test]
+    async fn the_api_door_names_no_subjects() {
+        let (mut core, _) = core_with_planner(Some(r#"{"need": ["mounting an E01"]}"#)).await;
+        core.learn.enabled = true;
+        core.weak_below = 1.0;
+        core.ask(&req("chunk"), Door::Api).await.unwrap();
+
+        let gaps = core
+            .store
+            .open_gap_refs(core.embedder.model(), core.weak_below)
+            .await
+            .unwrap();
+        assert!(
+            !gaps
+                .iter()
+                .any(|g| g.kind == crate::store::gaps::GapKind::Subject),
+            "a door that records no question recorded what its plan named"
         );
     }
 

--- a/src/core/ask/plan.rs
+++ b/src/core/ask/plan.rs
@@ -79,3 +79,107 @@ pub(super) async fn needed_queries(
     }
     queries
 }
+
+/// Which of the planned subjects the base turned out not to hold.
+///
+/// The plan names what the first round's excerpts miss; each subject then gets
+/// a search of its own. A subject whose search came back with every ranked
+/// candidate *weak* — under `vector.weak_below` — is a hole in the base, stated
+/// in the model's own words, for a question a person actually asked. Today that
+/// is computed, used to widen one answer, and thrown away.
+///
+/// Weakness rather than emptiness, and for the reason `GapKind::Unmatched`
+/// gives: retrieval always returns its best candidates however bad they are, so
+/// "no hits" almost never happens and "nothing near" is the measurable form of
+/// the same claim. It is deliberately the same threshold — one definition of
+/// "the base held nothing near this", read at a second door.
+///
+/// Only the *ranked* hits are read. What a round reached sideways is structure
+/// rather than a match: a neighbour is on the page because it sits next to
+/// something, and letting it argue that a subject was covered would silence the
+/// gap on evidence about a different passage.
+///
+/// A round that failed is not here at all — `fan_out` drops it — and that is
+/// right: a search that never ran is not evidence that the base lacks anything.
+pub(super) fn uncovered(rounds: &[super::Round]) -> Vec<String> {
+    rounds
+        .iter()
+        .filter(|r| r.hits[..r.ranked].iter().all(|h| h.weak))
+        .map(|r| r.query.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::search::SearchResult;
+
+    fn hit(weak: bool) -> SearchResult {
+        SearchResult {
+            artifact_id: "a".into(),
+            corpus_id: "s".into(),
+            title: None,
+            text: "body".into(),
+            category: None,
+            tags: vec![],
+            score: 0.5,
+            status: None,
+            superseded_by: None,
+            last_verified_at: None,
+            weak,
+            primed: false,
+            in_sitting: false,
+            past_cliff: false,
+            via: None,
+            reason: None,
+            model_written: false,
+            synthesized: false,
+            origin_count: 0,
+        }
+    }
+
+    fn round(query: &str, ranked: Vec<SearchResult>) -> super::super::Round {
+        super::super::Round {
+            query: query.into(),
+            ranked: ranked.len(),
+            hits: ranked,
+            retrieved: vec![],
+            cliff_at: None,
+        }
+    }
+
+    /// The subject the model asked for and the base could not answer. The
+    /// planning call already paid for this; today it is discarded.
+    #[test]
+    fn a_subject_whose_every_hit_was_weak_is_uncovered() {
+        let rounds = [round("job priority", vec![hit(true), hit(true)])];
+        assert_eq!(super::uncovered(&rounds), vec!["job priority".to_string()]);
+    }
+
+    /// One real match is coverage. The subject was named as missing and turned
+    /// out not to be, which is the fan-out working rather than a hole.
+    #[test]
+    fn a_subject_with_one_real_match_is_not_a_gap() {
+        let rounds = [round("job priority", vec![hit(true), hit(false)])];
+        assert!(super::uncovered(&rounds).is_empty());
+    }
+
+    /// Nothing came back at all. Rare, because retrieval returns its best
+    /// candidates however bad they are — but when it happens it is the same
+    /// claim in its strongest form.
+    #[test]
+    fn a_subject_that_returned_nothing_is_uncovered() {
+        let rounds = [round("job priority", vec![])];
+        assert_eq!(super::uncovered(&rounds), vec!["job priority".to_string()]);
+    }
+
+    /// What a round reached sideways is not a match. A neighbour is on the page
+    /// because it sits beside something, and letting it vouch for a subject
+    /// would close a gap on evidence about a different passage.
+    #[test]
+    fn a_neighbour_reached_sideways_does_not_cover_a_subject() {
+        let mut r = round("job priority", vec![hit(true)]);
+        // Appended past `ranked`, exactly as `reach_sideways` appends.
+        r.hits.push(hit(false));
+        assert_eq!(super::uncovered(&[r]), vec!["job priority".to_string()]);
+    }
+}

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -37,7 +37,7 @@ static COVER_SLOTS: std::sync::LazyLock<tokio::sync::Semaphore> =
 /// How many gaps one capture is checked against.
 ///
 /// `COVER_SLOTS` bounds how many queries are in the air, which is not a bound
-/// on how many there are. `open_gaps` caps each of four kinds at
+/// on how many there are. `open_gaps` caps each of five kinds at
 /// `MAX_OPEN_GAPS`, so one capture can ask two thousand questions of the vector
 /// store, and `settle_corpus` asks them once per document that reaches `ready`:
 /// an ingest of fifty documents is a hundred thousand round trips. Nothing
@@ -76,7 +76,7 @@ pub struct SweepReport {
 /// waiting, and two thousand at once is not concurrency but an outage in the
 /// vector store the whole memory shares. How many there are at all is
 /// `COVER_MAX_GAPS`, because concurrency is not a ceiling on the total — there
-/// are four kinds of gap, each capped at `MAX_OPEN_GAPS`, and since the
+/// are five kinds of gap, each capped at `MAX_OPEN_GAPS`, and since the
 /// unmatched ones are derived from the search log without anybody judging
 /// anything, a base with capture on reaches those caps as a matter of course
 /// rather than as a worst case.

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -690,6 +690,80 @@ impl Store {
             .collect())
     }
 
+    /// For each of `ids`, the next *active* artifact in the same document —
+    /// one read for a whole result list rather than one per row.
+    ///
+    /// What the rail needs to say "this one continues". Absent means the
+    /// artifact ends its document, or belongs to none: a merged artifact has no
+    /// `corpus_id` and therefore no reading order to continue in, and the join
+    /// drops it rather than reaching into another document's ordinals.
+    ///
+    /// A correlated subquery rather than a second round trip per hit. The rail
+    /// is drawn on every keystroke of a search-while-typing box, and N+1 reads
+    /// down a ten-row list is the shape that turns a lookup into a cost.
+    pub async fn continuations_of(&self, ids: &[String]) -> Result<HashMap<String, String>> {
+        if ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let holes = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT a.id AS id,
+                    (SELECT n.id FROM artifacts n
+                      WHERE n.corpus_id = a.corpus_id
+                        AND n.ordinal > a.ordinal
+                        AND n.status = 'active'
+                      ORDER BY n.ordinal ASC LIMIT 1) AS next_id
+             FROM artifacts a
+             WHERE a.id IN ({holes}) AND a.corpus_id IS NOT NULL"
+        )));
+        for id in ids {
+            q = q.bind(id);
+        }
+        Ok(q.fetch_all(&self.pool)
+            .await?
+            .iter()
+            .filter_map(|r| {
+                r.get::<Option<String>, _>("next_id")
+                    .map(|next| (r.get::<String, _>("id"), next))
+            })
+            .collect())
+    }
+
+    /// The next `limit` *active* artifacts after `ordinal`, in reading order.
+    ///
+    /// `adjacent_artifacts` answers "what is either side of this one" and stops
+    /// at one row each way, which is what a sideways reach wants. A reader who
+    /// has asked to read on wants the run that follows, and wants it again when
+    /// they ask again — so the bound is the caller's and the position is an
+    /// ordinal rather than a page number. Contiguous by construction: each call
+    /// starts where the last one ended, so a document with rows hidden in the
+    /// middle still reads as one sequence.
+    ///
+    /// `status = 'active'` for the same reason it is there next door — a
+    /// superseded passage is not the next thing in the document, the row that
+    /// replaced it is. An empty run means the document ended, which is a state
+    /// the pane renders rather than an error.
+    pub async fn following_artifacts(
+        &self,
+        corpus_id: &str,
+        ordinal: i64,
+        limit: i64,
+    ) -> Result<Vec<Chunk>> {
+        let rows = sqlx::query(
+            "SELECT * FROM artifacts
+             WHERE corpus_id = ? AND ordinal > ? AND status = 'active'
+             ORDER BY ordinal ASC LIMIT ?",
+        )
+        .bind(corpus_id)
+        .bind(ordinal)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_artifact).collect())
+    }
+
     pub async fn artifacts_for_corpus(&self, corpus_id: &str) -> Result<Vec<Chunk>> {
         let rows = sqlx::query("SELECT * FROM artifacts WHERE corpus_id = ? ORDER BY ordinal")
             .bind(corpus_id)
@@ -1909,6 +1983,143 @@ mod tests {
             vec![ids[0].clone()],
             "the walk did not start over"
         );
+    }
+
+    /// The rail says a hit continues, and the whole list has to be answered in
+    /// one read rather than one per row.
+    #[tokio::test]
+    async fn continuations_of_names_the_next_active_artifact_for_a_whole_list() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c")])
+            .await
+            .unwrap();
+
+        let ids = vec![made[0].id.clone(), made[1].id.clone()];
+        let got = s.continuations_of(&ids).await.unwrap();
+        assert_eq!(got.get(&made[0].id), Some(&made[1].id));
+        assert_eq!(got.get(&made[1].id), Some(&made[2].id));
+    }
+
+    /// The last passage of a document continues nowhere, and the rail must say
+    /// nothing rather than offer a link to the end of the list.
+    #[tokio::test]
+    async fn continuations_of_omits_the_last_artifact_of_a_document() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b")])
+            .await
+            .unwrap();
+
+        let got = s.continuations_of(&[made[1].id.clone()]).await.unwrap();
+        assert!(
+            !got.contains_key(&made[1].id),
+            "the end of a document was given a continuation"
+        );
+    }
+
+    /// The same lifecycle rule as everywhere else on this path: what results
+    /// hide is not what the document continues into.
+    #[tokio::test]
+    async fn continuations_of_steps_over_a_row_that_is_not_active() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c")])
+            .await
+            .unwrap();
+        s.set_artifact_status(&made[1].id, ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+
+        let got = s.continuations_of(&[made[0].id.clone()]).await.unwrap();
+        assert_eq!(got.get(&made[0].id), Some(&made[2].id));
+    }
+
+    /// A merged artifact belongs to no corpus, so it has no reading order to
+    /// continue in. Asking must not invent one out of another document's rows.
+    #[tokio::test]
+    async fn continuations_of_says_nothing_about_a_merged_artifact() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        s.insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b")])
+            .await
+            .unwrap();
+        let merged = s
+            .insert_merged_artifact(
+                &NewMerged {
+                    text: "merged".into(),
+                    title: Some("m".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let got = s.continuations_of(&[merged.id.clone()]).await.unwrap();
+        assert!(!got.contains_key(&merged.id));
+        assert!(s.continuations_of(&[]).await.unwrap().is_empty());
+    }
+
+    /// Reading on is not the same question as reaching sideways. `adjacent`
+    /// answers "what is either side of this one" and stops at one row; a reader
+    /// who has said "append the next" wants the run that follows, in order, as
+    /// far as they keep asking.
+    #[tokio::test]
+    async fn following_artifacts_returns_the_run_after_an_ordinal_in_order() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..6).map(|i| nc(i, &format!("chunk {i}"))).collect();
+        s.insert_artifacts(&src.id, &new).await.unwrap();
+
+        let got = s.following_artifacts(&src.id, 1, 3).await.unwrap();
+        let ordinals: Vec<i64> = got.iter().map(|c| c.ordinal).collect();
+        assert_eq!(ordinals, vec![2, 3, 4], "the run must follow in reading order");
+    }
+
+    /// The same lifecycle rule `adjacent_artifacts` already applies. A reader
+    /// asking to read on must not be handed what results hide: a superseded
+    /// passage is not the next thing in the document, the row that replaced it
+    /// is.
+    #[tokio::test]
+    async fn following_artifacts_skips_rows_that_are_not_active() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b"), nc(2, "c"), nc(3, "d")])
+            .await
+            .unwrap();
+        s.set_superseded_by(&made[1].id, Some(&made[3].id))
+            .await
+            .unwrap();
+        s.set_artifact_status(&made[2].id, ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+
+        let got = s.following_artifacts(&src.id, 0, 3).await.unwrap();
+        assert_eq!(
+            got.iter().map(|c| c.text.as_str()).collect::<Vec<_>>(),
+            vec!["d"]
+        );
+    }
+
+    /// What the pane reads to decide whether to offer the control at all. At
+    /// the end of a document the answer is an empty run, not an error — the
+    /// button is then replaced by the link to the document rather than
+    /// returning nothing on a click nobody could have known was pointless.
+    #[tokio::test]
+    async fn following_artifacts_at_the_end_of_the_document_is_empty() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let new: Vec<NewArtifact> = (0..3).map(|i| nc(i, &format!("chunk {i}"))).collect();
+        s.insert_artifacts(&src.id, &new).await.unwrap();
+
+        assert!(s.following_artifacts(&src.id, 2, 3).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -2061,7 +2061,10 @@ mod tests {
             .await
             .unwrap();
 
-        let got = s.continuations_of(&[merged.id.clone()]).await.unwrap();
+        let got = s
+            .continuations_of(std::slice::from_ref(&merged.id))
+            .await
+            .unwrap();
         assert!(!got.contains_key(&merged.id));
         assert!(s.continuations_of(&[]).await.unwrap().is_empty());
     }
@@ -2079,7 +2082,11 @@ mod tests {
 
         let got = s.following_artifacts(&src.id, 1, 3).await.unwrap();
         let ordinals: Vec<i64> = got.iter().map(|c| c.ordinal).collect();
-        assert_eq!(ordinals, vec![2, 3, 4], "the run must follow in reading order");
+        assert_eq!(
+            ordinals,
+            vec![2, 3, 4],
+            "the run must follow in reading order"
+        );
     }
 
     /// The same lifecycle rule `adjacent_artifacts` already applies. A reader
@@ -2119,7 +2126,12 @@ mod tests {
         let new: Vec<NewArtifact> = (0..3).map(|i| nc(i, &format!("chunk {i}"))).collect();
         s.insert_artifacts(&src.id, &new).await.unwrap();
 
-        assert!(s.following_artifacts(&src.id, 2, 3).await.unwrap().is_empty());
+        assert!(
+            s.following_artifacts(&src.id, 2, 3)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -31,6 +31,23 @@ pub enum GapKind {
     /// row. A pursuit written before that has none and is not a gap, which is
     /// the same rule `vec_dim > 0` already applies to everything else here.
     Pursuit,
+    /// A subject `[infer.ask] plan` named as missing from the excerpts, whose
+    /// own fan-out search then found nothing near it either.
+    ///
+    /// The measurement is `Unmatched`'s — every candidate under `weak_below` —
+    /// and that is deliberate: there is one definition of "the base held
+    /// nothing near this" and this reuses it rather than inventing a second.
+    /// What makes it a kind of its own is the *text*. `Unmatched` carries a
+    /// query somebody typed; this carries a subject a model named, in a
+    /// sentence written to describe a hole rather than to find a thing. A named
+    /// subject is the most specific thing on this list, and the badge says who
+    /// named it.
+    ///
+    /// Only at the web door. The subject is derived from a question, questions
+    /// are personal data of the same kind as a query, and `record_ask` already
+    /// draws that line — so this rides with the recording rather than around
+    /// it.
+    Subject,
 }
 
 impl GapKind {
@@ -40,6 +57,7 @@ impl GapKind {
             GapKind::Search => "search",
             GapKind::Unmatched => "unmatched",
             GapKind::Pursuit => "pursuit",
+            GapKind::Subject => "subject",
         }
     }
     pub fn parse(s: &str) -> Option<Self> {
@@ -48,6 +66,7 @@ impl GapKind {
             "search" => Some(GapKind::Search),
             "unmatched" => Some(GapKind::Unmatched),
             "pursuit" => Some(GapKind::Pursuit),
+            "subject" => Some(GapKind::Subject),
             _ => None,
         }
     }
@@ -119,8 +138,10 @@ pub struct GapRow {
 /// on every retention tick, and `ui::capture_page` — the page the app opens on —
 /// walks the same list with its full query vectors on every load.
 ///
-/// Per kind, and there are four of them, so what either reader actually gets is
-/// up to four times this. The sweep's clustering is quadratic in that total and
+/// Per kind, and there are five of them, so what either reader actually gets is
+/// up to five times this — the fifth, `Subject`, widened a quadratic loop by a
+/// quarter, which is the price of the kind and is named here rather than
+/// discovered later. The sweep's clustering is quadratic in that total and
 /// the capture page renders one row of it apiece, which is two million cosines
 /// on a timer and two thousand `<li>` before the first sweep has grouped
 /// anything. Both are the accepted cost of showing every kind of gap rather
@@ -235,6 +256,28 @@ macro_rules! unmatched_gaps_sql {
 /// naming prompt keeps the first twelve members, and a member that is itself a
 /// paragraph of queries would crowd out eleven other gaps. `queries` is JSON,
 /// so the first element is read out in Rust rather than in SQL.
+/// A subject the plan named and the fan-out could not cover.
+///
+/// The join to `ask_events` is what makes the row die with its question — a
+/// `DELETE` cascades, and a base whose foreign keys are off still cannot return
+/// an orphan through this. `dismissed_at` and `gap_coverage` close it the same
+/// way they close the other four.
+macro_rules! subject_gaps_sql {
+    ($cols:literal) => {
+        concat!(
+            "SELECT s.id, s.subject AS text",
+            $cols,
+            " FROM ask_subjects s
+              JOIN ask_events e ON e.id = s.event_id
+              WHERE s.dismissed_at IS NULL
+                AND s.embed_model = ? AND s.vec_dim > 0
+                AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                                 WHERE kind = 'subject' AND gap_id = s.id)
+              ORDER BY s.created_at DESC, s.id DESC LIMIT ?"
+        )
+    };
+}
+
 macro_rules! pursuit_gaps_sql {
     ($cols:literal) => {
         concat!(
@@ -376,7 +419,33 @@ impl Store {
         let pursuits_capped = (out.len() - before_pursuits) as i64 > MAX_OPEN_GAPS;
         out.truncate(before_pursuits + MAX_OPEN_GAPS as usize);
         let pursuits = out.len() - before_pursuits;
-        let capped = asks_capped || searches_capped || unmatched_capped || pursuits_capped;
+        let before_subjects = out.len();
+        for r in sqlx::query(subject_gaps_sql!(", s.query_vec, s.created_at"))
+            .bind(embed_model)
+            .bind(MAX_OPEN_GAPS + 1)
+            .fetch_all(&self.pool)
+            .await?
+        {
+            out.push((
+                r.get("created_at"),
+                GapVec {
+                    gap: Gap {
+                        kind: GapKind::Subject,
+                        id: r.get("id"),
+                        text: r.get("text"),
+                    },
+                    vec: blob_to_vec(&r.get::<Vec<u8>, _>("query_vec")),
+                },
+            ));
+        }
+        let subjects_capped = (out.len() - before_subjects) as i64 > MAX_OPEN_GAPS;
+        out.truncate(before_subjects + MAX_OPEN_GAPS as usize);
+        let subjects = out.len() - before_subjects;
+        let capped = asks_capped
+            || searches_capped
+            || unmatched_capped
+            || pursuits_capped
+            || subjects_capped;
         // The same key each half was already read by, applied across both:
         // whole-second `judged_at`, ties broken by a uuid v7 id, so a second's
         // worth of gaps is still ordered by when they were recorded.
@@ -389,10 +458,53 @@ impl Store {
                 searches,
                 unmatched,
                 pursuits,
+                subjects,
                 "more open gaps than one pass reads; the oldest are left out of this one"
             );
         }
         Ok(OpenGaps { gaps: out, capped })
+    }
+
+    /// A subject the plan named and the fan-out could not cover.
+    ///
+    /// Written only for the uncovered ones. A subject the fan-out answered is
+    /// not a hole and leaves no row, which is what keeps this table a list of
+    /// what the base lacks rather than a log of everything a planning call ever
+    /// said.
+    ///
+    /// The vector is handed in rather than embedded here. The fan-out already
+    /// embedded this subject in order to search for it, so the caller reads it
+    /// back out of the query cache and this costs no model call at all — which
+    /// is the whole argument for the kind: the call was paid for, and today its
+    /// findings are thrown away.
+    ///
+    /// An empty vector is stored as one rather than refused. Every reader here
+    /// already gates on `vec_dim > 0`, and a subject whose embedding could not
+    /// be recovered is a subject that was still named — refusing the row would
+    /// lose the fact to save a few bytes.
+    pub async fn record_uncovered_subject(
+        &self,
+        event_id: &str,
+        subject: &str,
+        query_vec: &[f32],
+        embed_model: &str,
+    ) -> Result<String> {
+        let id = crate::store::new_id();
+        sqlx::query(
+            "INSERT INTO ask_subjects
+               (id, event_id, subject, query_vec, vec_dim, embed_model, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(event_id)
+        .bind(subject)
+        .bind(crate::store::feedback::vec_to_blob(query_vec))
+        .bind(query_vec.len() as i64)
+        .bind(embed_model)
+        .bind(now())
+        .execute(&self.pool)
+        .await?;
+        Ok(id)
     }
 
     /// The same open gaps, without their vectors: what the capture page renders.
@@ -405,6 +517,7 @@ impl Store {
         for (sql, kind) in [
             (ask_gaps_sql!(""), GapKind::Ask),
             (search_gaps_sql!(""), GapKind::Search),
+            (subject_gaps_sql!(""), GapKind::Subject),
         ] {
             for r in sqlx::query(sql)
                 .bind(embed_model)
@@ -680,6 +793,17 @@ impl Store {
                     .execute(&self.pool)
                     .await?
             }
+            // Its own column, unlike `Search`/`Unmatched` above. A subject is
+            // not a second reading of some other row — it is a row of its own,
+            // written for one plan, and dismissing it says nothing about the
+            // question it came from.
+            GapKind::Subject => {
+                sqlx::query("UPDATE ask_subjects SET dismissed_at = ? WHERE id = ?")
+                    .bind(now())
+                    .bind(id)
+                    .execute(&self.pool)
+                    .await?
+            }
         };
         if res.rows_affected() == 0 {
             return Err(Error::NotFound);
@@ -831,6 +955,114 @@ mod tests {
             .unwrap();
         store.judge_ask(&id, AskVerdict::NothingHere).await.unwrap();
         id
+    }
+
+    /// A question whose plan named a subject the base could not cover.
+    async fn uncovered_subject(store: &Store, q: &str, subject: &str, vec: Vec<f32>) -> String {
+        let ask = store
+            .record_ask(NewAsk {
+                question: q.into(),
+                scope: None,
+                filters: "{}".into(),
+                query_vec: vec![1.0, 0.0],
+                embed_model: "fake".into(),
+                answer: "here is what I found".into(),
+                abstained: false,
+                dropped: 0,
+                truncated: false,
+                citations: vec![],
+            })
+            .await
+            .unwrap();
+        store
+            .record_uncovered_subject(&ask, subject, &vec, "fake")
+            .await
+            .unwrap()
+    }
+
+    /// The plan says out loud what the excerpts miss, and a subject whose
+    /// fan-out came back with nothing is a hole in the base named by the model,
+    /// for a question a person actually asked. It cost nothing to find — the
+    /// planning call was already paid for.
+    #[tokio::test]
+    async fn an_uncovered_subject_is_an_open_gap() {
+        let store = Store::memory().await.unwrap();
+        uncovered_subject(&store, "how do ticks work", "job priority", vec![0.0, 1.0]).await;
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        let subjects: Vec<&str> = gaps
+            .iter()
+            .filter(|g| g.gap.kind == GapKind::Subject)
+            .map(|g| g.gap.text.as_str())
+            .collect();
+        assert_eq!(subjects, vec!["job priority"]);
+    }
+
+    /// The same closing rule the other four use: a capture that covers it takes
+    /// it off the list, and what an automatic score decided never overwrites
+    /// what a person judged.
+    #[tokio::test]
+    async fn a_covered_subject_leaves_the_list() {
+        let store = Store::memory().await.unwrap();
+        let id =
+            uncovered_subject(&store, "how do ticks work", "job priority", vec![0.0, 1.0]).await;
+        // Coverage points at a real capture: the row carries foreign keys, and
+        // a gap closed by an artifact nobody stored would be a claim with
+        // nothing behind it.
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "job priority is a column".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        store
+            .cover_gap(GapKind::Subject, &id, &src.id, &made[0].id, 0.9)
+            .await
+            .unwrap();
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        assert!(
+            !gaps.iter().any(|g| g.gap.kind == GapKind::Subject),
+            "a covered subject stayed on the list"
+        );
+    }
+
+    /// The rule every kind here already applies: no vector, no grouping, so it
+    /// is not a gap this list can do anything with.
+    #[tokio::test]
+    async fn a_subject_with_no_vector_is_not_a_gap() {
+        let store = Store::memory().await.unwrap();
+        uncovered_subject(&store, "how do ticks work", "job priority", vec![]).await;
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        assert!(!gaps.iter().any(|g| g.gap.kind == GapKind::Subject));
+    }
+
+    /// A subject is a fact about one question. The question going means the
+    /// subject goes: it was never a hole anybody reported on its own, and left
+    /// behind it would name a plan whose ask no longer exists.
+    #[tokio::test]
+    async fn a_subject_dies_with_the_question_it_came_from() {
+        let store = Store::memory().await.unwrap();
+        uncovered_subject(&store, "how do ticks work", "job priority", vec![0.0, 1.0]).await;
+        sqlx::query("DELETE FROM ask_events")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
+        assert!(!gaps.iter().any(|g| g.gap.kind == GapKind::Subject));
     }
 
     async fn gap_search(store: &Store, q: &str, vec: Vec<f32>) -> String {

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -250,12 +250,6 @@ macro_rules! unmatched_gaps_sql {
     };
 }
 
-/// A run of searches the base did not answer.
-///
-/// The text is the leading clustered query rather than all of them joined: the
-/// naming prompt keeps the first twelve members, and a member that is itself a
-/// paragraph of queries would crowd out eleven other gaps. `queries` is JSON,
-/// so the first element is read out in Rust rather than in SQL.
 /// A subject the plan named and the fan-out could not cover.
 ///
 /// The join to `ask_events` is what makes the row die with its question — a
@@ -278,6 +272,12 @@ macro_rules! subject_gaps_sql {
     };
 }
 
+/// A run of searches the base did not answer.
+///
+/// The text is the leading clustered query rather than all of them joined: the
+/// naming prompt keeps the first twelve members, and a member that is itself a
+/// paragraph of queries would crowd out eleven other gaps. `queries` is JSON,
+/// so the first element is read out in Rust rather than in SQL.
 macro_rules! pursuit_gaps_sql {
     ($cols:literal) => {
         concat!(
@@ -679,11 +679,12 @@ impl Store {
         let holes = vec!["?"; corpus_ids.len()].join(", ");
         let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
             "SELECT c.corpus_id, c.kind, c.gap_id,
-                    COALESCE(a.question, s.query, p.queries) AS text
+                    COALESCE(a.question, s.query, p.queries, sub.subject) AS text
                FROM gap_coverage c
                LEFT JOIN ask_events a    ON c.kind = 'ask'    AND a.id = c.gap_id
                LEFT JOIN search_events s ON c.kind IN ('search', 'unmatched') AND s.id = c.gap_id
                LEFT JOIN pursuits p      ON c.kind = 'pursuit' AND p.id = c.gap_id
+               LEFT JOIN ask_subjects sub ON c.kind = 'subject' AND sub.id = c.gap_id
               WHERE c.corpus_id IN ({holes})
               ORDER BY c.covered_at DESC"
         )));
@@ -743,7 +744,9 @@ impl Store {
                      AND NOT EXISTS (SELECT 1 FROM search_events WHERE id = gap_coverage.gap_id))
                  OR (kind = 'pursuit'
                      AND NOT EXISTS (SELECT 1 FROM pursuits WHERE id = gap_coverage.gap_id))
-                 OR kind NOT IN ('ask', 'search', 'unmatched', 'pursuit')",
+                 OR (kind = 'subject'
+                     AND NOT EXISTS (SELECT 1 FROM ask_subjects WHERE id = gap_coverage.gap_id))
+                 OR kind NOT IN ('ask', 'search', 'unmatched', 'pursuit', 'subject')",
         )
         .execute(&self.pool)
         .await?
@@ -1036,6 +1039,62 @@ mod tests {
             !gaps.iter().any(|g| g.gap.kind == GapKind::Subject),
             "a covered subject stayed on the list"
         );
+    }
+
+    /// The repair pass collects coverage whose gap is gone, and a subject is a
+    /// gap like the others: its row survives, and the capture that closed it
+    /// still says which subject it closed. Both were once true of four kinds
+    /// and not of the fifth — the pass swept every `subject` row on sight, and
+    /// the covered-by list dropped what it could not name.
+    #[tokio::test]
+    async fn a_covered_subject_survives_the_repair_pass() {
+        let store = Store::memory().await.unwrap();
+        let id =
+            uncovered_subject(&store, "how do ticks work", "job priority", vec![0.0, 1.0]).await;
+        let src = store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "job priority is a column".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        store
+            .cover_gap(GapKind::Subject, &id, &src.id, &made[0].id, 0.9)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.trim_gap_coverage().await.unwrap(),
+            0,
+            "the repair pass collected a coverage whose subject still exists"
+        );
+        let covered = store
+            .gaps_covered_by_each(std::slice::from_ref(&src.id))
+            .await
+            .unwrap();
+        let named: Vec<&str> = covered
+            .get(&src.id)
+            .map(|v| v.iter().map(|c| c.text.as_str()).collect())
+            .unwrap_or_default();
+        assert_eq!(named, vec!["job priority"]);
+
+        // And when the subject is gone, the row goes with it.
+        sqlx::query("DELETE FROM ask_subjects WHERE id = ?")
+            .bind(&id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        assert_eq!(store.trim_gap_coverage().await.unwrap(), 1);
     }
 
     /// The rule every kind here already applies: no vector, no grouping, so it

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -379,6 +379,38 @@ CREATE TABLE IF NOT EXISTS ask_citations (
   PRIMARY KEY (event_id, n)
 );
 
+-- A subject the answer's excerpts did not cover, named by the planning call and
+-- then found by nothing.
+--
+-- `[infer.ask] plan` asks the model once, after the first round, which subjects
+-- the excerpts miss; each becomes a search of its own. A subject whose search
+-- came back with every candidate under `vector.weak_below` is a hole in the
+-- base stated in the model's own words, for a question a person actually asked
+-- — and it cost nothing to find, because the planning call was already paid
+-- for. Only the uncovered ones are written; a subject the fan-out answered is
+-- not a gap and leaves no row.
+--
+-- A child of its question rather than a row of its own kind. It is a fact about
+-- one ask: the ask going takes it, because a subject naming a plan whose
+-- question no longer exists says nothing anybody can act on.
+--
+-- `query_vec` costs no embedding call. The fan-out already embedded this
+-- subject to search for it, so the vector is read back out of the query cache
+-- at write time.
+CREATE TABLE IF NOT EXISTS ask_subjects (
+  id           TEXT PRIMARY KEY,
+  event_id     TEXT NOT NULL REFERENCES ask_events(id) ON DELETE CASCADE,
+  subject      TEXT NOT NULL,
+  query_vec    BLOB NOT NULL,
+  vec_dim      INTEGER NOT NULL,
+  embed_model  TEXT NOT NULL,
+  created_at   INTEGER NOT NULL,
+  -- Set when the operator says this subject has since been covered.
+  dismissed_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_ask_subjects_open
+  ON ask_subjects(dismissed_at, created_at DESC);
+
 -- ── Knowledge gaps ───────────────────────────────────────────────────────────
 -- Unanswered questions and gap searches, grouped by their stored vectors and
 -- named once. Membership is identity: a group whose members change is a new

--- a/src/web/corpus_view.rs
+++ b/src/web/corpus_view.rs
@@ -32,7 +32,34 @@ pub struct CorpusSlice {
 
 /// The lines of `source` around `span`, labelled for the pane. Without a span
 /// the opening of the source is shown as context.
+///
+/// One span through `slice_over`, so the single-passage pane and the appended
+/// run cannot drift apart: there is one definition of what a slice is and this
+/// is the narrow way into it.
 pub fn slice(source: &Corpus, span: Option<&CorpusSpan>, context: usize) -> CorpusSlice {
+    match span {
+        Some(sp) => slice_over(source, std::slice::from_ref(sp), context),
+        None => slice_over(source, &[], context),
+    }
+}
+
+/// The lines of `source` covering a *run* of spans, labelled for the pane.
+///
+/// The detail pane appends the passages that follow the one it opened on, and
+/// the source column beside them has to grow in step. Recomputed over the whole
+/// run rather than appended a slice at a time: every slice carries context lines
+/// at both edges, so appending would print the lines between two adjacent
+/// passages twice — on the column whose whole job is to show what the text was
+/// drawn from.
+///
+/// `in_span` is true for a line inside *any* of the spans. What falls between
+/// two of them is context, and is marked as such: a run that stepped over a
+/// superseded row has a hole in it, and claiming those lines were read would be
+/// the one dishonesty this column must not commit.
+///
+/// An empty run is the headless case — no span, so the opening of the source
+/// stands as context.
+pub fn slice_over(source: &Corpus, spans: &[CorpusSpan], context: usize) -> CorpusSlice {
     // An image corpus's lines are the model's reading of the picture, and a
     // PDF's are docling's extraction of it. The label says so in both cases: a
     // span into either is a claim about what was written down, not about what
@@ -45,7 +72,10 @@ pub fn slice(source: &Corpus, span: Option<&CorpusSpan>, context: usize) -> Corp
     let all: Vec<&str> = source.raw_text.lines().collect();
     let total = all.len() as i64;
 
-    let Some(span) = span else {
+    let (Some(first), Some(last)) = (
+        spans.iter().map(|s| s.start_line).min(),
+        spans.iter().map(|s| s.end_line).max(),
+    ) else {
         return CorpusSlice {
             lines: all
                 .iter()
@@ -61,35 +91,35 @@ pub fn slice(source: &Corpus, span: Option<&CorpusSpan>, context: usize) -> Corp
         };
     };
 
-    let start = (span.start_line - context as i64).max(1);
-    let end = (span.end_line + context as i64).min(total);
+    let start = (first - context as i64).max(1);
+    let end = (last + context as i64).min(total);
     let lines = (start..=end)
         .filter_map(|n| {
             all.get((n - 1) as usize).map(|t| CorpusLine {
                 number: n,
                 text: (*t).to_string(),
-                in_span: n >= span.start_line && n <= span.end_line,
+                in_span: spans.iter().any(|s| n >= s.start_line && n <= s.end_line),
             })
         })
         .collect();
 
     CorpusSlice {
         lines,
-        // Singular when the span is one line. "lines 576–576" is a range with
+        // Singular when the run covers one line. "lines 576–576" is a range with
         // one thing in it, and a pane that says it has not checked what it is
         // about to claim.
-        label: if span.start_line == span.end_line {
+        label: if first == last {
             format!(
                 "{}line {}",
                 written_down.map(|w| format!("{w} ")).unwrap_or_default(),
-                span.start_line
+                first
             )
         } else {
             format!(
                 "{}lines {}–{}",
                 written_down.map(|w| format!("{w} ")).unwrap_or_default(),
-                span.start_line,
-                span.end_line
+                first,
+                last
             )
         },
     }
@@ -344,6 +374,65 @@ mod tests {
             .map(|l| l.number)
             .collect();
         assert_eq!(marked, vec![3, 4]);
+    }
+
+    /// The pane appends the passages that follow, and the source column beside
+    /// it has to grow with them. Recomputed over the whole run rather than
+    /// appended: each slice carries context lines at both edges, so appending
+    /// would print the lines between two adjacent passages twice.
+    #[tokio::test]
+    async fn a_run_of_spans_is_one_slice_with_no_line_printed_twice() {
+        let src = a_corpus("l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8").await;
+        // Adjacent passages: 2–3 and 4–5. With one line of context each, the
+        // two single slices would both carry line 3 and line 4.
+        let slice = slice_over(&src, &[span(2, 3), span(4, 5)], 1);
+
+        let numbers: Vec<i64> = slice.lines.iter().map(|l| l.number).collect();
+        assert_eq!(numbers, vec![1, 2, 3, 4, 5, 6], "a line came back twice");
+    }
+
+    /// Every line the run was written from is the claim; the lines around it
+    /// are context. A gap between two passages — a superseded row stepped over
+    /// — is context too, and must not be marked as though something on screen
+    /// was drawn from it.
+    #[tokio::test]
+    async fn a_run_marks_every_span_and_nothing_between_them() {
+        let src = a_corpus("l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8").await;
+        let slice = slice_over(&src, &[span(2, 2), span(5, 6)], 1);
+
+        let marked: Vec<i64> = slice
+            .lines
+            .iter()
+            .filter(|l| l.in_span)
+            .map(|l| l.number)
+            .collect();
+        assert_eq!(marked, vec![2, 5, 6]);
+    }
+
+    /// The label names what is on screen. Over a run that is the union, and
+    /// saying only the first passage's range would describe a column the reader
+    /// can see is longer than that.
+    #[tokio::test]
+    async fn a_run_is_labelled_with_the_range_it_covers() {
+        let src = a_corpus("l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8").await;
+        let slice = slice_over(&src, &[span(2, 3), span(4, 5)], 1);
+        assert_eq!(slice.label, "lines 2–5");
+    }
+
+    /// One span through the run-aware path is the single-passage pane, which is
+    /// every pane before the reader has appended anything. It must not drift
+    /// from what `slice` produces.
+    #[tokio::test]
+    async fn one_span_over_the_run_is_what_the_single_slice_already_was() {
+        let src = a_corpus("l1\nl2\nl3\nl4\nl5\nl6").await;
+        let one = slice(&src, Some(&span(3, 4)), 1);
+        let run = slice_over(&src, &[span(3, 4)], 1);
+
+        assert_eq!(run.label, one.label);
+        assert_eq!(
+            run.lines.iter().map(|l| (l.number, l.in_span)).collect::<Vec<_>>(),
+            one.lines.iter().map(|l| (l.number, l.in_span)).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/src/web/corpus_view.rs
+++ b/src/web/corpus_view.rs
@@ -430,8 +430,14 @@ mod tests {
 
         assert_eq!(run.label, one.label);
         assert_eq!(
-            run.lines.iter().map(|l| (l.number, l.in_span)).collect::<Vec<_>>(),
-            one.lines.iter().map(|l| (l.number, l.in_span)).collect::<Vec<_>>()
+            run.lines
+                .iter()
+                .map(|l| (l.number, l.in_span))
+                .collect::<Vec<_>>(),
+            one.lines
+                .iter()
+                .map(|l| (l.number, l.in_span))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -216,6 +216,17 @@
         </form>
       </div>
 
+      {# The document, continuing. Appended rather than linked because the
+         answer to a question is often the paragraph after the one that
+         matched, and a link makes the reader decide whether it is worth a
+         page load before they can see it.
+
+         Under the artifact and above the neighbours: this is the same
+         document, and `Related` is other documents. Putting them in one list
+         would flatten the only distinction that matters here. #}
+      {% for item in d.run %}{% include "_run_item.html" %}{% endfor %}
+      {% if !d.merged %}{% include "_run_more.html" %}{% endif %}
+
       {% if !d.related.is_empty() %}
       {# Nearest by the vector already stored for this artifact: no embedding
          call, no completion. Swaps this detail for the neighbour's in place,
@@ -285,22 +296,12 @@
          corpus to link and no span to highlight, so the captured branch would
          render a dead link over an empty table — on the very artifact whose
          orphan notice matters most. #}
-      {% if !d.merged %}
-      <div class="label pane-label">
-        {# "highlighted" was doing no work: the highlight is visible in the table
-           directly below, and the label already names the lines. #}
-        <a href="{{ d.source_at_lines }}">Source</a> · {{ d.slice_label }}
-      </div>
-      <div class="raw">
-        <table>
-          {% for l in d.slice_lines %}
-          <tr class="{% if l.in_span %}in{% endif %}">
-            <td class="ln">{{ l.number }}</td><td>{{ l.text }}</td>
-          </tr>
-          {% endfor %}
-        </table>
-      </div>
-      {% endif %}
+      {# One statement of which lines these are, and it is the link — see the
+         note above. The block is a partial because an append re-renders it out
+         of band: the run grew, so the claim about where the text came from has
+         to grow with it, and there must not be two accounts of what that block
+         looks like. #}
+      {% if !d.merged %}{% include "_source_lines.html" %}{% endif %}
 
       {# A merge always shows its lineage, empty or not — the empty case is the
          orphan notice, and it matters most exactly there. A captured artifact

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -101,6 +101,20 @@
         {%- if r.model_written %}{% if r.primed || r.weak %} · {% endif %}written by a model{% if r.origin_count > 0 %} from {{ r.origin_count }} source{% if r.origin_count > 1 %}s{% endif %}{% endif %}{% endif -%}
       </p>
       {% endif %}
+      {# Its own line, under the ones that say why this row is *here*. This says
+         something else — what the document does next — and the two must not run
+         together into one sentence.
+
+         Exclusive by construction, not by an accident of the template: a
+         continuation that placed is named by its rank, and one that did not is
+         announced. `mark_continuations` sets exactly one of the two, so there is
+         no case where the row both points at a visible neighbour and offers to
+         go and get it. #}
+      {% if !r.continues_in.is_empty() %}
+      <p class="rail-continues"><span class="arrow" aria-hidden="true">↓</span> continues in {{ r.continues_in }}</p>
+      {% else if r.continues %}
+      <p class="rail-continues"><span class="arrow" aria-hidden="true">↳</span> continues in the next passage</p>
+      {% endif %}
     </a>
     {# No delete control here. It was the only irreversible act in the app that
        could be fired on something nobody had opened — a title, a snippet and a

--- a/src/web/templates/_run_append.html
+++ b/src/web/templates/_run_append.html
@@ -1,0 +1,10 @@
+{# What one click of "append next from corpus" answers with: the passage that
+   follows, the control moved on by one, and the source column re-rendered out
+   of band because the run it describes just grew.
+
+   The run here holds at most one item — the newly appended one. Everything
+   before it is already on the page, and sending it again would append the run
+   a second time under itself. #}
+{% for item in d.run %}{% include "_run_item.html" %}{% endfor %}
+{% include "_run_more.html" %}
+{% include "_source_lines.html" %}

--- a/src/web/templates/_run_item.html
+++ b/src/web/templates/_run_item.html
@@ -1,0 +1,21 @@
+{# One passage that follows the artifact above. Dashed and transparent, the way
+   `.rail-assoc` marks a row that was recalled rather than ranked: nothing
+   ranked this, and the pane must not borrow the shape of something that was.
+
+   No verify, no hide, no delete. Those act on *an* artifact, and the one the
+   reader opened is the one at the top of the pane; a row of controls on each
+   appended passage would make it ambiguous which artifact an action meant. The
+   way to act on this one is to make it the artifact, which is the link. #}
+<article class="run-item" data-ordinal="{{ item.ordinal }}">
+  <div class="run-head">
+    <span class="run-ord mono">passage {{ item.ordinal }}</span>
+    {% if !item.title.is_empty() %}
+    <span class="run-title">{{ item.title }}</span>
+    {% endif %}
+    <span class="spacer"></span>
+    <a class="quiet-link" href="/ui/artifacts/{{ item.id }}"
+       hx-get="/ui/artifacts/{{ item.id }}"
+       hx-target="closest [data-terms]" hx-swap="outerHTML" hx-push-url="true">open</a>
+  </div>
+  <div class="md">{{ item.html|safe }}</div>
+</article>

--- a/src/web/templates/_run_more.html
+++ b/src/web/templates/_run_more.html
@@ -1,0 +1,24 @@
+{# The foot of the run. Either the next passage is available and this asks for
+   it, or the document has ended and the honest thing left to offer is the
+   document.
+
+   `n` is the whole of the state and it lives in this link. The server keeps no
+   cursor, so two clicks cannot append the same passage twice and a reload
+   cannot resume a run nobody is in the middle of. #}
+<div id="run-more" class="run-more">
+  {% if let Some(n) = d.more.next %}
+  <button class="btn btn-ghost btn-sm" type="button"
+          hx-get="/ui/artifacts/{{ d.more.artifact_id }}/run?n={{ n }}&terms={{ d.more.terms|urlencode }}"
+          hx-target="#run-more" hx-swap="outerHTML"
+          hx-indicator="#run-more">
+    append next from corpus
+  </button>
+  {% else %}
+  <p class="run-end">
+    End of the document.
+    {% if !d.more.corpus_id.is_empty() %}
+    <a class="quiet-link" href="/ui/corpora/{{ d.more.corpus_id }}">Read it whole →</a>
+    {% endif %}
+  </p>
+  {% endif %}
+</div>

--- a/src/web/templates/_source_lines.html
+++ b/src/web/templates/_source_lines.html
@@ -1,0 +1,18 @@
+{# The lines the text on screen was drawn from. One block, rendered in place
+   when the pane is drawn whole and out of band when it arrives with an
+   appended passage — the run grew, so the claim about where it came from has
+   to grow with it. #}
+<div id="source-lines"{% if d.source_oob %} hx-swap-oob="outerHTML"{% endif %}>
+  <div class="label pane-label">
+    <a href="{{ d.source_at_lines }}">Source</a> · {{ d.slice_label }}
+  </div>
+  <div class="raw">
+    <table>
+      {% for l in d.slice_lines %}
+      <tr class="{% if l.in_span %}in{% endif %}">
+        <td class="ln">{{ l.number }}</td><td>{{ l.text }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
+</div>

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -62,6 +62,18 @@ pub struct RenderedResult {
     pub origin_count: usize,
     /// The judge's line, where the link was judged.
     pub reason: Option<String>,
+    /// The document goes on past this passage, and what comes next did not
+    /// place in this list. The answer to a question is often the paragraph
+    /// after the one that matched, and the row says so rather than leaving the
+    /// reader to go and find out.
+    ///
+    /// False where the continuation *did* place: it is already on the page,
+    /// and `continues_in` names where.
+    pub continues: bool,
+    /// The rank of the next passage, where that passage is itself in this list
+    /// — `#2`, as the row beside it is labelled. Empty otherwise, including
+    /// when the next passage placed as something with no rank of its own.
+    pub continues_in: String,
 }
 
 #[derive(Default)]
@@ -1152,11 +1164,31 @@ pub(crate) async fn search_results(
     // and the title is looked up among the ranked ones rather than fetched.
     let titles = ranked_titles(&hits);
     let (ranked, recalled): (Vec<_>, Vec<_>) = hits.into_iter().partition(|h| h.via.is_none());
-    let results: Vec<RenderedResult> = ranked
+    let mut results: Vec<RenderedResult> = ranked
         .into_iter()
         .enumerate()
         .map(|(i, h)| render_hit(i, h, &titles))
         .collect();
+    // What each hit's document does next, in one read for the whole list. Only
+    // over the ranked rows: an associated one is not an answer to the query,
+    // and telling the reader to read on from something the query never matched
+    // is an invitation into a document they did not ask about.
+    //
+    // Best-effort, exactly like the reach `ask` makes: a marker is a bonus, and
+    // failing to read one must not cost the results that were already found.
+    let next = match tenant
+        .core
+        .store
+        .continuations_of(&results.iter().map(|r| r.artifact_id.clone()).collect::<Vec<_>>())
+        .await
+    {
+        Ok(next) => next,
+        Err(e) => {
+            tracing::warn!(error = %e, "could not read what these hits continue into");
+            Default::default()
+        }
+    };
+    mark_continuations(&mut results, &next);
     let associated: Vec<RenderedResult> = recalled
         .into_iter()
         .map(|h| render_hit(0, h, &titles))
@@ -1233,6 +1265,49 @@ pub(crate) fn render_hit(
         reason: h.reason.clone(),
         model_written: h.model_written,
         origin_count: h.origin_count,
+        // Filled by `mark_continuations` over the finished list: whether a
+        // passage's continuation is *on the page* is a fact about the list, not
+        // about the hit, and one row cannot answer it.
+        continues: false,
+        continues_in: String::new(),
+    }
+}
+
+/// Say, on each row, what its document does next.
+///
+/// `next` maps an artifact to the passage that follows it — `Store::
+/// continuations_of`, one read for the whole list. Two outcomes, and they are
+/// deliberately exclusive: a continuation that *placed* is named by its rank,
+/// because the row is already on the page and offering to fetch it would claim
+/// two things are there when one is; a continuation that did not place is
+/// announced as such, and the pane is where it gets read.
+///
+/// A row with no rank is not a destination. Associated rows and weak ones carry
+/// no rank by design, and `setzt sich fort in` followed by nothing is worse
+/// than the marker's absence — so such a continuation falls back to the plain
+/// announcement, which is still true.
+pub(crate) fn mark_continuations(
+    results: &mut [RenderedResult],
+    next: &std::collections::HashMap<String, String>,
+) {
+    let ranks: std::collections::HashMap<&str, &str> = results
+        .iter()
+        .filter(|r| !r.rank.is_empty())
+        .map(|r| (r.artifact_id.as_str(), r.rank.as_str()))
+        .collect();
+    let marks: Vec<(bool, String)> = results
+        .iter()
+        .map(|r| match next.get(&r.artifact_id) {
+            None => (false, String::new()),
+            Some(n) => match ranks.get(n.as_str()) {
+                Some(rank) => (false, (*rank).to_string()),
+                None => (true, String::new()),
+            },
+        })
+        .collect();
+    for (r, (continues, continues_in)) in results.iter_mut().zip(marks) {
+        r.continues = continues;
+        r.continues_in = continues_in;
     }
 }
 
@@ -6128,6 +6203,135 @@ mod tests {
         assert!(d.html.contains("<pre"), "{}", d.html);
     }
 
+    /// A rail row reduced to what the continuation marker reads: which artifact
+    /// it is, and whether it carries a rank to be named by.
+    #[cfg(test)]
+    fn row(id: &str, rank: &str) -> RenderedResult {
+        RenderedResult {
+            artifact_id: id.into(),
+            title: String::new(),
+            html: String::new(),
+            snippet: String::new(),
+            category: None,
+            tags: vec![],
+            corpus_id: "s".into(),
+            rank: rank.into(),
+            weak: false,
+            primed: false,
+            in_sitting: false,
+            past_cliff: false,
+            via_title: None,
+            model_written: false,
+            origin_count: 0,
+            reason: None,
+            continues: false,
+            continues_in: String::new(),
+        }
+    }
+
+    /// The two markers are exclusive on the page as well as in the struct: a
+    /// row that names a rank must not also carry the offer to fetch, or the
+    /// rail says both "it is over there" and "there is more" about one thing.
+    #[test]
+    fn the_rail_prints_one_continuation_marker_or_the_other() {
+        let mut named = row("a", "#1");
+        named.continues_in = "#2".into();
+        let mut offered = row("b", "#2");
+        offered.continues = true;
+
+        let html = askama::Template::render(&ResultsTemplate {
+            results: vec![named, offered],
+            associated: vec![],
+            all_weak: false,
+            terms: String::new(),
+            reranked: false,
+        })
+        .unwrap();
+
+        assert!(html.contains("continues in #2"), "{html}");
+        assert!(html.contains("continues in the next passage"), "{html}");
+        assert_eq!(
+            html.matches("rail-continues").count(),
+            2,
+            "one marker per row, and no row wearing both: {html}"
+        );
+    }
+
+    /// The silent case, and the one worth pinning: a row that continues nowhere
+    /// must print nothing at all. An empty marker element is a line of space
+    /// the reader reads as meaning something.
+    #[test]
+    fn a_row_that_continues_nowhere_prints_no_marker() {
+        let html = askama::Template::render(&ResultsTemplate {
+            results: vec![row("a", "#1")],
+            associated: vec![],
+            all_weak: false,
+            terms: String::new(),
+            reranked: false,
+        })
+        .unwrap();
+
+        assert!(!html.contains("rail-continues"), "{html}");
+    }
+
+    /// A search result and its next passage both placed. The rail says so by
+    /// pointing at the rank the reader can already see, because the row is
+    /// there and sending them to a second copy of it would be a claim that two
+    /// things are on the page when one is.
+    #[test]
+    fn a_hit_whose_next_passage_also_placed_names_its_rank() {
+        let mut rows = vec![row("a", "#1"), row("b", "#2")];
+        let next = [("a".to_string(), "b".to_string())].into_iter().collect();
+        super::mark_continuations(&mut rows, &next);
+
+        assert_eq!(rows[0].continues_in, "#2");
+        assert!(
+            !rows[0].continues,
+            "a hit whose continuation is on the page must not also offer to fetch it"
+        );
+    }
+
+    /// The ordinary case: the document goes on, and what comes next did not
+    /// place. Nothing about it is on the page, so the row says the one true
+    /// thing — there is more — and the pane is where it gets read.
+    #[test]
+    fn a_hit_whose_next_passage_did_not_place_says_only_that_it_continues() {
+        let mut rows = vec![row("a", "#1")];
+        let next = [("a".to_string(), "elsewhere".to_string())]
+            .into_iter()
+            .collect();
+        super::mark_continuations(&mut rows, &next);
+
+        assert!(rows[0].continues);
+        assert!(rows[0].continues_in.is_empty());
+    }
+
+    /// The last passage of a document, and the case the whole marker must not
+    /// get wrong: an offer to read on where there is nothing to read.
+    #[test]
+    fn a_hit_at_the_end_of_its_document_is_marked_neither_way() {
+        let mut rows = vec![row("a", "#1")];
+        super::mark_continuations(&mut rows, &Default::default());
+
+        assert!(!rows[0].continues);
+        assert!(rows[0].continues_in.is_empty());
+    }
+
+    /// An associated row is not a ranked one and carries no rank. Naming it as
+    /// a destination would print "setzt sich fort in" followed by nothing.
+    #[test]
+    fn a_continuation_into_a_row_with_no_rank_is_not_named_by_rank() {
+        let mut rows = vec![row("a", "#1"), row("b", "")];
+        let next = [("a".to_string(), "b".to_string())].into_iter().collect();
+        super::mark_continuations(&mut rows, &next);
+
+        assert!(rows[0].continues_in.is_empty());
+        assert!(
+            rows[0].continues,
+            "the continuation exists and must still be offered"
+        );
+    }
+
     #[test]
     fn a_result_with_no_title_of_its_own_is_given_no_heading() {
         // "Untitled" is a heading that says nothing and looks like one that
@@ -6191,6 +6395,8 @@ mod tests {
             reason: reason.map(str::to_string),
             model_written: false,
             origin_count: 0,
+            continues: false,
+            continues_in: String::new(),
         }
     }
 
@@ -6339,6 +6545,8 @@ mod tests {
             reason: None,
             model_written: false,
             origin_count: 0,
+            continues: false,
+            continues_in: String::new(),
         }
     }
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -511,6 +511,9 @@ pub(crate) fn gap_member(g: crate::store::gaps::Gap) -> GapMember {
             GapKind::Ask => "asked",
             GapKind::Unmatched => "nothing near",
             GapKind::Pursuit => "pursued",
+            // What asked it, like the other four — and here what asked was the
+            // planning call, on a question somebody put to the base.
+            GapKind::Subject => "planned",
         },
         id: g.id,
         text: g.text,

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2960,7 +2960,11 @@ async fn artifact_run(
     // Only what is new. `split_off` at the last index leaves either one item —
     // the passage this click asked for — or none, which is what the end of a
     // document looks like from here.
-    d.run = if d.run.len() >= n {
+    d.run = if n <= 1 {
+        // The opening passage is already on the pane: a run of one has nothing
+        // new in it, and appending it would stack the passage under itself.
+        vec![]
+    } else if d.run.len() >= n {
         d.run.split_off(n - 1)
     } else {
         vec![]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -76,6 +76,38 @@ pub struct RenderedResult {
     pub continues_in: String,
 }
 
+/// One appended passage: the next thing in the document, and nothing more.
+///
+/// Deliberately thinner than the artifact above it. No verify, no hide, no
+/// delete — those act on *an* artifact, and the one the reader opened is the
+/// one at the top. A run item carries the way to make itself that artifact
+/// instead, which is an ordinary link to its own pane.
+#[derive(Clone)]
+pub struct RunItem {
+    pub id: String,
+    /// Empty where the passage has no title of its own, exactly as on the rail.
+    pub title: String,
+    /// Sanitized HTML from `markdown::render`. Rendered with `|safe`.
+    pub html: String,
+    /// Its place in the document, which is the one thing it can honestly say
+    /// about why it is on screen.
+    pub ordinal: i64,
+}
+
+/// The control at the foot of the run.
+#[derive(Clone, Default)]
+pub struct RunMore {
+    pub artifact_id: String,
+    /// Where to send a reader who wants the document rather than another
+    /// passage. Empty for an artifact that belongs to no document.
+    pub corpus_id: String,
+    /// The length of the run one more click would produce. `None` at the end of
+    /// the document, which is a state the pane renders rather than a control
+    /// that comes back empty.
+    pub next: Option<usize>,
+    pub terms: String,
+}
+
 #[derive(Default)]
 pub struct QueueRow {
     pub id: String,
@@ -194,6 +226,18 @@ pub struct ArtifactDetail {
     /// with the rest of the sentence visible in the column beside it and no
     /// way onward is.
     pub continues_at: Option<String>,
+    /// The passages that follow this one in its document, in reading order.
+    ///
+    /// One when the pane opens, and one more each time the reader asks. They
+    /// are not results and never claim to be: nothing ranked them, and what
+    /// they say about themselves is only that they came next.
+    pub run: Vec<RunItem>,
+    /// The control under the run: what to ask for next, or the way into the
+    /// document when there is nothing left to append.
+    pub more: RunMore,
+    /// The source block is rendered out of band when it arrives as part of an
+    /// append, and in place when the pane is drawn whole.
+    pub source_oob: bool,
     pub segment_idx: Option<i64>,
     pub slice_label: String,
     pub slice_lines: Vec<crate::web::corpus_view::CorpusLine>,
@@ -667,6 +711,12 @@ struct ArtifactFragment {
 #[derive(Template)]
 #[template(path = "_artifact_detail.html")]
 struct ArtifactDetailFragment {
+    d: ArtifactDetail,
+}
+
+#[derive(Template)]
+#[template(path = "_run_append.html")]
+struct RunAppendFragment {
     d: ArtifactDetail,
 }
 
@@ -1179,7 +1229,12 @@ pub(crate) async fn search_results(
     let next = match tenant
         .core
         .store
-        .continuations_of(&results.iter().map(|r| r.artifact_id.clone()).collect::<Vec<_>>())
+        .continuations_of(
+            &results
+                .iter()
+                .map(|r| r.artifact_id.clone())
+                .collect::<Vec<_>>(),
+        )
         .await
     {
         Ok(next) => next,
@@ -1887,7 +1942,11 @@ async fn put_artifact(
         .enqueue(crate::store::jobs::Stage::Embed, "artifact", &cid)
         .await?;
     if f.view == "detail" {
-        let d = build_artifact_detail(&tenant.core, &cid, &f.terms).await?;
+        // Back to one appended passage. The run's length lives in the link the
+        // reader last clicked, and a save posts a form rather than that link —
+        // carrying it would mean threading a count through every control on
+        // the pane to preserve something one click restores.
+        let d = build_artifact_detail(&tenant.core, &cid, &f.terms, 1).await?;
         return Ok(HtmlTemplate(ArtifactDetailFragment { d }).into_response());
     }
     let c = tenant.core.store.get_artifact(&cid).await?;
@@ -2398,7 +2457,9 @@ async fn artifact_changed(
     back: &ReturnTo,
 ) -> Result<Response> {
     if headers.contains_key("hx-request") {
-        let d = build_artifact_detail(&tenant.core, aid, terms).await?;
+        // As above: an action on the artifact redraws the pane at its opening
+        // length rather than reconstructing a run nobody passed along.
+        let d = build_artifact_detail(&tenant.core, aid, terms, 1).await?;
         return Ok(HtmlTemplate(ArtifactDetailFragment { d }).into_response());
     }
     Ok(Redirect::to(back.path()).into_response())
@@ -2622,6 +2683,7 @@ pub(crate) async fn build_artifact_detail(
     core: &crate::core::Core,
     artifact_id: &str,
     terms: &str,
+    run_len: usize,
 ) -> Result<ArtifactDetail> {
     let c = core.store.get_artifact(artifact_id).await?;
     let html = artifact_html(&c);
@@ -2633,10 +2695,53 @@ pub(crate) async fn build_artifact_detail(
         Some(id) => Some(core.store.get_corpus(id).await?),
         None => None,
     };
+    // The passages that follow, in reading order. Best-effort like every other
+    // addition to this pane: a run that cannot be read is a pane without one,
+    // never a pane that refuses to show the artifact beside its source.
+    let following = match (&c.corpus_id, run_len) {
+        (Some(cid), n) if n > 0 => core
+            .store
+            .following_artifacts(cid, c.ordinal, n as i64)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(artifact_id, error = %e, "could not read on from this passage");
+                vec![]
+            }),
+        _ => vec![],
+    };
+    // The source column is the claim about where the text on screen came from,
+    // so it covers the whole run. `slice_over` recomputes rather than appends,
+    // which is what keeps the lines between two adjacent passages from being
+    // printed twice.
+    let spans: Vec<crate::store::artifacts::CorpusSpan> = std::iter::once(&c)
+        .chain(following.iter())
+        .filter_map(|a| a.corpus_span.clone())
+        .collect();
     let slice = match &src {
-        Some(s) => crate::web::corpus_view::slice(s, c.corpus_span.as_ref(), 3),
+        Some(s) => crate::web::corpus_view::slice_over(s, &spans, 3),
         None => crate::web::corpus_view::CorpusSlice::default(),
     };
+    // Asked for one more than is on screen, which is how the end of the
+    // document is discovered without a second query: a run that came back
+    // shorter than it was asked for has nothing after it.
+    let more = RunMore {
+        artifact_id: c.id.clone(),
+        corpus_id: c.corpus_id.clone().unwrap_or_default(),
+        next: match (&c.corpus_id, following.len() >= run_len) {
+            (Some(_), true) => Some(run_len + 1),
+            _ => None,
+        },
+        terms: terms.to_string(),
+    };
+    let run: Vec<RunItem> = following
+        .iter()
+        .map(|a| RunItem {
+            id: a.id.clone(),
+            title: a.title.clone().unwrap_or_default(),
+            html: artifact_html(a),
+            ordinal: a.ordinal,
+        })
+        .collect();
     // A missing lineage is not a missing pane, for the same reason a missing
     // neighbour list is not: it is a layer over the artifact, and the artifact
     // beside its source is what the page is for.
@@ -2761,6 +2866,11 @@ pub(crate) async fn build_artifact_detail(
     let title = artifact_title(&c);
     Ok(ArtifactDetail {
         continues_at,
+        run,
+        more,
+        // Drawn in place: this is the whole pane, not a piece arriving to be
+        // slotted into one.
+        source_oob: false,
         related,
         seen_together,
         orphaned_source,
@@ -2814,6 +2924,48 @@ struct ArtifactViewParams {
 
 /// One route, two shapes. An htmx swap wants the pane's body; a pasted link
 /// wants a page with navigation around it.
+/// How long a run one click asks for. The whole of the state, and it rides in
+/// the link rather than sitting on the server: two clicks cannot append the
+/// same passage twice, and a reload cannot resume a run nobody is in.
+#[derive(serde::Deserialize)]
+struct RunParams {
+    n: usize,
+    #[serde(default)]
+    terms: String,
+}
+
+/// One more passage of the document, and the source column re-drawn around the
+/// longer run.
+///
+/// Built through `build_artifact_detail` rather than beside it, so there is one
+/// account of what a run is and what the source column says about it. Only the
+/// last item is sent: everything before it is already on the page, and sending
+/// the whole run again would stack it under itself.
+///
+/// A run asked past the end of the document appends nothing and answers with
+/// the end state, which is the same answer the pane would have drawn — the
+/// reader learns the document ended rather than clicking into silence.
+async fn artifact_run(
+    tenant: Tenant,
+    Path(aid): Path<String>,
+    Query(p): Query<RunParams>,
+) -> Result<Response> {
+    // At least one, so `n - 1` below cannot wrap and a hand-written `?n=0`
+    // asks for the opening state rather than for something meaningless.
+    let n = p.n.max(1);
+    let mut d = build_artifact_detail(&tenant.core, &aid, &p.terms, n).await?;
+    // Only what is new. `split_off` at the last index leaves either one item —
+    // the passage this click asked for — or none, which is what the end of a
+    // document looks like from here.
+    d.run = if d.run.len() >= n {
+        d.run.split_off(n - 1)
+    } else {
+        vec![]
+    };
+    d.source_oob = true;
+    Ok(HtmlTemplate(RunAppendFragment { d }).into_response())
+}
+
 async fn artifact_detail(
     tenant: Tenant,
     identity: crate::auth::Identity,
@@ -2821,7 +2973,10 @@ async fn artifact_detail(
     Path(cid): Path<String>,
     Query(p): Query<ArtifactViewParams>,
 ) -> Result<Response> {
-    let d = build_artifact_detail(&tenant.core, &cid, &p.terms).await?;
+    // One appended passage when the pane opens. The reader asked for an
+    // artifact and gets it plus the beginning of the answer to "and then?";
+    // everything past that is theirs to ask for.
+    let d = build_artifact_detail(&tenant.core, &cid, &p.terms, 1).await?;
     // Opening a chunk is the deliberate act that counts as remembering it.
     tenant.core.mark_artifact_seen(&cid);
     // And the act the pursuit sweep reads: opened, or pivoted through — unless
@@ -2988,6 +3143,7 @@ pub fn ui_router() -> Router<AppState> {
             post(unpromote_ui),
         )
         .route("/ui/artifacts/{id}", get(artifact_detail).put(put_artifact))
+        .route("/ui/artifacts/{id}/run", get(artifact_run))
         .route("/ui/artifacts/{cid}/reviewed", post(mark_artifact_reviewed))
         .route(
             "/ui/artifacts/{id}/links/{other}/dismiss",
@@ -3596,7 +3752,7 @@ mod tests {
         .await
         .unwrap();
 
-        let d = build_artifact_detail(&core, &m.id, "").await.unwrap();
+        let d = build_artifact_detail(&core, &m.id, "", 1).await.unwrap();
 
         assert_eq!(d.corpus_id, None, "a merged artifact claimed a corpus");
         assert!(
@@ -3626,7 +3782,7 @@ mod tests {
         let core = crate::core::test_support::test_core().await;
         let ids = crate::jobs::consolidate::tests::seed(&core, &[("a text", [1.0, 0.0])]).await;
 
-        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "", 1).await.unwrap();
 
         assert!(d.lineage.is_empty());
         assert!(!d.merged);
@@ -3663,7 +3819,7 @@ mod tests {
             core.store.delete_artifact(id).await.unwrap();
         }
 
-        let d = build_artifact_detail(&core, &m.id, "").await.unwrap();
+        let d = build_artifact_detail(&core, &m.id, "", 1).await.unwrap();
 
         assert!(
             d.lineage.roots.is_empty(),
@@ -3691,7 +3847,7 @@ mod tests {
             .unwrap()
             .remove(0);
 
-        let d = match super::build_artifact_detail(&core, &c.id, "").await {
+        let d = match super::build_artifact_detail(&core, &c.id, "", 1).await {
             Ok(d) => d,
             Err(e) => panic!("detail view failed: {e}"),
         };
@@ -3735,7 +3891,7 @@ mod tests {
         assert!(all.len() > 1, "the fixture produced one passage, not two");
 
         let first = all.iter().min_by_key(|c| c.ordinal).unwrap();
-        let d = super::build_artifact_detail(&core, &first.id, "")
+        let d = super::build_artifact_detail(&core, &first.id, "", 1)
             .await
             .unwrap();
         assert!(
@@ -3745,7 +3901,7 @@ mod tests {
         );
 
         let last = all.iter().max_by_key(|c| c.ordinal).unwrap();
-        let d = super::build_artifact_detail(&core, &last.id, "")
+        let d = super::build_artifact_detail(&core, &last.id, "", 1)
             .await
             .unwrap();
         assert!(
@@ -3767,7 +3923,7 @@ mod tests {
             .remove(0);
         core.delete_corpus(&out.id).await.unwrap();
 
-        match super::build_artifact_detail(&core, &c.id, "").await {
+        match super::build_artifact_detail(&core, &c.id, "", 1).await {
             Err(crate::error::Error::NotFound) => {}
             Err(e) => panic!("expected a not-found, got {e}"),
             Ok(_) => panic!("a chunk whose source was deleted must not resolve"),
@@ -5750,7 +5906,7 @@ mod tests {
             "a neighbour list needs something to be a neighbour of"
         );
 
-        let d = super::build_artifact_detail(&core, &artifacts[0].id, "")
+        let d = super::build_artifact_detail(&core, &artifacts[0].id, "", 1)
             .await
             .unwrap();
         assert!(!d.related.is_empty(), "the pane listed no neighbours");
@@ -5778,7 +5934,7 @@ mod tests {
             .await
             .unwrap();
 
-        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "", 1).await.unwrap();
         assert_eq!(d.seen_together.len(), 1);
         assert_eq!(d.seen_together[0].id, ids[1]);
         assert_eq!(
@@ -5808,7 +5964,7 @@ mod tests {
             .await
             .unwrap();
 
-        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "", 1).await.unwrap();
         assert_eq!(
             d.seen_together[0].why.as_deref(),
             Some("the tool and the error it prints")
@@ -5847,7 +6003,7 @@ mod tests {
             "the evidence was thrown away with the decision"
         );
         assert!(
-            build_artifact_detail(&core, &ids[0], "")
+            build_artifact_detail(&core, &ids[0], "", 1)
                 .await
                 .unwrap()
                 .seen_together
@@ -5866,7 +6022,7 @@ mod tests {
             .execute(&core.store.pool)
             .await
             .unwrap();
-        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "", 1).await.unwrap();
         assert!(d.seen_together.is_empty());
     }
 
@@ -5914,7 +6070,7 @@ mod tests {
             .await
             .unwrap();
 
-        let d = build_artifact_detail(&core, &ids[0], "").await.unwrap();
+        let d = build_artifact_detail(&core, &ids[0], "", 1).await.unwrap();
         let same = d
             .seen_together
             .iter()
@@ -6099,7 +6255,7 @@ mod tests {
             .unwrap()
             .remove(0);
 
-        let d = super::build_artifact_detail(&core, &c.id, "")
+        let d = super::build_artifact_detail(&core, &c.id, "", 1)
             .await
             .unwrap();
         assert!(d.related.is_empty());
@@ -6197,10 +6353,107 @@ mod tests {
         // The detail pane renders the same artifact and has to say the same
         // thing about it: it is the half of the search page that shows a
         // passage in full.
-        let d = super::build_artifact_detail(&core, &p[0].id, "")
+        let d = super::build_artifact_detail(&core, &p[0].id, "", 1)
             .await
             .unwrap();
         assert!(d.html.contains("<pre"), "{}", d.html);
+    }
+
+    /// The id of the first passage of the seeded corpus, in reading order.
+    #[cfg(test)]
+    async fn first_passage(app: &axum::Router, cookie: &str) -> String {
+        let rail = get(app, "/ui/search/results?q=alpha", cookie).await;
+        rail.split(r#"hx-get="/ui/artifacts/"#)
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .and_then(|s| s.split('?').next())
+            .expect("no result to open")
+            .to_string()
+    }
+
+    /// Opening a passage shows what comes next, once. The reader asked for one
+    /// artifact and gets it plus the beginning of the answer to "and then?";
+    /// everything beyond that is theirs to ask for.
+    #[tokio::test]
+    async fn opening_a_passage_appends_the_one_that_follows_it() {
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let id = first_passage(&app, &cookie).await;
+
+        let page = flat(&get(&app, &format!("/ui/artifacts/{id}"), &cookie).await);
+        assert_eq!(
+            page.matches("run-item").count(),
+            1,
+            "the pane opened with something other than one appended passage: {page}"
+        );
+    }
+
+    /// The control carries the length of the run it would produce, so clicking
+    /// it twice cannot append the same passage twice — the count is the whole
+    /// of the state, and it lives in the link rather than on the server.
+    #[tokio::test]
+    async fn the_run_control_asks_for_one_more_than_is_on_screen() {
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let id = first_passage(&app, &cookie).await;
+
+        let page = flat(&get(&app, &format!("/ui/artifacts/{id}"), &cookie).await);
+        assert!(
+            page.contains(&format!("/ui/artifacts/{id}/run?n=2")),
+            "the control does not ask for the second passage: {page}"
+        );
+    }
+
+    /// Clicking it appends the next one and nothing else, and the control that
+    /// comes back asks for the one after that.
+    #[tokio::test]
+    async fn asking_for_more_appends_the_next_passage() {
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let id = first_passage(&app, &cookie).await;
+
+        let frag = flat(&get(&app, &format!("/ui/artifacts/{id}/run?n=2"), &cookie).await);
+        assert_eq!(
+            frag.matches("run-item").count(),
+            1,
+            "a click must append one passage, not the whole run again: {frag}"
+        );
+        assert!(
+            frag.contains(&format!("/ui/artifacts/{id}/run?n=3")),
+            "the returned control does not move on: {frag}"
+        );
+    }
+
+    /// The end of the document is a state the pane renders, not a control that
+    /// returns nothing. What stands there instead is the way into the document
+    /// itself.
+    #[tokio::test]
+    async fn at_the_end_of_the_document_the_control_becomes_the_way_in() {
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let id = first_passage(&app, &cookie).await;
+
+        // Far past the end of a three-passage document.
+        let frag = flat(&get(&app, &format!("/ui/artifacts/{id}/run?n=99"), &cookie).await);
+        assert!(
+            !frag.contains("/run?n="),
+            "the document ended and the control still offered more: {frag}"
+        );
+        assert!(
+            frag.contains("/ui/corpora/"),
+            "nothing offered the document itself: {frag}"
+        );
+    }
+
+    /// The source column is the claim about where the text came from, so it has
+    /// to grow with the run rather than keep describing the first passage
+    /// alone.
+    #[tokio::test]
+    async fn the_source_column_grows_with_the_run() {
+        let (app, cookie) = app_with_embedded_corpus().await;
+        let id = first_passage(&app, &cookie).await;
+
+        let frag = flat(&get(&app, &format!("/ui/artifacts/{id}/run?n=3"), &cookie).await);
+        assert!(
+            frag.contains(r#"id="source-lines" hx-swap-oob"#),
+            "the source column was not re-rendered with the run: {frag}"
+        );
     }
 
     /// A rail row reduced to what the continuation marker reads: which artifact


### PR DESCRIPTION
Two roadmap items, plus the correction to the roadmap that finding them
required.

## The rail says what a document does next

A hit whose document goes on now says so, in the slot that already carries
a row's one quiet line of explanation. Two markers, exclusive by
construction: a continuation that itself placed is named by its rank —
`continues in #2` — because that row is already on the page and offering to
fetch it would claim two things are there when one is. A continuation that
did not place is announced instead.

A row with no rank is not a destination. Associated and weak rows carry none
by design, and `continues in` followed by nothing is worse than the marker's
absence, so such a continuation falls back to the announcement.

One query for the whole list — the rail is drawn on every keystroke — and
best-effort in the same way `ask`'s sideways reach is. The ask rail is
deliberately untouched: it says what an answer was written from, not how a
document continues.

## The pane actually continues it

Opening an artifact appends the passage that follows, and a control appends
the next as often as it is clicked. At the end of the document the control
becomes the way into the document.

One passage on open, not five: the reader asked for an artifact and gets it
plus the beginning of the answer to "and then?". The run length is the whole
of the state and it rides in the link, so two clicks cannot append the same
passage twice, a reload cannot resume a run nobody is in, and a run asked
past the end appends nothing and answers with the end state.

Appended passages are dashed and transparent, the way `.rail-assoc` marks a
row that was recalled rather than ranked — nothing ranked these. They carry
no verify, hide or delete: those act on *an* artifact, and the one the reader
opened is the one at the top. What they carry is the link that makes one of
them that artifact instead.

The source column grows with the run through a new `slice_over`, recomputed
rather than appended — every slice carries context lines at both edges, so
appending would print the lines between two adjacent passages twice. A line
between two spans stays context: a run that stepped over a superseded row has
a hole in it, and claiming those lines were read is what that column must not
do.

### Two shapes it did not become

**Not an inline expansion on the rail.** The rail is a `listbox` whose rows
are `option`s with arrow-key navigation; a disclosure holding focusable
content inside an option breaks the keyboard model as well as the ARIA.

**Not a semantic chain.** Adjacent passages are additionally similar through
their shared heading — the roadmap says so under *Server-side grouping* — so
a chain gated on similarity ends where the formatting changes rather than
where the meaning does. And a pane whose length is a computed judgement
cannot tell the reader whether it stopped because the document ended or
because a number was not met. The reader is the stopping rule instead.

**Cross-corpus belongs elsewhere.** `ordinal` is a per-corpus sequence, so
there is no reading order to continue into. A near artifact in another
document is a neighbour, and the pane already shows those as *Related* and
*Seen together*.

## The plan's uncovered subjects are gaps of their own

`[infer.ask] plan` names the subjects the excerpts miss; each becomes a
search. A subject whose search came back with every ranked candidate under
`weak_below` is a hole in the base, in the model's own words, for a question
a person actually asked — and until now it was computed, used to widen one
answer and thrown away. The cheapest gap on the list: the call was paid for.

Weakness, not emptiness, and deliberately the same threshold
`GapKind::Unmatched` reads. What makes `Subject` a kind of its own is the
text: `Unmatched` carries a query somebody typed, this carries a subject a
model named in a sentence written to describe a hole. Badged `planned`.

Only the ranked hits are read — a neighbour reached sideways is structure,
not a match, and letting one vouch for a subject would close a gap on
evidence about a different passage. `Round` now carries its query, because
zipping rounds against the plan's list misaligns the moment one endpoint
times out, and what would then be mislabelled is a claim about what the base
does not hold.

Rows hang off the question, cascade with it, and are written only where the
question was — the UI, with `[learn]` on. The vector costs nothing: the
fan-out embedded the subject to search for it, so it comes back out of the
query cache.

## A real bug found on the way

`open_gap_refs` did not read the new kind — only `open_gaps` had been wired.
That is the reader the capture page uses, so the gaps would have been grouped
by the sweep and shown on no page at all. Fixed and pinned.

## The roadmap was wrong in three places

Multi-user tenancy was listed as de-prioritised and payload-partitioned. It
shipped in #52 as a database and a Qdrant collection per user, with the queue
and one worker pool instance-wide, and the identity provider became the gate.

Two items are downstream of that. **Dropping the `scope` block** is unblocked:
with a collection per user every cluster carries the same subject, so the
block is a constant direction of magnitude 10 that orders nothing and, under
cosine, flattens the differences the seven blocks describing the situation can
make. Its cost is not "one weight to 0" as written — the weights *are* the
encoder version, so changing one retires every stored cluster and the offer
falls to its `Random` floor until the next context sweep. `config.example.toml`
now says what is true and what setting it to 0 costs. **OAuth 2.1 for `/mcp`**
stopped being administrative: a bearer token is what decides whose base a call
reads.

Both estimates for the work in this PR were also wrong and are corrected in
place rather than quietly dropped: *continues in* was "a badge and a route",
and the fifth `GapKind` was "one commit" — it wanted a table, because planned
rounds deliberately write nothing to the search log.

## Testing

Test-first throughout; the two places where implementation and test were
written together were mutation-checked to prove the tests bite.

- `cargo test` — 1891 lib tests plus 6 further suites, all green
- `cargo clippy --all-targets` — clean
- `cargo fmt` — clean

Not done: nothing was clicked in a browser. The behaviour is covered by
route-level tests against the real router, not by manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)