### PR TITLE
fix: duplicate hygiene was eating the verbatim substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,23 +106,44 @@ one click. No artifact spans two segments.
 
 ## Deployment
 
+Install the released binary:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/overcuriousity/engram/master/install.sh | sh
+```
+
+It takes the build for the machine it runs on — a statically linked `x86_64`
+one that needs no libc of any particular vintage, or `aarch64` — checks it
+against the release's `SHA256SUMS` before unpacking it, and installs to
+`/usr/local/bin` where that is writable and `~/.local/bin` otherwise. It never
+reaches for sudo. `ENGRAM_INSTALL_DIR` says where to put it instead,
+`ENGRAM_VERSION` pins a tag rather than taking the newest. The script is
+[`install.sh`](install.sh) in this repository and is worth reading before you
+pipe it to a shell; the archives are on the [releases
+page](https://github.com/overcuriousity/engram/releases) if you would rather
+take them by hand. Versions are dates — `v2026.827.0` — and are marked
+pre-release while the shape of things is still moving.
+
+Or build it:
+
 ```bash
 cargo build --release        # target/release/engram
+```
+
+Either way the first run is the same — `engram` below is the installed binary,
+or `./target/release/engram` if you built it. `config.example.toml` is in this
+repository and in every release archive:
+
+```bash
 cp config.example.toml config.toml
-./target/release/engram --hash-password 'your password'   # paste into config.toml
-./target/release/engram
+engram --hash-password 'your password'   # paste into config.toml
+engram
 ```
 
 Qdrant has to be answering on the address in `config.toml` — `127.0.0.1:6333`
 by default — before that last line. How you run it is your business: the
 [released binary](https://github.com/qdrant/qdrant/releases) and a container
 are equally fine, and engram only ever speaks to its REST port.
-
-Released builds are on the [releases
-page](https://github.com/overcuriousity/engram/releases): a statically linked
-`x86_64` binary that needs no libc of any particular vintage, and an `aarch64`
-one. Versions are dates — `v2026.827.0` — and are marked pre-release while the
-shape of things is still moving.
 
 Open <http://127.0.0.1:8080/auth/login>, capture something, and watch it move
 through `raw → embedding → ready` on Browse. `partial` means part of it has not
@@ -411,7 +432,9 @@ style = "tei"
 Everything above is the server's `config.toml`. The client half of the same
 binary — `engram -c`, `-s`, `-a`, and the piped form — never reads it: it talks
 to a running engram over HTTP and needs only an address and a token, which it
-reads from `~/.config/engram/cli.toml`.
+reads from `~/.config/engram/cli.toml`. On a laptop that is only ever a client,
+the [installer](#deployment) is the whole of the install, and
+`ENGRAM_INSTALL_DIR=~/.local/bin` keeps it out of a directory needing root.
 
 ```toml
 url = "http://127.0.0.1:8080"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ from the positions those searches actually gave.
   a score as a bar, the cliff as a break in the trace beside it — and in a pipe
   it is plain text with every one of those claims still said in words. Exit `1`
   means nothing was found, so `engram -s "x" || …` is a usable branch.
+  A list clips each hit to a couple of lines; `engram --show 3` then reads the
+  third of them in full, along with the document it was captured from. It takes
+  a rank from the last search, a leading piece of an id, or a whole id — and
+  the sources under an `-a` answer are numbered as the same kind of list, so
+  the `[9]` an answer cites is `engram --show 9`.
 - **Search by meaning** — type the situation, not the keywords. Loose matches
   are labelled as loose, and where the scores fall off a cliff the hits past it
   are greyed: they keep their rank but stop claiming to be answers.

--- a/config.example.toml
+++ b/config.example.toml
@@ -378,6 +378,17 @@ enabled = true
 # either way; parking only withholds the model call until you decide on Ops.
 near_dupe_min = 0.90
 # Cosine at or above which a pair of artifacts goes on the review queue.
+#
+# A floor, not an admission. Clearing it is necessary and not sufficient: a pair
+# reaches the model only when one text is wholly inside the other, or both came
+# out of one document. A cosine cannot tell "stored twice" from "taught by
+# thirteen authors", and on a corpus of scripts covering one subject the second
+# is the ordinary case — passages from different scripts sit at 0.89 to 0.93
+# while duplicating nothing. Two sources agreeing is evidence in its own right,
+# and merging them erases that they agreed.
+#
+# Passages are outside this entirely: they are the verbatim substrate and are
+# never one side of a pair, whatever they score.
 review_min = 0.88
 # Cosine at or above which the older artifact is hidden without asking. Well
 # clear of `review_min` on purpose: two genuinely distinct artifacts about one

--- a/docs/superpowers/plans/2026-08-27-consolidation-boundary.md
+++ b/docs/superpowers/plans/2026-08-27-consolidation-boundary.md
@@ -1,0 +1,700 @@
+# Consolidation Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop duplicate hygiene from consuming verbatim passages, and stop topical similarity alone from buying a model call.
+
+**Architecture:** Four independent guards, each a few lines at one call site. Passages never reach `record_pair`; a merged artifact never arms a neighbour query; `insert_merged_artifact` refuses a non-captured root; and admission to the dedupe queue needs containment or a shared corpus on top of the cosine. No new tables, no new config, no new job stages.
+
+**Tech Stack:** Rust, `sqlx` over SQLite, `tokio` tests inline in each module (`#[cfg(test)] mod tests`), `cargo test --lib`.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-consolidation-boundary-design.md`
+
+## Global Constraints
+
+- Test names are sentences, and each carries the bug it pins in a comment. This is a house rule visible throughout `src/jobs/` and it is not optional.
+- No new configuration keys. `review_min`, `auto_supersede`, `per_point`, `dedupe_interval_mins`, `max_dedupe_per_tick` keep their current meanings and defaults.
+- No schema change. `artifact_pairs.decided_by` is explicitly **out of scope** (spec §6).
+- Nothing in this plan touches the running instance. The repair described in spec §7 is a separate, separately approved action.
+- `Provenance::Passage` is the discriminator throughout. Never `corpus_id IS NULL`.
+- Existing behaviour that must survive every task: a repeated passage inside one corpus is still superseded by containment, and two `Synthesized` rows from one window still reach the model.
+
+---
+
+### Task 1: A passage is never one side of a pair
+
+Spec §4.1. Today `classify_pair` refuses a passage pair only when both sides share a corpus **and** a `segment_idx` (`src/jobs/relate.rs:149-155`). On the live base that guard fired on none of 33 pairs, because passages that duplicate each other come from different documents.
+
+The narrow guard stays exactly where it is — it protects the promoted-artifact-beside-its-passage case, which is a different question and already answered. The new guard goes at the end, immediately before `record_pair`, so the containment supersession in between keeps running for passages.
+
+**Files:**
+- Modify: `src/jobs/relate.rs` — add the guard just above `core.store.record_pair(...)` at line 266; add one test to the inline `mod tests`.
+
+**Interfaces:**
+- Consumes: `Provenance` (already imported at `src/jobs/relate.rs:22`), `Chunk::provenance`.
+- Produces: nothing new. `classify_pair`'s signature is unchanged: `async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<bool>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `src/jobs/relate.rs`. It needs a passage in a corpus of its own, which no existing helper produces, so the helper comes with it:
+
+```rust
+    /// One passage under a corpus of its own. `seed_rows` writes `captured`
+    /// rows, and the case under test is two passages from two documents.
+    async fn seed_passage(core: &Core, corpus: &str, text: &str) -> String {
+        let src = core.store.insert_corpus(corpus, "web", None).await.unwrap();
+        core.store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id
+    }
+
+    #[tokio::test]
+    async fn two_passages_from_different_documents_about_one_subject_are_not_a_pair() {
+        // The guard this joins asked for one corpus AND one `segment_idx`, so
+        // it never saw two passages from two documents — on the live base it
+        // fired on none of thirty-three pairs. Thirteen scripts teaching one
+        // subject produced passages at 0.89 to 0.93 that duplicate nothing, and
+        // they were merged into one synthetic document.
+        let core = test_core().await;
+        let a_id = seed_passage(&core, "skript-a", "Spuren sind materielle Veraenderungen.").await;
+        let b_id =
+            seed_passage(&core, "skript-b", "Als Spur gilt jede materielle Veraenderung.").await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "two passages from two documents are two sources, not a duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_with_a_passage_on_either_side_is_never_filed() {
+        // Eleven of the live base's thirty-three pairs were a passage against a
+        // captured artifact, so the rule cannot be about two passages only.
+        let core = test_core().await;
+        let passage = seed_passage(&core, "skript-a", "Spuren sind materielle Veraenderungen.").await;
+        let captured = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Als Spur gilt jede materielle Veraenderung.",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&passage).await.unwrap();
+        let b = core.store.get_artifact(&captured).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_repeated_passage_inside_one_corpus_is_still_superseded_by_containment() {
+        // What the new guard must not take away. Containment inside one corpus
+        // is deterministic, costs no call, and is the only ground on which
+        // anything is hidden unasked — so the guard sits below that block, not
+        // above it. Placed above, this hygiene disappears silently.
+        let core = test_core().await;
+        let src = core.store.insert_corpus("skript", "web", None).await.unwrap();
+        let rows = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "Spuren sind materielle Veraenderungen an Personen oder Sachen."
+                            .into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(0),
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "Spuren sind materielle Veraenderungen".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(1),
+                        caveats: vec![],
+                    },
+                ],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap();
+
+        classify_pair(&core, &rows[0], &rows[1], 0.97).await.unwrap();
+
+        let short = core.store.get_artifact(&rows[1].id).await.unwrap();
+        assert!(
+            !short.in_results(),
+            "a passage wholly inside another in one corpus is still hidden"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cargo test --lib relate::tests::two_passages_from_different relate::tests::a_pair_with_a_passage relate::tests::a_repeated_passage_inside`
+Expected: the first two FAIL — the assertion trips, because `record_pair` filed a pending row. `a_repeated_passage_inside_one_corpus_is_still_superseded_by_containment` PASSes already; it pins behaviour the change must not remove, which is worth having before the change rather than after.
+
+- [ ] **Step 3: Add the guard**
+
+In `src/jobs/relate.rs`, immediately before the `core.store.record_pair(&a.id, &b.id, score).await?;` call at line 266:
+
+```rust
+    // A passage is the verbatim substrate, not a claim anyone made twice.
+    // Passages under one heading are alike for how they were cut, and passages
+    // from different documents on one subject are alike because the subject is
+    // taught more than once — neither is duplication. The narrow rule above
+    // asks for one corpus and one `segment_idx` and so covers only the first;
+    // this is the same statement `run` already makes about the asking side
+    // (a passage never queries), applied to the side that gets filed.
+    //
+    // Below the containment block on purpose: a passage wholly inside another
+    // in the same corpus is still superseded, deterministically and without a
+    // call. What ends here is the model question, not the hygiene.
+    if a.provenance == Provenance::Passage || b.provenance == Provenance::Passage {
+        return Ok(false);
+    }
+
+```
+
+- [ ] **Step 4: Run the new test and the module's existing tests**
+
+Run: `cargo test --lib relate::`
+Expected: PASS, including `a_written_row_beside_its_own_passage_is_not_a_pair` and every containment test in the module. If a containment test fails, the guard was placed above the containment block instead of below it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/relate.rs
+git commit -m "fix: a passage is substrate, not somebody's duplicate"
+```
+
+---
+
+### Task 2: A merged artifact does not arm a neighbour query
+
+Spec §4.2. `mark_indexed` already refuses to arm a relate unit for a passage (`src/jobs/embed.rs:337-340`). A merged artifact is not a passage, so it arms one, queries its neighbours, and finds the next document's passage — twenty of the base's thirty-three pairs are passage against merged, which is that edge in the data.
+
+`Merged` specifically, **not** `is_model_written()`: that predicate also covers `Synthesized`, and `src/jobs/relate.rs:143-148` deliberately lets two written rows from one window through.
+
+**Files:**
+- Modify: `src/jobs/embed.rs:340` — extend the arming condition; add one test to the inline `mod tests`.
+
+**Interfaces:**
+- Consumes: `crate::store::artifacts::Provenance`, already named in full at this call site.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `src/jobs/embed.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_merged_artifact_does_not_arm_a_neighbour_query() {
+        // The feedback edge. A merge embeds, arms relate, finds the next
+        // document's passage on the same subject, and the ticker merges that
+        // too. Fifteen merges in sixty-eight minutes on the live base, roots
+        // running 2, 3, 4 … 16, ending at one synthetic artifact of ten
+        // thousand characters over sixteen passages from thirteen corpora.
+        let core = test_core().await;
+        let roots = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("first wording", [1.0, 0.0]), ("second wording", [0.99, 0.05])],
+        )
+        .await;
+        let m = core
+            .store
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    title: Some("merged".into()),
+                    text: "both wordings".into(),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &roots,
+            )
+            .await
+            .unwrap();
+
+        mark_indexed(&core, &m).await.unwrap();
+
+        assert_eq!(
+            job_state(&core, Stage::Relate, &m.id).await,
+            None,
+            "a merge that queries its neighbours walks the corpus one passage at a time"
+        );
+    }
+```
+
+`seed` writes `captured` rows, so this test still passes after Task 3 tightens what a merge root may be.
+
+Add a second test in the same block, for what Task 2 gives up:
+
+```rust
+    #[tokio::test]
+    async fn an_artifact_near_a_merge_but_near_neither_root_is_not_paired() {
+        // The cost of not arming, pinned so it stays a decision. An artifact
+        // that was never near either root but *is* near the merged text will
+        // not be paired. Closeness to a union is weak evidence of duplication
+        // with any member, which is why this is the right trade — but it is a
+        // behaviour change and not an accident.
+        let core = test_core().await;
+        let roots = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[("first wording", [1.0, 0.0]), ("second wording", [0.99, 0.05])],
+        )
+        .await;
+        crate::jobs::consolidate::tests::seed(&core, &[("a third subject", [0.9, 0.44])]).await;
+        let m = core
+            .store
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    title: Some("merged".into()),
+                    text: "both wordings".into(),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &roots,
+            )
+            .await
+            .unwrap();
+
+        mark_indexed(&core, &m).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cargo test --lib a_merged_artifact_does_not_arm_a_neighbour_query`
+Expected: FAIL — `job_state` returns `Some("pending")` because the unit was armed.
+
+- [ ] **Step 3: Extend the condition**
+
+In `src/jobs/embed.rs`, replace the condition at line 340:
+
+```rust
+    if chunk.provenance != crate::store::artifacts::Provenance::Passage
+        && chunk.provenance != crate::store::artifacts::Provenance::Merged
+        && let Err(e) = crate::jobs::relate::arm(core, &chunk.id, 0).await
+```
+
+and extend the comment above it, after the existing passage sentence:
+
+```rust
+    // A merged artifact is not an anchor either. It carries the union of its
+    // lineage's wording, so it scores above `review_min` against more of a
+    // subject than either side did, and every pair it files becomes the next
+    // merge — the artifact produces its own next question. Nothing is lost:
+    // whichever ordinary artifact is embedded later still finds it, so a merge
+    // is simply never the second member of a new pair.
+    //
+    // `Merged` and not `is_model_written()`: a synthesis is ordinary dedupe
+    // material, and `relate.rs:143-148` lets two written rows from one window
+    // through on purpose.
+```
+
+- [ ] **Step 4: Run the module's tests**
+
+Run: `cargo test --lib embed::`
+Expected: PASS. The merge-finish arming just below (`Provenance::Merged` → supersede its roots) is a different `if` and must still be reached; if a merge-finish test fails, the two conditions were folded into one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jobs/embed.rs
+git commit -m "fix: a merge that queries its neighbours writes its own next question"
+```
+
+---
+
+### Task 3: A merge refuses a root that is not captured
+
+Spec §4.3. `src/store/artifacts.rs:283` states that `artifact_sources.root_id` "only ever names a `captured` artifact — the invariant the whole anti-drift rule rests on". On the live base 135 of the merge path's 135 root rows name a passage. The claim is enforced where it is made, and **not** as a table constraint: the same table holds eleven rows for two `Synthesized` artifacts, where passage sources are correct.
+
+**Files:**
+- Modify: `src/store/artifacts.rs:285` — check the resolved roots before the transaction opens; add two tests to the inline `mod tests`.
+
+**Interfaces:**
+- Consumes: `roots_of(sources) -> HashMap<String, Vec<String>>`, already called at the top of `insert_merged_artifact`.
+- Produces: `insert_merged_artifact` gains a failure mode. Callers already handle `Result`; `src/jobs/merge.rs:34-50` propagates it, which leaves the pair pending and the unit retryable.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `src/store/artifacts.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_merge_whose_root_is_a_passage_is_refused() {
+        // The invariant this file claims at `insert_merged_artifact` and the
+        // live base violated in every one of its 135 merge-lineage rows. A
+        // merge over passages rewrites the verbatim substrate and hides it
+        // behind text that stands in no document.
+        let store = test_store().await;
+        let src = store.insert_corpus("skript", "web", None).await.unwrap();
+        let passages = store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "Spuren sind materielle Veraenderungen.".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        let ids: Vec<String> = passages.iter().map(|c| c.id.clone()).collect();
+
+        let err = store
+            .insert_merged_artifact(
+                &NewMerged {
+                    title: Some("merged".into()),
+                    text: "rewritten".into(),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &ids,
+            )
+            .await;
+
+        assert!(err.is_err(), "a passage is not a merge root");
+    }
+
+    #[tokio::test]
+    async fn a_synthesized_artifact_may_still_name_passage_sources() {
+        // Why the check is on the merge path and not on `artifact_sources`. A
+        // synthesis draws on passages by design; a table constraint would break
+        // it, and eleven rows in the live base are exactly this case.
+        let store = test_store().await;
+        let src = store.insert_corpus("skript", "web", None).await.unwrap();
+        let passages = store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[NewArtifact {
+                    ordinal: 0,
+                    text: "Spuren sind materielle Veraenderungen.".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap();
+        let ids: Vec<String> = passages.iter().map(|c| c.id.clone()).collect();
+
+        let made = store
+            .insert_synthesized_artifact(
+                &NewSynthesized {
+                    text: "Zusammenfassung".into(),
+                    title: Some("Spurenkunde".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec![],
+                },
+                &ids,
+            )
+            .await;
+
+        assert!(made.is_ok(), "synthesis over passages is what synthesis is");
+    }
+```
+
+- [ ] **Step 2: Run the tests and watch the first fail**
+
+Run: `cargo test --lib artifacts::tests::a_merge_whose_root_is_a_passage_is_refused artifacts::tests::a_synthesized_artifact_may_still_name_passage_sources`
+Expected: the first FAILs (the insert succeeds today), the second PASSes already. A failing second test means the argument shape is wrong, not the design.
+
+- [ ] **Step 3: Add the check**
+
+In `src/store/artifacts.rs`, after `let root_ids: BTreeSet<&String> = resolved.values().flatten().collect();` and before `let mut tx = self.pool.begin().await?;`:
+
+```rust
+        // The invariant this function's own documentation rests on, checked
+        // rather than assumed. A merge over passages rewrites the verbatim
+        // substrate into text that belongs to no corpus and carries no span,
+        // and hides the wording someone captured behind it. On the base this
+        // was written for, every merge-lineage row named a passage.
+        //
+        // Here and not as a constraint on `artifact_sources`: the same table
+        // carries a synthesis's passage sources, where naming a passage is
+        // correct.
+        for root in &root_ids {
+            let p: String = sqlx::query_scalar("SELECT provenance FROM artifacts WHERE id = ?")
+                .bind(root.as_str())
+                .fetch_one(&self.pool)
+                .await?;
+            if Provenance::parse(&p) != Provenance::Captured {
+                return Err(crate::error::Error::Validation(format!(
+                    "a merge root must be a captured artifact; {root} is {p}"
+                )));
+            }
+        }
+```
+
+`Error::Validation` and not `Error::Internal` (`src/error.rs:14`): the caller sent a root it may not merge, which is a refused request, and `src/error.rs:35` states why the two must not be confused.
+
+- [ ] **Step 4: Run the store's tests**
+
+Run: `cargo test --lib artifacts::`
+Expected: PASS. Merge tests elsewhere that seed passages as roots will now fail — that is the point; fix each by seeding captured rows, and note in its comment that the seed changed because a passage is no longer a legal root.
+
+- [ ] **Step 5: Run the whole suite, because this one reaches**
+
+Run: `cargo test`
+Expected: PASS. `src/jobs/merge.rs` and `src/jobs/dedupe.rs` tests are the likely fallers.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/artifacts.rs src/jobs/merge.rs src/jobs/dedupe.rs
+git commit -m "fix: the invariant a merge rests on, checked where it is claimed"
+```
+
+---
+
+### Task 4: Similarity alone no longer buys a call
+
+Spec §4.4 and §4.5. A cosine cannot separate "stored twice" from "taught thirteen times", and twenty-three of the base's thirty-three pairs are cross-corpus. A pair now reaches `record_pair` only with a corroborant: one text wholly inside the other, or both from one document.
+
+`contains_normalized` is already in this file and is a string operation, so computing it across corpora costs nothing. The same-corpus containment *supersession* block above is untouched; this only reuses its predicate.
+
+A refused pair writes nothing at all — in particular it does not bump `artifact_links`. A link means two artifacts were used together, and a bump derived from a cosine would put an observation about text into a table whose every other row is an observation about behaviour.
+
+**Files:**
+- Modify: `src/jobs/relate.rs` — the block added in Task 1 grows the corroborant check; add two tests.
+- Modify: `config.example.toml` — one sentence in `[consolidate]`.
+
+**Interfaces:**
+- Consumes: `contains_normalized(&str, &str) -> bool` from this module; `Chunk::corpus_id`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `src/jobs/relate.rs`:
+
+```rust
+    #[tokio::test]
+    async fn cross_corpus_similarity_alone_does_not_reach_the_model() {
+        // Twenty-three of the live base's thirty-three pairs were this: two
+        // documents covering one subject at 0.89 to 0.93, duplicating nothing.
+        // Thirteen scripts agreeing is evidence that the claim is standard, and
+        // a merge erases that they agreed.
+        let core = test_core().await;
+        let a_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen an Personen oder Sachen.",
+            [1.0, 0.0],
+        )
+        .await;
+        let b_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Als Spur gilt jede materielle Veraenderung an Person oder Objekt.",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn containment_across_corpora_still_reaches_the_model() {
+        // The case the corroborant keeps working: one document ingested twice.
+        // Containment is the predicate that says one side adds nothing, which
+        // is what duplication means — a score only says they are alike.
+        let core = test_core().await;
+        let long = "Spuren sind materielle Veraenderungen an Personen oder Sachen, \
+                    die zur Tataufklaerung beitragen koennen.";
+        let a_id =
+            crate::jobs::consolidate::tests::seed_into_new_corpus(&core, long, [1.0, 0.0]).await;
+        let b_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen an Personen oder Sachen,",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_pair_does_not_bump_a_link() {
+        // The link graph stays an observation about use. `bump_link` takes the
+        // cue that bound two artifacts, and the README calls the graph one
+        // learned from co-retrieval; a bump derived from a cosine would make
+        // the recommendation surface unable to tell the two apart.
+        let core = test_core().await;
+        let a_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen.",
+            [1.0, 0.0],
+        )
+        .await;
+        let b_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Als Spur gilt jede materielle Veraenderung.",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store.get_link(&a_id, &b_id).await.unwrap().is_none(),
+            "a cosine is not evidence that anyone used these together"
+        );
+    }
+```
+
+- [ ] **Step 2: Run them and watch the first and third fail**
+
+Run: `cargo test --lib relate::tests::cross_corpus relate::tests::containment_across relate::tests::a_refused_pair`
+Expected: `cross_corpus_similarity_alone_does_not_reach_the_model` FAILs (a pending row was filed). `containment_across_corpora_still_reaches_the_model` PASSes already. `a_refused_pair_does_not_bump_a_link` PASSes already — it pins behaviour that must not be added later, which is worth having before the change rather than after.
+
+- [ ] **Step 3: Add the corroborant to the guard from Task 1**
+
+In `src/jobs/relate.rs`, replace the block added in Task 1 with:
+
+```rust
+    // A passage is the verbatim substrate, not a claim anyone made twice.
+    // (See Task 1's comment — unchanged in substance.)
+    if a.provenance == Provenance::Passage || b.provenance == Provenance::Passage {
+        return Ok(false);
+    }
+
+    // A score says two texts are alike. Duplication says one of them adds
+    // nothing, and those are different claims — the comment above
+    // `contains_normalized` in this file states the distinction plainly. On a
+    // base of two hundred documents teaching one subject, "alike" is the
+    // ordinary condition and says nothing about duplication.
+    //
+    // So the cosine admits nothing on its own. One of two things has to hold:
+    // one text is wholly inside the other, or both came out of one document.
+    // Containment is what keeps the real cross-corpus case working — the same
+    // document ingested twice — while two scripts that merely cover one subject
+    // are refused. Refused, and nothing is written: not a pair, and not a link
+    // either, because a link means two artifacts were *used* together.
+    let (long, short) = if a.text.len() >= b.text.len() {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    let corroborated = contains_normalized(&long.text, &short.text)
+        || (a.corpus_id.is_some() && a.corpus_id == b.corpus_id);
+    if !corroborated {
+        tracing::debug!(a = %a.id, b = %b.id, score, "alike, but nothing says duplicate");
+        return Ok(false);
+    }
+
+```
+
+
+- [ ] **Step 4: Run the module and then the suite**
+
+Run: `cargo test --lib relate::` then `cargo test`
+Expected: PASS. Tests elsewhere that seeded two similar artifacts in one corpus still pass — `seed` puts everything in the corpus named `raw`, so the same-corpus arm covers them. A failure in `consolidate::` is likely a test that relied on cross-corpus similarity filing a pair; fix it by seeding into one corpus and say so in its comment.
+
+- [ ] **Step 5: Say it in the example config**
+
+In `config.example.toml`, in the `[consolidate]` block near `review_min`, add:
+
+```toml
+# `review_min` is a floor, not an admission. A pair reaches the model only when
+# one text is wholly inside the other or both came out of one document: a cosine
+# cannot tell "stored twice" from "taught by thirteen authors", and on a corpus
+# of scripts covering one subject the second is the ordinary case.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/jobs/relate.rs config.example.toml
+git commit -m "fix: alike is not duplicate, and a cosine cannot tell them apart"
+```
+
+---
+
+## After the four tasks
+
+`cargo test` green, `cargo clippy --all-targets` clean. Nothing has touched the running instance: the fifteen merges in the live base are still there, and undoing them is spec §7 — a separate action needing its own approval and a copy of `data/users/<id>.db` taken first.
+
+Spec §8 stays open: pair 25 was filed with a `score` of 0.0 where every other pair lies between 0.8887 and 0.9623, and no admission rule in the code can produce that. Task 1 makes that particular pair impossible, so it does not block anything, but the instance journal around 2026-08-27 07:13:47 is where the answer is.

--- a/docs/superpowers/specs/2026-08-27-consolidation-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-27-consolidation-boundary-design.md
@@ -1,0 +1,274 @@
+# Consolidation boundary — Design
+
+Date: 2026-08-27
+Status: draft
+Extends `src/jobs/relate.rs`, `src/jobs/embed.rs`, `src/store/artifacts.rs`,
+`src/store/pairs.rs`.
+Narrows an invariant the store already claims. See §4.3.
+
+## 1. Why
+
+On 2026-08-27 between 07:27 and 08:35 the running base wrote fifteen merged
+artifacts in one chain. Each took the previous one and exactly one further
+passage: the root counts run 2, 3, 4 … 16 without a gap, and the text grows from
+1,255 to 12,123 characters. What stands at the end is a single active artifact
+of 10,011 characters titled *Grundlagen der digitalen Forensik und
+Beweismittel*, and behind it sixteen verbatim passages drawn from **thirteen
+different corpora** are hidden from search.
+
+That is the outcome `src/store/schema.sql:51` and the ROADMAP's fidelity rule
+exist to prevent — a synthetic summary standing where stored passages used to.
+It happened without anyone deciding it: all fifteen merges hang off a pair with
+`merged_into` set, so every one of them came from the dedupe ticker. The
+eighteen remaining pairs in the base were closed by an operator.
+
+The numbers that matter, read from the live base:
+
+| | |
+|---|---|
+| Passages | 11,473 |
+| Captured artifacts | 9 |
+| Synthesized | 2 |
+| Merged | 15 |
+| Corpora | 226 |
+| Pairs ever filed | 33 |
+
+Of those 33 pairs: 20 are passage against merged, 11 passage against captured,
+one passage against passage, and **one** captured against captured. In its
+entire life this subsystem has seen a single pair of the material it was
+designed for, and an operator dismissed it.
+
+### 1.1 The existing guard never fired
+
+`classify_pair` refuses a pair only when the two sides share a corpus **and** a
+`segment_idx` **and** one of them is a passage (`src/jobs/relate.rs:149-155`).
+Nine of the 33 pairs sit in one corpus, and eight of those have different
+segments — 4 against 3, 2 against 0, 1 against 0, 3 against 0. The ninth has
+matching segments but is captured on both sides, so the passage clause fails.
+
+The guard's hit rate on this base is zero.
+
+### 1.2 The feedback edge
+
+A merged artifact is not a passage, so nothing stops it querying. It embeds,
+`mark_indexed` arms a relate unit for it (`src/jobs/embed.rs:340`), the unit
+queries `per_point` neighbours, finds the next document's passage on the same
+subject, and files a pair the ticker then merges. Twenty of the 33 pairs are
+passage against merged, which is that edge in the data: merged artifacts did not
+exist before the first merge.
+
+The chain stopped only when `merge::losses` began refusing every further
+merge — the five operator-closed rows still carrying the escalation text from
+`src/jobs/dedupe.rs:348`.
+
+## 2. The confusion this rests on
+
+Similarity says two texts are alike. Duplication says one of them adds nothing.
+The repository states the distinction plainly where containment is defined
+(`src/jobs/relate.rs:108`): "Not a similarity — containment. A score says two
+texts are alike; this says one of them adds nothing."
+
+Admission to the model is nonetheless a cosine, `review_min`. On a base of 226
+documents teaching one subject, passages from different scripts land at 0.89 to
+0.93 while duplicating nothing — it is the same material taught by different
+authors. Twenty-three of the 33 pairs are cross-corpus. A cosine cannot separate
+"stored twice" from "taught thirteen times", and where it decides admission the
+second is handled as the first.
+
+The model did not fail here. Its verdicts are in the base and they are correct:
+"Artifact A is a short excerpt from the much larger and more comprehensive
+Artifact B." The defect is that the question was asked.
+
+## 3. Goal
+
+Duplicate hygiene sees only material that can be duplicated, and asks the model
+only where something beyond topical similarity says it might be.
+
+### Non-goals
+
+- **Deciding which of two similar documents is better.** Out, as before.
+- **Reducing storage.** Passages are the substrate and stay whole.
+- **Changing what synthesis does.** `insert_synthesized_artifact` legitimately
+  records passage sources (§4.3), and nothing here touches it.
+- **Retrieval-time behaviour.** Unchanged. Everything here is background.
+
+## 4. The change
+
+### 4.1 The passage rule moves to `provenance`
+
+In `classify_pair`: if either side is `Provenance::Passage`, no pair is filed.
+
+This is the rule `relate::run` already applies to the asking side
+(`src/jobs/relate.rs:41`) — a passage does not query. The pair side was given a
+narrower rule for a different reason (one synthesis call emitting the same
+passage twice), and that reason does not generalise to two passages from two
+documents. Passages are the verbatim substrate; they are not artifacts anyone
+claimed were duplicates of each other.
+
+The containment supersession that the same block performs for a repeated passage
+inside one corpus is kept and is now the *whole* of what passages participate
+in: same corpus, one text wholly inside the other, deterministic, no model call.
+
+### 4.2 A merged artifact does not arm a relate unit
+
+At `src/jobs/embed.rs:340`, skip the arming when the artifact's provenance is
+`Merged`.
+
+`Merged` specifically, **not** `is_model_written()`. That predicate also covers
+`Synthesized`, and a synthesis is ordinary dedupe material: the comment at
+`src/jobs/relate.rs:143-148` records deliberately letting two written rows from
+one window through, because one synthesis call emitting the same passage twice
+is a defect worth finding. Excluding all model-written artifacts would take that
+away to fix something else.
+
+This removes the edge in §1.2 at its source, and it holds even if §4.1 is ever
+loosened. The completeness argument survives: a merged artifact is never the
+second member of a new pair, because whichever ordinary artifact is embedded
+later still finds it.
+
+What is given up: an artifact that already existed, was never near either root,
+and *is* near the merged text will not be paired. Closeness to a union is weak
+evidence of duplication with any member, so refusing that pair is right on its
+own terms — but it is a behaviour change and gets a test that says so.
+
+### 4.3 The root invariant is enforced, and narrowed to the merge path
+
+`src/store/artifacts.rs:283` claims that `artifact_sources.root_id` "only ever
+names a `captured` artifact — the invariant the whole anti-drift rule rests on".
+In the live base, 135 of the merge path's 135 root rows name a passage.
+
+The claim is enforced in `insert_merged_artifact`, which refuses a root whose
+provenance is not `captured`, and **not** on the table: the same table carries
+eleven rows for two `synthesized` artifacts, where passage sources are correct
+and intended. A constraint on `artifact_sources` would break synthesis.
+
+Refusing loudly is the point. The state this feature can produce silently is the
+one worth a hard failure.
+
+### 4.4 Admission needs a corroborant
+
+`review_min` stops being sufficient. A pair reaches the model only when the
+score clears `review_min` **and** one of two things holds:
+
+- **containment** — one text is wholly inside the other, already computed in
+  `classify_pair` and already the only ground on which anything is hidden
+  unasked;
+- **same corpus** — the two came out of one document, so one plausibly restates
+  the other.
+
+Cross-corpus similarity with neither is not a duplicate question.
+
+Containment keeps the genuine cross-corpus case working: the same document
+ingested twice produces texts that contain one another, and that pair is still
+admitted. What is refused is two different documents that merely cover one
+subject.
+
+The trade-off, stated rather than hidden: two sources that say the same thing in
+different words, in different corpora, are no longer merged at all — not
+automatically, and not by a proposal an operator could apply. Four things argue
+for it. Thirteen scripts agreeing is itself evidence, and a merge erases that
+they agreed. `merge::losses` covers values and machine literals but not prose,
+so the paraphrase case is exactly the one its net does not catch. A merged
+artifact has `corpus_id` and `corpus_span` NULL by construction, so merged
+paraphrase is wording that stands in no document a reader can be sent to. And
+the complaint a merge answers — the same thing three times in one result list —
+is a presentation problem with a presentation fix.
+
+The case this gets wrong is one document re-ingested in another *form*:
+reformatted, re-paginated, or translated — and `src/jobs/merge.rs:328` records
+that a rewrite between German and English is routine here. A proposal path for
+those was considered and **cut**: this collection does not hold the same lecture
+in two versions. Recorded so it is a decision and not an oversight; if that
+changes, `PairState::Superseded` plus `apply_supersede_ui` is the path, and no
+new mechanism is needed to add it.
+
+### 4.5 What falls out is written nowhere
+
+A pair refused by §4.4 files nothing, and in particular does **not** bump
+`artifact_links`. A link means two artifacts were used together — `bump_link`
+takes the cue that bound them, and the README calls the graph one learned from
+co-retrieval. A bump derived from a cosine would put an observation about text
+into a table whose every other row is an observation about behaviour. Two
+documents on one subject link on their own, from the first search that shows
+them together.
+
+This also closes a gap in the verdict contract: `Distinct` means different
+subjects, and there is no verdict for "same subject, legitimately separate
+sources". None is needed once such pairs are never asked about.
+
+## 5. Configuration
+
+No new knobs, no changed defaults. §4.4 narrows what `review_min` admits without
+changing what it is. `config.example.toml`'s `[consolidate]` block gains a
+sentence saying that similarity alone no longer admits a pair, and why.
+
+## 6. Not in this change
+
+**`artifact_pairs.decided_by`.** Whether a pair was settled by the model or by
+an operator is today reconstructable only by accident — `dismiss_pair_ui` passes
+`None` and nulls `detail` (`src/web/ui.rs:2487`) while `apply_supersede_ui`
+carries it through (`src/web/ui.rs:2574`). A column saying so plainly is worth
+having and is one line of schema, but it belongs to review and not to the
+boundary. Separate change.
+
+## 7. Repairing the running instance
+
+**Separate from the code change and requiring explicit approval before it is
+run.** Nothing here is a consequence of deploying §4.
+
+The fifteen merges are undone with `merge::undo`: the roots are reactivated, the
+merged artifact goes to `deprecated` rather than being deleted, and the pairs
+that named it are set `Dismissed` in the same action. The last part is not
+optional — `record_pair` is `INSERT OR IGNORE` and a dismissed row is what makes
+the undo survive the next sweep (`src/jobs/consolidate.rs:700` pins the bug).
+
+Sixteen passages from thirteen corpora return to search; one synthetic document
+leaves it. `data/users/<id>.db` is copied first.
+
+## 8. Open question
+
+The chain's ignition is pair 25, filed 2026-08-27 07:13:47 between two passages,
+and its `score` is **0.0**. Every other pair in the base lies between 0.8887 and
+0.9623. `relate` skips anything below `review_min`, so that row cannot have come
+from the neighbour loop as written.
+
+This is not resolved here and no mechanism is proposed for it. The place to look
+is the instance journal at that timestamp; the warning "neighbour came back with
+no cosine" (`src/jobs/relate.rs:65`) would appear there if that path was
+involved. §4.1 makes this particular pair impossible either way, which is why it
+does not block the change — but a score no admission rule can produce is worth
+understanding before it appears somewhere the guard does not cover.
+
+## 9. Testing
+
+**The boundary**
+- `a_pair_with_a_passage_on_either_side_is_never_filed` — the rule §4.1 makes
+  general. Both cross-corpus, which is where the old guard missed every case.
+- `two_passages_from_different_documents_about_one_subject_are_not_a_pair` —
+  carries the FAT12/FAT16/FAT32 lesson forward to the substrate: thirteen
+  scripts on one syllabus are thirteen sources.
+- `a_repeated_passage_inside_one_corpus_is_still_superseded_by_containment` —
+  what §4.1 must not break.
+- `a_merged_artifact_does_not_arm_a_neighbour_query`
+- `an_artifact_near_a_merge_but_near_neither_root_is_not_paired` — the cost of
+  §4.2, pinned so it is a decision and not a regression.
+
+**The invariant**
+- `a_merge_whose_root_is_a_passage_is_refused` — the 135 rows, made loud.
+- `a_synthesized_artifact_may_still_name_passage_sources` — why the check is on
+  the merge path and not the table.
+
+**Admission**
+- `cross_corpus_similarity_alone_does_not_reach_the_model`
+- `containment_across_corpora_still_reaches_the_model` — the re-ingested
+  document.
+- `a_refused_pair_does_not_bump_a_link` — §4.5. The link graph stays an
+  observation about use.
+
+## 10. What this does not change
+
+Retrieval still returns whole artifacts and never generated prose. A captured
+artifact is still never rewritten in place. Merging, where it still happens,
+keeps its verification, its lineage and its undo. Detection stays complete for
+the material it now covers: one neighbour query per non-passage artifact, no
+sampling, coverage independent of base size.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# Fetch the newest released engram binary for this machine and put it on PATH.
+#
+# POSIX sh, and nothing beyond curl, tar and a sha256 tool: the whole point of
+# a one-line installer is that it runs on the box you are already logged into,
+# which may be an Alpine container with no bash and no jq.
+#
+# Environment:
+#   ENGRAM_INSTALL_DIR   where to put the binary (default: see `pick_dir`)
+#   ENGRAM_VERSION       a specific tag, e.g. v2026.827.0 (default: the newest)
+set -eu
+
+REPO=overcuriousity/engram
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'install: %s\n' "$*" >&2; exit 1; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is needed and was not found"
+}
+
+# The two targets the release workflow builds, and no guessing beyond them: a
+# binary for the wrong architecture fails at exec with a message that says
+# nothing useful, so an unknown machine is told so here instead.
+pick_target() {
+  case "$(uname -s)" in
+    Linux) ;;
+    *) die "there are no released binaries for $(uname -s); build from source — see the README" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64 | amd64) echo x86_64-unknown-linux-musl ;;
+    aarch64 | arm64) echo aarch64-unknown-linux-gnu ;;
+    *) die "there is no released binary for $(uname -m); build from source — see the README" ;;
+  esac
+}
+
+# Releases are cut as pre-releases while the version is under 1.0, and
+# `/releases/latest` skips those — it would answer 404 here forever. The list
+# endpoint comes back newest first; drafts are not visible to an anonymous
+# caller, so the first entry is the newest published release.
+#
+# Read with sed rather than jq, which is not on a fresh server. Splitting on
+# `,` and `{` first means this does not depend on the API pretty-printing.
+newest_tag() {
+  curl -fsSL -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/$REPO/releases?per_page=10" |
+    tr ',{' '\n\n' |
+    sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' |
+    head -n 1
+}
+
+# Somewhere on PATH that this user can actually write to, without reaching for
+# sudo: a piped script silently escalating is a surprise, and one that prompts
+# for a password mid-pipe cannot read the answer anyway.
+pick_dir() {
+  if [ -n "${ENGRAM_INSTALL_DIR:-}" ]; then
+    echo "$ENGRAM_INSTALL_DIR"
+  elif [ -w /usr/local/bin ]; then
+    echo /usr/local/bin
+  else
+    echo "$HOME/.local/bin"
+  fi
+}
+
+verify() {
+  # `sha256sum` on Linux, `shasum` where coreutils is not what is installed.
+  if command -v sha256sum >/dev/null 2>&1; then
+    grep " \./$1\$" SHA256SUMS | sha256sum -c - >/dev/null
+  elif command -v shasum >/dev/null 2>&1; then
+    grep " \./$1\$" SHA256SUMS | shasum -a 256 -c - >/dev/null
+  else
+    die "no sha256sum or shasum, so the download cannot be checked; install one or download by hand"
+  fi
+}
+
+need curl
+need tar
+
+target=$(pick_target)
+tag=${ENGRAM_VERSION:-$(newest_tag)}
+[ -n "$tag" ] || die "could not find a release; check https://github.com/$REPO/releases"
+version=${tag#v}
+archive="engram-${version}-${target}.tar.gz"
+base="https://github.com/$REPO/releases/download/$tag"
+
+tmp=$(mktemp -d)
+# Including on the failure paths above: a half-downloaded archive left in /tmp
+# is the one piece of litter an installer has no excuse for.
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+say "engram $tag ($target)"
+curl -fsSL -o "$tmp/$archive" "$base/$archive" ||
+  die "no $archive in $tag — see https://github.com/$REPO/releases/tag/$tag"
+curl -fsSL -o "$tmp/SHA256SUMS" "$base/SHA256SUMS" ||
+  die "$tag publishes no SHA256SUMS, so this download cannot be checked"
+
+# Checked before anything is unpacked, and the archive is refused rather than
+# reported: an installer that carries on after a bad checksum has none.
+( cd "$tmp" && verify "$archive" ) ||
+  die "$archive does not match the published checksum; nothing was installed"
+
+tar -xzf "$tmp/$archive" -C "$tmp"
+binary="$tmp/engram-${version}-${target}/engram"
+[ -f "$binary" ] || die "the archive did not contain the binary it should"
+
+dir=$(pick_dir)
+mkdir -p "$dir" || die "cannot create $dir; set ENGRAM_INSTALL_DIR to somewhere writable"
+# Written under a temporary name and moved into place, so an install that is
+# interrupted never leaves a truncated binary where a working one was.
+cp "$binary" "$dir/.engram.new" || die "cannot write to $dir; set ENGRAM_INSTALL_DIR to somewhere writable"
+chmod 755 "$dir/.engram.new"
+mv "$dir/.engram.new" "$dir/engram"
+
+say "installed $dir/engram"
+
+case ":${PATH}:" in
+  *":$dir:"*) ;;
+  # Said rather than fixed: editing somebody's shell profile from inside a
+  # piped script is not this program's business.
+  *) say "note: $dir is not on your PATH" ;;
+esac
+
+cat <<EOF
+
+Next:
+  engram --hash-password 'your password'   # paste the hash into config.toml
+  engram --print-config                    # what engram resolved, secrets redacted
+  engram                                   # needs Qdrant answering on its REST port
+
+config.example.toml, cli.example.toml and engram.service ship in the same
+archive, at https://github.com/$REPO/releases/tag/$tag
+EOF

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -48,6 +48,10 @@ pub struct CliArgs {
     /// After capturing, follow the background stages until they finish.
     #[arg(long)]
     pub watch: bool,
+    /// Read one artifact in full: a rank from the last search, a leading piece
+    /// of an id, or a whole id.
+    #[arg(long, value_name = "RANK|ID", conflicts_with_all = ["capture", "search", "ask"])]
+    pub show: Option<String>,
 }
 
 /// When the drawn rendering is used. `Auto` is the only honest default: a pipe
@@ -73,6 +77,10 @@ pub enum Verb {
         query: String,
     },
     Ask(String),
+    /// One artifact, read in full. Carries what the operator typed rather than
+    /// an id: a rank means nothing until the remembered list is read, and that
+    /// is a file, which is not something this decision touches.
+    Show(String),
 }
 
 /// The verb, or `None` for "no verb was asked for — be the server".
@@ -95,6 +103,7 @@ pub fn verb(
         !args.capture.is_empty(),
         !args.search.is_empty(),
         !args.ask.is_empty(),
+        args.show.is_some(),
     ]
     .iter()
     .filter(|x| **x)
@@ -110,8 +119,8 @@ pub fn verb(
         // prompt below would then be handed EOF.
         if named > 0 {
             return Err(Error::Validation(
-                "`-c`, `-s` and `-a` are the client half of this binary; \
-                 run them on their own, without the server's own flags"
+                "`-c`, `-s`, `-a` and `--show` are the client half of this \
+                 binary; run them on their own, without the server's own flags"
                     .into(),
             ));
         }
@@ -123,10 +132,16 @@ pub fn verb(
         // this is here for the caller that built `CliArgs` itself — which is
         // every test, and one day some other entry point.
         return Err(Error::Validation(
-            "one verb at a time: `-c`, `-s` or `-a`".into(),
+            "one verb at a time: `-c`, `-s`, `-a` or `--show`".into(),
         ));
     }
 
+    if let Some(which) = &args.show {
+        // Answered before the pipe is looked at. `engram --show 3 | less` is
+        // the ordinary way to read a long artifact, and without this the pipe
+        // would be taken for the capture gesture the door below exists for.
+        return Ok(Some(Verb::Show(which.clone())));
+    }
     if !args.capture.is_empty() {
         // Not read here: a capture target may be a path or a link, and the
         // reading of each belongs to the verb that knows what to do with it.
@@ -272,6 +287,41 @@ mod tests {
         a.search = vec!["a".into()];
         a.ask = vec!["b".into()];
         assert!(verb(&a, false, false, piped("")).is_err());
+    }
+
+    #[test]
+    fn show_names_one_artifact_to_read_in_full() {
+        let a = CliArgs {
+            show: Some("3".into()),
+            ..Default::default()
+        };
+        let v = verb(&a, false, false, piped("")).unwrap().unwrap();
+        assert!(matches!(v, Verb::Show(ref which) if which == "3"));
+    }
+
+    /// A reading is its own verb, so it is refused alongside another one for
+    /// the same reason `-s` and `-a` are: quietly picking one loses the other.
+    #[test]
+    fn show_alongside_another_verb_is_refused() {
+        let a = CliArgs {
+            show: Some("3".into()),
+            search: vec!["forensik".into()],
+            ..Default::default()
+        };
+        assert!(verb(&a, false, false, piped("")).is_err());
+    }
+
+    /// And `engram --show 3 | less` must stay a reading. Without `show` in the
+    /// count, the pipe would be read as the capture gesture and the id would
+    /// be stored as a note.
+    #[test]
+    fn show_down_a_pipe_is_still_a_reading_and_not_a_capture() {
+        let a = CliArgs {
+            show: Some("3".into()),
+            ..Default::default()
+        };
+        let v = verb(&a, false, true, piped("something")).unwrap().unwrap();
+        assert!(matches!(v, Verb::Show(ref which) if which == "3"));
     }
 
     /// The gesture this guards: `--delete-user` prints a prompt, and the

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -22,9 +22,11 @@ pub struct CliArgs {
     /// Ask one question across the base.
     #[arg(short = 'a', value_name = "QUESTION", num_args = 1.., conflicts_with_all = ["capture", "search"])]
     pub ask: Vec<String>,
-    #[arg(long, value_name = "TITLE")]
+    /// What to call this capture. Refused with every verb but `-c`, for the
+    /// reason `--tag` is refused with `-a`: a search has no title to set.
+    #[arg(long, value_name = "TITLE", conflicts_with_all = ["search", "ask", "show"])]
     pub title: Option<String>,
-    #[arg(long, value_name = "NOTE")]
+    #[arg(long, value_name = "NOTE", conflicts_with_all = ["search", "ask", "show"])]
     pub note: Option<String>,
     /// Narrow a search to artifacts carrying this tag. Repeatable.
     ///
@@ -32,12 +34,20 @@ pub struct CliArgs {
     /// accepts all three over its JSON API, but no interactive door offers a
     /// filtered ask, and a flag that is accepted and then dropped is worse
     /// than one that is refused. See `cli::ask::run`.
-    #[arg(long = "tag", value_name = "TAG", conflicts_with = "ask")]
+    ///
+    /// Refused with `--show` for the plainer version of the same reason: one
+    /// artifact named by id is not a list there is anything to narrow.
+    #[arg(long = "tag", value_name = "TAG", conflicts_with_all = ["ask", "show"])]
     pub tags: Vec<String>,
-    #[arg(long, value_name = "CATEGORY", conflicts_with = "ask")]
+    #[arg(long, value_name = "CATEGORY", conflicts_with_all = ["ask", "show"])]
     pub category: Option<String>,
     /// Print the results as JSON instead of for a person.
-    #[arg(long, conflicts_with = "ask")]
+    ///
+    /// `--show` refuses it rather than ignoring it: the reading door renders a
+    /// body for a person to read and has no JSON form, and being handed the
+    /// human rendering after asking for JSON is the failure this whole rule is
+    /// about.
+    #[arg(long, conflicts_with_all = ["ask", "show"])]
     pub json: bool,
     /// Never colour, never animate, never leave ASCII.
     #[arg(long)]
@@ -46,12 +56,18 @@ pub struct CliArgs {
     #[arg(long, value_name = "WHEN", default_value = "auto")]
     pub fancy: Fancy,
     /// After capturing, follow the background stages until they finish.
-    #[arg(long)]
+    ///
+    /// There is nothing to follow behind the other three verbs: they finish
+    /// when their response arrives.
+    #[arg(long, conflicts_with_all = ["search", "ask", "show"])]
     pub watch: bool,
     /// Read one artifact in full: a rank from the last search, a leading piece
     /// of an id, or a whole id.
     #[arg(long, value_name = "RANK|ID", conflicts_with_all = ["capture", "search", "ask"])]
     pub show: Option<String>,
+    // Every flag `--show` does not honour refuses it from the other side —
+    // `--json`, `--tag`, `--category`, `--title`, `--note`, `--watch` — so the
+    // conflict is declared once, on the flag whose own doc comment explains it.
 }
 
 /// When the drawn rendering is used. `Auto` is the only honest default: a pipe

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -113,6 +113,13 @@ pub fn render_citations(hits: &[serde_json::Value], unicode: bool) -> String {
 
 /// The ids of those sources, in the order they were numbered, so `--show 9`
 /// after an answer reaches what `[9]` meant.
+///
+/// A citation carrying no `artifact_id` keeps its place as an empty string
+/// rather than being dropped: `render_citations` numbers every hit it is given,
+/// so skipping one here would shift every rank below it and `--show 9` would
+/// open the tenth source. `last::resolve` is what turns the empty place back
+/// into a sentence — before that it was sent to the server as an id, which
+/// asked for `/api/v1/artifacts/` and answered with a bare 404.
 pub fn citation_ids(hits: &[serde_json::Value]) -> Vec<String> {
     hits.iter()
         .map(|c| c["artifact_id"].as_str().unwrap_or_default().to_string())
@@ -182,7 +189,14 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
                 // Said, not swallowed: an answer that stopped and an answer
                 // that failed look identical on a terminal otherwise.
                 "error" => {
+                    use std::io::Write;
                     print!("{}", readout.finish());
+                    // Flushed before a word goes to stderr. The erase is a
+                    // bare escape with no newline, so stdout's line buffer
+                    // holds it: without this the failure prints over a readout
+                    // still on screen, and the erase lands at process exit,
+                    // eating part of whatever line the cursor is on by then.
+                    std::io::stdout().flush().ok();
                     eprintln!(
                         "\n{}",
                         data["error"].as_str().unwrap_or("the answer failed")

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -40,10 +40,11 @@ pub fn frames(buf: &mut String) -> Vec<(String, serde_json::Value)> {
 
 /// One question, asked and printed as it is answered.
 ///
-/// Takes no `CliArgs`: nothing on it applies here. `--tag`, `--category` and
-/// `--json` are refused alongside `-a` by clap rather than accepted and
-/// dropped, and the face has nothing to draw for a stream of prose. A
-/// parameter kept "for later" is how three flags came to be silently ignored.
+/// Takes the `CliArgs` for `--plain` and `--fancy` only: `--tag`, `--category`
+/// and `--json` are refused alongside `-a` by clap rather than accepted and
+/// dropped. This used to take nothing at all, on the grounds that the face had
+/// nothing to draw for a stream of prose — which stopped being true when the
+/// stream got a readout and the sources got a shape.
 /// Take every complete character out of `pending`, leaving a partial one behind.
 ///
 /// `frames` is this one boundary up: a chunk from the network is cut at
@@ -76,8 +77,56 @@ pub fn decode(pending: &mut Vec<u8>) -> Result<String> {
     Ok(String::from_utf8(head).expect("checked just above"))
 }
 
-pub async fn run(e: &Endpoint, question: &str) -> Result<i32> {
+/// The sources under an answer, numbered the way the answer cited them and
+/// drawn as a tree rooted at the answer.
+///
+/// The numbering is the server's: `ask` hands the model this list in this
+/// order and the model writes `[9]` for the ninth of it. Printing the list
+/// without the numbers left the reader holding a citation they could not
+/// follow, which is most of what a citation is for.
+///
+/// The tree is drawn where the terminal can draw it and said in ASCII where it
+/// cannot, and neither form carries a claim the other does not: the numbers,
+/// the titles and the ids are the content, and the branches are how it is
+/// shaped.
+pub fn render_citations(hits: &[serde_json::Value], unicode: bool) -> String {
+    let (tee, last) = if unicode {
+        ("├─", "└─")
+    } else {
+        ("|-", "`-")
+    };
+    let mut out = String::from("\nfrom:\n");
+    // Right-aligned to the widest number, so the titles line up whether the
+    // answer cited three sources or twenty-two.
+    let room = hits.len().to_string().len();
+    for (i, c) in hits.iter().enumerate() {
+        let branch = if i + 1 == hits.len() { last } else { tee };
+        out.push_str(&format!(
+            "{branch} [{:>room$}] {}  {}\n",
+            i + 1,
+            c["title"].as_str().unwrap_or("(untitled)"),
+            c["artifact_id"].as_str().unwrap_or(""),
+        ));
+    }
+    out
+}
+
+/// The ids of those sources, in the order they were numbered, so `--show 9`
+/// after an answer reaches what `[9]` meant.
+pub fn citation_ids(hits: &[serde_json::Value]) -> Vec<String> {
+    hits.iter()
+        .map(|c| c["artifact_id"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) -> Result<i32> {
     use tokio_stream::StreamExt;
+    let face = crate::cli::face::Face::decide(
+        cli,
+        std::io::IsTerminal::is_terminal(&std::io::stdout()),
+        std::env::var_os("NO_COLOR").is_some(),
+        crate::cli::face::locale().as_deref(),
+    );
     let http = reqwest::Client::builder()
         .user_agent(USER_AGENT)
         .build()
@@ -104,6 +153,12 @@ pub async fn run(e: &Endpoint, question: &str) -> Result<i32> {
     let mut buf = String::new();
     let mut citations = Vec::new();
     let mut said_anything = false;
+    // A strand travelling while nothing has arrived yet — the question is
+    // embedded, the pool assembled, the activation read — and then the readout
+    // takes over, driven by the answer's own arrival rate.
+    let mut waiting = face.pulse("thinking");
+    let mut readout = face.readout();
+    let began = std::time::Instant::now();
     while let Some(chunk) = body.next().await {
         let chunk = chunk.map_err(|err| Error::Validation(format!("{err}")))?;
         pending.extend_from_slice(&chunk);
@@ -113,7 +168,10 @@ pub async fn run(e: &Endpoint, question: &str) -> Result<i32> {
                 "token" => {
                     if let Some(t) = data["text"].as_str() {
                         use std::io::Write;
-                        print!("{t}");
+                        // The waiting strand ends the moment there is something
+                        // to show, before a byte of the answer is printed.
+                        waiting.take();
+                        print!("{}", readout.push(t, began.elapsed().as_millis() as u64));
                         // Flushed per token: an answer that appears a
                         // paragraph at a time is an answer that looks stalled.
                         std::io::stdout().flush().ok();
@@ -124,6 +182,7 @@ pub async fn run(e: &Endpoint, question: &str) -> Result<i32> {
                 // Said, not swallowed: an answer that stopped and an answer
                 // that failed look identical on a terminal otherwise.
                 "error" => {
+                    print!("{}", readout.finish());
                     eprintln!(
                         "\n{}",
                         data["error"].as_str().unwrap_or("the answer failed")
@@ -134,15 +193,19 @@ pub async fn run(e: &Endpoint, question: &str) -> Result<i32> {
             }
         }
     }
+    // Taken back before anything else is printed, so no part of it survives
+    // into the scrollback the answer is read from tomorrow.
+    print!("{}", readout.finish());
     println!();
     if !citations.is_empty() {
-        println!("\nfrom:");
-        for c in &citations {
-            println!(
-                "  \\- {}  {}",
-                c["title"].as_str().unwrap_or("(untitled)"),
-                c["artifact_id"].as_str().unwrap_or("")
-            );
+        print!("{}", render_citations(&citations, face.unicode && face.on));
+        // The numbered list is one `--show` can name a rank out of, exactly as
+        // a search's is: a citation nobody can open is half a citation.
+        if crate::cli::last::worth_remembering(
+            std::io::IsTerminal::is_terminal(&std::io::stdout()),
+            false,
+        ) {
+            crate::cli::last::save(question, citation_ids(&citations));
         }
     }
     // `1` when the base had nothing to say, matching `-s`: a shell branches on
@@ -153,6 +216,43 @@ pub async fn run(e: &Endpoint, question: &str) -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cite(title: Option<&str>, id: &str) -> serde_json::Value {
+        serde_json::json!({ "title": title, "artifact_id": id })
+    }
+
+    /// The answer cites `[9]`, and until now the list under it was 22 unnumbered
+    /// lines: there was no way to tell which one `[9]` meant. The number the
+    /// model used is the position in this list, and the list has to say so.
+    #[test]
+    fn every_source_carries_the_number_the_answer_cited_it_by() {
+        let out = render_citations(
+            &[
+                cite(Some("Physische Extraktion"), "id-a"),
+                cite(None, "id-b"),
+                cite(Some("JTAG"), "id-c"),
+            ],
+            true,
+        );
+        let lines: Vec<&str> = out.lines().filter(|l| l.contains("id-")).collect();
+        assert_eq!(lines.len(), 3, "{out}");
+        assert!(lines[0].contains("[1]"), "{out}");
+        assert!(lines[2].contains("[3]"), "{out}");
+        assert!(
+            lines[2].contains("JTAG") && lines[2].contains("id-c"),
+            "{out}"
+        );
+        assert!(lines[1].contains("(untitled)"), "{out}");
+    }
+
+    /// A reading follows a citation: the numbers under an answer are a list
+    /// `--show` can name a rank out of, the same way the ones under a search
+    /// are.
+    #[test]
+    fn the_sources_are_a_list_show_can_read_a_rank_out_of() {
+        let ids = citation_ids(&[cite(None, "id-a"), cite(None, "id-b")]);
+        assert_eq!(ids, vec!["id-a".to_string(), "id-b".to_string()]);
+    }
 
     #[test]
     fn frames_are_read_out_of_a_buffer_that_splits_mid_event() {
@@ -217,7 +317,7 @@ mod tests {
         // and the frame reader rather than the words that come back.
         let code = tokio::time::timeout(
             std::time::Duration::from_secs(30),
-            run(&e, "what is stored here"),
+            run(&e, "what is stored here", &Default::default()),
         )
         .await
         .expect("the stream must end")

--- a/src/cli/capture.rs
+++ b/src/cli/capture.rs
@@ -25,7 +25,8 @@ pub async fn run(
     let mut ids = Vec::new();
     for target in targets {
         let (bytes, content_type) = read_target(target)?;
-        ids.push(post(&http, e, bytes, &content_type, target, title, note, face).await?);
+        let meta = Meta { title, note };
+        ids.push(post(&http, e, bytes, &content_type, target, meta, face).await?);
     }
     Ok(ids)
 }
@@ -49,8 +50,7 @@ pub async fn run_piped(
         text.into_bytes(),
         "text/plain",
         "stdin",
-        title,
-        note,
+        Meta { title, note },
         face,
     )
     .await?;
@@ -64,6 +64,17 @@ fn client() -> Result<reqwest::Client> {
         .map_err(|err| Error::Internal(format!("http client: {err}")))
 }
 
+/// What a door knows about a capture beyond its bytes.
+///
+/// The two travel together everywhere — `run`, `run_piped` and `post` each
+/// take both or neither — and threading them as a separate pair is what pushed
+/// `post` past the argument count that is worth reading at a call site.
+#[derive(Clone, Copy)]
+struct Meta<'a> {
+    title: Option<&'a str>,
+    note: Option<&'a str>,
+}
+
 /// One capture, answering with the corpus id. `label` is what the target is
 /// called when something goes wrong — a path, or `stdin`.
 async fn post(
@@ -72,17 +83,16 @@ async fn post(
     bytes: Vec<u8>,
     content_type: &str,
     label: &str,
-    title: Option<&str>,
-    note: Option<&str>,
+    meta: Meta<'_>,
     face: &crate::cli::face::Face,
 ) -> Result<String> {
     let target = label;
     {
         let mut url = format!("{}?", e.api("/capture"));
-        if let Some(t) = title {
+        if let Some(t) = meta.title {
             url.push_str(&format!("title={}&", encode(t)));
         }
-        if let Some(n) = note {
+        if let Some(n) = meta.note {
             url.push_str(&format!("note={}", encode(n)));
         }
         // The body is handed over in pieces so the track can fill as it goes.
@@ -422,7 +432,7 @@ mod tests {
             CorpusStatus::NeedsReview,
         ] {
             core.store
-                .set_corpus_status(&ids[0], terminal.clone())
+                .set_corpus_status(&ids[0], terminal)
                 .await
                 .expect("set the status");
             tokio::time::timeout(

--- a/src/cli/capture.rs
+++ b/src/cli/capture.rs
@@ -92,10 +92,19 @@ async fn post(
         //
         // Where the face is off the whole vector goes at once, exactly as it
         // did before: a pipe gets no chunked encoding it did not ask for.
+        //
+        // And where it is on, `content-length` is set by hand so the pieces are
+        // sent length-framed too. The length is known — it is `bytes.len()`,
+        // the whole reason the track can show a percentage — and without the
+        // header a streamed body goes out chunked, which made what the server
+        // and every proxy in front of it saw depend on nothing but whether the
+        // operator's stdout happened to be a terminal.
+        let len = bytes.len();
         let res = http
             .post(url.trim_end_matches(['?', '&']))
             .bearer_auth(&e.token)
             .header("content-type", content_type)
+            .header(reqwest::header::CONTENT_LENGTH, len)
             .body(tracked_body(bytes, face))
             .send()
             .await
@@ -125,19 +134,24 @@ async fn post(
     }
 }
 
+/// How much of the body goes out at a time. Small enough that the track moves
+/// on a slow link, large enough that a book is not a hundred thousand yields.
+const PIECE: usize = 64 * 1024;
+
 /// The request body, filling a track as the transport reads it.
 ///
 /// One vector where the face is off, so nothing about a scripted capture
-/// changes: no chunked transfer encoding, no lost `content-length`, no track.
+/// changes: no track, and the length comes from the body itself.
+///
+/// The streamed form carries no length of its own, so the caller sets
+/// `content-length` from the vector before handing it over; both forms then go
+/// out identically framed.
 fn tracked_body(bytes: Vec<u8>, face: &crate::cli::face::Face) -> reqwest::Body {
     if !face.on {
         return reqwest::Body::from(bytes);
     }
     let total = bytes.len();
     let mut fill = face.fill();
-    // Small enough that the track moves on a slow link, large enough that a
-    // book is not a hundred thousand yields.
-    const PIECE: usize = 64 * 1024;
     let stream = async_stream::stream! {
         let mut at = 0usize;
         while at < total {
@@ -147,7 +161,9 @@ fn tracked_body(bytes: Vec<u8>, face: &crate::cli::face::Face) -> reqwest::Body 
             fill.show(at, total);
             yield Ok::<Vec<u8>, std::io::Error>(piece);
         }
-        // Before the response is read, and so before anything is printed.
+        // Before the response is read, and so before anything is printed. The
+        // request that never gets here — a reset, a refusal mid-upload — is
+        // covered by `Fill`'s own `Drop`, which this only makes earlier.
         fill.clear();
     };
     reqwest::Body::wrap_stream(stream)
@@ -287,6 +303,43 @@ mod tests {
         assert_eq!(ids.len(), 1);
         let stored = core.store.get_corpus(&ids[0]).await.expect("stored");
         assert!(stored.raw_text.contains("a procedure worth keeping"));
+    }
+
+    /// The one case `off()` cannot reach: with the face on the body goes out in
+    /// pieces, and the length is set by hand so it is framed the same way the
+    /// single vector is. Bigger than `PIECE`, so several chunks actually go.
+    ///
+    /// What this guards is that the two forms are the same request. Before the
+    /// header was set, a streamed body went out chunked with no
+    /// `content-length` — so what the server and any proxy in front of it saw
+    /// depended on nothing but whether the operator's stdout was a terminal.
+    #[tokio::test]
+    async fn a_body_sent_in_pieces_arrives_whole() {
+        let (e, core) = endpoint().await;
+        let face = crate::cli::face::Face::decide(
+            &crate::cli::args::CliArgs {
+                fancy: crate::cli::args::Fancy::Always,
+                ..Default::default()
+            },
+            true,
+            false,
+            None,
+        );
+        let body = "eine Zeile, die sich wiederholt\n".repeat(8_000);
+        assert!(body.len() > PIECE, "the test body fits in one piece");
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("lang.txt");
+        std::fs::write(&file, &body).unwrap();
+
+        let ids = run(&e, &[file.display().to_string()], None, None, &face)
+            .await
+            .unwrap();
+        let stored = core.store.get_corpus(&ids[0]).await.expect("stored");
+        assert_eq!(
+            stored.raw_text.len(),
+            body.len(),
+            "the streamed body arrived a different length than it left"
+        );
     }
 
     #[tokio::test]

--- a/src/cli/capture.rs
+++ b/src/cli/capture.rs
@@ -19,12 +19,13 @@ pub async fn run(
     targets: &[String],
     title: Option<&str>,
     note: Option<&str>,
+    face: &crate::cli::face::Face,
 ) -> Result<Vec<String>> {
     let http = client()?;
     let mut ids = Vec::new();
     for target in targets {
         let (bytes, content_type) = read_target(target)?;
-        ids.push(post(&http, e, bytes, &content_type, target, title, note).await?);
+        ids.push(post(&http, e, bytes, &content_type, target, title, note, face).await?);
     }
     Ok(ids)
 }
@@ -39,6 +40,7 @@ pub async fn run_piped(
     text: String,
     title: Option<&str>,
     note: Option<&str>,
+    face: &crate::cli::face::Face,
 ) -> Result<Vec<String>> {
     let http = client()?;
     let id = post(
@@ -49,6 +51,7 @@ pub async fn run_piped(
         "stdin",
         title,
         note,
+        face,
     )
     .await?;
     Ok(vec![id])
@@ -71,6 +74,7 @@ async fn post(
     label: &str,
     title: Option<&str>,
     note: Option<&str>,
+    face: &crate::cli::face::Face,
 ) -> Result<String> {
     let target = label;
     {
@@ -81,11 +85,18 @@ async fn post(
         if let Some(n) = note {
             url.push_str(&format!("note={}", encode(n)));
         }
+        // The body is handed over in pieces so the track can fill as it goes.
+        // A book is tens of megabytes and the upload is the part of a capture
+        // an operator waits through; a client that showed nothing until the
+        // response arrived looked wedged for the whole of it.
+        //
+        // Where the face is off the whole vector goes at once, exactly as it
+        // did before: a pipe gets no chunked encoding it did not ask for.
         let res = http
             .post(url.trim_end_matches(['?', '&']))
             .bearer_auth(&e.token)
             .header("content-type", content_type)
-            .body(bytes)
+            .body(tracked_body(bytes, face))
             .send()
             .await
             .map_err(|err| Error::Validation(format!("{target}: {err}")))?;
@@ -114,6 +125,34 @@ async fn post(
     }
 }
 
+/// The request body, filling a track as the transport reads it.
+///
+/// One vector where the face is off, so nothing about a scripted capture
+/// changes: no chunked transfer encoding, no lost `content-length`, no track.
+fn tracked_body(bytes: Vec<u8>, face: &crate::cli::face::Face) -> reqwest::Body {
+    if !face.on {
+        return reqwest::Body::from(bytes);
+    }
+    let total = bytes.len();
+    let mut fill = face.fill();
+    // Small enough that the track moves on a slow link, large enough that a
+    // book is not a hundred thousand yields.
+    const PIECE: usize = 64 * 1024;
+    let stream = async_stream::stream! {
+        let mut at = 0usize;
+        while at < total {
+            let end = (at + PIECE).min(total);
+            let piece = bytes[at..end].to_vec();
+            at = end;
+            fill.show(at, total);
+            yield Ok::<Vec<u8>, std::io::Error>(piece);
+        }
+        // Before the response is read, and so before anything is printed.
+        fill.clear();
+    };
+    reqwest::Body::wrap_stream(stream)
+}
+
 /// Follow a capture through the stages that run after it is stored.
 ///
 /// The other doors describe those stages in a sentence and leave; a terminal is
@@ -132,7 +171,12 @@ pub async fn watch(e: &Endpoint, id: &str, face: &crate::cli::face::Face) -> Res
         .user_agent(USER_AGENT)
         .build()
         .map_err(|err| Error::Internal(format!("http client: {err}")))?;
-    let lamps = face.pulse("reading");
+    // The three background stages, redrawn in place from each poll. The
+    // generic strand that used to sit here said only "something is happening";
+    // these say which of the three it is, which is the whole reason `--watch`
+    // exists. No poll is added for them: they are drawn from the answer the
+    // loop was already asking for.
+    let mut track = face.track();
     for _ in 0..WATCH_POLLS {
         let res = http
             .get(format!("{}/corpora/{id}", e.api("")))
@@ -151,29 +195,30 @@ pub async fn watch(e: &Endpoint, id: &str, face: &crate::cli::face::Face) -> Res
         // fixes.
         let code = res.status();
         if code.is_client_error() {
-            drop(lamps);
+            track.clear();
             return Err(Error::Validation(format!(
                 "{id}: the server would not say how it is getting on ({code})"
             )));
         }
         let body: serde_json::Value = res.json().await.unwrap_or(serde_json::Value::Null);
         let status: Option<CorpusStatus> = serde_json::from_value(body["status"].clone()).ok();
-        if let Some(s) = status
-            && matches!(
+        if let Some(s) = status {
+            track.show(s);
+            if matches!(
                 s,
                 CorpusStatus::Ready
                     | CorpusStatus::Partial
                     | CorpusStatus::Failed
                     | CorpusStatus::NeedsReview
-            )
-        {
-            drop(lamps);
-            println!("{id}  {}", s.as_str());
-            return Ok(());
+            ) {
+                track.clear();
+                println!("{id}  {}", s.as_str());
+                return Ok(());
+            }
         }
         tokio::time::sleep(WATCH_EVERY).await;
     }
-    drop(lamps);
+    track.clear();
     // Said rather than hidden: a capture still moving after five minutes is
     // information, and a client that exits silently claims a completion it
     // never saw.
@@ -216,6 +261,12 @@ fn read_target(target: &str) -> Result<(Vec<u8>, String)> {
 
 #[cfg(test)]
 mod tests {
+    /// A face with nothing drawn: every assertion in this module is about the
+    /// bytes a capture sends, and a track on stderr is not one of them.
+    fn off() -> crate::cli::face::Face {
+        crate::cli::face::Face::decide(&Default::default(), false, false, None)
+    }
+
     use super::*;
 
     async fn endpoint() -> (Endpoint, crate::core::Core) {
@@ -230,7 +281,7 @@ mod tests {
         let file = dir.path().join("notes.txt");
         std::fs::write(&file, "a procedure worth keeping").unwrap();
 
-        let ids = run(&e, &[file.display().to_string()], None, None)
+        let ids = run(&e, &[file.display().to_string()], None, None, &off())
             .await
             .unwrap();
         assert_eq!(ids.len(), 1);
@@ -251,7 +302,7 @@ mod tests {
             std::fs::write(&p, body).unwrap();
             targets.push(p.display().to_string());
         }
-        let ids = run(&e, &targets, None, None).await.unwrap();
+        let ids = run(&e, &targets, None, None, &off()).await.unwrap();
         assert_eq!(ids.len(), 2);
         assert_ne!(ids[0], ids[1]);
     }
@@ -267,6 +318,7 @@ mod tests {
             &[file.display().to_string()],
             Some("A title with spaces"),
             None,
+            &off(),
         )
         .await
         .unwrap();
@@ -300,7 +352,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("notes.txt");
         std::fs::write(&file, "a procedure worth keeping").unwrap();
-        let ids = run(&e, &[file.display().to_string()], None, None)
+        let ids = run(&e, &[file.display().to_string()], None, None, &off())
             .await
             .unwrap();
         let face = crate::cli::face::Face::decide(&Default::default(), false, true, None);
@@ -333,7 +385,7 @@ mod tests {
     #[tokio::test]
     async fn a_target_that_stops_the_run_is_named_in_the_error() {
         let (e, _core) = endpoint().await;
-        let err = run(&e, &["/no/such/file/anywhere".into()], None, None)
+        let err = run(&e, &["/no/such/file/anywhere".into()], None, None, &off())
             .await
             .unwrap_err();
         assert!(
@@ -352,7 +404,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("a.txt");
         std::fs::write(&file, "anything").unwrap();
-        let err = run(&e, &[file.display().to_string()], None, None)
+        let err = run(&e, &[file.display().to_string()], None, None, &off())
             .await
             .unwrap_err();
         assert!(!err.to_string().is_empty());

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -172,6 +172,18 @@ impl Fill {
     }
 }
 
+/// Taken back on drop, the way `Pulse` stops on drop.
+///
+/// The one caller draws from inside a request body, and a request that fails
+/// partway — a reset connection, a 413 mid-upload — drops that stream without
+/// ever reaching its own `clear`. The track was then left half-filled on stderr
+/// underneath the error message, describing an upload that did not happen.
+impl Drop for Fill {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
 /// The three lamps, drawn in place while a capture is watched.
 ///
 /// Holds no timer and starts no thread: it is redrawn from each poll the watch
@@ -305,22 +317,32 @@ impl Readout {
 
     /// One cell per bucket of the window, oldest on the left, each cell as tall
     /// as that bucket was busy.
+    ///
+    /// Bucketed by each mark's age rather than by an absolute span per cell:
+    /// the same arithmetic done from the end, and it cannot go wrong at either
+    /// edge. Spans computed forwards left the newest cell covering
+    /// `[now - BUCKET, now)`, so the token that triggered this very redraw —
+    /// the one at `now` — fell outside every cell and the readout never showed
+    /// the character being printed beside it. Those spans also collapsed onto a
+    /// `saturating_sub` floor of zero for the first second of a stream, drawing
+    /// one bucket several times over.
     fn strand(&self, now_ms: u64) -> String {
         let blocks = if self.unicode { BLOCKS } else { ASCII_BLOCKS };
-        (0..READOUT_CELLS)
-            .map(|i| {
-                let age = (READOUT_CELLS - i) as u64 * READOUT_BUCKET_MS;
-                let from = now_ms.saturating_sub(age);
-                let to = from + READOUT_BUCKET_MS;
-                let n = self
-                    .marks
-                    .iter()
-                    .filter(|m| **m >= from && **m < to)
-                    .count();
-                match n {
-                    0 => ' ',
-                    n => blocks[(n - 1).min(blocks.len() - 1)],
-                }
+        let mut counts = [0usize; READOUT_CELLS];
+        for m in &self.marks {
+            // Age zero is the newest cell, so a mark landing exactly now is
+            // drawn now. A mark from ahead of `now` saturates to the same
+            // place, which is where a clock that stepped back belongs.
+            let back = (now_ms.saturating_sub(*m) / READOUT_BUCKET_MS) as usize;
+            if back < READOUT_CELLS {
+                counts[READOUT_CELLS - 1 - back] += 1;
+            }
+        }
+        counts
+            .iter()
+            .map(|n| match n {
+                0 => ' ',
+                n => blocks[(n - 1).min(blocks.len() - 1)],
             })
             .collect()
     }
@@ -541,6 +563,65 @@ mod tests {
     use super::*;
     use crate::cli::args::{CliArgs, Fancy};
     use crate::cli::search::fixture::hit;
+
+    fn readout() -> Readout {
+        Readout {
+            on: true,
+            unicode: true,
+            width: 200,
+            marks: Vec::new(),
+            col: 0,
+            tail: 0,
+        }
+    }
+
+    /// The readout is drawn beside the character that triggered it, so the
+    /// newest cell has to hold that character. Cells computed as forward spans
+    /// left the newest one covering everything up to but not including `now`,
+    /// and the mark just pushed fell off the end of the strand it caused.
+    #[test]
+    fn the_token_that_triggered_the_redraw_is_in_the_strand() {
+        let mut r = readout();
+        r.marks.push(1_000);
+        let strand = r.strand(1_000);
+        assert_eq!(strand.chars().count(), READOUT_CELLS);
+        assert_ne!(
+            strand.chars().next_back(),
+            Some(' '),
+            "the newest cell is empty on the very tick a token arrived: {strand:?}"
+        );
+        assert!(
+            strand.chars().take(READOUT_CELLS - 1).all(|c| c == ' '),
+            "one mark lit more than its own cell: {strand:?}"
+        );
+    }
+
+    /// Inside the first second every cell's start saturated to zero, so several
+    /// of them counted the same marks and the strand drew one bucket over and
+    /// over. One mark can only ever light one cell.
+    #[test]
+    fn the_first_second_of_a_stream_draws_no_duplicate_cells() {
+        let mut r = readout();
+        r.marks.push(10);
+        for now in [10, 50, 99, 150, 300, 999] {
+            let strand = r.strand(now);
+            assert_eq!(
+                strand.chars().filter(|c| *c != ' ').count(),
+                1,
+                "one mark lit several cells at {now}ms: {strand:?}"
+            );
+        }
+    }
+
+    /// A mark older than the window is off the strand entirely, which is what
+    /// makes the readout fall away when a model stops to think.
+    #[test]
+    fn a_mark_older_than_the_window_is_not_drawn() {
+        let mut r = readout();
+        r.marks.push(0);
+        let window = READOUT_CELLS as u64 * READOUT_BUCKET_MS;
+        assert!(r.strand(window).chars().all(|c| c == ' '));
+    }
 
     fn always() -> CliArgs {
         CliArgs {

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -49,6 +49,317 @@ pub fn locale() -> Option<String> {
     locale_from(|k| std::env::var(k).ok())
 }
 
+/// Where one background stage has got to.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Lamp {
+    /// Not reached yet.
+    Waiting,
+    /// The stage the corpus is in right now.
+    Running,
+    /// Finished, whether this client watched it happen or it was already past.
+    Done,
+    /// Not finished, and not going to be.
+    Stopped,
+}
+
+/// Extraction, segmentation and embedding — the three stages `-c --watch`
+/// follows, drawn from the one status the server reports.
+///
+/// The mapping is a total function of the status rather than a tally this
+/// client keeps, because a client that starts watching late has missed the
+/// transitions and must still draw the truth: a corpus that is embedding was
+/// segmented, whoever saw it happen.
+pub struct Lamps(pub [Lamp; 3]);
+
+impl Lamps {
+    pub fn of(status: crate::store::corpora::CorpusStatus) -> Lamps {
+        use crate::store::corpora::CorpusStatus as S;
+        use Lamp::*;
+        Lamps(match status {
+            S::Describing | S::Extracting => [Running, Waiting, Waiting],
+            S::Raw => [Done, Waiting, Waiting],
+            S::Segmenting => [Done, Running, Waiting],
+            S::Segmented => [Done, Done, Waiting],
+            S::Embedding => [Done, Done, Running],
+            S::Ready => [Done, Done, Done],
+            // Stored on purpose without being segmented: the extraction is
+            // real and finished, and the two stages after it are not coming.
+            S::NeedsReview => [Done, Stopped, Stopped],
+            // Some of it embedded and some of it did not.
+            S::Partial => [Done, Done, Stopped],
+            // Nothing can be claimed about a capture that failed.
+            S::Failed => [Stopped, Stopped, Stopped],
+        })
+    }
+
+    /// One line, drawn and said. The words are the claim; the glyphs are how
+    /// you see at a glance which of the three is moving.
+    pub fn render(&self, unicode: bool) -> String {
+        let glyph = |l: Lamp| match (l, unicode) {
+            (Lamp::Waiting, true) => '·',
+            (Lamp::Running, true) => '◉',
+            (Lamp::Done, true) => '●',
+            (Lamp::Stopped, true) => '×',
+            (Lamp::Waiting, false) => '.',
+            (Lamp::Running, false) => 'o',
+            (Lamp::Done, false) => 'O',
+            (Lamp::Stopped, false) => 'x',
+        };
+        ["extract", "segment", "embed"]
+            .iter()
+            .zip(self.0)
+            .map(|(name, lamp)| format!("{} {name}", glyph(lamp)))
+            .collect::<Vec<_>>()
+            .join("  ")
+    }
+}
+
+/// A track that fills as a body is read out of this process and into the
+/// request.
+///
+/// It reports bytes handed to the transport, which is what this client can
+/// honestly know: it is not a claim about what the server has received, and
+/// the word beside it says `read` rather than `sent` for that reason.
+pub struct Fill {
+    on: bool,
+    unicode: bool,
+    width: usize,
+    drawn: bool,
+}
+
+impl Fill {
+    /// What this chunk would draw, or `None` where the face is off.
+    pub fn line(&self, done: usize, total: usize) -> Option<String> {
+        if !self.on || total == 0 {
+            return None;
+        }
+        let (full, empty) = if self.unicode {
+            ('█', '░')
+        } else {
+            ('#', '.')
+        };
+        // A quarter of the terminal, so the track never crowds out the word
+        // beside it on a narrow window.
+        let cells = (self.width / 4).clamp(8, 40);
+        let done = done.min(total);
+        let lit = (cells * done) / total;
+        let bar: String = (0..cells)
+            .map(|i| if i < lit { full } else { empty })
+            .collect();
+        Some(format!(
+            "{bar}  read {}%",
+            (100 * done as u64) / total as u64
+        ))
+    }
+
+    pub fn show(&mut self, done: usize, total: usize) {
+        let Some(line) = self.line(done, total) else {
+            return;
+        };
+        use std::io::Write;
+        eprint!("\r\u{1b}[2K{line}");
+        std::io::stderr().flush().ok();
+        self.drawn = true;
+    }
+
+    pub fn clear(&mut self) {
+        if self.drawn {
+            use std::io::Write;
+            eprint!("\r\u{1b}[2K");
+            std::io::stderr().flush().ok();
+            self.drawn = false;
+        }
+    }
+}
+
+/// The three lamps, drawn in place while a capture is watched.
+///
+/// Holds no timer and starts no thread: it is redrawn from each poll the watch
+/// loop was already making, so nothing here can delay a result or outlive the
+/// loop that owns it.
+pub struct Track {
+    on: bool,
+    unicode: bool,
+    drawn: bool,
+}
+
+impl Track {
+    /// What this poll would draw, or `None` where the face is off.
+    ///
+    /// Separate from `show` because the rule worth asserting is that a pipe
+    /// receives nothing, and stderr is a poor place to assert it from.
+    pub fn line(&self, status: crate::store::corpora::CorpusStatus) -> Option<String> {
+        self.on.then(|| Lamps::of(status).render(self.unicode))
+    }
+
+    /// Draw this poll's stage, over the last one.
+    ///
+    /// On stderr, and by rewriting the current line rather than on the
+    /// alternate screen: the ids `-c` prints on stdout have to stay in
+    /// scrollback and stay pipeable.
+    pub fn show(&mut self, status: crate::store::corpora::CorpusStatus) {
+        let Some(line) = self.line(status) else {
+            return;
+        };
+        use std::io::Write;
+        eprint!("\r\u{1b}[2K{line}");
+        std::io::stderr().flush().ok();
+        self.drawn = true;
+    }
+
+    /// Take the line back before anything else prints, or a result lands on
+    /// top of half a track.
+    pub fn clear(&mut self) {
+        if self.drawn {
+            use std::io::Write;
+            eprint!("\r\u{1b}[2K");
+            std::io::stderr().flush().ok();
+            self.drawn = false;
+        }
+    }
+}
+
+/// How many cells the streaming readout is wide, and how long each one covers.
+/// Ten hundred-millisecond buckets: a one-second window, which is short enough
+/// that a model pausing to think shows as the readout falling away.
+const READOUT_CELLS: usize = 10;
+const READOUT_BUCKET_MS: u64 = 100;
+
+/// An activity readout of a thing genuinely happening: the rate at which the
+/// answer's own tokens are arriving.
+///
+/// Drawn at the cursor, immediately after the text written so far, and taken
+/// back before the next text is written. That is the only place a line can be
+/// redrawn without either disturbing what is already on the screen or moving to
+/// the alternate screen, and the answer has to stay in scrollback.
+///
+/// The amplitude is measured, never invented. A readout that animated on a
+/// timer would claim arrivals that did not happen, which is the one thing an
+/// activity display must not do.
+pub struct Readout {
+    on: bool,
+    unicode: bool,
+    width: usize,
+    /// When each recent token arrived. Pruned to the window on every push, so
+    /// this holds at most a second of arrivals however long the answer is.
+    marks: Vec<u64>,
+    /// Column the cursor sits at, so the readout is dropped rather than wrapped
+    /// when the sentence being written has filled the line.
+    col: usize,
+    /// Cells drawn last time, to be walked back over before anything else.
+    tail: usize,
+}
+
+impl Readout {
+    /// The text to write for one arriving chunk: what was drawn last taken
+    /// back, the chunk itself, then the readout at the new cursor.
+    ///
+    /// `at_ms` is passed rather than read from the clock so the shape of a
+    /// stream can be tested without one.
+    pub fn push(&mut self, text: &str, at_ms: u64) -> String {
+        if !self.on {
+            return text.to_string();
+        }
+        let mut out = self.erase();
+        out.push_str(text);
+        self.advance(text);
+        self.marks.push(at_ms);
+        let window = READOUT_CELLS as u64 * READOUT_BUCKET_MS;
+        self.marks.retain(|m| at_ms.saturating_sub(*m) < window);
+        let strand = self.strand(at_ms);
+        // Two spaces of gap, and only if the line has room. A readout that
+        // wrapped would push the answer's own text down a line and leave the
+        // walk-back pointing at the wrong row.
+        if self.col + strand.chars().count() + 2 < self.width {
+            out.push_str("  ");
+            out.push_str(&strand);
+            self.tail = strand.chars().count() + 2;
+        }
+        out
+    }
+
+    /// Take the readout back for good. Called before the sources are printed,
+    /// so nothing of it survives into the scrollback.
+    pub fn finish(&mut self) -> String {
+        self.erase()
+    }
+
+    fn erase(&mut self) -> String {
+        if self.tail == 0 {
+            return String::new();
+        }
+        let back = self.tail;
+        self.tail = 0;
+        // Back over what was drawn, then erase to the end of the line: the
+        // cursor is left exactly where the answer's own text ended.
+        format!("\u{1b}[{back}D\u{1b}[K")
+    }
+
+    /// Where the cursor ends up after this chunk is written.
+    fn advance(&mut self, text: &str) {
+        match text.rsplit_once('\n') {
+            Some((_, after)) => self.col = after.chars().count(),
+            None => self.col += text.chars().count(),
+        }
+    }
+
+    /// One cell per bucket of the window, oldest on the left, each cell as tall
+    /// as that bucket was busy.
+    fn strand(&self, now_ms: u64) -> String {
+        let blocks = if self.unicode { BLOCKS } else { ASCII_BLOCKS };
+        (0..READOUT_CELLS)
+            .map(|i| {
+                let age = (READOUT_CELLS - i) as u64 * READOUT_BUCKET_MS;
+                let from = now_ms.saturating_sub(age);
+                let to = from + READOUT_BUCKET_MS;
+                let n = self
+                    .marks
+                    .iter()
+                    .filter(|m| **m >= from && **m < to)
+                    .count();
+                match n {
+                    0 => ' ',
+                    n => blocks[(n - 1).min(blocks.len() - 1)],
+                }
+            })
+            .collect()
+    }
+}
+
+/// The span of one ranked list, and where a score sits in it.
+///
+/// Its own type because "best full, worst empty" is only meaningful relative to
+/// a list, and because the degenerate list — one hit, or several that tied — is
+/// a division by zero that has to be answered somewhere.
+struct Scale {
+    low: f32,
+    span: f32,
+}
+
+impl Scale {
+    fn over(hits: &[SearchResult]) -> Scale {
+        let low = hits.iter().map(|h| h.score).fold(f32::INFINITY, f32::min);
+        let high = hits
+            .iter()
+            .map(|h| h.score)
+            .fold(f32::NEG_INFINITY, f32::max);
+        Scale {
+            low,
+            span: high - low,
+        }
+    }
+
+    /// Zero to seven. A list with no spread gets the top rung throughout:
+    /// nothing separates those hits, and drawing them all empty would say the
+    /// opposite of what a tie means.
+    fn rung(&self, score: f32) -> usize {
+        if !self.span.is_finite() || self.span <= f32::EPSILON {
+            return 7;
+        }
+        ((((score - self.low) / self.span) * 7.0).round() as usize).min(7)
+    }
+}
+
 impl Face {
     /// `is_tty`, `no_color` and `lang` are passed rather than read, so every
     /// rule about when the face appears is testable in a process that has no
@@ -86,9 +397,14 @@ impl Face {
         } else {
             ('|', ':')
         };
+        // The list is its own scale. A score here is a fused rank rather than a
+        // probability — `search::prime` says so about the same numbers — and a
+        // whole list of them is routinely negative, so a fixed `0.0..=1.0`
+        // clamp put every hit on the bottom rung and the bar said nothing.
+        let scale = Scale::over(hits);
         let mut out = String::new();
         for (i, h) in hits.iter().enumerate() {
-            let rung = ((h.score.clamp(0.0, 1.0) * 7.0).round() as usize).min(7);
+            let rung = scale.rung(h.score);
             let trace = if h.past_cliff { broken } else { solid };
             let (dim, reset) = if h.past_cliff { (DIM, RESET) } else { ("", "") };
             out.push_str(&format!(
@@ -112,6 +428,40 @@ impl Face {
             out.push_str(&format!("{trace}\n"));
         }
         out
+    }
+
+    /// A readout of the rate an answer's tokens are arriving at.
+    ///
+    /// Off where the face is off, and then `push` hands back the text
+    /// unchanged: `engram -a … | tee` writes the answer and nothing else.
+    pub fn readout(&self) -> Readout {
+        Readout {
+            on: self.on,
+            unicode: self.unicode,
+            width: self.width,
+            marks: Vec::new(),
+            col: 0,
+            tail: 0,
+        }
+    }
+
+    /// A track for a body being read into a request.
+    pub fn fill(&self) -> Fill {
+        Fill {
+            on: self.on,
+            unicode: self.unicode,
+            width: self.width,
+            drawn: false,
+        }
+    }
+
+    /// The three background stages, for a watch loop to redraw from its polls.
+    pub fn track(&self) -> Track {
+        Track {
+            on: self.on,
+            unicode: self.unicode,
+            drawn: false,
+        }
     }
 
     /// A pulse travelling along a strand while a request is in flight — an
@@ -246,6 +596,117 @@ mod tests {
             !drawn.contains('█') && !drawn.contains('┃'),
             "a drawing glyph reached a non-UTF-8 terminal: {drawn}"
         );
+    }
+
+    /// A score here is a fused rank, not a probability, and a whole list of
+    /// them is routinely negative — the shell that prompted this drew ten hits
+    /// between -3.57 and -5.45. Clamping to `0.0..=1.0` gave every one of them
+    /// the bottom rung, so the bar said nothing at all. The list is its own
+    /// scale: best full, worst empty, and the steps between them real.
+    /// The three background stages every other door only describes in a
+    /// sentence. The corpus status names exactly one of them as running, and
+    /// everything before it is finished by definition — a corpus cannot be
+    /// embedding without having been segmented first.
+    /// A face that is off draws no track at all — not an ASCII one, none.
+    /// `-c --watch` down a pipe prints one status line per corpus and nothing
+    /// else, which is what every script reading it was written against.
+    #[test]
+    fn a_track_is_not_drawn_where_the_face_is_off() {
+        use crate::store::corpora::CorpusStatus as S;
+        let off = Face::decide(&Default::default(), false, false, Some("en_US.UTF-8"));
+        assert!(off.track().line(S::Segmenting).is_none());
+
+        let on = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        assert!(on.track().line(S::Segmenting).is_some());
+    }
+
+    #[test]
+    fn the_lamps_read_the_stage_the_corpus_is_actually_in() {
+        use crate::store::corpora::CorpusStatus as S;
+        use Lamp::*;
+        assert_eq!(Lamps::of(S::Extracting).0, [Running, Waiting, Waiting]);
+        assert_eq!(Lamps::of(S::Describing).0, [Running, Waiting, Waiting]);
+        assert_eq!(Lamps::of(S::Raw).0, [Done, Waiting, Waiting]);
+        assert_eq!(Lamps::of(S::Segmenting).0, [Done, Running, Waiting]);
+        assert_eq!(Lamps::of(S::Segmented).0, [Done, Done, Waiting]);
+        assert_eq!(Lamps::of(S::Embedding).0, [Done, Done, Running]);
+        assert_eq!(Lamps::of(S::Ready).0, [Done, Done, Done]);
+    }
+
+    /// A capture that stopped did not finish the stage it stopped in, and a
+    /// rendering that lit all three would say it did.
+    #[test]
+    fn a_capture_that_stopped_does_not_light_the_stage_it_never_reached() {
+        use crate::store::corpora::CorpusStatus as S;
+        use Lamp::*;
+        assert_eq!(Lamps::of(S::Failed).0, [Stopped, Stopped, Stopped]);
+        assert_eq!(
+            Lamps::of(S::NeedsReview).0,
+            [Done, Stopped, Stopped],
+            "captured and stored, and deliberately not segmented"
+        );
+        assert_eq!(
+            Lamps::of(S::Partial).0,
+            [Done, Done, Stopped],
+            "some of it embedded and some of it did not"
+        );
+    }
+
+    /// Drawn and said, like every other claim this face makes: a lamp that is
+    /// only a glyph is a lamp nobody reading a screen reader sees.
+    #[test]
+    fn the_lamps_name_their_stages_in_words() {
+        use crate::store::corpora::CorpusStatus as S;
+        let drawn = Lamps::of(S::Segmenting).render(true);
+        for stage in ["extract", "segment", "embed"] {
+            assert!(drawn.contains(stage), "{drawn}");
+        }
+    }
+
+    #[test]
+    fn a_terminal_that_cannot_draw_gets_the_same_lamps_in_ascii() {
+        use crate::store::corpora::CorpusStatus as S;
+        let drawn = Lamps::of(S::Embedding).render(false);
+        assert!(drawn.is_ascii(), "a drawing glyph reached it: {drawn}");
+        for stage in ["extract", "segment", "embed"] {
+            assert!(drawn.contains(stage), "{drawn}");
+        }
+    }
+
+    #[test]
+    fn the_bar_is_drawn_against_the_list_it_is_in() {
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let drawn = f.render(&[
+            hit("a", -3.57, false, false),
+            hit("b", -4.42, false, false),
+            hit("c", -5.45, false, false),
+        ]);
+        let rungs: Vec<char> = drawn
+            .lines()
+            .filter_map(|l| l.chars().find(|c| BLOCKS.contains(c)))
+            .collect();
+        assert_eq!(rungs.len(), 3, "one bar per hit: {drawn}");
+        assert_eq!(rungs[0], '█', "the best hit of the list fills the bar");
+        assert_eq!(rungs[2], '▁', "and the worst empties it");
+        assert!(
+            rungs[1] != rungs[0] && rungs[1] != rungs[2],
+            "the middle hit got no step of its own: {drawn}"
+        );
+    }
+
+    /// One hit, or several that tied, have no spread to be drawn against.
+    /// Dividing by that spread is a division by zero.
+    #[test]
+    fn a_list_with_no_spread_still_draws() {
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let drawn = f.render(&[hit("a", -2.0, false, false), hit("b", -2.0, false, false)]);
+        assert!(!drawn.contains("NaN"), "{drawn}");
+        let rungs: Vec<char> = drawn
+            .lines()
+            .filter_map(|l| l.chars().find(|c| BLOCKS.contains(c)))
+            .collect();
+        assert_eq!(rungs.len(), 2, "{drawn}");
+        assert_eq!(rungs[0], rungs[1], "nothing separates them: {drawn}");
     }
 
     #[test]

--- a/src/cli/last.rs
+++ b/src/cli/last.rs
@@ -110,6 +110,13 @@ pub fn resolve(needle: &str, last: Option<&LastSearch>) -> Result<String> {
             )));
         };
         return match n.checked_sub(1).and_then(|i| last.ids.get(i)) {
+            // A source the answer cited and named no artifact for. It holds a
+            // rank so the numbering matches what was printed
+            // (`ask::citation_ids`), and there is nothing behind it to open.
+            Some(id) if id.is_empty() => Err(Error::Validation(format!(
+                "the source listed as [{n}] carried no artifact id, so there \
+                 is nothing to read"
+            ))),
             Some(id) => Ok(id.clone()),
             None => Err(Error::Validation(format!(
                 "the last search — {} — had {} hit(s), so there is no {n}",
@@ -126,7 +133,7 @@ pub fn resolve(needle: &str, last: Option<&LastSearch>) -> Result<String> {
         let matched: Vec<&String> = last
             .ids
             .iter()
-            .filter(|id| id.starts_with(needle))
+            .filter(|id| !id.is_empty() && id.starts_with(needle))
             .collect();
         match matched.as_slice() {
             [one] => return Ok((*one).clone()),
@@ -239,6 +246,31 @@ mod tests {
     fn a_rank_with_nothing_remembered_says_so_rather_than_asking_the_server() {
         let said = resolve("3", None).unwrap_err().to_string();
         assert!(said.contains("no search"), "{said}");
+    }
+
+    /// An answer can cite a source the API named no artifact for. The rank
+    /// still has to line up with the printed list, so the place is kept empty
+    /// (`ask::citation_ids`) — and an empty place sent on as an id asked the
+    /// server for `/artifacts/`, which answers with a bare 404 that says
+    /// nothing about the rank the operator typed.
+    #[test]
+    fn a_rank_naming_a_source_with_no_id_says_so_rather_than_asking_the_server() {
+        let held = last(&["id-a", "", "id-c"]);
+        let said = resolve("2", Some(&held)).unwrap_err().to_string();
+        assert!(said.contains("no artifact id"), "{said}");
+        assert_eq!(
+            resolve("3", Some(&held)).unwrap(),
+            "id-c",
+            "the empty place shifted the ranks under it"
+        );
+    }
+
+    /// And it is not a prefix of anything either: every needle starts with the
+    /// empty string, so the empty place matched the first thing typed.
+    #[test]
+    fn a_source_with_no_id_is_not_a_prefix_of_what_was_typed() {
+        let held = last(&["", "id-c"]);
+        assert_eq!(resolve("id-c", Some(&held)).unwrap(), "id-c");
     }
 
     #[test]

--- a/src/cli/last.rs
+++ b/src/cli/last.rs
@@ -1,0 +1,298 @@
+//! What the last search printed, so a rank in it can be named later.
+//!
+//! `engram -s` is one process and `engram --show 3` is another, and nothing
+//! between them remembers which artifact was third. A small file does: the ids
+//! in the order they were drawn, the question they answered, and when. It holds
+//! no text and no scores — everything in it is already on the operator's screen.
+
+use crate::error::{Error, Result};
+use std::path::PathBuf;
+
+/// The ranked ids of one search, in the order they were printed.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct LastSearch {
+    pub query: String,
+    pub at: i64,
+    pub ids: Vec<String>,
+}
+
+/// Where the list is kept: `$XDG_STATE_HOME/engram/last-search.json`, or the
+/// path the specification says that variable defaults to.
+///
+/// State rather than config or cache: it is neither something the operator
+/// edits nor something that can be regenerated, which is exactly what the XDG
+/// state directory is for.
+///
+/// `get` is passed rather than read for the reason `Face::decide` takes its
+/// facts as arguments — two tests must not race on one process's environment.
+pub fn path_from(get: impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
+    let base = match get("XDG_STATE_HOME").filter(|v| !v.is_empty()) {
+        Some(dir) => PathBuf::from(dir),
+        None => PathBuf::from(get("HOME").filter(|v| !v.is_empty())?)
+            .join(".local")
+            .join("state"),
+    };
+    Some(base.join("engram").join("last-search.json"))
+}
+
+/// `path_from`, against this process.
+pub fn path() -> Option<PathBuf> {
+    path_from(|k| std::env::var(k).ok())
+}
+
+/// Whether a search is one anybody will name a rank out of.
+///
+/// A search in a pipeline is not, and neither is `--json`, which is read by a
+/// machine even when a person is watching it arrive. Both would otherwise
+/// overwrite the list somebody is working from in another window.
+pub fn worth_remembering(is_tty: bool, json: bool) -> bool {
+    is_tty && !json
+}
+
+/// Remember what was drawn. Failure is silent by design: a search that found
+/// its hits succeeded, whatever the state directory did, and an error here
+/// would report a working search as broken.
+pub fn save_to(p: &std::path::Path, query: &str, ids: Vec<String>) {
+    let Some(dir) = p.parent() else { return };
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or_default();
+    let held = LastSearch {
+        query: query.to_string(),
+        at,
+        ids,
+    };
+    if let Ok(text) = serde_json::to_string(&held) {
+        std::fs::write(p, text).ok();
+    }
+}
+
+/// `save_to`, at the path this process keeps it.
+pub fn save(query: &str, ids: Vec<String>) {
+    if let Some(p) = path() {
+        save_to(&p, query, ids);
+    }
+}
+
+/// What was drawn last, or `None` when nothing was or the file cannot be read.
+pub fn load_from(p: &std::path::Path) -> Option<LastSearch> {
+    serde_json::from_str(&std::fs::read_to_string(p).ok()?).ok()
+}
+
+/// `load_from`, at the path this process keeps it.
+pub fn load() -> Option<LastSearch> {
+    load_from(&path()?)
+}
+
+/// Turn what the operator typed into one artifact id.
+///
+/// Three forms, because three are what a person actually types: a rank from the
+/// list still on screen, a leading piece of an id, or the whole id pasted from
+/// somewhere else. The first two need the remembered list; the last one does
+/// not, and must keep working in a shell that has never run a search.
+pub fn resolve(needle: &str, last: Option<&LastSearch>) -> Result<String> {
+    let needle = needle.trim();
+    if needle.is_empty() {
+        return Err(Error::Validation("--show needs a rank or an id".into()));
+    }
+
+    // A rank first: a small integer is never an id, and reading it as one would
+    // send `3` to the server as a lookup that can only 404.
+    if let Ok(n) = needle.parse::<usize>() {
+        let Some(last) = last else {
+            return Err(Error::Validation(format!(
+                "`--show {n}` names a hit from the last search, and no search \
+                 has been run from this shell yet"
+            )));
+        };
+        return match n.checked_sub(1).and_then(|i| last.ids.get(i)) {
+            Some(id) => Ok(id.clone()),
+            None => Err(Error::Validation(format!(
+                "the last search — {} — had {} hit(s), so there is no {n}",
+                last.query,
+                last.ids.len()
+            ))),
+        };
+    }
+
+    // A prefix, against what was drawn. Checked before the pass-through so that
+    // a prefix naming two hits is refused rather than sent to the server, where
+    // it would 404 and say nothing about the ambiguity.
+    if let Some(last) = last {
+        let matched: Vec<&String> = last
+            .ids
+            .iter()
+            .filter(|id| id.starts_with(needle))
+            .collect();
+        match matched.as_slice() {
+            [one] => return Ok((*one).clone()),
+            [] => {}
+            many => {
+                return Err(Error::Validation(format!(
+                    "`{needle}` names {} hits of the last search; type more of it",
+                    many.len()
+                )));
+            }
+        }
+    }
+
+    // Neither a rank nor a prefix of anything remembered: it is an id, and the
+    // server is the one that decides whether it exists.
+    Ok(needle.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| {
+            owned
+                .iter()
+                .find(|(name, _)| name == k)
+                .map(|(_, v)| v.clone())
+        }
+    }
+
+    fn last(ids: &[&str]) -> LastSearch {
+        LastSearch {
+            query: "nuix forensik".into(),
+            at: 1_787_000_000,
+            ids: ids.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    /// The rule that keeps a script from overwriting the list a person is
+    /// working from. A search in a pipeline is not a search anyone will name a
+    /// rank out of, and `--json` is read by a machine even on a terminal.
+    #[test]
+    fn only_a_search_a_person_watched_is_remembered() {
+        assert!(worth_remembering(true, false));
+        assert!(!worth_remembering(false, false), "a pipe");
+        assert!(
+            !worth_remembering(true, true),
+            "--json is read by a machine"
+        );
+    }
+
+    #[test]
+    fn what_a_search_remembered_is_what_show_reads_back() {
+        let dir = std::env::temp_dir().join(format!("engram-last-{}", std::process::id()));
+        let p = dir.join("deep").join("last-search.json");
+        std::fs::remove_dir_all(&dir).ok();
+
+        save_to(&p, "nuix forensik", vec!["id-a".into(), "id-b".into()]);
+        let back = load_from(&p).expect("the list that was just written");
+
+        assert_eq!(back.query, "nuix forensik");
+        assert_eq!(back.ids, vec!["id-a".to_string(), "id-b".to_string()]);
+        assert_eq!(
+            resolve("2", Some(&back)).unwrap(),
+            "id-b",
+            "the whole point of writing it"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn nothing_remembered_is_not_a_failure() {
+        let p = std::env::temp_dir().join("engram-no-such-list-at-all.json");
+        std::fs::remove_file(&p).ok();
+        assert!(load_from(&p).is_none());
+    }
+
+    #[test]
+    fn the_rank_the_list_printed_is_the_rank_show_reads() {
+        let held = last(&["id-a", "id-b", "id-c"]);
+        assert_eq!(resolve("3", Some(&held)).unwrap(), "id-c");
+        assert_eq!(
+            resolve("1", Some(&held)).unwrap(),
+            "id-a",
+            "the list is one-based on screen and must be one-based here"
+        );
+    }
+
+    #[test]
+    fn a_rank_past_the_end_says_what_the_last_search_actually_had() {
+        let held = last(&["id-a", "id-b"]);
+        let said = resolve("7", Some(&held)).unwrap_err().to_string();
+        assert!(said.contains("nuix forensik"), "{said}");
+        assert!(said.contains('2'), "{said}");
+    }
+
+    /// Zero is off the end in the other direction, and `ids[0 - 1]` is the
+    /// panic that would be.
+    #[test]
+    fn rank_zero_is_off_the_list_rather_than_a_panic() {
+        assert!(resolve("0", Some(&last(&["id-a"]))).is_err());
+    }
+
+    #[test]
+    fn a_rank_with_nothing_remembered_says_so_rather_than_asking_the_server() {
+        let said = resolve("3", None).unwrap_err().to_string();
+        assert!(said.contains("no search"), "{said}");
+    }
+
+    #[test]
+    fn a_prefix_is_enough_when_it_names_one_hit_of_the_last_search() {
+        let held = last(&["01a04209-3b06", "01a03a96-5a8a"]);
+        assert_eq!(resolve("01a042", Some(&held)).unwrap(), "01a04209-3b06");
+    }
+
+    #[test]
+    fn a_prefix_naming_two_hits_is_refused_rather_than_guessed() {
+        let held = last(&["01a03a96-5a8a", "01a03a96-4a65"]);
+        let said = resolve("01a03a96", Some(&held)).unwrap_err().to_string();
+        assert!(said.contains("2 hits"), "{said}");
+    }
+
+    /// The id pasted from a citation list, in a shell that has never searched.
+    #[test]
+    fn a_whole_id_needs_no_remembered_search() {
+        let id = "01a04209-3b06-7af1-aead-4fbf5dd0a4b4";
+        assert_eq!(resolve(id, None).unwrap(), id);
+        assert_eq!(
+            resolve(id, Some(&last(&["something-else"]))).unwrap(),
+            id,
+            "a remembered list that does not hold it must not swallow it"
+        );
+    }
+
+    #[test]
+    fn the_state_file_follows_xdg_and_falls_back_to_where_xdg_says_it_would() {
+        assert_eq!(
+            path_from(env(&[("XDG_STATE_HOME", "/s"), ("HOME", "/home/u")])),
+            Some(PathBuf::from("/s/engram/last-search.json"))
+        );
+        assert_eq!(
+            path_from(env(&[("HOME", "/home/u")])),
+            Some(PathBuf::from(
+                "/home/u/.local/state/engram/last-search.json"
+            )),
+            "the default the XDG specification gives for that variable"
+        );
+        assert_eq!(
+            path_from(env(&[("XDG_STATE_HOME", ""), ("HOME", "/home/u")])),
+            Some(PathBuf::from(
+                "/home/u/.local/state/engram/last-search.json"
+            )),
+            "an empty value is unset"
+        );
+        assert_eq!(path_from(env(&[])), None, "nowhere to keep it");
+    }
+
+    #[test]
+    fn what_was_written_is_what_comes_back() {
+        let held = last(&["id-a", "id-b"]);
+        let text = serde_json::to_string(&held).unwrap();
+        assert_eq!(serde_json::from_str::<LastSearch>(&text).unwrap(), held);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,7 +9,9 @@ pub mod ask;
 pub mod capture;
 pub mod endpoint;
 pub mod face;
+pub mod last;
 pub mod search;
+pub mod show;
 #[cfg(test)]
 pub(crate) mod test_support;
 
@@ -45,6 +47,16 @@ pub async fn run(verb: args::Verb, cli: &args::CliArgs) -> i32 {
             return 2;
         }
     };
+    // One face for the whole invocation. It used to be decided inside the
+    // `--watch` branch alone; now the upload track, the readout and the lamps
+    // all read the same decision, and a second `decide` could only disagree
+    // with the first.
+    let face = face::Face::decide(
+        cli,
+        std::io::IsTerminal::is_terminal(&std::io::stdout()),
+        std::env::var_os("NO_COLOR").is_some(),
+        crate::cli::face::locale().as_deref(),
+    );
     match verb {
         args::Verb::Capture(_) | args::Verb::CapturePiped(_) => {
             let captured = match &verb {
@@ -54,6 +66,7 @@ pub async fn run(verb: args::Verb, cli: &args::CliArgs) -> i32 {
                         targets,
                         cli.title.as_deref(),
                         cli.note.as_deref(),
+                        &face,
                     )
                     .await
                 }
@@ -63,6 +76,7 @@ pub async fn run(verb: args::Verb, cli: &args::CliArgs) -> i32 {
                         text.clone(),
                         cli.title.as_deref(),
                         cli.note.as_deref(),
+                        &face,
                     )
                     .await
                 }
@@ -76,12 +90,6 @@ pub async fn run(verb: args::Verb, cli: &args::CliArgs) -> i32 {
                         println!("{id}");
                     }
                     if cli.watch {
-                        let face = face::Face::decide(
-                            cli,
-                            std::io::IsTerminal::is_terminal(&std::io::stdout()),
-                            std::env::var_os("NO_COLOR").is_some(),
-                            crate::cli::face::locale().as_deref(),
-                        );
                         for id in &ids {
                             if let Err(e) = capture::watch(&endpoint, id, &face).await {
                                 eprintln!("{e}");
@@ -106,7 +114,14 @@ pub async fn run(verb: args::Verb, cli: &args::CliArgs) -> i32 {
                 }
             }
         }
-        args::Verb::Ask(question) => match ask::run(&endpoint, &question).await {
+        args::Verb::Show(which) => match show::run(&endpoint, &which, last::load()).await {
+            Ok(code) => code,
+            Err(e) => {
+                eprintln!("{e}");
+                2
+            }
+        },
+        args::Verb::Ask(question) => match ask::run(&endpoint, &question, cli).await {
             Ok(code) => code,
             Err(e) => {
                 eprintln!("{e}");

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -33,9 +33,10 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
         .user_agent(USER_AGENT)
         .build()
         .map_err(|err| Error::Internal(format!("http client: {err}")))?;
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
     let face = crate::cli::face::Face::decide(
         cli,
-        std::io::IsTerminal::is_terminal(&std::io::stdout()),
+        is_tty,
         std::env::var_os("NO_COLOR").is_some(),
         crate::cli::face::locale().as_deref(),
     );
@@ -65,6 +66,13 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
     }
     let hits: Vec<SearchResult> =
         serde_json::from_str(&body).map_err(|err| Error::Internal(format!("results: {err}")))?;
+
+    // What `--show 3` will mean. Written before anything is printed, so the
+    // list on screen and the list on disk cannot disagree, and only for a
+    // search a person watched: see `last::worth_remembering`.
+    if crate::cli::last::worth_remembering(is_tty, cli.json) {
+        crate::cli::last::save(query, hits.iter().map(|h| h.artifact_id.clone()).collect());
+    }
 
     if cli.json {
         // The server's own JSON, unchanged. A client that re-serialised it

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -102,7 +102,7 @@ pub async fn fetch(e: &Endpoint, id: &str) -> Result<Option<Detail>> {
         .build()
         .map_err(|err| crate::error::Error::Internal(format!("http client: {err}")))?;
     let res = http
-        .get(e.api(&format!("/artifacts/{}", crate::cli::encode(&id))))
+        .get(e.api(&format!("/artifacts/{}", crate::cli::encode(id))))
         .bearer_auth(&e.token)
         .send()
         .await

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -1,0 +1,255 @@
+//! `--show`: one artifact, read in full.
+//!
+//! The ranked list clips every hit to a couple of lines, which is right for a
+//! list and useless for reading. This is the door that never clips: whatever
+//! the artifact holds is what is printed.
+
+use crate::cli::endpoint::Endpoint;
+use crate::error::Result;
+
+/// What the reading door renders, which is less than the API answers with.
+///
+/// Deserialised into its own shape rather than into `store::artifacts::Chunk`:
+/// the client renders a title, a body and a provenance line, and a struct that
+/// named every column would have to be kept in step with a schema it never
+/// reads.
+#[derive(serde::Deserialize, Debug)]
+pub struct Detail {
+    pub id: String,
+    pub title: Option<String>,
+    pub text: String,
+    pub category: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub source: Option<SourceRef>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct SourceRef {
+    pub title: Option<String>,
+    pub origin: String,
+    pub source_url: Option<String>,
+}
+
+/// The form a pipe, a test and a script see: no colour, no glyph outside
+/// ASCII, and the whole body.
+pub fn render_plain(d: &Detail) -> String {
+    let mut out = String::new();
+    out.push_str(d.title.as_deref().unwrap_or("(untitled)"));
+    out.push('\n');
+    out.push_str(&d.id);
+    out.push('\n');
+    if let Some(src) = &d.source {
+        let name = src.title.as_deref().unwrap_or("(untitled document)");
+        out.push_str(&format!("from: {name} ({})\n", src.origin));
+        if let Some(url) = &src.source_url {
+            out.push_str(&format!("      {url}\n"));
+        }
+    }
+    if let Some(c) = &d.category {
+        out.push_str(&format!("category: {c}\n"));
+    }
+    if !d.tags.is_empty() {
+        out.push_str(&format!("tags: {}\n", d.tags.join(", ")));
+    }
+    out.push('\n');
+    // Whole, and unwrapped: the terminal knows its own width, and a client that
+    // rewrapped would destroy the one thing this door promises.
+    out.push_str(&d.text);
+    if !d.text.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Ask for one artifact and print it.
+///
+/// The rank and the prefix are resolved here, against the list `-s` left
+/// behind, so the server only ever receives an id.
+///
+/// `last` is passed rather than loaded, for the reason `Face::decide` takes its
+/// facts as arguments: a test that read the developer's own state file would
+/// pass or fail on what they last searched for.
+pub async fn run(
+    e: &Endpoint,
+    which: &str,
+    last: Option<crate::cli::last::LastSearch>,
+) -> Result<i32> {
+    let id = crate::cli::last::resolve(which, last.as_ref())?;
+    match fetch(e, &id).await? {
+        Some(detail) => {
+            print!("{}", render_plain(&detail));
+            Ok(0)
+        }
+        None => {
+            // `1`, the same code `-s` answers with when it found nothing: a
+            // shell branches on "it is not there" the same way whichever door
+            // asked.
+            eprintln!("no artifact {id}");
+            Ok(1)
+        }
+    }
+}
+
+/// The artifact behind an id, or `None` when there is none.
+///
+/// Split from `run` because what a reading is *of* is the thing worth
+/// asserting, and it cannot be asserted through a function whose only output
+/// is stdout and an exit code.
+pub async fn fetch(e: &Endpoint, id: &str) -> Result<Option<Detail>> {
+    let http = reqwest::Client::builder()
+        .user_agent(crate::cli::capture::USER_AGENT)
+        .build()
+        .map_err(|err| crate::error::Error::Internal(format!("http client: {err}")))?;
+    let res = http
+        .get(e.api(&format!("/artifacts/{}", crate::cli::encode(&id))))
+        .bearer_auth(&e.token)
+        .send()
+        .await
+        .map_err(|err| crate::error::Error::Validation(format!("{err}")))?;
+    if res.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !res.status().is_success() {
+        return Err(crate::error::Error::Validation(format!(
+            "the reading was refused: {}",
+            res.status()
+        )));
+    }
+    let body = res
+        .text()
+        .await
+        .map_err(|err| crate::error::Error::Validation(format!("{err}")))?;
+    let detail: Detail = serde_json::from_str(&body)
+        .map_err(|err| crate::error::Error::Internal(format!("artifact: {err}")))?;
+    Ok(Some(detail))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End to end against the real router: the rank the list printed reaches
+    /// the right artifact, and its body arrives whole.
+    #[tokio::test]
+    async fn a_rank_from_the_last_search_reads_the_artifact_it_named() {
+        let (url, token, core) = crate::cli::test_support::serve_test_app().await;
+        let e = Endpoint { url, token };
+        let src = core
+            .store
+            .insert_corpus("raw", "web", Some("Handbuch Mobilforensik"))
+            .await
+            .unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &["first".to_string(), "second".to_string()]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, t)| crate::store::artifacts::NewArtifact {
+                        ordinal: i as i64,
+                        text: t.clone(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: None,
+                        caveats: vec![],
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap();
+        let held = crate::cli::last::LastSearch {
+            query: "whatever was asked".into(),
+            at: 0,
+            ids: made.iter().map(|c| c.id.clone()).collect(),
+        };
+
+        assert_eq!(run(&e, "2", Some(held.clone())).await.unwrap(), 0);
+
+        // Which one it actually read. The exit code alone would pass on an
+        // off-by-one, and an off-by-one is the whole risk in a one-based list
+        // indexed into a zero-based vector.
+        let id = crate::cli::last::resolve("2", Some(&held)).unwrap();
+        let got = fetch(&e, &id).await.unwrap().expect("the second hit");
+        assert_eq!(got.id, made[1].id, "rank 2 on screen is the second hit");
+        assert_eq!(got.text, "second");
+        assert_eq!(
+            got.source.and_then(|s| s.title).as_deref(),
+            Some("Handbuch Mobilforensik"),
+            "the document it came from must travel with a reading"
+        );
+    }
+
+    /// The same code `-s` answers with when it found nothing, so a shell
+    /// branches on it the same way.
+    #[tokio::test]
+    async fn an_id_that_is_not_there_exits_one() {
+        let (url, token, _core) = crate::cli::test_support::serve_test_app().await;
+        let e = Endpoint { url, token };
+        assert_eq!(
+            run(&e, "01a00000-0000-7000-8000-000000000000", None)
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
+    fn detail(text: &str) -> Detail {
+        Detail {
+            id: "01a04209-3b06-7af1-aead-4fbf5dd0a4b4".into(),
+            title: Some("Physische Extraktion".into()),
+            text: text.into(),
+            category: Some("methode".into()),
+            tags: vec!["forensik".into(), "mobil".into()],
+            source: Some(SourceRef {
+                title: Some("Handbuch Mobilforensik".into()),
+                origin: "upload".into(),
+                source_url: None,
+            }),
+        }
+    }
+
+    /// The whole reason this door exists. A rendering that clips is the
+    /// rendering `-s` already has.
+    #[test]
+    fn the_body_is_printed_whole_however_long_it_is() {
+        let long: String = (1..=40).map(|n| format!("line {n}\n")).collect();
+        let out = render_plain(&detail(&long));
+        for n in 1..=40 {
+            assert!(out.contains(&format!("line {n}")), "line {n} was clipped");
+        }
+    }
+
+    #[test]
+    fn a_reading_says_which_artifact_it_is_and_where_it_came_from() {
+        let out = render_plain(&detail("body"));
+        assert!(out.contains("Physische Extraktion"), "{out}");
+        assert!(
+            out.contains("01a04209-3b06-7af1-aead-4fbf5dd0a4b4"),
+            "{out}"
+        );
+        assert!(out.contains("Handbuch Mobilforensik"), "{out}");
+        assert!(out.contains("forensik"), "{out}");
+    }
+
+    /// A merged artifact belongs to no corpus, and a corpus deleted since
+    /// leaves its artifacts readable. Neither is a reason to print nothing.
+    #[test]
+    fn an_artifact_with_no_document_behind_it_still_reads() {
+        let mut d = detail("body");
+        d.source = None;
+        d.title = None;
+        let out = render_plain(&d);
+        assert!(out.contains("body"), "{out}");
+        assert!(out.contains("(untitled)"), "{out}");
+    }
+
+    #[test]
+    fn the_plain_form_holds_no_escape_byte_at_all() {
+        let out = render_plain(&detail("body"));
+        assert!(!out.contains('\u{1b}'), "an escape reached it: {out:?}");
+    }
+}

--- a/src/core/ingest.rs
+++ b/src/core/ingest.rs
@@ -78,7 +78,7 @@ impl IngestOutcome {
     fn existing(c: &Corpus) -> Self {
         IngestOutcome {
             id: c.id.clone(),
-            status: c.status.clone(),
+            status: c.status,
             duplicate: true,
             near_duplicate: None,
         }

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -506,20 +506,42 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
             // reason is rendered verbatim in the "Seen together" pane and in
             // the associated-results rail, so it must not assert a handover
             // that did not happen.
-            let handed = core
+            //
+            // Except over passages, which are not consolidation's material at
+            // all. This handover writes a pair row directly, so none of the
+            // rules `relate::classify_pair` applies are in force here — and on
+            // the base this was written for, this is the path that started the
+            // damage: a link judge over two passages filed the pair, dedupe
+            // merged it, and the merge then walked thirteen documents one
+            // passage at a time. The link itself is sound and stays; only the
+            // handover is refused.
+            let over_passages = a.provenance == crate::store::artifacts::Provenance::Passage
+                || b.provenance == crate::store::artifacts::Provenance::Passage;
+            // Three outcomes and three sentences, because this one is rendered
+            // verbatim beside the link and must not claim a handover that did
+            // not happen — nor claim consolidation already holds a pair it was
+            // never offered.
+            let reason = if over_passages {
+                tracing::debug!(
+                    a = %link.a_id, b = %link.b_id,
+                    "duplicate verdict over a passage; not handing it to consolidation"
+                );
+                "same content, and both are stored source text"
+            } else if core
                 .store
                 .record_pair_with_detail(&link.a_id, &link.b_id, 0.0, "link")
-                .await?;
+                .await?
+            {
+                "same content; handed to consolidation"
+            } else {
+                "same content; consolidation already has this pair"
+            };
             core.store
                 .set_link_state(
                     &link.a_id,
                     &link.b_id,
                     LinkState::Related,
-                    Some(if handed {
-                        "same content; handed to consolidation"
-                    } else {
-                        "same content; consolidation already has this pair"
-                    }),
+                    Some(reason),
                     revs,
                 )
                 .await?;
@@ -1316,6 +1338,81 @@ mod tests {
             .unwrap();
         assert_eq!(l.state, LinkState::Related);
         assert!(l.reason.as_deref().unwrap().contains("consolidation"));
+    }
+
+    /// Two passages, each in a corpus of its own, linked the way co-retrieval
+    /// links anything.
+    async fn seed_passages(core: &Core, n: usize) -> Vec<String> {
+        let mut ids = Vec::new();
+        for i in 0..n {
+            let src = core
+                .store
+                .insert_corpus(&format!("skript {i}"), "web", None)
+                .await
+                .unwrap();
+            let made = core
+                .store
+                .insert_artifacts_with_provenance(
+                    &src.id,
+                    &[NewArtifact {
+                        ordinal: 0,
+                        text: format!("Spuren sind materielle Veraenderungen {i}"),
+                        corpus_span: None,
+                        title: Some(format!("t{i}")),
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(0),
+                        caveats: vec![],
+                    }],
+                    crate::store::artifacts::Provenance::Passage,
+                )
+                .await
+                .unwrap();
+            ids.push(made[0].id.clone());
+        }
+        ids
+    }
+
+    #[tokio::test]
+    async fn a_duplicate_verdict_over_passages_is_not_handed_to_consolidation() {
+        // The hole the boundary in `relate::classify_pair` does not cover. This
+        // handover writes a pair directly, so every rule that pass applies is
+        // simply absent here — and on the live base this is what ignited the
+        // merge chain: at 07:13:47 a link judge over two passages filed pair 25
+        // with a score of 0.0, dedupe merged it, and the merge then walked
+        // thirteen documents one passage at a time.
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"duplicate","reason":"the same definition twice"}"#.into()),
+        }));
+        let ids = seed_passages(&core, 2).await;
+        core.store
+            .bump_link(&ids[0], &ids[1], 5.0, Some("q"), 30.0, crate::store::now())
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&ids[0], &ids[1])).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .pair_state_between(&ids[0], &ids[1])
+                .await
+                .unwrap(),
+            None,
+            "a passage is substrate on this path too"
+        );
+        let l = core
+            .store
+            .get_link(&ids[0], &ids[1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            l.state,
+            LinkState::Related,
+            "the reader should still see the connection"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -521,12 +521,24 @@ pub async fn judge(core: &Core, target: &str) -> Result<()> {
             // verbatim beside the link and must not claim a handover that did
             // not happen — nor claim consolidation already holds a pair it was
             // never offered.
+            //
+            // Four sentences and not three, because `over_passages` is an
+            // `||`: a passage beside a captured artifact refuses the handover
+            // for the same reason, but "both are stored source text" is false
+            // about one of them — and this string is rendered verbatim, so it
+            // must not describe an artifact as something it is not.
             let reason = if over_passages {
                 tracing::debug!(
                     a = %link.a_id, b = %link.b_id,
                     "duplicate verdict over a passage; not handing it to consolidation"
                 );
-                "same content, and both are stored source text"
+                if a.provenance == crate::store::artifacts::Provenance::Passage
+                    && b.provenance == crate::store::artifacts::Provenance::Passage
+                {
+                    "same content, and both are stored source text"
+                } else {
+                    "same content, and one of these is stored source text"
+                }
             } else if core
                 .store
                 .record_pair_with_detail(&link.a_id, &link.b_id, 0.0, "link")
@@ -1412,6 +1424,61 @@ mod tests {
             l.state,
             LinkState::Related,
             "the reader should still see the connection"
+        );
+        assert_eq!(
+            l.reason.as_deref(),
+            Some("same content, and both are stored source text"),
+            "two passages are both source text, and the line may say so"
+        );
+    }
+
+    /// The refusal is an `||`, so a passage beside a captured artifact takes
+    /// the same branch — and eleven of the live base's thirty-three pairs were
+    /// exactly that shape. The sentence is rendered verbatim beside the link,
+    /// so it must describe the two artifacts that are actually there.
+    #[tokio::test]
+    async fn a_duplicate_over_one_passage_does_not_call_the_other_one_source_text() {
+        let mut core = test_core().await;
+        on(&mut core).await;
+        core.link_judge = Some(std::sync::Arc::new(crate::infer::fake::FakeCompleter {
+            reply: Some(r#"{"relation":"duplicate","reason":"the same definition twice"}"#.into()),
+        }));
+        let passage = seed_passages(&core, 1).await.remove(0);
+        let captured = seed(&core, 1).await.remove(0);
+        core.store
+            .bump_link(
+                &passage,
+                &captured,
+                5.0,
+                Some("q"),
+                30.0,
+                crate::store::now(),
+            )
+            .await
+            .unwrap();
+
+        judge(&core, &link_target(&passage, &captured))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            core.store
+                .pair_state_between(&passage, &captured)
+                .await
+                .unwrap(),
+            None,
+            "the handover is refused whichever side the passage is on"
+        );
+        assert_eq!(
+            core.store
+                .get_link(&passage, &captured)
+                .await
+                .unwrap()
+                .unwrap()
+                .reason
+                .as_deref(),
+            Some("same content, and one of these is stored source text"),
+            "the line claimed something untrue about the captured artifact"
         );
     }
 

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -406,6 +406,7 @@ pub async fn run(core: &Core) -> Result<Outcome> {
                 p.id,
                 crate::store::pairs::PairState::NoConflict,
                 Some(&detail),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
         {
@@ -493,7 +494,12 @@ pub(crate) async fn arm_dedupe(core: &Core) -> Result<usize> {
         // because a pair can be retired while it waits.
         if !a_live || !b_live {
             core.store
-                .set_pair_state(p.id, crate::store::pairs::PairState::Dismissed, None)
+                .set_pair_state(
+                    p.id,
+                    crate::store::pairs::PairState::Dismissed,
+                    None,
+                    crate::store::pairs::DecidedBy::Model,
+                )
                 .await?;
             continue;
         }
@@ -733,7 +739,12 @@ pub(crate) mod tests {
             .unwrap()[0]
             .id;
         core.store
-            .set_pair_state(id, PairState::Contradiction, Some("30 seconds vs 90"))
+            .set_pair_state(
+                id,
+                PairState::Contradiction,
+                Some("30 seconds vs 90"),
+                crate::store::pairs::DecidedBy::Model,
+            )
             .await
             .unwrap();
         // Behind the write path's back, which is what a crash between its two
@@ -826,7 +837,12 @@ pub(crate) mod tests {
             .unwrap()
             .id;
         core.store
-            .set_pair_state(id, PairState::Contradiction, Some("30 seconds vs 90"))
+            .set_pair_state(
+                id,
+                PairState::Contradiction,
+                Some("30 seconds vs 90"),
+                crate::store::pairs::DecidedBy::Model,
+            )
             .await
             .unwrap();
         core.deprecate(&ids[1]).await.unwrap();
@@ -2257,6 +2273,7 @@ pub(crate) mod tests {
                 id,
                 crate::store::pairs::PairState::Oversized,
                 Some("12 sources, cap is 8"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();

--- a/src/jobs/consolidate.rs
+++ b/src/jobs/consolidate.rs
@@ -2193,7 +2193,12 @@ pub(crate) mod tests {
             .unwrap()[0]
             .id;
         core.store
-            .set_pair_merged(pid, &m.id, Some("same claim"))
+            .set_pair_merged(
+                pid,
+                &m.id,
+                Some("same claim"),
+                crate::store::pairs::DecidedBy::Model,
+            )
             .await
             .unwrap();
         // The embed job has exhausted its retries and cannot succeed.

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -38,7 +38,7 @@ use crate::core::Core;
 use crate::error::{Error, Result};
 use crate::infer::prompt::{MergedDraft, Relation};
 use crate::store::artifacts::Chunk;
-use crate::store::pairs::{ArtifactPair, PairState};
+use crate::store::pairs::{ArtifactPair, DecidedBy, PairState};
 
 /// What the model decided, with everything the write path needs already read.
 pub struct Settlement {
@@ -569,7 +569,9 @@ async fn settle(
     state: PairState,
     detail: Option<&str>,
 ) -> Result<()> {
-    core.store.set_pair_state(pair.id, state, detail).await
+    core.store
+        .set_pair_state(pair.id, state, detail, DecidedBy::Model)
+        .await
 }
 
 #[cfg(test)]

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -37,7 +37,7 @@
 use crate::core::Core;
 use crate::error::{Error, Result};
 use crate::infer::prompt::{MergedDraft, Relation};
-use crate::store::artifacts::Chunk;
+use crate::store::artifacts::{Chunk, Provenance};
 use crate::store::pairs::{ArtifactPair, DecidedBy, PairState};
 
 /// What the model decided, with everything the write path needs already read.
@@ -114,6 +114,46 @@ pub async fn run(core: &Core, pair_id: &str) -> Result<()> {
             &p,
             PairState::Dismissed,
             Some("one of these is a source of the other"),
+        )
+        .await;
+    }
+
+    // Every root a merge would record has to be a captured artifact. That is
+    // the invariant `insert_merged_artifact` enforces and the whole anti-drift
+    // rule rests on: a merge over verbatim source text rewrites the substrate
+    // into wording that belongs to no corpus and carries no span.
+    //
+    // Asked here, before the model call, and not left to the merge path. That
+    // path refuses with `Error::Validation`, and `apply` propagates it — which
+    // leaves the pair `Pending`, so `arm_dedupe` re-arms it on the next tick
+    // and the same pair buys the same refusal every tick, forever. Refusing at
+    // admission costs nothing and settles the row once.
+    //
+    // A synthesis over passages is the ordinary way to arrive here, and it is
+    // not a defect: `roots_of` resolves such an artifact to the passages it
+    // drew on, which is exactly what a synthesis is made of. A passage member
+    // reaches it too, since a passage is its own root.
+    //
+    // `Contradiction` and not `Dismissed`: these two may well say the same
+    // thing, and that question stays open on somebody's queue. What is
+    // unavailable is only the automatic answer.
+    let all_roots: Vec<String> = root_map.values().flatten().cloned().collect();
+    let roots = core.store.artifacts_by_ids(&all_roots).await?;
+    if let Some(r) = roots.iter().find(|r| r.provenance != Provenance::Captured) {
+        tracing::info!(
+            pair = p.id,
+            root = %r.id,
+            provenance = r.provenance.as_str(),
+            "a member's lineage names something a merge may not rewrite; handing the pair to a person"
+        );
+        return settle(
+            core,
+            &p,
+            PairState::Contradiction,
+            Some(
+                "These cannot be merged automatically: what one of them is made of is \
+                 stored source text, and a merge must not rewrite that. Resolve by hand.",
+            ),
         )
         .await;
     }
@@ -457,7 +497,34 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
             // to the new one. `insert_merged_artifact` flattens both of them to
             // captured roots, and `subsumed_merges` catches the merged member.
             let sources: Vec<String> = s.members.iter().map(|m| m.id.clone()).collect();
-            let m = crate::jobs::merge::write(core, draft, &sources).await?;
+            // `Validation` is the merge path's own refusal — a root it may not
+            // rewrite — and not a failure to retry. Retrying is precisely the
+            // damage: the pair would stay `Pending`, `arm_dedupe` re-arms it,
+            // and the same refusal is bought again every tick. `run` already
+            // declines such a pair before the call, so reaching this is a case
+            // that check does not cover; the row is handed to a person rather
+            // than left circling.
+            let m = match crate::jobs::merge::write(core, draft, &sources).await {
+                Ok(m) => m,
+                Err(Error::Validation(why)) => {
+                    tracing::warn!(
+                        pair = s.pair.id,
+                        reason = %why,
+                        "the merge path refused this draft; handing the pair to a person"
+                    );
+                    return settle(
+                        core,
+                        &s.pair,
+                        PairState::Contradiction,
+                        Some(
+                            "These could not be merged: the merge was refused because of \
+                             what one of them is made of. Resolve by hand.",
+                        ),
+                    )
+                    .await;
+                }
+                Err(e) => return Err(e),
+            };
             // `merged_into` rather than a detail string: if the embed never
             // lands, the sweep's reap has to find exactly this pair and reopen
             // it (`reap_stranded`).
@@ -615,6 +682,108 @@ mod tests {
             .find(|p| (p.a_id == a || p.b_id == a) && (p.a_id == b || p.b_id == b))
             .expect("the pair was just recorded")
             .id
+    }
+
+    /// A passage, and a synthesis drawn from it, under a corpus of their own.
+    async fn a_passage_and_a_synthesis_over_it(core: &Core) -> (String, String) {
+        let src = core
+            .store
+            .insert_corpus("skript", "web", None)
+            .await
+            .unwrap();
+        let passage = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "Spuren sind materielle Veraenderungen.".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id;
+        let synth = core
+            .store
+            .insert_synthesized_artifact(
+                &crate::store::artifacts::NewSynthesized {
+                    text: "Spuren sind Veraenderungen am Material.".into(),
+                    title: Some("Spurenkunde".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec![],
+                },
+                std::slice::from_ref(&passage),
+            )
+            .await
+            .unwrap()
+            .id;
+        (passage, synth)
+    }
+
+    /// A synthesis is made of passages, by design — so `roots_of` resolves it
+    /// to source text, and `insert_merged_artifact` refuses to merge it.
+    ///
+    /// The refusal has to happen before the model call. Leaving it to the merge
+    /// path means `apply` propagates `Validation`, the pair stays `Pending`, and
+    /// `arm_dedupe` arms it again on the next tick — the same pair buying the
+    /// same refusal at full price, forever.
+    #[tokio::test]
+    async fn a_pair_a_merge_could_not_write_is_handed_over_before_the_call() {
+        let mut core = test_core().await;
+        let judge = Arc::new(ScriptedCompleter::new(vec![]));
+        core.judge = Some(judge.clone());
+        let (_passage, synth) = a_passage_and_a_synthesis_over_it(&core).await;
+        let other = seed(&core, &[("Spuren am Material", [1.0, 0.0])])
+            .await
+            .remove(0);
+        let pair = queue_pair(&core, &synth, &other).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(
+            judge.calls(),
+            0,
+            "a pair no merge can write was still judged"
+        );
+        let read = core.store.get_pair(pair).await.unwrap();
+        assert_eq!(
+            read.state,
+            PairState::Contradiction,
+            "the pair was left for `arm_dedupe` to buy again"
+        );
+    }
+
+    /// The same, for a passage on one side. A passage is its own root, so it
+    /// reaches the merge path's refusal by a different route and must be
+    /// declined by the same rule.
+    #[tokio::test]
+    async fn a_pair_naming_a_passage_is_handed_over_before_the_call() {
+        let mut core = test_core().await;
+        let judge = Arc::new(ScriptedCompleter::new(vec![]));
+        core.judge = Some(judge.clone());
+        let (passage, _synth) = a_passage_and_a_synthesis_over_it(&core).await;
+        let other = seed(&core, &[("Spuren am Material", [1.0, 0.0])])
+            .await
+            .remove(0);
+        let pair = queue_pair(&core, &passage, &other).await;
+
+        run(&core, &pair.to_string()).await.unwrap();
+
+        assert_eq!(judge.calls(), 0, "a passage pair was sent to the judge");
+        assert_eq!(
+            core.store.get_pair(pair).await.unwrap().state,
+            PairState::Contradiction
+        );
     }
 
     /// The button and the judge reach one helper, and the row has to say which

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -377,7 +377,9 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
         // artifacts waiting on a person holding no more evidence than the judge
         // had — and unlike a merge, nothing here is rewritten: both sides are
         // one press from active and still readable under `include_deprecated`.
-        Relation::Vacuous => discard_both(core, &s.pair, s.detail.as_deref()).await,
+        Relation::Vacuous => {
+            discard_both(core, &s.pair, s.detail.as_deref(), DecidedBy::Model).await
+        }
         Relation::Replaced => {
             let obsolete = s
                 .obsolete
@@ -482,10 +484,16 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
 /// both" button — reach it through here rather than each writing the sequence,
 /// because the orderings and the one refusal below are the whole of what makes
 /// it safe and none of them is obvious from the outside.
+///
+/// Which is also why `by` is a parameter and not `DecidedBy::Model`. The two
+/// callers are a judge and a person, and a shared helper that picked one of
+/// them would record every press of "Discard both" as the model's decision —
+/// the precise untruth `DecidedBy` exists to end.
 pub(crate) async fn discard_both(
     core: &Core,
     pair: &ArtifactPair,
     detail: Option<&str>,
+    by: DecidedBy,
 ) -> Result<()> {
     // Both sides read before either is retired. A side already hidden in
     // favour of another artifact — an applied supersede from a neighbouring
@@ -524,7 +532,7 @@ pub(crate) async fn discard_both(
                 hidden = hidden.join(", "),
                 "refused to retire an artifact others are hidden behind"
             );
-            return settle(
+            return settle_as(
                 core,
                 pair,
                 PairState::Contradiction,
@@ -532,6 +540,7 @@ pub(crate) async fn discard_both(
                     "One of these is the current version of another artifact, so retiring \
                      both would leave that one pointing at nothing. Resolve by hand.",
                 ),
+                by,
             )
             .await;
         }
@@ -559,19 +568,31 @@ pub(crate) async fn discard_both(
     // line rather than dropping it: it is the only record of why both sides
     // were retired, and `set_pair_state` writes `detail` unconditionally, so
     // `None` would null it.
-    settle(core, pair, PairState::Dismissed, detail).await
+    settle_as(core, pair, PairState::Dismissed, detail, by).await
 }
 
-/// One pair, one verdict.
+/// One pair, one verdict, decided by the judge.
+///
+/// Everything on this path is the model's: the unit runs unattended, and the
+/// rules it applies without asking are the judge's too (`DecidedBy::Model`).
 async fn settle(
     core: &Core,
     pair: &ArtifactPair,
     state: PairState,
     detail: Option<&str>,
 ) -> Result<()> {
-    core.store
-        .set_pair_state(pair.id, state, detail, DecidedBy::Model)
-        .await
+    settle_as(core, pair, state, detail, DecidedBy::Model).await
+}
+
+/// The same write, for the one path here a person can also reach.
+async fn settle_as(
+    core: &Core,
+    pair: &ArtifactPair,
+    state: PairState,
+    detail: Option<&str>,
+    by: DecidedBy,
+) -> Result<()> {
+    core.store.set_pair_state(pair.id, state, detail, by).await
 }
 
 #[cfg(test)]
@@ -594,6 +615,31 @@ mod tests {
             .find(|p| (p.a_id == a || p.b_id == a) && (p.a_id == b || p.b_id == b))
             .expect("the pair was just recorded")
             .id
+    }
+
+    /// The button and the judge reach one helper, and the row has to say which
+    /// of them pressed it — the whole point of the column.
+    #[tokio::test]
+    async fn discarding_both_records_whoever_asked_for_it() {
+        let core = test_core().await;
+        let ids = seed(&core, &[("a", [1.0, 0.0]), ("b", [0.93, 0.37])]).await;
+        let pair = queue_pair(&core, &ids[0], &ids[1]).await;
+        let row = core.store.get_pair(pair).await.unwrap();
+
+        discard_both(
+            &core,
+            &row,
+            Some("each body is its own file path"),
+            DecidedBy::Operator,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            core.store.get_pair(pair).await.unwrap().decided_by,
+            Some(DecidedBy::Operator),
+            "a person's press was recorded as the model's decision"
+        );
     }
 
     #[tokio::test]
@@ -699,9 +745,14 @@ mod tests {
             .unwrap();
         let pair = core.store.get_pair(pid).await.unwrap();
 
-        discard_both(&core, &pair, Some("each body is its own file path"))
-            .await
-            .unwrap();
+        discard_both(
+            &core,
+            &pair,
+            Some("each body is its own file path"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             core.store.get_artifact(&ids[1]).await.unwrap().status,
@@ -741,9 +792,14 @@ mod tests {
         core.supersede(&ids[2], &ids[0]).await.unwrap();
         let pair = core.store.get_pair(pid).await.unwrap();
 
-        discard_both(&core, &pair, Some("each body is its own file path"))
-            .await
-            .unwrap();
+        discard_both(
+            &core,
+            &pair,
+            Some("each body is its own file path"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         for id in &ids[..2] {
             assert_eq!(

--- a/src/jobs/dedupe.rs
+++ b/src/jobs/dedupe.rs
@@ -529,7 +529,7 @@ async fn apply(core: &Core, s: Settlement) -> Result<()> {
             // lands, the sweep's reap has to find exactly this pair and reopen
             // it (`reap_stranded`).
             core.store
-                .set_pair_merged(s.pair.id, &m.id, s.detail.as_deref())
+                .set_pair_merged(s.pair.id, &m.id, s.detail.as_deref(), DecidedBy::Model)
                 .await
         }
     }

--- a/src/jobs/embed.rs
+++ b/src/jobs/embed.rs
@@ -336,7 +336,23 @@ async fn mark_indexed(core: &Core, chunk: &Chunk) -> Result<()> {
     // A passage is never a relate anchor: neighbours under one heading are
     // similar for structural reasons, and duplicate detection over verbatim
     // text waits until use promotes it (spec §6).
+    //
+    // A merged artifact is not an anchor either. It carries the union of its
+    // lineage's wording — `merge::losses` refuses a draft that drops a value or
+    // a machine literal of either side — so it scores above `review_min`
+    // against more of a subject than either side did, and every pair it files
+    // becomes the next merge. The artifact produces its own next question, and
+    // on the live base that walked thirteen documents in sixty-eight minutes.
+    // Nothing is lost: whichever ordinary artifact is embedded later still
+    // finds it, so a merge is simply never the second member of a new pair.
+    //
+    // `Merged` and not `is_model_written()`, which would also catch
+    // `Synthesized`: a synthesis is ordinary dedupe material, and
+    // `relate::classify_pair` lets two written rows from one window through on
+    // purpose — one call emitting the same passage twice is a defect worth
+    // finding.
     if chunk.provenance != crate::store::artifacts::Provenance::Passage
+        && chunk.provenance != crate::store::artifacts::Provenance::Merged
         && let Err(e) = crate::jobs::relate::arm(core, &chunk.id, 0).await
     {
         tracing::warn!(
@@ -1077,6 +1093,50 @@ mod tests {
             .fetch_optional(&core.store.control.pool)
             .await
             .unwrap()
+    }
+
+    /// A merged artifact over two captured roots, indexed and nothing more.
+    async fn merged_over(core: &Core, roots: &[String]) -> crate::store::artifacts::Chunk {
+        core.store
+            .insert_merged_artifact(
+                &crate::store::artifacts::NewMerged {
+                    title: Some("merged".into()),
+                    text: "both wordings".into(),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                roots,
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_merged_artifact_does_not_arm_a_neighbour_query() {
+        // The feedback edge. A merge embeds, arms relate, finds the next
+        // document's passage on the same subject, and the ticker merges that
+        // too. Fifteen merges in sixty-eight minutes on the live base, roots
+        // running 2, 3, 4 … 16, ending at one synthetic artifact of ten
+        // thousand characters over sixteen passages from thirteen corpora.
+        let core = crate::core::test_support::test_core().await;
+        let roots = crate::jobs::consolidate::tests::seed(
+            &core,
+            &[
+                ("first wording", [1.0, 0.0]),
+                ("second wording", [0.99, 0.05]),
+            ],
+        )
+        .await;
+        let m = merged_over(&core, &roots).await;
+
+        mark_indexed(&core, &m).await.unwrap();
+
+        assert_eq!(
+            job_state(&core, Stage::Relate, &m.id).await,
+            None,
+            "a merge that queries its neighbours walks the corpus one passage at a time"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -209,6 +209,8 @@ pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
                 pair.id,
                 crate::store::pairs::PairState::Dismissed,
                 Some("merge undone"),
+                // The undo is the review: a person pressed it.
+                crate::store::pairs::DecidedBy::Operator,
             )
             .await?;
     }
@@ -888,6 +890,7 @@ mod tests {
                 verdict,
                 PairState::Contradiction,
                 Some("mount vs never mount"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();

--- a/src/jobs/merge.rs
+++ b/src/jobs/merge.rs
@@ -219,7 +219,12 @@ pub async fn undo(core: &Core, merged_id: &str) -> Result<()> {
     // the pairs were settled the moment the merge was written, and leaving
     // them would keep the duplicates invisible to every later sweep.
     core.store
-        .dismiss_pairs_merged_into(&m.id, "merge undone")
+        .dismiss_pairs_merged_into(
+            &m.id,
+            "merge undone",
+            // The same press, recorded the same way as the branch above it.
+            crate::store::pairs::DecidedBy::Operator,
+        )
         .await?;
     tracing::info!(merged = %m.id, restored = restored.len(), "undid a merge");
     Ok(())
@@ -1109,7 +1114,12 @@ mod tests {
             .await
             .unwrap();
         core.store
-            .set_pair_merged(pair, &m.id, Some("duplicate"))
+            .set_pair_merged(
+                pair,
+                &m.id,
+                Some("duplicate"),
+                crate::store::pairs::DecidedBy::Model,
+            )
             .await
             .unwrap();
         // No embed ran: nothing is superseded by m yet.
@@ -1123,6 +1133,14 @@ mod tests {
             "the pair stayed settled behind a deprecated merge: {p:?}"
         );
         assert_eq!(p.merged_into, None);
+        // The same press that dismissed the pairs `pairs_among` finds. Reached
+        // through the lineage branch here, because no embed ran — which before
+        // `finish` is every undo — and that branch recorded nobody.
+        assert_eq!(
+            p.decided_by,
+            Some(crate::store::pairs::DecidedBy::Operator),
+            "an undo a person pressed was recorded as nobody's: {p:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -263,6 +263,21 @@ async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<
     //
     // It survives as a prior in the prompt and as the input to the merge
     // verification. It is no longer an admission gate. See the design, §6.5.
+    // A passage is the verbatim substrate, not a claim anyone made twice.
+    // Passages under one heading are alike for how they were cut, and passages
+    // from different documents on one subject are alike because the subject is
+    // taught more than once — neither is duplication. The narrow rule above
+    // asks for one corpus and one `segment_idx` and so covers only the first;
+    // this is the same statement `run` already makes about the asking side (a
+    // passage never queries), applied to the side that gets filed.
+    //
+    // Below the containment block on purpose: a passage wholly inside another
+    // in the same corpus is still superseded, deterministically and without a
+    // call. What ends here is the model question, not the hygiene.
+    if a.provenance == Provenance::Passage || b.provenance == Provenance::Passage {
+        return Ok(false);
+    }
+
     core.store.record_pair(&a.id, &b.id, score).await?;
     Ok(false)
 }
@@ -410,6 +425,137 @@ mod tests {
             core.store.get_artifact(&ids[0]).await.unwrap(),
             core.store.get_artifact(&ids[1]).await.unwrap(),
         )
+    }
+
+    /// One passage under a corpus of its own. `seed_rows` writes `captured`
+    /// rows, and the case under test is two passages from two documents.
+    async fn seed_passage(core: &Core, corpus: &str, text: &str) -> String {
+        let src = core.store.insert_corpus(corpus, "web", None).await.unwrap();
+        core.store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: text.to_string(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: Some(0),
+                    caveats: vec![],
+                }],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap()
+            .remove(0)
+            .id
+    }
+
+    #[tokio::test]
+    async fn two_passages_from_different_documents_about_one_subject_are_not_a_pair() {
+        // The guard this joins asked for one corpus AND one `segment_idx`, so
+        // it never saw two passages from two documents — on the live base it
+        // fired on none of thirty-three pairs. Thirteen scripts teaching one
+        // subject produced passages at 0.89 to 0.93 that duplicate nothing, and
+        // they were merged into one synthetic document.
+        let core = test_core().await;
+        let a_id = seed_passage(&core, "skript-a", "Spuren sind materielle Veraenderungen.").await;
+        let b_id =
+            seed_passage(&core, "skript-b", "Als Spur gilt jede materielle Veraenderung.").await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "two passages from two documents are two sources, not a duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pair_with_a_passage_on_either_side_is_never_filed() {
+        // Eleven of the live base's thirty-three pairs were a passage against a
+        // captured artifact, so the rule cannot be about two passages only.
+        let core = test_core().await;
+        let passage =
+            seed_passage(&core, "skript-a", "Spuren sind materielle Veraenderungen.").await;
+        let captured = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Als Spur gilt jede materielle Veraenderung.",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&passage).await.unwrap();
+        let b = core.store.get_artifact(&captured).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_repeated_passage_inside_one_corpus_is_still_superseded_by_containment() {
+        // What the new guard must not take away. Containment inside one corpus
+        // is deterministic, costs no call, and is the only ground on which
+        // anything is hidden unasked — so the guard sits below that block, not
+        // above it. Placed above, this hygiene disappears silently.
+        let core = test_core().await;
+        let src = core
+            .store
+            .insert_corpus("skript", "web", None)
+            .await
+            .unwrap();
+        let rows = core
+            .store
+            .insert_artifacts_with_provenance(
+                &src.id,
+                &[
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 0,
+                        text: "Spuren sind materielle Veraenderungen an Personen oder Sachen."
+                            .into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(0),
+                        caveats: vec![],
+                    },
+                    crate::store::artifacts::NewArtifact {
+                        ordinal: 1,
+                        text: "Spuren sind materielle Veraenderungen".into(),
+                        corpus_span: None,
+                        title: None,
+                        category: None,
+                        tags: vec![],
+                        segment_idx: Some(1),
+                        caveats: vec![],
+                    },
+                ],
+                Provenance::Passage,
+            )
+            .await
+            .unwrap();
+
+        classify_pair(&core, &rows[0], &rows[1], 0.97).await.unwrap();
+
+        let short = core.store.get_artifact(&rows[1].id).await.unwrap();
+        assert!(
+            !short.in_results(),
+            "a passage wholly inside another in one corpus is still hidden"
+        );
     }
 
     #[tokio::test]

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -36,9 +36,13 @@ pub async fn arm(core: &Core, artifact_id: &str, seq: i64) -> Result<()> {
 
 pub async fn run(core: &Core, artifact_id: &str) -> Result<()> {
     let me = core.store.get_artifact(artifact_id).await?;
-    // A passage is not anchored: see `embed::mark_indexed`. Said here too, so a
-    // unit armed some other way files nothing.
-    if me.provenance == Provenance::Passage {
+    // Neither a passage nor a merge is anchored: see `embed::mark_indexed` for
+    // why each is withheld. Said here too, so a unit armed some other way —
+    // the sweep's repair pass, an operator, a re-embed — files nothing.
+    //
+    // `Merged` and not `is_model_written()`, the same distinction the embed
+    // path draws: a synthesis is ordinary dedupe material and stays an anchor.
+    if me.provenance == Provenance::Passage || me.provenance == Provenance::Merged {
         return Ok(());
     }
     // A retired artifact has no duplicates worth recording. Every pair naming
@@ -318,6 +322,50 @@ mod tests {
     use super::*;
     use crate::core::test_support::test_core;
     use crate::jobs::consolidate::tests::seed;
+
+    /// A merge is not an anchor, and the guard has to be here and not only in
+    /// `embed::mark_indexed`. The embed path withholds the arming; the sweep's
+    /// repair pass arms a unit for anything that has none, which after that
+    /// withholding is every merge on the base. Without this the merge is an
+    /// anchor again one tick later, and files the pair that becomes the next
+    /// merge.
+    #[tokio::test]
+    async fn a_merge_armed_by_the_repair_pass_still_files_nothing() {
+        let core = test_core().await;
+        let ids = seed(
+            &core,
+            &[
+                ("Mount the filesystem before writing.", [1.0, 0.0]),
+                ("Attach the volume before writing.", [0.93, 0.37]),
+            ],
+        )
+        .await;
+        let m = crate::jobs::merge::write(
+            &core,
+            &crate::infer::prompt::MergedDraft {
+                text: "Attach the volume, then mount the filesystem, before writing.".into(),
+                title: Some("before writing".into()),
+                category: None,
+                tags: vec![],
+                caveats: vec![],
+            },
+            &ids,
+        )
+        .await
+        .unwrap();
+
+        run(&core, &m.id).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .iter()
+                .all(|p| p.a_id != m.id && p.b_id != m.id),
+            "the merge was an anchor after all"
+        );
+    }
 
     #[tokio::test]
     async fn an_artifact_finds_its_duplicate_the_moment_it_is_embedded() {

--- a/src/jobs/relate.rs
+++ b/src/jobs/relate.rs
@@ -278,6 +278,37 @@ async fn classify_pair(core: &Core, a: &Chunk, b: &Chunk, score: f32) -> Result<
         return Ok(false);
     }
 
+    // A score says two texts are alike. Duplication says one of them adds
+    // nothing, and those are different claims — the comment above
+    // `contains_normalized` states the distinction plainly. On a base of two
+    // hundred documents teaching one subject, "alike" is the ordinary condition
+    // and says nothing at all about duplication: twenty-three of the thirty-
+    // three pairs the live base ever filed were two scripts covering one topic.
+    //
+    // So the cosine admits nothing on its own. One of two things has to hold:
+    // one text is wholly inside the other, or both came out of one document.
+    // Containment is what keeps the real cross-corpus case working — the same
+    // document ingested twice — while two scripts that merely cover one subject
+    // are refused.
+    //
+    // Refused, and nothing is written. Not a pair, and not a link either: a
+    // link means two artifacts were *used* together, `bump_link` takes the cue
+    // that bound them, and a bump derived from a cosine would put an
+    // observation about text into a table whose every other row is an
+    // observation about behaviour. Two documents on one subject link on their
+    // own, from the first search that shows them together.
+    let (longer, shorter) = if a.text.len() >= b.text.len() {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    let corroborated = contains_normalized(&longer.text, &shorter.text)
+        || (a.corpus_id.is_some() && a.corpus_id == b.corpus_id);
+    if !corroborated {
+        tracing::debug!(a = %a.id, b = %b.id, score, "alike, but nothing says duplicate");
+        return Ok(false);
+    }
+
     core.store.record_pair(&a.id, &b.id, score).await?;
     Ok(false)
 }
@@ -461,8 +492,12 @@ mod tests {
         // they were merged into one synthetic document.
         let core = test_core().await;
         let a_id = seed_passage(&core, "skript-a", "Spuren sind materielle Veraenderungen.").await;
-        let b_id =
-            seed_passage(&core, "skript-b", "Als Spur gilt jede materielle Veraenderung.").await;
+        let b_id = seed_passage(
+            &core,
+            "skript-b",
+            "Als Spur gilt jede materielle Veraenderung.",
+        )
+        .await;
         let a = core.store.get_artifact(&a_id).await.unwrap();
         let b = core.store.get_artifact(&b_id).await.unwrap();
 
@@ -502,6 +537,103 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_corpus_similarity_alone_does_not_reach_the_model() {
+        // Twenty-three of the live base's thirty-three pairs were this: two
+        // documents covering one subject at 0.89 to 0.93, duplicating nothing.
+        // Thirteen scripts agreeing is evidence that the claim is standard, and
+        // a merge erases that they agreed.
+        let core = test_core().await;
+        let a_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen an Personen oder Sachen.",
+            [1.0, 0.0],
+        )
+        .await;
+        let b_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Als Spur gilt jede materielle Veraenderung an Person oder Objekt.",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn containment_across_corpora_still_reaches_the_model() {
+        // The case the corroborant keeps working: one document ingested twice.
+        // Containment is the predicate that says one side adds nothing, which
+        // is what duplication means — a score only says they are alike.
+        let core = test_core().await;
+        let a_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen an Personen oder Sachen, \
+             die zur Tataufklaerung beitragen koennen.",
+            [1.0, 0.0],
+        )
+        .await;
+        let b_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen an Personen oder Sachen,",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert_eq!(
+            core.store
+                .pairs_by_state(PairState::Pending, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_pair_does_not_bump_a_link() {
+        // The link graph stays an observation about use. `bump_link` takes the
+        // cue that bound two artifacts, and the README calls the graph one
+        // learned from co-retrieval; a bump derived from a cosine would leave
+        // the recommendation surface unable to tell the two apart.
+        let core = test_core().await;
+        let a_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Spuren sind materielle Veraenderungen.",
+            [1.0, 0.0],
+        )
+        .await;
+        let b_id = crate::jobs::consolidate::tests::seed_into_new_corpus(
+            &core,
+            "Als Spur gilt jede materielle Veraenderung.",
+            [0.99, 0.05],
+        )
+        .await;
+        let a = core.store.get_artifact(&a_id).await.unwrap();
+        let b = core.store.get_artifact(&b_id).await.unwrap();
+
+        classify_pair(&core, &a, &b, 0.93).await.unwrap();
+
+        assert!(
+            core.store.get_link(&a_id, &b_id).await.unwrap().is_none(),
+            "a cosine is not evidence that anyone used these together"
         );
     }
 
@@ -549,7 +681,9 @@ mod tests {
             .await
             .unwrap();
 
-        classify_pair(&core, &rows[0], &rows[1], 0.97).await.unwrap();
+        classify_pair(&core, &rows[0], &rows[1], 0.97)
+            .await
+            .unwrap();
 
         let short = core.store.get_artifact(&rows[1].id).await.unwrap();
         assert!(

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -610,20 +610,30 @@ impl Store {
         if ids.is_empty() {
             return Ok(vec![]);
         }
-        let holes = std::iter::repeat_n("?", ids.len())
-            .collect::<Vec<_>>()
-            .join(",");
-        let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
-            "SELECT * FROM artifacts WHERE id IN ({holes})"
-        )));
-        for id in ids {
-            q = q.bind(id);
+        // Deduplicated and chunked, because the callers hand this whatever
+        // their own walk produced. `dedupe::run` passes every root of both
+        // members flattened together, which repeats an id whenever two members
+        // share a source and is bounded by nothing: the pre-merge check it
+        // feeds has no count-based cap by design. One `?` per id past
+        // SQLITE_MAX_VARIABLE_NUMBER — 999 on the builds predating 3.32 — is a
+        // prepare error, not a slow query, so the same 500 the pair repair
+        // chunks at is used here (`store::pairs::stale_unreachable_pairs`).
+        let mut seen = std::collections::HashSet::with_capacity(ids.len());
+        let unique: Vec<&String> = ids.iter().filter(|id| seen.insert(*id)).collect();
+        let mut out = Vec::with_capacity(unique.len());
+        for chunk in unique.chunks(500) {
+            let holes = std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+                "SELECT * FROM artifacts WHERE id IN ({holes})"
+            )));
+            for id in chunk {
+                q = q.bind(*id);
+            }
+            out.extend(q.fetch_all(&self.pool).await?.iter().map(row_to_artifact));
         }
-        Ok(q.fetch_all(&self.pool)
-            .await?
-            .iter()
-            .map(row_to_artifact)
-            .collect())
+        Ok(out)
     }
 
     /// The caveats of many artifacts in one query, keyed by id.
@@ -1954,6 +1964,30 @@ mod tests {
         let mut texts: Vec<&str> = got.iter().map(|c| c.text.as_str()).collect();
         texts.sort_unstable();
         assert_eq!(texts, vec!["a", "c"]);
+    }
+
+    /// One `?` per id, and the callers hand this whatever their own walk
+    /// produced: `dedupe::run` flattens every root of both members together,
+    /// which repeats a shared source and is capped by nothing. Past
+    /// SQLITE_MAX_VARIABLE_NUMBER that is a prepare error, not a slow query.
+    #[tokio::test]
+    async fn a_long_repetitive_list_of_ids_is_still_one_answer() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b")])
+            .await
+            .unwrap();
+        // Well past 999, and mostly repeats.
+        let mut ids: Vec<String> = (0..2_000).map(|i| format!("gone-{i}")).collect();
+        for _ in 0..40 {
+            ids.push(made[0].id.clone());
+            ids.push(made[1].id.clone());
+        }
+        let got = s.artifacts_by_ids(&ids).await.unwrap();
+        let mut texts: Vec<&str> = got.iter().map(|c| c.text.as_str()).collect();
+        texts.sort_unstable();
+        assert_eq!(texts, vec!["a", "b"], "a repeated id came back twice");
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -302,6 +302,31 @@ impl Store {
         // precisely the case the counter was added for.
         let root_ids: std::collections::BTreeSet<&String> = resolved.values().flatten().collect();
 
+        // The invariant stated above, checked rather than assumed. A merge over
+        // passages rewrites the verbatim substrate into text that belongs to no
+        // corpus and carries no span, and hides the wording someone captured
+        // behind it. On the base this was written for, every one of the merge
+        // path's root rows named a passage, silently, for as long as it ran.
+        //
+        // Here and not as a constraint on `artifact_sources`: the same table
+        // carries a synthesis's passage sources, where naming a passage is
+        // correct and intended.
+        //
+        // `Validation` and not `Internal` (`src/error.rs`): the caller sent a
+        // root it may not merge, which is a refused request and not a broken
+        // server.
+        for root in &root_ids {
+            let p: String = sqlx::query_scalar("SELECT provenance FROM artifacts WHERE id = ?")
+                .bind(root.as_str())
+                .fetch_one(&self.pool)
+                .await?;
+            if Provenance::parse(&p) != Provenance::Captured {
+                return Err(crate::error::Error::Validation(format!(
+                    "a merge root must be a captured artifact; {root} is {p}"
+                )));
+            }
+        }
+
         let mut tx = self.pool.begin().await?;
         let created_at = now();
         let c = Chunk {
@@ -1398,6 +1423,70 @@ mod tests {
             read.source_count, 0,
             "a captured artifact was merged from something"
         );
+    }
+
+    /// One passage in a corpus of its own, for the root-provenance cases.
+    async fn a_passage(s: &Store) -> String {
+        let src = s.insert_corpus("skript", "web", None).await.unwrap();
+        let mut p = nc(0, "Spuren sind materielle Veraenderungen.");
+        p.segment_idx = Some(0);
+        s.insert_artifacts_with_provenance(&src.id, &[p], Provenance::Passage)
+            .await
+            .unwrap()
+            .remove(0)
+            .id
+    }
+
+    #[tokio::test]
+    async fn a_merge_whose_root_is_a_passage_is_refused() {
+        // The invariant `insert_merged_artifact` documents and the live base
+        // violated in every one of its 135 merge-lineage rows. A merge over
+        // passages rewrites the verbatim substrate into text that belongs to no
+        // corpus and carries no span, and hides the wording someone captured
+        // behind it — the outcome `schema.sql` and the ROADMAP's fidelity rule
+        // exist to prevent.
+        let s = Store::memory().await.unwrap();
+        let root = a_passage(&s).await;
+
+        let refused = s
+            .insert_merged_artifact(
+                &NewMerged {
+                    title: Some("merged".into()),
+                    text: "rewritten".into(),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[root],
+            )
+            .await;
+
+        assert!(refused.is_err(), "a passage is not a merge root");
+    }
+
+    #[tokio::test]
+    async fn a_synthesized_artifact_may_still_name_passage_sources() {
+        // Why the check is on the merge path and not on `artifact_sources`. A
+        // synthesis draws on passages by design, and eleven rows in the live
+        // base are exactly that; a table constraint would break it.
+        let s = Store::memory().await.unwrap();
+        let root = a_passage(&s).await;
+
+        let made = s
+            .insert_synthesized_artifact(
+                &NewSynthesized {
+                    text: "Zusammenfassung".into(),
+                    title: Some("Spurenkunde".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                    cues: vec![],
+                },
+                &[root],
+            )
+            .await;
+
+        assert!(made.is_ok(), "synthesis over passages is what synthesis is");
     }
 
     /// One query for every hit's caveats: each id maps to its own list, an id

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -1153,6 +1153,14 @@ impl Store {
     /// backstop for an arming that failed after the embed committed. A row
     /// survives its completion, so "no job at all" is exactly "never asked".
     ///
+    /// Neither passages nor merges are anchors, and both exclusions belong
+    /// here rather than only in `embed::mark_indexed`. A backstop for "never
+    /// asked" cannot distinguish an arming that failed from one that was
+    /// deliberately withheld: every merged artifact now has no relate row *by
+    /// design*, so a filter on passages alone would arm one for each of them on
+    /// the next repair tick and undo the rule the embed path applies. The
+    /// reason merges are not anchors is spelled out there.
+    ///
     /// Walked in windows behind a cursor, rather than always from the oldest
     /// artifact forward. The "never asked" test lives in the other database
     /// now, so it cannot be a `WHERE` clause any more and the `LIMIT` has to be
@@ -1186,7 +1194,7 @@ impl Store {
             "SELECT a.id, a.created_at FROM artifacts a
               WHERE a.status = 'active' AND a.superseded_by IS NULL
                 AND a.embed_state = 'embedded'
-                AND a.provenance <> 'passage'
+                AND a.provenance <> 'passage' AND a.provenance <> 'merged'
                 AND (a.created_at > ? OR (a.created_at = ? AND a.id > ?))
               ORDER BY a.created_at ASC, a.id ASC
               LIMIT ?",
@@ -1962,6 +1970,46 @@ mod tests {
         }
         let ids = s.list_unrelated_artifact_ids(10).await.unwrap();
         assert_eq!(ids, vec![c[0].id.clone()]);
+    }
+
+    /// Nor a merge, and for a reason the passage case does not carry: a merge
+    /// is *never* armed by the embed path (`embed::mark_indexed`), so the
+    /// backstop's own test — no relate row means the arming was lost — is true
+    /// of every merge on the base. Filtering passages alone therefore hands one
+    /// back on the very next repair tick and makes each merge an anchor again,
+    /// which is exactly the walk the withholding was added to stop.
+    #[tokio::test]
+    async fn the_relate_backstop_never_lists_a_merge_either() {
+        let s = Store::memory().await.unwrap();
+        let src = s.insert_corpus("raw", "web", None).await.unwrap();
+        let made = s
+            .insert_artifacts(&src.id, &[nc(0, "a"), nc(1, "b")])
+            .await
+            .unwrap();
+        let m = s
+            .insert_merged_artifact(
+                &NewMerged {
+                    text: "a and b".into(),
+                    title: Some("both".into()),
+                    category: None,
+                    tags: vec![],
+                    caveats: vec![],
+                },
+                &[made[0].id.clone(), made[1].id.clone()],
+            )
+            .await
+            .unwrap();
+        for id in [&made[0].id, &made[1].id, &m.id] {
+            s.mark_embedded(id, "fake", 0).await.unwrap();
+        }
+
+        let ids = s.list_unrelated_artifact_ids(10).await.unwrap();
+
+        assert!(
+            !ids.contains(&m.id),
+            "the repair pass would arm a relate unit for a merge"
+        );
+        assert_eq!(ids.len(), 2, "it should still list the two captured rows");
     }
 
     /// The backstop has to be able to see past its own window.

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -110,6 +110,15 @@ impl CorpusStatus {
     }
 }
 
+/// The four columns that say where a corpus came from. See `corpus_origin`.
+#[derive(Debug, Clone)]
+pub struct CorpusOrigin {
+    pub id: String,
+    pub title_hint: Option<String>,
+    pub origin: String,
+    pub source_url: Option<String>,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct Corpus {
     pub id: String,
@@ -331,6 +340,30 @@ impl Store {
                 .await?;
         }
         Ok(Insertion::Created(src))
+    }
+
+    /// Where a corpus came from, without its text.
+    ///
+    /// `get_corpus` is `SELECT *`, and `raw_text` on a captured book is the
+    /// whole book. The single-artifact read needs four columns of it to name a
+    /// source, and reading the row to get them made the cheapest door in the
+    /// API load tens of megabytes per request — the cost `web::api::SourceRef`
+    /// was shaped to avoid on the wire and still paid in the query.
+    ///
+    /// `Ok(None)` and not `NotFound` for a corpus that is gone: a reading is
+    /// not refused because the document behind it was deleted.
+    pub async fn corpus_origin(&self, id: &str) -> Result<Option<CorpusOrigin>> {
+        let row =
+            sqlx::query("SELECT id, title_hint, origin, source_url FROM corpora WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|r| CorpusOrigin {
+            id: r.get("id"),
+            title_hint: r.get("title_hint"),
+            origin: r.get("origin"),
+            source_url: r.get("source_url"),
+        }))
     }
 
     pub async fn get_corpus(&self, id: &str) -> Result<Corpus> {
@@ -687,6 +720,26 @@ impl Store {
 mod tests {
     use super::*;
     use crate::store::Store;
+
+    /// Four columns and not the row: `raw_text` on a captured book is the whole
+    /// book, and the single-artifact read that needs a source name was loading
+    /// it on every request to print a title.
+    #[tokio::test]
+    async fn where_a_corpus_came_from_is_read_without_its_text() {
+        let s = Store::memory().await.unwrap();
+        let src = s
+            .insert_corpus("a very long body", "web", Some("Handbuch"))
+            .await
+            .unwrap();
+        let got = s.corpus_origin(&src.id).await.unwrap().unwrap();
+        assert_eq!(got.id, src.id);
+        assert_eq!(got.title_hint.as_deref(), Some("Handbuch"));
+        assert_eq!(got.origin, "web");
+
+        // A corpus deleted since is not a refusal: the artifact is still there
+        // to read, it just no longer says where it came from.
+        assert!(s.corpus_origin("gone").await.unwrap().is_none());
+    }
 
     #[tokio::test]
     async fn insert_and_get_roundtrip() {

--- a/src/store/corpora.rs
+++ b/src/store/corpora.rs
@@ -58,7 +58,7 @@ impl Reading {
 /// `as_str` writes `needs_review` for the database and serde writes
 /// `needsreview` for a response — and a client comparing strings would pick the
 /// wrong one and silently never match.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CorpusStatus {
     /// An image whose text has not been read yet. Only image corpora hold it.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -154,11 +154,23 @@ impl Store {
         // additive" would make this boot path guess, and the guess would be
         // wrong the first time a column's default is not what its old rows
         // should say. Everything not on this list still recreates.
-        const ADDITIVE: [(&str, &str, &str); 1] = [(
-            "artifacts",
-            "updated_at",
-            "ALTER TABLE artifacts ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0",
-        )];
+        const ADDITIVE: [(&str, &str, &str); 2] = [
+            (
+                "artifacts",
+                "updated_at",
+                "ALTER TABLE artifacts ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0",
+            ),
+            // Nullable and with no default, which is the whole reason it
+            // qualifies: NULL on an existing row says "nobody recorded who
+            // decided this", which is exactly true of every row written before
+            // the column existed. A default would have those rows claim an
+            // author they never had.
+            (
+                "artifact_pairs",
+                "decided_by",
+                "ALTER TABLE artifact_pairs ADD COLUMN decided_by TEXT",
+            ),
+        ];
         for (table, column, ddl) in ADDITIVE {
             let key = format!("{table}.{column}");
             let Some(i) = missing.iter().position(|m| *m == key) else {

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -138,6 +138,48 @@ impl PairState {
     }
 }
 
+/// Who settled a pair.
+///
+/// Not derivable from `state`: `Dismissed` is written both by an operator
+/// pressing dismiss and by `dedupe` applying a `Replaced` verdict, and
+/// `NoConflict` both by the judge and by a lifecycle shortcut. Before this
+/// existed the only trace of a person's decision was whether a detail string
+/// happened to survive the write — `dismiss_pair_ui` passes `None` and
+/// `set_pair_state` writes `detail` unconditionally, so it nulled it, while
+/// `apply_supersede_ui` carries the judge's through on purpose.
+///
+/// Passed rather than defaulted at every call site, so that a new operator
+/// surface cannot be recorded as the model by forgetting to say otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecidedBy {
+    /// A judge's verdict, or a rule the background applied without asking.
+    Model,
+    /// A person pressed something.
+    Operator,
+}
+
+impl DecidedBy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DecidedBy::Model => "model",
+            DecidedBy::Operator => "operator",
+        }
+    }
+
+    /// Anything unrecognised reads as absent rather than as one of the two: a
+    /// row written by a version that did not have this column says nothing
+    /// about who decided, and guessing would be the untruth the column exists
+    /// to end.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "model" => Some(DecidedBy::Model),
+            "operator" => Some(DecidedBy::Operator),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ArtifactPair {
     pub id: i64,
@@ -147,6 +189,9 @@ pub struct ArtifactPair {
     pub state: PairState,
     pub detail: Option<String>,
     pub created_at: i64,
+    /// Who settled it, where that was recorded. `None` on an open pair, and on
+    /// every row written before the column existed.
+    pub decided_by: Option<DecidedBy>,
     /// Model calls this pair has already cost, successful or not. Orders the
     /// judge's queue so a pair it cannot read does not starve the rest.
     pub judge_attempts: i64,
@@ -201,6 +246,10 @@ pub(crate) fn row_to_pair(r: &sqlx::sqlite::SqliteRow) -> ArtifactPair {
         state: PairState::parse(r.get::<String, _>("state").as_str()),
         detail: r.get("detail"),
         created_at: r.get("created_at"),
+        decided_by: r
+            .get::<Option<String>, _>("decided_by")
+            .as_deref()
+            .and_then(DecidedBy::parse),
         judge_attempts: r.get("judge_attempts"),
         judge_unreadable: r.get("judge_unreadable"),
         obsolete_id: r.get("obsolete_id"),
@@ -443,14 +492,16 @@ impl Store {
         id: i64,
         state: PairState,
         detail: Option<&str>,
+        by: DecidedBy,
     ) -> Result<()> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
-                SET state = ?, detail = ?, obsolete_id = NULL, merged_into = NULL
+                SET state = ?, detail = ?, decided_by = ?, obsolete_id = NULL, merged_into = NULL
               WHERE id = ?",
         )
         .bind(state.as_str())
         .bind(detail)
+        .bind(by.as_str())
         .bind(id)
         .execute(&self.pool)
         .await?;
@@ -618,6 +669,7 @@ impl Store {
                         p.id,
                         PairState::Dismissed,
                         Some("both of these went into the same merge"),
+                        DecidedBy::Model,
                     )
                     .await?;
                     continue;
@@ -627,6 +679,7 @@ impl Store {
                         p.id,
                         PairState::Dismissed,
                         Some("a pair between these two already exists"),
+                        DecidedBy::Model,
                     )
                     .await?;
                     continue;
@@ -778,6 +831,7 @@ impl Store {
                     p.id,
                     PairState::Stale,
                     Some("the supersession of these two answered this"),
+                    DecidedBy::Model,
                 )
                 .await?;
                 out.staled += 1;
@@ -788,6 +842,7 @@ impl Store {
                     p.id,
                     PairState::Stale,
                     Some("the artifact this proposed hiding is already hidden"),
+                    DecidedBy::Model,
                 )
                 .await?;
                 out.staled += 1;
@@ -801,6 +856,7 @@ impl Store {
                         "a vacuous verdict is about the two bodies it was read over, \
                           and one of them is hidden",
                     ),
+                    DecidedBy::Model,
                 )
                 .await?;
                 out.staled += 1;
@@ -822,6 +878,7 @@ impl Store {
                     p.id,
                     PairState::Stale,
                     Some("a pair between these two already exists"),
+                    DecidedBy::Model,
                 )
                 .await?;
                 out.staled += 1;
@@ -1395,6 +1452,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn who_settled_a_pair_is_recorded_rather_than_reconstructed() {
+        // Before this column the two were tellable apart only by accident:
+        // `dismiss_pair_ui` passes no detail and `set_pair_state` writes
+        // `detail` unconditionally, so a person's dismissal nulled the judge's
+        // reasoning, while `apply_supersede_ui` carried it through. Whether a
+        // string survived was the entire evidence that a human had decided.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+        assert_eq!(
+            s.get_pair(p).await.unwrap().decided_by,
+            None,
+            "an open pair has been decided by nobody"
+        );
+
+        s.set_pair_state(p, PairState::Dismissed, None, DecidedBy::Operator)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.get_pair(p).await.unwrap().decided_by,
+            Some(DecidedBy::Operator)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_row_written_before_the_column_existed_claims_no_author() {
+        // The reason `decided_by` is nullable with no default, and so belongs
+        // on the additive list at all. A default would have all 33 rows of an
+        // existing base assert an author none of them recorded.
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        sqlx::query(
+            "UPDATE artifact_pairs SET state = 'dismissed', decided_by = NULL WHERE id = ?",
+        )
+        .bind(p)
+        .execute(&s.pool)
+        .await
+        .unwrap();
+
+        let read = s.get_pair(p).await.unwrap();
+        assert_eq!(read.state, PairState::Dismissed);
+        assert_eq!(read.decided_by, None, "silence is not a claim about anyone");
+    }
+
+    #[tokio::test]
     async fn an_oversized_pair_leaves_the_pending_queue_but_stays_visible() {
         // Past the fan-in cap nothing is merged, and the pair must not sit on
         // the pending queue costing a call per sweep for a decision that will
@@ -1404,9 +1511,14 @@ mod tests {
         let (a, b) = two_artifacts(&s).await;
         s.record_pair(&a, &b, 0.91).await.unwrap();
         let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(p, PairState::Oversized, Some("9 roots, cap is 8"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            p,
+            PairState::Oversized,
+            Some("9 roots, cap is 8"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         assert!(s.pairs_to_judge(10).await.unwrap().is_empty());
         let found = s.pairs_by_state(PairState::Oversized, 10).await.unwrap();
@@ -1433,7 +1545,9 @@ mod tests {
             s.record_pair(&a, &b, 0.91).await.unwrap();
             let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
             if state != PairState::Pending {
-                s.set_pair_state(p, state, None).await.unwrap();
+                s.set_pair_state(p, state, None, DecidedBy::Model)
+                    .await
+                    .unwrap();
             }
             assert_eq!(
                 s.get_pair(p).await.unwrap().state,
@@ -1525,7 +1639,7 @@ mod tests {
         s.record_pair(&m[1], &m[2], 0.90).await.unwrap();
         let all = s.pairs_by_state(PairState::Pending, 10).await.unwrap();
         let (seed, other) = (all[0].id, all[1].id);
-        s.set_pair_state(other, PairState::Dismissed, None)
+        s.set_pair_state(other, PairState::Dismissed, None, DecidedBy::Model)
             .await
             .unwrap();
 
@@ -1578,7 +1692,7 @@ mod tests {
         let m = four_artifacts(&s).await;
         s.record_pair(&m[0], &m[1], 0.91).await.unwrap();
         let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(p, PairState::NoConflict, None)
+        s.set_pair_state(p, PairState::NoConflict, None, DecidedBy::Model)
             .await
             .unwrap();
 
@@ -1622,6 +1736,7 @@ mod tests {
             p.id,
             PairState::Contradiction,
             Some("version differs: 1.2 vs 1.4"),
+            DecidedBy::Model,
         )
         .await
         .unwrap();
@@ -1655,7 +1770,7 @@ mod tests {
             .await
             .unwrap()
             .remove(0);
-        s.set_pair_state(p.id, PairState::Dismissed, None)
+        s.set_pair_state(p.id, PairState::Dismissed, None, DecidedBy::Model)
             .await
             .unwrap();
 
@@ -1690,7 +1805,7 @@ mod tests {
             Some(a.as_str())
         );
 
-        s.set_pair_state(p.id, PairState::Dismissed, None)
+        s.set_pair_state(p.id, PairState::Dismissed, None, DecidedBy::Model)
             .await
             .unwrap();
 
@@ -1727,7 +1842,7 @@ mod tests {
             .await
             .unwrap()
             .remove(0);
-        s.set_pair_state(p.id, PairState::Dismissed, None)
+        s.set_pair_state(p.id, PairState::Dismissed, None, DecidedBy::Model)
             .await
             .unwrap();
         s.record_settled_pair(&a, &b, 0.91, PairState::NoConflict)
@@ -1750,7 +1865,8 @@ mod tests {
         // shorter than it is.
         let s = Store::memory().await.unwrap();
         assert!(matches!(
-            s.set_pair_state(9999, PairState::Dismissed, None).await,
+            s.set_pair_state(9999, PairState::Dismissed, None, DecidedBy::Model)
+                .await,
             Err(crate::error::Error::NotFound)
         ));
     }
@@ -1843,7 +1959,7 @@ mod tests {
             .await
             .unwrap();
         let id = s.pairs_by_state(PairState::NoConflict, 10).await.unwrap()[0].id;
-        s.set_pair_state(id, PairState::Dismissed, None)
+        s.set_pair_state(id, PairState::Dismissed, None, DecidedBy::Model)
             .await
             .unwrap();
 
@@ -1875,7 +1991,7 @@ mod tests {
         assert_eq!(p.merged_into.as_deref(), Some("merge-1"));
 
         // Leaving the settlement drops the record, exactly as obsolete_id does.
-        s.set_pair_state(id, PairState::Dismissed, None)
+        s.set_pair_state(id, PairState::Dismissed, None, DecidedBy::Model)
             .await
             .unwrap();
         assert_eq!(s.get_pair(id).await.unwrap().merged_into, None);
@@ -1965,9 +2081,14 @@ mod tests {
         let (b, c, m) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(c, m, 0.80).await.unwrap();
         let existing = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(existing, PairState::Dismissed, Some("operator"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            existing,
+            PairState::Dismissed,
+            Some("operator"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
         s.record_pair(b, c, 0.91).await.unwrap();
 
         let moved = s
@@ -2023,7 +2144,7 @@ mod tests {
         let (b, c, m) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(b, c, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(id, PairState::NoConflict, None)
+        s.set_pair_state(id, PairState::NoConflict, None, DecidedBy::Model)
             .await
             .unwrap();
 
@@ -2048,9 +2169,14 @@ mod tests {
         let (a, b) = two_artifacts(&s).await;
         s.record_pair(&a, &b, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(id, PairState::Oversized, Some("12 sources, cap is 8"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::Oversized,
+            Some("12 sources, cap is 8"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(s.reopen_oversized().await.unwrap(), 1);
 
@@ -2081,9 +2207,14 @@ mod tests {
             s.record_judge_attempt(id).await.unwrap();
             s.record_unreadable_judgement(id).await.unwrap();
         }
-        s.set_pair_state(id, PairState::Oversized, Some("12 sources, cap is 8"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::Oversized,
+            Some("12 sources, cap is 8"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(s.reopen_oversized().await.unwrap(), 1);
 
@@ -2160,9 +2291,14 @@ mod tests {
         let (loser, other, winner) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(loser, other, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(id, PairState::Contradiction, Some("30 seconds vs 90"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::Contradiction,
+            Some("30 seconds vs 90"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         s.follow_supersession(loser, winner).await.unwrap();
 
@@ -2204,15 +2340,25 @@ mod tests {
         let (loser, other, winner) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(loser, other, 0.91).await.unwrap();
         let verdict = s.pair_between(loser, other).await.unwrap().unwrap().id;
-        s.set_pair_state(verdict, PairState::Contradiction, Some("30 seconds vs 90"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            verdict,
+            PairState::Contradiction,
+            Some("30 seconds vs 90"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
         // Already judged, and judged the other way.
         s.record_pair(other, winner, 0.72).await.unwrap();
         let standing = s.pair_between(other, winner).await.unwrap().unwrap().id;
-        s.set_pair_state(standing, PairState::NoConflict, Some("nothing in common"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            standing,
+            PairState::NoConflict,
+            Some("nothing in common"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         s.follow_supersession(loser, winner).await.unwrap();
 
@@ -2243,14 +2389,24 @@ mod tests {
         let (loser, other, winner) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(loser, other, 0.91).await.unwrap();
         let verdict = s.pair_between(loser, other).await.unwrap().unwrap().id;
-        s.set_pair_state(verdict, PairState::Contradiction, Some("30 seconds vs 90"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            verdict,
+            PairState::Contradiction,
+            Some("30 seconds vs 90"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
         s.record_pair(other, winner, 0.72).await.unwrap();
         let standing = s.pair_between(other, winner).await.unwrap().unwrap().id;
-        s.set_pair_state(standing, PairState::Dismissed, Some("not worth looking at"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            standing,
+            PairState::Dismissed,
+            Some("not worth looking at"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         s.follow_supersession(loser, winner).await.unwrap();
 
@@ -2277,6 +2433,7 @@ mod tests {
             id,
             PairState::Vacuous,
             Some("each body is its own file path"),
+            DecidedBy::Model,
         )
         .await
         .unwrap();
@@ -2350,9 +2507,14 @@ mod tests {
         let (loser, other, winner) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(loser, other, 0.91).await.unwrap();
         let id = s.pair_between(loser, other).await.unwrap().unwrap().id;
-        s.set_pair_state(id, PairState::Contradiction, Some("30 seconds vs 90"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::Contradiction,
+            Some("30 seconds vs 90"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
         s.set_superseded_by(loser, Some(winner)).await.unwrap();
 
         assert_eq!(
@@ -2399,9 +2561,14 @@ mod tests {
         let (a, b) = two_artifacts(&s).await;
         s.record_pair(&a, &b, 0.91).await.unwrap();
         let id = s.pair_between(&a, &b).await.unwrap().unwrap().id;
-        s.set_pair_state(id, PairState::Contradiction, Some("30 seconds vs 90"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::Contradiction,
+            Some("30 seconds vs 90"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
         s.set_artifact_status(&b, crate::store::artifacts::ArtifactStatus::Deprecated)
             .await
             .unwrap();
@@ -2487,6 +2654,7 @@ mod tests {
             existing.id,
             PairState::NoConflict,
             Some("nothing in common"),
+            DecidedBy::Model,
         )
         .await
         .unwrap();
@@ -2513,9 +2681,14 @@ mod tests {
         let (loser, other, winner) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(loser, other, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(id, PairState::NoConflict, Some("nothing in common"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::NoConflict,
+            Some("nothing in common"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             s.follow_supersession(loser, winner)
@@ -2566,9 +2739,14 @@ mod tests {
         let ids = n_artifacts(&s, 3).await;
         s.record_pair(&ids[0], &ids[1], 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_state(id, PairState::Contradiction, Some("30 vs 90"))
-            .await
-            .unwrap();
+        s.set_pair_state(
+            id,
+            PairState::Contradiction,
+            Some("30 vs 90"),
+            DecidedBy::Model,
+        )
+        .await
+        .unwrap();
         s.set_superseded_by(&ids[0], Some(&ids[2])).await.unwrap();
 
         assert!(

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -522,18 +522,27 @@ impl Store {
     /// `set_pair_state` because this is the only path that writes
     /// `obsolete_id`, and a plain contradiction must never carry a stale value
     /// left over from a different pair.
+    ///
+    /// `by` is written for the reason `set_pair_state` writes it, and is passed
+    /// rather than defaulted for the reason `DecidedBy` gives: a settled row
+    /// with `decided_by` left `NULL` is indistinguishable from one written
+    /// before the column existed, so the review surface cannot tell a verdict
+    /// from a legacy row.
     pub async fn set_pair_superseded(
         &self,
         id: i64,
         obsolete_id: &str,
         detail: Option<&str>,
+        by: DecidedBy,
     ) -> Result<()> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
-                SET state = 'superseded', detail = ?, obsolete_id = ?, merged_into = NULL
+                SET state = 'superseded', detail = ?, decided_by = ?,
+                    obsolete_id = ?, merged_into = NULL
               WHERE id = ?",
         )
         .bind(detail)
+        .bind(by.as_str())
         .bind(obsolete_id)
         .bind(id)
         .execute(&self.pool)
@@ -547,18 +556,27 @@ impl Store {
     /// Settle a pair as answered by an applied merge. `merged_into` names the
     /// merged artifact, which is what lets the stranded-merge reap reopen
     /// exactly the pairs a merge that never embedded had closed.
+    ///
+    /// `by` for the reason `set_pair_superseded` takes it: without it the one
+    /// settlement this path writes — a merge the judge applied unattended —
+    /// landed as `decided_by = NULL`, which the column defines as "still open,
+    /// or written before the column existed". The merge is the most attributable
+    /// answer in the queue and was the only one saying nothing about who gave it.
     pub async fn set_pair_merged(
         &self,
         id: i64,
         merged_into: &str,
         detail: Option<&str>,
+        by: DecidedBy,
     ) -> Result<()> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
-                SET state = 'no_conflict', detail = ?, merged_into = ?, obsolete_id = NULL
+                SET state = 'no_conflict', detail = ?, decided_by = ?,
+                    merged_into = ?, obsolete_id = NULL
               WHERE id = ?",
         )
         .bind(detail)
+        .bind(by.as_str())
         .bind(merged_into)
         .bind(id)
         .execute(&self.pool)
@@ -573,10 +591,16 @@ impl Store {
     /// person. Contradiction rather than Pending on purpose: re-arming the
     /// model would regenerate the same unembeddable draft, at full price,
     /// forever.
+    ///
+    /// `decided_by` is rewritten and not left standing: the row is being moved
+    /// to a state nobody has answered yet by a rule the sweep applied on its
+    /// own, so the name on it is the model's — the same attribution
+    /// `follow_supersession` writes when it settles a row the same way.
     pub async fn reopen_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
-                SET state = 'contradiction', detail = ?, merged_into = NULL
+                SET state = 'contradiction', detail = ?, decided_by = 'model',
+                    merged_into = NULL
               WHERE merged_into = ?",
         )
         .bind(detail)
@@ -592,13 +616,26 @@ impl Store {
     /// pairs were settled the moment the merge was written. Dismissed, not
     /// Contradiction: an undo is an operator overruling the verdict, and
     /// `record_pair` respecting dismissed rows is what makes that last.
-    pub async fn dismiss_pairs_merged_into(&self, merged_id: &str, detail: &str) -> Result<u64> {
+    ///
+    /// `by` is a parameter for the reason `discard_both` takes one, and this is
+    /// the case that made it matter: `undo` settles the pairs it finds through
+    /// `pairs_among` as the operator who pressed it, and reached this — the
+    /// branch that covers an undo outrunning the embed, which before `finish`
+    /// runs is *every* undo — writing no name at all. One button recorded
+    /// itself two different ways depending on timing.
+    pub async fn dismiss_pairs_merged_into(
+        &self,
+        merged_id: &str,
+        detail: &str,
+        by: DecidedBy,
+    ) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
-                SET state = 'dismissed', detail = ?, merged_into = NULL
+                SET state = 'dismissed', detail = ?, decided_by = ?, merged_into = NULL
               WHERE merged_into = ?",
         )
         .bind(detail)
+        .bind(by.as_str())
         .bind(merged_id)
         .execute(&self.pool)
         .await?;
@@ -972,6 +1009,15 @@ impl Store {
     /// the question back (`reopen_stale_pairs`). Both ways out of results are
     /// reversible; settling these as somebody's decision would make the queue
     /// the one place where they are not.
+    ///
+    /// `decided_by` is overwritten rather than left alone, which is the same
+    /// distinction one level down: the *state* is nobody's answer, but the row
+    /// still has to say who last wrote it. These candidates come from
+    /// `('pending','contradiction','superseded','vacuous')`, and a
+    /// contradiction an operator escalated carries their name — left standing
+    /// beside `'stale'` it reads "an operator decided this went stale", which
+    /// they did not. `'model'`, like every other rule this file applies
+    /// unattended (`follow_supersession` settles `Stale` exactly so).
     pub async fn stale_unreachable_pairs(&self) -> Result<u64> {
         let rows = sqlx::query(
             "SELECT p.id AS pair_id, x.id AS side, x.superseded_by AS winner
@@ -1024,6 +1070,7 @@ impl Store {
             let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
                 "UPDATE artifact_pairs
                     SET state = 'stale', obsolete_id = NULL, merged_into = NULL,
+                        decided_by = 'model',
                         detail = 'one of these artifacts is no longer in results'
                   WHERE id IN ({holes})"
             )));
@@ -1877,7 +1924,7 @@ mod tests {
             .await
             .unwrap()
             .remove(0);
-        s.set_pair_superseded(p.id, &a, Some("a is stale"))
+        s.set_pair_superseded(p.id, &a, Some("a is stale"), DecidedBy::Model)
             .await
             .unwrap();
         assert_eq!(
@@ -2062,7 +2109,7 @@ mod tests {
         s.record_pair(&a, &b, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
 
-        s.set_pair_merged(id, "merge-1", Some("same claim"))
+        s.set_pair_merged(id, "merge-1", Some("same claim"), DecidedBy::Model)
             .await
             .unwrap();
 
@@ -2077,13 +2124,71 @@ mod tests {
         assert_eq!(s.get_pair(id).await.unwrap().merged_into, None);
     }
 
+    /// The settlement this whole column exists for. A merge the judge applied
+    /// unattended is the most attributable answer the queue has, and it was the
+    /// one row landing with `decided_by` unset — which the column defines as
+    /// "still open, or written before this existed". The review surface could
+    /// not tell an applied merge from a legacy row.
+    #[tokio::test]
+    async fn an_applied_merge_says_who_applied_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+
+        s.set_pair_merged(id, "merge-1", None, DecidedBy::Model)
+            .await
+            .unwrap();
+        assert_eq!(
+            s.get_pair(id).await.unwrap().decided_by,
+            Some(DecidedBy::Model)
+        );
+
+        s.set_pair_superseded(id, &a, None, DecidedBy::Operator)
+            .await
+            .unwrap();
+        assert_eq!(
+            s.get_pair(id).await.unwrap().decided_by,
+            Some(DecidedBy::Operator),
+            "the proposed direction was recorded as nobody's"
+        );
+    }
+
+    /// One button, one attribution. `merge::undo` settles the pairs it finds
+    /// through `pairs_among` as the operator who pressed it and reaches this
+    /// for the rest — which before `finish` runs is *every* pair the merge
+    /// settled. Recording those two halves differently made how an undo is
+    /// remembered depend on whether the embed had landed yet.
+    #[tokio::test]
+    async fn dismissing_a_merge_s_pairs_carries_the_name_the_undo_gives_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_merged(id, "merge-1", None, DecidedBy::Model)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.dismiss_pairs_merged_into("merge-1", "merge undone", DecidedBy::Operator)
+                .await
+                .unwrap(),
+            1
+        );
+        let p = s.get_pair(id).await.unwrap();
+        assert_eq!(p.state, PairState::Dismissed);
+        assert_eq!(p.decided_by, Some(DecidedBy::Operator));
+    }
+
     #[tokio::test]
     async fn reopening_a_stranded_merge_s_pairs_touches_only_its_own() {
         let s = Store::memory().await.unwrap();
         let (a, b) = two_artifacts(&s).await;
         s.record_pair(&a, &b, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_merged(id, "merge-1", None).await.unwrap();
+        s.set_pair_merged(id, "merge-1", None, DecidedBy::Model)
+            .await
+            .unwrap();
 
         assert_eq!(
             s.reopen_pairs_merged_into("merge-other", "unrelated")
@@ -2101,6 +2206,11 @@ mod tests {
         let p = s.get_pair(id).await.unwrap();
         assert_eq!(p.state, PairState::Contradiction);
         assert_eq!(p.merged_into, None);
+        assert_eq!(
+            p.decided_by,
+            Some(DecidedBy::Model),
+            "the reap is a rule the sweep applied on its own; the row has to say so"
+        );
     }
 
     /// The whole point of re-pointing: C was a duplicate of B, B is now inside
@@ -2573,6 +2683,29 @@ mod tests {
         assert_eq!(s.stale_unreachable_pairs().await.unwrap(), 1);
     }
 
+    /// `Stale` is not the operator's answer even when the row it lands on was
+    /// theirs. A contradiction a person escalated carries their name; leaving
+    /// it standing beside `'stale'` reads "an operator decided this went
+    /// stale", which is a lifecycle event nobody decided.
+    #[tokio::test]
+    async fn going_stale_does_not_leave_an_operator_s_name_on_the_row() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(id, PairState::Contradiction, None, DecidedBy::Operator)
+            .await
+            .unwrap();
+        s.set_artifact_status(&b, crate::store::artifacts::ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+
+        assert_eq!(s.stale_unreachable_pairs().await.unwrap(), 1);
+        let p = s.get_pair(id).await.unwrap();
+        assert_eq!(p.state, PairState::Stale);
+        assert_eq!(p.decided_by, Some(DecidedBy::Model));
+    }
+
     /// The stale pass ran unbounded straight after a repair pass that takes 200
     /// supersessions a sweep, so it reached everything the repair had not got to
     /// yet and settled it `Stale` first. That is a one-way door:
@@ -2698,7 +2831,7 @@ mod tests {
         let (loser, other, winner) = (&ids[0], &ids[1], &ids[2]);
         s.record_pair(loser, other, 0.91).await.unwrap();
         let id = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
-        s.set_pair_superseded(id, loser, Some("the older reading"))
+        s.set_pair_superseded(id, loser, Some("the older reading"), DecidedBy::Model)
             .await
             .unwrap();
 

--- a/src/store/pairs.rs
+++ b/src/store/pairs.rs
@@ -353,11 +353,13 @@ impl Store {
     ///
     /// `from` narrows the write to a row still in the state the caller wrote,
     /// so a decision that landed in between — a judge's, an operator's — is
-    /// never reopened underneath them.
+    /// never reopened underneath them. `decided_by` clears with the state, for
+    /// the reason `reopen_pair` gives: a pending row attributed to anyone is a
+    /// claim about a question nobody has answered.
     pub async fn unsettle_pair(&self, a: &str, b: &str, from: PairState) -> Result<bool> {
         let (a, b) = if a <= b { (a, b) } else { (b, a) };
         let res = sqlx::query(
-            "UPDATE artifact_pairs SET state = 'pending'
+            "UPDATE artifact_pairs SET state = 'pending', decided_by = NULL
               WHERE a_id = ? AND b_id = ? AND state = ?",
         )
         .bind(a)
@@ -727,11 +729,17 @@ impl Store {
     /// them: the row is being asked again from nothing, and attempts earned
     /// under an older question would push it straight past the ceilings that
     /// decide whether it is worth a call.
+    ///
+    /// `decided_by` clears with them, and for a stronger reason than the
+    /// counters: an open pair carries nobody's decision, so leaving the old
+    /// value behind reads back as "pending, decided by operator" — a row that
+    /// says a person answered a question still being asked. The column exists
+    /// to end exactly that kind of untruth (`DecidedBy`).
     async fn reopen_pair(&self, id: i64) -> Result<()> {
         sqlx::query(
             "UPDATE artifact_pairs
                 SET state = 'pending', detail = NULL, obsolete_id = NULL, merged_into = NULL,
-                    judge_attempts = 0, judge_unreadable = 0
+                    decided_by = NULL, judge_attempts = 0, judge_unreadable = 0
               WHERE id = ?",
         )
         .bind(id)
@@ -1046,11 +1054,16 @@ impl Store {
     /// does not put a question back that names another artifact somebody
     /// retired in the meantime. That row stays `Stale` and comes back with its
     /// own artifact.
+    ///
+    /// `decided_by` clears with the state (`reopen_pair`). These rows are the
+    /// case that makes it matter most: a pair an operator dismissed by hand is
+    /// reopened here, and keeping their name on it would attribute a pending
+    /// question to a person who answered a different one.
     pub async fn reopen_stale_pairs(&self, artifact_id: &str) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
                 SET state = 'pending', detail = NULL, obsolete_id = NULL, merged_into = NULL,
-                    judge_attempts = 0, judge_unreadable = 0
+                    decided_by = NULL, judge_attempts = 0, judge_unreadable = 0
               WHERE state = 'stale'
                 AND (a_id = ?1 OR b_id = ?1)
                 AND NOT EXISTS (
@@ -1166,10 +1179,12 @@ impl Store {
     /// such a row can come back already at or past `MAX_UNREADABLE_JUDGEMENTS`
     /// — and `pairs_to_judge` holds those back, so it would sit pending for
     /// good, never judged and never surfaced.
+    ///
+    /// `decided_by` clears with them, for the reason `reopen_pair` gives.
     pub async fn reopen_oversized(&self) -> Result<u64> {
         let res = sqlx::query(
             "UPDATE artifact_pairs
-                SET state = 'pending', detail = NULL,
+                SET state = 'pending', detail = NULL, decided_by = NULL,
                     judge_attempts = 0, judge_unreadable = 0
               WHERE state = 'oversized'",
         )
@@ -1477,6 +1492,71 @@ mod tests {
             s.get_pair(p).await.unwrap().decided_by,
             Some(DecidedBy::Operator)
         );
+    }
+
+    /// Reopening is the other half of that column meaning anything: a row put
+    /// back on the queue has been decided by nobody again.
+    ///
+    /// The case that makes it concrete is an operator's. They dismiss a pair,
+    /// the loser is later restored, `reopen_stale_pairs` puts the row back to
+    /// `pending` — and with `decided_by` left standing the row reads "pending,
+    /// decided by operator": a person's name on a question still being asked.
+    #[tokio::test]
+    async fn reopening_a_pair_takes_the_old_decider_off_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(
+            p,
+            PairState::Stale,
+            Some("its side was hidden"),
+            DecidedBy::Operator,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(s.reopen_stale_pairs(&a).await.unwrap(), 1);
+
+        let read = s.get_pair(p).await.unwrap();
+        assert_eq!(read.state, PairState::Pending);
+        assert_eq!(
+            read.decided_by, None,
+            "an open pair still named the person who answered a different question"
+        );
+    }
+
+    /// The same for the sweep's own reopening, which has no operator in it but
+    /// the identical failure: a `pending` row asserting an author.
+    #[tokio::test]
+    async fn reopening_an_oversized_pair_takes_the_old_decider_off_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(p, PairState::Oversized, Some("9 roots"), DecidedBy::Model)
+            .await
+            .unwrap();
+
+        assert_eq!(s.reopen_oversized().await.unwrap(), 1);
+
+        assert_eq!(s.get_pair(p).await.unwrap().decided_by, None);
+    }
+
+    /// And for the unsettle a failed side effect leaves behind.
+    #[tokio::test]
+    async fn unsettling_a_pair_takes_the_old_decider_off_it() {
+        let s = Store::memory().await.unwrap();
+        let (a, b) = two_artifacts(&s).await;
+        s.record_pair(&a, &b, 0.91).await.unwrap();
+        let p = s.pairs_by_state(PairState::Pending, 10).await.unwrap()[0].id;
+        s.set_pair_state(p, PairState::Dismissed, None, DecidedBy::Operator)
+            .await
+            .unwrap();
+
+        assert!(s.unsettle_pair(&a, &b, PairState::Dismissed).await.unwrap());
+
+        assert_eq!(s.get_pair(p).await.unwrap().decided_by, None);
     }
 
     #[tokio::test]

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -254,6 +254,16 @@ CREATE TABLE IF NOT EXISTS artifact_pairs (
   -- Which merged artifact answered this pair, when the settlement was an
   -- applied merge. The stranded-merge reap reopens pairs by it.
   merged_into    TEXT,
+  -- Who settled this pair: 'model' or 'operator'. NULL for a row still open,
+  -- and for the rows a base carried before this column existed — an absence,
+  -- honestly, rather than a guess.
+  --
+  -- Reconstructing it was impossible before: `dismiss_pair_ui` passes no detail
+  -- and so nulls it, while `apply_supersede_ui` carries the judge's through, so
+  -- the only trace of a person's decision was which string survived. For a
+  -- subsystem whose defence is that every decision is reversible and
+  -- reviewable, who decided is not something to infer.
+  decided_by     TEXT,
   UNIQUE(a_id, b_id)
 );
 CREATE INDEX IF NOT EXISTS idx_pairs_state ON artifact_pairs(state, created_at DESC);

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1107,11 +1107,52 @@ async fn resurface(
     Ok(Json(tenant.core.resurface(p.limit.unwrap_or(5)).await?))
 }
 
-async fn get_artifact(
-    tenant: Tenant,
-    Path(cid): Path<String>,
-) -> Result<Json<crate::store::artifacts::Chunk>> {
+/// Enough of a corpus to say where a passage came from, and no more.
+///
+/// Not the `Corpus` row itself: that carries `raw_text`, which for a captured
+/// book is the whole book. Shipping it beside every single-artifact read would
+/// make the cheapest door in the API the most expensive one, to say a name.
+#[derive(serde::Serialize)]
+pub struct SourceRef {
+    pub id: String,
+    pub title: Option<String>,
+    pub origin: String,
+    pub source_url: Option<String>,
+}
+
+/// One artifact, and the document it was captured from.
+///
+/// The chunk is flattened rather than nested, so every key this door has ever
+/// answered with is still at the top level and no reader of it had to change.
+/// `source` is `None` in the two cases that are not failures: a merged
+/// artifact belongs to no single corpus, and a corpus deleted since leaves its
+/// artifacts readable.
+#[derive(serde::Serialize)]
+pub struct ArtifactDetail {
+    #[serde(flatten)]
+    pub artifact: crate::store::artifacts::Chunk,
+    pub source: Option<SourceRef>,
+}
+
+async fn get_artifact(tenant: Tenant, Path(cid): Path<String>) -> Result<Json<ArtifactDetail>> {
     let chunk = tenant.core.store.get_artifact(&cid).await?;
+    // A reading is not refused because the document behind it is gone: the
+    // artifact is the thing that was asked for and it is still here.
+    let source = match &chunk.corpus_id {
+        Some(id) => tenant
+            .core
+            .store
+            .get_corpus(id)
+            .await
+            .ok()
+            .map(|c| SourceRef {
+                id: c.id,
+                title: c.title_hint,
+                origin: c.origin,
+                source_url: c.source_url,
+            }),
+        None => None,
+    };
     // Asking for one artifact by id is the same deliberate act the detail pane
     // records, and it is the whole of what this door can honestly say: there
     // is no navigation to have pivoted through, so no `via`, and no session to
@@ -1121,7 +1162,10 @@ async fn get_artifact(
     tenant
         .core
         .record_interaction(&cid, None, Some(&tenant.user.subject));
-    Ok(Json(chunk))
+    Ok(Json(ArtifactDetail {
+        artifact: chunk,
+        source,
+    }))
 }
 
 async fn patch_artifact(
@@ -1580,6 +1624,75 @@ pub(crate) mod tests {
         // The API has no navigation to pivot through and no session to belong
         // to: a bearer token is not a conversation.
         assert_eq!(got[0].via, None);
+    }
+
+    /// The terminal's `--show` reads one artifact in full, and the whole point
+    /// of it is that nothing is clipped: a rendering that shows two lines is
+    /// the rendering that made this door necessary. The source travels with it
+    /// because a passage without the document it came from is the citation
+    /// problem `-a` already has.
+    #[tokio::test]
+    async fn one_artifact_is_readable_in_full_with_the_document_it_came_from() {
+        let (app, token, core) = app_token_and_core().await;
+        let src = core
+            .store
+            .insert_corpus("der Rohtext", "web", Some("Handbuch Mobilforensik"))
+            .await
+            .unwrap();
+        let long = "eine Zeile\n".repeat(40);
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: long.clone(),
+                    corpus_span: None,
+                    title: Some("Physische Extraktion".into()),
+                    category: None,
+                    tags: vec!["forensik".into()],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+
+        let res = app
+            .clone()
+            .oneshot(get(
+                &format!("/api/v1/artifacts/{}", made[0].id),
+                Some(&token),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = json_of(res).await;
+        assert_eq!(body["id"], made[0].id, "{body}");
+        assert_eq!(
+            body["text"].as_str().unwrap(),
+            long,
+            "the text arrived clipped, which is the one thing this door exists to prevent"
+        );
+        assert_eq!(body["title"], "Physische Extraktion", "{body}");
+        assert_eq!(
+            body["source"]["title"], "Handbuch Mobilforensik",
+            "the document it came from did not travel with it: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_artifact_that_is_not_there_is_a_404_rather_than_an_empty_reading() {
+        let (app, token) = app_and_token().await;
+        let res = app
+            .oneshot(get(
+                "/api/v1/artifacts/01a00000-0000-7000-8000-000000000000",
+                Some(&token),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 
     fn get(uri: &str, token: Option<&str>) -> Request<Body> {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1524,6 +1524,7 @@ pub(crate) mod tests {
                 pair.id,
                 crate::store::pairs::PairState::Contradiction,
                 Some("30 seconds vs 90"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1139,12 +1139,13 @@ async fn get_artifact(tenant: Tenant, Path(cid): Path<String>) -> Result<Json<Ar
     // A reading is not refused because the document behind it is gone: the
     // artifact is the thing that was asked for and it is still here.
     let source = match &chunk.corpus_id {
+        // `corpus_origin` and not `get_corpus`: the four columns below are the
+        // whole of what this answers with, and the row carries `raw_text`.
         Some(id) => tenant
             .core
             .store
-            .get_corpus(id)
-            .await
-            .ok()
+            .corpus_origin(id)
+            .await?
             .map(|c| SourceRef {
                 id: c.id,
                 title: c.title_hint,

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2484,7 +2484,12 @@ async fn dismiss_pair_ui(
     tenant
         .core
         .store
-        .set_pair_state(pid, crate::store::pairs::PairState::Dismissed, None)
+        .set_pair_state(
+            pid,
+            crate::store::pairs::PairState::Dismissed,
+            None,
+            crate::store::pairs::DecidedBy::Operator,
+        )
         .await?;
     Ok(Redirect::to(back.path()).into_response())
 }
@@ -2578,6 +2583,7 @@ async fn apply_pair_supersede_ui(
             pid,
             crate::store::pairs::PairState::Dismissed,
             pair.detail.as_deref(),
+            crate::store::pairs::DecidedBy::Operator,
         )
         .await?;
     Ok(Redirect::to(f.back.path()).into_response())
@@ -4672,6 +4678,7 @@ mod tests {
                 id,
                 crate::store::pairs::PairState::Contradiction,
                 Some("one says the opposite of the other"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();
@@ -7890,6 +7897,7 @@ mod tests {
                 pair.id,
                 crate::store::pairs::PairState::Contradiction,
                 Some("they disagree about the tag"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();
@@ -7975,6 +7983,7 @@ mod tests {
                 pair.id,
                 crate::store::pairs::PairState::Contradiction,
                 Some("30 seconds vs 90"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();
@@ -8051,6 +8060,7 @@ mod tests {
                 pair.id,
                 crate::store::pairs::PairState::Vacuous,
                 Some("each body is its own file path"),
+                crate::store::pairs::DecidedBy::Model,
             )
             .await
             .unwrap();

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -2515,7 +2515,13 @@ async fn discard_pair_ui(
 ) -> Result<Response> {
     let pair = tenant.core.store.get_pair(pid).await?;
     let detail = pair.detail.clone();
-    crate::jobs::dedupe::discard_both(&tenant.core, &pair, detail.as_deref()).await?;
+    crate::jobs::dedupe::discard_both(
+        &tenant.core,
+        &pair,
+        detail.as_deref(),
+        crate::store::pairs::DecidedBy::Operator,
+    )
+    .await?;
     Ok(Redirect::to(back.path()).into_response())
 }
 


### PR DESCRIPTION
Duplicate hygiene was consuming the verbatim substrate. On 2026-08-27 between 07:27 and 08:35 the running instance wrote fifteen merged artifacts in one chain — root counts 2, 3, 4 … 16 without a gap, text growing from 1,255 to 12,123 characters — ending at one active synthetic artifact of 10,011 characters with sixteen verbatim passages from **thirteen different corpora** hidden behind it. All fifteen came from the dedupe ticker; nobody decided any of them.

That is the outcome `src/store/schema.sql:51` and the ROADMAP's fidelity rule exist to prevent.

## What the base showed

| | |
|---|---|
| Passages | 11,473 |
| Captured artifacts | 9 |
| Synthesized | 2 |
| Merged | 15 |
| Corpora | 226 |
| Pairs ever filed | 33 |

Of the 33 pairs: 20 passage against merged, 11 passage against captured, one passage against passage, and **one** captured against captured — a single pair of the material this subsystem was designed for, which an operator dismissed. Twenty-three of the 33 are cross-corpus.

The existing passage guard asks for one corpus **and** one `segment_idx` **and** a passage. Nine pairs sit in one corpus and eight of those have different segments; the ninth is captured on both sides. Its hit rate on this base is zero.

And `insert_merged_artifact` documents that `artifact_sources.root_id` "only ever names a `captured` artifact — the invariant the whole anti-drift rule rests on". All 135 merge-lineage rows named a passage. Nothing checked it.

## Root cause

A cosine says two texts are alike. Duplication says one of them adds nothing — the comment above `contains_normalized` states the distinction plainly. Admission was nonetheless `review_min`, a cosine. On 226 documents teaching one subject, passages from different scripts land at 0.89–0.93 while duplicating nothing: it is the same material taught by thirteen authors.

The model did not fail. Its verdicts are in the base and they are right — "Artifact A is a short excerpt from the much larger and more comprehensive Artifact B". The defect is that the question was asked.

## The changes

1. **A passage is never one side of a pair.** The rule moves from a corpus/segment coincidence onto `provenance`, and sits below the containment block so a passage wholly inside another in one corpus is still superseded without a call.
2. **A merged artifact does not arm a relate unit.** It carries the union of its lineage's wording, so it scores above `review_min` against more of a subject than either side did and every pair it files becomes the next merge — the artifact writes its own next question. `Merged` and not `is_model_written()`: a synthesis is ordinary dedupe material.
3. **`insert_merged_artifact` refuses a non-captured root**, with `Error::Validation`. On the merge path only — a synthesis legitimately names passage sources, and eleven rows in that base are exactly that.
4. **Clearing `review_min` becomes necessary, not sufficient.** A pair needs a corroborant: containment, or one shared corpus. Containment keeps the real cross-corpus case — the same document ingested twice. A refused pair writes nothing, and deliberately does not bump a link: `bump_link` takes the cue that bound two artifacts, so a bump from a cosine would put an observation about text into a table whose every other row is an observation about use.
5. **The link judge no longer hands consolidation a passage pair.** `classify_pair` is not the only producer: a `duplicate` verdict from the link judge writes a pair row directly (`src/jobs/associate.rs:511`), so none of the rules above were in force on that path. See "The ignition" below. The link itself stays — passages are retrievable, so co-retrieval linking them is right; only the handover is refused, and the sentence rendered beside the link now says which of three things happened instead of claiming consolidation already holds a pair it was never offered.
6. **`artifact_pairs.decided_by`.** `'model'` or `'operator'`, passed at every call site rather than defaulted, so a new operator surface cannot be recorded as the model by saying nothing. Nullable with no default and on the `ADDITIVE` list on exactly that ground: NULL says nobody recorded who decided, which is true of every row written before the column existed.

## Deliberately out of scope

- **Repairing the running instance.** The fifteen merges are still there. Undoing them is a separate, separately approved action with a copy of the database taken first.
- **A proposal path for cross-corpus paraphrase** (one lecture in two versions, reformatted or translated). Considered and cut — this collection does not hold that. `PairState::Superseded` plus `apply_supersede_ui` is the path if it ever does.

## The ignition

Pair 25 was filed at 07:13:47 between two passages with a `score` of **0.0**, where every other pair in the base lies between 0.8887 and 0.9623. `relate` skips anything below `review_min`, so it cannot have come from the neighbour loop — and the instance journal says what did:

```
07:13:47 INFO job{id=1498 stage="link_judge"
         target=01a03a96-5a5b-7552-b849-c5f2d79901d7|01a03a96-6b93-71d1-b51b-d8220530db8b}
```

Those are exactly pair 25's two sides. The associative memory judged a learned link between two passages `duplicate` and handed it to consolidation; the score is zero because no cosine was ever measured, which the code says in so many words. Dedupe merged that pair, and the merge then armed its own neighbour query and walked thirteen documents one passage at a time. Change 5 closes that path.

## Testing

`cargo test` green: 2014 unit tests plus the integration suites, `cargo fmt --check` clean. Twelve new tests, each named for the behaviour it pins:

- `two_passages_from_different_documents_about_one_subject_are_not_a_pair`
- `a_pair_with_a_passage_on_either_side_is_never_filed`
- `a_repeated_passage_inside_one_corpus_is_still_superseded_by_containment`
- `a_merged_artifact_does_not_arm_a_neighbour_query`
- `a_merge_whose_root_is_a_passage_is_refused`
- `a_synthesized_artifact_may_still_name_passage_sources`
- `cross_corpus_similarity_alone_does_not_reach_the_model`
- `containment_across_corpora_still_reaches_the_model`
- `a_refused_pair_does_not_bump_a_link`
- `a_duplicate_verdict_over_passages_is_not_handed_to_consolidation`
- `who_settled_a_pair_is_recorded_rather_than_reconstructed`
- `a_row_written_before_the_column_existed_claims_no_author`

Design and plan are in `docs/superpowers/specs/2026-08-27-consolidation-boundary-design.md` and `docs/superpowers/plans/2026-08-27-consolidation-boundary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHJL3RRjB36teq26k39yu9
