### PR TITLE
The terminal door draws what happened, and the shell is heard

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1925,7 +1925,23 @@
     // replay guard checks.
     document.body.addEventListener('htmx:beforeRequest', function (e) {
       if (!e.detail) return;
-      if (e.detail.elt === form) cancel();
+      if (e.detail.elt === form) {
+        cancel();
+        // Which of the two passes is in flight, said rather than left as one
+        // word for both. `searching…` was true of everything and therefore
+        // told you nothing: the fast pass is vector order at embedding speed
+        // and the second one is the reranker's opinion, and how long each is
+        // worth waiting for is not the same answer.
+        //
+        // The limit of the claim, stated because it is easy to mistake for
+        // more: this names the request that is open, not the stage the server
+        // is inside. `Core::search_events` reports that, and the box does not
+        // read it — adopting the channel here means rebuilding what htmx does
+        // around this form by hand, which is not worth two words. See
+        // `docs/superpowers/specs/2026-08-28-cli-face-design.md` §1.
+        var spinner = document.getElementById('search-spinner');
+        if (spinner) spinner.textContent = wasRefine(e) ? 'reranking…' : 'retrieving…';
+      }
       var cfg = e.detail.requestConfig;
       if (cfg && cfg.verb && String(cfg.verb).toLowerCase() !== 'get') refined = null;
     });

--- a/docs/superpowers/plans/2026-08-28-cli-face.md
+++ b/docs/superpowers/plans/2026-08-28-cli-face.md
@@ -1,0 +1,1419 @@
+# Terminal face and the shell as a door — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every drawn thing in the terminal client a report of something that
+happened, and make a search or a question typed at a shell something the base can
+learn from.
+
+**Architecture:** One stage channel added to the existing search pipeline in
+`Core::search_inner`, published over a new SSE route and consumed by both the CLI
+and the web refine pass; the CLI face splits colour from layout and re-renders the
+ranked list; the recorded-search origin stops conflating "typing door" with
+"scoped door" so a CLI open attaches to a CLI search in the pursuit sweep.
+
+**Tech Stack:** Rust 2024 (rust-version 1.94), axum 0.8, tokio, `async-stream`,
+`tokio-stream`, sqlx/SQLite, clap 4 derive, reqwest 0.13, crossterm (terminal size
+only), plain JS + htmx on the web side.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-cli-face-design.md`
+
+## Global Constraints
+
+- **Build and test with `./build-lowmem.sh`, never bare `cargo`.** The box is 2 GB
+  with no swap; the script sets `-j 1`, drops debuginfo and links with lld.
+  Every test command below is `./build-lowmem.sh test …`.
+- **Tests live beside the code** in `#[cfg(test)] mod tests` at the foot of the
+  same file. `tests/` holds only browser, eval, qdrant and multi-tenant suites.
+- **The three face rules from `src/cli/face.rs:1-6` are invariants.** It never
+  survives a pipe, it never delays a result, and it never says by colour or by
+  glyph alone what it must say in words.
+- **`render_plain` is the one rendering a script can see** and is not modified by
+  this plan.
+- **`GET /api/v1/search` keeps answering a bare JSON array**, byte-identical to
+  today. Streaming is a separate route.
+- **Colour is the ANSI 8 only.** SGR `1`, `2`, `31`, `32`, `33`, `36`, `0`. No
+  256-colour indices, no RGB, no theme detection.
+- **`Door::Api` and `Door::Mcp` stay unscoped.** A bearer token is not a person.
+- Commit messages follow the repository's voice: lower-case conventional prefix,
+  a sentence that says what changed and why, body in prose.
+
+## File Structure
+
+| File | Responsibility after this plan |
+|---|---|
+| `src/cli/face.rs` | `Face { on, color, unicode, width }`, the SGR vocabulary, `Lamps`/`Stages`/`Fill`/`Readout`, the drawn ranked list. `Pulse` is gone. |
+| `src/cli/search.rs` | Consumes `/api/v1/search/stream`, falls back to the plain GET, prints the list. |
+| `src/cli/ask.rs` | Renders `retrieved` and `needs` frames as stage lines; no invented motion. |
+| `src/cli/status.rs` | **new** — the `--status` verb: fetch, render, `--json` passthrough. |
+| `src/cli/args.rs` | `--status` flag and `Verb::Status`. |
+| `src/cli/mod.rs` | Dispatch for `Verb::Status`. |
+| `src/core/search.rs` | `SearchStage`, `SearchEvent`, the optional sender through `search_inner`, `Core::search_events`. |
+| `src/web/api.rs` | `GET /search/stream`, `search_sse_event`, `Door::Cli` scoping, the ask door named by the request, `StatusResponse.learning`. |
+| `src/core/ask/mod.rs` | `record_ask` admits `Door::Ui | Door::Cli`. |
+| `src/web/ui.rs` | `GET /ui/search/stream` — stage frames then one rendered-HTML frame. |
+| `assets/app.js` | The refine pass consumes the stream; the spinner says the stage. |
+
+---
+
+### Task 1: `Face` separates colour from layout
+
+**Files:**
+- Modify: `src/cli/face.rs:11-15` (the struct), `src/cli/face.rs:393-412` (`decide`)
+- Test: `src/cli/face.rs` (`mod tests` at the foot of the file)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub struct Face { pub on: bool, pub color: bool, pub unicode: bool, pub width: usize }`. Every later task reads `face.color`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `src/cli/face.rs`:
+
+```rust
+fn args(fancy: Fancy, plain: bool, json: bool) -> CliArgs {
+    CliArgs { fancy, plain, json, ..Default::default() }
+}
+
+#[test]
+fn no_color_keeps_the_layout_and_drops_only_the_ink() {
+    let f = Face::decide(&args(Fancy::Auto, false, false), true, true, Some("en_US.UTF-8"));
+    assert!(f.on, "NO_COLOR is about colour, not about lamps and layout");
+    assert!(!f.color);
+}
+
+#[test]
+fn asking_for_the_drawn_form_does_not_override_no_color() {
+    let f = Face::decide(&args(Fancy::Always, false, false), false, true, Some("en_US.UTF-8"));
+    assert!(f.on);
+    assert!(!f.color, "--fancy always says draw, not colour");
+}
+
+#[test]
+fn plain_and_pipes_and_json_clear_both() {
+    for (a, tty) in [
+        (args(Fancy::Auto, true, false), true),
+        (args(Fancy::Auto, false, true), true),
+        (args(Fancy::Auto, false, false), false),
+        (args(Fancy::Never, false, false), true),
+    ] {
+        let f = Face::decide(&a, tty, false, Some("en_US.UTF-8"));
+        assert!(!f.on);
+        assert!(!f.color);
+    }
+}
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `./build-lowmem.sh test --lib cli::face -- --nocapture`
+Expected: FAIL — `no field 'color' on type 'Face'`.
+
+- [ ] **Step 3: Make the change**
+
+```rust
+pub struct Face {
+    pub on: bool,
+    /// SGR escapes. Separate from `on` because `NO_COLOR` is a statement about
+    /// ink and nothing else: the lamps, the upload track and the layout are
+    /// not colour, and turning them off with it took a progress display away
+    /// from everyone who had ever set the variable.
+    pub color: bool,
+    pub unicode: bool,
+    pub width: usize,
+}
+```
+
+and in `decide`:
+
+```rust
+let on = match cli.fancy {
+    Fancy::Always => true,
+    Fancy::Never => false,
+    Fancy::Auto => is_tty && !cli.plain && !cli.json,
+};
+Face {
+    on,
+    // Never colour where nothing is drawn at all, and never against
+    // `NO_COLOR` however the drawn form was asked for.
+    color: on && !no_color,
+    unicode: lang.is_some_and(|l| l.to_ascii_uppercase().contains("UTF-8")),
+    width: crossterm::terminal::size().map(|(w, _)| w as usize).unwrap_or(80),
+}
+```
+
+- [ ] **Step 4: Run the whole CLI suite**
+
+Run: `./build-lowmem.sh test --lib cli::`
+Expected: PASS. Existing constructions of `Face { … }` in tests need the new field; fix each by copying `color: on`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/face.rs
+git commit -m "fix: NO_COLOR was taking the lamps with it"
+```
+
+---
+
+### Task 2: The colour vocabulary, and the rule that it is never load-bearing
+
+**Files:**
+- Modify: `src/cli/face.rs` (constants near `DIM`/`RESET`, line 30-32)
+- Test: `src/cli/face.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `Face.color` from Task 1.
+- Produces: `impl Face { fn ink(&self, code: &str, s: &str) -> String }` and the
+  constants `BOLD`, `DIM`, `CYAN`, `RED`, `GREEN`, `YELLOW`, `RESET`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+/// Every escape this file can emit, so the stripper below cannot fall behind
+/// the vocabulary.
+fn strip_sgr(s: &str) -> String {
+    let mut out = String::new();
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            for c in chars.by_ref() {
+                if c == 'm' { break; }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[test]
+fn colour_never_carries_a_claim_on_its_own() {
+    let hits = sample_hits();
+    let coloured = Face { on: true, color: true, unicode: true, width: 80 };
+    let bare = Face { on: true, color: false, unicode: true, width: 80 };
+    assert_eq!(strip_sgr(&coloured.render(&hits)), bare.render(&hits));
+}
+
+#[test]
+fn ink_is_a_no_op_without_colour() {
+    let bare = Face { on: true, color: false, unicode: true, width: 80 };
+    assert_eq!(bare.ink(CYAN, "x"), "x");
+    let lit = Face { color: true, ..bare };
+    assert_eq!(lit.ink(CYAN, "x"), "\u{1b}[36mx\u{1b}[0m");
+}
+```
+
+`sample_hits()` — add it to `mod tests` if it is not already there:
+
+```rust
+fn hit(title: &str, id: &str, score: f32, past_cliff: bool) -> SearchResult {
+    SearchResult {
+        artifact_id: id.into(),
+        corpus_id: "c".into(),
+        title: Some(title.into()),
+        text: "the journal is a ring buffer on disk".into(),
+        score,
+        past_cliff,
+        ..Default::default()
+    }
+}
+
+fn sample_hits() -> Vec<SearchResult> {
+    vec![
+        hit("systemd-journald ring buffer", "01J8Z4K2QW7NR3T9X0YB5C6D8E", 0.4, false),
+        hit("btrfs subvolume quotas", "01J7QQ4TQW7NR3T9X0YB5C6D8E", -0.2, true),
+    ]
+}
+```
+
+If `SearchResult` has no `Default`, build the literal with every field — do not
+add a `Default` impl to a serialised type for a test's convenience.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `./build-lowmem.sh test --lib cli::face`
+Expected: FAIL — `no method named 'ink'`.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Bold, dim, and the four hues. The ANSI 8 and nothing else: the user's own
+/// theme has already mapped these to inks that work on their ground, and a hex
+/// value out of `app.css` composes on `#0e1015` and nowhere else.
+const BOLD: &str = "1";
+const DIM: &str = "2";
+const RED: &str = "31";
+const GREEN: &str = "32";
+const YELLOW: &str = "33";
+const CYAN: &str = "36";
+const RESET: &str = "\u{1b}[0m";
+```
+
+```rust
+impl Face {
+    /// `s` wrapped in an SGR code, or `s`. The one place an escape is written,
+    /// so "strip every escape and the rendering is unchanged" is a property of
+    /// the file rather than a habit.
+    pub fn ink(&self, code: &str, s: &str) -> String {
+        match self.color {
+            true => format!("\u{1b}[{code}m{s}{RESET}"),
+            false => s.to_string(),
+        }
+    }
+}
+```
+
+The existing `DIM`/`RESET` pair used inline in `render` is replaced by `ink` in
+Task 3; leave `render` alone for now and let the second test fail until then.
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib cli::face::tests::ink_is_a_no_op_without_colour`
+Expected: PASS. `colour_never_carries_a_claim_on_its_own` may still fail — it is
+Task 3's gate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/face.rs
+git commit -m "feat: one place an escape is written, and eight colours to write"
+```
+
+---
+
+### Task 3: The ranked list
+
+**Files:**
+- Modify: `src/cli/face.rs:415-465` (`Face::render`)
+- Test: `src/cli/face.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `Face::ink` (Task 2), `Scale::rung`, `crate::cli::search::{badges, excerpt}`.
+- Produces: `Face::render(&self, hits: &[SearchResult], elapsed_ms: Option<u128>) -> String`.
+  Task 6 passes the measured elapsed time; `None` renders the header without it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn the_cliff_is_said_in_words() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let out = f.render(&sample_hits(), Some(412));
+    assert!(out.contains("relevance falls off here"), "{out}");
+    assert!(!out.contains('┃'), "the trace says nothing the divider does not: {out}");
+}
+
+#[test]
+fn the_raw_score_leaves_the_human_rendering() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let out = f.render(&sample_hits(), Some(412));
+    assert!(!out.contains("0.40"), "the bar carries rank-within-list: {out}");
+    assert!(out.contains("▇"), "{out}");
+}
+
+#[test]
+fn the_id_is_short_enough_to_read_and_long_enough_to_name() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let out = f.render(&sample_hits(), Some(412));
+    assert!(out.contains("01J8Z4K2"), "{out}");
+    assert!(!out.contains("01J8Z4K2QW7NR3T9X0YB5C6D8E"), "{out}");
+}
+
+#[test]
+fn the_header_says_what_was_measured() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let out = f.render(&sample_hits(), Some(412));
+    assert!(out.contains("2 hits"), "{out}");
+    assert!(out.contains("412 ms"), "{out}");
+}
+
+#[test]
+fn a_list_with_no_cliff_has_no_divider() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let hits = vec![sample_hits().remove(0)];
+    assert!(!f.render(&hits, None).contains("relevance falls off"));
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib cli::face`
+Expected: FAIL — `render` takes one argument; no divider in the output.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Cells in a hit's score bar.
+const BAR_CELLS: usize = 7;
+
+pub fn render(&self, hits: &[SearchResult], elapsed_ms: Option<u128>) -> String {
+    if !self.on {
+        return crate::cli::search::render_plain(hits);
+    }
+    let (full, empty) = if self.unicode { ('▇', '░') } else { ('#', '.') };
+    let scale = Scale::over(hits);
+    let mut out = String::new();
+
+    // Measured, both of them: the count is the list, the time is what the
+    // client timed. A header that guessed either would be the first invented
+    // thing in this file.
+    let mut head = format!("{} hits", hits.len());
+    if let Some(ms) = elapsed_ms {
+        head.push_str(&format!(" · {ms} ms"));
+    }
+    out.push_str(&format!("\n  {}\n\n", self.ink(DIM, &head)));
+
+    let mut said_cliff = false;
+    for (i, h) in hits.iter().enumerate() {
+        if h.past_cliff && !said_cliff {
+            said_cliff = true;
+            let rule = "─".repeat(18);
+            let (rule, gap) = match self.unicode {
+                true => (rule, "  "),
+                false => ("-".repeat(18), "  "),
+            };
+            out.push_str(&format!(
+                "  {}\n\n",
+                self.ink(CYAN, &format!("{rule}{gap}relevance falls off here{gap}{rule}"))
+            ));
+        }
+        let rung = scale.rung(h.score);
+        // Zero to seven becomes one to seven cells: every hit in the list was
+        // returned, so no row is drawn empty.
+        let lit = (rung + 1).min(BAR_CELLS);
+        let bar: String = (0..BAR_CELLS)
+            .map(|c| if c < lit { full } else { empty })
+            .collect();
+        let title = h.title.as_deref().unwrap_or("(untitled)");
+        // Eight characters, which is what `last::resolve` already accepts as a
+        // prefix and what a person can carry across a terminal to type.
+        let short: String = h.artifact_id.chars().take(8).collect();
+        let (bar, title) = match h.past_cliff {
+            true => (self.ink(DIM, &bar), self.ink(DIM, title)),
+            false => (self.ink(CYAN, &bar), self.ink(BOLD, title)),
+        };
+        out.push_str(&format!(
+            "  {:>2}  {bar}  {title}   {}\n",
+            i + 1,
+            self.ink(DIM, &short)
+        ));
+        if let Some(said) = crate::cli::search::badges(h) {
+            out.push_str(&format!("      {}\n", self.ink(DIM, &said.replace(", ", " · "))));
+        }
+        for line in
+            crate::cli::search::excerpt(&h.text, EXCERPT_LINES, self.width.saturating_sub(6))
+        {
+            out.push_str(&format!("      {line}\n"));
+        }
+        out.push('\n');
+    }
+    if !hits.is_empty() {
+        out.push_str(&format!(
+            "  {}\n",
+            self.ink(DIM, "engram --show 1   reads the first hit in full")
+        ));
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib cli::`
+Expected: PASS, including `colour_never_carries_a_claim_on_its_own` from Task 2.
+Fix the one caller in `src/cli/search.rs` (`face.render(&hits)` → `face.render(&hits, None)`)
+so the crate compiles; Task 6 gives it a real number.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/face.rs src/cli/search.rs
+git commit -m "feat: a list that says where relevance falls off"
+```
+
+---
+
+### Task 4: The stage channel in the search pipeline
+
+**Files:**
+- Modify: `src/core/search.rs:973-1010` (the three entry points), `src/core/search.rs:1013` (`search_inner`), `src/core/search.rs:1071-1087` (embed), `:1140` (retrieve), `:1264` (rerank)
+- Test: `src/core/search.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  ```rust
+  pub enum SearchStage { Embed, Retrieve, Rerank }   // Serialize/Deserialize, snake_case
+  pub enum SearchEvent { Stages(Vec<SearchStage>), Stage(SearchStage), Results(Vec<SearchResult>) }
+  impl Core {
+      pub fn search_events(&self, query: SearchQuery, cap: Option<usize>, origin: Origin)
+          -> impl tokio_stream::Stream<Item = Result<SearchEvent>> + 'static;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn a_search_names_the_stages_it_will_run_before_it_runs_them() {
+    use tokio_stream::StreamExt as _;
+    let core = crate::core::test_support::test_core().await;
+    seed_one_artifact(&core).await;
+    let q = SearchQuery { q: "journal".into(), rerank: false, ..Default::default() };
+    let mut seen = Vec::new();
+    let s = core.search_events(q, None, Door::Cli.into());
+    tokio::pin!(s);
+    while let Some(ev) = s.next().await {
+        seen.push(ev.expect("no failure"));
+    }
+    assert!(matches!(&seen[0], SearchEvent::Stages(v)
+        if v == &vec![SearchStage::Embed, SearchStage::Retrieve]),
+        "a search with no reranker must not promise a rerank: {seen:?}");
+    assert!(matches!(seen.last(), Some(SearchEvent::Results(_))));
+}
+
+#[tokio::test]
+async fn every_named_stage_is_also_announced_as_it_starts() {
+    use tokio_stream::StreamExt as _;
+    let core = crate::core::test_support::test_core().await;
+    seed_one_artifact(&core).await;
+    let q = SearchQuery { q: "journal".into(), rerank: false, ..Default::default() };
+    let s = core.search_events(q, None, Door::Cli.into());
+    tokio::pin!(s);
+    let mut named: Vec<SearchStage> = Vec::new();
+    let mut started: Vec<SearchStage> = Vec::new();
+    while let Some(ev) = s.next().await {
+        match ev.expect("no failure") {
+            SearchEvent::Stages(v) => named = v,
+            SearchEvent::Stage(s) => started.push(s),
+            SearchEvent::Results(_) => {}
+        }
+    }
+    assert_eq!(named, started, "a stage promised and not started is invention");
+}
+```
+
+`seed_one_artifact` — reuse whatever the neighbouring tests in this file already
+use to put one artifact in `MemoryVectors`; do not write a second seeder.
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib core::search`
+Expected: FAIL — `no method named 'search_events'`.
+
+- [ ] **Step 3: Implement**
+
+Types, near `SearchOutcome` (`src/core/search.rs:94`):
+
+```rust
+/// A stage of the search pipeline, in the order it runs.
+///
+/// Named by the server rather than assumed by a client: whether the reranker
+/// runs is decided here, from configuration and from the door, and a client
+/// drawing a lamp for it regardless would be drawing work that is not going to
+/// happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchStage {
+    Embed,
+    Retrieve,
+    Rerank,
+}
+
+/// What one search emits while it happens.
+#[derive(Debug, Clone)]
+pub enum SearchEvent {
+    /// The stages this search will pass through. Always first.
+    Stages(Vec<SearchStage>),
+    /// This stage has started.
+    Stage(SearchStage),
+    /// Terminal, and exactly what the blocking door returns.
+    Results(Vec<SearchResult>),
+}
+```
+
+`search_inner` grows one parameter, `stages: Option<tokio::sync::mpsc::UnboundedSender<SearchEvent>>`,
+and the three public entry points pass `None`. Emission is three `send`s and one
+list, and a send that fails is ignored — a client that hung up must not fail a
+search that is already running:
+
+```rust
+let say = |ev: SearchEvent| {
+    if let Some(tx) = &stages {
+        let _ = tx.send(ev);
+    }
+};
+```
+
+Move the `reranking` computation (currently at `:1104`) above `let started`, then:
+
+```rust
+let mut will = vec![SearchStage::Embed, SearchStage::Retrieve];
+if reranking && self.reranker.is_some() {
+    will.push(SearchStage::Rerank);
+}
+say(SearchEvent::Stages(will));
+```
+
+`say(SearchEvent::Stage(SearchStage::Embed))` immediately before `let started`;
+`Retrieve` immediately before `self.vectors.search_weighted(…)`; `Rerank` inside
+the `if let Some(reranker)` block, immediately before `reranker.rerank(…)`.
+
+The stream:
+
+```rust
+/// `search_with`, reporting each stage as it starts.
+///
+/// The whole reason this lives in `Core` and not in a door: the CLI and the web
+/// box both draw these, and two implementations of "what a search is doing"
+/// would disagree inside a month.
+pub fn search_events(
+    &self,
+    query: SearchQuery,
+    cap: Option<usize>,
+    origin: Origin,
+) -> impl tokio_stream::Stream<Item = Result<SearchEvent>> + 'static {
+    let core = self.clone();
+    let weight = self.ranking.read().expect("ranking lock").recency_weight;
+    async_stream::try_stream! {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut task = tokio::spawn(async move {
+            core.search_inner(&query, cap, weight, origin, true, Some(tx)).await
+        });
+        loop {
+            tokio::select! {
+                Some(ev) = rx.recv() => yield ev,
+                joined = &mut task => {
+                    let (results, _) = joined
+                        .map_err(|e| Error::Internal(format!("search task: {e}")))??;
+                    // Anything queued between the last poll and the return: the
+                    // channel is drained before the terminal frame so no stage
+                    // is reported after the results it preceded.
+                    while let Ok(ev) = rx.try_recv() { yield ev; }
+                    yield SearchEvent::Results(results);
+                    break;
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib core::search`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/search.rs
+git commit -m "feat: a search that says which stage it is in"
+```
+
+---
+
+### Task 5: `GET /api/v1/search/stream`
+
+**Files:**
+- Modify: `src/web/api.rs:1457` (routes), `src/web/api.rs:996` (near `search`)
+- Test: `src/web/api.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `Core::search_events`, `SearchEvent`, `SearchStage` (Task 4).
+- Produces: SSE frames `stages`, `stage`, `results`; `fn search_sse_event(SearchEvent) -> Result<SseEvent>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn the_stream_names_its_stages_then_answers() {
+    let (app, token) = app_and_token().await;
+    let res = app
+        .oneshot(get("/api/v1/search/stream?q=journal&door=cli", Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap().to_vec(),
+    )
+    .unwrap();
+    assert!(body.contains("event: stages"), "{body}");
+    assert!(body.contains("event: results"), "{body}");
+}
+
+#[tokio::test]
+async fn the_plain_search_route_still_answers_a_bare_array() {
+    let (app, token) = app_and_token().await;
+    let res = app.oneshot(get("/api/v1/search?q=journal", Some(&token))).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap(),
+    )
+    .unwrap();
+    assert!(v.is_array(), "four clients read this shape: {v}");
+}
+```
+
+- [ ] **Step 2: Run and watch the first fail**
+
+Run: `./build-lowmem.sh test --lib web::api`
+Expected: FAIL — 404 on `/api/v1/search/stream`.
+
+- [ ] **Step 3: Implement**
+
+A frame builder of its own, deliberately **not** added to `api_sse_event`: a test
+at `src/web/api.rs:3277` asserts the browser panel handles every frame name that
+function mentions, and the panel has no business with a search's stages.
+
+```rust
+fn search_sse_event(ev: crate::core::search::SearchEvent) -> Result<SseEvent> {
+    use crate::core::search::SearchEvent::*;
+    let (name, data) = match ev {
+        Stages(v) => ("stages", serde_json::json!({ "stages": v })),
+        Stage(s) => ("stage", serde_json::json!({ "stage": s })),
+        Results(hits) => ("results", serde_json::json!({ "results": hits })),
+    };
+    Ok(SseEvent::default().event(name).data(serde_json::to_string(&data)?))
+}
+
+/// The same search, reporting its stages as it runs. `GET /search` is untouched
+/// and still answers a bare array: the response shape of that route has four
+/// readers, and a route that answers two shapes by header is worse than a
+/// second route.
+async fn search_stream(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<Response> {
+    use tokio_stream::StreamExt as _;
+    let (query, origin) = search_request(&tenant, q);   // extracted in step 4 below
+    let cap = tenant.core.ranking.read().expect("ranking lock").per_source_cap;
+    let core = tenant.core.clone();
+    let events = async_stream::stream! {
+        let s = core.search_events(query, cap, origin);
+        tokio::pin!(s);
+        while let Some(ev) = s.next().await {
+            yield Ok::<_, Error>(match ev {
+                Ok(e) => search_sse_event(e).unwrap_or_else(|e| error_frame(&e)),
+                Err(e) => error_frame(&e),
+            });
+        }
+    };
+    Ok(Sse::new(events).keep_alive(KeepAlive::default()).into_response())
+}
+```
+
+Extract the body of the existing `search` handler that builds `SearchQuery` and
+`Origin` into `fn search_request(tenant: &Tenant, q: SearchParams) -> (SearchQuery, Origin)`
+and call it from both handlers — two doors deciding `typing`, `mark` or `rerank`
+differently is exactly the drift this route must not introduce.
+
+Route: `.route("/search/stream", get(search_stream))` beside `/search`.
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib web::api`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/api.rs
+git commit -m "feat: a second door onto the same search, that talks while it works"
+```
+
+---
+
+### Task 6: The CLI search draws the stages
+
+**Files:**
+- Modify: `src/cli/search.rs:30-85` (`run`), `src/cli/face.rs` (add `Stages`, delete `Pulse`)
+- Test: `src/cli/face.rs`, `src/cli/search.rs`
+
+**Interfaces:**
+- Consumes: the SSE route (Task 5), `Face::render(hits, elapsed_ms)` (Task 3).
+- Produces: `Face::stages(&self) -> Stages`, `Stages::{start, at, clear}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// src/cli/face.rs
+#[test]
+fn a_stage_line_is_drawn_and_said() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let mut s = f.stages();
+    s.start(&[SearchStage::Embed, SearchStage::Retrieve, SearchStage::Rerank]);
+    let line = s.at(SearchStage::Retrieve).expect("a line");
+    assert!(line.contains("embed") && line.contains("retrieve") && line.contains("rerank"));
+    assert!(line.contains('●') && line.contains('◉'));
+}
+
+#[test]
+fn a_face_that_is_off_draws_no_stage_at_all() {
+    let f = Face { on: false, color: false, unicode: true, width: 80 };
+    let mut s = f.stages();
+    s.start(&[SearchStage::Embed]);
+    assert!(s.at(SearchStage::Embed).is_none());
+}
+
+#[test]
+fn nothing_is_drawn_before_the_quiet_floor() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let mut s = f.stages();
+    s.start(&[SearchStage::Embed, SearchStage::Retrieve]);
+    assert!(s.at_after(SearchStage::Embed, 40).is_none(), "a fast search shows nothing");
+    assert!(s.at_after(SearchStage::Retrieve, 300).is_some());
+}
+```
+
+```rust
+// src/cli/search.rs
+#[tokio::test]
+async fn a_search_over_the_stream_returns_the_same_hits_as_the_plain_door() {
+    let (url, token, core) = crate::cli::test_support::serve_test_app().await;
+    seed_one_artifact(&core).await;
+    let e = Endpoint { url, token };
+    let streamed = fetch_streamed(&e, None, "journal", &Default::default()).await.unwrap();
+    let plain = fetch_plain(&e, None, "journal", &Default::default()).await.unwrap();
+    assert_eq!(streamed.len(), plain.len());
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib cli::`
+Expected: FAIL — `no method named 'stages'`, `fetch_streamed` not found.
+
+- [ ] **Step 3: Implement**
+
+In `face.rs`, extract the glyph from `Lamps::render` into a free function so one
+vocabulary serves both:
+
+```rust
+fn lamp_glyph(l: Lamp, unicode: bool) -> char { /* the match currently inside Lamps::render */ }
+```
+
+```rust
+/// The stages of one search, redrawn in place as the server names them.
+///
+/// Holds no timer: it is redrawn from frames that arrived, so it cannot animate
+/// past the work. `floor_ms` is the quiet floor — a search answered inside it
+/// draws nothing at all, because a display that flashes on and off is worse
+/// than no display.
+pub struct Stages {
+    on: bool,
+    color: bool,
+    unicode: bool,
+    names: Vec<crate::core::search::SearchStage>,
+    began: std::time::Instant,
+    drawn: bool,
+}
+
+const QUIET_FLOOR_MS: u128 = 120;
+
+impl Stages {
+    pub fn start(&mut self, names: &[crate::core::search::SearchStage]) {
+        self.names = names.to_vec();
+        self.began = std::time::Instant::now();
+    }
+
+    /// What this frame would draw, or `None` — face off, or still inside the
+    /// quiet floor.
+    pub fn at(&mut self, now: crate::core::search::SearchStage) -> Option<String> {
+        self.at_after(now, self.began.elapsed().as_millis())
+    }
+
+    /// `at`, with the elapsed time passed rather than read, so the floor is
+    /// testable without a clock.
+    pub fn at_after(
+        &self,
+        now: crate::core::search::SearchStage,
+        elapsed_ms: u128,
+    ) -> Option<String> {
+        if !self.on || elapsed_ms < QUIET_FLOOR_MS {
+            return None;
+        }
+        let mut reached = false;
+        Some(
+            self.names
+                .iter()
+                .map(|s| {
+                    let lamp = match (*s == now, reached) {
+                        (true, _) => { reached = true; Lamp::Running }
+                        (false, false) => Lamp::Done,
+                        (false, true) => Lamp::Waiting,
+                    };
+                    let ink = match lamp {
+                        Lamp::Running => CYAN,
+                        Lamp::Done => GREEN,
+                        _ => DIM,
+                    };
+                    let name = match s {
+                        SearchStage::Embed => "embed",
+                        SearchStage::Retrieve => "retrieve",
+                        SearchStage::Rerank => "rerank",
+                    };
+                    let cell = format!("{} {name}", lamp_glyph(lamp, self.unicode));
+                    match self.color {
+                        true => format!("\u{1b}[{ink}m{cell}{RESET}"),
+                        false => cell,
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("   "),
+        )
+    }
+
+    pub fn show(&mut self, now: crate::core::search::SearchStage) { /* \r\x1b[2K + line, as Track::show */ }
+    pub fn clear(&mut self) { /* as Track::clear */ }
+}
+```
+
+Delete `Pulse` and `Face::pulse`. In `search.rs`, split the fetch in two so the
+fallback is a function rather than a branch inside `run`:
+
+```rust
+/// The streaming door. `None` where the server does not have the route, which
+/// is what an older server answers with.
+async fn fetch_streamed(
+    e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs, face: &Face,
+) -> Result<Option<(Vec<SearchResult>, u128)>>;
+
+/// The door every version of the server has had.
+async fn fetch_plain(
+    e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs,
+) -> Result<(Vec<SearchResult>, u128, String)>;
+```
+
+`run` calls `fetch_streamed` first, falls back to `fetch_plain` on `Ok(None)` or
+any transport failure, prints `face.render(&hits, Some(elapsed))`, and keeps the
+existing `--json` path on `fetch_plain` alone — a machine reader has no use for
+frames and every use for the server's own body, unchanged.
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib cli::`
+Expected: PASS.
+
+- [ ] **Step 5: See it**
+
+Run: `./build-lowmem.sh run -- -s "journal size cap"` against a running server.
+Expected: no motion for a fast search; three lamps for a slow one; the list below it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/face.rs src/cli/search.rs
+git commit -m "feat: a wait that says which stage, and a strand that was only ever a timer"
+```
+
+---
+
+### Task 7: The ask stops animating over frames it was already sent
+
+**Files:**
+- Modify: `src/cli/ask.rs:160-210`
+- Test: `src/cli/ask.rs`
+
+**Interfaces:**
+- Consumes: `Stages`-style in-place drawing from Task 6; the `retrieved` and
+  `needs` frames `api_sse_event` has always emitted (`src/web/api.rs:1392-1408`).
+- Produces: nothing other tasks read.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn a_retrieved_frame_becomes_a_line_a_person_can_read() {
+    let f = crate::cli::face::Face { on: true, color: false, unicode: true, width: 80 };
+    let line = retrieved_line(&f, &serde_json::json!({
+        "round": 1, "retrieved": 24, "shown": 6, "dropped": 18, "cliff_at": 6
+    }))
+    .expect("a line");
+    assert!(line.contains("24"), "{line}");
+    assert!(line.contains("6"), "{line}");
+    assert!(line.contains("retrieved"), "the number needs a word beside it: {line}");
+}
+
+#[test]
+fn a_needs_frame_names_what_is_still_missing() {
+    let f = crate::cli::face::Face { on: true, color: false, unicode: true, width: 80 };
+    let line = needs_line(&f, &serde_json::json!({ "queries": ["journal rotation policy"] }))
+        .expect("a line");
+    assert!(line.contains("journal rotation policy"), "{line}");
+}
+
+#[test]
+fn a_face_that_is_off_renders_no_stage_lines() {
+    let f = crate::cli::face::Face { on: false, color: false, unicode: true, width: 80 };
+    assert!(retrieved_line(&f, &serde_json::json!({"round":1,"retrieved":1,"shown":1,"dropped":0,"cliff_at":null})).is_none());
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib cli::ask`
+Expected: FAIL — `retrieved_line` not found.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// A retrieval, said. On stderr and taken back when the answer starts, so the
+/// scrollback holds the answer and not the machinery.
+fn retrieved_line(face: &Face, data: &serde_json::Value) -> Option<String> {
+    if !face.on {
+        return None;
+    }
+    let (got, shown) = (data["retrieved"].as_u64()?, data["shown"].as_u64()?);
+    Some(format!("  {} retrieved {got}, showing {shown}", lamp_done(face)))
+}
+
+/// What the model said it was still missing, which is round two happening.
+fn needs_line(face: &Face, data: &serde_json::Value) -> Option<String> {
+    if !face.on {
+        return None;
+    }
+    let q = data["queries"].as_array()?;
+    if q.is_empty() {
+        return None;
+    }
+    let said: Vec<&str> = q.iter().filter_map(|v| v.as_str()).collect();
+    Some(format!("  {} still missing: {}", lamp_running(face), said.join(", ")))
+}
+```
+
+In the frame loop, add `"retrieved"` and `"needs"` arms that write the line to
+stderr in place (`\r\x1b[2K`), remove `let mut waiting = face.pulse("thinking")`
+and the `waiting.take()` call, and clear the stage line at the first `token`
+frame before a byte of the answer is printed.
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib cli::`
+Expected: PASS. `Pulse` now has no callers anywhere; `grep -rn "pulse" src/` must
+return nothing outside comments.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/ask.rs src/cli/face.rs
+git commit -m "feat: the ask reads the frames it was already being sent"
+```
+
+---
+
+### Task 8: A CLI search carries who searched
+
+**Files:**
+- Modify: `src/web/api.rs:1040-1048` (inside `search_request` from Task 5)
+- Test: `src/web/api.rs`, `src/jobs/pursuit.rs`
+
+**Interfaces:**
+- Consumes: `search_request` (Task 5).
+- Produces: recorded CLI events with `scope = Some(subject)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// src/jobs/pursuit.rs — the test this whole section exists for.
+#[tokio::test]
+async fn a_run_of_searches_at_a_shell_can_earn_a_synthesis() {
+    let core = armed_core().await;          // the helper the neighbouring pursuit tests use
+    let (a, b) = (seeded(&core, "one").await, seeded(&core, "two").await);
+    let origin = Door::Cli.by("alice");
+    core.search(&SearchQuery { q: "journal size".into(), ..Default::default() }, origin.clone())
+        .await
+        .unwrap();
+    core.store.record_interaction(&a, "opened", None, Some("alice"), now() + 5).await.unwrap();
+    core.store.record_interaction(&b, "opened", None, Some("alice"), now() + 6).await.unwrap();
+    advance_past_idle(&core).await;
+    run(&core).await.unwrap();
+    let p = core.store.recent_pursuits(10).await.unwrap();
+    assert_eq!(p.len(), 1);
+    assert_ne!(p[0].state, "unsatisfied", "the opens never attached to the search");
+}
+```
+
+```rust
+// src/web/api.rs
+#[tokio::test]
+async fn a_cli_search_is_recorded_against_the_subject_who_ran_it() {
+    let (app, token) = app_and_token_with_learning().await;
+    app.clone().oneshot(get("/api/v1/search?q=journal&door=cli", Some(&token))).await.unwrap();
+    let events = core.store.events_between(0, now() + 1).await.unwrap();
+    assert_eq!(events[0].scope.as_deref(), Some("alice"));
+}
+
+#[tokio::test]
+async fn a_bearer_token_is_still_not_a_person() {
+    let (app, token) = app_and_token_with_learning().await;
+    app.clone().oneshot(get("/api/v1/search?q=journal", Some(&token))).await.unwrap();
+    let events = core.store.events_between(0, now() + 1).await.unwrap();
+    assert_eq!(events[0].scope, None, "Door::Api must stay unscoped");
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib jobs::pursuit web::api`
+Expected: FAIL — the pursuit closes `unsatisfied`; the CLI event's scope is `None`.
+
+- [ ] **Step 3: Implement**
+
+```rust
+// Typing and scoped are two decisions, and they were one. A shell is not a
+// typing door — it wants the reranker and it marks what it retrieved — but it
+// is a door with a known subject, and the pursuit sweep attaches an open to a
+// search only when the scopes match (`jobs/pursuit.rs:317`). Unscoped, a
+// shell-only session opened pursuits that collected no engagement at all.
+//
+// `Api` and `Mcp` stay unscoped on purpose: a bearer token is not a person, and
+// two agents sharing one would fold into each other's queries. Same reason
+// `sitting.rs` keeps no sitting for them.
+let origin = match door {
+    Door::Extension | Door::Cli => door.by(tenant.user.subject),
+    _ => door.into(),
+};
+```
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib jobs::pursuit web::api store::feedback`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/api.rs src/jobs/pursuit.rs
+git commit -m "fix: a shell could open a pursuit and never feed one"
+```
+
+---
+
+### Task 9: A question typed at a shell is written down
+
+**Files:**
+- Modify: `src/core/ask/mod.rs:911`, `src/web/api.rs:1325-1331`
+- Test: `src/core/ask/mod.rs`, `src/web/api.rs`
+
+**Interfaces:**
+- Consumes: `Door::from_client` (`src/store/feedback.rs:73`).
+- Produces: `AskRequest` carries `door: Option<String>`; `record_ask` admits `Ui | Cli`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// src/core/ask/mod.rs
+#[tokio::test]
+async fn a_question_asked_at_a_shell_is_recorded() {
+    let core = asking_core().await;
+    core.ask(&AskRequest { q: "how big is the journal".into(), ..Default::default() },
+             Door::Cli.by("alice")).await.unwrap();
+    let asks = core.store.asks_between(0, crate::store::now() + 1).await.unwrap();
+    assert_eq!(asks.len(), 1);
+    assert_eq!(asks[0].scope.as_deref(), Some("alice"));
+}
+
+#[tokio::test]
+async fn an_api_question_is_still_not_recorded() {
+    let core = asking_core().await;
+    core.ask(&AskRequest { q: "how big is the journal".into(), ..Default::default() },
+             Door::Api.into()).await.unwrap();
+    assert!(core.store.asks_between(0, crate::store::now() + 1).await.unwrap().is_empty());
+}
+```
+
+```rust
+// src/web/api.rs
+#[tokio::test]
+async fn the_ask_door_says_which_door_it_was() {
+    let (app, token) = app_and_token_with_learning().await;
+    post_json_ok(&app, "/api/v1/ask/stream", &token,
+                 serde_json::json!({"q": "how big", "door": "cli"})).await;
+    let asks = core.store.asks_between(0, now() + 1).await.unwrap();
+    assert_eq!(asks.len(), 1, "a CLI question must reach the log");
+}
+
+#[tokio::test]
+async fn a_panel_that_names_no_door_is_still_the_panel() {
+    let (app, token) = app_and_token_with_learning().await;
+    post_json_ok(&app, "/api/v1/ask/stream", &token,
+                 serde_json::json!({"q": "how big"})).await;
+    assert!(core.store.asks_between(0, now() + 1).await.unwrap().is_empty());
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib core::ask web::api`
+Expected: FAIL — nothing recorded for `Door::Cli`.
+
+- [ ] **Step 3: Implement**
+
+`AskRequest` gains `#[serde(default)] pub door: Option<String>`. In `ask_stream`:
+
+```rust
+// The door the question came through, named by the caller the way `?door=`
+// already names it for search. Defaulting to `Extension` keeps the panel's
+// behaviour exactly what it was for a client that says nothing.
+let door = req.door.as_deref().map(Door::from_client).unwrap_or(Door::Extension);
+let origin = door.by(tenant.user.subject);
+```
+
+In `record_ask`:
+
+```rust
+// `Ui` and `Cli`. Both are a person composing a question in a place where the
+// answer will be read by them; neither is an agent on a token. A CLI ask
+// carries no `event_id` and so is never judged — recorded and unjudged is a
+// coherent state: the sweep learns what was needed, and the judge still grades
+// only answers somebody saw somewhere they could grade them.
+if !(self.learn.enabled && matches!(origin.door, Door::Ui | Door::Cli)) {
+    return Ok(response);
+}
+```
+
+Then in `src/cli/ask.rs`, send `"door": "cli"` in the POST body.
+
+- [ ] **Step 4: Run**
+
+Run: `./build-lowmem.sh test --lib core::ask web::api cli::ask`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ask/mod.rs src/web/api.rs src/cli/ask.rs
+git commit -m "feat: the strongest statement of a need, finally written down"
+```
+
+---
+
+### Task 10: `engram --status`
+
+**Files:**
+- Create: `src/cli/status.rs`
+- Modify: `src/cli/mod.rs`, `src/cli/args.rs`, `src/web/api.rs:164-171` and `:1278`
+- Test: `src/cli/status.rs`, `src/cli/args.rs`, `src/web/api.rs`
+
+**Interfaces:**
+- Consumes: `Endpoint::api`, `Face::ink`.
+- Produces: `Verb::Status`; `pub async fn run(e: &Endpoint, face: &Face, json: bool) -> Result<i32>`;
+  `StatusResponse.learning: Option<Learning>` with
+  `Learning { pursuits_open: i64, pursuits_unsatisfied: i64, from_pursuits: i64, gaps_open: i64 }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// src/cli/args.rs
+#[test]
+fn status_is_a_verb_of_its_own() {
+    let a = CliArgs { status: true, ..Default::default() };
+    assert_eq!(verb(&a, false, false, || Ok(String::new())).unwrap(), Some(Verb::Status));
+}
+
+#[test]
+fn status_refuses_to_share_an_invocation_with_another_verb() {
+    let a = CliArgs { status: true, search: vec!["x".into()], ..Default::default() };
+    assert!(verb(&a, false, false, || Ok(String::new())).is_err());
+}
+```
+
+```rust
+// src/cli/status.rs
+#[test]
+fn the_learning_block_is_absent_when_the_layer_is_off() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let out = render(&f, &serde_json::json!({
+        "sources": [["ready", 3]], "jobs": [], "failed": [],
+        "oldest_pending_secs": null, "chunks": 3, "vectors": 3, "learning": null
+    }));
+    assert!(!out.contains("learning"), "{out}");
+    assert!(out.contains("3 artifacts"), "{out}");
+}
+
+#[test]
+fn a_pursuit_that_found_nothing_is_reported_as_such() {
+    let f = Face { on: true, color: false, unicode: true, width: 80 };
+    let out = render(&f, &serde_json::json!({
+        "sources": [["ready", 3]], "jobs": [], "failed": [],
+        "oldest_pending_secs": null, "chunks": 3, "vectors": 3,
+        "learning": {"pursuits_open": 7, "pursuits_unsatisfied": 4, "from_pursuits": 3, "gaps_open": 11}
+    }));
+    assert!(out.contains("7 pursuits open"), "{out}");
+    assert!(out.contains("4 closed unsatisfied"), "{out}");
+    assert!(out.contains("11 gaps"), "{out}");
+}
+```
+
+```rust
+// src/web/api.rs
+#[tokio::test]
+async fn status_says_nothing_about_learning_while_the_layer_is_off() {
+    let (app, token) = app_and_token().await;   // learn.enabled defaults off
+    let v = get_json(&app, "/api/v1/status", &token).await;
+    assert!(v["learning"].is_null());
+    assert!(v["chunks"].is_i64(), "the existing fields are unchanged: {v}");
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `./build-lowmem.sh test --lib cli:: web::api`
+Expected: FAIL — no `status` field on `CliArgs`, no `src/cli/status.rs`.
+
+- [ ] **Step 3: Implement the server half**
+
+```rust
+/// What the base has been learning. `None` while `[learn]` is off, so the
+/// absence is the honest answer rather than four zeroes that read like a
+/// feature failing.
+#[derive(serde::Serialize)]
+pub struct Learning {
+    pub pursuits_open: i64,
+    pub pursuits_unsatisfied: i64,
+    pub from_pursuits: i64,
+    pub gaps_open: i64,
+}
+```
+
+`StatusResponse` gains `pub learning: Option<Learning>`, filled in `status()` from
+`recent_pursuits` and the gap store the insights page already reads
+(`src/web/insights.rs:404-409`) — reuse those store calls, do not write new SQL.
+
+- [ ] **Step 4: Implement the client half**
+
+`CliArgs` gains:
+
+```rust
+/// What the base is doing and what it has been learning. One shot, like every
+/// other verb; there is no ambient status line, because a footer on an ordinary
+/// search would make the cheapest door in the application pay for information
+/// nobody asked for at that moment.
+#[arg(long, conflicts_with_all = ["capture", "search", "ask", "show"])]
+pub status: bool,
+```
+
+`Verb::Status` is decided before the pipe is looked at, beside `Verb::Show`, for
+the same reason: `engram --status | grep failed` is an ordinary thing to type.
+
+`src/cli/status.rs` fetches `/api/v1/status`, prints the server's body unchanged
+under `--json`, and otherwise renders the block from the spec: yellow on
+`needs review`, red on failed counts and rows, dim on ages, nothing else tinted.
+
+- [ ] **Step 5: Run**
+
+Run: `./build-lowmem.sh test --lib cli:: web::api`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/status.rs src/cli/args.rs src/cli/mod.rs src/web/api.rs
+git commit -m "feat: a shell can ask what the base is doing"
+```
+
+---
+
+### Task 11: The web box reads the same frames
+
+**Files:**
+- Create: handler `search_stream` in `src/web/ui.rs`
+- Modify: `src/web/ui.rs` (routes), `assets/app.js:1781-1885` (`refinePass`), `src/web/templates/workspace.html:174`
+- Test: `src/web/ui.rs`, `tests/browser/`
+
+**Interfaces:**
+- Consumes: `Core::search_events` (Task 4).
+- Produces: `GET /ui/search/stream` — `stage` frames, then one `results` frame whose
+  data is the rendered `#results` HTML, the same string `/ui/search/results` returns.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// src/web/ui.rs
+#[tokio::test]
+async fn the_ui_stream_ends_with_the_html_the_swap_needs() {
+    let (app, cookie) = app_and_session().await;
+    let body = sse_body(&app, "/ui/search/stream?q=journal&rerank=1", &cookie).await;
+    assert!(body.contains("event: stage"), "{body}");
+    let last = body.rsplit("event: results").next().unwrap();
+    assert!(last.contains("rail-item"), "the terminal frame carries the rendered rail: {last}");
+}
+
+#[tokio::test]
+async fn the_typing_route_is_untouched() {
+    let (app, cookie) = app_and_session().await;
+    let res = get_with_cookie(&app, "/ui/search/results?q=jou", &cookie).await;
+    assert_eq!(res.status(), StatusCode::OK, "the fast pass stays plain htmx");
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `./build-lowmem.sh test --lib web::ui`
+Expected: FAIL — 404 on `/ui/search/stream`.
+
+- [ ] **Step 3: Implement the route**
+
+Render the same Askama template `/ui/search/results` renders and put the string in
+the terminal frame — the pattern `/ui/ask/{id}/stream` already uses, whose frames
+carry rendered HTML for the same reason: the page swaps HTML and a second
+renderer on the client would be a second definition of a result row.
+
+- [ ] **Step 4: Move the refine pass onto it**
+
+In `assets/app.js`, `refinePass` currently issues
+`htmx.ajax('GET', '/ui/search/results', {source: form, …})`. Replace that one call
+with an `EventSource` on `/ui/search/stream`, and:
+
+- write each `stage` frame's name into `#search-spinner` (`retrieving…`, `reranking…`),
+- swap the `results` frame's HTML into `#results` exactly as the htmx swap did,
+  then call `htmx.process(target)`, `enhance(target)`, `markOpenRow()`,
+  `trackDwell()` and `glide()` — the five calls the existing swap handler makes,
+- **close the EventSource on the next keystroke.** `source: form` put the refine
+  in the form's `hx-sync` queue and a keystroke replaced it; an `EventSource` is
+  outside that queue, so the keystroke handler has to close it explicitly or a
+  stale refine will swap over a newer list.
+
+**The typing pass is not touched.** It stays htmx, it stays one sub-200 ms
+request, and it names no stages: there is nothing there worth naming.
+
+- [ ] **Step 5: Run**
+
+Run: `./build-lowmem.sh test --lib web::ui` and the browser suite:
+`./build-lowmem.sh test --test browser`
+Expected: PASS.
+
+- [ ] **Step 6: See it**
+
+Load `/ui`, type a query, press Enter. Expected: the spinner says `retrieving…`
+then `reranking…`, the list swaps once, the glide still runs, and a keystroke
+during a refine cancels it rather than swapping late.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/ui.rs assets/app.js src/web/templates/workspace.html
+git commit -m "feat: the box says which stage, from the same channel the shell reads"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** §1 the stage channel → Tasks 4, 5, 6; §1c the ask's discarded
+frames → Task 7; §1 the web door → Task 11; §2 the list → Task 3; §3 colour →
+Tasks 1, 2; §4 `--status` → Task 10; §5 the scope fix → Task 8 and the recorded
+ask → Task 9. Every test named in the spec's Testing section appears in a task:
+the stage list with the reranker on and off (Task 4), the quiet floor (Task 6),
+`/api/v1/search` unchanged (Task 5), the `decide` truth table (Task 1), stripped
+escapes equal `color: false` (Task 2), the pursuit that clears `min_engagement`
+(Task 8), the recorded CLI ask (Task 9), `--status --json` (Task 10).
+
+**Type consistency.** `SearchStage` and `SearchEvent` are defined in Task 4 and
+used by that name in Tasks 5, 6 and 11. `Face { on, color, unicode, width }` is
+defined in Task 1 and constructed with all four fields in every later test.
+`Face::render` takes `(&[SearchResult], Option<u128>)` from Task 3 onward, and
+Task 6 is the only caller that passes `Some`.
+
+**Known risk, stated rather than hidden.** Task 11 is the only task that touches
+`assets/app.js`'s refine pass, which is the most delicate JS in the application:
+`hx-sync`, the replay cache and the glide all meet there. It is last and it is one
+commit, so it reverts cleanly without taking the CLI work with it.

--- a/docs/superpowers/plans/2026-08-28-cli-face.md
+++ b/docs/superpowers/plans/2026-08-28-cli-face.md
@@ -1312,89 +1312,33 @@ git commit -m "feat: a shell can ask what the base is doing"
 
 ---
 
-### Task 11: The web box reads the same frames
+### Task 11: The spinner says which pass is in flight
+
+**Rewritten during execution.** The original task moved `refinePass` onto an
+`EventSource`. That was priced wrong — see the spec's revised §1 — so this task
+is the smaller, honest change that was actually made.
 
 **Files:**
-- Create: handler `search_stream` in `src/web/ui.rs`
-- Modify: `src/web/ui.rs` (routes), `assets/app.js:1781-1885` (`refinePass`), `src/web/templates/workspace.html:174`
-- Test: `src/web/ui.rs`, `tests/browser/`
+- Modify: `assets/app.js` (the `htmx:beforeRequest` handler in `refinePass`)
+- Test: `src/web/ui.rs`
 
-**Interfaces:**
-- Consumes: `Core::search_events` (Task 4).
-- Produces: `GET /ui/search/stream` — `stage` frames, then one `results` frame whose
-  data is the rendered `#results` HTML, the same string `/ui/search/results` returns.
+- [x] **Step 1: Name the pass in the handler that already knows**
 
-- [ ] **Step 1: Write the failing test**
-
-```rust
-// src/web/ui.rs
-#[tokio::test]
-async fn the_ui_stream_ends_with_the_html_the_swap_needs() {
-    let (app, cookie) = app_and_session().await;
-    let body = sse_body(&app, "/ui/search/stream?q=journal&rerank=1", &cookie).await;
-    assert!(body.contains("event: stage"), "{body}");
-    let last = body.rsplit("event: results").next().unwrap();
-    assert!(last.contains("rail-item"), "the terminal frame carries the rendered rail: {last}");
-}
-
-#[tokio::test]
-async fn the_typing_route_is_untouched() {
-    let (app, cookie) = app_and_session().await;
-    let res = get_with_cookie(&app, "/ui/search/results?q=jou", &cookie).await;
-    assert_eq!(res.status(), StatusCode::OK, "the fast pass stays plain htmx");
+```js
+if (e.detail.elt === form) {
+  cancel();
+  var spinner = document.getElementById('search-spinner');
+  if (spinner) spinner.textContent = wasRefine(e) ? 'reranking…' : 'retrieving…';
 }
 ```
 
-- [ ] **Step 2: Run and watch it fail**
+- [x] **Step 2: Pin the seam, which has a compiler on neither side**
 
-Run: `./build-lowmem.sh test --lib web::ui`
-Expected: FAIL — 404 on `/ui/search/stream`.
+The id is in `workspace.html`, the words are in `app.js`, and `wasRefine` is what
+discriminates. A test in `src/web/ui.rs` reads all three files and fails if any
+of them stops matching.
 
-- [ ] **Step 3: Implement the route**
-
-Render the same Askama template `/ui/search/results` renders and put the string in
-the terminal frame — the pattern `/ui/ask/{id}/stream` already uses, whose frames
-carry rendered HTML for the same reason: the page swaps HTML and a second
-renderer on the client would be a second definition of a result row.
-
-- [ ] **Step 4: Move the refine pass onto it**
-
-In `assets/app.js`, `refinePass` currently issues
-`htmx.ajax('GET', '/ui/search/results', {source: form, …})`. Replace that one call
-with an `EventSource` on `/ui/search/stream`, and:
-
-- write each `stage` frame's name into `#search-spinner` (`retrieving…`, `reranking…`),
-- swap the `results` frame's HTML into `#results` exactly as the htmx swap did,
-  then call `htmx.process(target)`, `enhance(target)`, `markOpenRow()`,
-  `trackDwell()` and `glide()` — the five calls the existing swap handler makes,
-- **close the EventSource on the next keystroke.** `source: form` put the refine
-  in the form's `hx-sync` queue and a keystroke replaced it; an `EventSource` is
-  outside that queue, so the keystroke handler has to close it explicitly or a
-  stale refine will swap over a newer list.
-
-**The typing pass is not touched.** It stays htmx, it stays one sub-200 ms
-request, and it names no stages: there is nothing there worth naming.
-
-- [ ] **Step 5: Run**
-
-Run: `./build-lowmem.sh test --lib web::ui` and the browser suite:
-`./build-lowmem.sh test --test browser`
-Expected: PASS.
-
-- [ ] **Step 6: See it**
-
-Load `/ui`, type a query, press Enter. Expected: the spinner says `retrieving…`
-then `reranking…`, the list swaps once, the glide still runs, and a keystroke
-during a refine cancels it rather than swapping late.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add src/web/ui.rs assets/app.js src/web/templates/workspace.html
-git commit -m "feat: the box says which stage, from the same channel the shell reads"
-```
-
----
+- [x] **Step 3: Commit**
 
 ## Self-review
 

--- a/docs/superpowers/specs/2026-08-28-cli-face-design.md
+++ b/docs/superpowers/specs/2026-08-28-cli-face-design.md
@@ -162,12 +162,35 @@ back when the answer starts:
 exactly what the model wrote. Nothing here is drawn on a timer, and when a fast
 ask arrives with nothing before its first token, nothing is drawn at all.
 
-### The web door reads the same frames
+### The web door, and why it does not read the frames yet
 
-The search box consumes `/search/stream` and renders the same three stages. This
-is the reason the channel lives in `Core` rather than in the CLI: one definition
-of what a search is doing, rendered twice, rather than two implementations that
-will disagree within a month.
+**Revised during implementation.** The design said the search box would consume
+`/search/stream` and render the same three stages. Reading `refinePass` properly
+made the cost clear, and it is not the cost this section assumed.
+
+The box is not a form that issues a request. It is driven *by* htmx's lifecycle:
+`htmx:beforeRequest` cancels the pending refine and clears the replay cache on
+any non-GET; `htmx:afterSwap` decides refine-from-typing by reading
+`requestConfig.unfilteredParameters`, then marks the open row, writes the replay
+cache and runs the glide, or re-arms the quiet timer; the fragment carries an
+out-of-band `#rail-head` that htmx swaps and the JS reads back afterwards; and
+`hx-sync="this:replace"` is what aborts a refine when a keystroke lands.
+
+An `EventSource` sits outside all of it. Adopting the channel here means
+hand-rolling htmx's out-of-band swap, the abort, the discrimination and the cache
+writes — in the most delicate JavaScript in the application, with no automated
+coverage of any of it (`tests/browser/` holds one file, for the ask stream). That
+is a large, unverifiable change bought with two words of spinner text.
+
+So the box keeps htmx, and says which of its **two real passes** is in flight:
+`retrieving…` for the fast vector pass, `reranking…` for the refine. Both passes
+exist and the label reports which request is open — it is true, and it is a
+smaller claim than the CLI's, which reports the stage the server is inside.
+
+The channel is still shared in the sense that matters: it lives in `Core`, one
+definition of what a search is doing, and `/ui/search/stream` is a contained
+piece of work whenever the box is next opened up. What was avoided was rebuilding
+htmx by hand to get there today.
 
 ## 2. The list
 

--- a/docs/superpowers/specs/2026-08-28-cli-face-design.md
+++ b/docs/superpowers/specs/2026-08-28-cli-face-design.md
@@ -1,0 +1,364 @@
+# The terminal door, drawn and joined
+
+**Status:** design, awaiting review
+**Date:** 2026-08-28
+
+## The situation
+
+`src/cli/` is 3 424 lines and already has a face. `face.rs` carries a `Pulse`
+for a request in flight, a `Fill` for bytes leaving the process, three `Lamps`
+for the background stages a capture passes through, a `Readout` measuring the
+rate an answer's tokens arrive at, and a ranked list with score rungs and a
+broken trace past the cliff. It was written to three rules, stated at the top of
+the file: it never survives a pipe, it never delays a result, and it never says
+by colour or by glyph alone what it must say in words.
+
+Those rules are right and this design does not touch them. What it touches is
+the two places the door falls short of them, and the one place where the door is
+connected to nothing.
+
+**The wait is the only dishonest thing in the file.** `Readout` says of itself
+that "the amplitude is measured, never invented", and it earns that: it draws
+the arrivals it saw. `Pulse` is the opposite — a cell travelling along a strand
+on an 80 ms timer, drawn identically for a search that took 90 ms and one that
+took nine seconds, saying only "a request is open". Every other display in the
+file is a function of something that happened. This one is a function of the
+clock.
+
+**The list spends its width on the wrong things.** A hit's line carries the raw
+fused score to two decimals and a 26-character id, and the cliff — the one
+element the frontend audit named as worth keeping — is marked only by a dimmer
+row and a `╵` instead of a `┃`. The score is not a probability; `search::prime`
+says so about those very numbers, and a whole list of them is routinely
+negative. The id in full is not needed either: `last::resolve` already accepts a
+leading piece.
+
+**Colour is decided by a rule that is too coarse in one direction and absent in
+the other.** `Face::decide` folds `NO_COLOR` into the single `on` flag, so
+`NO_COLOR=1 engram -c big.pdf --watch` loses the lamps, the upload track and the
+layout — none of which are colour. In the other direction `--fancy always`
+ignores `NO_COLOR` entirely, so the flag that means "I want the drawn form"
+silently overrides a preference that was never about drawing.
+
+**And the shell is a door the base does not learn from.** This is the finding
+that turned a face change into a system change:
+
+- `engram -s` reaches `GET /api/v1/search?door=cli`. The event is recorded, the
+  door is `captured()`, the pursuit sweep reads it.
+- `engram --show` reaches `GET /api/v1/artifacts/{id}`, which calls
+  `record_interaction(cid, None, Some(subject))` — the open is logged.
+- They never join. `src/web/api.rs:1044` hands a non-typing door
+  `door.into()`, which is `scope: None`. The interaction carries
+  `scope: Some(subject)`. `jobs/pursuit.rs:317` attaches an interaction to a
+  search only `if e.scope == i.scope`.
+
+A shell-only session therefore opens pursuits that accumulate exactly zero
+engagement, fall under `min_engagement = 3.0` and `min_sources = 2`, and close
+`unsatisfied`. The CLI can widen the hole in the base and can never fill it.
+
+`engram -a` is worse. `Core::record_ask` admits `Door::Ui` alone
+(`src/core/ask/mod.rs:911`) and `/api/v1/ask/stream` labels every caller
+`Door::Extension` (`src/web/api.rs:1331`), so a question typed at a shell — the
+strongest statement of a need engram can receive — is written down nowhere at
+all.
+
+## The principle
+
+**Nothing is drawn that did not happen.**
+
+The face already half-believes this. This design finishes it: the animation
+during a wait becomes a report of the stage the server is actually in, the
+progress display is drawn only for stages that are actually going to run, and
+what the shell does is actually recorded, so the base can learn from a person
+who never opens a browser.
+
+The corollary, which decides several arguments below: **engram does not own the
+terminal.** Not its palette, not its scrollback, not its alternate screen. This
+is the conclusion `c853210` reached for the mark — an ink that composes on one
+ground only is the wrong ink — applied to a surface whose ground is a stranger's
+colour scheme.
+
+## 1. The wait says which stage
+
+### The stage channel
+
+`Core::search_inner` already measures the pipeline: it stamps `embed_ms` at
+line 1087 and `total_ms` at 1441, and reports both as `server-timing`. The
+spans exist; nothing publishes their *starts*.
+
+Add one optional parameter to `search_inner` — a `Option<mpsc::Sender<Stage>>` —
+and send at the head of each span. The three public entry points (`search`,
+`search_with`, `search_with_ranking`) pass `None` and are otherwise unchanged, so
+the tuning sweep and every existing caller keep the signature they have.
+
+`Core::search_events(query, cap, origin) -> impl Stream<Item = SearchEvent>`
+wraps it, in the shape `ask_events` already established: one `async_stream`,
+terminal by construction, ending at its first error.
+
+```
+stages  { "stages": ["embed", "retrieve", "rerank"] }
+stage   { "stage": "retrieve" }
+stage   { "stage": "rerank" }
+results { "results": [ … ] }
+```
+
+The first frame is the load-bearing one. **The server names the stages this
+search will pass through, and the client draws lamps for those and no others.**
+A search with the reranker off never shows a `rerank` lamp waiting to light,
+because there is nothing there to light it. A stage list is a promise about work
+that is going to happen, which is the only kind of progress display this
+codebase permits.
+
+### The route
+
+`GET /api/v1/search` is unchanged — a bare array, as scripts, `/mcp` and the
+extension read it today. Streaming is a second route, `GET
+/api/v1/search/stream`, taking the same query parameters including `door=`, and
+answering `text/event-stream`.
+
+Not a content negotiation on the existing path: the response shape of `/search`
+is depended on by four clients, and the one thing worse than adding a route is
+having an existing route answer two different shapes depending on a header.
+
+### What the CLI draws
+
+`Pulse` is deleted. In its place, the same `Lamps` renderer `-c --watch` already
+uses, driven by the frames:
+
+```
+  ● embed   ● retrieve   ◉ rerank
+```
+
+Two rules govern when it appears:
+
+- **Nothing is drawn for the first 120 ms.** A fast search shows no motion at
+  all. Most searches on a warm box are fast, and a display that flashes on and
+  off is worse than no display.
+- **The results frame is the last frame.** The list is printed the moment it
+  arrives; nothing is buffered to let an animation finish. "Never delay a
+  result" is preserved because there is no timer left to wait for.
+
+Fallback is by status: a `404` or an unparseable stream falls back to the plain
+`GET /api/v1/search`, so a new client against an old server loses the lamps and
+nothing else.
+
+### The ask already streams its milestones, and the CLI throws them away
+
+`AskEvent` (`src/core/ask/stream.rs:11`) emits `Retrieved { round, retrieved,
+shown, dropped, cliff_at }`, `Needs`, `Citations` and `Reasoning` before the
+first `Token`. `src/cli/ask.rs:174` matches on `token`, `citations` and `error`,
+and drops the rest — and then draws `pulse("thinking")` over the gap. Truthful
+material discarded and invented motion put in its place, in one function.
+
+The strand is replaced by what the frames say, one line each, on stderr, taken
+back when the answer starts:
+
+```
+  ● retrieved 24, showing 6
+  ◉ still missing: journal rotation policy
+```
+
+`Reasoning` is a stage line too, not prose in the answer — the answer body stays
+exactly what the model wrote. Nothing here is drawn on a timer, and when a fast
+ask arrives with nothing before its first token, nothing is drawn at all.
+
+### The web door reads the same frames
+
+The search box consumes `/search/stream` and renders the same three stages. This
+is the reason the channel lives in `Core` rather than in the CLI: one definition
+of what a search is doing, rendered twice, rather than two implementations that
+will disagree within a month.
+
+## 2. The list
+
+Before:
+
+```
+┃  1 ▆ -0.18  systemd-journald ring buffer  01J8Z4K2QW7NR3T9X0YB5C6D8E
+┃    [merged]
+┃    The journal is a ring buffer on disk; SystemMaxUse caps its total
+┃    size and MaxRetentionSec caps its age. Both apply per-namespace.
+┃
+```
+
+After:
+
+```
+  journal size cap                              7 hits · 412 ms
+
+   1  ▇▇▇▇▇▇▇  systemd-journald ring buffer         01J8Z4K2
+                merged · 2 sources
+      The journal is a ring buffer on disk; SystemMaxUse caps its
+      total size and MaxRetentionSec caps its age.
+
+   2  ▇▇▇▇▇░░  journalctl --vacuum-size             01K2M9PA
+      Removes archived journal files until the total falls below
+      the given size.
+
+  ──────────────────  relevance falls off here  ──────────────────
+
+   3  ▇▇░░░░░  btrfs subvolume quotas               01J7QQ4T
+      Quota groups account for shared extents, so the reported…
+
+  engram --show 2   reads hit 2 in full
+```
+
+- **The cliff is said in words.** A divider carrying the sentence, which is what
+  the results rail on the web already does and what the audit named as the
+  thing to keep. Once it is there the `┃` trace carries nothing the divider does
+  not, so the trace goes. This is a deletion.
+- **The score number leaves the human rendering.** The bar carries
+  rank-within-list, which is all the number honestly means; `--json` and
+  `--explain` still carry the float for anyone debugging ranking.
+- **The rung becomes a seven-cell bar.** The same eight steps `Scale::rung`
+  already computes, drawn wide enough to compare two rows at a glance. It costs
+  six columns, and that is the one genuine trade in this section.
+- **The id is truncated to eight characters**, which `last::resolve` already
+  accepts as a prefix.
+- **Badges move under the title** as words separated by `·`, replacing the
+  bracketed line.
+- **A header and a footer**, both measured: the query, the count, the elapsed
+  time from the stream, and one line naming the next command.
+
+`render_plain` is untouched. There remains exactly one rendering a script can
+ever see, and the drawn form still falls straight through to it when the face is
+off.
+
+## 3. Colour
+
+`Face` becomes `{ on, color, unicode, width }`, and `decide` separates the two
+decisions it currently conflates:
+
+| Input | `on` | `color` |
+|---|---|---|
+| pipe, `--json` | off | off |
+| `--plain` | off | off |
+| `NO_COLOR` | **on** | off |
+| `--fancy never` | off | off |
+| `--fancy always` | on | off if `NO_COLOR`, else on |
+
+`NO_COLOR` keeping the layout is the fix; `--fancy always` no longer overriding
+it is the other half.
+
+**Only the ANSI 8 are used. No 256-colour indices, no RGB.** The user's theme
+has already mapped those eight to inks that work on their ground; a hex value
+lifted from `app.css` would compose on `#0e1015` and nowhere else, which is
+precisely the failure the mark commit fixed.
+
+| Role | SGR | Where |
+|---|---|---|
+| body, titles | *none* | The default foreground is the highest-contrast ink available and is never overridden. |
+| hierarchy | `1` bold | Titles above the cliff. Weight, not hue. |
+| recessive | `2` dim | Ids, timings, header, footer, every row past the cliff. |
+| the one accent | `36` cyan | Score bars above the cliff, the running lamp, the divider rule. The nearest ANSI reading of `--color-accent`. |
+| failure | `31` red | Stopped lamps, refused captures, failed job rows. |
+| done | `32` green | Finished lamps, confirmed. |
+| caution | `33` yellow | `NeedsReview`, `Partial`. |
+
+Four hues and two attributes, and the third rule holds unchanged: every claim
+made in colour is also made in words or in a glyph. Strip every escape from the
+mockup above and it is the same rendering.
+
+## 4. `engram --status`
+
+`/api/v1/status` (`src/web/api.rs:1278`) already answers the machine half:
+corpora by status, job counts, failed jobs, oldest pending age, artifact and
+vector counts. It says nothing about what the base has been learning, which is
+the half that is invisible from a shell.
+
+`StatusResponse` gains a `learning` block, present only when `learn.enabled` —
+pursuits open, pursuits closed unsatisfied, artifacts written from pursuits,
+open gaps. Additive: every existing reader of the endpoint is unaffected.
+
+A new verb, `--status`, one shot like the other four. `--json` prints the
+server's own body unchanged, by the rule `-s --json` already follows. Exit `0`,
+or `2` when the endpoint cannot be reached.
+
+```
+  engram.mikoshi.de                    1 842 artifacts · 1 842 vectors
+
+  sources    1 780 ready   3 embedding   1 needs review   2 failed
+  jobs           4 pending   1 running   2 failed · oldest 38 s
+
+  learning   7 pursuits open · 4 closed unsatisfied · 11 gaps
+             3 artifacts written from pursuits
+
+  2 failed jobs
+     embed   01J8Z4K2   connection refused          4 h ago
+     extract 01K2M9PA   no text in the PDF          2 d ago
+```
+
+No footer on other verbs, and no ambient status line. A status display that
+costs a request per invocation would make the cheapest door in the application
+pay for information nobody asked for at that moment.
+
+## 5. The shell becomes a door the base learns from
+
+### Searches carry a scope
+
+`src/web/api.rs:1044` currently reads *typing* and *scoped* as one decision.
+They are two. `Door::Cli` is not a typing door — it wants the reranker, it marks
+what it retrieved — and it is a door with a known subject.
+
+```rust
+let origin = match door {
+    Door::Extension | Door::Cli => door.by(tenant.user.subject),
+    _ => door.into(),
+};
+```
+
+`Door::Api` and `Door::Mcp` are deliberately left unscoped: a bearer token is
+not a person, and two agents sharing one token would fold into each other's
+queries — the reason `sitting.rs` refuses to keep a sitting for those doors.
+
+The cost, stated: two shells belonging to one user, searching within
+`coalesce_secs`, fold into one recorded event. That is the same fold the web UI
+already accepts per subject, and it is the correct behaviour far more often than
+not — a query retyped in a second terminal usually is the same query.
+
+### Asks are recorded, and every door says its own name
+
+`record_ask`'s gate widens from `origin.door == Door::Ui` to `Ui | Cli`, and
+`/api/v1/ask/stream` stops hardcoding `Door::Extension`: the request names its
+door the way `?door=` already does for search, defaulting to `Extension` so the
+panel's behaviour is unchanged when it says nothing.
+
+A recorded CLI ask arms a pursuit through `asks_between`, and its citations
+count as engagement through `mark_artifacts_cited`, which already runs on that
+path. It carries no `event_id` to the judge page — only `Door::Ui` asks are
+judged, and that stays true. **Recorded and unjudged is a coherent state**: the
+sweep learns what was needed, and the judge still only grades answers a person
+saw in a place where they could grade them.
+
+### What this earns
+
+A person who lives in a shell can now search, read, ask, and have the run of it
+close as a satisfied pursuit that writes one artifact — the thing the feature
+exists to do, and the thing it could not do from this door at all.
+
+## Testing
+
+- `engram -a` renders a `retrieved` frame as a stage line and never draws
+  anything while no frame has arrived.
+- `search_events` emits the stage list it will run and no stage it will not,
+  asserted with the reranker on and off.
+- The 120 ms floor: a search answered immediately draws nothing.
+- `/api/v1/search` still answers a bare array, byte-identical to today.
+- `Face::decide` truth table, all five rows.
+- The drawn list with every escape stripped equals the drawn list rendered with
+  `color: false` — the "said in words" rule, as an assertion rather than a
+  comment.
+- A CLI search followed by a CLI `--show`, swept: the pursuit's engagement
+  clears `min_engagement` and it does not close `unsatisfied`. This is the test
+  the whole of §5 exists for.
+- A CLI ask is recorded; an API ask still is not.
+- `--status --json` is the server's body, unchanged.
+
+## Explicitly not in this design
+
+- **No interactive session.** No REPL, no arrow-key selection, no alternate
+  screen. Every verb remains one shot that leaves its output in scrollback, and
+  the speed of `engram -s` is the property this whole design is written around.
+- **No status footer on ordinary verbs.**
+- **No RGB, no 256-colour, no theme detection.** See §3.
+- **No scope for `Door::Api` or `Door::Mcp`.** See §5.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -65,6 +65,15 @@ pub struct CliArgs {
     /// of an id, or a whole id.
     #[arg(long, value_name = "RANK|ID", conflicts_with_all = ["capture", "search", "ask"])]
     pub show: Option<String>,
+    /// What the base holds, what it is working through, and what it has been
+    /// learning.
+    ///
+    /// One shot, like every other verb. There is no ambient status line and no
+    /// footer under an ordinary search: that would make the cheapest door in
+    /// the application pay a request for something nobody asked for at that
+    /// moment.
+    #[arg(long, conflicts_with_all = ["capture", "search", "ask", "show"])]
+    pub status: bool,
     // Every flag `--show` does not honour refuses it from the other side —
     // `--json`, `--tag`, `--category`, `--title`, `--note`, `--watch` — so the
     // conflict is declared once, on the flag whose own doc comment explains it.
@@ -93,6 +102,8 @@ pub enum Verb {
         query: String,
     },
     Ask(String),
+    /// What the base holds and what it has been learning.
+    Status,
     /// One artifact, read in full. Carries what the operator typed rather than
     /// an id: a rank means nothing until the remembered list is read, and that
     /// is a file, which is not something this decision touches.
@@ -120,6 +131,7 @@ pub fn verb(
         !args.search.is_empty(),
         !args.ask.is_empty(),
         args.show.is_some(),
+        args.status,
     ]
     .iter()
     .filter(|x| **x)
@@ -135,8 +147,9 @@ pub fn verb(
         // prompt below would then be handed EOF.
         if named > 0 {
             return Err(Error::Validation(
-                "`-c`, `-s`, `-a` and `--show` are the client half of this \
-                 binary; run them on their own, without the server's own flags"
+                "`-c`, `-s`, `-a`, `--show` and `--status` are the client half \
+                 of this binary; run them on their own, without the server's \
+                 own flags"
                     .into(),
             ));
         }
@@ -148,10 +161,16 @@ pub fn verb(
         // this is here for the caller that built `CliArgs` itself — which is
         // every test, and one day some other entry point.
         return Err(Error::Validation(
-            "one verb at a time: `-c`, `-s`, `-a` or `--show`".into(),
+            "one verb at a time: `-c`, `-s`, `-a`, `--show` or `--status`".into(),
         ));
     }
 
+    // Answered before the pipe is looked at, for the reason `--show` is:
+    // `engram --status | grep failed` is an ordinary thing to type, and without
+    // this the pipe would be taken for the capture gesture below.
+    if args.status {
+        return Ok(Some(Verb::Status));
+    }
     if let Some(which) = &args.show {
         // Answered before the pipe is looked at. `engram --show 3 | less` is
         // the ordinary way to read a long artifact, and without this the pipe
@@ -221,6 +240,42 @@ fn read(words: &[String], stdin: impl FnOnce() -> std::io::Result<String>) -> Re
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn status_is_a_verb_of_its_own() {
+        let a = CliArgs {
+            status: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            verb(&a, false, false, || Ok(String::new())).unwrap(),
+            Some(Verb::Status)
+        );
+    }
+
+    /// Answered before the pipe is looked at, exactly as `--show` is:
+    /// `engram --status | grep failed` is an ordinary thing to type.
+    #[test]
+    fn status_down_a_pipe_is_still_status_and_not_a_capture() {
+        let a = CliArgs {
+            status: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            verb(&a, false, true, || Ok("some piped text".into())).unwrap(),
+            Some(Verb::Status)
+        );
+    }
+
+    #[test]
+    fn status_does_not_share_an_invocation_with_another_verb() {
+        let a = CliArgs {
+            status: true,
+            search: vec!["x".into()],
+            ..Default::default()
+        };
+        assert!(verb(&a, false, false, || Ok(String::new())).is_err());
+    }
     use super::*;
 
     fn args() -> CliArgs {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -24,9 +24,9 @@ pub struct CliArgs {
     pub ask: Vec<String>,
     /// What to call this capture. Refused with every verb but `-c`, for the
     /// reason `--tag` is refused with `-a`: a search has no title to set.
-    #[arg(long, value_name = "TITLE", conflicts_with_all = ["search", "ask", "show"])]
+    #[arg(long, value_name = "TITLE", conflicts_with_all = ["search", "ask", "show", "status"])]
     pub title: Option<String>,
-    #[arg(long, value_name = "NOTE", conflicts_with_all = ["search", "ask", "show"])]
+    #[arg(long, value_name = "NOTE", conflicts_with_all = ["search", "ask", "show", "status"])]
     pub note: Option<String>,
     /// Narrow a search to artifacts carrying this tag. Repeatable.
     ///
@@ -37,9 +37,9 @@ pub struct CliArgs {
     ///
     /// Refused with `--show` for the plainer version of the same reason: one
     /// artifact named by id is not a list there is anything to narrow.
-    #[arg(long = "tag", value_name = "TAG", conflicts_with_all = ["ask", "show"])]
+    #[arg(long = "tag", value_name = "TAG", conflicts_with_all = ["ask", "show", "status"])]
     pub tags: Vec<String>,
-    #[arg(long, value_name = "CATEGORY", conflicts_with_all = ["ask", "show"])]
+    #[arg(long, value_name = "CATEGORY", conflicts_with_all = ["ask", "show", "status"])]
     pub category: Option<String>,
     /// Print the results as JSON instead of for a person.
     ///
@@ -59,7 +59,7 @@ pub struct CliArgs {
     ///
     /// There is nothing to follow behind the other three verbs: they finish
     /// when their response arrives.
-    #[arg(long, conflicts_with_all = ["search", "ask", "show"])]
+    #[arg(long, conflicts_with_all = ["search", "ask", "show", "status"])]
     pub watch: bool,
     /// Read one artifact in full: a rank from the last search, a leading piece
     /// of an id, or a whole id.
@@ -77,6 +77,11 @@ pub struct CliArgs {
     // Every flag `--show` does not honour refuses it from the other side —
     // `--json`, `--tag`, `--category`, `--title`, `--note`, `--watch` — so the
     // conflict is declared once, on the flag whose own doc comment explains it.
+    //
+    // `--status` is the same rule with one exception: it honours `--json` and
+    // nothing else, so the other five name it too. It had named none of them,
+    // which made `engram --status --watch` parse cleanly and then drop the
+    // flag — the failure the rule above exists to prevent.
 }
 
 /// When the drawn rendering is used. `Auto` is the only honest default: a pipe
@@ -350,6 +355,41 @@ mod tests {
             verb(&args(), false, false, piped("")).unwrap().is_none(),
             "`engram` alone must not change meaning"
         );
+    }
+
+    /// The conflict rules themselves, which every other test here walks past:
+    /// `verb` is handed a built `CliArgs`, so nothing in this file exercised
+    /// what clap does with a command line. `--status` named none of the five
+    /// flags it drops, and `engram --status --watch` parsed cleanly.
+    #[test]
+    fn status_refuses_every_flag_it_does_not_honour() {
+        #[derive(clap::Parser)]
+        struct OnlyTheClientHalf {
+            #[command(flatten)]
+            cli: CliArgs,
+        }
+        let parsed = |argv: &[&str]| {
+            <OnlyTheClientHalf as clap::Parser>::try_parse_from(
+                std::iter::once("engram").chain(argv.iter().copied()),
+            )
+        };
+        for dropped in [
+            vec!["--watch"],
+            vec!["--tag", "linux"],
+            vec!["--category", "forensik"],
+            vec!["--title", "x"],
+            vec!["--note", "x"],
+        ] {
+            let mut argv = vec!["--status"];
+            argv.extend_from_slice(&dropped);
+            assert!(
+                parsed(&argv).is_err(),
+                "accepted and then dropped: engram {}",
+                argv.join(" ")
+            );
+        }
+        // The one it does honour stays accepted.
+        assert!(parsed(&["--status", "--json"]).unwrap().cli.status);
     }
 
     #[test]

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -62,7 +62,7 @@ impl Drop for Note {
 fn within(face: &crate::cli::face::Face, lamp: crate::cli::face::Lamp, said: &str) -> String {
     face.lamp_line(
         lamp,
-        &crate::cli::face::clip(said, face.width.saturating_sub(4)),
+        &crate::cli::face::clip(said, face.width.saturating_sub(4), face.unicode),
     )
 }
 
@@ -316,6 +316,13 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
     }
     // Taken back before anything else is printed, so no part of it survives
     // into the scrollback the answer is read from tomorrow.
+    //
+    // Here rather than left to the drop: `note` outlives this block, and a
+    // stream that carried citations and no token at all reaches here with the
+    // line still on screen — `finish` is empty, the `println!` steps past it,
+    // the citations print underneath, and the drop's erase then takes an
+    // unrelated blank row while the note itself stays.
+    note.clear();
     print!("{}", readout.finish());
     println!();
     if !citations.is_empty() {

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -198,7 +198,9 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
         .build()
         .map_err(|err| Error::Internal(format!("http client: {err}")))?;
     let res = http
-        .post(e.api("/ask/stream"))
+        // `door=cli`, exactly as `-s` names its door: a question typed at a
+        // shell is recorded, and the log should hold what it was.
+        .post(format!("{}?door=cli", e.api("/ask/stream")))
         .bearer_auth(&e.token)
         .json(&serde_json::json!({ "q": question }))
         .send()

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -40,6 +40,32 @@ impl Note {
     }
 }
 
+/// Taken back on every way out, not only the two that were written down.
+///
+/// `clear` was called from the `token` and `error` arms, which leaves the line
+/// on screen for the two exits nobody typed: a transport that dies after a
+/// `retrieved` frame, where the error is printed straight onto it, and a stream
+/// that ends with citations and no token at all. `Stages` and `Fill` have both
+/// had this since they were written; the rule is the type's, not the caller's.
+impl Drop for Note {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+/// One lamp line, held inside the terminal's width.
+///
+/// Clipped here rather than in `Note::show`, because by then the text is
+/// wrapped in escapes and a count of its characters is not a count of its
+/// columns. Four columns go to what is drawn around it: the two of indent
+/// `show` prints and the two of the lamp and its space.
+fn within(face: &crate::cli::face::Face, lamp: crate::cli::face::Lamp, said: &str) -> String {
+    face.lamp_line(
+        lamp,
+        &crate::cli::face::clip(said, face.width.saturating_sub(4)),
+    )
+}
+
 /// What a `retrieved` frame says, in words. `None` where the face is off, so a
 /// redirected answer receives none of it.
 fn retrieved_line(face: &crate::cli::face::Face, data: &serde_json::Value) -> Option<String> {
@@ -47,7 +73,8 @@ fn retrieved_line(face: &crate::cli::face::Face, data: &serde_json::Value) -> Op
         return None;
     }
     let (got, shown) = (data["retrieved"].as_u64()?, data["shown"].as_u64()?);
-    Some(face.lamp_line(
+    Some(within(
+        face,
         crate::cli::face::Lamp::Done,
         &format!("retrieved {got}, showing {shown}"),
     ))
@@ -67,7 +94,12 @@ fn needs_line(face: &crate::cli::face::Face, data: &serde_json::Value) -> Option
     if said.is_empty() {
         return None;
     }
-    Some(face.lamp_line(
+    // The subjects are the model's own words and have no bound; two or three
+    // named ones routinely pass eighty columns, and `show` erases one physical
+    // row, so a wrapped line leaves its head on the screen for the answer to
+    // be written under.
+    Some(within(
+        face,
         crate::cli::face::Lamp::Running,
         &format!("still missing: {}", said.join(", ")),
     ))
@@ -349,6 +381,34 @@ mod tests {
         assert!(line.contains("journal rotation policy"), "{line}");
         // A round that named nothing is not a round that happened.
         assert!(needs_line(&face, &serde_json::json!({"queries": []})).is_none());
+    }
+
+    /// `show` erases one physical row, so a line that wraps leaves its head on
+    /// the screen and the answer is written under a note that was taken back.
+    #[test]
+    fn a_note_longer_than_the_terminal_is_clipped_rather_than_wrapped() {
+        for width in [24usize, 40, 80] {
+            let face = crate::cli::face::Face {
+                on: true,
+                color: false,
+                unicode: true,
+                width,
+            };
+            let line = needs_line(
+                &face,
+                &serde_json::json!({"queries": [
+                    "journal rotation policy",
+                    "retention window for archived corpora",
+                    "who signs off on a deletion"
+                ]}),
+            )
+            .expect("a line");
+            // The lamp is already in `line`; `show` adds the two of indent.
+            assert!(
+                line.chars().count() + 2 <= width,
+                "width {width}: over the width: {line:?}"
+            );
+        }
     }
 
     /// A redirected answer receives none of it.

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -59,7 +59,11 @@ fn needs_line(face: &crate::cli::face::Face, data: &serde_json::Value) -> Option
     if !face.on {
         return None;
     }
-    let said: Vec<&str> = data["queries"].as_array()?.iter().filter_map(|v| v.as_str()).collect();
+    let said: Vec<&str> = data["queries"]
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
     if said.is_empty() {
         return None;
     }
@@ -337,8 +341,11 @@ mod tests {
             false,
             Some("en_US.UTF-8"),
         );
-        let line = needs_line(&face, &serde_json::json!({"queries": ["journal rotation policy"]}))
-            .expect("a line");
+        let line = needs_line(
+            &face,
+            &serde_json::json!({"queries": ["journal rotation policy"]}),
+        )
+        .expect("a line");
         assert!(line.contains("journal rotation policy"), "{line}");
         // A round that named nothing is not a round that happened.
         assert!(needs_line(&face, &serde_json::json!({"queries": []})).is_none());
@@ -348,9 +355,7 @@ mod tests {
     #[test]
     fn a_face_that_is_off_says_nothing_between_the_frames() {
         let face = crate::cli::face::Face::decide(&Default::default(), false, false, None);
-        assert!(
-            retrieved_line(&face, &serde_json::json!({"retrieved": 1, "shown": 1})).is_none()
-        );
+        assert!(retrieved_line(&face, &serde_json::json!({"retrieved": 1, "shown": 1})).is_none());
         assert!(needs_line(&face, &serde_json::json!({"queries": ["x"]})).is_none());
     }
     use super::*;

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -10,6 +10,65 @@ use crate::error::{Error, Result};
 /// the reader has to be able to say "not yet" and keep what it has. Split out of
 /// the request loop because that is the only way to test it against a split that
 /// actually happened rather than one that was imagined.
+/// One line on stderr, redrawn in place and taken back before anything else is
+/// written.
+///
+/// Its own small type because the rule is not about what it says: whatever is
+/// drawn here must be gone before the answer starts, or it survives into the
+/// scrollback the answer is read from tomorrow.
+#[derive(Default)]
+struct Note {
+    drawn: bool,
+}
+
+impl Note {
+    fn show(&mut self, line: Option<String>) {
+        let Some(line) = line else { return };
+        use std::io::Write;
+        eprint!("\r\u{1b}[2K  {line}");
+        std::io::stderr().flush().ok();
+        self.drawn = true;
+    }
+
+    fn clear(&mut self) {
+        if self.drawn {
+            use std::io::Write;
+            eprint!("\r\u{1b}[2K");
+            std::io::stderr().flush().ok();
+            self.drawn = false;
+        }
+    }
+}
+
+/// What a `retrieved` frame says, in words. `None` where the face is off, so a
+/// redirected answer receives none of it.
+fn retrieved_line(face: &crate::cli::face::Face, data: &serde_json::Value) -> Option<String> {
+    if !face.on {
+        return None;
+    }
+    let (got, shown) = (data["retrieved"].as_u64()?, data["shown"].as_u64()?);
+    Some(face.lamp_line(
+        crate::cli::face::Lamp::Done,
+        &format!("retrieved {got}, showing {shown}"),
+    ))
+}
+
+/// What a `needs` frame says: the subjects the model named as still missing,
+/// which is the second round beginning.
+fn needs_line(face: &crate::cli::face::Face, data: &serde_json::Value) -> Option<String> {
+    if !face.on {
+        return None;
+    }
+    let said: Vec<&str> = data["queries"].as_array()?.iter().filter_map(|v| v.as_str()).collect();
+    if said.is_empty() {
+        return None;
+    }
+    Some(face.lamp_line(
+        crate::cli::face::Lamp::Running,
+        &format!("still missing: {}", said.join(", ")),
+    ))
+}
+
 pub fn frames(buf: &mut String) -> Vec<(String, serde_json::Value)> {
     let mut out = Vec::new();
     while let Some(end) = buf.find("\n\n") {
@@ -160,10 +219,12 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
     let mut buf = String::new();
     let mut citations = Vec::new();
     let mut said_anything = false;
-    // A strand travelling while nothing has arrived yet — the question is
-    // embedded, the pool assembled, the activation read — and then the readout
-    // takes over, driven by the answer's own arrival rate.
-    let mut waiting = face.pulse("thinking");
+    // What the ask says about itself while nothing has been written yet. It
+    // has emitted `retrieved`, `needs` and `citations` since it was written and
+    // this client dropped all three on the floor, drawing a strand on a timer
+    // over the gap instead. The readout takes over at the first token, driven
+    // by the answer's own arrival rate.
+    let mut note = Note::default();
     let mut readout = face.readout();
     let began = std::time::Instant::now();
     while let Some(chunk) = body.next().await {
@@ -172,12 +233,19 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
         buf.push_str(&decode(&mut pending)?);
         for (name, data) in frames(&mut buf) {
             match name.as_str() {
+                // A retrieval, said. The pool and what came out of it is the
+                // one number a reader can act on: a wide search that showed a
+                // handful is the fan-out working.
+                "retrieved" => note.show(retrieved_line(&face, &data)),
+                // Round two happening, in the model's own words for what the
+                // first round missed.
+                "needs" => note.show(needs_line(&face, &data)),
                 "token" => {
                     if let Some(t) = data["text"].as_str() {
                         use std::io::Write;
-                        // The waiting strand ends the moment there is something
-                        // to show, before a byte of the answer is printed.
-                        waiting.take();
+                        // The line ends the moment there is something to show,
+                        // before a byte of the answer is printed.
+                        note.clear();
                         print!("{}", readout.push(t, began.elapsed().as_millis() as u64));
                         // Flushed per token: an answer that appears a
                         // paragraph at a time is an answer that looks stalled.
@@ -190,6 +258,7 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
                 // that failed look identical on a terminal otherwise.
                 "error" => {
                     use std::io::Write;
+                    note.clear();
                     print!("{}", readout.finish());
                     // Flushed before a word goes to stderr. The erase is a
                     // bare escape with no newline, so stdout's line buffer
@@ -229,6 +298,59 @@ pub async fn run(e: &Endpoint, question: &str, cli: &crate::cli::args::CliArgs) 
 
 #[cfg(test)]
 mod tests {
+
+    /// The frames were being sent and dropped on the floor while a strand
+    /// animated over the gap. What they say is worth more than what it said.
+    #[test]
+    fn a_retrieved_frame_becomes_a_line_a_person_can_read() {
+        let face = crate::cli::face::Face::decide(
+            &crate::cli::args::CliArgs {
+                fancy: crate::cli::args::Fancy::Always,
+                ..Default::default()
+            },
+            true,
+            false,
+            Some("en_US.UTF-8"),
+        );
+        let line = retrieved_line(
+            &face,
+            &serde_json::json!({"round": 1, "retrieved": 24, "shown": 6, "dropped": 18, "cliff_at": 6}),
+        )
+        .expect("a line");
+        assert!(line.contains("24") && line.contains('6'), "{line}");
+        assert!(
+            line.contains("retrieved") && line.contains("showing"),
+            "a number with no word beside it is a number nobody can read: {line}"
+        );
+    }
+
+    #[test]
+    fn a_needs_frame_names_what_the_first_round_missed() {
+        let face = crate::cli::face::Face::decide(
+            &crate::cli::args::CliArgs {
+                fancy: crate::cli::args::Fancy::Always,
+                ..Default::default()
+            },
+            true,
+            false,
+            Some("en_US.UTF-8"),
+        );
+        let line = needs_line(&face, &serde_json::json!({"queries": ["journal rotation policy"]}))
+            .expect("a line");
+        assert!(line.contains("journal rotation policy"), "{line}");
+        // A round that named nothing is not a round that happened.
+        assert!(needs_line(&face, &serde_json::json!({"queries": []})).is_none());
+    }
+
+    /// A redirected answer receives none of it.
+    #[test]
+    fn a_face_that_is_off_says_nothing_between_the_frames() {
+        let face = crate::cli::face::Face::decide(&Default::default(), false, false, None);
+        assert!(
+            retrieved_line(&face, &serde_json::json!({"retrieved": 1, "shown": 1})).is_none()
+        );
+        assert!(needs_line(&face, &serde_json::json!({"queries": ["x"]})).is_none());
+    }
     use super::*;
 
     fn cite(title: Option<&str>, id: &str) -> serde_json::Value {

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -58,6 +58,7 @@ const BOLD: &str = "1";
 const DIM: &str = "2";
 const GREEN: &str = "32";
 const RED: &str = "31";
+const YELLOW: &str = "33";
 const CYAN: &str = "36";
 const RESET: &str = "\u{1b}[0m";
 
@@ -97,6 +98,30 @@ pub enum Lamp {
     Done,
     /// Not finished, and not going to be.
     Stopped,
+}
+
+/// Every escape this module can emit, taken back out again.
+///
+/// Lives beside the writing of them rather than in a test module: two files
+/// assert "strip the escapes and the rendering is unchanged", and a second copy
+/// of this could fall behind the vocabulary and make both assertions weaker
+/// without either failing.
+#[cfg(test)]
+pub(crate) fn strip_sgr(s: &str) -> String {
+    let mut out = String::new();
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            for c in chars.by_ref() {
+                if c == 'm' {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// One lamp, drawn. A free function because the capture stages and the search
@@ -565,6 +590,22 @@ impl Face {
             true => format!("\u{1b}[{code}m{s}{RESET}"),
             false => s.to_string(),
         }
+    }
+
+    /// Recessive: an id, a timing, a row that is already past.
+    pub fn ink_dim(&self, s: &str) -> String {
+        self.ink(DIM, s)
+    }
+
+    /// Something that failed, and can be acted on.
+    pub fn ink_bad(&self, s: &str) -> String {
+        self.ink(RED, s)
+    }
+
+    /// Something waiting on a person: a capture held for review, a partial
+    /// embedding.
+    pub fn ink_caution(&self, s: &str) -> String {
+        self.ink(YELLOW, s)
     }
 
     /// One lamp and the words beside it: `● retrieved 24, showing 6`.
@@ -1132,24 +1173,6 @@ mod tests {
         // And the whole point of reading it: the glyphs follow.
         assert!(super::Face::decide(&always(), true, false, Some("UTF-8")).unicode);
         assert!(!super::Face::decide(&always(), true, false, Some("C")).unicode);
-    }
-
-    /// Every escape this file can emit, taken back out again.
-    fn strip_sgr(s: &str) -> String {
-        let mut out = String::new();
-        let mut chars = s.chars();
-        while let Some(c) = chars.next() {
-            if c == '\u{1b}' {
-                for c in chars.by_ref() {
-                    if c == 'm' {
-                        break;
-                    }
-                }
-            } else {
-                out.push(c);
-            }
-        }
-        out
     }
 
     fn drawn(color: bool) -> Face {

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -625,8 +625,10 @@ impl Face {
                 out.push_str(&format!("  {}\n\n", self.ink(CYAN, &self.divider())));
             }
             // Zero to seven rungs becomes one to seven lit cells: every hit in
-            // this list was returned by the search, so no row is drawn empty.
-            let lit = (scale.rung(h.score) + 1).min(BAR_CELLS);
+            // this list was returned by the search, so no row is drawn empty —
+            // and only the bottom rung is lifted, because adding a cell to all
+            // of them pushed the top two together and lost the step between.
+            let lit = scale.rung(h.score).max(1);
             let bar: String = (0..BAR_CELLS)
                 .map(|c| if c < lit { full } else { empty })
                 .collect();

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -8,6 +8,7 @@
 use crate::cli::args::{CliArgs, Fancy};
 use crate::core::search::SearchResult;
 
+#[derive(Clone, Copy)]
 pub struct Face {
     pub on: bool,
     /// The SGR escapes. Separate from `on` because `NO_COLOR` is a statement
@@ -56,6 +57,7 @@ fn clip(s: &str, room: usize) -> String {
 const BOLD: &str = "1";
 const DIM: &str = "2";
 const GREEN: &str = "32";
+const RED: &str = "31";
 const CYAN: &str = "36";
 const RESET: &str = "\u{1b}[0m";
 
@@ -100,7 +102,7 @@ pub enum Lamp {
 /// One lamp, drawn. A free function because the capture stages and the search
 /// stages are the same vocabulary seen at two doors, and two tables of glyphs
 /// would drift.
-fn lamp_glyph(l: Lamp, unicode: bool) -> char {
+pub(crate) fn lamp_glyph(l: Lamp, unicode: bool) -> char {
     match (l, unicode) {
         (Lamp::Waiting, true) => '·',
         (Lamp::Running, true) => '◉',
@@ -213,7 +215,7 @@ impl Fill {
     }
 }
 
-/// Taken back on drop, the way `Pulse` stops on drop.
+/// Taken back on drop, the way every line this file draws is.
 ///
 /// The one caller draws from inside a request body, and a request that fails
 /// partway — a reset connection, a 413 mid-upload — drops that stream without
@@ -287,9 +289,7 @@ const QUIET_FLOOR_MS: u128 = 120;
 /// server's to name — whether a rerank happens is decided there — so a lamp is
 /// never drawn for work that is not going to run.
 pub struct Stages {
-    on: bool,
-    color: bool,
-    unicode: bool,
+    face: Face,
     names: Vec<crate::core::search::SearchStage>,
     began: std::time::Instant,
     drawn: bool,
@@ -312,7 +312,7 @@ impl Stages {
         elapsed_ms: u128,
     ) -> Option<String> {
         use crate::core::search::SearchStage;
-        if !self.on || self.names.is_empty() || elapsed_ms < QUIET_FLOOR_MS {
+        if !self.face.on || self.names.is_empty() || elapsed_ms < QUIET_FLOOR_MS {
             return None;
         }
         let mut reached = false;
@@ -338,16 +338,7 @@ impl Stages {
                         SearchStage::Rerank => "rerank",
                     };
                     // Drawn *and* said, like every other lamp in this file.
-                    let cell = format!("{} {name}", lamp_glyph(lamp, self.unicode));
-                    let code = match lamp {
-                        Lamp::Running => CYAN,
-                        Lamp::Done => GREEN,
-                        _ => DIM,
-                    };
-                    match self.color {
-                        true => format!("\u{1b}[{code}m{cell}{RESET}"),
-                        false => cell,
-                    }
+                    self.face.lamp_line(lamp, name)
                 })
                 .collect::<Vec<_>>()
                 .join("   "),
@@ -576,6 +567,22 @@ impl Face {
         }
     }
 
+    /// One lamp and the words beside it: `● retrieved 24, showing 6`.
+    ///
+    /// The glyph is how you see at a glance which of several is moving; the
+    /// words are the claim, and they are what survives a screenshot, a
+    /// redirected file and a terminal with no colour.
+    pub fn lamp_line(&self, lamp: Lamp, said: &str) -> String {
+        let cell = format!("{} {said}", lamp_glyph(lamp, self.unicode));
+        let code = match lamp {
+            Lamp::Running => CYAN,
+            Lamp::Done => GREEN,
+            Lamp::Stopped => RED,
+            Lamp::Waiting => DIM,
+        };
+        self.ink(code, &cell)
+    }
+
     /// The ranked list, drawn.
     ///
     /// Falls straight through to the plain renderer when the face is off, so
@@ -706,9 +713,7 @@ impl Face {
     /// The stages of one search, for a client reading the streaming door.
     pub fn stages(&self) -> Stages {
         Stages {
-            on: self.on,
-            color: self.color,
-            unicode: self.unicode,
+            face: *self,
             names: Vec::new(),
             began: std::time::Instant::now(),
             drawn: false,
@@ -734,76 +739,6 @@ impl Face {
         }
     }
 
-    /// A pulse travelling along a strand while a request is in flight — an
-    /// impulse propagating, which is what the server is actually doing.
-    ///
-    /// `None` when the face is off, so a caller writes the same two lines
-    /// either way. It stops on drop, and drop happens the moment the response
-    /// arrives: nothing is buffered to let a frame land evenly, and no result
-    /// waits on an animation.
-    ///
-    /// Drawn on stderr, so a redirected stdout never receives a frame of it
-    /// even in the case where someone forced `--fancy always` into a pipe.
-    pub fn pulse(&self, label: &'static str) -> Option<Pulse> {
-        self.on.then(|| Pulse::start(label, self.unicode))
-    }
-}
-
-pub struct Pulse {
-    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    handle: Option<std::thread::JoinHandle<()>>,
-}
-
-impl Pulse {
-    fn start(label: &'static str, unicode: bool) -> Pulse {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        let stop = std::sync::Arc::new(AtomicBool::new(false));
-        let flag = stop.clone();
-        let handle = std::thread::spawn(move || {
-            // One bright cell with a decaying tail behind it.
-            let cells = if unicode {
-                ['●', '◦', '·', '·']
-            } else {
-                ['O', 'o', '.', '.']
-            };
-            let span = 12usize;
-            let mut head = 0usize;
-            while !flag.load(Ordering::Relaxed) {
-                let strand: String = (0..span)
-                    .map(|i| {
-                        let behind = (span + head - i) % span;
-                        cells[behind.min(cells.len() - 1)]
-                    })
-                    .collect();
-                // Rewritten in place, never on the alternate screen: results
-                // have to stay in scrollback after the process exits.
-                eprint!("\r\u{1b}[2K{strand}  {label}");
-                use std::io::Write;
-                std::io::stderr().flush().ok();
-                head = (head + 1) % span;
-                std::thread::sleep(std::time::Duration::from_millis(80));
-            }
-            eprint!("\r\u{1b}[2K");
-            use std::io::Write;
-            std::io::stderr().flush().ok();
-        });
-        Pulse {
-            stop,
-            handle: Some(handle),
-        }
-    }
-}
-
-impl Drop for Pulse {
-    fn drop(&mut self) {
-        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
-        if let Some(h) = self.handle.take() {
-            // Joined rather than detached: the line has to be erased before
-            // anything else prints, or a result lands on top of a half-drawn
-            // strand.
-            h.join().ok();
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1146,12 +1081,6 @@ mod tests {
         let hits = [hit("a", 0.9, false, false), hit("b", 0.2, true, true)];
         let off = Face::decide(&Default::default(), false, false, Some("en_US.UTF-8"));
         assert_eq!(off.render(&hits, None), crate::cli::search::render_plain(&hits));
-    }
-
-    #[test]
-    fn a_pulse_is_not_started_when_the_face_is_off() {
-        let off = Face::decide(&Default::default(), false, false, None);
-        assert!(off.pulse("searching").is_none());
     }
 
     /// POSIX precedence, which is not what this used to read.

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -32,9 +32,30 @@ const BLOCKS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█
 const EXCERPT_LINES: usize = 4;
 const ASCII_BLOCKS: [char; 8] = ['.', '.', ':', ':', '-', '=', '#', '#'];
 
-/// Dim, and back. Written out rather than pulled from a styling crate: two
-/// escapes used in three places do not need a dependency's opinion.
-const DIM: &str = "\u{1b}[2m";
+/// Cells in a hit's score bar. One block said "this one ranks lower than that
+/// one" only to an eye that went looking; seven say it across the list at a
+/// glance, and cost six columns.
+const BAR_CELLS: usize = 7;
+
+/// `s`, or as much of it as `room` holds with an ellipsis for the rest.
+fn clip(s: &str, room: usize) -> String {
+    match s.chars().count() > room && room > 1 {
+        true => s.chars().take(room - 1).chain(['…']).collect(),
+        false => s.to_string(),
+    }
+}
+
+/// Bold, dim, and the four hues — the whole vocabulary, written out rather than
+/// pulled from a styling crate: seven codes used through one function do not
+/// need a dependency's opinion.
+///
+/// The ANSI 8 and nothing else. No 256-colour indices and no RGB: the terminal
+/// belongs to the person in front of it, their theme has already mapped these
+/// eight to inks that compose on their ground, and a hex value lifted from
+/// `app.css` composes on `#0e1015` and nowhere else.
+const BOLD: &str = "1";
+const DIM: &str = "2";
+const CYAN: &str = "36";
 const RESET: &str = "\u{1b}[0m";
 
 /// The locale that decides whether the glyphs are drawable, in POSIX order.
@@ -421,57 +442,128 @@ impl Face {
         }
     }
 
+    /// `s` wrapped in an SGR code, or `s` untouched.
+    ///
+    /// The one place in this file an escape is written, which is what makes
+    /// "strip every escape and the rendering is unchanged" a property the
+    /// tests can assert rather than a habit the next edit forgets.
+    pub fn ink(&self, code: &str, s: &str) -> String {
+        match self.color {
+            true => format!("\u{1b}[{code}m{s}{RESET}"),
+            false => s.to_string(),
+        }
+    }
+
     /// The ranked list, drawn.
     ///
     /// Falls straight through to the plain renderer when the face is off, so
     /// there is exactly one code path a script can ever see.
-    pub fn render(&self, hits: &[SearchResult]) -> String {
+    ///
+    /// `elapsed_ms` is what the client timed for the whole round trip, and
+    /// `None` where it did not time one. Reported rather than computed here:
+    /// this function draws, and a duration it invented would be the first
+    /// invented thing in the file.
+    pub fn render(&self, hits: &[SearchResult], elapsed_ms: Option<u128>) -> String {
         if !self.on {
             return crate::cli::search::render_plain(hits);
         }
-        let blocks = if self.unicode { BLOCKS } else { ASCII_BLOCKS };
-        // The trace running down the list, and what it becomes past the cliff.
-        let (solid, broken) = if self.unicode {
-            ('┃', '╵')
-        } else {
-            ('|', ':')
-        };
+        let (full, empty) = if self.unicode { ('▇', '░') } else { ('#', '.') };
         // The list is its own scale. A score here is a fused rank rather than a
         // probability — `search::prime` says so about the same numbers — and a
         // whole list of them is routinely negative, so a fixed `0.0..=1.0`
         // clamp put every hit on the bottom rung and the bar said nothing.
         let scale = Scale::over(hits);
         let mut out = String::new();
+
+        // Both halves measured: the count is the list, the time is what the
+        // client timed. The query is not echoed — a terminal already has the
+        // command that produced this two lines up, which a page does not.
+        let mut head = format!("{} hit{}", hits.len(), if hits.len() == 1 { "" } else { "s" });
+        if let Some(ms) = elapsed_ms {
+            head.push_str(&format!(" · {ms} ms"));
+        }
+        out.push_str(&format!("\n  {}\n\n", self.ink(DIM, &head)));
+
+        let mut said_cliff = false;
         for (i, h) in hits.iter().enumerate() {
-            let rung = scale.rung(h.score);
-            let trace = if h.past_cliff { broken } else { solid };
-            let (dim, reset) = if h.past_cliff { (DIM, RESET) } else { ("", "") };
-            out.push_str(&format!(
-                "{dim}{trace} {:>2} {} {:.2}  {}  {}{reset}\n",
-                i + 1,
-                blocks[rung],
-                h.score,
-                h.title.as_deref().unwrap_or("(untitled)"),
-                h.artifact_id
-            ));
-            // Drawn *and* said. The break in the trace is the thing you cannot
-            // miss; the words are the thing everyone else can still read.
-            if let Some(said) = crate::cli::search::badges(h) {
-                out.push_str(&format!("{dim}{trace}    [{said}]{reset}\n"));
+            // Said once, where the fall happens, and said in words. The `┃`
+            // trace this replaces marked it by breaking, which marks it for
+            // nobody reading a screenshot, a redirected file or a monochrome
+            // terminal — and once the sentence is on screen the trace beside it
+            // carries nothing at all.
+            if h.past_cliff && !said_cliff {
+                said_cliff = true;
+                out.push_str(&format!("  {}\n\n", self.ink(CYAN, &self.divider())));
             }
-            // Four wrapped lines, not two source lines. A passage's own blank
+            // Zero to seven rungs becomes one to seven lit cells: every hit in
+            // this list was returned by the search, so no row is drawn empty.
+            let lit = (scale.rung(h.score) + 1).min(BAR_CELLS);
+            let bar: String = (0..BAR_CELLS)
+                .map(|c| if c < lit { full } else { empty })
+                .collect();
+            // Eight characters: what `last::resolve` already accepts as a
+            // prefix, and what a person can carry across a terminal by eye. The
+            // whole 26 crowded the title off its own line and named nothing the
+            // eight do not.
+            let short: String = h.artifact_id.chars().take(8).collect();
+            let title = clip(
+                h.title.as_deref().unwrap_or("(untitled)"),
+                self.width.saturating_sub(25),
+            );
+            let (bar, title) = match h.past_cliff {
+                true => (self.ink(DIM, &bar), self.ink(DIM, &title)),
+                false => (self.ink(CYAN, &bar), self.ink(BOLD, &title)),
+            };
+            out.push_str(&format!(
+                "  {:>2}  {bar}  {title}   {}\n",
+                i + 1,
+                self.ink(DIM, &short)
+            ));
+            // Drawn *and* said, as the trace used to be: the words are what
+            // everyone else can still read.
+            if let Some(said) = crate::cli::search::badges(h) {
+                out.push_str(&format!(
+                    "      {}\n",
+                    self.ink(DIM, &said.replace(", ", " · "))
+                ));
+            }
+            // Four wrapped lines, not four source lines. A passage's own blank
             // lines are structure in the document and nothing at all here, and
             // a clip at the terminal's edge discarded the rest of a sentence
-            // rather than spending the next line on it — between them a
-            // captured PDF drew a list of one-line fragments with gaps under
-            // them. The budget is what you can read without the list stopping
-            // being a list; `--show` is still where a whole artifact is read.
-            for line in crate::cli::search::excerpt(&h.text, EXCERPT_LINES, self.width.saturating_sub(6)) {
-                out.push_str(&format!("{dim}{trace}    {line}{reset}\n"));
+            // rather than spending the next line on it.
+            for line in
+                crate::cli::search::excerpt(&h.text, EXCERPT_LINES, self.width.saturating_sub(6))
+            {
+                out.push_str(&format!("      {line}\n"));
             }
-            out.push_str(&format!("{trace}\n"));
+            out.push('\n');
+        }
+        // Named once, and only where it fits: a hint that wraps is worse than
+        // no hint.
+        if !hits.is_empty() && self.width >= 60 {
+            out.push_str(&format!(
+                "  {}\n",
+                self.ink(DIM, "engram --show 1   reads the first hit in full")
+            ));
         }
         out
+    }
+
+    /// The cliff, as a rule with the sentence in it, laid out to the width.
+    ///
+    /// A narrow terminal gets the sentence alone: the rules are what make it
+    /// read as a divider, and half a rule reads as damage.
+    fn divider(&self) -> String {
+        const SAID: &str = "relevance falls off here";
+        let dash = if self.unicode { '─' } else { '-' };
+        let room = self.width.saturating_sub(2);
+        match room.checked_sub(SAID.chars().count() + 4) {
+            Some(n) if n >= 6 => {
+                let side: String = std::iter::repeat_n(dash, n / 2).collect();
+                format!("{side}  {SAID}  {side}")
+            }
+            _ => SAID.to_string(),
+        }
     }
 
     /// A readout of the rate an answer's tokens are arriving at.
@@ -645,6 +737,15 @@ mod tests {
         assert!(r.strand(window).chars().all(|c| c == ' '));
     }
 
+    /// Lit cells per bar, one entry per hit.
+    fn lit_cells(drawn: &str) -> Vec<usize> {
+        drawn
+            .lines()
+            .map(|l| l.chars().filter(|c| *c == '▇').count())
+            .filter(|n| *n > 0)
+            .collect()
+    }
+
     fn always() -> CliArgs {
         CliArgs {
             fancy: Fancy::Always,
@@ -690,7 +791,7 @@ mod tests {
     fn a_locale_that_does_not_say_utf8_gets_the_ascii_shapes() {
         let f = Face::decide(&always(), true, false, Some("C"));
         assert!(!f.unicode);
-        let drawn = f.render(&[hit("a", 0.9, false, false)]);
+        let drawn = f.render(&[hit("a", 0.9, false, false)], None);
         assert!(
             !drawn.contains('█') && !drawn.contains('┃'),
             "a drawing glyph reached a non-UTF-8 terminal: {drawn}"
@@ -775,20 +876,20 @@ mod tests {
     #[test]
     fn the_bar_is_drawn_against_the_list_it_is_in() {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
-        let drawn = f.render(&[
-            hit("a", -3.57, false, false),
-            hit("b", -4.42, false, false),
-            hit("c", -5.45, false, false),
-        ]);
-        let rungs: Vec<char> = drawn
-            .lines()
-            .filter_map(|l| l.chars().find(|c| BLOCKS.contains(c)))
-            .collect();
-        assert_eq!(rungs.len(), 3, "one bar per hit: {drawn}");
-        assert_eq!(rungs[0], '█', "the best hit of the list fills the bar");
-        assert_eq!(rungs[2], '▁', "and the worst empties it");
+        let drawn = f.render(
+            &[
+                hit("a", -3.57, false, false),
+                hit("b", -4.42, false, false),
+                hit("c", -5.45, false, false),
+            ],
+            None,
+        );
+        let bars = lit_cells(&drawn);
+        assert_eq!(bars.len(), 3, "one bar per hit: {drawn}");
+        assert_eq!(bars[0], BAR_CELLS, "the best hit of the list fills the bar");
+        assert_eq!(bars[2], 1, "and the worst is down to its last cell");
         assert!(
-            rungs[1] != rungs[0] && rungs[1] != rungs[2],
+            bars[1] != bars[0] && bars[1] != bars[2],
             "the middle hit got no step of its own: {drawn}"
         );
     }
@@ -798,28 +899,74 @@ mod tests {
     #[test]
     fn a_list_with_no_spread_still_draws() {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
-        let drawn = f.render(&[hit("a", -2.0, false, false), hit("b", -2.0, false, false)]);
+        let drawn = f.render(
+            &[hit("a", -2.0, false, false), hit("b", -2.0, false, false)],
+            None,
+        );
         assert!(!drawn.contains("NaN"), "{drawn}");
-        let rungs: Vec<char> = drawn
-            .lines()
-            .filter_map(|l| l.chars().find(|c| BLOCKS.contains(c)))
-            .collect();
-        assert_eq!(rungs.len(), 2, "{drawn}");
-        assert_eq!(rungs[0], rungs[1], "nothing separates them: {drawn}");
+        let bars = lit_cells(&drawn);
+        assert_eq!(bars.len(), 2, "{drawn}");
+        assert_eq!(bars[0], bars[1], "nothing separates them: {drawn}");
     }
 
     #[test]
-    fn the_trace_breaks_where_the_cliff_is() {
+    fn the_cliff_is_said_where_it_falls() {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
-        let drawn = f.render(&[hit("a", 0.9, false, false), hit("b", 0.2, true, true)]);
+        let drawn = f.render(&[hit("a", 0.9, false, false), hit("b", 0.2, true, true)], None);
+        // A mark made only of glyphs is a mark a screen reader, a screenshot
+        // and a monochrome terminal never reach. The trace that used to break
+        // here was exactly that, and the sentence says what it was for.
+        assert!(drawn.contains("relevance falls off here"), "{drawn}");
         assert!(
-            drawn.contains('┃') && drawn.contains('╵'),
-            "the trace must snap: {drawn}"
+            !drawn.contains('┃') && !drawn.contains('╵'),
+            "the trace says nothing the divider does not: {drawn}"
         );
-        // Drawn is not enough: a mark made only of glyphs is a mark a screen
-        // reader never reaches.
         assert!(drawn.contains("past the cliff"), "{drawn}");
         assert!(drawn.contains("loose match"), "{drawn}");
+    }
+
+    /// One hit is a list with nothing to fall off.
+    #[test]
+    fn a_list_that_does_not_fall_off_has_no_divider() {
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let drawn = f.render(&[hit("a", 0.9, false, false)], None);
+        assert!(!drawn.contains("relevance falls off"), "{drawn}");
+    }
+
+    /// The raw number was a fused rank printed to two decimals, and a whole
+    /// list of them is routinely negative. The bar says the only thing it
+    /// honestly said; `--json` still carries the float.
+    #[test]
+    fn the_raw_score_leaves_the_human_rendering() {
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let drawn = f.render(&[hit("a", -3.57, false, false)], None);
+        assert!(!drawn.contains("-3.57"), "{drawn}");
+        assert!(drawn.contains('▇'), "{drawn}");
+    }
+
+    /// Eight characters name the artifact and leave the title its line;
+    /// `last::resolve` has always accepted a prefix.
+    #[test]
+    fn the_id_is_cut_to_a_prefix_that_still_names_it() {
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let mut h = hit("a", 0.9, false, false);
+        h.artifact_id = "01J8Z4K2QW7NR3T9X0YB5C6D8E".into();
+        let drawn = f.render(&[h], None);
+        assert!(drawn.contains("01J8Z4K2"), "{drawn}");
+        assert!(!drawn.contains("01J8Z4K2QW"), "the whole id crowds the title: {drawn}");
+    }
+
+    /// Both halves of the header are measurements. Nothing else belongs in it.
+    #[test]
+    fn the_header_says_what_was_counted_and_what_was_timed() {
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let drawn = f.render(&[hit("a", 0.9, false, false), hit("b", 0.2, false, false)], Some(412));
+        assert!(drawn.contains("2 hits"), "{drawn}");
+        assert!(drawn.contains("412 ms"), "{drawn}");
+        // A client that timed nothing says nothing about time.
+        let untimed = f.render(&[hit("a", 0.9, false, false)], None);
+        assert!(untimed.contains("1 hit"), "{untimed}");
+        assert!(!untimed.contains(" ms"), "{untimed}");
     }
 
     /// A sentence past the terminal's edge is wrapped, not thrown away.
@@ -836,7 +983,7 @@ mod tests {
                   Oberflaeche. Sie sind fuer periodische und zeitaufwendige \
                   Aufgaben geeignet."
             .into();
-        let drawn = f.render(&[h]);
+        let drawn = f.render(&[h], None);
         assert!(drawn.contains("zeitaufwendige"), "the tail was cut: {drawn}");
         for line in drawn.lines() {
             assert!(line.chars().count() <= 40, "over the width: {line:?}");
@@ -854,7 +1001,7 @@ mod tests {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
         let mut h = hit("a", -4.18, false, false);
         h.text = "Betriebssysteme f\u{fc}r Server\n\nDienste bezeichnen Anwendungen.\n".into();
-        let drawn = f.render(&[h]);
+        let drawn = f.render(&[h], None);
         assert!(drawn.contains("Betriebssysteme"), "{drawn}");
         assert!(drawn.contains("Dienste bezeichnen"), "second line lost: {drawn}");
     }
@@ -864,7 +1011,7 @@ mod tests {
         // The boundary that keeps the plain form the only one a script sees.
         let hits = [hit("a", 0.9, false, false), hit("b", 0.2, true, true)];
         let off = Face::decide(&Default::default(), false, false, Some("en_US.UTF-8"));
-        assert_eq!(off.render(&hits), crate::cli::search::render_plain(&hits));
+        assert_eq!(off.render(&hits, None), crate::cli::search::render_plain(&hits));
     }
 
     #[test]
@@ -920,6 +1067,51 @@ mod tests {
         // And the whole point of reading it: the glyphs follow.
         assert!(super::Face::decide(&always(), true, false, Some("UTF-8")).unicode);
         assert!(!super::Face::decide(&always(), true, false, Some("C")).unicode);
+    }
+
+    /// Every escape this file can emit, taken back out again.
+    fn strip_sgr(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    fn drawn(color: bool) -> Face {
+        Face {
+            on: true,
+            color,
+            unicode: true,
+            width: 80,
+        }
+    }
+
+    /// The third rule of this file, as an assertion rather than a comment: a
+    /// claim made in colour is made in words as well, so the coloured
+    /// rendering and the bare one differ by escapes and by nothing else.
+    #[test]
+    fn colour_never_carries_a_claim_on_its_own() {
+        let hits = [hit("a", 0.9, false, false), hit("b", 0.2, true, true)];
+        assert_eq!(
+            strip_sgr(&drawn(true).render(&hits, Some(412))),
+            drawn(false).render(&hits, Some(412))
+        );
+    }
+
+    #[test]
+    fn ink_is_a_no_op_without_colour() {
+        assert_eq!(drawn(false).ink(CYAN, "x"), "x");
+        assert_eq!(drawn(true).ink(CYAN, "x"), "\u{1b}[36mx\u{1b}[0m");
     }
 
     /// `NO_COLOR` is about ink. It used to take the lamps, the upload track and

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -10,6 +10,11 @@ use crate::core::search::SearchResult;
 
 pub struct Face {
     pub on: bool,
+    /// The SGR escapes. Separate from `on` because `NO_COLOR` is a statement
+    /// about ink and nothing else: the lamps, the upload track and the layout
+    /// are not colour, and folding the two together took the whole progress
+    /// display away from everyone who had ever set the variable.
+    pub color: bool,
     pub unicode: bool,
     pub width: usize,
 }
@@ -401,10 +406,14 @@ impl Face {
             Fancy::Never => false,
             // `--json` is off as well: its reader is a machine even when a
             // person is watching it arrive.
-            Fancy::Auto => is_tty && !no_color && !cli.plain && !cli.json,
+            Fancy::Auto => is_tty && !cli.plain && !cli.json,
         };
         Face {
             on,
+            // Never ink where nothing is drawn at all, and never against
+            // `NO_COLOR` however the drawn form was asked for — `--fancy
+            // always` says draw, which is not the same as saying colour.
+            color: on && !no_color,
             unicode: lang.is_some_and(|l| l.to_ascii_uppercase().contains("UTF-8")),
             width: crossterm::terminal::size()
                 .map(|(w, _)| w as usize)
@@ -657,10 +666,6 @@ mod tests {
             !Face::decide(&Default::default(), false, false, Some("en_US.UTF-8")).on,
             "a pipe"
         );
-        assert!(
-            !Face::decide(&Default::default(), true, true, Some("en_US.UTF-8")).on,
-            "NO_COLOR"
-        );
         let json = CliArgs {
             json: true,
             ..Default::default()
@@ -822,6 +827,7 @@ mod tests {
     fn a_long_line_is_wrapped_onto_the_budget_rather_than_cut_at_the_edge() {
         let f = Face {
             on: true,
+            color: false,
             unicode: true,
             width: 40,
         };
@@ -914,6 +920,53 @@ mod tests {
         // And the whole point of reading it: the glyphs follow.
         assert!(super::Face::decide(&always(), true, false, Some("UTF-8")).unicode);
         assert!(!super::Face::decide(&always(), true, false, Some("C")).unicode);
+    }
+
+    /// `NO_COLOR` is about ink. It used to take the lamps, the upload track and
+    /// the layout with it, so `NO_COLOR=1 engram -c big.pdf --watch` followed a
+    /// capture with no display of any kind.
+    #[test]
+    fn no_color_keeps_the_layout_and_drops_only_the_ink() {
+        let f = Face::decide(&Default::default(), true, true, Some("en_US.UTF-8"));
+        assert!(f.on, "the lamps and the layout are not colour");
+        assert!(!f.color);
+    }
+
+    /// The other direction, and the worse one: the flag that means "draw"
+    /// silently overrode a preference that was never about drawing.
+    #[test]
+    fn asking_for_the_drawn_form_does_not_override_no_color() {
+        let f = Face::decide(&always(), false, true, Some("en_US.UTF-8"));
+        assert!(f.on);
+        assert!(!f.color, "--fancy always says draw, not colour");
+    }
+
+    /// Everywhere the face is off there is no ink either: `color` can never be
+    /// the one thing left on when nothing is being drawn.
+    #[test]
+    fn nothing_is_drawn_and_nothing_is_coloured() {
+        let plain = CliArgs {
+            plain: true,
+            ..Default::default()
+        };
+        let json = CliArgs {
+            json: true,
+            ..Default::default()
+        };
+        let never = CliArgs {
+            fancy: Fancy::Never,
+            ..Default::default()
+        };
+        for (args, tty) in [
+            (plain, true),
+            (json, true),
+            (CliArgs::default(), false),
+            (never, true),
+        ] {
+            let f = Face::decide(&args, tty, false, Some("en_US.UTF-8"));
+            assert!(!f.on);
+            assert!(!f.color);
+        }
     }
 }
 

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -39,10 +39,18 @@ const ASCII_BLOCKS: [char; 8] = ['.', '.', ':', ':', '-', '=', '#', '#'];
 const BAR_CELLS: usize = 7;
 
 /// `s`, or as much of it as `room` holds with an ellipsis for the rest.
-fn clip(s: &str, room: usize) -> String {
-    match s.chars().count() > room && room > 1 {
-        true => s.chars().take(room - 1).chain(['…']).collect(),
-        false => s.to_string(),
+///
+/// A `room` of one or zero is a real answer rather than a reason to give up: a
+/// narrow terminal is the case clipping exists for, and returning the whole
+/// string there put the one line nobody can widen over the edge.
+pub(crate) fn clip(s: &str, room: usize) -> String {
+    if s.chars().count() <= room {
+        return s.to_string();
+    }
+    match room {
+        0 => String::new(),
+        1 => "…".to_string(),
+        _ => s.chars().take(room - 1).chain(['…']).collect(),
     }
 }
 
@@ -686,9 +694,13 @@ impl Face {
             // whole 26 crowded the title off its own line and named nothing the
             // eight do not.
             let short: String = h.artifact_id.chars().take(8).collect();
+            // 26, counted off the format below: two of indent, two of rank,
+            // two, the bar's seven, two, three, and the short id's eight. It
+            // was 25, and a title of exactly that length drew a line one column
+            // over the width, which every terminal wraps.
             let title = clip(
                 h.title.as_deref().unwrap_or("(untitled)"),
-                self.width.saturating_sub(25),
+                self.width.saturating_sub(26),
             );
             let (bar, title) = match h.past_cliff {
                 true => (self.ink(DIM, &bar), self.ink(DIM, &title)),
@@ -1119,6 +1131,52 @@ mod tests {
         for line in drawn.lines() {
             assert!(line.chars().count() <= 40, "over the width: {line:?}");
         }
+    }
+
+    /// The title's own budget, at the width where being one column out shows.
+    ///
+    /// A row spends 26 fixed columns around the title; the clip allowed 25, so
+    /// a title of exactly that length drew `width + 1` and wrapped. Walked
+    /// Walked at widths a terminal
+    /// actually has. Below about thirty the rendering has floors that clipping
+    /// a title cannot lift — the row spends 26 columns on the rank, the bar and
+    /// the short id, and `excerpt` will not wrap under 24 — so asserting the
+    /// width there would be asserting a promise this file does not make.
+    #[test]
+    fn a_title_that_fills_the_row_is_clipped_rather_than_wrapped() {
+        for width in [40usize, 60, 80, 120] {
+            let f = Face {
+                on: true,
+                color: false,
+                unicode: true,
+                width,
+            };
+            for len in [width.saturating_sub(26), width, width + 20] {
+                // Wrappable words rather than one long run: the excerpt under
+                // the row is word-wrapped, and an unbreakable token would fail
+                // this on a line the title's budget does not govern.
+                let title: String = "wort ".repeat(width).chars().take(len.max(1)).collect();
+                let drawn = f.render(&[hit(&title, -4.18, false, false)], None);
+                for line in drawn.lines() {
+                    assert!(
+                        line.chars().count() <= width,
+                        "width {width}, title of {len}: over the width: {line:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The narrow end of `clip`, which used to hand back the whole string.
+    #[test]
+    fn clipping_into_no_room_at_all_still_clips() {
+        assert_eq!(clip("Dienste", 7), "Dienste");
+        assert_eq!(clip("Dienste", 8), "Dienste");
+        assert_eq!(clip("Dienste", 6), "Diens…");
+        assert_eq!(clip("Dienste", 2), "D…");
+        assert_eq!(clip("Dienste", 1), "…");
+        assert_eq!(clip("Dienste", 0), "");
+        assert_eq!(clip("", 0), "");
     }
 
     /// The two lines a list spends are two lines that carry text.

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -43,14 +43,21 @@ const BAR_CELLS: usize = 7;
 /// A `room` of one or zero is a real answer rather than a reason to give up: a
 /// narrow terminal is the case clipping exists for, and returning the whole
 /// string there put the one line nobody can widen over the edge.
-pub(crate) fn clip(s: &str, room: usize) -> String {
+///
+/// The marker comes off the locale like every other glyph in this file. It was
+/// a hardcoded `…`, which is one character of mojibake at the end of a row on
+/// the terminal that asked for the ASCII shapes — and this is now on the two
+/// paths that clip most, a hit's title and an ask's lamp line.
+pub(crate) fn clip(s: &str, room: usize, unicode: bool) -> String {
     if s.chars().count() <= room {
         return s.to_string();
     }
-    match room {
-        0 => String::new(),
-        1 => "…".to_string(),
-        _ => s.chars().take(room - 1).chain(['…']).collect(),
+    let more = if unicode { "…" } else { "..." };
+    match room.checked_sub(more.chars().count()) {
+        // Narrower than the marker itself: as much of it as fits, which still
+        // says there is more and still stops at the edge.
+        None => more.chars().take(room).collect(),
+        Some(keep) => s.chars().take(keep).chain(more.chars()).collect(),
     }
 }
 
@@ -307,24 +314,24 @@ impl Track {
     }
 }
 
-/// How long a search may take before anything at all is drawn.
-///
-/// Most searches on a warm box come back inside this, and a display that
-/// appears and disappears inside a tenth of a second is worse than no display:
-/// it reads as a flicker, not as progress. Nothing here delays a result — the
-/// floor decides what is drawn, never when the answer is printed.
-const QUIET_FLOOR_MS: u128 = 120;
-
 /// The stages of one search, redrawn in place as the server names them.
 ///
 /// Holds no timer and invents no frames: it is redrawn from events that
 /// arrived, so it cannot run ahead of the work. The stages themselves are the
 /// server's to name — whether a rerank happens is decided there — so a lamp is
 /// never drawn for work that is not going to run.
+///
+/// It held a quiet floor as well — a tenth of a second before anything was
+/// drawn, so a fast search did not flicker. Because a frame is the only thing
+/// that draws, and the floor was read at the frame's own instant, a search
+/// whose *first* stage was the slow one was suppressed at the only moment it
+/// would ever have been drawn: a cold embedder showed a blank terminal for as
+/// long as it took, which is the case the display exists for. A floor would
+/// have to be paired with a clock of its own to be safe, and the flicker it
+/// spared is worth less than the wait it hid.
 pub struct Stages {
     face: Face,
     names: Vec<crate::core::search::SearchStage>,
-    began: std::time::Instant,
     drawn: bool,
 }
 
@@ -334,45 +341,68 @@ impl Stages {
         self.names = names.to_vec();
     }
 
-    /// What this frame would draw, or `None` — the face is off, or the search
-    /// is still inside the quiet floor.
+    /// What this frame would draw, or `None` where the face is off.
     ///
-    /// `elapsed_ms` is passed rather than read so the floor is testable without
-    /// a clock, in the way `Face::decide` takes its facts as arguments.
-    pub fn at_after(
-        &self,
-        now: crate::core::search::SearchStage,
-        elapsed_ms: u128,
-    ) -> Option<String> {
+    /// Separate from `show` for the reason `Track::line` is: the rule worth
+    /// asserting is what a person sees, and stderr is a poor place to assert
+    /// it from.
+    pub fn at(&self, now: crate::core::search::SearchStage) -> Option<String> {
         use crate::core::search::SearchStage;
-        if !self.face.on || self.names.is_empty() || elapsed_ms < QUIET_FLOOR_MS {
+        if !self.face.on || self.names.is_empty() {
             return None;
         }
         let mut reached = false;
-        Some(
-            self.names
+        let lamps: Vec<(Lamp, &str)> = self
+            .names
+            .iter()
+            .map(|s| {
+                // Everything before the running stage is finished, and
+                // everything after it is not: a client that started watching
+                // late has missed the transitions and must still draw the
+                // truth, exactly as `Lamps::of` does.
+                let lamp = match (*s == now, reached) {
+                    (true, _) => {
+                        reached = true;
+                        Lamp::Running
+                    }
+                    (false, false) => Lamp::Done,
+                    (false, true) => Lamp::Waiting,
+                };
+                let name = match s {
+                    SearchStage::Embed => "embed",
+                    SearchStage::Retrieve => "retrieve",
+                    SearchStage::Rerank => "rerank",
+                };
+                (lamp, name)
+            })
+            .collect();
+        // The room `show`'s two columns of indent leave. Counted before the ink
+        // goes on, because by then a count of characters is not a count of
+        // columns — the same reason `ask::within` clips where it does.
+        let room = self.face.width.saturating_sub(2);
+        // Two columns for each lamp and its space, three between neighbours.
+        let wide: usize = lamps
+            .iter()
+            .map(|(_, n)| n.chars().count() + 2)
+            .sum::<usize>()
+            + 3 * lamps.len().saturating_sub(1);
+        // A terminal too narrow for the row gets the running stage alone, the
+        // way `divider` gives it the sentence without its rules. `show` erases
+        // one physical row, so a line that wrapped would leave its head above
+        // the results for good.
+        if wide > room {
+            let (lamp, name) = lamps
                 .iter()
-                .map(|s| {
-                    // Everything before the running stage is finished, and
-                    // everything after it is not: a client that started
-                    // watching late has missed the transitions and must still
-                    // draw the truth, exactly as `Lamps::of` does.
-                    let lamp = match (*s == now, reached) {
-                        (true, _) => {
-                            reached = true;
-                            Lamp::Running
-                        }
-                        (false, false) => Lamp::Done,
-                        (false, true) => Lamp::Waiting,
-                    };
-                    let name = match s {
-                        SearchStage::Embed => "embed",
-                        SearchStage::Retrieve => "retrieve",
-                        SearchStage::Rerank => "rerank",
-                    };
-                    // Drawn *and* said, like every other lamp in this file.
-                    self.face.lamp_line(lamp, name)
-                })
+                .find(|(l, _)| *l == Lamp::Running)
+                .or_else(|| lamps.last())?;
+            let said = clip(name, room.saturating_sub(2), self.face.unicode);
+            return Some(self.face.lamp_line(*lamp, &said));
+        }
+        Some(
+            lamps
+                .iter()
+                // Drawn *and* said, like every other lamp in this file.
+                .map(|(lamp, name)| self.face.lamp_line(*lamp, name))
                 .collect::<Vec<_>>()
                 .join("   "),
         )
@@ -383,7 +413,7 @@ impl Stages {
     /// On stderr and by rewriting the current line, for the reason `Track` is:
     /// the results this precedes have to stay in scrollback and stay pipeable.
     pub fn show(&mut self, now: crate::core::search::SearchStage) {
-        let Some(line) = self.at_after(now, self.began.elapsed().as_millis()) else {
+        let Some(line) = self.at(now) else {
             return;
         };
         use std::io::Write;
@@ -701,6 +731,7 @@ impl Face {
             let title = clip(
                 h.title.as_deref().unwrap_or("(untitled)"),
                 self.width.saturating_sub(26),
+                self.unicode,
             );
             let (bar, title) = match h.past_cliff {
                 true => (self.ink(DIM, &bar), self.ink(DIM, &title)),
@@ -778,7 +809,6 @@ impl Face {
         Stages {
             face: *self,
             names: Vec::new(),
-            began: std::time::Instant::now(),
             drawn: false,
         }
     }
@@ -922,9 +952,13 @@ mod tests {
     fn a_locale_that_does_not_say_utf8_gets_the_ascii_shapes() {
         let f = Face::decide(&always(), true, false, Some("C"));
         assert!(!f.unicode);
-        let drawn = f.render(&[hit("a", 0.9, false, false)], None);
+        // A title long enough to be clipped. The fixture was three characters
+        // wide and never reached the clip, which is how a hardcoded `…` sat on
+        // the one path in this renderer that draws a glyph nobody chose.
+        let long = "Betriebssysteme fuer Server und die Dienste die auf ihnen laufen";
+        let drawn = f.render(&[hit(long, 0.9, false, false)], None);
         assert!(
-            !drawn.contains('█') && !drawn.contains('┃'),
+            drawn.is_ascii(),
             "a drawing glyph reached a non-UTF-8 terminal: {drawn}"
         );
     }
@@ -1170,13 +1204,26 @@ mod tests {
     /// The narrow end of `clip`, which used to hand back the whole string.
     #[test]
     fn clipping_into_no_room_at_all_still_clips() {
-        assert_eq!(clip("Dienste", 7), "Dienste");
-        assert_eq!(clip("Dienste", 8), "Dienste");
-        assert_eq!(clip("Dienste", 6), "Diens…");
-        assert_eq!(clip("Dienste", 2), "D…");
-        assert_eq!(clip("Dienste", 1), "…");
-        assert_eq!(clip("Dienste", 0), "");
-        assert_eq!(clip("", 0), "");
+        assert_eq!(clip("Dienste", 7, true), "Dienste");
+        assert_eq!(clip("Dienste", 8, true), "Dienste");
+        assert_eq!(clip("Dienste", 6, true), "Diens…");
+        assert_eq!(clip("Dienste", 2, true), "D…");
+        assert_eq!(clip("Dienste", 1, true), "…");
+        assert_eq!(clip("Dienste", 0, true), "");
+        assert_eq!(clip("", 0, true), "");
+    }
+
+    /// The marker is a glyph like any other here, and the row it ends is
+    /// counted in columns either way.
+    #[test]
+    fn a_clip_on_an_ascii_terminal_ends_in_ascii() {
+        for room in 0..8 {
+            let out = clip("Dienste", room, false);
+            assert!(out.is_ascii(), "room {room}: {out:?}");
+            assert!(out.chars().count() <= room, "room {room}: {out:?}");
+        }
+        assert_eq!(clip("Dienste", 6, false), "Die...");
+        assert_eq!(clip("Dienste", 2, false), "..");
     }
 
     /// The two lines a list spends are two lines that carry text.
@@ -1292,7 +1339,7 @@ mod tests {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
         let mut s = f.stages();
         s.start(&[Embed, Retrieve, Rerank]);
-        let line = s.at_after(Retrieve, 500).expect("a line");
+        let line = s.at(Retrieve).expect("a line");
         assert!(line.contains("embed") && line.contains("retrieve") && line.contains("rerank"));
         assert!(
             line.contains('●'),
@@ -1310,20 +1357,46 @@ mod tests {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
         let mut s = f.stages();
         s.start(&[Embed, Retrieve]);
-        let line = s.at_after(Retrieve, 500).expect("a line");
+        let line = s.at(Retrieve).expect("a line");
         assert!(!line.contains("rerank"), "{line}");
     }
 
-    /// Most searches come back inside the floor, and a display that flickers
-    /// on and off is worse than none.
+    /// The first stage is drawn the moment it is reported. A floor on the
+    /// elapsed time, read at the instant of a frame, took the whole display
+    /// away from the search that most needed it: a cold embedder drew nothing
+    /// at all until `retrieve` started.
     #[test]
-    fn a_search_answered_inside_the_quiet_floor_draws_nothing() {
+    fn the_first_stage_is_drawn_as_soon_as_it_is_reported() {
         use crate::core::search::SearchStage::*;
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
         let mut s = f.stages();
         s.start(&[Embed, Retrieve]);
-        assert!(s.at_after(Embed, 40).is_none());
-        assert!(s.at_after(Retrieve, 300).is_some());
+        assert!(s.at(Embed).is_some());
+    }
+
+    /// `show` erases one physical row, so a stage line wider than the terminal
+    /// left its head above the results for good — the failure a note is
+    /// clipped to prevent, one type over.
+    #[test]
+    fn a_stage_line_wider_than_the_terminal_is_cut_down_rather_than_wrapped() {
+        use crate::core::search::SearchStage::*;
+        for width in 4..40 {
+            let f = Face {
+                width,
+                ..Face::decide(&always(), true, false, Some("en_US.UTF-8"))
+            };
+            let mut s = f.stages();
+            s.start(&[Embed, Retrieve, Rerank]);
+            let line = s.at(Retrieve).expect("a line");
+            assert!(
+                strip_sgr(&line).chars().count() + 2 <= width,
+                "width {width}: {line:?}"
+            );
+            assert!(
+                width < 10 || strip_sgr(&line).contains("retr"),
+                "width {width}: the running stage is the one it keeps: {line:?}"
+            );
+        }
     }
 
     #[test]
@@ -1332,7 +1405,7 @@ mod tests {
         let off = Face::decide(&Default::default(), false, false, None);
         let mut s = off.stages();
         s.start(&[Embed, Retrieve]);
-        assert!(s.at_after(Embed, 5_000).is_none());
+        assert!(s.at(Embed).is_none());
     }
 
     /// `NO_COLOR` is about ink. It used to take the lamps, the upload track and

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -637,7 +637,11 @@ impl Face {
         if !self.on {
             return crate::cli::search::render_plain(hits);
         }
-        let (full, empty) = if self.unicode { ('▇', '░') } else { ('#', '.') };
+        let (full, empty) = if self.unicode {
+            ('▇', '░')
+        } else {
+            ('#', '.')
+        };
         // The list is its own scale. A score here is a fused rank rather than a
         // probability — `search::prime` says so about the same numbers — and a
         // whole list of them is routinely negative, so a fixed `0.0..=1.0`
@@ -648,7 +652,11 @@ impl Face {
         // Both halves measured: the count is the list, the time is what the
         // client timed. The query is not echoed — a terminal already has the
         // command that produced this two lines up, which a page does not.
-        let mut head = format!("{} hit{}", hits.len(), if hits.len() == 1 { "" } else { "s" });
+        let mut head = format!(
+            "{} hit{}",
+            hits.len(),
+            if hits.len() == 1 { "" } else { "s" }
+        );
         if let Some(ms) = elapsed_ms {
             head.push_str(&format!(" · {ms} ms"));
         }
@@ -781,7 +789,6 @@ impl Face {
             drawn: false,
         }
     }
-
 }
 
 #[cfg(test)]
@@ -1024,7 +1031,10 @@ mod tests {
     #[test]
     fn the_cliff_is_said_where_it_falls() {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
-        let drawn = f.render(&[hit("a", 0.9, false, false), hit("b", 0.2, true, true)], None);
+        let drawn = f.render(
+            &[hit("a", 0.9, false, false), hit("b", 0.2, true, true)],
+            None,
+        );
         // A mark made only of glyphs is a mark a screen reader, a screenshot
         // and a monochrome terminal never reach. The trace that used to break
         // here was exactly that, and the sentence says what it was for.
@@ -1065,14 +1075,20 @@ mod tests {
         h.artifact_id = "01J8Z4K2QW7NR3T9X0YB5C6D8E".into();
         let drawn = f.render(&[h], None);
         assert!(drawn.contains("01J8Z4K2"), "{drawn}");
-        assert!(!drawn.contains("01J8Z4K2QW"), "the whole id crowds the title: {drawn}");
+        assert!(
+            !drawn.contains("01J8Z4K2QW"),
+            "the whole id crowds the title: {drawn}"
+        );
     }
 
     /// Both halves of the header are measurements. Nothing else belongs in it.
     #[test]
     fn the_header_says_what_was_counted_and_what_was_timed() {
         let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
-        let drawn = f.render(&[hit("a", 0.9, false, false), hit("b", 0.2, false, false)], Some(412));
+        let drawn = f.render(
+            &[hit("a", 0.9, false, false), hit("b", 0.2, false, false)],
+            Some(412),
+        );
         assert!(drawn.contains("2 hits"), "{drawn}");
         assert!(drawn.contains("412 ms"), "{drawn}");
         // A client that timed nothing says nothing about time.
@@ -1096,7 +1112,10 @@ mod tests {
                   Aufgaben geeignet."
             .into();
         let drawn = f.render(&[h], None);
-        assert!(drawn.contains("zeitaufwendige"), "the tail was cut: {drawn}");
+        assert!(
+            drawn.contains("zeitaufwendige"),
+            "the tail was cut: {drawn}"
+        );
         for line in drawn.lines() {
             assert!(line.chars().count() <= 40, "over the width: {line:?}");
         }
@@ -1115,7 +1134,10 @@ mod tests {
         h.text = "Betriebssysteme f\u{fc}r Server\n\nDienste bezeichnen Anwendungen.\n".into();
         let drawn = f.render(&[h], None);
         assert!(drawn.contains("Betriebssysteme"), "{drawn}");
-        assert!(drawn.contains("Dienste bezeichnen"), "second line lost: {drawn}");
+        assert!(
+            drawn.contains("Dienste bezeichnen"),
+            "second line lost: {drawn}"
+        );
     }
 
     #[test]
@@ -1123,7 +1145,10 @@ mod tests {
         // The boundary that keeps the plain form the only one a script sees.
         let hits = [hit("a", 0.9, false, false), hit("b", 0.2, true, true)];
         let off = Face::decide(&Default::default(), false, false, Some("en_US.UTF-8"));
-        assert_eq!(off.render(&hits, None), crate::cli::search::render_plain(&hits));
+        assert_eq!(
+            off.render(&hits, None),
+            crate::cli::search::render_plain(&hits)
+        );
     }
 
     /// POSIX precedence, which is not what this used to read.
@@ -1211,7 +1236,10 @@ mod tests {
         s.start(&[Embed, Retrieve, Rerank]);
         let line = s.at_after(Retrieve, 500).expect("a line");
         assert!(line.contains("embed") && line.contains("retrieve") && line.contains("rerank"));
-        assert!(line.contains('●'), "the stage before it is finished: {line}");
+        assert!(
+            line.contains('●'),
+            "the stage before it is finished: {line}"
+        );
         assert!(line.contains('◉'), "the stage running: {line}");
         assert!(line.contains('·'), "the stage still to come: {line}");
     }
@@ -1296,4 +1324,3 @@ mod tests {
         }
     }
 }
-

--- a/src/cli/face.rs
+++ b/src/cli/face.rs
@@ -55,6 +55,7 @@ fn clip(s: &str, room: usize) -> String {
 /// `app.css` composes on `#0e1015` and nowhere else.
 const BOLD: &str = "1";
 const DIM: &str = "2";
+const GREEN: &str = "32";
 const CYAN: &str = "36";
 const RESET: &str = "\u{1b}[0m";
 
@@ -96,6 +97,22 @@ pub enum Lamp {
     Stopped,
 }
 
+/// One lamp, drawn. A free function because the capture stages and the search
+/// stages are the same vocabulary seen at two doors, and two tables of glyphs
+/// would drift.
+fn lamp_glyph(l: Lamp, unicode: bool) -> char {
+    match (l, unicode) {
+        (Lamp::Waiting, true) => '·',
+        (Lamp::Running, true) => '◉',
+        (Lamp::Done, true) => '●',
+        (Lamp::Stopped, true) => '×',
+        (Lamp::Waiting, false) => '.',
+        (Lamp::Running, false) => 'o',
+        (Lamp::Done, false) => 'O',
+        (Lamp::Stopped, false) => 'x',
+    }
+}
+
 /// Extraction, segmentation and embedding — the three stages `-c --watch`
 /// follows, drawn from the one status the server reports.
 ///
@@ -129,20 +146,10 @@ impl Lamps {
     /// One line, drawn and said. The words are the claim; the glyphs are how
     /// you see at a glance which of the three is moving.
     pub fn render(&self, unicode: bool) -> String {
-        let glyph = |l: Lamp| match (l, unicode) {
-            (Lamp::Waiting, true) => '·',
-            (Lamp::Running, true) => '◉',
-            (Lamp::Done, true) => '●',
-            (Lamp::Stopped, true) => '×',
-            (Lamp::Waiting, false) => '.',
-            (Lamp::Running, false) => 'o',
-            (Lamp::Done, false) => 'O',
-            (Lamp::Stopped, false) => 'x',
-        };
         ["extract", "segment", "embed"]
             .iter()
             .zip(self.0)
-            .map(|(name, lamp)| format!("{} {name}", glyph(lamp)))
+            .map(|(name, lamp)| format!("{} {name}", lamp_glyph(lamp, unicode)))
             .collect::<Vec<_>>()
             .join("  ")
     }
@@ -262,6 +269,121 @@ impl Track {
             std::io::stderr().flush().ok();
             self.drawn = false;
         }
+    }
+}
+
+/// How long a search may take before anything at all is drawn.
+///
+/// Most searches on a warm box come back inside this, and a display that
+/// appears and disappears inside a tenth of a second is worse than no display:
+/// it reads as a flicker, not as progress. Nothing here delays a result — the
+/// floor decides what is drawn, never when the answer is printed.
+const QUIET_FLOOR_MS: u128 = 120;
+
+/// The stages of one search, redrawn in place as the server names them.
+///
+/// Holds no timer and invents no frames: it is redrawn from events that
+/// arrived, so it cannot run ahead of the work. The stages themselves are the
+/// server's to name — whether a rerank happens is decided there — so a lamp is
+/// never drawn for work that is not going to run.
+pub struct Stages {
+    on: bool,
+    color: bool,
+    unicode: bool,
+    names: Vec<crate::core::search::SearchStage>,
+    began: std::time::Instant,
+    drawn: bool,
+}
+
+impl Stages {
+    /// The stages this search said it will pass through.
+    pub fn start(&mut self, names: &[crate::core::search::SearchStage]) {
+        self.names = names.to_vec();
+    }
+
+    /// What this frame would draw, or `None` — the face is off, or the search
+    /// is still inside the quiet floor.
+    ///
+    /// `elapsed_ms` is passed rather than read so the floor is testable without
+    /// a clock, in the way `Face::decide` takes its facts as arguments.
+    pub fn at_after(
+        &self,
+        now: crate::core::search::SearchStage,
+        elapsed_ms: u128,
+    ) -> Option<String> {
+        use crate::core::search::SearchStage;
+        if !self.on || self.names.is_empty() || elapsed_ms < QUIET_FLOOR_MS {
+            return None;
+        }
+        let mut reached = false;
+        Some(
+            self.names
+                .iter()
+                .map(|s| {
+                    // Everything before the running stage is finished, and
+                    // everything after it is not: a client that started
+                    // watching late has missed the transitions and must still
+                    // draw the truth, exactly as `Lamps::of` does.
+                    let lamp = match (*s == now, reached) {
+                        (true, _) => {
+                            reached = true;
+                            Lamp::Running
+                        }
+                        (false, false) => Lamp::Done,
+                        (false, true) => Lamp::Waiting,
+                    };
+                    let name = match s {
+                        SearchStage::Embed => "embed",
+                        SearchStage::Retrieve => "retrieve",
+                        SearchStage::Rerank => "rerank",
+                    };
+                    // Drawn *and* said, like every other lamp in this file.
+                    let cell = format!("{} {name}", lamp_glyph(lamp, self.unicode));
+                    let code = match lamp {
+                        Lamp::Running => CYAN,
+                        Lamp::Done => GREEN,
+                        _ => DIM,
+                    };
+                    match self.color {
+                        true => format!("\u{1b}[{code}m{cell}{RESET}"),
+                        false => cell,
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("   "),
+        )
+    }
+
+    /// Draw this frame's stage over the last one.
+    ///
+    /// On stderr and by rewriting the current line, for the reason `Track` is:
+    /// the results this precedes have to stay in scrollback and stay pipeable.
+    pub fn show(&mut self, now: crate::core::search::SearchStage) {
+        let Some(line) = self.at_after(now, self.began.elapsed().as_millis()) else {
+            return;
+        };
+        use std::io::Write;
+        eprint!("\r\u{1b}[2K  {line}");
+        std::io::stderr().flush().ok();
+        self.drawn = true;
+    }
+
+    /// Take the line back before anything else prints.
+    pub fn clear(&mut self) {
+        if self.drawn {
+            use std::io::Write;
+            eprint!("\r\u{1b}[2K");
+            std::io::stderr().flush().ok();
+            self.drawn = false;
+        }
+    }
+}
+
+/// Taken back on drop, the way `Fill` is: a search that fails partway leaves
+/// its error under a stage line describing work that stopped.
+impl Drop for Stages {
+    fn drop(&mut self) {
+        self.clear();
     }
 }
 
@@ -578,6 +700,18 @@ impl Face {
             marks: Vec::new(),
             col: 0,
             tail: 0,
+        }
+    }
+
+    /// The stages of one search, for a client reading the streaming door.
+    pub fn stages(&self) -> Stages {
+        Stages {
+            on: self.on,
+            color: self.color,
+            unicode: self.unicode,
+            names: Vec::new(),
+            began: std::time::Instant::now(),
+            drawn: false,
         }
     }
 
@@ -1112,6 +1246,53 @@ mod tests {
     fn ink_is_a_no_op_without_colour() {
         assert_eq!(drawn(false).ink(CYAN, "x"), "x");
         assert_eq!(drawn(true).ink(CYAN, "x"), "\u{1b}[36mx\u{1b}[0m");
+    }
+
+    /// The stage line is drawn and said, like every other lamp in this file.
+    #[test]
+    fn a_stage_line_names_every_stage_and_marks_the_one_that_is_running() {
+        use crate::core::search::SearchStage::*;
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let mut s = f.stages();
+        s.start(&[Embed, Retrieve, Rerank]);
+        let line = s.at_after(Retrieve, 500).expect("a line");
+        assert!(line.contains("embed") && line.contains("retrieve") && line.contains("rerank"));
+        assert!(line.contains('●'), "the stage before it is finished: {line}");
+        assert!(line.contains('◉'), "the stage running: {line}");
+        assert!(line.contains('·'), "the stage still to come: {line}");
+    }
+
+    /// The client draws what it was told and nothing more: a search that named
+    /// two stages never grows a third.
+    #[test]
+    fn only_the_stages_the_server_named_are_drawn() {
+        use crate::core::search::SearchStage::*;
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let mut s = f.stages();
+        s.start(&[Embed, Retrieve]);
+        let line = s.at_after(Retrieve, 500).expect("a line");
+        assert!(!line.contains("rerank"), "{line}");
+    }
+
+    /// Most searches come back inside the floor, and a display that flickers
+    /// on and off is worse than none.
+    #[test]
+    fn a_search_answered_inside_the_quiet_floor_draws_nothing() {
+        use crate::core::search::SearchStage::*;
+        let f = Face::decide(&always(), true, false, Some("en_US.UTF-8"));
+        let mut s = f.stages();
+        s.start(&[Embed, Retrieve]);
+        assert!(s.at_after(Embed, 40).is_none());
+        assert!(s.at_after(Retrieve, 300).is_some());
+    }
+
+    #[test]
+    fn a_face_that_is_off_draws_no_stage_at_all() {
+        use crate::core::search::SearchStage::*;
+        let off = Face::decide(&Default::default(), false, false, None);
+        let mut s = off.stages();
+        s.start(&[Embed, Retrieve]);
+        assert!(s.at_after(Embed, 5_000).is_none());
     }
 
     /// `NO_COLOR` is about ink. It used to take the lamps, the upload track and

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ pub mod face;
 pub mod last;
 pub mod search;
 pub mod show;
+pub mod status;
 #[cfg(test)]
 pub(crate) mod test_support;
 
@@ -115,6 +116,13 @@ pub async fn run(verb: args::Verb, cli: &args::CliArgs) -> i32 {
             }
         }
         args::Verb::Show(which) => match show::run(&endpoint, &which, last::load()).await {
+            Ok(code) => code,
+            Err(e) => {
+                eprintln!("{e}");
+                2
+            }
+        },
+        args::Verb::Status => match status::run(&endpoint, &face, cli.json).await {
             Ok(code) => code,
             Err(e) => {
                 eprintln!("{e}");

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -79,7 +79,7 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
         // would be a second definition of the response shape.
         println!("{body}");
     } else {
-        print!("{}", face.render(&hits));
+        print!("{}", face.render(&hits, None));
     }
     // `1` for nothing found, so `engram -s "x" || …` is a usable branch.
     Ok(if hits.is_empty() { 1 } else { 0 })

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -20,13 +20,7 @@ pub fn stream_url(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs
     url_for(e, "/search/stream", limit, query, cli)
 }
 
-fn url_for(
-    e: &Endpoint,
-    path: &str,
-    limit: Option<usize>,
-    query: &str,
-    cli: &CliArgs,
-) -> String {
+fn url_for(e: &Endpoint, path: &str, limit: Option<usize>, query: &str, cli: &CliArgs) -> String {
     // `door=cli` rather than the default `api`: a query typed at a shell is
     // composed before anything came back, which is the least contaminated
     // question the base receives, and the judge queue should be able to tell.
@@ -254,9 +248,7 @@ pub(crate) fn excerpt(text: &str, budget: usize, width: usize) -> Vec<String> {
         for word in line.split_whitespace() {
             match out.last_mut() {
                 // `+ 1` is the space that joining would add.
-                Some(last)
-                    if !fresh && last.chars().count() + 1 + word.chars().count() <= room =>
-                {
+                Some(last) if !fresh && last.chars().count() + 1 + word.chars().count() <= room => {
                     last.push(' ');
                     last.push_str(word);
                 }
@@ -341,7 +333,10 @@ mod tests {
         h.text = "One\n\nTwo\n\nThree\n\nFour".into();
         let out = render_plain(&[h]);
         assert!(out.contains("Three"), "{out}");
-        assert!(!out.contains("Four"), "a fourth line is past the budget: {out}");
+        assert!(
+            !out.contains("Four"),
+            "a fourth line is past the budget: {out}"
+        );
     }
 
     #[test]
@@ -447,7 +442,12 @@ mod tests {
             ..Default::default()
         };
         let face = crate::cli::face::Face::decide(&cli, false, false, None);
-        assert!(streaming(&e, None, "journal", &cli, &face).await.unwrap().is_none());
+        assert!(
+            streaming(&e, None, "journal", &cli, &face)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -12,10 +12,25 @@ use crate::error::{Error, Result};
 /// Its own function because one test asserts the door this client claims, and a
 /// whole request is a poor place to assert it from.
 pub fn query_url(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs) -> String {
+    url_for(e, "/search", limit, query, cli)
+}
+
+/// The same search, at the door that reports its stages.
+pub fn stream_url(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs) -> String {
+    url_for(e, "/search/stream", limit, query, cli)
+}
+
+fn url_for(
+    e: &Endpoint,
+    path: &str,
+    limit: Option<usize>,
+    query: &str,
+    cli: &CliArgs,
+) -> String {
     // `door=cli` rather than the default `api`: a query typed at a shell is
     // composed before anything came back, which is the least contaminated
     // question the base receives, and the judge queue should be able to tell.
-    let mut url = format!("{}?q={}&door=cli", e.api("/search"), encode(query));
+    let mut url = format!("{}?q={}&door=cli", e.api(path), encode(query));
     if let Some(n) = limit {
         url.push_str(&format!("&limit={n}"));
     }
@@ -29,10 +44,6 @@ pub fn query_url(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
 }
 
 pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs) -> Result<i32> {
-    let http = reqwest::Client::builder()
-        .user_agent(USER_AGENT)
-        .build()
-        .map_err(|err| Error::Internal(format!("http client: {err}")))?;
     let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
     let face = crate::cli::face::Face::decide(
         cli,
@@ -40,15 +51,128 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
         std::env::var_os("NO_COLOR").is_some(),
         crate::cli::face::locale().as_deref(),
     );
-    let waiting = face.pulse("searching");
+    // `--json` never streams: its reader wants the server's own body, and
+    // frames are of no use to it.
+    let streamed = match cli.json {
+        true => None,
+        false => streaming(e, limit, query, cli, &face).await?,
+    };
+    let (hits, elapsed, body) = match streamed {
+        Some((hits, ms)) => (hits, Some(ms), None),
+        // The door every version of the server has had. Reached when this one
+        // does not know the streaming route, when the transport failed before a
+        // frame arrived, or when the search was refused — and in that last case
+        // it is this door that says why, in the words it has always used.
+        None => {
+            let (hits, ms, body) = plain(e, limit, query, cli).await?;
+            (hits, Some(ms), Some(body))
+        }
+    };
+
+    // What `--show 3` will mean. Written before anything is printed, so the
+    // list on screen and the list on disk cannot disagree, and only for a
+    // search a person watched: see `last::worth_remembering`.
+    if crate::cli::last::worth_remembering(is_tty, cli.json) {
+        crate::cli::last::save(query, hits.iter().map(|h| h.artifact_id.clone()).collect());
+    }
+
+    match body {
+        // The server's own JSON, unchanged. A client that re-serialised it
+        // would be a second definition of the response shape.
+        Some(body) if cli.json => println!("{body}"),
+        _ => print!("{}", face.render(&hits, elapsed)),
+    }
+    // `1` for nothing found, so `engram -s "x" || …` is a usable branch.
+    Ok(if hits.is_empty() { 1 } else { 0 })
+}
+
+/// The streaming door: the hits and what the whole round trip took, or `None`
+/// where this client should ask the plain one instead.
+///
+/// Every failure is a `None` rather than an error. The plain door runs the same
+/// search and has said why a search was refused since before this one existed,
+/// so one code path reports failure and it is the older one. Nothing is
+/// recorded twice by falling back: a search that fails records nothing at all.
+async fn streaming(
+    e: &Endpoint,
+    limit: Option<usize>,
+    query: &str,
+    cli: &CliArgs,
+    face: &crate::cli::face::Face,
+) -> Result<Option<(Vec<SearchResult>, u128)>> {
+    use tokio_stream::StreamExt as _;
+    let http = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|err| Error::Internal(format!("http client: {err}")))?;
+    let began = std::time::Instant::now();
+    let res = http
+        .get(stream_url(e, limit, query, cli))
+        .bearer_auth(&e.token)
+        .send()
+        .await;
+    let res = match res {
+        Ok(r) if r.status().is_success() => r,
+        _ => return Ok(None),
+    };
+
+    let mut stages = face.stages();
+    let mut body = res.bytes_stream();
+    // Two buffers, for the reason `ask` keeps two: a chunk from the network is
+    // cut at neither boundary that matters.
+    let mut pending: Vec<u8> = Vec::new();
+    let mut buf = String::new();
+    let mut hits: Option<Vec<SearchResult>> = None;
+    while let Some(chunk) = body.next().await {
+        let Ok(chunk) = chunk else { return Ok(None) };
+        pending.extend_from_slice(&chunk);
+        buf.push_str(&crate::cli::ask::decode(&mut pending)?);
+        for (name, data) in crate::cli::ask::frames(&mut buf) {
+            match name.as_str() {
+                "stages" => {
+                    let named: Vec<crate::core::search::SearchStage> =
+                        serde_json::from_value(data["stages"].clone()).unwrap_or_default();
+                    stages.start(&named);
+                }
+                "stage" => {
+                    if let Ok(now) = serde_json::from_value(data["stage"].clone()) {
+                        stages.show(now);
+                    }
+                }
+                "results" => {
+                    hits = serde_json::from_value(data["results"].clone()).ok();
+                }
+                // Said by the plain door, which is about to run this search
+                // again and refuse it in the words it has always used.
+                "error" => return Ok(None),
+                _ => {}
+            }
+        }
+    }
+    // Taken back before a result lands on top of half a stage line.
+    stages.clear();
+    Ok(hits.map(|h| (h, began.elapsed().as_millis())))
+}
+
+/// The door every version of the server has had, and the one that says why a
+/// search was refused. Answers the body as well, for `--json`.
+async fn plain(
+    e: &Endpoint,
+    limit: Option<usize>,
+    query: &str,
+    cli: &CliArgs,
+) -> Result<(Vec<SearchResult>, u128, String)> {
+    let http = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|err| Error::Internal(format!("http client: {err}")))?;
+    let began = std::time::Instant::now();
     let res = http
         .get(query_url(e, limit, query, cli))
         .bearer_auth(&e.token)
         .send()
-        .await;
-    // The response is here; the animation ends now, before anything is printed.
-    drop(waiting);
-    let res = res.map_err(|err| Error::Validation(format!("{err}")))?;
+        .await
+        .map_err(|err| Error::Validation(format!("{err}")))?;
     let status = res.status();
     let body = res
         .text()
@@ -66,23 +190,7 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
     }
     let hits: Vec<SearchResult> =
         serde_json::from_str(&body).map_err(|err| Error::Internal(format!("results: {err}")))?;
-
-    // What `--show 3` will mean. Written before anything is printed, so the
-    // list on screen and the list on disk cannot disagree, and only for a
-    // search a person watched: see `last::worth_remembering`.
-    if crate::cli::last::worth_remembering(is_tty, cli.json) {
-        crate::cli::last::save(query, hits.iter().map(|h| h.artifact_id.clone()).collect());
-    }
-
-    if cli.json {
-        // The server's own JSON, unchanged. A client that re-serialised it
-        // would be a second definition of the response shape.
-        println!("{body}");
-    } else {
-        print!("{}", face.render(&hits, None));
-    }
-    // `1` for nothing found, so `engram -s "x" || …` is a usable branch.
-    Ok(if hits.is_empty() { 1 } else { 0 })
+    Ok((hits, began.elapsed().as_millis(), body))
 }
 
 /// The form a pipe, a test and a script see.
@@ -279,6 +387,69 @@ mod tests {
         );
     }
 
+    /// The streaming door is the same search, so it has to answer with the
+    /// same hits in the same order — and the fallback has to be reachable
+    /// without either of them saying anything different.
+    #[tokio::test]
+    async fn both_doors_answer_one_search_the_same_way() {
+        let (url, token, core) = crate::cli::test_support::serve_test_app().await;
+        let e = Endpoint { url, token };
+        let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
+        let made = core
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "the journal is a ring buffer on disk".into(),
+                    corpus_span: None,
+                    title: Some("journald".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap();
+        for c in &made {
+            crate::jobs::embed::run(&core, &c.id).await.unwrap();
+        }
+        let cli = CliArgs {
+            plain: true,
+            ..Default::default()
+        };
+        let face = crate::cli::face::Face::decide(&cli, false, false, None);
+        let (streamed, _ms) = streaming(&e, None, "journal", &cli, &face)
+            .await
+            .unwrap()
+            .expect("the streaming door answered");
+        let (plainly, _ms, _body) = plain(&e, None, "journal", &cli).await.unwrap();
+        assert!(!streamed.is_empty(), "the base holds one artifact");
+        assert_eq!(
+            streamed.iter().map(|h| &h.artifact_id).collect::<Vec<_>>(),
+            plainly.iter().map(|h| &h.artifact_id).collect::<Vec<_>>()
+        );
+    }
+
+    /// A server that has never heard of the streaming route is answered by
+    /// falling back, not by failing.
+    #[tokio::test]
+    async fn a_door_that_is_not_there_falls_back_rather_than_failing() {
+        let (url, token, _core) = crate::cli::test_support::serve_test_app().await;
+        // A path the router does not know: the same 404 an older server gives.
+        let e = Endpoint {
+            url: format!("{url}/nowhere"),
+            token,
+        };
+        let cli = CliArgs {
+            plain: true,
+            ..Default::default()
+        };
+        let face = crate::cli::face::Face::decide(&cli, false, false, None);
+        assert!(streaming(&e, None, "journal", &cli, &face).await.unwrap().is_none());
+    }
+
     #[test]
     fn the_client_claims_the_cli_door_and_asks_as_wide_as_it_was_told() {
         let e = Endpoint {
@@ -287,6 +458,9 @@ mod tests {
         };
         let url = query_url(&e, Some(40), "loop device", &Default::default());
         assert!(url.contains("door=cli"), "{url}");
+        let streaming = stream_url(&e, Some(40), "loop device", &Default::default());
+        assert!(streaming.contains("/search/stream?"), "{streaming}");
+        assert!(streaming.contains("door=cli"), "{streaming}");
         assert!(url.contains("limit=40"), "{url}");
         assert!(url.contains("q=loop%20device"), "{url}");
     }

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -83,10 +83,16 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
 /// The streaming door: the hits and what the whole round trip took, or `None`
 /// where this client should ask the plain one instead.
 ///
-/// Every failure is a `None` rather than an error. The plain door runs the same
-/// search and has said why a search was refused since before this one existed,
-/// so one code path reports failure and it is the older one. Nothing is
-/// recorded twice by falling back: a search that fails records nothing at all.
+/// A failure before the search ran is a `None` rather than an error. The plain
+/// door runs the same search and has said why a search was refused since before
+/// this one existed, so one code path reports failure and it is the older one.
+///
+/// A failure after it ran is an error, and this is the whole of the difference.
+/// The server yields `results` only once `search_inner` has returned, so that
+/// frame is the line between "nothing happened" and "the search completed and
+/// the learning layer wrote the event down". Falling back across that line ran
+/// the same query a second time and recorded it a second time, which is a
+/// duplicate in the data nobody typed and nobody can tell from a real repeat.
 async fn streaming(
     e: &Endpoint,
     limit: Option<usize>,
@@ -117,8 +123,16 @@ async fn streaming(
     let mut pending: Vec<u8> = Vec::new();
     let mut buf = String::new();
     let mut hits: Option<Vec<SearchResult>> = None;
+    // Whether a `results` frame has been seen at all — not whether it could be
+    // read. Once the server has sent one the search is behind us either way.
+    let mut ran = false;
     while let Some(chunk) = body.next().await {
-        let Ok(chunk) = chunk else { return Ok(None) };
+        let chunk = match chunk {
+            Ok(c) => c,
+            // Nothing has been recorded yet, so the older door can run it.
+            Err(_) if !ran => return Ok(None),
+            Err(err) => return Err(Error::Validation(format!("{err}"))),
+        };
         pending.extend_from_slice(&chunk);
         buf.push_str(&crate::cli::ask::decode(&mut pending)?);
         for (name, data) in crate::cli::ask::frames(&mut buf) {
@@ -134,6 +148,7 @@ async fn streaming(
                     }
                 }
                 "results" => {
+                    ran = true;
                     hits = serde_json::from_value(data["results"].clone()).ok();
                 }
                 // Said by the plain door, which is about to run this search
@@ -145,7 +160,17 @@ async fn streaming(
     }
     // Taken back before a result lands on top of half a stage line.
     stages.clear();
-    Ok(hits.map(|h| (h, began.elapsed().as_millis())))
+    match (hits, ran) {
+        (Some(h), _) => Ok(Some((h, began.elapsed().as_millis()))),
+        // A results frame arrived and could not be read. The search is already
+        // recorded, so the plain door must not be asked to run it again.
+        (None, true) => Err(Error::Validation(
+            "the search answered in a shape this client could not read".into(),
+        )),
+        // The stream ended before the search finished. Nothing was recorded and
+        // the older door can be asked cleanly.
+        (None, false) => Ok(None),
+    }
 }
 
 /// The door every version of the server has had, and the one that says why a

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -88,11 +88,18 @@ pub async fn run(e: &Endpoint, limit: Option<usize>, query: &str, cli: &CliArgs)
 /// this one existed, so one code path reports failure and it is the older one.
 ///
 /// A failure after it ran is an error, and this is the whole of the difference.
-/// The server yields `results` only once `search_inner` has returned, so that
-/// frame is the line between "nothing happened" and "the search completed and
-/// the learning layer wrote the event down". Falling back across that line ran
-/// the same query a second time and recorded it a second time, which is a
-/// duplicate in the data nobody typed and nobody can tell from a real repeat.
+/// Falling back across that line runs the same query a second time and records
+/// it a second time, which is a duplicate in the data nobody typed and nobody
+/// can tell from a real repeat — `record_search` coalesces the two typing
+/// doors and not this one, so a shell's duplicate never folds.
+///
+/// The line is drawn at the first `stage` frame rather than at `results`,
+/// which is later than it needs to be and is the point. `record_search` is
+/// spawned onto the server's background inside `search_inner`, before the
+/// `results` frame is yielded and out of reach of the client hanging up, so a
+/// transport that dies in that window has recorded a search this client never
+/// saw. A stage frame proves the search is running over there; from then on
+/// the honest answer to a dead stream is to say so, not to run it again.
 async fn streaming(
     e: &Endpoint,
     limit: Option<usize>,
@@ -123,8 +130,8 @@ async fn streaming(
     let mut pending: Vec<u8> = Vec::new();
     let mut buf = String::new();
     let mut hits: Option<Vec<SearchResult>> = None;
-    // Whether a `results` frame has been seen at all — not whether it could be
-    // read. Once the server has sent one the search is behind us either way.
+    // Whether this search may already have been written down over there. Set
+    // from the first stage frame, for the reason above, and never unset.
     let mut ran = false;
     while let Some(chunk) = body.next().await {
         let chunk = match chunk {
@@ -143,6 +150,7 @@ async fn streaming(
                     stages.start(&named);
                 }
                 "stage" => {
+                    ran = true;
                     if let Ok(now) = serde_json::from_value(data["stage"].clone()) {
                         stages.show(now);
                     }
@@ -152,7 +160,8 @@ async fn streaming(
                     hits = serde_json::from_value(data["results"].clone()).ok();
                 }
                 // Said by the plain door, which is about to run this search
-                // again and refuse it in the words it has always used.
+                // again and refuse it in the words it has always used. A
+                // refusal recorded nothing, whatever stages preceded it.
                 "error" => return Ok(None),
                 _ => {}
             }
@@ -162,12 +171,14 @@ async fn streaming(
     stages.clear();
     match (hits, ran) {
         (Some(h), _) => Ok(Some((h, began.elapsed().as_millis()))),
-        // A results frame arrived and could not be read. The search is already
-        // recorded, so the plain door must not be asked to run it again.
+        // The search started and its results never arrived here: a frame in a
+        // shape this client could not read, or a stream that stopped between
+        // the stages and the list. Either way it may already be recorded, so
+        // the plain door must not be asked to run it again.
         (None, true) => Err(Error::Validation(
-            "the search answered in a shape this client could not read".into(),
+            "the search ran and its results did not arrive".into(),
         )),
-        // The stream ended before the search finished. Nothing was recorded and
+        // The stream ended before the search started. Nothing was recorded and
         // the older door can be asked cleanly.
         (None, false) => Ok(None),
     }
@@ -472,6 +483,54 @@ mod tests {
                 .await
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    /// A stream that reported a stage and then died is not run again.
+    ///
+    /// The server spawns `record_search` onto its own background before the
+    /// `results` frame is yielded, and that spawn outlives the client hanging
+    /// up. Falling back here asked the plain door for the same query, which
+    /// records a second time — and `record_search` coalesces the two typing
+    /// doors and not the shell, so the duplicate is permanent.
+    #[tokio::test]
+    async fn a_stream_that_dies_after_a_stage_is_not_run_a_second_time() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("a port");
+        let addr = listener.local_addr().expect("the port it got");
+        tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt as _;
+            let (mut sock, _) = listener.accept().await.expect("a client");
+            // Enough of a chunked response to carry two frames, and then the
+            // socket goes away without its terminating chunk: a proxy timing
+            // out mid-search, seen from here.
+            let body = "event: stages\ndata: {\"stages\":[\"embed\",\"retrieve\"]}\n\n\
+                        event: stage\ndata: {\"stage\":\"embed\"}\n\n";
+            sock.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                     Transfer-Encoding: chunked\r\n\r\n{:x}\r\n{body}\r\n",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .ok();
+            sock.flush().await.ok();
+        });
+        let e = Endpoint {
+            url: format!("http://{addr}"),
+            token: "engram_x".into(),
+        };
+        let cli = CliArgs {
+            plain: true,
+            ..Default::default()
+        };
+        let face = crate::cli::face::Face::decide(&cli, false, false, None);
+        assert!(
+            streaming(&e, None, "journal", &cli, &face).await.is_err(),
+            "a search that started over there is reported, not repeated"
         );
     }
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -101,13 +101,13 @@ pub(crate) fn render(face: &Face, e: &Endpoint, s: &serde_json::Value) -> String
         ));
         for f in failed.iter().take(10) {
             let stage = f["stage"].as_str().unwrap_or("?");
-            let subject: String = f["subject_id"]
+            let subject: String = f["target_id"]
                 .as_str()
                 .unwrap_or("")
                 .chars()
                 .take(8)
                 .collect();
-            let why = f["error"].as_str().unwrap_or("no reason recorded");
+            let why = f["last_error"].as_str().unwrap_or("no reason recorded");
             out.push_str(&format!("     {stage:<8} {subject:<10} {why}\n"));
         }
     }
@@ -205,13 +205,25 @@ mod tests {
         assert!(out.contains("3 artifacts written from pursuits"), "{out}");
     }
 
+    /// Serialised from the struct the server actually sends, not from a
+    /// hand-written object: the keys drifted once already, and a fixture that
+    /// spells them itself cannot notice.
+    fn failed(target_id: &str, last_error: Option<&str>) -> serde_json::Value {
+        serde_json::to_value(crate::store::jobs::FailedJob {
+            id: 1,
+            stage: "embed".into(),
+            target_id: target_id.into(),
+            attempts: 5,
+            last_error: last_error.map(str::to_string),
+        })
+        .expect("a failed job serialises")
+    }
+
     /// A failed job nobody can name is a failed job nobody can retry.
     #[test]
     fn a_failed_job_is_named_and_not_only_counted() {
         let mut b = body(serde_json::Value::Null);
-        b["failed"] = serde_json::json!([
-            {"stage": "embed", "subject_id": "01J8Z4K2QW7NR3T9", "error": "connection refused"}
-        ]);
+        b["failed"] = serde_json::json!([failed("01J8Z4K2QW7NR3T9", Some("connection refused"))]);
         let out = render(&face(), &endpoint(), &b);
         assert!(out.contains("1 failed jobs"), "{out}");
         assert!(out.contains("01J8Z4K2"), "{out}");
@@ -228,9 +240,7 @@ mod tests {
         let mut b = body(serde_json::json!({
             "pursuits_open": 7, "pursuits_unsatisfied": 4, "from_pursuits": 3, "gaps_open": 11
         }));
-        b["failed"] = serde_json::json!([
-            {"stage": "embed", "subject_id": "01J8Z4K2", "error": "connection refused"}
-        ]);
+        b["failed"] = serde_json::json!([failed("01J8Z4K2", Some("connection refused"))]);
         let stripped = crate::cli::face::strip_sgr(&render(&face(), &endpoint(), &b));
         assert_eq!(stripped, render(&bare, &endpoint(), &b));
     }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,0 +1,242 @@
+//! `--status`: what the base holds, what it is working through, and what it has
+//! been learning.
+//!
+//! One shot, and no ambient version of it. A footer under every search would
+//! make the cheapest door in the application pay a request for something nobody
+//! asked for at that moment.
+
+use crate::cli::endpoint::Endpoint;
+use crate::cli::face::{Face, Lamp};
+use crate::error::{Error, Result};
+
+/// Ask the server what it is doing, and say it.
+pub async fn run(e: &Endpoint, face: &Face, json: bool) -> Result<i32> {
+    let http = reqwest::Client::builder()
+        .user_agent(crate::cli::capture::USER_AGENT)
+        .build()
+        .map_err(|err| Error::Internal(format!("http client: {err}")))?;
+    let res = http
+        .get(e.api("/status"))
+        .bearer_auth(&e.token)
+        .send()
+        .await
+        .map_err(|err| Error::Validation(format!("{err}")))?;
+    let status = res.status();
+    let body = res
+        .text()
+        .await
+        .map_err(|err| Error::Validation(format!("{err}")))?;
+    if !status.is_success() {
+        return Err(Error::Validation(format!(
+            "the status was refused: {status}"
+        )));
+    }
+    if json {
+        // The server's own body, unchanged, by the rule `-s --json` follows.
+        println!("{body}");
+        return Ok(0);
+    }
+    let said: serde_json::Value =
+        serde_json::from_str(&body).map_err(|err| Error::Internal(format!("status: {err}")))?;
+    print!("{}", render(face, e, &said));
+    Ok(0)
+}
+
+/// The screen, as a string. Split from `run` for the reason every renderer in
+/// this module is: what is said is worth asserting, and it cannot be asserted
+/// through a function whose only output is stdout.
+pub(crate) fn render(face: &Face, e: &Endpoint, s: &serde_json::Value) -> String {
+    let mut out = String::new();
+    let host = e
+        .url
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/');
+    let held = format!(
+        "{} artifacts · {} vectors",
+        s["chunks"].as_i64().unwrap_or(0),
+        s["vectors"].as_u64().unwrap_or(0)
+    );
+    out.push_str(&format!("\n  {host}   {}\n\n", face.ink_dim(&held)));
+
+    // Corpora by status. `needs review` and `failed` are the two a person can
+    // act on, so they are the two that carry a colour — and they say their own
+    // names either way.
+    if let Some(rows) = s["sources"].as_array() {
+        out.push_str(&format!("  sources    {}\n", counts(face, rows)));
+    }
+    if let Some(rows) = s["jobs"].as_array() {
+        let mut line = counts(face, rows);
+        if let Some(age) = s["oldest_pending_secs"].as_i64() {
+            line.push_str(&format!(" · {}", face.ink_dim(&format!("oldest {}", ago(age)))));
+        }
+        out.push_str(&format!("  jobs       {line}\n"));
+    }
+
+    // Absent while `[learn]` is off, which is the honest answer: four zeroes
+    // read like a faculty failing, and one that was never switched on is not.
+    if let Some(l) = s["learning"].as_object() {
+        let n = |k: &str| l.get(k).and_then(serde_json::Value::as_i64).unwrap_or(0);
+        out.push_str(&format!(
+            "\n  learning   {} pursuits open · {} closed unsatisfied · {} gaps\n",
+            n("pursuits_open"),
+            n("pursuits_unsatisfied"),
+            n("gaps_open"),
+        ));
+        out.push_str(&format!(
+            "             {} artifacts written from pursuits\n",
+            n("from_pursuits")
+        ));
+    }
+
+    // The rows, not only the count: a failed job nobody can name is a failed
+    // job nobody can retry.
+    if let Some(failed) = s["failed"].as_array().filter(|f| !f.is_empty()) {
+        out.push_str(&format!(
+            "\n  {}\n",
+            face.lamp_line(Lamp::Stopped, &format!("{} failed jobs", failed.len()))
+        ));
+        for f in failed.iter().take(10) {
+            let stage = f["stage"].as_str().unwrap_or("?");
+            let subject: String = f["subject_id"]
+                .as_str()
+                .unwrap_or("")
+                .chars()
+                .take(8)
+                .collect();
+            let why = f["error"].as_str().unwrap_or("no reason recorded");
+            out.push_str(&format!("     {stage:<8} {subject:<10} {why}\n"));
+        }
+    }
+    out
+}
+
+/// `1 780 ready   3 embedding   2 failed`, with the two anyone can act on lit.
+fn counts(face: &Face, rows: &[serde_json::Value]) -> String {
+    rows.iter()
+        .filter_map(|r| {
+            let name = r.get(0)?.as_str()?;
+            let n = r.get(1)?.as_i64()?;
+            let said = format!("{n} {}", name.replace('_', " "));
+            Some(match name {
+                "failed" => face.ink_bad(&said),
+                "needs_review" => face.ink_caution(&said),
+                _ => said,
+            })
+        })
+        .collect::<Vec<_>>()
+        .join("   ")
+}
+
+/// A duration a person reads rather than a count of seconds.
+fn ago(secs: i64) -> String {
+    match secs {
+        s if s < 90 => format!("{s} s"),
+        s if s < 5_400 => format!("{} min", s / 60),
+        s if s < 172_800 => format!("{} h", s / 3_600),
+        s => format!("{} d", s / 86_400),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn endpoint() -> Endpoint {
+        Endpoint {
+            url: "https://engram.mikoshi.de".into(),
+            token: "engram_x".into(),
+        }
+    }
+
+    fn face() -> Face {
+        Face::decide(
+            &crate::cli::args::CliArgs {
+                fancy: crate::cli::args::Fancy::Always,
+                ..Default::default()
+            },
+            true,
+            false,
+            Some("en_US.UTF-8"),
+        )
+    }
+
+    fn body(learning: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "sources": [["ready", 1780], ["embedding", 3], ["needs_review", 1]],
+            "jobs": [["pending", 4], ["running", 1]],
+            "failed": [],
+            "oldest_pending_secs": 38,
+            "chunks": 1842,
+            "vectors": 1842,
+            "learning": learning,
+        })
+    }
+
+    /// A faculty that was never switched on is not a faculty at zero.
+    #[test]
+    fn nothing_is_said_about_learning_while_the_layer_is_off() {
+        let out = render(&face(), &endpoint(), &body(serde_json::Value::Null));
+        assert!(!out.contains("learning"), "{out}");
+        assert!(out.contains("1842 artifacts"), "{out}");
+        assert!(out.contains("engram.mikoshi.de"), "{out}");
+    }
+
+    /// The half that was invisible from a shell: a pursuit closed unsatisfied
+    /// is a hole somebody went looking through and did not fill.
+    #[test]
+    fn the_learning_half_is_counted_and_named() {
+        let out = render(
+            &face(),
+            &endpoint(),
+            &body(serde_json::json!({
+                "pursuits_open": 7,
+                "pursuits_unsatisfied": 4,
+                "from_pursuits": 3,
+                "gaps_open": 11
+            })),
+        );
+        assert!(out.contains("7 pursuits open"), "{out}");
+        assert!(out.contains("4 closed unsatisfied"), "{out}");
+        assert!(out.contains("11 gaps"), "{out}");
+        assert!(out.contains("3 artifacts written from pursuits"), "{out}");
+    }
+
+    /// A failed job nobody can name is a failed job nobody can retry.
+    #[test]
+    fn a_failed_job_is_named_and_not_only_counted() {
+        let mut b = body(serde_json::Value::Null);
+        b["failed"] = serde_json::json!([
+            {"stage": "embed", "subject_id": "01J8Z4K2QW7NR3T9", "error": "connection refused"}
+        ]);
+        let out = render(&face(), &endpoint(), &b);
+        assert!(out.contains("1 failed jobs"), "{out}");
+        assert!(out.contains("01J8Z4K2"), "{out}");
+        assert!(out.contains("connection refused"), "{out}");
+    }
+
+    /// Everything colour says here is said in words as well.
+    #[test]
+    fn the_screen_survives_having_every_escape_stripped() {
+        let bare = Face {
+            color: false,
+            ..face()
+        };
+        let mut b = body(serde_json::json!({
+            "pursuits_open": 7, "pursuits_unsatisfied": 4, "from_pursuits": 3, "gaps_open": 11
+        }));
+        b["failed"] = serde_json::json!([
+            {"stage": "embed", "subject_id": "01J8Z4K2", "error": "connection refused"}
+        ]);
+        let stripped = crate::cli::face::strip_sgr(&render(&face(), &endpoint(), &b));
+        assert_eq!(stripped, render(&bare, &endpoint(), &b));
+    }
+
+    #[test]
+    fn an_age_is_read_rather_than_counted_in_seconds() {
+        assert_eq!(ago(38), "38 s");
+        assert_eq!(ago(600), "10 min");
+        assert_eq!(ago(14_400), "4 h");
+        assert_eq!(ago(200_000), "2 d");
+    }
+}

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -68,7 +68,10 @@ pub(crate) fn render(face: &Face, e: &Endpoint, s: &serde_json::Value) -> String
     if let Some(rows) = s["jobs"].as_array() {
         let mut line = counts(face, rows);
         if let Some(age) = s["oldest_pending_secs"].as_i64() {
-            line.push_str(&format!(" · {}", face.ink_dim(&format!("oldest {}", ago(age)))));
+            line.push_str(&format!(
+                " · {}",
+                face.ink_dim(&format!("oldest {}", ago(age)))
+            ));
         }
         out.push_str(&format!("  jobs       {line}\n"));
     }

--- a/src/core/ask/mod.rs
+++ b/src/core/ask/mod.rs
@@ -908,7 +908,17 @@ impl Core {
         mut response: AskResponse,
         uncovered: &[String],
     ) -> Result<AskResponse> {
-        if !(self.learn.enabled && origin.door == Door::Ui) {
+        // `Ui` and `Cli`. Both are a person composing a question in a place
+        // where they will read the answer; neither is an agent on a token. A
+        // shell question was recorded nowhere at all until now, which made the
+        // strongest statement of a need engram can receive the one thing it
+        // never wrote down.
+        //
+        // A CLI ask carries no `event_id` back to the judging view, and that
+        // stays true: recorded and unjudged is a coherent state. The sweep
+        // learns what was needed; the judge still grades only answers somebody
+        // saw somewhere they could grade them.
+        if !(self.learn.enabled && matches!(origin.door, Door::Ui | Door::Cli)) {
             return Ok(response);
         }
         let ask = NewAsk {
@@ -1598,6 +1608,51 @@ mod tests {
             tags: vec![],
             category: None,
         }
+    }
+
+    /// A question typed at a shell is the strongest statement of a need engram
+    /// can receive, and it was written down nowhere at all: `record_ask`
+    /// admitted `Door::Ui` alone.
+    #[tokio::test]
+    async fn a_question_asked_at_a_shell_is_recorded() {
+        let mut core = test_core().await;
+        core.learn.enabled = true;
+        seed(&core, 2, 2).await;
+        core.ask(&req("how do I do the thing"), Door::Cli.by("me"))
+            .await
+            .unwrap();
+        let asks = core
+            .store
+            .asks_between(0, crate::store::now() + 1)
+            .await
+            .unwrap();
+        assert_eq!(asks.len(), 1, "{asks:?}");
+        assert_eq!(
+            asks[0].scope.as_deref(),
+            Some("me"),
+            "unscoped, the sweep cannot join it to anything"
+        );
+    }
+
+    /// And the doors that are not a person, which must stay out of the log.
+    #[tokio::test]
+    async fn a_question_from_an_agent_is_still_not_recorded() {
+        let mut core = test_core().await;
+        core.learn.enabled = true;
+        seed(&core, 2, 2).await;
+        core.ask(&req("how do I do the thing"), Door::Api)
+            .await
+            .unwrap();
+        core.ask(&req("how do I do the other thing"), Door::Mcp)
+            .await
+            .unwrap();
+        assert!(
+            core.store
+                .asks_between(0, crate::store::now() + 1)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -96,6 +96,35 @@ pub struct SearchOutcome {
     pub explanation: crate::core::explain::SearchExplanation,
 }
 
+/// A stage of the search pipeline, in the order it runs.
+///
+/// Named by the server rather than assumed by a client: whether the reranker
+/// runs at all is decided here, out of configuration and out of which door
+/// asked, and a client that drew a lamp for it regardless would be drawing work
+/// that is not going to happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchStage {
+    Embed,
+    Retrieve,
+    Rerank,
+}
+
+/// What one search emits while it happens.
+///
+/// The producer is `search_inner`, which is also what the blocking door runs:
+/// one pipeline reporting on itself, rather than a second description of a
+/// search that could drift from the search.
+#[derive(Debug, Clone)]
+pub enum SearchEvent {
+    /// The stages this search will pass through. Always first, always once.
+    Stages(Vec<SearchStage>),
+    /// This stage has started.
+    Stage(SearchStage),
+    /// Terminal, and exactly what the blocking door returns.
+    Results(Vec<SearchResult>),
+}
+
 /// Deserialised as well as serialised, because the terminal client reads the
 /// very JSON this door writes. One type for both ends means a field added here
 /// cannot silently stop reaching the shell.
@@ -977,7 +1006,7 @@ impl Core {
         origin: impl Into<Origin>,
     ) -> Result<(Vec<SearchResult>, SearchOutcome)> {
         let weight = self.ranking.read().expect("ranking lock").recency_weight;
-        self.search_inner(query, cap, weight, origin.into(), true)
+        self.search_inner(query, cap, weight, origin.into(), true, None)
             .await
     }
 
@@ -1004,8 +1033,44 @@ impl Core {
             params.recency_weight,
             origin.into(),
             false,
+            None,
         )
         .await
+    }
+
+    /// `search_with`, reporting each stage as it starts.
+    ///
+    /// Why this lives in `Core` and not in the door that draws it: the terminal
+    /// client and the web box both show these, and two implementations of "what
+    /// a search is doing" would disagree inside a month. The producer is the
+    /// pipeline itself, so a stage cannot be reported for work that was not run
+    /// and cannot be missed for work that was.
+    ///
+    /// The blocking `GET /search` is untouched and still answers a bare array.
+    pub fn search_events(
+        &self,
+        query: SearchQuery,
+        cap: Option<usize>,
+        origin: Origin,
+    ) -> impl tokio_stream::Stream<Item = Result<SearchEvent>> + 'static {
+        let core = self.clone();
+        let weight = self.ranking.read().expect("ranking lock").recency_weight;
+        async_stream::try_stream! {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let task = tokio::spawn(async move {
+                core.search_inner(&query, cap, weight, origin, true, Some(tx)).await
+            });
+            // The sender lives inside the search and is dropped when it
+            // returns, so this ends exactly once every stage it reported has
+            // been handed on — and never before the results it preceded.
+            while let Some(ev) = rx.recv().await {
+                yield ev;
+            }
+            let joined = task
+                .await
+                .map_err(|e| Error::Internal(format!("the search task: {e}")))?;
+            yield SearchEvent::Results(joined?.0);
+        }
     }
 
     /// `waited_on` is whether a person is on the other end of this search. It
@@ -1017,8 +1082,16 @@ impl Core {
         recency_weight: f32,
         origin: Origin,
         waited_on: bool,
+        stages: Option<tokio::sync::mpsc::UnboundedSender<SearchEvent>>,
     ) -> Result<(Vec<SearchResult>, SearchOutcome)> {
         let door = origin.door;
+        // A client that hung up must not fail a search that is already running:
+        // the send is the report, not the work.
+        let say = |ev: SearchEvent| {
+            if let Some(tx) = &stages {
+                let _ = tx.send(ev);
+            }
+        };
         // Filled in as the stages run. Always computed: a conditional path
         // through the ranking would be a second pipeline, and the unexercised
         // one is the one that ships. `query.explain` decides only what is
@@ -1050,6 +1123,29 @@ impl Core {
             n => n.min(MAX_LIMIT),
         };
 
+        // Whether the reranker runs on *this* search: one is configured, the
+        // scope covers this door, and the query did not opt out. The scope
+        // collapses every door but `Ask` into "search" — the judging view, the
+        // API, MCP and the extension all show the operator a ranked list, and
+        // `apply = ["ask"]` means none of them wait on a rerank call.
+        //
+        // Decided here rather than beside the call it guards, because the stage
+        // list below is a promise about work that is going to happen and it has
+        // to be made before any of it starts.
+        let reranking = query.rerank
+            && match door {
+                Door::Ask => self.reranks_ask(),
+                // The same predicate that arms the UI's refining pass: written
+                // once, so the form can never advertise a refine this search
+                // would not run.
+                _ => self.reranks_search(),
+            };
+        let mut will = vec![SearchStage::Embed, SearchStage::Retrieve];
+        if reranking && self.reranker.is_some() {
+            will.push(SearchStage::Rerank);
+        }
+        say(SearchEvent::Stages(will));
+
         // Embedding the query is a model call, and so is the reranker, so a
         // search is a person waiting on the endpoint exactly as `ask` is — and
         // it is the more common way in, through the UI and through MCP. Without
@@ -1068,6 +1164,7 @@ impl Core {
             false => Lane::Background(self.gate.background_light().await),
         };
 
+        say(SearchEvent::Stage(SearchStage::Embed));
         let started = std::time::Instant::now();
         // Prefixes repeat constantly inside one search and whole queries repeat
         // across sessions, so this is the difference between one embedding call
@@ -1098,20 +1195,6 @@ impl Core {
             // the coverage check's question, not a searcher's.
             corpus_id: None,
         };
-        // Whether the reranker runs on *this* search: one is configured, the
-        // scope covers this door, and the query did not opt out. The scope
-        // collapses every door but `Ask` into "search" — the judging view, the
-        // API, MCP and the extension all show the operator a ranked list, and
-        // `apply = ["ask"]` means none of them wait on a rerank call.
-        let reranking = query.rerank
-            && match door {
-                Door::Ask => self.reranks_ask(),
-                // The same predicate that arms the UI's refining pass: written
-                // once, so the form can never advertise a refine this search
-                // would not run.
-                _ => self.reranks_search(),
-            };
-
         // Over-fetch whenever something downstream narrows the list: both the
         // per-source cap and the reranker can only discard what they are given.
         let candidates = if cap.is_some() || reranking {
@@ -1138,6 +1221,7 @@ impl Core {
         // The lexical half of the query. Computed locally and for free, so it
         // costs nothing when the store ignores it.
         let sparse = crate::vector::sparse::encode_query(query.q.trim());
+        say(SearchEvent::Stage(SearchStage::Retrieve));
         let hits = self
             .vectors
             .search_weighted(&vector, &sparse, candidates, &filter, recency_weight)
@@ -1277,6 +1361,7 @@ impl Core {
             } else {
                 limit
             };
+            say(SearchEvent::Stage(SearchStage::Rerank));
             match reranker.rerank(&query.q, &docs, top_n).await {
                 Ok(order) => {
                     reranked = true;
@@ -1496,6 +1581,107 @@ mod tests {
             crate::jobs::embed::run(core, &c.id).await.unwrap();
         }
         src.id
+    }
+
+    /// Every event one search emitted, in order.
+    async fn events_of(core: &crate::core::Core, text: &str, origin: Origin) -> Vec<SearchEvent> {
+        use tokio_stream::StreamExt as _;
+        let s = core.search_events(q(text), None, origin);
+        tokio::pin!(s);
+        let mut seen = Vec::new();
+        while let Some(ev) = s.next().await {
+            seen.push(ev.expect("a search that was going to succeed"));
+        }
+        seen
+    }
+
+    /// A lamp drawn for work that is not going to happen is the one thing a
+    /// progress display must not do, so the client is told the stages up front
+    /// rather than left to assume the pipeline's shape.
+    #[tokio::test]
+    async fn a_search_names_the_stages_it_will_run_before_it_runs_them() {
+        let core = test_core().await;
+        seed(&core, &[("the journal is a ring buffer", "linux", &[])]).await;
+        let seen = events_of(&core, "journal", Door::Cli.into()).await;
+        match &seen[0] {
+            SearchEvent::Stages(v) => assert_eq!(
+                v,
+                &vec![SearchStage::Embed, SearchStage::Retrieve],
+                "no reranker is configured, so nothing may promise a rerank"
+            ),
+            other => panic!("the stage list is the first frame, not {other:?}"),
+        }
+        assert!(matches!(seen.last(), Some(SearchEvent::Results(_))));
+    }
+
+    #[tokio::test]
+    async fn a_configured_reranker_is_named_and_a_query_that_opts_out_is_not() {
+        use tokio_stream::StreamExt as _;
+        let (core, _calls) = test_core_counting_reranked_docs().await;
+        seed(&core, &[("the journal is a ring buffer", "linux", &[])]).await;
+        let seen = events_of(&core, "journal", Door::Cli.into()).await;
+        assert!(
+            matches!(&seen[0], SearchEvent::Stages(v) if v.contains(&SearchStage::Rerank)),
+            "{seen:?}"
+        );
+
+        let opted_out = SearchQuery {
+            rerank: false,
+            ..q("journal")
+        };
+        let s = core.search_events(opted_out, None, Door::Cli.into());
+        tokio::pin!(s);
+        let first = s.next().await.unwrap().unwrap();
+        assert!(
+            matches!(&first, SearchEvent::Stages(v) if !v.contains(&SearchStage::Rerank)),
+            "a query that opted out was promised a rerank: {first:?}"
+        );
+    }
+
+    /// The other half of the same rule: a stage promised and never started is
+    /// as much an invention as one drawn that never ran.
+    #[tokio::test]
+    async fn every_named_stage_is_also_announced_as_it_starts() {
+        let (core, _calls) = test_core_counting_reranked_docs().await;
+        seed(&core, &[("the journal is a ring buffer", "linux", &[])]).await;
+        let seen = events_of(&core, "journal", Door::Cli.into()).await;
+        let mut named: Vec<SearchStage> = Vec::new();
+        let mut started: Vec<SearchStage> = Vec::new();
+        for ev in &seen {
+            match ev {
+                SearchEvent::Stages(v) => named = v.clone(),
+                SearchEvent::Stage(s) => started.push(*s),
+                SearchEvent::Results(_) => {}
+            }
+        }
+        assert_eq!(named, started, "{seen:?}");
+    }
+
+    /// The stream is the same search, so it has to answer with the same hits.
+    #[tokio::test]
+    async fn the_streamed_search_returns_what_the_blocking_one_returns() {
+        let core = test_core().await;
+        seed(
+            &core,
+            &[
+                ("the journal is a ring buffer", "linux", &[]),
+                ("btrfs subvolume quotas", "linux", &[]),
+            ],
+        )
+        .await;
+        let blocking = core.search(&q("journal"), Door::Cli).await.unwrap();
+        let streamed = events_of(&core, "journal", Door::Cli.into())
+            .await
+            .into_iter()
+            .find_map(|ev| match ev {
+                SearchEvent::Results(hits) => Some(hits),
+                _ => None,
+            })
+            .expect("a terminal frame");
+        assert_eq!(
+            blocking.iter().map(|h| &h.artifact_id).collect::<Vec<_>>(),
+            streamed.iter().map(|h| &h.artifact_id).collect::<Vec<_>>()
+        );
     }
 
     /// Rewrite every vector payload from the current chunk rows.

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -1344,6 +1344,14 @@ impl Core {
             .collect();
 
         let mut reranked = false;
+        // Said on the same condition the stage list was built from, and before
+        // the emptiness check below: a stage named in `stages` and never
+        // started is a client waiting on a step that is not coming. A search
+        // that retrieved nothing still enters the stage, finds nothing to order
+        // and leaves it.
+        if reranking && self.reranker.is_some() {
+            say(SearchEvent::Stage(SearchStage::Rerank));
+        }
         if let Some(reranker) = &self.reranker
             && reranking
             && !results.is_empty()
@@ -1361,7 +1369,6 @@ impl Core {
             } else {
                 limit
             };
-            say(SearchEvent::Stage(SearchStage::Rerank));
             match reranker.rerank(&query.q, &docs, top_n).await {
                 Ok(order) => {
                     reranked = true;
@@ -1654,6 +1661,32 @@ mod tests {
                 SearchEvent::Results(_) => {}
             }
         }
+        assert_eq!(named, started, "{seen:?}");
+    }
+
+    /// The case the rule was broken on: a rerank was promised whenever one was
+    /// configured, but the call itself was also guarded on there being
+    /// something to order, so a search that retrieved nothing named a stage it
+    /// never entered.
+    #[tokio::test]
+    async fn a_search_that_retrieves_nothing_still_runs_every_stage_it_named() {
+        let (core, _calls) = test_core_counting_reranked_docs().await;
+        let seen = events_of(&core, "journal", Door::Cli.into()).await;
+        let mut named: Vec<SearchStage> = Vec::new();
+        let mut started: Vec<SearchStage> = Vec::new();
+        let mut hits = 1;
+        for ev in &seen {
+            match ev {
+                SearchEvent::Stages(v) => named = v.clone(),
+                SearchEvent::Stage(s) => started.push(*s),
+                SearchEvent::Results(r) => hits = r.len(),
+            }
+        }
+        assert_eq!(hits, 0, "the empty base returned hits: {seen:?}");
+        assert!(
+            named.contains(&SearchStage::Rerank),
+            "the fixture stopped configuring a reranker: {named:?}"
+        );
         assert_eq!(named, started, "{seen:?}");
     }
 

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -778,13 +778,36 @@ mod tests {
         shown: &[&str],
         at: i64,
     ) -> String {
+        event_from(
+            core,
+            crate::store::feedback::Door::Ui,
+            Some("me"),
+            q,
+            vec,
+            shown,
+            at,
+        )
+        .await
+    }
+
+    /// A recorded search, as a named door with a named scope makes it. The two
+    /// tests below turn on the scope alone.
+    async fn event_from(
+        core: &crate::core::Core,
+        door: crate::store::feedback::Door,
+        scope: Option<&str>,
+        q: &str,
+        vec: Vec<f32>,
+        shown: &[&str],
+        at: i64,
+    ) -> String {
         let id = core
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
                     query: q.into(),
-                    door: crate::store::feedback::Door::Ui,
-                    scope: Some("me".into()),
+                    door,
+                    scope: scope.map(str::to_string),
                     filters: "{}".into(),
                     query_vec: vec,
                     embed_model: "fake".into(),
@@ -812,6 +835,84 @@ mod tests {
             .await
             .unwrap();
         id
+    }
+
+    /// The join the terminal door had never been able to make.
+    ///
+    /// A search typed at a shell records with a scope now, and the `--show`
+    /// that follows it records the open with the same one, so the sweep can see
+    /// that the two are one run. What it does with that run is the ordinary
+    /// decision; what matters here is that it has the run at all.
+    #[tokio::test]
+    async fn an_open_at_a_shell_attaches_to_the_search_that_led_to_it() {
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        // Exactly the origin `GET /search?door=cli` now builds.
+        event_from(
+            &core,
+            crate::store::feedback::Door::Cli,
+            Some("me"),
+            "how do I read the journal",
+            vec![1.0, 0.0],
+            &[&ids[0], &ids[1]],
+            now - 100,
+        )
+        .await;
+        // Exactly what `GET /artifacts/{id}` records for `engram --show`.
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), now - 97)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "opened", None, Some("me"), now - 96)
+            .await
+            .unwrap();
+
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
+        assert_eq!(
+            p.sources.len(),
+            2,
+            "the opens did not reach the pursuit: {p:?}"
+        );
+        assert_ne!(
+            p.reason.as_deref(),
+            Some("nothing engaged"),
+            "a shell that read two artifacts engaged two artifacts: {p:?}"
+        );
+    }
+
+    /// The bug, kept as a witness. Unscoped — which is what every CLI search
+    /// recorded before this — the same run reads as a search nobody followed.
+    #[tokio::test]
+    async fn an_unscoped_search_cannot_be_joined_to_the_opens_after_it() {
+        let core = pursuing_core().await;
+        let ids = two_sources(&core).await;
+        let now = crate::store::now();
+        event_from(
+            &core,
+            crate::store::feedback::Door::Cli,
+            None,
+            "how do I read the journal",
+            vec![1.0, 0.0],
+            &[&ids[0], &ids[1]],
+            now - 100,
+        )
+        .await;
+        core.store
+            .record_interaction(&ids[0], "opened", None, Some("me"), now - 97)
+            .await
+            .unwrap();
+        core.store
+            .record_interaction(&ids[1], "opened", None, Some("me"), now - 96)
+            .await
+            .unwrap();
+
+        assert_eq!(run(&core).await.unwrap(), 1);
+        let p = &core.store.recent_pursuits(10).await.unwrap()[0];
+        assert_eq!(p.state, "unsatisfied", "{p:?}");
+        assert_eq!(p.reason.as_deref(), Some("nothing engaged"), "{p:?}");
     }
 
     #[tokio::test]

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -482,6 +482,20 @@ impl Store {
         Ok(rows.iter().map(row_to_artifact).collect())
     }
 
+    /// How many artifacts a pursuit wrote, with no page over it. The predicate
+    /// is `synthesized_artifacts`', which answers a page for a table to be
+    /// drawn from and cannot be counted for a total.
+    pub async fn count_synthesized_artifacts(&self) -> Result<i64> {
+        use sqlx::Row;
+        Ok(sqlx::query(
+            "SELECT COUNT(*) AS n FROM artifacts
+              WHERE provenance = 'synthesized' AND status = 'active' AND superseded_by IS NULL",
+        )
+        .fetch_one(&self.pool)
+        .await?
+        .get("n"))
+    }
+
     pub async fn insert_artifacts(
         &self,
         corpus_id: &str,

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -278,16 +278,24 @@ macro_rules! subject_gaps_sql {
 /// naming prompt keeps the first twelve members, and a member that is itself a
 /// paragraph of queries would crowd out eleven other gaps. `queries` is JSON,
 /// so the first element is read out in Rust rather than in SQL.
+/// Which pursuits are on the gap list, written once so that the page and the
+/// count of it cannot come to disagree about what "still unsatisfied" means.
+macro_rules! pursuit_gaps_from {
+    () => {
+        " FROM pursuits
+          WHERE state = 'unsatisfied' AND embed_model = ? AND vec_dim > 0
+            AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                             WHERE kind = 'pursuit' AND gap_id = pursuits.id)"
+    };
+}
+
 macro_rules! pursuit_gaps_sql {
     ($cols:literal) => {
         concat!(
             "SELECT id, queries",
             $cols,
-            " FROM pursuits
-              WHERE state = 'unsatisfied' AND embed_model = ? AND vec_dim > 0
-                AND NOT EXISTS (SELECT 1 FROM gap_coverage
-                                 WHERE kind = 'pursuit' AND gap_id = pursuits.id)
-              ORDER BY opened_at DESC, id DESC LIMIT ?"
+            pursuit_gaps_from!(),
+            " ORDER BY opened_at DESC, id DESC LIMIT ?"
         )
     };
 }
@@ -586,6 +594,23 @@ impl Store {
             .iter()
             .map(|r| r.get::<String, _>("id"))
             .collect())
+    }
+
+    /// How many pursuits are on the gap list, with no page over it.
+    ///
+    /// `open_pursuit_gap_ids` answers a page — `MAX_OPEN_GAPS` of them — because
+    /// its caller draws a list. A status line reports a total, and a total that
+    /// silently stops at the page size is a number that stops moving on exactly
+    /// the base whose operator most needs it to move.
+    pub async fn count_open_pursuit_gaps(&self, embed_model: &str) -> Result<i64> {
+        use sqlx::Row;
+        Ok(
+            sqlx::query(concat!("SELECT COUNT(*) AS n", pursuit_gaps_from!()))
+                .bind(embed_model)
+                .fetch_one(&self.pool)
+                .await?
+                .get("n"),
+        )
     }
 
     /// Query vectors from every recorded search and question under this
@@ -1470,6 +1495,55 @@ mod tests {
             .map(|g| (g.gap.id.as_str(), g.gap.text.as_str()))
             .collect();
         assert_eq!(mine, vec![(id.as_str(), "how do I mount an E01")]);
+    }
+
+    /// The count and the page are one predicate, and the count is not the page.
+    ///
+    /// `--status` read the length of a fifty-row page and printed it as a
+    /// total, so a base with more than fifty pursuits reported fifty for ever.
+    #[tokio::test]
+    async fn the_pursuit_gap_count_is_a_total_and_not_the_length_of_a_page() {
+        let store = Store::memory().await.unwrap();
+        for i in 0..60i64 {
+            let id = store
+                .insert_pursuit(
+                    i * 10,
+                    &[format!("how do I mount an E01 {i}")],
+                    &[],
+                    Some((&[1.0, 0.0], "fake")),
+                )
+                .await
+                .unwrap();
+            store
+                .close_pursuit(&id, "unsatisfied", "nothing strong was engaged", i * 10 + 5)
+                .await
+                .unwrap();
+        }
+        // Sixty, not the fifty a page of pursuits would have held.
+        assert_eq!(store.count_open_pursuit_gaps("fake").await.unwrap(), 60);
+        assert_eq!(store.count_pursuits("unsatisfied").await.unwrap(), 60);
+        assert_eq!(store.count_pursuits("open").await.unwrap(), 0);
+        // Under the gap list's own cap the two agree exactly, which is what
+        // keeps the predicate from drifting away from the count of it.
+        assert_eq!(
+            store.open_pursuit_gap_ids("fake").await.unwrap().len() as i64,
+            store.count_open_pursuit_gaps("fake").await.unwrap()
+        );
+        // A pursuit that has been answered leaves both.
+        store
+            .dismiss_gap(
+                GapKind::Pursuit,
+                store
+                    .open_pursuit_gap_ids("fake")
+                    .await
+                    .unwrap()
+                    .iter()
+                    .next()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.count_open_pursuit_gaps("fake").await.unwrap(), 59);
     }
 
     #[tokio::test]

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -162,24 +162,36 @@ pub struct GapRow {
 /// exactly like a grouping of all of them.
 pub const MAX_OPEN_GAPS: i64 = 500;
 
-/// The predicate both readers of the open gaps share, once.
+/// The predicate every reader of the open gaps shares, once.
 ///
-/// Two projections over one `WHERE`: the sweep needs `query_vec`, the capture
-/// page needs only the words. Written as a macro rather than as four statements
-/// because the two projections drifting apart would mean the page and the sweep
-/// disagreeing about what is open — and because nothing from a request reaches
-/// the statement text either way, the `embed_model` being bound.
+/// Three projections over one `WHERE`: the sweep needs `query_vec`, the capture
+/// page needs only the words, and `count_open_gaps` needs neither. Written as a
+/// macro rather than as separate statements because the projections drifting
+/// apart would mean the page, the sweep and the count disagreeing about what is
+/// open — and because nothing from a request reaches the statement text either
+/// way, the `embed_model` being bound.
+///
+/// The `WHERE` is split out from the `SELECT` for the reason
+/// `pursuit_gaps_from!` is: a total is a count over the predicate, and reading
+/// a page of rows to take its length is how a page size came to be printed as
+/// a total.
+macro_rules! ask_gaps_from {
+    () => {
+        " FROM ask_events
+          WHERE verdict = 'nothing_here' AND dismissed_at IS NULL
+            AND embed_model = ? AND vec_dim > 0
+            AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                             WHERE kind = 'ask' AND gap_id = ask_events.id)"
+    };
+}
+
 macro_rules! ask_gaps_sql {
     ($cols:literal) => {
         concat!(
             "SELECT id, question AS text",
             $cols,
-            " FROM ask_events
-              WHERE verdict = 'nothing_here' AND dismissed_at IS NULL
-                AND embed_model = ? AND vec_dim > 0
-                AND NOT EXISTS (SELECT 1 FROM gap_coverage
-                                 WHERE kind = 'ask' AND gap_id = ask_events.id)
-              ORDER BY judged_at DESC, id DESC LIMIT ?"
+            ask_gaps_from!(),
+            " ORDER BY judged_at DESC, id DESC LIMIT ?"
         )
     };
 }
@@ -195,18 +207,24 @@ macro_rules! ask_gaps_sql {
 /// that already answers it puts it back on the capture page as a fresh hole.
 /// The other direction cannot happen: `unmatched` is `verdict IS NULL`, so a
 /// judged search never enters by that door.
+macro_rules! search_gaps_from {
+    () => {
+        " FROM search_events
+          WHERE verdict = 'gap' AND dismissed_at IS NULL
+            AND embed_model = ? AND vec_dim > 0
+            AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                             WHERE kind IN ('search', 'unmatched')
+                               AND gap_id = search_events.id)"
+    };
+}
+
 macro_rules! search_gaps_sql {
     ($cols:literal) => {
         concat!(
             "SELECT id, query AS text",
             $cols,
-            " FROM search_events
-              WHERE verdict = 'gap' AND dismissed_at IS NULL
-                AND embed_model = ? AND vec_dim > 0
-                AND NOT EXISTS (SELECT 1 FROM gap_coverage
-                                 WHERE kind IN ('search', 'unmatched')
-                                   AND gap_id = search_events.id)
-              ORDER BY judged_at DESC, id DESC LIMIT ?"
+            search_gaps_from!(),
+            " ORDER BY judged_at DESC, id DESC LIMIT ?"
         )
     };
 }
@@ -233,19 +251,25 @@ macro_rules! search_gaps_sql {
 /// The guard this needs already exists. A typing burst folds into one event by
 /// `feedback.coalesce_secs`, so what is measured is the finished query and not
 /// its first two letters.
+macro_rules! unmatched_gaps_from {
+    () => {
+        " FROM search_events e
+          WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
+            AND e.verdict IS NULL
+            AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                             WHERE kind = 'unmatched' AND gap_id = e.id)
+            AND (SELECT MAX(c.similarity) FROM search_candidates c
+                  WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?"
+    };
+}
+
 macro_rules! unmatched_gaps_sql {
     ($cols:literal) => {
         concat!(
             "SELECT e.id, e.query AS text",
             $cols,
-            " FROM search_events e
-              WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
-                AND e.verdict IS NULL
-                AND NOT EXISTS (SELECT 1 FROM gap_coverage
-                                 WHERE kind = 'unmatched' AND gap_id = e.id)
-                AND (SELECT MAX(c.similarity) FROM search_candidates c
-                      WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?
-              ORDER BY e.created_at DESC, e.id DESC LIMIT ?"
+            unmatched_gaps_from!(),
+            " ORDER BY e.created_at DESC, e.id DESC LIMIT ?"
         )
     };
 }
@@ -256,18 +280,24 @@ macro_rules! unmatched_gaps_sql {
 /// `DELETE` cascades, and a base whose foreign keys are off still cannot return
 /// an orphan through this. `dismissed_at` and `gap_coverage` close it the same
 /// way they close the other four.
+macro_rules! subject_gaps_from {
+    () => {
+        " FROM ask_subjects s
+          JOIN ask_events e ON e.id = s.event_id
+          WHERE s.dismissed_at IS NULL
+            AND s.embed_model = ? AND s.vec_dim > 0
+            AND NOT EXISTS (SELECT 1 FROM gap_coverage
+                             WHERE kind = 'subject' AND gap_id = s.id)"
+    };
+}
+
 macro_rules! subject_gaps_sql {
     ($cols:literal) => {
         concat!(
             "SELECT s.id, s.subject AS text",
             $cols,
-            " FROM ask_subjects s
-              JOIN ask_events e ON e.id = s.event_id
-              WHERE s.dismissed_at IS NULL
-                AND s.embed_model = ? AND s.vec_dim > 0
-                AND NOT EXISTS (SELECT 1 FROM gap_coverage
-                                 WHERE kind = 'subject' AND gap_id = s.id)
-              ORDER BY s.created_at DESC, s.id DESC LIMIT ?"
+            subject_gaps_from!(),
+            " ORDER BY s.created_at DESC, s.id DESC LIMIT ?"
         )
     };
 }
@@ -602,6 +632,43 @@ impl Store {
     /// its caller draws a list. A status line reports a total, and a total that
     /// silently stops at the page size is a number that stops moving on exactly
     /// the base whose operator most needs it to move.
+    /// How many gaps are open, all five kinds, with no page over any of them.
+    ///
+    /// `open_gap_refs` answers the capture page's list and caps each kind at
+    /// `MAX_OPEN_GAPS`, so its length saturates at five times that and then
+    /// stops moving — on exactly the base whose operator opened `--status` to
+    /// find out whether the number is moving. It also decoded every gap's text
+    /// to throw all of it away.
+    ///
+    /// The same five predicates the list is built from, so the sentence in a
+    /// terminal and the page in a browser cannot come apart about what is being
+    /// counted; only the cap is gone.
+    pub async fn count_open_gaps(&self, embed_model: &str, weak_below: f32) -> Result<i64> {
+        use sqlx::Row;
+        let mut n: i64 = 0;
+        for sql in [
+            concat!("SELECT COUNT(*) AS n", ask_gaps_from!()),
+            concat!("SELECT COUNT(*) AS n", search_gaps_from!()),
+            concat!("SELECT COUNT(*) AS n", subject_gaps_from!()),
+            concat!("SELECT COUNT(*) AS n", pursuit_gaps_from!()),
+        ] {
+            n += sqlx::query(sql)
+                .bind(embed_model)
+                .fetch_one(&self.pool)
+                .await?
+                .get::<i64, _>("n");
+        }
+        // One more bind than the other four, so it is read on its own — the
+        // same reason `open_gap_refs` reads it outside its loop.
+        n += sqlx::query(concat!("SELECT COUNT(*) AS n", unmatched_gaps_from!()))
+            .bind(embed_model)
+            .bind(weak_below)
+            .fetch_one(&self.pool)
+            .await?
+            .get::<i64, _>("n");
+        Ok(n)
+    }
+
     pub async fn count_open_pursuit_gaps(&self, embed_model: &str) -> Result<i64> {
         use sqlx::Row;
         Ok(
@@ -1660,6 +1727,28 @@ mod tests {
             MAX_OPEN_GAPS,
             "the display path is bounded by the same cap"
         );
+        assert_eq!(
+            store.count_open_gaps("fake", 0.35).await.unwrap(),
+            MAX_OPEN_GAPS + 1,
+            "a total is not a page: `--status` is opened to find out whether \
+             the number is moving, and the length of a capped list stops"
+        );
+    }
+
+    /// The count and the list are the same five predicates, so `--status` and
+    /// the capture page cannot disagree about what is open.
+    #[tokio::test]
+    async fn the_count_of_open_gaps_is_the_length_of_the_list_it_is_under_the_cap() {
+        let store = Store::memory().await.unwrap();
+        nothing_here(&store, "q1", vec![1.0]).await;
+        let s = gap_search(&store, "s1", vec![1.0]).await;
+        assert_eq!(
+            store.count_open_gaps("fake", 0.35).await.unwrap(),
+            store.open_gap_refs("fake", 0.35).await.unwrap().len() as i64
+        );
+        assert_eq!(store.count_open_gaps("fake", 0.35).await.unwrap(), 2);
+        store.dismiss_gap(GapKind::Search, &s).await.unwrap();
+        assert_eq!(store.count_open_gaps("fake", 0.35).await.unwrap(), 1);
     }
 
     #[tokio::test]

--- a/src/store/pursuits.rs
+++ b/src/store/pursuits.rs
@@ -325,6 +325,22 @@ impl Store {
         Ok(rows.iter().map(row_to_pursuit).collect())
     }
 
+    /// How many pursuits are in one state, with no page over it.
+    ///
+    /// `recent_pursuits` answers a page for a list to be drawn from. Counting
+    /// that page reported the page size as a total the moment a base held more
+    /// pursuits than the page held rows.
+    pub async fn count_pursuits(&self, state: &str) -> Result<i64> {
+        use sqlx::Row;
+        Ok(
+            sqlx::query("SELECT COUNT(*) AS n FROM pursuits WHERE state = ?")
+                .bind(state)
+                .fetch_one(&self.pool)
+                .await?
+                .get("n"),
+        )
+    }
+
     /// Forget every pursuit and every interaction. Rows dropped.
     pub async fn purge_pursuits(&self) -> Result<u64> {
         let a = sqlx::query("DELETE FROM interaction_events")

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1108,18 +1108,44 @@ async fn stale(
 
 async fn ask(
     tenant: Tenant,
+    Query(q): Query<AskParams>,
     Json(req): Json<crate::core::ask::AskRequest>,
 ) -> Result<Json<crate::core::ask::AskResponse>> {
     // No ask model, no ask door: the route is not there. See `Core::asks`.
     if !tenant.core.asks() {
         return Err(Error::NotFound);
     }
-    Ok(Json(
-        tenant
-            .core
-            .ask(&req, crate::store::feedback::Door::Api)
-            .await?,
-    ))
+    let origin = ask_origin(&q, &tenant, crate::store::feedback::Door::Api);
+    Ok(Json(tenant.core.ask(&req, origin).await?))
+}
+
+/// Which door asked, in the query string, exactly as search names it.
+///
+/// A query parameter rather than a body field: `AskRequest` is the shape a
+/// dozen internal callers build by hand, and how a question arrived is a fact
+/// about the request rather than part of the question.
+#[derive(serde::Deserialize)]
+pub struct AskParams {
+    pub door: Option<String>,
+}
+
+/// Which door asked, and on whose behalf.
+///
+/// `default` is the door a caller that names none has always been treated as,
+/// which differs per route and is why it is a parameter. The scope rule is
+/// search's, for search's reasons: a door with a known person says who, and a
+/// bearer token is not a person.
+fn ask_origin(
+    q: &AskParams,
+    tenant: &Tenant,
+    default: crate::store::feedback::Door,
+) -> crate::store::feedback::Origin {
+    use crate::store::feedback::Door;
+    let door = q.door.as_deref().map(Door::from_client).unwrap_or(default);
+    match door {
+        Door::Extension | Door::Cli => door.by(tenant.user.subject.clone()),
+        _ => door.into(),
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -1340,6 +1366,7 @@ async fn status(tenant: Tenant) -> Result<Json<StatusResponse>> {
 /// One question, one request, and no handoff to expire.
 async fn ask_stream(
     tenant: Tenant,
+    Query(q): Query<AskParams>,
     Json(req): Json<crate::core::ask::AskRequest>,
 ) -> Result<Response> {
     // No ask model, no ask door: the route is not there. See `Core::asks`.
@@ -1349,13 +1376,9 @@ async fn ask_stream(
     use tokio_stream::StreamExt as _;
 
     let core = tenant.core.clone();
-    // The door an ask came through, which names the caller and nothing more.
-    // Unlike search, where `door=extension` decides how the query is recorded,
-    // no ask is recorded from here: `record_ask` admits `Door::Ui` alone, so
-    // this answer carries no `event_id` and is never judged. Named anyway,
-    // because a question composed while reading is a different thing from one
-    // typed into an API client, and the log should not have to guess.
-    let origin = crate::store::feedback::Door::Extension.by(tenant.user.subject);
+    // The door an ask came through, named by the caller. The panel says
+    // nothing and keeps the door it has always had.
+    let origin = ask_origin(&q, &tenant, crate::store::feedback::Door::Extension);
     let events = async_stream::stream! {
         let s = core.ask_events(&req, origin);
         tokio::pin!(s);
@@ -1833,6 +1856,64 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(events.len(), 1, "{events:?}");
         assert_eq!(events[0].scope, None, "Door::Api must stay unscoped");
+    }
+
+    /// A question typed at a shell reaches the log; the panel, which names no
+    /// door, keeps the door it has always had and records nothing.
+    #[tokio::test]
+    async fn a_shell_question_is_recorded_and_the_panel_is_unchanged() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let (app, token, core) = app_from_core(core).await;
+        let out = core
+            .ingest("alpha line\n\nbravo line", "web", None)
+            .await
+            .unwrap();
+        crate::jobs::synthesize::segment_all(&core, &out.id).await;
+        crate::jobs::embed::run_corpus(&core, &out.id).await.unwrap();
+
+        // Drained, not just received: the answer is produced while the body is
+        // read, and `record_ask` runs at the end of it.
+        let res = app
+            .clone()
+            .oneshot(post_json(
+                "/api/v1/ask/stream?door=cli",
+                &token,
+                serde_json::json!({"q": "what is alpha"}),
+            ))
+            .await
+            .unwrap();
+        crate::web::test_support::body_of(res).await;
+        core.background.wait_idle().await;
+        let asks = core
+            .store
+            .asks_between(0, crate::store::now() + 1)
+            .await
+            .unwrap();
+        assert_eq!(asks.len(), 1, "a shell question reached nothing: {asks:?}");
+        assert!(asks[0].scope.is_some(), "{asks:?}");
+
+        // The same route, named by nobody: the panel, recording nothing, as
+        // it has since it was written.
+        let res = app
+            .oneshot(post_json(
+                "/api/v1/ask/stream",
+                &token,
+                serde_json::json!({"q": "what is bravo"}),
+            ))
+            .await
+            .unwrap();
+        crate::web::test_support::body_of(res).await;
+        core.background.wait_idle().await;
+        assert_eq!(
+            core.store
+                .asks_between(0, crate::store::now() + 1)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the panel's asks are not recorded and that has not changed"
+        );
     }
 
     #[tokio::test]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -168,6 +168,24 @@ pub struct StatusResponse {
     pub oldest_pending_secs: Option<i64>,
     pub chunks: i64,
     pub vectors: u64,
+    /// What the base has been learning, or `None` while `[learn]` is off.
+    ///
+    /// Absent rather than zeroed: four zeroes read like a faculty failing, and
+    /// a faculty that was never switched on is not failing.
+    pub learning: Option<Learning>,
+}
+
+/// The half of `status` that is not about machinery.
+///
+/// The counts the insights page renders, in the shape a shell can read. A
+/// pursuit closed unsatisfied is a hole in the base somebody went looking
+/// through and did not fill.
+#[derive(serde::Serialize)]
+pub struct Learning {
+    pub pursuits_open: i64,
+    pub pursuits_unsatisfied: i64,
+    pub from_pursuits: i64,
+    pub gaps_open: i64,
 }
 
 /// Capture channels. `origin` is derived from which field arrived, not
@@ -1338,7 +1356,41 @@ async fn status(tenant: Tenant) -> Result<Json<StatusResponse>> {
         .await?
         .get("n");
 
+    // Read from the same store calls the insights page reads, so the sentence
+    // in a terminal and the screen in a browser cannot come apart.
+    let learning = match tenant.core.learn.enabled {
+        false => None,
+        true => {
+            let recent = tenant.core.store.recent_pursuits(50).await?;
+            let on_the_gap_list = tenant
+                .core
+                .store
+                .open_pursuit_gap_ids(tenant.core.embedder.model())
+                .await
+                .unwrap_or_default();
+            Some(Learning {
+                pursuits_open: recent.iter().filter(|p| p.state == "open").count() as i64,
+                // The ones still on the gap list: `unsatisfied` is how a run
+                // ended, and a capture that answers one afterwards leaves the
+                // word alone deliberately.
+                pursuits_unsatisfied: recent
+                    .iter()
+                    .filter(|p| p.state == "unsatisfied" && on_the_gap_list.contains(&p.id))
+                    .count() as i64,
+                from_pursuits: tenant.core.store.synthesized_artifacts(200).await?.len() as i64,
+                gaps_open: tenant
+                    .core
+                    .store
+                    .open_gap_refs(tenant.core.embedder.model(), tenant.core.weak_below)
+                    .await
+                    .unwrap_or_default()
+                    .len() as i64,
+            })
+        }
+    };
+
     Ok(Json(StatusResponse {
+        learning,
         sources: corpus_rows
             .iter()
             .map(|r| (r.get("status"), r.get("n")))
@@ -1860,6 +1912,35 @@ pub(crate) mod tests {
 
     /// A question typed at a shell reaches the log; the panel, which names no
     /// door, keeps the door it has always had and records nothing.
+    /// The block is absent while the layer is off, and the fields every
+    /// existing reader of this endpoint depends on are untouched.
+    #[tokio::test]
+    async fn status_says_nothing_about_learning_while_the_layer_is_off() {
+        let (app, token) = app_and_token().await;
+        let v = json_of(app.oneshot(get("/api/v1/status", Some(&token))).await.unwrap()).await;
+        assert!(v["learning"].is_null(), "{v}");
+        assert!(v["chunks"].is_i64(), "{v}");
+        assert!(v["jobs"].is_array(), "{v}");
+    }
+
+    #[tokio::test]
+    async fn status_counts_what_the_base_has_been_learning() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let (app, token, _core) = app_from_core(core).await;
+        let v = json_of(app.oneshot(get("/api/v1/status", Some(&token))).await.unwrap()).await;
+        let l = &v["learning"];
+        assert!(l.is_object(), "{v}");
+        for k in [
+            "pursuits_open",
+            "pursuits_unsatisfied",
+            "from_pursuits",
+            "gaps_open",
+        ] {
+            assert!(l[k].is_i64(), "{k} is missing from {l}");
+        }
+    }
+
     #[tokio::test]
     async fn a_shell_question_is_recorded_and_the_panel_is_unchanged() {
         let mut core = crate::core::test_support::test_core().await;

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1384,9 +1384,8 @@ async fn status(tenant: Tenant) -> Result<Json<StatusResponse>> {
             gaps_open: tenant
                 .core
                 .store
-                .open_gap_refs(tenant.core.embedder.model(), tenant.core.weak_below)
-                .await?
-                .len() as i64,
+                .count_open_gaps(tenant.core.embedder.model(), tenant.core.weak_below)
+                .await?,
         }),
     };
 
@@ -1445,8 +1444,8 @@ async fn ask_stream(
                 // Terminal by construction: the producer is a `try_stream!` and
                 // ends at its first error, so the panel sees one `error` frame
                 // and nothing after it.
-                Ok(e) => api_sse_event(e).unwrap_or_else(|e| error_frame(&e)),
-                Err(e) => error_frame(&e),
+                Ok(e) => api_sse_event(e).unwrap_or_else(|e| error_frame("ask", &e)),
+                Err(e) => error_frame("ask", &e),
             });
         }
     };
@@ -1504,8 +1503,8 @@ async fn search_stream(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<
             // Terminal by construction: the producer ends at its first error,
             // so a client sees one `error` frame and nothing after it.
             yield Ok::<_, Error>(match ev {
-                Ok(e) => search_sse_event(e).unwrap_or_else(|e| error_frame(&e)),
-                Err(e) => error_frame(&e),
+                Ok(e) => search_sse_event(e).unwrap_or_else(|e| error_frame("search", &e)),
+                Err(e) => error_frame("search", &e),
             });
         }
     };
@@ -1514,11 +1513,14 @@ async fn search_stream(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<
         .into_response())
 }
 
-fn error_frame(e: &Error) -> SseEvent {
+/// `stream` is the route the failure came out of. Two routes yield these now,
+/// and a search that failed logged as `ask stream failed` sends whoever is
+/// reading the log to the wrong half of the application.
+fn error_frame(stream: &'static str, e: &Error) -> SseEvent {
     if e.status().is_server_error() {
-        tracing::error!(error = %e, "ask stream failed");
+        tracing::error!(error = %e, stream, "stream failed");
     } else {
-        tracing::debug!(error = %e, "ask stream rejected");
+        tracing::debug!(error = %e, stream, "stream rejected");
     }
     SseEvent::default()
         .event("error")

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1356,37 +1356,38 @@ async fn status(tenant: Tenant) -> Result<Json<StatusResponse>> {
         .await?
         .get("n");
 
-    // Read from the same store calls the insights page reads, so the sentence
-    // in a terminal and the screen in a browser cannot come apart.
+    // Counted rather than paged. Every one of these was the length of a list
+    // the insights page draws — fifty pursuits, two hundred artifacts — which
+    // reads as a total right up to the base that has more than that, and then
+    // reports the page size for ever. `--status` is opened to find out whether
+    // a number is moving.
+    //
+    // The predicates are the same store's, so the sentence in a terminal and
+    // the screen in a browser still cannot come apart about what is being
+    // counted; only the cap is gone.
     let learning = match tenant.core.learn.enabled {
         false => None,
-        true => {
-            let recent = tenant.core.store.recent_pursuits(50).await?;
-            let on_the_gap_list = tenant
+        true => Some(Learning {
+            pursuits_open: tenant.core.store.count_pursuits("open").await?,
+            // The ones still on the gap list: `unsatisfied` is how a run ended,
+            // and a capture that answers one afterwards leaves the word alone
+            // deliberately.
+            pursuits_unsatisfied: tenant
                 .core
                 .store
-                .open_pursuit_gap_ids(tenant.core.embedder.model())
-                .await
-                .unwrap_or_default();
-            Some(Learning {
-                pursuits_open: recent.iter().filter(|p| p.state == "open").count() as i64,
-                // The ones still on the gap list: `unsatisfied` is how a run
-                // ended, and a capture that answers one afterwards leaves the
-                // word alone deliberately.
-                pursuits_unsatisfied: recent
-                    .iter()
-                    .filter(|p| p.state == "unsatisfied" && on_the_gap_list.contains(&p.id))
-                    .count() as i64,
-                from_pursuits: tenant.core.store.synthesized_artifacts(200).await?.len() as i64,
-                gaps_open: tenant
-                    .core
-                    .store
-                    .open_gap_refs(tenant.core.embedder.model(), tenant.core.weak_below)
-                    .await
-                    .unwrap_or_default()
-                    .len() as i64,
-            })
-        }
+                .count_open_pursuit_gaps(tenant.core.embedder.model())
+                .await?,
+            from_pursuits: tenant.core.store.count_synthesized_artifacts().await?,
+            // `?`, not `unwrap_or_default`: a store that cannot be read has to
+            // say so. Reported as zero, a failure here reads as a healthy base
+            // on the one screen an operator opens because something is wrong.
+            gaps_open: tenant
+                .core
+                .store
+                .open_gap_refs(tenant.core.embedder.model(), tenant.core.weak_below)
+                .await?
+                .len() as i64,
+        }),
     };
 
     Ok(Json(StatusResponse {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1886,7 +1886,10 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(events.len(), 1, "{events:?}");
-        assert!(events[0].scope.is_some(), "an unscoped shell search: {events:?}");
+        assert!(
+            events[0].scope.is_some(),
+            "an unscoped shell search: {events:?}"
+        );
     }
 
     /// The other half of the rule, and the one that must not move: a token is
@@ -1917,7 +1920,12 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn status_says_nothing_about_learning_while_the_layer_is_off() {
         let (app, token) = app_and_token().await;
-        let v = json_of(app.oneshot(get("/api/v1/status", Some(&token))).await.unwrap()).await;
+        let v = json_of(
+            app.oneshot(get("/api/v1/status", Some(&token)))
+                .await
+                .unwrap(),
+        )
+        .await;
         assert!(v["learning"].is_null(), "{v}");
         assert!(v["chunks"].is_i64(), "{v}");
         assert!(v["jobs"].is_array(), "{v}");
@@ -1928,7 +1936,12 @@ pub(crate) mod tests {
         let mut core = crate::core::test_support::test_core().await;
         core.learn.enabled = true;
         let (app, token, _core) = app_from_core(core).await;
-        let v = json_of(app.oneshot(get("/api/v1/status", Some(&token))).await.unwrap()).await;
+        let v = json_of(
+            app.oneshot(get("/api/v1/status", Some(&token)))
+                .await
+                .unwrap(),
+        )
+        .await;
         let l = &v["learning"];
         assert!(l.is_object(), "{v}");
         for k in [
@@ -1951,7 +1964,9 @@ pub(crate) mod tests {
             .await
             .unwrap();
         crate::jobs::synthesize::segment_all(&core, &out.id).await;
-        crate::jobs::embed::run_corpus(&core, &out.id).await.unwrap();
+        crate::jobs::embed::run_corpus(&core, &out.id)
+            .await
+            .unwrap();
 
         // Drained, not just received: the answer is produced while the body is
         // read, and `record_ask` runs at the end of it.
@@ -2005,7 +2020,10 @@ pub(crate) mod tests {
         assert!(body.contains("\"embed\""), "{body}");
         assert!(body.contains("event: results"), "{body}");
         let (before, after) = body.split_once("event: results").expect("a terminal frame");
-        assert!(before.contains("event: stage"), "no stage was announced: {body}");
+        assert!(
+            before.contains("event: stage"),
+            "no stage was announced: {body}"
+        );
         assert!(
             !after.contains("event: stage"),
             "a stage was reported after the results it preceded: {body}"
@@ -2021,9 +2039,12 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
-        let v: serde_json::Value =
-            serde_json::from_slice(&axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap())
-                .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(res.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
         assert!(v.is_array(), "{v}");
     }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -993,7 +993,15 @@ pub struct SearchParams {
     pub explain: Option<bool>,
 }
 
-async fn search(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<Json<serde_json::Value>> {
+/// What both search doors make of one set of query parameters.
+///
+/// Extracted rather than repeated: `typing`, `mark` and `rerank` are decisions
+/// with reasons, and two doors reaching them separately is exactly the drift a
+/// second route must not introduce.
+fn search_request(
+    tenant: &Tenant,
+    q: SearchParams,
+) -> (SearchQuery, crate::store::feedback::Origin, bool) {
     use crate::store::feedback::Door;
     let door = q
         .door
@@ -1041,18 +1049,27 @@ async fn search(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<Json<se
     // is typing, or two operators' panels fold into each other's queries. A
     // deliberate API call is one event and has nothing to fold with.
     let origin: crate::store::feedback::Origin = if typing {
-        door.by(tenant.user.subject)
+        door.by(tenant.user.subject.clone())
     } else {
         door.into()
     };
-    // The cap `Core::search` would have applied, read the same way, so asking
-    // for an explanation cannot change what this door returns.
-    let cap = tenant
+    (query, origin, explain)
+}
+
+/// The cap `Core::search` would have applied, read the same way, so asking for
+/// an explanation — or for the stages — cannot change what a door returns.
+fn search_cap(tenant: &Tenant) -> Option<usize> {
+    tenant
         .core
         .ranking
         .read()
         .expect("ranking lock")
-        .per_source_cap;
+        .per_source_cap
+}
+
+async fn search(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<Json<serde_json::Value>> {
+    let cap = search_cap(&tenant);
+    let (query, origin, explain) = search_request(&tenant, q);
     let (results, outcome) = tenant.core.search_with(&query, cap, origin).await?;
     Ok(Json(if explain {
         serde_json::json!({ "results": results, "explanation": outcome.explanation })
@@ -1365,6 +1382,52 @@ async fn ask_stream(
 /// prompt fragments, and a stream is no less a door than a status code. This
 /// is also where the detail goes to the log, since a frame yielded from inside
 /// the body never reaches `IntoResponse` and would otherwise fail in silence.
+/// One search event as a JSON frame.
+///
+/// Deliberately not an arm of `api_sse_event`: a test over that function
+/// asserts the browser panel handles every frame name it mentions, and a
+/// search's stages are no business of the panel's.
+fn search_sse_event(ev: crate::core::search::SearchEvent) -> Result<SseEvent> {
+    use crate::core::search::SearchEvent::*;
+    let (name, data) = match ev {
+        Stages(v) => ("stages", serde_json::json!({ "stages": v })),
+        Stage(s) => ("stage", serde_json::json!({ "stage": s })),
+        Results(hits) => ("results", serde_json::json!({ "results": hits })),
+    };
+    Ok(SseEvent::default().event(name).data(
+        serde_json::to_string(&data)
+            .map_err(|e| Error::Internal(format!("serialising a search frame: {e}")))?,
+    ))
+}
+
+/// The same search, reporting each stage as it starts.
+///
+/// A second route rather than a header on the first: `GET /search` answers a
+/// bare array to the terminal client, the extension, `/mcp` and anything a
+/// person has scripted, and a route that answers two shapes depending on what
+/// was asked for is worse than two routes that each answer one.
+async fn search_stream(tenant: Tenant, Query(q): Query<SearchParams>) -> Result<Response> {
+    use tokio_stream::StreamExt as _;
+    let cap = search_cap(&tenant);
+    let (query, origin, _explain) = search_request(&tenant, q);
+    let core = tenant.core.clone();
+    let events = async_stream::stream! {
+        let s = core.search_events(query, cap, origin);
+        tokio::pin!(s);
+        while let Some(ev) = s.next().await {
+            // Terminal by construction: the producer ends at its first error,
+            // so a client sees one `error` frame and nothing after it.
+            yield Ok::<_, Error>(match ev {
+                Ok(e) => search_sse_event(e).unwrap_or_else(|e| error_frame(&e)),
+                Err(e) => error_frame(&e),
+            });
+        }
+    };
+    Ok(Sse::new(events)
+        .keep_alive(KeepAlive::default())
+        .into_response())
+}
+
 fn error_frame(e: &Error) -> SseEvent {
     if e.status().is_server_error() {
         tracing::error!(error = %e, "ask stream failed");
@@ -1455,6 +1518,7 @@ pub fn api_router(image_max_bytes: usize, pdf_max_bytes: usize) -> Router<AppSta
         .route("/corpora/{id}/reprocess", post(reprocess))
         .route("/corpora/{id}/resolve", post(resolve_near_dupe))
         .route("/search", get(search))
+        .route("/search/stream", get(search_stream))
         .route("/ask", post(ask))
         .route("/ask/stream", post(ask_stream))
         .route("/resurface", get(resurface))
@@ -1702,6 +1766,49 @@ pub(crate) mod tests {
             b = b.header("authorization", format!("Bearer {t}"));
         }
         b.body(Body::empty()).unwrap()
+    }
+
+    /// The whole SSE body of a GET, as text.
+    async fn sse_body(app: &axum::Router, uri: &str, token: &str) -> String {
+        let res = app.clone().oneshot(get(uri, Some(token))).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "{uri}");
+        String::from_utf8(
+            axum::body::to_bytes(res.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn the_streaming_door_names_its_stages_and_then_answers() {
+        let (app, token) = app_and_token().await;
+        let body = sse_body(&app, "/api/v1/search/stream?q=journal&door=cli", &token).await;
+        assert!(body.contains("event: stages"), "{body}");
+        assert!(body.contains("\"embed\""), "{body}");
+        assert!(body.contains("event: results"), "{body}");
+        let (before, after) = body.split_once("event: results").expect("a terminal frame");
+        assert!(before.contains("event: stage"), "no stage was announced: {body}");
+        assert!(
+            !after.contains("event: stage"),
+            "a stage was reported after the results it preceded: {body}"
+        );
+    }
+
+    /// The shape four clients read. It is not this change's to alter.
+    #[tokio::test]
+    async fn the_plain_search_door_still_answers_a_bare_array() {
+        let (app, token) = app_and_token().await;
+        let res = app
+            .oneshot(get("/api/v1/search?q=journal", Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert!(v.is_array(), "{v}");
     }
 
     fn bg_point(id: &str, v: Vec<f32>) -> crate::vector::VectorPoint {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1044,14 +1044,24 @@ fn search_request(
         rerank: q.rerank.unwrap_or(!typing),
         explain,
     };
+    // Typing and scoped were one decision here, and they are two.
+    //
     // Coalescing folds a keystroke into the query it was an early spelling of,
     // and it folds only within one scope — so a box that types has to say who
-    // is typing, or two operators' panels fold into each other's queries. A
-    // deliberate API call is one event and has nothing to fold with.
-    let origin: crate::store::feedback::Origin = if typing {
-        door.by(tenant.user.subject.clone())
-    } else {
-        door.into()
+    // is typing, or two operators' panels fold into each other's queries. But a
+    // shell is not a typing door and still has a subject: `--show` records the
+    // open it leads to with a scope, and `jobs/pursuit.rs` attaches an
+    // interaction to a search only when the scopes match. Unscoped, a
+    // shell-only session opened pursuits that collected no engagement at all
+    // and closed unsatisfied every time — it could widen a hole in the base and
+    // never fill one.
+    //
+    // `Api` and `Mcp` stay unscoped on purpose: a bearer token is not a person,
+    // and two agents sharing one would fold into each other's queries. The same
+    // reason `sitting.rs` keeps no sitting for them.
+    let origin: crate::store::feedback::Origin = match door {
+        Door::Extension | Door::Cli => door.by(tenant.user.subject.clone()),
+        _ => door.into(),
     };
     (query, origin, explain)
 }
@@ -1779,6 +1789,50 @@ pub(crate) mod tests {
                 .to_vec(),
         )
         .unwrap()
+    }
+
+    /// A shell has a subject, and the open it leads to is recorded with one.
+    /// Unscoped, the two could never be joined.
+    #[tokio::test]
+    async fn a_cli_search_is_recorded_against_whoever_ran_it() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let (app, token, core) = app_from_core(core).await;
+        app.clone()
+            .oneshot(get("/api/v1/search?q=journal&door=cli", Some(&token)))
+            .await
+            .unwrap();
+        // The recording is off the request path, as everything the learning
+        // layer writes is.
+        core.background.wait_idle().await;
+        let events = core
+            .store
+            .events_between(0, crate::store::now() + 1)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1, "{events:?}");
+        assert!(events[0].scope.is_some(), "an unscoped shell search: {events:?}");
+    }
+
+    /// The other half of the rule, and the one that must not move: a token is
+    /// not a person, and two agents sharing one must not fold together.
+    #[tokio::test]
+    async fn a_bearer_token_is_still_not_a_person() {
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let (app, token, core) = app_from_core(core).await;
+        app.clone()
+            .oneshot(get("/api/v1/search?q=journal", Some(&token)))
+            .await
+            .unwrap();
+        core.background.wait_idle().await;
+        let events = core
+            .store
+            .events_between(0, crate::store::now() + 1)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1, "{events:?}");
+        assert_eq!(events[0].scope, None, "Door::Api must stay unscoped");
     }
 
     #[tokio::test]

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -7297,6 +7297,31 @@ mod tests {
         );
     }
 
+    /// The spinner names which of the two passes is running.
+    ///
+    /// A seam with a compiler on neither side: the id lives in the template,
+    /// the words live in `app.js`, and the discrimination is `wasRefine` —
+    /// which the fast branch also reads. Renaming any one of the three
+    /// silently leaves the box saying the wrong thing about what it is doing,
+    /// with nothing failing anywhere.
+    #[test]
+    fn the_spinner_says_which_pass_is_in_flight() {
+        let js = include_str!("../../assets/app.js");
+        assert!(
+            js.contains("'reranking…' : 'retrieving…'"),
+            "the two passes are no longer named apart in app.js"
+        );
+        assert!(
+            js.contains("getElementById('search-spinner')"),
+            "app.js no longer reaches the element the template renders"
+        );
+        let tpl = include_str!("templates/workspace.html");
+        assert!(
+            tpl.contains(r#"id="search-spinner""#),
+            "the element the words are written into is gone from the template"
+        );
+    }
+
     #[tokio::test]
     async fn search_results_are_a_fragment_not_a_page() {
         let (app, cookie) = app_with_session().await;


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-28-cli-face-design.md` via `docs/superpowers/plans/2026-08-28-cli-face.md`.

One thesis: **nothing is drawn that did not happen**, and what is typed at a shell is written down.

## The wait

`search_inner` has always measured itself — `embed_ms` at one end, `total_ms` at the other — and published no start. It now takes an optional sender and reports the stages a search *will* pass through, then each as it begins. The list is the load-bearing half: whether the reranker runs is decided in the pipeline, out of configuration and out of which door asked, so a client that assumed the shape would eventually draw a lamp for work that was never coming.

`GET /api/v1/search/stream` carries the frames. `GET /api/v1/search` is untouched and still answers a bare array — four clients read that shape.

The CLI draws the lamps, and nothing at all for the first 120 ms, which is most searches on a warm box. `Pulse` — a cell travelling a strand on an 80 ms timer, drawn identically for 90 ms and for nine seconds — is deleted. The ask needed no new server work: `AskEvent` has emitted `Retrieved`, `Needs` and `Citations` since it was written, and `cli/ask.rs` dropped all three on the floor and animated over the gap.

## The list

The fused score printed to two decimals is gone (the bar carried the only claim it honestly made; `--json` keeps the float), the id is cut to the 8 characters `last::resolve` already accepts, and the cliff — marked until now by a dimmer row and a broken `┃` — says its sentence. Once the sentence is there the trace carries nothing, so it went too.

## Colour

`NO_COLOR` took the lamps, the upload track and the layout with it; `--fancy always` overrode `NO_COLOR` entirely. Both directions fixed: `on` is layout, `color` is SGR. The palette is the ANSI 8 and nothing else — the terminal belongs to the person in front of it, and a hex value out of `app.css` composes on `#0e1015` and nowhere else.

## The shell as a door the base learns from

The bug this uncovered: a CLI search recorded with `scope = None`, the `--show` after it recorded the open with `scope = Some(subject)`, and the sweep joins an interaction to a search only when the scopes match. **A shell-only session opened pursuits that collected exactly zero engagement and closed "nothing engaged" every time** — it could widen a hole in the base and never fill one. `Extension` and `Cli` are scoped now; `Api` and `Mcp` stay unscoped, because a bearer token is not a person.

And `record_ask` admitted `Door::Ui` alone while the streaming route called every caller `Door::Extension`, so a question typed at a shell was recorded nowhere at all. The gate is `Ui | Cli`; the door is named in the query string exactly as search names it.

## `engram --status`

`/api/v1/status` answered the machine half and nothing about what the base had been learning. It grows a `learning` block — absent, not zeroed, while `[learn]` is off — and the shell gets a verb for it.

## What changed against the design

The spec had the web search box consuming the same channel. Reading `refinePass` properly priced that differently: the box is driven *by* htmx's lifecycle — `beforeRequest` cancels the pending refine and clears the replay cache, `afterSwap` discriminates refine from typing off the request config then marks the open row, writes the cache and glides, the fragment carries an out-of-band `#rail-head` htmx swaps and the JS reads back, and `hx-sync` aborts a refine when a keystroke lands. An `EventSource` sits outside all of it, and `tests/browser/` holds one file, for the ask stream. Rebuilding htmx by hand, unverifiable, for two words of spinner text.

So the box keeps htmx and says which of its **two real passes** is in flight — `retrieving…`, then `reranking…`. True, and a smaller claim than the CLI's. The spec records the revision where the old plan was, and `/ui/search/stream` stays contained work for whenever the box is next opened up.

## Verification

- `./build-lowmem.sh test` — **2126 passed, 0 failed** (61 ignored: the Qdrant and browser suites, which need a live service)
- `cargo fmt --check` clean, `cargo clippy --lib` clean
- Not exercised against a running server; the end-to-end check is the author's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CMkR5kka9AnV8pdT9N3c3