### PR TITLE
fix: rerank startup probe checked the wrong path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1615,6 +1615,20 @@ pub enum RerankStyle {
     Vllm,
 }
 
+impl RerankStyle {
+    /// Where the startup probe checks this server is up. `base_url` for a
+    /// rerank role is the bare host — the request path itself carries any
+    /// `v1` prefix, per style, so the probe has to do the same rather than
+    /// assume `models` off the bare host. TEI has no model-list endpoint;
+    /// `info` is the one it actually serves.
+    pub fn probe_path(self) -> &'static str {
+        match self {
+            RerankStyle::Tei => "info",
+            RerankStyle::Cohere | RerankStyle::Vllm => "v1/models",
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct AuthConfig {
     pub mode: AuthMode,

--- a/src/infer/openai.rs
+++ b/src/infer/openai.rs
@@ -1311,8 +1311,15 @@ impl Describer for HttpDescriber {
 /// One cheap reachability check per role at startup. Failure is a warning, not
 /// a fatal error: ingest is designed to survive a dead inference endpoint.
 pub async fn probe(role: &str, base_url: &str, api_key: Option<&str>) -> bool {
+    probe_path(role, base_url, "models", api_key).await
+}
+
+/// Same as [`probe`], against a caller-chosen path instead of the OpenAI
+/// convention of `models` — for a server whose reachability isn't checked
+/// under that name.
+pub async fn probe_path(role: &str, base_url: &str, path: &str, api_key: Option<&str>) -> bool {
     let c = client(crate::config::DEFAULT_TIMEOUT_SECS);
-    let mut req = c.get(url(base_url, "models"));
+    let mut req = c.get(url(base_url, path));
     if let Some(k) = api_key {
         req = req.bearer_auth(k);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,13 @@ async fn startup_checks(cfg: &Config) -> Result<()> {
     )
     .await;
     if let Some(r) = &cfg.infer.rerank {
-        engram::infer::openai::probe("rerank", &r.base_url, r.api_key.as_deref()).await;
+        engram::infer::openai::probe_path(
+            "rerank",
+            &r.base_url,
+            r.style.probe_path(),
+            r.api_key.as_deref(),
+        )
+        .await;
         if !r.applies_to(engram::config::RerankApply::Search) {
             tracing::info!("rerank scoped to ask; search returns vector order");
         }


### PR DESCRIPTION
## Summary
- The startup reachability probe always did `GET {base_url}/models` for every inference role, regardless of that role's actual endpoint conventions.
- For chat/embed/vision, `base_url` conventionally includes `/v1`, so that check happened to resolve correctly.
- For rerank, `base_url` is deliberately the bare host — any `v1` prefix lives in the per-style request path instead (e.g. vLLM's `v1/rerank`). So the probe hit bare `/models`, which 404s on backends (e.g. llama.cpp/llama-swap) that only serve `/v1/models` — producing a false-negative `WARN ... role="rerank" status=404` on every startup, even when reranking itself works fine.
- `RerankStyle` now carries its own `probe_path()` (`v1/models` for `vllm`/`cohere`, `info` for `tei`), and the startup check in `main.rs` uses it via a new `probe_path()` helper in `infer/openai.rs`.

## Test plan
- [x] `cargo check` — compiles clean
- [ ] Deploy and confirm `role="rerank"` no longer logs a spurious 404 at startup when the reranker is actually reachable

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>