### PR TITLE
One dial instead of eight gates: learn.mode = off | learning | full

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,33 @@ Any key can be set by environment variable: prefix `ENGRAM__`, `__` between
 levels, e.g. `ENGRAM__INFER__EMBED__DIM=768`. Put secrets there rather than in
 the file — the loader warns if it finds one.
 
+### One dial over the learning layer
+
+`learn.mode` is the line to set first, and on a base that only wants capture,
+search and ask it is the only one from that half of the file:
+
+```toml
+[learn]
+mode = "full"     # "off" | "learning" | "full"
+```
+
+- `off` — record nothing, learn nothing, prime nothing, promote nothing;
+  consolidation is left with the exact and near duplicates capture finds for a
+  hash. A config naming `[server]`, `[vector]`, `[infer.embed]`, `[auth]` and
+  this one line starts and searches.
+- `learning` — searches and asks are recorded, activation and links are
+  written, and nothing reads any of it on the query path: no priming, no
+  associative spread, no promotion, no offers under the search box. This is the
+  mode to run `cargo test --test eval` in. A default that changes ranking moves
+  only after it has been measured, and it cannot be measured while its own
+  inputs are moving the ranking it is measured against.
+- `full` — the defaults, unchanged.
+
+Every key the mode stands for is still a key, and one written in the file wins
+over what the mode would have said. `--print-config` names the mode first and
+then the keys it decided, so which of the two you are looking at is never a
+guess.
+
 ### Inference endpoints
 
 engram speaks one protocol, the OpenAI-compatible HTTP API, and does not care

--- a/README.md
+++ b/README.md
@@ -274,10 +274,12 @@ mode = "full"     # "off" | "learning" | "full"
   this one line starts and searches.
 - `learning` — searches and asks are recorded, activation and links are
   written, and nothing reads any of it on the query path: no priming, no
-  associative spread, no promotion, no offers under the search box. This is the
-  mode to run `cargo test --test eval` in. A default that changes ranking moves
-  only after it has been measured, and it cannot be measured while its own
-  inputs are moving the ranking it is measured against.
+  associative spread, no promotion, no offers under the search box, and no
+  pursuit generation — the corpus holds still as well as the ranking. This is
+  the mode to run `cargo test --test eval` in. A default that changes ranking
+  moves only after it has been measured, and it cannot be measured while its
+  own inputs are moving the ranking it is measured against, or growing the
+  corpus it is measured over.
 - `full` — the defaults, unchanged.
 
 Every key the mode stands for is still a key, and one written in the file wins

--- a/config.example.toml
+++ b/config.example.toml
@@ -32,10 +32,12 @@
 #          hash. What is left is capture, hybrid search and ask.
 # learning record searches and asks, write the activation and the links — and
 #          read none of it on the query path. No priming, no associative
-#          spread, no promotion, no offers under the search box. This is the
-#          mode to run the evaluation harness in: a default that changes
-#          ranking moves only after it has been measured, and it cannot be
-#          measured against a ranking its own inputs have already moved.
+#          spread, no promotion, no offers under the search box, and no
+#          pursuit generation, so the corpus holds still as well as the
+#          ranking. This is the mode to run the evaluation harness in: a
+#          default that changes ranking moves only after it has been measured,
+#          and it cannot be measured against a ranking its own inputs have
+#          already moved — nor against a corpus they have grown.
 # full     all of it, which is what the tuning section below describes.
 mode = "full"
 
@@ -596,7 +598,10 @@ idle_secs = 900
 # Fewer engaged artifacts than this is a promotion case, not generation.
 min_sources = 2
 # Engagement weight a pursuit needs before it is worth a call: opened 1.0,
-# pivoted 1.5, returned 2.0, confirmed 3.0.
+# pivoted 1.5, returned 2.0, confirmed 3.0. This is the key `learn.mode` sets
+# to `inf` at "off" and "learning" — a total no pursuit reaches is how "never
+# generate" is said in the keys that already exist, the same way
+# promote.activation_above says it for promotion.
 min_engagement = 3.0
 
 # ── A recommendation under the search box ────────────────────────────────────
@@ -614,6 +619,11 @@ min_engagement = 3.0
 # young base sees the bottom rung — a card drawn at random, claiming nothing —
 # until it has something to say.
 [recommend]
+# Not one of the keys `learn.mode = "off"` sets: the offers are already off
+# there through [learn] itself, and this key is also what arms the sweep that
+# ages the recorded situations and interactions out. Switching learning off is
+# when that data most needs to leave, so the mode leaves this alone and only
+# "learning" — which keeps recording — turns it off.
 enabled = true
 # Cosine above which an event joins a cluster rather than opening its own.
 cluster_merge_at = 0.82

--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,47 @@
 # Secrets (client_secret, api_key) belong in the environment, NOT in this file.
 # The loader warns at startup if it finds one here.
 
+# ── Learning from what happens here ─────────────────────────────────────────
+# One dial over the whole layer: recording searches, learning links from
+# co-retrieval, activation, promotion, pursuits, and the area under the search
+# box. These were three separate flags — [feedback], [associate] and [pursuit]
+# each had their own — and two of their combinations were refused at startup
+# while a third was a warning, which is how you find out they were one setting
+# written three times. The sections further down keep their thresholds; this is
+# the one line that decides which of them agree with each other.
+#
+# The three old keys are refused at startup rather than ignored. Deserialization
+# drops what it does not recognise, and `[feedback] enabled = false` is a key
+# whose whole purpose was to say "keep none of this" — ignored, it would have
+# said nothing, and an upgrade would have turned recording back on for the
+# operator who had most explicitly refused it.
+#
+# On by default. Everything downstream of it moves only while the log is being
+# written, so off is the deliberate act. Nothing here leaves the machine, Ops
+# forgets all of it on one press, and off means nothing is recorded in the
+# first place.
+[learn]
+# off      record nothing, learn nothing, prime nothing, promote nothing;
+#          consolidate only the exact and near duplicates capture finds for a
+#          hash. What is left is capture, hybrid search and ask.
+# learning record searches and asks, write the activation and the links — and
+#          read none of it on the query path. No priming, no associative
+#          spread, no promotion, no offers under the search box. This is the
+#          mode to run the evaluation harness in: a default that changes
+#          ranking moves only after it has been measured, and it cannot be
+#          measured against a ranking its own inputs have already moved.
+# full     all of it, which is what the tuning section below describes.
+mode = "full"
+
+# Every key the mode stands for is still a key, and a key written in this file
+# wins over what the mode would have said. `--print-config` prints the mode
+# first and then names the keys it decided, so the two are never a guess.
+#
+# `enabled` is the recording switch itself, left commented because the mode is
+# what sets it: "full" and "learning" record, "off" does not. Uncomment it to
+# say so regardless of the mode.
+#enabled = true
+
 [server]
 bind = "127.0.0.1:8080"
 # Background worker tasks draining the job queue. One is right when every role
@@ -416,26 +457,13 @@ interval_hours = 24
 # is ever asked about.
 dedupe_interval_mins = 15
 max_dedupe_per_tick = 5
-# ── Learning from what happens here ─────────────────────────────────────────
-# One switch over the whole layer: recording searches, learning links from
-# co-retrieval, activation, pursuits, and the area under the search box. These
-# were three separate flags — [feedback], [associate] and [pursuit] each had
-# their own — and two of their combinations were refused at startup while a
-# third was a warning, which is how you find out they were one setting written
-# three times. The sections below keep their thresholds; this is the switch.
+# ══ Tuning the learning layer ═══════════════════════════════════════════════
+# You do not need to read this unless you are tuning.
 #
-# The three old keys are refused at startup rather than ignored. Deserialization
-# drops what it does not recognise, and `[feedback] enabled = false` is a key
-# whose whole purpose was to say "keep none of this" — ignored, it would have
-# said nothing, and an upgrade would have turned recording back on for the
-# operator who had most explicitly refused it.
-#
-# On by default. Everything downstream of it moves only while the log is being
-# written, so off is the deliberate act. Nothing here leaves the machine, Ops
-# forgets all of it on one press, and off means nothing is recorded in the
-# first place.
-[learn]
-enabled = true
+# Every key from here to the end of [sitting] is one `learn.mode` above already
+# set to a value that agrees with the others. They are here because a dial with
+# no keys under it is a dial nobody can disagree with, and because tuning is a
+# real thing people do — but a working base needs none of them.
 
 # Recording real searches so they can be judged later, and turned into the
 # query/artifact pairs the evaluation harness scores against.
@@ -638,6 +666,23 @@ environment = 0.2
 # Off. A monthly rhythm is real, but nothing has shown one here yet.
 month_cycle = 0.0
 
+# ── The sitting ──────────────────────────────────────────────────────────────
+# What this session has touched, carried between search, ask and capture. In
+# memory only: it dies with the process, because a working memory that survives
+# a restart is a long-term memory and engram has one of those already. The web
+# door only — an access token is not a conversation.
+#
+# Carrying is always on and changes no order: a prefilled ask box, the question
+# an answer answered, a rail of what you have been in.
+[sitting]
+# Let what this sitting has touched lift a result.
+#
+# The only part of the sitting that moves an order, and the same query ranking
+# differently in two sittings is exactly what is disorienting about it — so it
+# is off, the lift shares the one budget `associate.prime_lift` bounds, rank 0
+# never moves, and a hit it lifted says so on the row.
+prime = false
+
 # ── Scheduling ───────────────────────────────────────────────────────────────
 # The queue is the scheduler. Whether somebody is waiting on a unit is a
 # constant per stage rather than a setting: a priority you can set wrong
@@ -669,23 +714,6 @@ age_after_mins = 60
 # cancels the wait outright, because every producer already pulls a sleeping
 # unit forward, so a quiet base runs its sweeps late and never not at all.
 # backoff_max_hours = 24
-
-# ── The sitting ──────────────────────────────────────────────────────────────
-# What this session has touched, carried between search, ask and capture. In
-# memory only: it dies with the process, because a working memory that survives
-# a restart is a long-term memory and engram has one of those already. The web
-# door only — an access token is not a conversation.
-#
-# Carrying is always on and changes no order: a prefilled ask box, the question
-# an answer answered, a rail of what you have been in.
-[sitting]
-# Let what this sitting has touched lift a result.
-#
-# The only part of the sitting that moves an order, and the same query ranking
-# differently in two sittings is exactly what is disorienting about it — so it
-# is off, the lift shares the one budget `associate.prime_lift` bounds, rank 0
-# never moves, and a hit it lifted says so on the row.
-prime = false
 
 # ── Pacing ───────────────────────────────────────────────────────────────────
 # One gap in front of every inference call, whatever its role. The roles share

--- a/src/config.rs
+++ b/src/config.rs
@@ -1916,6 +1916,7 @@ impl Config {
         cfg.normalize();
         cfg.validate()?;
         cfg.warn_on_file_secrets(path);
+        cfg.warn_on_defaulted_store(&raw);
         cfg.warn_on_inert_settings();
         cfg.warn_on_inferred_ceiling_param();
         cfg.warn_on_unplaced_plan_cost();
@@ -2001,7 +2002,6 @@ impl Config {
                 resolve!("associate.spread_max", self.associate.spread_max, 0);
                 resolve!("associate.prime_lift", self.associate.prime_lift, 0);
                 resolve!("sitting.prime", self.sitting.prime, false);
-                resolve!("recommend.enabled", self.recommend.enabled, false);
                 // Promotion is the other reader. It is gated on a threshold
                 // rather than a switch, so the way to say "never" in the keys
                 // that exist is a threshold no activation reaches — which is
@@ -2012,10 +2012,18 @@ impl Config {
                     self.promote.activation_above,
                     f64::INFINITY
                 );
+                // A pursuit is the third writer, and the one that writes a new
+                // artifact rather than reordering existing ones. Neither mode
+                // may grow the corpus from what was recorded: at `learning`
+                // that is the whole promise — a sweep that generates while it
+                // measures is measuring a corpus its own inputs have moved —
+                // and at `off` it follows from the rest. Said in the same
+                // shape as promotion, because it is the same kind of gate: an
+                // engagement total no pursuit reaches.
                 resolve!(
-                    "promote.resynthesize_after_unconfirmed",
-                    self.promote.resynthesize_after_unconfirmed,
-                    0
+                    "pursuit.min_engagement",
+                    self.pursuit.min_engagement,
+                    f64::INFINITY
                 );
             }
         }
@@ -2036,6 +2044,15 @@ impl Config {
             }
             LearnMode::Learning => {
                 resolve!("learn.enabled", self.learn.enabled, true);
+                // The offers under the search box are read from the recorded
+                // clusters, so they are a query-path reader and go off here.
+                // Not in the shared block: at `off` this key is what arms the
+                // retention sweep that ages the recorded rows out
+                // (`core/background.rs`), and `recommends()` already ands
+                // `learn.enabled`, so resolving it there would buy nothing and
+                // freeze every situation and interaction already written down
+                // in the database for ever.
+                resolve!("recommend.enabled", self.recommend.enabled, false);
             }
             LearnMode::Full => {}
         }
@@ -2195,6 +2212,27 @@ impl Config {
     /// letting an operator discover a faculty has been idle since they turned
     /// `[learn]` off. The combinations that used to be refused here are gone —
     /// there is one switch now, and it cannot disagree with itself.
+    /// `[store]` is defaulted rather than required, and a defaulted store is
+    /// indistinguishable at runtime from the one the operator meant.
+    ///
+    /// A missing section is the ordinary case — the five-section file this
+    /// mode exists for names none of it — but so is a mistyped `[stroe]` or a
+    /// section lost in an edit, and those start on a fresh control database in
+    /// the process's working directory rather than the base the operator has.
+    /// An empty base and a refusal are both survivable; an empty base that
+    /// says nothing is not. Say which paths are in force, once, at startup.
+    fn warn_on_defaulted_store(&self, raw: &config::Config) {
+        if raw.get::<config::Value>("store").is_ok() {
+            return;
+        }
+        tracing::info!(
+            control_path = %self.store.control_path,
+            dir = %self.store.dir,
+            "no [store] section: using the default paths, resolved against the working \
+             directory. If this base has data elsewhere, the section is missing or misspelt."
+        );
+    }
+
     fn warn_on_inert_settings(&self) {
         if self.infer.synthesis == SynthesisMode::Earned && !self.learn.enabled {
             tracing::warn!(
@@ -2948,12 +2986,39 @@ mode = "off"
         // the promotion it wanted one for cannot happen at `off` anyway.
         assert_eq!(cfg.infer.synthesis, SynthesisMode::Off);
         assert!(cfg.infer.synthesize.is_none());
-        assert!(!cfg.recommend.enabled);
         assert!(!cfg.consolidate.enabled);
         assert!(!cfg.sitting.prime);
         assert_eq!(cfg.associate.spread_max, 0);
         assert_eq!(cfg.associate.prime_lift, 0);
         assert!(cfg.promote.activation_above.is_infinite());
+        assert!(cfg.pursuit.min_engagement.is_infinite());
+        // Left alone on purpose. `recommends()` is already false through
+        // `learn.enabled`, and this key is what arms the retention sweep — an
+        // operator switching learning off is exactly who needs the situations
+        // and interactions already recorded to keep ageing out.
+        assert!(cfg.recommend.enabled);
+    }
+
+    #[test]
+    fn off_leaves_the_key_that_ages_recorded_rows_out_alone() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, &format!("{MINIMAL}\n[learn]\nmode = \"off\"\n"));
+        let cfg = Config::load(Some(&p)).unwrap();
+        // `core::background::periodic_units` arms `Stage::Retention` on
+        // `feedback.retain_days > 0 || learn.enabled || recommend.enabled`.
+        // At `off` the first two are false, so this key is the whole of what
+        // keeps `expire_context_events` and `expire_interactions` running.
+        assert!(!cfg.learn.enabled);
+        assert_eq!(cfg.feedback.retain_days, 0);
+        assert!(cfg.recommend.enabled);
+        // And the mode never says so, so nothing about it reads as decided.
+        assert!(
+            !cfg.learn
+                .resolved
+                .iter()
+                .any(|(k, _)| *k == "recommend.enabled")
+        );
     }
 
     #[test]
@@ -2970,6 +3035,9 @@ mode = "off"
         assert!(!cfg.sitting.prime);
         assert!(!cfg.recommend.enabled);
         assert!(cfg.promote.activation_above.is_infinite());
+        // Nothing new is written into the corpus either: a sweep that
+        // generates while it measures is measuring its own inputs.
+        assert!(cfg.pursuit.min_engagement.is_infinite());
         // Synthesis is not the mode's business here: `learning` is about what
         // moves a rank, and an eager base still writes what it always wrote.
         assert_eq!(cfg.infer.synthesis, SynthesisMode::Earned);

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub server: ServerConfig,
+    /// Defaulted rather than required: every field under it already has a
+    /// default, and the file that names five sections and one mode should not
+    /// be refused over an empty table naming none of them.
+    #[serde(default)]
     pub store: StoreConfig,
     pub vector: VectorConfig,
     pub infer: InferConfig,
@@ -125,12 +129,65 @@ pub struct PacingConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct LearnConfig {
+    /// The named bundle. Every key it stands for is still a key, and a key
+    /// written in the file wins over what the mode would have said.
+    pub mode: LearnMode,
     pub enabled: bool,
+    /// What the mode decided, in the order it decided it, for
+    /// `--print-config` to show. Not a setting: it is filled in during
+    /// `load` and skipped by deserialization, so a file naming it is
+    /// ignored the way any unknown key is.
+    #[serde(skip)]
+    pub resolved: Vec<(&'static str, String)>,
 }
 
 impl Default for LearnConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            mode: LearnMode::default(),
+            enabled: true,
+            resolved: Vec::new(),
+        }
+    }
+}
+
+/// The dial: one word for a coherent bundle of the keys below it.
+///
+/// The keys did not go anywhere. What the mode does is decide the ones the
+/// file does not, which is what makes `off` a line rather than a page: the
+/// half-dozen settings that have to agree for "learn nothing" to mean
+/// anything are settings that only ever agreed by hand before, and the
+/// combinations that did not agree were refused at startup or warned about.
+/// A mode cannot disagree with itself.
+///
+/// `learning` is the one that did not exist. It is the mode the roadmap's own
+/// rule asks for — a default that changes ranking moves only after the harness
+/// has been run — and it is the only way to run the harness honestly: the log
+/// is written, activation and links accumulate, and nothing reads any of it on
+/// the query path, so a sweep compares a ranking against itself rather than
+/// against a ranking the sweep's own inputs have already moved.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LearnMode {
+    /// Record nothing, learn nothing, prime nothing, promote nothing;
+    /// consolidate only the exact and near duplicates capture finds for a
+    /// hash. What is left is capture, hybrid search and ask.
+    Off,
+    /// Record and accumulate, read none of it on the query path. The mode to
+    /// run the harness in before any of this is allowed to move a rank.
+    Learning,
+    /// Today's defaults, unchanged.
+    #[default]
+    Full,
+}
+
+impl LearnMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LearnMode::Off => "off",
+            LearnMode::Learning => "learning",
+            LearnMode::Full => "full",
+        }
     }
 }
 
@@ -1854,7 +1911,8 @@ impl Config {
             )
             .build()?;
         Self::refuse_removed_keys(&raw)?;
-        let mut cfg: Config = raw.try_deserialize()?;
+        let mut cfg: Config = raw.clone().try_deserialize()?;
+        cfg.apply_learn_mode(&raw);
         cfg.normalize();
         cfg.validate()?;
         cfg.warn_on_file_secrets(path);
@@ -1904,6 +1962,84 @@ impl Config {
              setting that says \"keep none of this\" into a setting that says nothing.",
             found.join("\n")
         )))
+    }
+
+    /// The dial, resolved to the keys it stands for.
+    ///
+    /// Runs after deserialization and before validation, so what the mode
+    /// decides is what the rest of the file is checked against: `off` turns
+    /// synthesis off, and the config that names five sections and one mode is
+    /// then a config that starts, rather than one refused for having no
+    /// `[infer.synthesize]` behind a promotion that can no longer happen.
+    ///
+    /// A key written in the file — or given in the environment, which lands in
+    /// the same merged source — is never touched. That is the whole of the
+    /// promise that nobody loses a knob: the mode fills in what was left
+    /// unsaid, and says so afterwards through `--print-config`.
+    ///
+    /// `full` decides nothing, because `full` is the defaults. That is not a
+    /// special case so much as the definition: the mode exists to describe the
+    /// two bundles that were previously a page of agreeing settings.
+    fn apply_learn_mode(&mut self, raw: &config::Config) {
+        let mut resolved: Vec<(&'static str, String)> = Vec::new();
+        macro_rules! resolve {
+            ($key:literal, $field:expr, $value:expr) => {
+                if raw.get::<config::Value>($key).is_err() {
+                    $field = $value;
+                    resolved.push(($key, format!("{}", $field)));
+                }
+            };
+        }
+        match self.learn.mode {
+            LearnMode::Full => {}
+            LearnMode::Off | LearnMode::Learning => {
+                // Nothing reads the log on the query path in either mode.
+                // Priming and the associative spread are the two things that
+                // reorder or extend a result list from what was learned; the
+                // sitting's lift is the third, and the offers under the search
+                // box are read from the same clusters.
+                resolve!("associate.spread_max", self.associate.spread_max, 0);
+                resolve!("associate.prime_lift", self.associate.prime_lift, 0);
+                resolve!("sitting.prime", self.sitting.prime, false);
+                resolve!("recommend.enabled", self.recommend.enabled, false);
+                // Promotion is the other reader. It is gated on a threshold
+                // rather than a switch, so the way to say "never" in the keys
+                // that exist is a threshold no activation reaches — which is
+                // also what `--print-config` then shows, in the units the
+                // operator would have typed.
+                resolve!(
+                    "promote.activation_above",
+                    self.promote.activation_above,
+                    f64::INFINITY
+                );
+                resolve!(
+                    "promote.resynthesize_after_unconfirmed",
+                    self.promote.resynthesize_after_unconfirmed,
+                    0
+                );
+            }
+        }
+        match self.learn.mode {
+            LearnMode::Off => {
+                resolve!("learn.enabled", self.learn.enabled, false);
+                // Capture-time near-duplicate detection is not this switch: it
+                // costs a hash and stays on. What stops is the background
+                // sweep, which is a stream of model calls about pairs.
+                resolve!("consolidate.enabled", self.consolidate.enabled, false);
+                // With nothing promoted, `earned` is `off` with a synthesizer
+                // requirement attached. Resolving it here is what lets the
+                // five-section config start.
+                if raw.get::<config::Value>("infer.synthesis").is_err() {
+                    self.infer.synthesis = SynthesisMode::Off;
+                    resolved.push(("infer.synthesis", SynthesisMode::Off.as_str().into()));
+                }
+            }
+            LearnMode::Learning => {
+                resolve!("learn.enabled", self.learn.enabled, true);
+            }
+            LearnMode::Full => {}
+        }
+        self.learn.resolved = resolved;
     }
 
     /// Values that would make a feature quietly useless, put back rather than
@@ -2066,6 +2202,17 @@ impl Config {
                  moves, so nothing is ever promoted — this is `off` under another name."
             );
         }
+        if self.infer.synthesis == SynthesisMode::Earned
+            && self.learn.mode == LearnMode::Learning
+            && self.promote.activation_above.is_infinite()
+        {
+            tracing::warn!(
+                "infer.synthesis = \"earned\" at learn.mode = \"learning\": activation is \
+                 recorded but nothing reads it, so no window is ever promoted. That is what \
+                 the mode is for — run the harness here, then move to \"full\" — but the \
+                 synthesizer is idle until you do."
+            );
+        }
     }
 
     /// The output ceiling's name is a guess whenever `reasoning_effort` is set
@@ -2213,7 +2360,20 @@ impl Config {
         if let Some(l) = c.auth.local.as_mut() {
             l.password_hash = R.into();
         }
-        format!("{c:#?}")
+        // The dial first, and in the file's own spelling. The dump below it is
+        // the resolved config, so the values are all in there — but reading a
+        // hundred fields to work out which of them the mode decided is the
+        // question this line answers directly.
+        let mut head = format!("# learn.mode = \"{}\"\n", c.learn.mode.as_str());
+        if c.learn.resolved.is_empty() {
+            head.push_str("# nothing was resolved from it: every key it stands for is set\n");
+        } else {
+            head.push_str("# resolved from it, because the file did not say:\n");
+            for (key, value) in &c.learn.resolved {
+                head.push_str(&format!("#   {key} = {value}\n"));
+            }
+        }
+        format!("{head}\n{c:#?}")
     }
 }
 
@@ -2747,6 +2907,127 @@ mode = "local"
 username = "dev"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
 "#;
+
+    /// The five sections the issue names, one mode, and nothing else. No
+    /// synthesizer, no tiers, no ask: the base this starts is capture, hybrid
+    /// search and whatever `[infer.embed]` can reach.
+    const FIVE_SECTIONS: &str = r#"
+[server]
+bind = "127.0.0.1:8080"
+
+[vector]
+url = "http://localhost:6334"
+collection = "chunks"
+
+[infer.embed]
+base_url = "http://localhost:8000/v1"
+model = "bge-m3"
+dim = 1024
+max_input_tokens = 8192
+
+[auth]
+mode = "local"
+
+[auth.local]
+username = "dev"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aaaa"
+
+[learn]
+mode = "off"
+"#;
+
+    #[test]
+    fn five_sections_and_one_mode_start() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, FIVE_SECTIONS);
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert_eq!(cfg.learn.mode, LearnMode::Off);
+        assert!(!cfg.learn.enabled);
+        // `earned` would have refused this file for having no synthesizer, and
+        // the promotion it wanted one for cannot happen at `off` anyway.
+        assert_eq!(cfg.infer.synthesis, SynthesisMode::Off);
+        assert!(cfg.infer.synthesize.is_none());
+        assert!(!cfg.recommend.enabled);
+        assert!(!cfg.consolidate.enabled);
+        assert!(!cfg.sitting.prime);
+        assert_eq!(cfg.associate.spread_max, 0);
+        assert_eq!(cfg.associate.prime_lift, 0);
+        assert!(cfg.promote.activation_above.is_infinite());
+    }
+
+    #[test]
+    fn learning_records_everything_and_reads_none_of_it() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, &format!("{MINIMAL}\n[learn]\nmode = \"learning\"\n"));
+        let cfg = Config::load(Some(&p)).unwrap();
+        // Written: the log, and the activation and links read from it.
+        assert!(cfg.learn.enabled);
+        // Read on the query path: none of it.
+        assert_eq!(cfg.associate.spread_max, 0);
+        assert_eq!(cfg.associate.prime_lift, 0);
+        assert!(!cfg.sitting.prime);
+        assert!(!cfg.recommend.enabled);
+        assert!(cfg.promote.activation_above.is_infinite());
+        // Synthesis is not the mode's business here: `learning` is about what
+        // moves a rank, and an eager base still writes what it always wrote.
+        assert_eq!(cfg.infer.synthesis, SynthesisMode::Earned);
+        assert!(cfg.consolidate.enabled);
+    }
+
+    #[test]
+    fn full_is_todays_defaults_and_resolves_nothing() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let with = write(&dir, &format!("{MINIMAL}\n[learn]\nmode = \"full\"\n"));
+        let cfg = Config::load(Some(&with)).unwrap();
+        assert!(cfg.learn.resolved.is_empty(), "{:?}", cfg.learn.resolved);
+        let plain = Config::load(Some(&write(&tempfile::tempdir().unwrap(), MINIMAL))).unwrap();
+        assert_eq!(cfg.learn.mode, plain.learn.mode);
+        assert_eq!(cfg.learn.enabled, plain.learn.enabled);
+        assert_eq!(cfg.recommend.enabled, plain.recommend.enabled);
+        assert_eq!(cfg.associate.spread_max, plain.associate.spread_max);
+        assert_eq!(cfg.promote.activation_above, plain.promote.activation_above);
+    }
+
+    #[test]
+    fn a_key_in_the_file_beats_the_mode() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        // `off` with three of its keys contradicted: the mode fills in what
+        // was left unsaid and touches nothing else.
+        let p = write(
+            &dir,
+            &format!(
+                "{MINIMAL}\n[learn]\nmode = \"off\"\nenabled = true\n\
+                 [recommend]\nenabled = true\n[associate]\nspread_max = 2\n"
+            ),
+        );
+        let cfg = Config::load(Some(&p)).unwrap();
+        assert!(cfg.learn.enabled);
+        assert!(cfg.recommend.enabled);
+        assert_eq!(cfg.associate.spread_max, 2);
+        // ...and the rest of the bundle still applies.
+        assert!(!cfg.consolidate.enabled);
+        assert!(cfg.promote.activation_above.is_infinite());
+        let named: Vec<&str> = cfg.learn.resolved.iter().map(|(k, _)| *k).collect();
+        assert!(!named.contains(&"learn.enabled"), "{named:?}");
+        assert!(!named.contains(&"associate.spread_max"), "{named:?}");
+        assert!(named.contains(&"consolidate.enabled"), "{named:?}");
+    }
+
+    #[test]
+    fn print_config_names_what_the_mode_decided() {
+        let _guard = env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(&dir, FIVE_SECTIONS);
+        let dump = Config::load(Some(&p)).unwrap().redacted();
+        assert!(dump.contains("learn.mode = \"off\""), "{dump}");
+        assert!(dump.contains("consolidate.enabled = false"), "{dump}");
+        assert!(dump.contains("infer.synthesis = off"), "{dump}");
+        assert!(dump.contains("promote.activation_above = inf"), "{dump}");
+    }
 
     #[test]
     fn loads_minimal_config() {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -568,7 +568,10 @@ pub mod test_support {
             pinned_boost: 0.15,
             // Off in tests, whatever ships: the tests that need a log switch
             // it on and the rest assert nothing is recorded.
-            learn: crate::config::LearnConfig { enabled: false },
+            learn: crate::config::LearnConfig {
+                enabled: false,
+                ..Default::default()
+            },
             feedback: crate::config::FeedbackConfig::default(),
             capture: crate::config::CaptureConfig::default(),
             // Inert in most tests whatever it says, because `learn` is off and

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -535,7 +535,10 @@ async fn a_pair_naming_a_frozen_artifact_can_actually_be_found() {
         weak_below: 0.0,
         recency_half_life_days: 180,
         pinned_boost: 0.15,
-        learn: engram::config::LearnConfig { enabled: false },
+        learn: engram::config::LearnConfig {
+            enabled: false,
+            ..Default::default()
+        },
         feedback: engram::config::FeedbackConfig::default(),
         capture: engram::config::CaptureConfig::default(),
         associate: engram::config::AssociateConfig::default(),


### PR DESCRIPTION
Closes #72. First of the four branches under #84.

`[learn]` grows a `mode`, and the mode is the line to set first. It resolves to the keys that already exist rather than replacing them: `off` and `learning` each stand for a bundle of settings that only ever meant anything when they agreed, and agreeing was previously something an operator did by hand across six sections while the startup refusals caught the combinations that did not.

```toml
[learn]
mode = "full"     # "off" | "learning" | "full"
```

- **`off`** — nothing recorded, nothing primed, nothing promoted, no offers under the search box, and consolidation left with the exact and near duplicates capture finds for a hash. It also resolves `infer.synthesis` to `off`, because `earned` is a promotion that cannot happen at this mode and a synthesizer requirement that would otherwise refuse the file. That is what makes the five-section config in the issue start.
- **`learning`** — the mode that did not exist. The log is written and activation and links accumulate; nothing reads them on the query path — no priming, no associative spread, no promotion, no offers. The only honest way to run the harness: a sweep otherwise compares a ranking against inputs that have already moved it.
- **`full`** — today's defaults, resolving nothing. A no-op for every existing config.

## How it resolves

`apply_learn_mode` runs after deserialization and before validation, against the merged raw source — so a key written in the file *or* given as `ENGRAM__…` always wins, and the mode only fills in what was left unsaid. What it decided is recorded on `learn.resolved` and printed as a header by `--print-config`:

```
# learn.mode = "off"
# resolved from it, because the file did not say:
#   associate.spread_max = 0
#   associate.prime_lift = 0
#   sitting.prime = false
#   recommend.enabled = false
#   promote.activation_above = inf
#   promote.resynthesize_after_unconfirmed = 0
#   learn.enabled = false
#   consolidate.enabled = false
#   infer.synthesis = off
```

Promotion off is expressed as an unreachable threshold, because `promote.activation_above` is the only key that exists to say it — and `inf` is what the operator then reads back, in the units they would have typed.

## Also

- `[store]` became `#[serde(default)]`. Every field under it already had a default, and the config that names five sections should not be refused over an empty table.
- A new `WARN` for `infer.synthesis = "earned"` at `mode = "learning"`: activation is recorded, nothing reads it, so the synthesizer is idle until you move to `full`. That is what the mode is for, but it should not be silent.
- `config.example.toml` leads with the dial and puts the tuning keys behind a heading that says you do not need to read them unless you are tuning; `[schedule]` moved below `[sitting]` so that region is contiguous.
- README gains a short section on the dial.

## Acceptance

- ✅ A config with only `[server]`, `[vector]`, `[infer.embed]`, `[auth]` and `learn.mode = "off"` starts. Verified against a live Qdrant: the server boots and listens. It was **not** verified that it *searches* — this box has no embed endpoint on `:8000`, so that half of the criterion is untested.
- ✅ `--print-config` shows what the mode resolved each key to.

Five new tests cover the five-section start, `learning` recording without reading, `full` resolving nothing, a file key beating the mode, and the `--print-config` header. Full suite green: 2142 lib tests plus the integration suites, `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMzYtygHUsrezakWMVFdNc
