### PR TITLE
Drop the scope block from the context vector

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -244,6 +244,36 @@ thirty days, on Ops. Everything left here but the last item is gated on that
 instrument having months behind it, not on anybody's judgement; the last is
 the write-time half of the same question and carries an instrument of its own.
 
+Built: **the `scope` block is gone**, and with it the last thing in the vector
+that described who was asking rather than what the situation was. It existed to
+keep one person's situations from being ranked first for another while everyone
+shared a collection, at weight 10 against a block total under 5. Everyone no
+longer does: each user has their own database and their own Qdrant collection,
+and the read path cuts foreign clusters by an exact match on top of that, which
+was always the guarantee — a near-orthogonal direction is a probability, and
+isolation must not be one. Inside one collection the block had become a
+constant, ordering nothing and, under cosine, compressing the differences the
+blocks that do describe the situation are able to make.
+
+Two numbers became one. The full cosine ranked and `context_score` — the same
+vector with that block sliced off — decided the rung, because counting it in the
+gate would have dragged every same-subject pair above 0.95 and left `strong_at`
+and `weak_at` four hundredths apart. With the block gone the rank and the rung
+read the same evidence, and both thresholds keep the values they were calibrated
+at: the gate never saw what went. What is *not* collapsed is the loop over
+candidates. The rung still turns on `firm_at` as well as the score, so the
+closest situation can be a cluster seen twice that fails `strong_at` while an
+established pattern sits second and would pass — an argmax and a single gate is
+what used to drop that page to a random card.
+
+The cost was the one this file named and one it did not. The weights are the
+encoder version, so every stored cluster is retired and the offer falls to its
+`Random` floor until `jobs::context` has re-clustered. And the width changed,
+45 dimensions rather than 53 — a named vector cannot be resized in place, so an
+existing collection rejects the new one until `--reindex` has built the next
+generation. That copies the dense vectors across and re-embeds nothing; sets of
+the old width are discarded rather than reinterpreted.
+
 - **Learned block weights.** The weights in `[recommend.weights]` are chosen,
   not measured, and the honest description of them is "chosen". Once the
   shown/clicked rate has history, they can be fitted to it.
@@ -252,7 +282,9 @@ the write-time half of the same question and carries an instrument of its own.
   **Cost:** a fit over `offer_rates` history and the restraint to leave the
   defaults alone until the history exists. **A branch**, gated on data rather
   than on code. Fitting them before the data exists is guessing with extra
-  steps.
+  steps. Its one code-level precondition is met: with the `scope` block gone,
+  every weight left is a weight over something that actually varies, so a fit
+  is no longer a fit over a mostly-constant direction.
 
 - **Conjunctions across scopes.** The context vector can already hold "on the
   phone the hour matters, at the desk it does not"; nothing yet learns which of
@@ -270,29 +302,6 @@ the write-time half of the same question and carries an instrument of its own.
   **Cost:** no code — the mechanism is built. A harness run either way, and a
   commit of its own carrying both numbers in its message. It moves that way or
   it does not move.
-
-- **Dropping the `scope` block.** *(unblocked)* At weight 10 against a total
-  under 5, that block is what kept one person's situations from being ranked
-  first for another while everyone shared a collection. Everyone no longer does:
-  each user has their own database and their own Qdrant collection, and the read
-  path cuts foreign clusters exactly on top of that (`recommend.rs:177`), which
-  was always the guarantee. Inside one collection every cluster now carries the
-  same subject, so the block is a constant: the same direction of magnitude 10
-  in every stored vector and in the query, ordering nothing and — under
-  cosine — compressing the differences the seven blocks that *do* describe the
-  situation are able to make. `context_score` already slices it off, so the
-  gate never read it; only the ranking still carries it.
-  **Worth:** the full cosine stops being dominated by a block that decides
-  nothing, so the two numbers behind an offer are read on the same evidence.
-  Small in itself, and the honest precondition for fitting weights to history —
-  a fit over a mostly-constant block is a fit over noise.
-  **Cost:** not one weight after all. The weights are the encoder version
-  (`core::context::encoder_version`), so changing one retires every stored
-  cluster: they are skipped rather than explained with the wrong blocks, and the
-  offer falls to its `Random` floor until `jobs::context` has re-clustered. That
-  is correct behaviour and it is still a cost, and it argues for spending it
-  before the shown/clicked history is long enough to be worth keeping.
-  **One commit**, plus one sweep before the offer speaks again.
 
 - **The situation as a term in ranking.** The `ctx` vectors decide the offer
   under the search box and nothing else. The moment something is typed the
@@ -602,8 +611,8 @@ structural — there is no tenant filter to forget, because no tenant filter
 exists. Identity comes with it: the provider is the gate, and the local account
 store engram used to keep for a single operator is gone.
 
-Two items above are downstream of that. **Dropping the `scope` block** is
-unblocked and now has a cost worth naming. **OAuth 2.1 for `/mcp`** stopped
+Two items above are downstream of that. **Dropping the `scope` block** was
+unblocked by it and has shipped. **OAuth 2.1 for `/mcp`** stopped
 being administrative — with a collection per user, a bearer token is what
 decides whose base a call reads.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -587,8 +587,8 @@ firm_at = 2.5
 # Score at or above which an established situation is called a pattern, and
 # above which it is called a resemblance. Below both, a card is drawn at random
 # with no reason printed beside it — something to look at while the base has
-# nothing to say about the situation. Scored without the `scope` block, which
-# decides *who* may be offered something rather than how well it matches.
+# nothing to say about the situation. This is the same score the store ranked
+# on: the whole vector, every block of which describes the situation.
 strong_at = 0.75
 weak_at = 0.45
 # What an open of something this offered counts for, back into the profile.
@@ -601,21 +601,6 @@ self_weight = 0.0
 # weight however many dimensions it uses — seven one-hot slots for the weekday
 # do not outweigh two for the hour because there are seven of them.
 [recommend.weights]
-# Interim, and no longer load-bearing. This kept one person's situations from
-# being ranked first for another back when everyone shared one collection; each
-# user now has their own database and their own collection, and the read path
-# cuts foreign clusters by an exact match on top of that, which was always the
-# guarantee. Inside one collection every cluster carries the same subject, so
-# this block is the same direction in every stored vector and in the query: it
-# orders nothing, and under cosine it flattens the differences the blocks below
-# can make. `strong_at`/`weak_at` never saw it — the gate slices it off — so
-# only the ranking still carries it.
-#
-# It stays at 10.0 for one reason: the weights *are* the encoder version, so
-# changing this retires every cluster already learnt and the offer falls back
-# to a random card until the next context sweep has rebuilt them. Set it to 0
-# when you would rather pay that sweep than keep the distortion.
-scope = 10.0
 # The hour, as an angle — 23:30 and 00:30 are an hour apart, and 14:55 against a
 # 15:00 pattern costs almost nothing.
 time_of_day = 1.0

--- a/docs/superpowers/specs/2026-08-21-context-recommendation-design.md
+++ b/docs/superpowers/specs/2026-08-21-context-recommendation-design.md
@@ -9,6 +9,20 @@ Adds one named vector to the collection, two tables, one endpoint, and no model
 call anywhere.
 See §11 for what it is not allowed to break.
 
+> **Amended 2026-08-26: the `scope` block is gone.** §6 called it an interim
+> measure that would go to 0 once each user had their own collection, and
+> `2026-08-24-multi-user-tenancy-design.md` gave them one. It was removed rather
+> than zeroed, because a weight of 0 leaves the dimensions and the reasoning in
+> place: the layout is ten blocks and 45 dimensions, `encode` takes no `scope`
+> argument, and `context_score` is the cosine over the whole vector rather than
+> over everything after the block. The rung thresholds are unchanged — the gate
+> never read the block that went. Isolation is the exact cut in `Core::offer`,
+> which §11 already named as the thing that guarantees it. The changed width
+> means an existing collection needs `--reindex` before it will accept the new
+> vectors; that copies the dense vectors and re-embeds nothing. Read §6 and §11
+> below as the record of why the block existed, not as a description of the
+> code.
+
 ## 1. Why
 
 The area under the search box is empty, and the base knows something that could
@@ -231,7 +245,6 @@ operator can change.
 
 | Block | Encoding | Dims | Default weight |
 |---|---|---|---|
-| `scope` | one-hot | ~8 | 10.0 |
 | `time_of_day` | circular, `sin`/`cos` of the hour angle | 2 | 1.0 |
 | `weekday` | one-hot | 7 | 1.0 |
 | `weekend` | weekday / weekend | 2 | 0.3 |
@@ -243,14 +256,13 @@ operator can change.
 | `environment` | colour scheme, touch, orientation, audio outputs | 5 | 0.2 |
 | `month_cycle` | circular over the month | 2 | 0.0 (off) |
 
-Roughly 55 dimensions.
+Roughly 45 dimensions.
 
-`scope` at weight 10 is an interim measure. Today every scope shares one
-collection, and a point's multivector mixes the clusters of everyone who opened
-that artifact; a payload filter cannot help, because it acts on the point and
-not on elements of the set. A dominating `scope` block means a foreign cluster
-can never win `max_sim`. When each user gets their own collection, the weight
-goes to 0 and nothing else changes.
+*As shipped, this table also carried a `scope` block: a pseudo-random direction
+per subject over ~8 dimensions at weight 10, so that a foreign cluster could
+never win `max_sim` while every subject shared one collection and a payload
+filter — which acts on the point, not on elements of the set — could not make
+the cut. It was removed on 2026-08-26; see the amendment at the top.*
 
 Two rules that are easy to get wrong:
 
@@ -480,9 +492,10 @@ which must fall to `resurface` and say so.
   surface and disappears the moment a query exists. Nothing here moves a hit's
   position in a result list, which is why it does not wait on the harness.
 - **Read-time cost.** One vector query, no embedding, no model call.
-- **`scope` isolation.** Until per-user collections exist, the `scope` block's
-  weight is what keeps one person's clusters from being offered to another. It
-  is load-bearing and needs a test.
+- **`scope` isolation.** One person's clusters must never be offered to
+  another, and it needs a test. *As shipped this was two things, the block's
+  weight and the exact cut in `Core::offer`; only the exact cut remains, which
+  was always the guarantee — a near-orthogonal direction is a probability.*
 - **The reason must match the hit.** If the local recomputation and the store
   disagree, the line explains a different artifact than the one shown. Test 3.
 
@@ -507,4 +520,4 @@ sweep reading older rows.
 - *Conjunctions across scopes.* The vector can hold them; nothing yet learns
   which ones matter.
 - *Dropping the `scope` block.* It goes when each user has their own
-  collection, not before.
+  collection, not before. **Done, 2026-08-26** — see the amendment at the top.

--- a/src/config.rs
+++ b/src/config.rs
@@ -403,13 +403,6 @@ impl Default for SittingConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct BlockWeights {
-    /// Interim, and load-bearing. Every scope shares one collection today, and
-    /// a point's multivector mixes the clusters of everyone who opened that
-    /// artifact — a payload filter cannot help, because it acts on the point
-    /// and not on elements of the set. A dominating `scope` block is what keeps
-    /// a foreign cluster from ever winning `max_sim`. When each user gets their
-    /// own collection this goes to 0 and nothing else changes.
-    pub scope: f32,
     /// The hour, as an angle. See `core::context::encode`.
     pub time_of_day: f32,
     pub weekday: f32,
@@ -430,7 +423,6 @@ pub struct BlockWeights {
 impl Default for BlockWeights {
     fn default() -> Self {
         Self {
-            scope: 10.0,
             time_of_day: 1.0,
             weekday: 1.0,
             weekend: 0.3,
@@ -452,7 +444,6 @@ impl BlockWeights {
     /// recommendation nobody could account for.
     pub fn of(&self, block: &str) -> f32 {
         match block {
-            "scope" => self.scope,
             "time_of_day" => self.time_of_day,
             "weekday" => self.weekday,
             "weekend" => self.weekend,
@@ -506,13 +497,13 @@ pub struct RecommendConfig {
     /// "Twice before" — and demands a strong situational match before saying
     /// anything. At the default half-life this is the third repetition.
     pub firm_at: f64,
-    /// Context score — the vector with its `scope` block sliced off — at or
-    /// above which the offer is called a pattern.
+    /// Context score at or above which the offer is called a pattern.
     ///
-    /// Scored without `scope` because that block decides *who* may be offered
-    /// something, at weight 10 against a total of under 5. Counting it here
-    /// would drag every same-scope score above 0.95 and leave these two
-    /// thresholds four hundredths apart.
+    /// The same number the store ranked on. These two lived on a scale of their
+    /// own while a `scope` block dominated the full cosine at weight 10 against
+    /// a total of under 5 — counting it would have dragged every same-subject
+    /// pair above 0.95 and left them four hundredths apart. That block is gone
+    /// and these values are unchanged: the gate never read it.
     pub strong_at: f32,
     /// And above which it is called a resemblance. Below it the ladder falls
     /// through to the sitting, and then to what has been forgotten.
@@ -2332,19 +2323,18 @@ mod tests {
         // is young. It still needs `[learn]`, which is where the log it reads
         // is switched on — see `Core::recommends`.
         assert!(r.enabled);
-        // The scope block dominates so a foreign cluster can never win
-        // `max_sim`. When each user has their own collection this goes to 0
-        // and nothing else changes.
-        assert_eq!(r.weights.of("scope"), 10.0);
         assert_eq!(r.weights.of("weekday"), 1.0);
+        // Nothing weights who is asking. Isolation is a database and a
+        // collection per user, plus the exact cut in `Core::offer` — never a
+        // direction in a vector.
+        assert_eq!(r.weights.of("scope"), 0.0);
         assert_eq!(r.weights.of("month_cycle"), 0.0, "off by default");
         // A block nobody named contributes nothing rather than a default. The
         // block table and this lookup are edited together, and a typo that
         // silently gave a block weight 1.0 would be a recommendation nobody
         // could account for.
         assert_eq!(r.weights.of("phase_of_the_moon"), 0.0);
-        // The two rungs are far enough apart to mean different things, which
-        // is only true because `scope` is left out of the score.
+        // The two rungs are far enough apart to mean different things.
         assert!(r.strong_at > r.weak_at + 0.2);
         assert_eq!(r.self_weight, 0.0, "the offer does not teach itself");
     }
@@ -2364,7 +2354,6 @@ mod tests {
             "and so is every weight the offer rests on"
         );
         for block in [
-            "scope",
             "time_of_day",
             "weekday",
             "weekend",

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -123,79 +123,75 @@ pub struct Block {
     pub dims: usize,
 }
 
-/// The layout, in order. `scope` leads because `context_score` slices it off by
-/// taking everything after it, which only works while it is first.
+/// The layout, in order. Every block describes the situation and nothing
+/// describes who is in it: each user has their own database and their own
+/// collection, and `Core::offer` cuts foreign clusters by an exact match on top
+/// of that.
 ///
 /// Circular where there is a circle, one-hot where there is not. The hour is a
 /// circle, so 23:30 and 00:30 are an hour apart. The weekday is *not* a useful
 /// circle — "Friday is three from Tuesday" means nothing, and the pattern is
 /// exactly Friday — so it is one-hot, with a separate weak weekday/weekend
 /// block for the part that genuinely is gradual.
-pub const BLOCKS: [Block; 11] = [
-    Block {
-        name: "scope",
-        label: "who",
-        at: 0,
-        dims: 8,
-    },
+pub const BLOCKS: [Block; 10] = [
     Block {
         name: "time_of_day",
         label: "hour",
-        at: 8,
+        at: 0,
         dims: 2,
     },
     Block {
         name: "weekday",
         label: "weekday",
-        at: 10,
+        at: 2,
         dims: 7,
     },
     Block {
         name: "weekend",
         label: "weekend",
-        at: 17,
+        at: 9,
         dims: 2,
     },
     Block {
         name: "device",
         label: "device",
-        at: 19,
+        at: 11,
         dims: 8,
     },
     Block {
         name: "viewport",
         label: "screen",
-        at: 27,
+        at: 19,
         dims: 4,
     },
     Block {
         name: "locale",
         label: "language",
-        at: 31,
+        at: 23,
         dims: 8,
     },
     Block {
         name: "network",
         label: "network",
-        at: 39,
+        at: 31,
         dims: 4,
     },
     Block {
         name: "power",
         label: "battery",
-        at: 43,
+        at: 35,
         dims: 3,
     },
     Block {
         name: "environment",
         label: "surroundings",
-        at: 46,
+        at: 38,
         dims: 5,
     },
     Block {
         name: "month_cycle",
         label: "month",
-        at: 51,
+        at: 43,
         dims: 2,
     },
 ];
@@ -203,14 +199,25 @@ pub const BLOCKS: [Block; 11] = [
 /// Fixed at collection creation, so a new block invalidates every stored
 /// centroid. That is what `encoder_version` and whole-bundle storage are for:
 /// the sweep rebuilds from the raw bundles rather than losing the history.
-pub const CTX_DIM: usize = 53;
-
-/// The width of the leading `scope` block. See `context_score`.
-pub const SCOPE_DIMS: usize = 8;
+///
+/// A *changed* width is the heavier case, because a named vector cannot be
+/// resized in place: an existing collection keeps the size it was created with
+/// and rejects the new one. `--reindex` is the migration — it creates the next
+/// generation with this size and copies the dense vectors across, so nothing is
+/// re-embedded, and sets of the old width are discarded rather than reinterpreted
+/// (see `ctx_of` in `vector/qdrant.rs`).
+pub const CTX_DIM: usize = 45;
 
 /// Bumped whenever `BLOCKS` changes in any way — a width, an order, or what a
 /// slot means. Not what is stored: see `encoder_version`.
-pub const LAYOUT_VERSION: i64 = 1;
+///
+/// 2: the `scope` block dropped. It existed to keep one person's situations from
+/// being ranked first for another while everyone shared a collection, and each
+/// user has had their own since. Inside one collection it was the same direction
+/// of magnitude 10 in every stored vector and in the query — ordering nothing,
+/// and under cosine compressing the differences the ten blocks that describe the
+/// situation are able to make.
+pub const LAYOUT_VERSION: i64 = 2;
 
 /// What a stored cluster carries, and what the read path insists on matching.
 ///
@@ -356,18 +363,13 @@ fn bucket(s: &str, n: usize) -> usize {
 ///
 /// A block whose values are all zero is left at zero rather than normalised —
 /// dividing by nothing is how absence turns into a manufactured direction.
-pub fn encode(
-    at: i64,
-    scope: Option<&str>,
-    b: &Bundle,
-    w: &crate::config::BlockWeights,
-) -> Vec<f32> {
+pub fn encode(at: i64, b: &Bundle, w: &crate::config::BlockWeights) -> Vec<f32> {
     let t = local_time(at, b.tz.as_deref(), b.tz_offset_mins);
     let mut v = vec![0.0f32; CTX_DIM];
 
     for block in BLOCKS {
         let slot = &mut v[block.at..block.at + block.dims];
-        fill(block.name, slot, &t, scope, b);
+        fill(block.name, slot, &t, b);
         scale(slot, w.of(block.name));
     }
     v
@@ -375,35 +377,9 @@ pub fn encode(
 
 /// Raw values into one block's slots. Every arm either fills or leaves zeros;
 /// leaving zeros is how "the browser did not say" is expressed.
-fn fill(name: &str, s: &mut [f32], t: &LocalTime, scope: Option<&str>, b: &Bundle) {
+fn fill(name: &str, s: &mut [f32], t: &LocalTime, b: &Bundle) {
     use std::f32::consts::TAU;
     match name {
-        "scope" => {
-            // A deterministic pseudo-random direction per scope, spread over
-            // every slot — *not* one-hot over eight buckets.
-            //
-            // One-hot was the first version and was wrong: two people had a
-            // one-in-eight chance of landing in the same bucket, and a shared
-            // bucket means identical scope blocks, which means one person's
-            // Friday afternoon offered to another at a perfect score. A test
-            // with two names caught it on the first run.
-            //
-            // Spread this way, two distinct scopes are near-orthogonal rather
-            // than identical. That keeps a foreign cluster from ranking first
-            // in the store; what *guarantees* isolation is the exact scope
-            // check in `Core::offer`, because a near-orthogonal direction is
-            // still a probability and isolation must not be one.
-            if let Some(sc) = scope {
-                for (i, x) in s.iter_mut().enumerate() {
-                    let h = fnv1a(&format!("{sc}#{i}"));
-                    // The top 53 bits into [-1, 1): the low bits of FNV-1a move
-                    // least between neighbouring inputs, and `sc#0`..`sc#7` are
-                    // exactly neighbouring inputs.
-                    let unit = (h >> 11) as f64 / (1u64 << 53) as f64;
-                    *x = (unit * 2.0 - 1.0) as f32;
-                }
-            }
-        }
         "time_of_day" => {
             let a = TAU * t.hour / 24.0;
             s[0] = a.sin();
@@ -528,19 +504,17 @@ fn scale(s: &mut [f32], weight: f32) {
     }
 }
 
-/// How well the situation matches, ignoring who is asking.
+/// How well the situation matches.
 ///
-/// The `scope` block decides *which* artifact may be offered — it is what keeps
-/// a foreign cluster from ever winning `max_sim`, at weight 10 against a total
-/// of under 5 — and that same dominance would drag every same-scope full cosine
-/// above 0.95, leaving `strong_at` and `weak_at` four hundredths apart. So the
-/// choice is made on the full vector and the rung is decided here. Two
-/// questions, two scales.
+/// One number, and the same one the store ranked on. It was two while the
+/// `scope` block dominated the full cosine at weight 10 against a total of under
+/// 5: counting it would have dragged every same-subject pair above 0.95 and left
+/// `strong_at` and `weak_at` four hundredths apart, so the choice was made on
+/// the full vector and the rung on the rest of it. With that block gone the two
+/// scales are one, and `strong_at`/`weak_at` keep the values they were
+/// calibrated at — they never saw the block that went.
 pub fn context_score(now: &[f32], cluster: &[f32]) -> f32 {
-    if now.len() < SCOPE_DIMS || cluster.len() < SCOPE_DIMS {
-        return 0.0;
-    }
-    crate::vector::cosine(&now[SCOPE_DIMS..], &cluster[SCOPE_DIMS..])
+    crate::vector::cosine(now, cluster)
 }
 
 /// What each named block contributed, largest first.
@@ -554,9 +528,6 @@ pub fn context_score(now: &[f32], cluster: &[f32]) -> f32 {
 /// one cosine over the whole vector and each of these is a cosine over a slice,
 /// with a different denominator. They rank which blocks decided it, which is
 /// what the line under the offer needs and all it claims.
-///
-/// `scope` is excluded. It is always either a perfect match or a rejection, so
-/// it would lead every list while explaining nothing.
 pub fn contributions(
     now: &[f32],
     cluster: &[f32],
@@ -564,7 +535,6 @@ pub fn contributions(
 ) -> Vec<(&'static str, f32)> {
     let mut out: Vec<(&'static str, f32)> = BLOCKS
         .iter()
-        .filter(|b| b.name != "scope")
         .filter(|b| now.len() >= b.at + b.dims && cluster.len() >= b.at + b.dims)
         .map(|b| {
             let a = &now[b.at..b.at + b.dims];
@@ -613,6 +583,30 @@ mod tests {
             network: Some("cellular".into()),
             audio_outputs: Some(1),
             ..Default::default()
+        }
+    }
+
+    /// A bundle a desktop in London would send. Nothing about it agrees with
+    /// `phone()`, which is what makes it useful.
+    fn desktop() -> Bundle {
+        Bundle {
+            platform: Some("macOS".into()),
+            ua_family: Some("Firefox".into()),
+            touch: Some(false),
+            orientation: Some("landscape".into()),
+            network: Some("wired".into()),
+            color_scheme: Some("light".into()),
+            language: Some("en-GB".into()),
+            viewport_w: Some(1920.0),
+            viewport_h: Some(1080.0),
+            screen_w: Some(2560.0),
+            screen_h: Some(1440.0),
+            dpr: Some(2.0),
+            // No Battery API on a desktop, so that block says nothing at all
+            // rather than agreeing with a phone at some invented level.
+            battery_level: None,
+            charging: None,
+            ..phone()
         }
     }
 
@@ -679,8 +673,6 @@ mod tests {
             at += b.dims;
         }
         assert_eq!(at, CTX_DIM);
-        assert_eq!(BLOCKS[0].name, "scope");
-        assert_eq!(BLOCKS[0].dims, SCOPE_DIMS);
     }
 
     #[test]
@@ -688,8 +680,8 @@ mod tests {
         // The hour is a circle, so the two are an hour apart rather than
         // twenty-three. A one-hot hour would have called them maximally
         // different, which is the whole reason this block is an angle.
-        let late = encode(FRIDAY - 2 * 3600 - 22 * 60, None, &phone(), &weights());
-        let early = encode(FRIDAY - 3600 - 22 * 60, None, &phone(), &weights());
+        let late = encode(FRIDAY - 2 * 3600 - 22 * 60, &phone(), &weights());
+        let early = encode(FRIDAY - 3600 - 22 * 60, &phone(), &weights());
         let c = crate::vector::cosine(
             slice_of(&late, "time_of_day"),
             slice_of(&early, "time_of_day"),
@@ -699,8 +691,8 @@ mod tests {
 
     #[test]
     fn five_past_three_costs_almost_nothing_against_a_three_o_clock_pattern() {
-        let at_three = encode(FRIDAY - 52 * 60, None, &phone(), &weights());
-        let five_past = encode(FRIDAY - 47 * 60, None, &phone(), &weights());
+        let at_three = encode(FRIDAY - 52 * 60, &phone(), &weights());
+        let five_past = encode(FRIDAY - 47 * 60, &phone(), &weights());
         let c = crate::vector::cosine(
             slice_of(&at_three, "time_of_day"),
             slice_of(&five_past, "time_of_day"),
@@ -713,18 +705,18 @@ mod tests {
         // The rule the whole design rests on. Seven one-hot slots for the
         // weekday do not outweigh two for the hour because there are seven of
         // them: each block is normalised and *then* scaled.
-        let v = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let v = encode(FRIDAY, &phone(), &weights());
         let w = weights();
         assert!((norm(slice_of(&v, "weekday")) - w.weekday).abs() < 1e-5);
         assert!((norm(slice_of(&v, "time_of_day")) - w.time_of_day).abs() < 1e-5);
-        assert!((norm(slice_of(&v, "scope")) - w.scope).abs() < 1e-5);
+        assert!((norm(slice_of(&v, "device")) - w.device).abs() < 1e-5);
     }
 
     #[test]
     fn a_block_switched_off_contributes_nothing() {
         let mut w = weights();
         w.month_cycle = 0.0;
-        let v = encode(FRIDAY, None, &phone(), &w);
+        let v = encode(FRIDAY, &phone(), &w);
         assert_eq!(norm(slice_of(&v, "month_cycle")), 0.0);
     }
 
@@ -736,7 +728,7 @@ mod tests {
         let mut b = phone();
         b.battery_level = None;
         b.charging = None;
-        let v = encode(FRIDAY, None, &b, &weights());
+        let v = encode(FRIDAY, &b, &weights());
         assert_eq!(norm(slice_of(&v, "power")), 0.0, "power says nothing");
         assert!(
             norm(slice_of(&v, "weekday")) > 0.0,
@@ -752,7 +744,7 @@ mod tests {
         let mut b = phone();
         b.battery_level = None;
         b.charging = None;
-        let v = encode(FRIDAY, None, &b, &weights());
+        let v = encode(FRIDAY, &b, &weights());
         let c = contributions(&v, &v, &weights());
         let power = c.iter().find(|(n, _)| *n == "battery").unwrap();
         assert_eq!(power.1, 0.0);
@@ -765,7 +757,7 @@ mod tests {
         // hardened browser is a situation, not a gap.
         let bare = Bundle::default();
         assert!(device_key(&bare).is_none());
-        let v = encode(FRIDAY, None, &bare, &weights());
+        let v = encode(FRIDAY, &bare, &weights());
         assert!((norm(slice_of(&v, "device")) - weights().device).abs() < 1e-5);
     }
 
@@ -786,66 +778,44 @@ mod tests {
     }
 
     #[test]
-    fn two_people_in_the_same_situation_are_still_far_apart() {
-        // Until each person has their own collection, the `scope` block is the
-        // only thing keeping one person's situations from being offered to
-        // another. It is load-bearing and this is the test that says so.
-        let alice = encode(FRIDAY, Some("alice"), &phone(), &weights());
-        let bob = encode(FRIDAY, Some("bob"), &phone(), &weights());
-        let same = encode(FRIDAY, Some("alice"), &phone(), &weights());
+    fn nothing_in_the_vector_says_who_is_asking() {
+        // Each user has their own database and their own Qdrant collection, and
+        // the read path cuts foreign clusters by an exact match on top of that.
+        // Inside one collection every cluster carries the same subject, so a
+        // block for it is the same direction in every stored vector and in the
+        // query: it orders nothing and, under cosine, compresses the
+        // differences the blocks that *do* describe the situation can make.
         assert!(
-            crate::vector::cosine(&alice, &bob) < crate::vector::cosine(&alice, &same),
-            "a foreign scope must never win max_sim"
+            !BLOCKS.iter().any(|b| b.name == "scope"),
+            "the situation is what the browser reports, not who is holding it"
         );
+        assert_eq!(CTX_DIM, 45, "eight dimensions of constant went with it");
     }
 
     #[test]
-    fn the_rung_is_scored_without_the_scope_block() {
-        // The scope block decides *who* may be offered something. If it counted
-        // towards the rung too, it would drag every same-scope score above 0.95
-        // and `strong_at` and `weak_at` would have to live four hundredths
-        // apart. Two different jobs, two different scales.
-        let friday_phone = encode(FRIDAY, Some("alice"), &phone(), &weights());
-        let mut desktop = phone();
-        desktop.platform = Some("macOS".into());
-        desktop.ua_family = Some("Firefox".into());
-        desktop.touch = Some(false);
-        desktop.orientation = Some("landscape".into());
-        desktop.network = Some("wired".into());
-        desktop.color_scheme = Some("light".into());
-        desktop.language = Some("en-GB".into());
-        desktop.viewport_w = Some(1920.0);
-        desktop.viewport_h = Some(1080.0);
-        desktop.screen_w = Some(2560.0);
-        desktop.screen_h = Some(1440.0);
-        desktop.dpr = Some(2.0);
-        desktop.battery_level = None;
-        desktop.charging = None;
-        // A Monday morning at a desk: nothing about the situation agrees.
-        let monday_desk = encode(
-            FRIDAY + 3 * 86_400 - 8 * 3600,
-            Some("alice"),
-            &desktop,
-            &weights(),
-        );
-
+    fn the_situation_is_the_whole_vector() {
+        // Two numbers were needed while one block dominated the full cosine and
+        // was sliced off the gate. With that block gone there is one number:
+        // what ranks in the store is what `strong_at` and `weak_at` read.
+        let friday_phone = encode(FRIDAY, &phone(), &weights());
+        let monday_desk = encode(FRIDAY + 3 * 86_400 - 8 * 3600, &desktop(), &weights());
+        let full = crate::vector::cosine(&friday_phone, &monday_desk);
+        let scored = context_score(&friday_phone, &monday_desk);
         assert!(
-            crate::vector::cosine(&friday_phone, &monday_desk) > 0.9,
-            "scope alone carries it, which is the problem being solved"
+            (full - scored).abs() < 1e-6,
+            "the rank and the rung read the same evidence: {full} against {scored}"
         );
-        let s = context_score(&friday_phone, &monday_desk);
-        assert!(s < 0.4, "and the situation does not agree at all, got {s}");
+        assert!(
+            scored < 0.4,
+            "a Monday at a desk does not resemble a Friday on a phone, got {scored}"
+        );
     }
 
     #[test]
     fn the_reason_names_the_blocks_that_decided_it() {
-        let a = encode(FRIDAY, Some("alice"), &phone(), &weights());
+        let a = encode(FRIDAY, &phone(), &weights());
         let c = contributions(&a, &a, &weights());
-        assert!(
-            !c.iter().any(|(n, _)| *n == "who"),
-            "scope explains nothing"
-        );
-        assert_eq!(c.len(), BLOCKS.len() - 1);
+        assert_eq!(c.len(), BLOCKS.len());
         for pair in c.windows(2) {
             assert!(
                 pair[0].1 >= pair[1].1,
@@ -863,7 +833,7 @@ mod tests {
         // filled; the weekday and the hour still stand.
         let b = parse_bundle("}{ not json");
         assert!(b.tz.is_none());
-        let v = encode(FRIDAY, Some("alice"), &b, &weights());
+        let v = encode(FRIDAY, &b, &weights());
         assert_eq!(v.len(), CTX_DIM);
         assert!(norm(slice_of(&v, "weekday")) > 0.0);
     }
@@ -962,7 +932,7 @@ mod tests {
             tz: Some("Europe/Berlin".into()),
             ..Default::default()
         };
-        let v = encode(FRIDAY_1352_UTC, Some("alice"), &bare, &w);
+        let v = encode(FRIDAY_1352_UTC, &bare, &w);
         let named = contributions(&v, &v, &w);
         // Every block is still in the list — the `<details>` pane is where
         // exactness lives — but the ones the browser said nothing about are
@@ -970,7 +940,7 @@ mod tests {
         // `device`, `network` and `language` are not among them: their last
         // slot means "nothing identifying was sent", which is a state that
         // recurs and not an absence.
-        assert_eq!(named.len(), BLOCKS.len() - 1, "{named:?}");
+        assert_eq!(named.len(), BLOCKS.len(), "{named:?}");
         let spoken: Vec<&str> = named
             .iter()
             .filter(|(_, c)| *c > 0.0)

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -206,6 +206,10 @@ pub const BLOCKS: [Block; 10] = [
 /// generation with this size and copies the dense vectors across, so nothing is
 /// re-embedded, and sets of the old width are discarded rather than reinterpreted
 /// (see `ctx_of` in `vector/qdrant.rs`).
+///
+/// `ensure_collection` refuses to start against a collection whose `ctx` vector
+/// is a different width, because the failure without it is silent: the rejected
+/// query leaves `offer` on its random floor and the sweep dies part way through.
 pub const CTX_DIM: usize = 45;
 
 /// Bumped whenever `BLOCKS` changes in any way — a width, an order, or what a
@@ -513,6 +517,11 @@ fn scale(s: &mut [f32], weight: f32) {
 /// the full vector and the rung on the rest of it. With that block gone the two
 /// scales are one, and `strong_at`/`weak_at` keep the values they were
 /// calibrated at — they never saw the block that went.
+///
+/// A centroid of the wrong width scores zero rather than something plausible:
+/// `cosine` fails closed on a length mismatch, so a cluster stored under an
+/// older `CTX_DIM` cannot rank on a truncated comparison even if it reaches
+/// here past the caller's own layout check.
 pub fn context_score(now: &[f32], cluster: &[f32]) -> f32 {
     crate::vector::cosine(now, cluster)
 }

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -12,12 +12,11 @@
 use crate::core::Core;
 use crate::core::context::{Bundle, context_score, contributions, encode};
 use crate::error::Result;
-use crate::vector::cosine;
 
 /// How many artifacts the store is asked for.
 ///
 /// Ten. Every one of them has its clusters reloaded and rescored locally, at
-/// most five clusters of 53 dimensions apiece — a few thousand multiplications,
+/// most five clusters of 45 dimensions apiece — a few thousand multiplications,
 /// which is free next to the round trip that fetched them.
 pub const CANDIDATES: usize = 10;
 
@@ -119,7 +118,7 @@ impl Core {
             return Ok(None);
         }
         let now_at = self.clock.now();
-        let now = encode(now_at, scope, bundle, &self.recommend.weights);
+        let now = encode(now_at, bundle, &self.recommend.weights);
 
         // Superseded and deprecated are out, by `must_not` — the same rule
         // search obeys, and for the same reason a hand-written point carrying
@@ -139,19 +138,17 @@ impl Core {
         let ids: Vec<String> = hits.iter().map(|h| h.payload.artifact_id.clone()).collect();
         let clusters = self.store.context_clusters_of(&ids).await?;
 
-        // Ranked by the **full** vector — that is what reproduces the store's
-        // choice, because that is what `max_sim` scored. The rung comes from
-        // `context_score`, which slices the `scope` block off: the two numbers
-        // answer different questions and live on different scales.
+        // Ranked by `context_score`, which is the whole vector — the same
+        // number `max_sim` scored in the store, so this reproduces its choice
+        // rather than re-deciding it. It was two numbers while a `scope` block
+        // dominated the ranking at weight 10 and was sliced off the gate; with
+        // that block gone the rank and the rung read the same evidence.
         //
-        // Every candidate, in that order, and not only the argmax. The two
-        // numbers disagreeing is not an edge case here — `scope` is weighted
-        // 10 against a total under 5, so it dominates the ranking and barely
-        // participates in the gate. A thin cluster could take the top of the
-        // list on the strength of the block the gate does not read, fail the
-        // gate on the blocks it does, and drop the whole page to a random card
-        // while an established Friday-afternoon pattern sat second and would
-        // have passed. The first candidate that clears its rung is the offer.
+        // Still every candidate in that order rather than the argmax alone: the
+        // rung also turns on `firm_at`, so the closest situation can be a
+        // cluster seen twice that fails `strong_at` while an established
+        // Friday-afternoon pattern sits second and would pass. The first
+        // candidate that clears its rung is the offer.
         let mut ranked: Vec<(
             &crate::vector::SearchHit,
             &crate::store::context::StoredCluster,
@@ -162,18 +159,19 @@ impl Core {
                 continue;
             };
             for c in mine {
-                // Exact, not probabilistic. The `scope` block keeps a foreign
-                // cluster from ranking first in the store, but it is a
-                // direction in 53 dimensions and two of them are only ever
-                // *near*-orthogonal — and isolation must not be a probability.
-                // A cluster belongs to whoever opened the artifact, and this
-                // reads only the ones that belong to the caller.
+                // Exact, and now the only cut there is. A `scope` block in the
+                // vector used to keep a foreign cluster from ranking first,
+                // but a near-orthogonal direction is a probability and
+                // isolation must not be one — so this check was always the
+                // guarantee and the block was never more than a nudge in front
+                // of it. A cluster belongs to whoever opened the artifact, and
+                // this reads only the ones that belong to the caller.
                 //
-                // This is also why the multivector's own `scope` block cannot
-                // be the guarantee: a payload filter acts on the point, not on
-                // elements of the set, so Qdrant cannot make this cut. Loading
-                // the clusters is what makes it available, and the read path
-                // loads them anyway to produce the reason.
+                // Qdrant cannot make the cut for us: a payload filter acts on
+                // the point, not on elements of the set, and the `ctx`
+                // multivector is one array shared by everyone who opened this
+                // artifact. Loading the clusters is what makes it available,
+                // and the read path loads them anyway to produce the reason.
                 if c.scope.as_deref() != scope {
                     continue;
                 }
@@ -187,16 +185,15 @@ impl Core {
                 {
                     continue;
                 }
-                ranked.push((hit, c, cosine(&now, &c.centroid)));
+                ranked.push((hit, c, context_score(&now, &c.centroid)));
             }
         }
-        // Descending, and stable underneath: two clusters on the same full
-        // cosine keep the store's own order rather than swapping between page
-        // views.
+        // Descending, and stable underneath: two clusters on the same score
+        // keep the store's own order rather than swapping between page views.
         ranked.sort_by(|a, b| b.2.total_cmp(&a.2));
 
-        for (hit, cluster, _) in &ranked {
-            let score = context_score(&now, &cluster.centroid);
+        for (hit, cluster, score) in &ranked {
+            let score = *score;
             // Established, or seen only once or twice. A thin cluster has to
             // match the situation *better* before anything is said, which is
             // what keeps a single accident from being offered as if it meant
@@ -509,7 +506,7 @@ mod tests {
         weight: f64,
         events: i64,
     ) {
-        let v = encode(at, Some(scope), b, &core.recommend.weights);
+        let v = encode(at, b, &core.recommend.weights);
         core.store
             .replace_context_clusters(
                 aid,
@@ -713,7 +710,7 @@ mod tests {
         )
         .await;
 
-        let now = encode(FRIDAY, Some("alice"), &phone(), &core.recommend.weights);
+        let now = encode(FRIDAY, &phone(), &core.recommend.weights);
         let from_store = core
             .vectors
             .context_query(&now, CANDIDATES, &Default::default())
@@ -787,11 +784,13 @@ mod tests {
 
     #[tokio::test]
     async fn a_foreign_scope_is_cut_exactly_rather_than_out_scored() {
-        // The `scope` block keeps a foreign cluster from ranking first in the
-        // store, but it is a direction in 53 dimensions and two of them are
-        // only ever near-orthogonal. What makes isolation exact is that the
-        // read path loads the clusters — which it does anyway, to produce the
-        // reason — and reads only the ones belonging to the caller.
+        // Nothing in the vector says whose situation it is, and nothing ever
+        // should have: a `scope` block kept a foreign cluster from ranking
+        // first in the store, but it was a direction two of which are only
+        // ever near-orthogonal, and isolation must not be a probability. What
+        // makes it exact is that the read path loads the clusters — which it
+        // does anyway, to produce the reason — and reads only the ones
+        // belonging to the caller.
         //
         // So: bob has learned nothing, and alice's cluster is the *only* thing
         // in the index. The store therefore returns it however anyone scores,
@@ -800,7 +799,7 @@ mod tests {
         let aid = seed_artifact(&core, "recycling centre").await;
         learn(&core, &aid, "alice", FRIDAY - 7 * 86_400, &phone()).await;
 
-        let now = encode(FRIDAY, Some("bob"), &phone(), &core.recommend.weights);
+        let now = encode(FRIDAY, &phone(), &core.recommend.weights);
         let from_store = core
             .vectors
             .context_query(&now, CANDIDATES, &Default::default())
@@ -1107,12 +1106,11 @@ mod tests {
 
     #[tokio::test]
     async fn a_candidate_that_fails_its_rung_does_not_take_the_others_down_with_it() {
-        // The ladder reads two numbers that are not the same number. The full
-        // cosine ranks — it is what `max_sim` scored — and `context_score`,
-        // which slices `scope` off, decides the rung. `scope` is weighted 10
-        // against a block total under 5, so it dominates the first and barely
-        // enters the second, and the two can disagree about which candidate is
-        // best.
+        // The rung is not the ranking. One number orders the candidates, and
+        // `firm_at` decides which threshold each of them has to clear: a
+        // cluster seen once needs a *strong* match where an established one
+        // needs only a resemblance. So the closest situation can be the one
+        // that fails.
         //
         // This used to be an argmax and a single gate: whichever cluster won
         // the ranking was the only one ever tested, and if it failed, the page
@@ -1120,39 +1118,30 @@ mod tests {
         // second that would have passed. A pattern replaced by a card claiming
         // nothing is the worst rung the ladder can produce.
         let core = core_at(FRIDAY).await;
-        let now = encode(
-            FRIDAY,
-            Some("alice"),
-            &Bundle::default(),
-            &core.recommend.weights,
-        );
-        let dims = crate::core::context::SCOPE_DIMS;
+        let now = encode(FRIDAY, &Bundle::default(), &core.recommend.weights);
 
-        // Thin, and nothing outside `scope`. It takes the top of the ranking on
-        // the strength of the block the gate does not read, and scores 0 on the
-        // blocks it does — so `Tentative`, which needs a *strong* match, is
-        // refused.
-        let mut thin = vec![0.0; now.len()];
-        thin[..dims].copy_from_slice(&now[..dims]);
-
-        // Established, and a real half-match on the blocks that decide the
-        // rung: `Similar` at `weak_at`. Its extra length outside `scope` costs
-        // it the ranking against the candidate that has none.
-        let rest = &now[dims..];
-        let norm = rest.iter().map(|v| v * v).sum::<f32>().sqrt();
-        // The device block, which an empty bundle leaves at zero — so this is a
-        // direction the current situation has nothing in.
+        // A direction the present situation has nothing in, so a candidate can
+        // be placed at a chosen angle to it. An empty bundle reports no
+        // viewport at all, which leaves that block at zero.
         let free = crate::core::context::BLOCKS
             .iter()
-            .find(|b| b.name == "device")
+            .find(|b| b.name == "viewport")
             .unwrap()
             .at;
-        let mut firm = vec![0.0; now.len()];
-        firm[..dims].copy_from_slice(&now[..dims]);
-        for i in dims..now.len() {
-            firm[i] = now[i] / norm;
-        }
-        firm[free] += 3f32.sqrt();
+        // `cos(t) * now_hat + sin(t) * e` scores exactly `cos(t)` against
+        // `now`, because `e` is orthogonal to it.
+        let at_score = |target: f32| {
+            let n = now.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let mut v: Vec<f32> = now.iter().map(|x| x / n * target).collect();
+            v[free] += (1.0 - target * target).sqrt();
+            v
+        };
+
+        // Seen once, and the closest match there is — but a thin cluster has to
+        // clear `strong_at` to be offered at all, and this does not.
+        let thin = at_score(0.65);
+        // Established, and further away. `weak_at` is all it has to clear.
+        let firm = at_score(0.55);
 
         let a = seed_artifact(&core, "a coincidence").await;
         let b = seed_artifact(&core, "recycling centre").await;
@@ -1163,12 +1152,13 @@ mod tests {
         // one that clears a rung. Asserted rather than assumed — if the
         // encoder's weights move, this test must fail loudly rather than pass
         // for a reason it was not written for.
+        let thin_score = context_score(&now, &thin);
+        let firm_score = context_score(&now, &firm);
         assert!(
-            cosine(&now, &thin) > cosine(&now, &firm),
+            thin_score > firm_score,
             "the thin cluster no longer wins the ranking"
         );
-        assert!(context_score(&now, &thin) < core.recommend.strong_at);
-        let firm_score = context_score(&now, &firm);
+        assert!(thin_score < core.recommend.strong_at);
         assert!(
             firm_score >= core.recommend.weak_at && firm_score < core.recommend.strong_at,
             "the firm cluster is not a Similar: {firm_score}"

--- a/src/core/recommend.rs
+++ b/src/core/recommend.rs
@@ -531,10 +531,9 @@ mod tests {
     }
 
     /// Give `aid` one cluster whose centroid is written by hand, so a test can
-    /// place a candidate at a chosen full cosine and a chosen `context_score`
-    /// — the two numbers the ladder reads, which the encoder always moves
-    /// together and which have to be separable to test what happens when they
-    /// disagree.
+    /// place a candidate at a chosen `context_score` — the one number the
+    /// ladder reads — without going through the encoder, which only ever
+    /// produces the scores some real bundle happens to land on.
     async fn learn_raw(
         core: &Core,
         aid: &str,

--- a/src/jobs/context.rs
+++ b/src/jobs/context.rs
@@ -246,7 +246,7 @@ fn blend(centroid: &mut [f32], have: f64, add: &[f32], w: f64) {
 
 /// The two nearest centroids, as `(keep, drop)` with `keep < drop`.
 ///
-/// Quadratic, over at most `max_clusters + 1` vectors of 53 dimensions. That is
+/// Quadratic, over at most `max_clusters + 1` vectors of 45 dimensions. That is
 /// a few hundred multiplications on a path that runs every six hours.
 fn closest_pair(centroids: &[&[f32]]) -> Option<(usize, usize)> {
     let mut best: Option<(usize, usize, f32)> = None;
@@ -356,12 +356,11 @@ pub async fn run(core: &Core) -> Result<Report> {
             continue;
         }
 
-        let scope_arg = (!scope.is_empty()).then_some(scope.as_str());
         by_pair
             .entry((scope.clone(), artifact_id))
             .or_default()
             .push(Member {
-                vec: crate::core::context::encode(at, scope_arg, &bundle, &cfg.weights),
+                vec: crate::core::context::encode(at, &bundle, &cfg.weights),
                 weight,
                 at,
                 bundle: raw,

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -397,6 +397,15 @@ pub trait VectorStore: Send + Sync {
 }
 
 pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    // Vectors of different widths are not directions in the same space. Zipping
+    // them would truncate the dot product to the shorter one while both norms
+    // stayed full-length, which answers a plausible-looking number for what is
+    // always a bug — a stored vector written under an older layout, or a slice
+    // taken at the wrong offset. Fail closed: no similarity, so nothing ranks
+    // on it and the caller's own guard, if it has one, still sees zero.
+    if a.len() != b.len() {
+        return 0.0;
+    }
     let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
     let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
     let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -406,4 +415,28 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
         return 0.0;
     }
     dot / (na * nb)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cosine;
+
+    #[test]
+    fn a_width_mismatch_scores_zero_rather_than_a_truncated_cosine() {
+        // Zipping alone would take the dot product over the first two slots and
+        // divide it by the full norm of both sides — a number in range, ordered
+        // against real scores, and meaningless. The case that produces it is a
+        // centroid stored under an older layout.
+        let short = [1.0, 1.0];
+        let long = [1.0, 1.0, 1.0];
+        assert_eq!(cosine(&short, &long), 0.0);
+        assert_eq!(cosine(&long, &short), 0.0);
+    }
+
+    #[test]
+    fn equal_widths_are_untouched_by_the_guard() {
+        let a = [1.0, 0.0];
+        assert!((cosine(&a, &a) - 1.0).abs() < 1e-6);
+        assert!((cosine(&a, &[0.0, 1.0]) - 0.0).abs() < 1e-6);
+    }
 }

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -83,6 +83,31 @@ pub fn dimension_mismatch(collection: &str, configured: usize, existing: usize) 
     ))
 }
 
+/// A named vector cannot be resized in place, so a collection created under an
+/// older `BLOCKS` keeps the `ctx` width it was made with and answers 400 to
+/// every read and write at the new one.
+///
+/// Unlike `dimension_mismatch` this *is* repairable, and saying so is the whole
+/// point of the check: left to run, the service starts normally, `offer`
+/// swallows its rejected context query and falls back to its random floor
+/// forever, and the context sweep dies on its first artifact — after it has
+/// already replaced that artifact's stored centroids with the new width.
+fn ctx_dimension_mismatch(collection: &str, configured: usize, existing: Option<u64>) -> Error {
+    let found = match existing {
+        Some(n) => format!("has a `{CTX}` vector {n} wide"),
+        None => format!("has no `{CTX}` vector at all"),
+    };
+    Error::Vector(format!(
+        "collection `{collection}` {found}, but this build encodes situations at {configured}. \
+         Refusing to start: Qdrant rejects every context read and write at the other width, \
+         which would leave recommendations silently falling back to random and the context \
+         sweep failing part way through. Run `--reindex --user <slug>`, once per user, to \
+         build the next generation at {configured} — dense vectors are copied across, so \
+         nothing is re-embedded, and the situations rebuild from `context_events` on the \
+         next sweep."
+    ))
+}
+
 /// Qdrant refuses an alias whose name collides with an existing collection, so
 /// a plain collection sitting where the alias belongs blocks every read and
 /// write. It is not ours and nothing here may delete it.
@@ -716,6 +741,28 @@ impl QdrantVectors {
             .ok_or_else(|| Error::Vector("could not read collection vector dimension".into()))
     }
 
+    /// The width of the `ctx` named vector, or `None` for a collection created
+    /// before there was one — which is the same problem for the same reason,
+    /// and is why the caller decides rather than this.
+    async fn ctx_dim(&self, collection: &str) -> Result<Option<u64>> {
+        let info: Value = self
+            .call(Method::GET, &format!("/collections/{collection}"), None)
+            .await?;
+        Ok(info
+            .pointer(&format!("/config/params/vectors/{CTX}/size"))
+            .and_then(Value::as_u64))
+    }
+
+    /// Refuse a collection whose `ctx` width is not the one this build encodes.
+    /// See `ctx_dimension_mismatch` for what running on anyway costs.
+    async fn check_ctx_dim(&self, collection: &str) -> Result<()> {
+        let want = crate::core::context::CTX_DIM;
+        match self.ctx_dim(collection).await? {
+            Some(n) if n as usize == want => Ok(()),
+            found => Err(ctx_dimension_mismatch(collection, want, found)),
+        }
+    }
+
     /// `exact` because the collection-info counter is allowed to lag behind an
     /// accepted write, and both callers act on the number.
     async fn exact_count(&self, collection: &str) -> Result<u64> {
@@ -1107,6 +1154,7 @@ impl VectorStore for QdrantVectors {
             if existing as usize != dim {
                 return Err(dimension_mismatch(&current, dim, existing as usize));
             }
+            self.check_ctx_dim(&current).await?;
             // An already-serving collection predates any index this release
             // added, so this is the path that matters most.
             self.ensure_payload_indexes(&current).await?;
@@ -1127,6 +1175,7 @@ impl VectorStore for QdrantVectors {
             if existing as usize != dim {
                 return Err(dimension_mismatch(&orphan, dim, existing as usize));
             }
+            self.check_ctx_dim(&orphan).await?;
             tracing::warn!(
                 collection = %orphan,
                 alias = %self.alias,
@@ -2202,6 +2251,109 @@ mod tests {
         let msg = dimension_mismatch("chunks_v1", 768, 1024).to_string();
         assert!(msg.contains("cannot change their width"), "{msg}");
         assert!(msg.contains("embed again"), "no way forward offered: {msg}");
+    }
+
+    #[test]
+    fn ctx_dimension_mismatch_names_the_repair_that_exists() {
+        // The dense message rules a rebuild out; this one is the case where a
+        // rebuild is exactly the answer, and the reader has to be able to tell
+        // the two apart from the text alone.
+        let msg = ctx_dimension_mismatch("engram_v1", 45, Some(53)).to_string();
+        assert!(msg.contains("45"), "{msg}");
+        assert!(msg.contains("53"), "{msg}");
+        assert!(msg.contains("--reindex"), "no way forward offered: {msg}");
+    }
+
+    #[test]
+    fn a_collection_predating_context_vectors_reads_as_a_mismatch() {
+        // `None` is not "nothing to check": writes to a named vector the
+        // collection does not have fail the same way, for the same reason, and
+        // are fixed by the same rebuild.
+        let msg = ctx_dimension_mismatch("engram_v1", 45, None).to_string();
+        assert!(msg.contains("no `ctx` vector at all"), "{msg}");
+        assert!(msg.contains("--reindex"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn a_collection_with_the_old_context_width_stops_startup() {
+        // Without this the service comes up clean: the dense width is what the
+        // check used to read and the embedding model never changed, so a
+        // collection built under the previous `BLOCKS` passed. Every context
+        // query after that was a 400 that `offer` swallowed.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/aliases"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "aliases": [
+                    { "alias_name": "engram", "collection_name": "engram_v1" }
+                ] }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/collections/engram_v1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "config": { "params": { "vectors": {
+                    DENSE: { "size": 768 },
+                    CTX: { "size": 53 },
+                } } } }
+            })))
+            .mount(&server)
+            .await;
+
+        let err = against(&server)
+            .await
+            .ensure_collection(768)
+            .await
+            .expect_err("the dense width matching is not enough to serve on");
+        let msg = err.to_string();
+        assert!(msg.contains("53"), "{msg}");
+        assert!(msg.contains("--reindex"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn a_collection_at_the_current_context_width_starts() {
+        // The other half: the check must not turn a healthy collection away,
+        // and it runs on every startup.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/aliases"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "aliases": [
+                    { "alias_name": "engram", "collection_name": "engram_v1" }
+                ] }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/collections/engram_v1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "config": { "params": { "vectors": {
+                    DENSE: { "size": 768 },
+                    CTX: { "size": crate::core::context::CTX_DIM },
+                } } }, "payload_schema": {} }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/collections/engram_v1/index"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": { "status": "completed" }, "status": "ok"
+            })))
+            .mount(&server)
+            .await;
+
+        against(&server)
+            .await
+            .ensure_collection(768)
+            .await
+            .expect("a collection at the current width is the ordinary case");
     }
 
     #[test]

--- a/src/vector/qdrant.rs
+++ b/src/vector/qdrant.rs
@@ -222,7 +222,7 @@ fn collection_body(dim: usize) -> Value {
                 "distance": "Cosine",
                 "multivector_config": { "comparator": "max_sim" },
                 // No index, an exact scan. The candidates are only artifacts
-                // ever opened, at 53 dimensions, and an HNSW graph would be
+                // ever opened, at 45 dimensions, and an HNSW graph would be
                 // rebuilt on every sweep write to beat a scan it cannot beat at
                 // that size.
                 "hnsw_config": { "m": 0 },
@@ -2047,7 +2047,7 @@ mod tests {
         );
         // No HNSW, an exact scan. Right here rather than thrifty: the
         // candidates are only artifacts ever opened — hundreds to a few
-        // thousand at 53 dimensions — and an index would be rebuilt on every
+        // thousand at 45 dimensions — and an index would be rebuilt on every
         // sweep write to beat a scan it cannot beat at that size.
         assert_eq!(body["vectors"][CTX]["hnsw_config"]["m"], 0);
         // And nothing else moved.

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -5141,7 +5141,7 @@ mod tests {
             tz: Some("Europe/Berlin".into()),
             ..Default::default()
         };
-        let v = crate::core::context::encode(at, Some("user-1"), &bundle, &core.recommend.weights);
+        let v = crate::core::context::encode(at, &bundle, &core.recommend.weights);
         core.store
             .replace_context_clusters(
                 &aid,


### PR DESCRIPTION
## Why

The `scope` block kept one person's situations from being ranked first for another while everyone shared a Qdrant collection, at weight 10 against a block total under 5. Nobody shares one since the multi-user tenancy work: each user has their own database and their own collection, and `Core::offer` cuts foreign clusters by an exact match on top of that.

That exact cut was always the guarantee. The block was a direction two of which are only ever *near*-orthogonal, and isolation must not be a probability — the block was never more than a nudge in front of the check that actually decides it.

Inside one collection it had become a constant: the same direction of magnitude 10 in every stored vector and in the query, ordering nothing and, under cosine, compressing the differences the blocks that *do* describe the situation can make.

This is the **Dropping the `scope` block** item from `ROADMAP.md` under `[Anticipation]`.

## What changed

Removed rather than zeroed — a weight of 0 leaves the dimensions and the reasoning standing.

- `BLOCKS` is ten entries, `CTX_DIM` is 45 (was 53), `SCOPE_DIMS` is gone
- `encode()` and `fill()` take no `scope` argument
- `LAYOUT_VERSION` 1 → 2

**Two numbers become one.** The full cosine ranked and `context_score` — the same vector with the block sliced off — decided the rung, because counting it in the gate would have dragged every same-subject pair above 0.95 and left `strong_at` and `weak_at` four hundredths apart. `context_score` is now the cosine over the whole vector, and `offer()` ranks on it. Both thresholds keep their values: the gate never read what went.

**Not collapsed:** the loop over candidates. The rung turns on `firm_at` as well as the score, so the closest situation can be a cluster seen twice that fails `strong_at` while an established pattern sits second and would pass. An argmax and a single gate is what used to drop that page to a random card.

## Migration — two things, not one

1. The weights **are** the encoder version, so every stored cluster is retired and the offer falls to its `Random` floor until `jobs::context` has re-clustered. This was the cost the roadmap named.
2. The **width changed**, which it did not name. A named vector cannot be resized in place, so an existing collection rejects the new vectors until `--reindex` has built the next generation. That copies the dense vectors across and re-embeds nothing.

## Tests

TDD: the two new tests failed first with a full cosine of 0.963 against a situation score of −0.12 — the block carrying the ranking on its own — then passed.

- `nothing_in_the_vector_says_who_is_asking`
- `the_situation_is_the_whole_vector` — rank and rung read the same evidence
- `a_candidate_that_fails_its_rung_does_not_take_the_others_down_with_it` — rewritten on the one-number premise
- Isolation still pinned by `a_foreign_scope_is_cut_exactly_rather_than_out_scored` and `one_persons_situations_are_never_offered_to_another`

Suite: **1912 passed, 2 failed**. Both failures are in `web::ui` (`opening_a_passage_appends_the_one_that_follows_it`, `the_run_control_asks_for_one_more_than_is_on_screen`), concern the continues-in feature, and predate this branch — verified against `master` at fc505e0. `cargo fmt --check` clean; `clippy` is not installed locally, so CI is the gate as usual.

## Docs

`ROADMAP.md` records it as built with its reasons and notes the `--reindex` cost; `docs/superpowers/specs/2026-08-21-context-recommendation-design.md` carries a dated amendment at the top so §6 and §11 read as the record of why the block existed rather than as a description of the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhKgsKTfn8C5V2aQHk4JJh