### PR TITLE
feat: judge at the moment of search (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ positions those searches really gave. Not a proxy score.
   supports gets badged. That badge is the best part.
 - **From a shell** — capture, search, ask, read. Drawn on a terminal, plain text
   in a pipe. See [The client](#the-client).
-- **Judge** — recorded searches come back shuffled and unlabelled, one keystroke
-  each. It all stays on your machine, and one button forgets it.
+- **Judge** — a result you read, or answer *Was this what you were looking
+  for?* under, is a labelled pair; what that leaves comes back as a card, top
+  five in order, one keystroke each. It all stays on your machine, and one
+  button forgets it.
 - **Duplicates** — near-duplicates parked at capture, close pairs queued for a
   person. Nothing deleted. No merge drops a number, a command or a path. Undo on
   everything.

--- a/assets/app.js
+++ b/assets/app.js
@@ -2272,7 +2272,12 @@
       // Disabled options are skipped, matching the badges: a deprecated or
       // superseded candidate is shown at its place in the pool but carries no
       // digit, and the numbering runs over the choosable ones without a gap.
-      var pick = card.querySelectorAll('.judge-option:not([disabled])')[Number(e.key) - 1];
+      // Options behind the fold are skipped too — they carry no digit, and a
+      // key that pressed what cannot be seen would be a verdict on nothing.
+      var pick = Array.prototype.filter.call(
+        card.querySelectorAll('.judge-option:not([disabled])'),
+        function (o) { return !o.closest('.judge-more'); }
+      )[Number(e.key) - 1];
       if (pick) { e.preventDefault(); pick.click(); }
       return;
     }

--- a/assets/app.js
+++ b/assets/app.js
@@ -626,19 +626,18 @@
   // pursuit signal there is, and it is sent as a beacon so leaving costs
   // nothing. Under three seconds is a glance, not a read, and is not sent.
   //
-  // Where the pane names the search it was opened from, that goes too: a
-  // read long enough is taken, provisionally, as the search having found
-  // what it was for. The server decides how long is long enough.
-  var dwell = { id: null, event: null, since: 0 };
+  // A pursuit signal only. This used to carry the search the pane was opened
+  // from, and a long enough read was written as that search having found its
+  // answer — but the beacon flushes as the pane is *left*, so it landed after
+  // the buttons under the result and overwrote them. The bar answers now.
+  var dwell = { id: null, since: 0 };
   function flushDwell() {
     if (!dwell.id) return;
     var secs = Math.round((Date.now() - dwell.since) / 1000);
     var id = dwell.id;
-    var event = dwell.event;
     dwell.id = null;
     if (secs < 3) return;
     var body = new URLSearchParams({ secs: String(secs) });
-    if (event) body.set('event', event);
     if (navigator.sendBeacon) {
       navigator.sendBeacon('/ui/artifacts/' + id + '/dwell', body);
     } else {
@@ -652,7 +651,6 @@
     flushDwell();
     if (id) {
       dwell.id = id;
-      dwell.event = open.getAttribute('data-event');
       dwell.since = Date.now();
     }
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -625,14 +625,20 @@
   // next pane swap, the page going away, the tab going hidden. The weakest
   // pursuit signal there is, and it is sent as a beacon so leaving costs
   // nothing. Under three seconds is a glance, not a read, and is not sent.
-  var dwell = { id: null, since: 0 };
+  //
+  // Where the pane names the search it was opened from, that goes too: a
+  // read long enough is taken, provisionally, as the search having found
+  // what it was for. The server decides how long is long enough.
+  var dwell = { id: null, event: null, since: 0 };
   function flushDwell() {
     if (!dwell.id) return;
     var secs = Math.round((Date.now() - dwell.since) / 1000);
     var id = dwell.id;
+    var event = dwell.event;
     dwell.id = null;
     if (secs < 3) return;
     var body = new URLSearchParams({ secs: String(secs) });
+    if (event) body.set('event', event);
     if (navigator.sendBeacon) {
       navigator.sendBeacon('/ui/artifacts/' + id + '/dwell', body);
     } else {
@@ -644,7 +650,11 @@
     var id = open ? open.getAttribute('data-artifact') : null;
     if (id === dwell.id) return;
     flushDwell();
-    if (id) { dwell.id = id; dwell.since = Date.now(); }
+    if (id) {
+      dwell.id = id;
+      dwell.event = open.getAttribute('data-event');
+      dwell.since = Date.now();
+    }
   }
 
   // ── The end of the empty base ─────────────────────────────────────────────

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -132,6 +132,36 @@
 }
 .judge-options > li:has(.judge-option:hover),
 .judge-options > li:has(.judge-option:focus-visible) { border-color: var(--color-accent-muted); }
+
+/* The fold under the first five. A row of the pool rather than a browser
+   default: unstyled it arrived as a native triangle and a line of body text
+   sitting between two lists that are neither. The chevron is `.judge-peek`'s,
+   turned to point down, because it is the same gesture at a different scale —
+   there, one option's full text; here, the rest of the list.
+
+   No border or ground of its own: the fold is a line between two halves of one
+   list, and boxing it would make the second half read as a different kind of
+   thing from the first — which is the one thing the ordering says it is not. */
+.judge-more > summary {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.35rem 0.7rem 0.5rem; cursor: pointer; list-style: none;
+  font-size: var(--text-sm); color: var(--color-fg-muted);
+}
+.judge-more > summary::-webkit-details-marker { display: none; }
+.judge-more > summary::before {
+  content: ""; width: 0.38rem; height: 0.38rem; flex: none;
+  border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor;
+  transform: translateY(-0.1rem) rotate(45deg); transition: transform 160ms ease;
+}
+.judge-more > summary:hover { color: var(--color-fg-primary); }
+.judge-more > summary:focus-visible {
+  outline: 2px solid var(--color-accent); outline-offset: -2px;
+  border-radius: var(--radius-sm);
+}
+.judge-more[open] > summary::before { transform: translateY(0.05rem) rotate(-135deg); }
+/* The first five already end in the list's own padding, so the fold's own top
+   padding would double it into a gap the ordering has to be read across. */
+.judge-more > .judge-options { padding-top: 0; }
 .judge-option {
   display: grid; grid-template-columns: 1.6rem minmax(0, 1fr); gap: 0.15rem 0.55rem;
   width: 100%; text-align: left; padding: 0.6rem 0.3rem 0.6rem 0.7rem;

--- a/assets/css/42-judge.css
+++ b/assets/css/42-judge.css
@@ -60,70 +60,18 @@
 .judge-ask { margin: 0.8rem 0 0; }
 .judge-ask .mono { font-size: var(--text-xs); color: var(--color-fg-muted); }
 
-/* ── The bar ─────────────────────────────────────────────────────────────────
-   An object with a height, under the query, where the work is.
+/* ── The count ───────────────────────────────────────────────────────────────
+   A number, under the query, where the work is.
 
-   Three things move on it, and all three are borrowed from the bars games put
-   experience and health in — for the reason those bars are built that way: a
-   quantity that only ever changes its endpoint is hard to notice changing at
-   all.
-
-   · The pale trail goes straight to the new value while the solid fill follows
-     late, so the ground just won reads as area rather than as a number that is
-     now different.
-   · The fill overshoots slightly and settles, so it arrives rather than stops.
-   · A sheen crosses once.
-
-   None of it responds to *what* was judged — only to the fact that something
-   was, which is `Pulse::delta` being non-empty. A bar that celebrated
-   confirmations would be teaching agreement with the ranker it exists to
-   measure, and the flash line above the card already says the informative
-   thing, quietly, in the opposite direction. */
+   There was a bar here, with a trail, a sheen and notches, borrowed from the
+   ones games put experience in. It made the page prettier and the question no
+   easier, and most of the distance is covered by searching now rather than by
+   this page — so what is left is the figure itself, sized to be read at a
+   glance and not animated at all. Nothing here reacts to *which* verdict was
+   given; the flash line above the card is where a judgement is spoken about. */
 .judge-live { margin: 0; }
-.judge-xp {
-  position: relative; height: 14px; border-radius: 7px;
-  background: var(--color-bg-active); border: 1px solid var(--color-border-subtle);
-  overflow: hidden;
-}
-.judge-xp > span { position: absolute; inset: 0; border-radius: 7px; }
-.judge-xp-trail { width: var(--to); background: var(--color-accent-muted); }
-.judge-xp-fill {
-  width: var(--to);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--color-accent) 82%, white) 0%,
-    var(--color-accent) 55%,
-    color-mix(in srgb, var(--color-accent) 84%, black) 100%);
-}
-/* Notches, so the bar is a distance rather than a percentage: ten of them,
-   because the two counts it spans are always round numbers of judgements. */
-.judge-xp-notches {
-  pointer-events: none; opacity: 0.45;
-  background-image: repeating-linear-gradient(
-    90deg, transparent 0 calc(10% - 1px), var(--color-bg-base) calc(10% - 1px) 10%);
-}
-.judge-xp-sheen { pointer-events: none; transform: translateX(-110%); }
-
-@keyframes judge-xp-fill { from { width: var(--from); } to { width: var(--to); } }
-@keyframes judge-xp-sheen { to { transform: translateX(110%); } }
-@keyframes judge-xp-pulse {
-  0% { box-shadow: 0 0 0 0 var(--color-accent-muted); }
-  35% { box-shadow: 0 0 0 5px transparent; }
-  100% { box-shadow: 0 0 0 0 transparent; }
-}
-/* `backwards`, so the fill holds where it started for the length of its delay
-   instead of standing at the new value until the animation begins — which is
-   the delay the trail is visible in, and so the whole effect. */
-.judge-xp-moved .judge-xp-fill {
-  animation: judge-xp-fill 620ms 180ms cubic-bezier(0.34, 1.4, 0.64, 1) backwards;
-}
-.judge-xp-moved .judge-xp-sheen { animation: judge-xp-sheen 850ms 200ms ease-out 1; }
-/* Once, and then still. A bar that pulsed continuously would be asking for
-   attention on a page whose actual work is reading. */
-.judge-xp-moved { animation: judge-xp-pulse 700ms ease-out 1; }
-
-.judge-xp-read { margin: 0.45rem 0 0; font-size: var(--text-base); }
-.judge-xp-read b { font-weight: 500; font-size: var(--text-lg); }
+.judge-count { margin: 0.45rem 0 0; font-size: var(--text-base); }
+.judge-count b { font-weight: 500; font-size: var(--text-lg); }
 .judge-live .hint { margin: 0.25rem 0 0; }
 /* Four counts, two figures and a delta do not fit across a phone. They wrap
    rather than run off the side — the row is a readout, and a readout that has
@@ -319,13 +267,11 @@
 .judge-assign .input { max-width: 32rem; }
 
 /* Every rule above is one-shot and cheap, and all of it is skipped for anyone
-   who asked not to be moved. The bar still shows where it stands; it simply
+   who asked not to be moved. Each thing still shows where it stands; it simply
    arrives there. */
 @media (prefers-reduced-motion: reduce) {
   .judge-ghost, .judge-card, .judge-peek > summary::after { transition: none; }
-  .judge-card-enter, .judge-tick, .judge-delta,
-  .judge-xp-moved, .judge-xp-moved .judge-xp-fill,
-  .judge-xp-moved .judge-xp-sheen { animation: none; }
+  .judge-card-enter, .judge-tick, .judge-delta { animation: none; }
   .judge-delta { opacity: 1; }
   #card.htmx-swapping .judge-card { transform: none; opacity: 1; }
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -487,14 +487,21 @@ max_dedupe_per_tick = 5
 # setting — an empty pool leaves every card with nothing to choose — and is put
 # back to the default with a line in the log.
 candidates = 20
-# Window in which another query — a longer one, a rewording, or the same one
-# again — replaces the previous event instead of starting its own, so a burst of
-# searches that ends in one open is one search. Opening a result closes the
-# window: the list that was read is the list the hit is scored on. 0 turns
-# folding off. Applies to the search box only, and only within one signed-in
-# operator: a call through the API or MCP is a deliberate query, not a
+# Window in which another query — a longer one, a shorter one, a rewording, or
+# the same one again — replaces the previous event instead of starting its own,
+# so a burst of searches that ends in one open is one search. Opening a result
+# closes the window: the list that was read is the list the hit is scored on. 0
+# turns folding off. Applies to the search box only, and only within one
+# signed-in operator: a call through the API or MCP is a deliberate query, not a
 # keystroke, and two people typing at once are not typing the same thing.
-coalesce_secs = 15
+#
+# Keep this at the length of a typing burst. Because *any* rewording folds, the
+# window doubles as how long a finished search has left to live: search, read
+# the titles, think, search again inside the window, and the first search is
+# gone — the one case where nobody opened anything being precisely what the
+# unmatched-gap sweep is there to catch. It was 15s, which is long enough to
+# swallow a second, deliberate question.
+coalesce_secs = 5
 # Days an unjudged captured search is kept. 0 keeps them forever. A judged hit
 # or gap is exempt: it is the labelled pair the whole feature exists to produce,
 # and expiring it would empty `--export-eval` a month at a time. A `discard` is

--- a/config.example.toml
+++ b/config.example.toml
@@ -487,12 +487,13 @@ max_dedupe_per_tick = 5
 # setting — an empty pool leaves every card with nothing to choose — and is put
 # back to the default with a line in the log.
 candidates = 20
-# Window in which a longer query — or the same one again — replaces the previous
-# event instead of starting its own. 0 turns folding off. Applies to the search
-# box only, and only
-# within one signed-in operator: a call through the API or MCP is a deliberate
-# query, not a keystroke, and two people typing at once are not typing the same
-# thing.
+# Window in which another query — a longer one, a rewording, or the same one
+# again — replaces the previous event instead of starting its own, so a burst of
+# searches that ends in one open is one search. Opening a result closes the
+# window: the list that was read is the list the hit is scored on. 0 turns
+# folding off. Applies to the search box only, and only within one signed-in
+# operator: a call through the API or MCP is a deliberate query, not a
+# keystroke, and two people typing at once are not typing the same thing.
 coalesce_secs = 15
 # Days an unjudged captured search is kept. 0 keeps them forever. A judged hit
 # or gap is exempt: it is the labelled pair the whole feature exists to produce,

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -60,11 +60,15 @@ said about the original.
 Nothing here is fixtures. The corpus is whatever you actually want to search,
 and it is **not in this repository and must not be**.
 
-Pairs are made by judging, at `/ui/judge`: a recorded search comes back with its
-candidates shuffled and unlabelled, and you say which one you needed. The
-shuffling is not decoration — a label assigned while reading the answer
-contaminates the question, which is the same reason the query is recorded in the
-moment and the verdict is not.
+Pairs are made mostly by searching. A result opened from the rail and read for
+twenty seconds is recorded, provisionally, as the one the search was for; the
+bar under it — *Was this what you were looking for? Yes · No · Not sure* — makes
+that a person's verdict, and *Nothing here has it* on a rail that matched
+nothing records a gap. Only what none of these labelled reaches `/ui/judge`,
+where a recorded search comes back with its candidates shuffled and unlabelled
+and you say which one you needed. The shuffling is not decoration — a label
+assigned while reading the answer contaminates the question, which is the same
+reason the query is recorded in the moment and the verdict is not.
 
 ```bash
 engram --export-eval ~/engram-eval

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -60,13 +60,15 @@ said about the original.
 Nothing here is fixtures. The corpus is whatever you actually want to search,
 and it is **not in this repository and must not be**.
 
-Pairs are made mostly by searching. A result opened from the rail and read for
-twenty seconds is recorded, provisionally, as the one the search was for; the
-bar under it — *Was this what you were looking for? Yes · No · Not sure* — makes
-that a person's verdict, and *Nothing here has it* on a rail that matched
-nothing records a gap. *Not sure* is not a verdict: it leaves the search for the
-deck, which is where a question nobody could answer in the moment belongs. Only
-what none of these labelled reaches `/ui/judge`,
+Pairs are made mostly by searching. Under a result opened from the rail there is
+a bar — *Was this what you were looking for? Yes · No · Not sure* — and on a rail
+that matched nothing there is *Nothing here has it*, which records a gap. Every
+pair comes from somebody pressing one of those. A long read used to count as a
+*Yes* on its own; it does not any more, because what it measured was a pane left
+open, which is an abandoned tab about as often as it is an answer. *Not sure* is
+not a verdict either: it leaves the search for the deck, which is where a
+question nobody could answer in the moment belongs. Only what none of these
+labelled reaches `/ui/judge`,
 where a recorded search comes back with the top five of its pool in the order
 the search gave them, the rest behind a fold, and you say which one you needed.
 Showing the order is a known cost: a person is likelier to confirm what came

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -64,7 +64,9 @@ Pairs are made mostly by searching. A result opened from the rail and read for
 twenty seconds is recorded, provisionally, as the one the search was for; the
 bar under it — *Was this what you were looking for? Yes · No · Not sure* — makes
 that a person's verdict, and *Nothing here has it* on a rail that matched
-nothing records a gap. Only what none of these labelled reaches `/ui/judge`,
+nothing records a gap. *Not sure* is not a verdict: it leaves the search for the
+deck, which is where a question nobody could answer in the moment belongs. Only
+what none of these labelled reaches `/ui/judge`,
 where a recorded search comes back with the top five of its pool in the order
 the search gave them, the rest behind a fold, and you say which one you needed.
 Showing the order is a known cost: a person is likelier to confirm what came

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -65,10 +65,13 @@ twenty seconds is recorded, provisionally, as the one the search was for; the
 bar under it — *Was this what you were looking for? Yes · No · Not sure* — makes
 that a person's verdict, and *Nothing here has it* on a rail that matched
 nothing records a gap. Only what none of these labelled reaches `/ui/judge`,
-where a recorded search comes back with its candidates shuffled and unlabelled
-and you say which one you needed. The shuffling is not decoration — a label
-assigned while reading the answer contaminates the question, which is the same
-reason the query is recorded in the moment and the verdict is not.
+where a recorded search comes back with the top five of its pool in the order
+the search gave them, the rest behind a fold, and you say which one you needed.
+Showing the order is a known cost: a person is likelier to confirm what came
+first, so the recall@10 and MRR read off deck verdicts lean slightly towards
+the ranker. Five in order is a question a person answers; twenty shuffled was
+one nobody answered twice. Scores are still withheld, and the query is still
+recorded in the moment and the verdict is not.
 
 ```bash
 engram --export-eval ~/engram-eval

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,8 +236,14 @@ pub struct FeedbackConfig {
     /// over-fetches anyway, so the extra rows are free, and they are what lets a
     /// buried hit be confirmed later.
     pub candidates: usize,
-    /// Window in which a query that extends the previous one replaces it
-    /// instead of starting a new event. `0` turns folding off.
+    /// Window in which another query from the same searcher replaces the
+    /// previous event instead of starting a new one. `0` turns folding off.
+    ///
+    /// Sized for a typing burst and not for a train of thought. Any rewording
+    /// inside the window folds, so the window is also how long a finished
+    /// search has left to live: search, read the titles, search again, and the
+    /// first one is gone — including the case where nothing was opened, which
+    /// is exactly what the unmatched-gap sweep exists to see.
     pub coalesce_secs: i64,
     /// Days captured searches are kept. `0` keeps them forever.
     pub retain_days: i64,
@@ -252,7 +258,7 @@ impl Default for FeedbackConfig {
     fn default() -> Self {
         Self {
             candidates: 20,
-            coalesce_secs: 15,
+            coalesce_secs: 5,
             retain_days: 0,
             sweep_hours: 6,
             tune: TuneConfig::default(),

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -4369,6 +4369,9 @@ mod tests {
     async fn a_synthesized_artifact_leading_the_list_marks_the_search_answered() {
         let mut core = test_core().await;
         core.learn.enabled = true;
+        // Two deliberate searches, not one being reworded: with the window on
+        // the second would fold into the first and there would be one event.
+        core.feedback.coalesce_secs = 0;
         let src = core.store.insert_corpus("raw", "web", None).await.unwrap();
         let captured = core
             .store

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -1607,6 +1607,10 @@ impl Core {
                 query: query.q.trim().to_string(),
                 door,
                 scope: origin.scope.clone(),
+                // The event the page sending this is holding, where the door
+                // named one — what keeps a second tab's keystroke from folding
+                // into the first tab's search. See `record_search`.
+                fold_onto: origin.fold_onto.clone(),
                 filters: serde_json::json!({
                     "tags": query.tags,
                     "category": query.category,

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -94,6 +94,12 @@ pub struct SearchTiming {
 pub struct SearchOutcome {
     pub timing: SearchTiming,
     pub explanation: crate::core::explain::SearchExplanation,
+    /// The capture this search wrote, where the door waited for it. Only the
+    /// UI door does — it is the one whose answer a person then clicks, and the
+    /// id is what lets the open and the "nothing here has it" name the search
+    /// they came from instead of guessing at it. `None` everywhere else, and
+    /// wherever the capture is off or failed.
+    pub event: Option<String>,
 }
 
 /// A stage of the search pipeline, in the order it runs.
@@ -1581,6 +1587,10 @@ impl Core {
         // ordering is final. Off the request path via `Background`, like
         // `mark_seen` below it: a search must not get slower, or fail, because
         // bookkeeping did.
+        //
+        // Except at the UI door, which waits for its own capture — see
+        // `captured_event` below.
+        let mut captured_event = None;
         if self.learn.enabled && door.captured() {
             let candidates: Vec<crate::store::feedback::NewCandidate> = results
                 .iter()
@@ -1614,13 +1624,34 @@ impl Core {
                 // good it was, which is why `weak` is read beside it.
                 answered: results.first().is_some_and(|r| r.synthesized && !r.weak),
             };
-            let store = self.store.clone();
             let window = self.feedback.coalesce_secs;
-            self.background.spawn(async move {
-                if let Err(e) = store.record_search(event, window).await {
-                    tracing::warn!(error = %e, "could not record the search");
+            match door {
+                // The one door whose answer a person then clicks on. It waits,
+                // because the page it fills has to name the search on every row
+                // — that is what lets an open, a verdict and a gap report
+                // against the search they actually came from. Guessing at it
+                // afterwards, from recency and pool membership, was wrong in
+                // both directions: a fast click found no capture yet, and a
+                // slow one could be answered by an unrelated search that merely
+                // held the same artifact.
+                //
+                // The rule above still holds. This is one small transaction
+                // behind an embedding call and a vector search the person is
+                // already waiting on, and its failure is logged and dropped:
+                // the results go out either way, without the bar.
+                Door::Ui => match self.store.record_search(event, window).await {
+                    Ok(id) => captured_event = Some(id),
+                    Err(e) => tracing::warn!(error = %e, "could not record the search"),
+                },
+                _ => {
+                    let store = self.store.clone();
+                    self.background.spawn(async move {
+                        if let Err(e) = store.record_search(event, window).await {
+                            tracing::warn!(error = %e, "could not record the search");
+                        }
+                    });
                 }
-            });
+            }
         }
 
         results.truncate(limit);
@@ -1690,6 +1721,7 @@ impl Core {
                     reranked,
                     ..explanation
                 },
+                event: captured_event,
             },
         ))
     }

--- a/src/eval/export.rs
+++ b/src/eval/export.rs
@@ -187,7 +187,10 @@ mod tests {
         let store = Store::memory().await.unwrap();
         let artifact_id = seed_one_artifact(&store).await;
         let event = record_one_search(&store, "how do I read a deleted entry", &artifact_id).await;
-        store.judge_hit(&event, &artifact_id).await.unwrap();
+        store
+            .judge_hit(&event, &artifact_id, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
 
         let (artifacts, pairs, _) = export(&store, dir.path()).await.unwrap();
         assert_eq!((artifacts, pairs), (1, 1));
@@ -242,7 +245,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::memory().await.unwrap();
         let event = record_one_search(&store, "gone", "no-such-artifact").await;
-        store.judge_hit(&event, "no-such-artifact").await.unwrap();
+        store
+            .judge_hit(
+                &event,
+                "no-such-artifact",
+                crate::store::feedback::Labeller::Deck,
+            )
+            .await
+            .unwrap();
 
         let (_, pairs, _) = export(&store, dir.path()).await.unwrap();
         assert_eq!(pairs, 0);
@@ -254,9 +264,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::memory().await.unwrap();
         let g = record_one_search(&store, "nothing about this", "x").await;
-        store.judge(&g, Verdict::Gap).await.unwrap();
+        store
+            .judge(&g, Verdict::Gap, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         let d = record_one_search(&store, "asdf", "x").await;
-        store.judge(&d, Verdict::Discard).await.unwrap();
+        store
+            .judge(&d, Verdict::Discard, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
 
         let (_, pairs, _) = export(&store, dir.path()).await.unwrap();
         assert_eq!(pairs, 0);

--- a/src/eval/export.rs
+++ b/src/eval/export.rs
@@ -161,6 +161,7 @@ mod tests {
         store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: query.into(),
                     door: Door::Ui,
                     scope: None,

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -183,7 +183,7 @@ pub async fn run_sweep(core: &Core) -> Result<()> {
     if pairs.is_empty() {
         return Ok(());
     }
-    let judged = core.store.feedback_stats().await?.judged;
+    let judged = core.store.feedback_stats(core.weak_below).await?.judged;
     let current = *core.ranking.read().expect("ranking lock");
 
     let grid = grid(current);
@@ -314,7 +314,7 @@ impl Drop for Sweeping {
 
 async fn sweep_if_due(core: &Core) -> Result<()> {
     let tune = &core.feedback.tune;
-    let judged = core.store.feedback_stats().await?.judged;
+    let judged = core.store.feedback_stats(core.weak_below).await?.judged;
     if judged < tune.min_judgements {
         return Ok(());
     }
@@ -625,13 +625,13 @@ mod tests {
         core.learn.enabled = true;
         judge(&core, &order[3]).await;
         judge(&core, &order[4]).await;
-        let before = core.store.feedback_stats().await.unwrap().captured;
+        let before = core.store.feedback_stats(0.0).await.unwrap().captured;
 
         run_sweep(&core).await.unwrap();
         core.background.wait_idle().await;
 
         assert_eq!(
-            core.store.feedback_stats().await.unwrap().captured,
+            core.store.feedback_stats(0.0).await.unwrap().captured,
             before,
             "the sweep's own searches became data"
         );

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -398,6 +398,7 @@ mod tests {
             .store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: QUERY.into(),
                     door: Door::Ui,
                     scope: None,
@@ -595,6 +596,7 @@ mod tests {
             .store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: QUERY.into(),
                     door: Door::Ui,
                     scope: None,

--- a/src/eval/sweep.rs
+++ b/src/eval/sweep.rs
@@ -413,7 +413,10 @@ mod tests {
             )
             .await
             .unwrap();
-        core.store.judge_hit(&id, expect).await.unwrap();
+        core.store
+            .judge_hit(&id, expect, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -605,7 +608,10 @@ mod tests {
             )
             .await
             .unwrap();
-        core.store.judge(&id, Verdict::Gap).await.unwrap();
+        core.store
+            .judge(&id, Verdict::Gap, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
 
         run_sweep(&core).await.unwrap();
         assert!(core.store.latest_eval_run().await.unwrap().is_none());

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -622,6 +622,7 @@ mod tests {
         core.store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: query.into(),
                     door: Door::Ui,
                     scope: None,

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -33,7 +33,7 @@ pub fn link_target(a: &str, b: &str) -> String {
 /// The newest `created_at` a settled event may still have. An event is
 /// settled once `created_at < settled_cutoff(at, coalesce_secs)` — the exact
 /// complement of `record_search`'s fold predicate at
-/// `src/store/feedback.rs:271` (`at - created <= coalesce_secs`), so there is
+/// `src/store/feedback.rs:334` (`at - created <= coalesce_secs`), so there is
 /// no instant where both are true and an event still a keystroke away from
 /// folding gets replayed early.
 fn settled_cutoff(at: i64, coalesce_secs: i64) -> i64 {
@@ -767,7 +767,7 @@ mod tests {
     #[tokio::test]
     async fn an_event_exactly_at_the_fold_boundary_waits_one_more_sweep() {
         // `record_search` treats an event as still foldable while
-        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs:271).
+        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs:334).
         // The sweep's read must be the complement of that with nothing
         // shared, or there is an instant where both are true and the sweep
         // binds an event a further keystroke could still fold into — the
@@ -822,7 +822,7 @@ mod tests {
     #[test]
     fn settled_cutoff_is_the_exact_complement_of_the_fold_predicate() {
         // `replay_events` folds an event's watermark against `settled_cutoff`
-        // with `<`. `record_search` (src/store/feedback.rs:271) treats an
+        // with `<`. `record_search` (src/store/feedback.rs:334) treats an
         // event as still foldable while `at - created <= coalesce_secs`. For
         // the two to share no instant, `created < settled_cutoff(at, cs)`
         // must be false exactly where `at - created <= cs` is true, and true

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -880,7 +880,10 @@ mod tests {
         on(&mut core).await;
         let ids = seed(&core, 3).await;
         let ev = record(&core, "q", &[&ids[0], &ids[1], &ids[2]], &[]).await;
-        core.store.judge_hit(&ev, &ids[0]).await.unwrap();
+        core.store
+            .judge_hit(&ev, &ids[0], crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         settle(&core).await;
 
         run(&core).await.unwrap();
@@ -924,7 +927,10 @@ mod tests {
         let ids = seed(&core, 3).await;
         // ids[2] is never offered as a candidate at all.
         let ev = record(&core, "q", &[&ids[0], &ids[1]], &[]).await;
-        core.store.judge_hit(&ev, &ids[2]).await.unwrap();
+        core.store
+            .judge_hit(&ev, &ids[2], crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         settle(&core).await;
 
         run(&core).await.unwrap();
@@ -967,7 +973,10 @@ mod tests {
         on(&mut core).await;
         let ids = seed(&core, 2).await;
         let g = record(&core, "nothing about this", &[&ids[0], &ids[1]], &[]).await;
-        core.store.judge(&g, Verdict::Gap).await.unwrap();
+        core.store
+            .judge(&g, Verdict::Gap, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         settle(&core).await;
 
         run(&core).await.unwrap();
@@ -1617,7 +1626,10 @@ mod tests {
         let ids = seed(&core, 3).await;
 
         let first = record(&core, "one", &[&ids[0], &ids[1]], &[]).await;
-        core.store.judge_hit(&first, &ids[0]).await.unwrap();
+        core.store
+            .judge_hit(&first, &ids[0], crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         sqlx::query("UPDATE search_events SET judged_at = 1000 WHERE id = ?")
             .bind(&first)
             .execute(&core.store.pool)
@@ -1629,7 +1641,10 @@ mod tests {
 
         // A second verdict written moments later, still inside second 1000.
         let second = record(&core, "two", &[&ids[0], &ids[2]], &[]).await;
-        core.store.judge_hit(&second, &ids[2]).await.unwrap();
+        core.store
+            .judge_hit(&second, &ids[2], crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         sqlx::query("UPDATE search_events SET judged_at = 1000 WHERE id = ?")
             .bind(&second)
             .execute(&core.store.pool)

--- a/src/jobs/associate.rs
+++ b/src/jobs/associate.rs
@@ -33,7 +33,7 @@ pub fn link_target(a: &str, b: &str) -> String {
 /// The newest `created_at` a settled event may still have. An event is
 /// settled once `created_at < settled_cutoff(at, coalesce_secs)` — the exact
 /// complement of `record_search`'s fold predicate at
-/// `src/store/feedback.rs:206` (`at - created <= coalesce_secs`), so there is
+/// `src/store/feedback.rs:271` (`at - created <= coalesce_secs`), so there is
 /// no instant where both are true and an event still a keystroke away from
 /// folding gets replayed early.
 fn settled_cutoff(at: i64, coalesce_secs: i64) -> i64 {
@@ -766,7 +766,7 @@ mod tests {
     #[tokio::test]
     async fn an_event_exactly_at_the_fold_boundary_waits_one_more_sweep() {
         // `record_search` treats an event as still foldable while
-        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs:206).
+        // `(at - created_at) <= coalesce_secs` (src/store/feedback.rs:271).
         // The sweep's read must be the complement of that with nothing
         // shared, or there is an instant where both are true and the sweep
         // binds an event a further keystroke could still fold into — the
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn settled_cutoff_is_the_exact_complement_of_the_fold_predicate() {
         // `replay_events` folds an event's watermark against `settled_cutoff`
-        // with `<`. `record_search` (src/store/feedback.rs:206) treats an
+        // with `<`. `record_search` (src/store/feedback.rs:271) treats an
         // event as still foldable while `at - created <= coalesce_secs`. For
         // the two to share no instant, `created < settled_cutoff(at, cs)`
         // must be false exactly where `at - created <= cs` is true, and true

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -385,6 +385,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: q.into(),
                     door: crate::store::feedback::Door::Api,
                     scope: None,

--- a/src/jobs/gaps.rs
+++ b/src/jobs/gaps.rs
@@ -399,7 +399,11 @@ mod tests {
             .await
             .unwrap();
         core.store
-            .judge(&id, crate::store::feedback::Verdict::Gap)
+            .judge(
+                &id,
+                crate::store::feedback::Verdict::Gap,
+                crate::store::feedback::Labeller::Deck,
+            )
             .await
             .unwrap();
         id

--- a/src/jobs/pursuit.rs
+++ b/src/jobs/pursuit.rs
@@ -995,6 +995,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: q.into(),
                     door,
                     scope: scope.map(str::to_string),

--- a/src/jobs/retention.rs
+++ b/src/jobs/retention.rs
@@ -160,6 +160,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "old".into(),
                     door: crate::store::feedback::Door::Ui,
                     scope: None,

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -178,14 +178,24 @@ pub struct Chunk {
     pub cues: Vec<String>,
 }
 
+/// Whether search may return an artifact: active and not hidden behind a
+/// winner. This is the predicate every consolidation decision gates on — what
+/// may win a cluster, be shown to the model, or be superseded — so it has
+/// exactly one spelling. A third lifecycle state changes this function, not a
+/// dozen call sites.
+///
+/// A free function rather than only `Chunk::in_results`, because the web layer
+/// asks the same question of a struct that is not a `Chunk` — `ui::
+/// ArtifactDetail`, which carries the two columns and not the chunk — and the
+/// copy it kept was a second spelling of exactly what this paragraph forbids.
+pub fn in_results(status: ArtifactStatus, superseded_by: Option<&str>) -> bool {
+    status == ArtifactStatus::Active && superseded_by.is_none()
+}
+
 impl Chunk {
-    /// Whether search may return this artifact: active and not hidden behind
-    /// a winner. This is the predicate every consolidation decision gates on —
-    /// what may win a cluster, be shown to the model, or be superseded — so it
-    /// has exactly one spelling. A third lifecycle state changes this method,
-    /// not a dozen call sites.
+    /// See [`in_results`].
     pub fn in_results(&self) -> bool {
-        self.status == ArtifactStatus::Active && self.superseded_by.is_none()
+        in_results(self.status, self.superseded_by.as_deref())
     }
 }
 

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -2296,6 +2296,7 @@ mod tests {
         let ev = s
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "q".into(),
                     door: crate::store::feedback::Door::Api,
                     scope: None,

--- a/src/store/artifacts.rs
+++ b/src/store/artifacts.rs
@@ -2299,7 +2299,9 @@ mod tests {
             )
             .await
             .unwrap();
-        s.judge_hit(&ev, &made[0].id).await.unwrap();
+        s.judge_hit(&ev, &made[0].id, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         assert!(s.artifact_confirmed(&made[0].id).await.unwrap());
     }
 

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -96,6 +96,9 @@ pub struct Origin {
     /// sitting out of the API and `/mcp`: an access token is not a
     /// conversation. Read only by priming, and only when `sitting.prime` is on.
     pub session: Option<String>,
+    /// The event this search is a rewording of, named by the page that is
+    /// typing. See `NewEvent::fold_onto`.
+    pub fold_onto: Option<String>,
 }
 
 impl From<Door> for Origin {
@@ -104,6 +107,7 @@ impl From<Door> for Origin {
             door,
             scope: None,
             session: None,
+            fold_onto: None,
         }
     }
 }
@@ -115,6 +119,7 @@ impl Door {
             door: self,
             scope: Some(scope.into()),
             session: None,
+            fold_onto: None,
         }
     }
 }
@@ -124,6 +129,13 @@ impl Origin {
     /// identity may say so — see `Origin::session`.
     pub fn in_sitting(mut self, session: Option<String>) -> Origin {
         self.session = session;
+        self
+    }
+
+    /// The search event the page sending this one is holding, where the door
+    /// can name one. See `NewEvent::fold_onto`.
+    pub fn folding_onto(mut self, event_id: Option<String>) -> Origin {
+        self.fold_onto = event_id;
         self
     }
 }
@@ -155,6 +167,10 @@ pub struct NewEvent {
     /// A synthesized artifact led the list above `weak_below`: the base
     /// answered, and the pursuit this lands in closes satisfied.
     pub answered: bool,
+    /// The event this one is a rewording of, as named by the page that is
+    /// typing — the id it was handed by the last answer it drew. `None` from a
+    /// door with nothing to name. See the fold rule in `record_search`.
+    pub fold_onto: Option<String>,
 }
 
 /// One recorded search as the pursuit sweep reads it.
@@ -198,7 +214,8 @@ impl Store {
     /// one before it. What survives is the final wording: the query that was
     /// actually meant, asked once, holding the pool that answered it.
     ///
-    /// Only text boxes fold, and only within one `scope`. That is the web UI's
+    /// Only text boxes fold, and only into the event the box is holding — see
+    /// `fold_onto` and the rule below it. That is the web UI's
     /// search field and the browser extension's panel, both of which search as
     /// you type — the panel debounces at 200ms, so one query still arrives as
     /// several. A call through the API or MCP is a deliberate query, and an
@@ -219,10 +236,50 @@ impl Store {
         let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
         let at = now();
 
-        // `scope IS ?` rather than `=`, so a UI event recorded without a
-        // subject still finds its own predecessor instead of matching nothing.
+        // Which stored event this one may fold into, and the two doors answer
+        // that differently because only one of them can name a row.
+        //
+        // The web UI names it: every answer hands the page the id it was
+        // recorded under, and the box sends that id back with the next
+        // keystroke. So a fold is onto that one row and no other. Keyed on
+        // scope alone it was onto whatever the searcher wrote last through this
+        // door, which is the same row for every tab they have open — a second
+        // window searching inside the window overwrote the first one's query
+        // and its whole pool, while the first one's rail went on naming the id
+        // on every row. The open that followed was then either refused (the
+        // artifact is no longer in the pool) or scored against a query nobody
+        // in that tab had typed.
+        //
+        // The extension panel names nothing — the API answer it reads carries
+        // no event id — so it still folds by the searcher, and two panels of
+        // one browser can still collide inside the window. `scope IS ?` rather
+        // than `=` so an event recorded without a subject finds its own
+        // predecessor instead of matching nothing.
+        //
+        // Both carry the same two guards, and for the same reason the query
+        // below is guarded at all: a judged or opened event is finished, and
+        // folding into one would rewrite the search a verdict already answered.
         let prev = match ev.door {
-            Door::Ui | Door::Extension => {
+            Door::Ui => match ev.fold_onto.as_deref() {
+                Some(prev_id) => {
+                    sqlx::query(
+                        "SELECT id, created_at,
+                                (SELECT COUNT(*) FROM search_candidates
+                                  WHERE event_id = search_events.id) AS pool
+                           FROM search_events
+                          WHERE id = ? AND door = ? AND scope IS ?
+                            AND judged_at IS NULL AND opened_at IS NULL",
+                    )
+                    .bind(prev_id)
+                    .bind(ev.door.as_str())
+                    .bind(&ev.scope)
+                    .fetch_optional(&mut *tx)
+                    .await?
+                }
+                // The first search of a page, which has nothing to fold into.
+                None => None,
+            },
+            Door::Extension => {
                 sqlx::query(
                     "SELECT id, created_at,
                             (SELECT COUNT(*) FROM search_candidates
@@ -617,12 +674,20 @@ impl Store {
         Ok(())
     }
 
+    /// `AND judged_at IS NULL`, as `decline` and `gap_event` both carry: the
+    /// bar under an opened result is drawn against an unjudged search, and the
+    /// deck can answer that same search in the time a tab is left open. Without
+    /// the guard, Yes in the stale tab overwrote whatever the deck had recorded
+    /// — a gap became a hit, and `pairs.json` gained a pair nobody meant. The
+    /// deck cannot hit an already-judged event (it deals only unjudged ones),
+    /// so this costs it nothing: for the deck, `NotFound` still means what it
+    /// meant, a row that is no longer there.
     pub async fn judge_hit(&self, event_id: &str, artifact_id: &str, by: Labeller) -> Result<()> {
         Self::judged_one(
             sqlx::query(
                 "UPDATE search_events
                  SET judged_at = ?, verdict = 'hit', expect_id = ?, judged_by = ?
-                 WHERE id = ?",
+                 WHERE id = ? AND judged_at IS NULL",
             )
             .bind(now())
             .bind(artifact_id)
@@ -745,16 +810,26 @@ impl Store {
     /// Not `judge`, which would report a second click as an error and a purged
     /// event as the same error: the button has two outcomes and both of them
     /// are ordinary.
-    pub async fn gap_event(&self, event_id: &str) -> Result<bool> {
+    ///
+    /// `AND query = ?` is this button's version of the check `open_event` makes
+    /// against the pool: the row may have been folded into by a trailing
+    /// keystroke between the rail being rendered and the button being pressed,
+    /// and the gap has to be recorded against the query that was on the screen.
+    /// Without it, "nothing here has it" could land on a later wording that did
+    /// return something — a hole reported in the base over a search that
+    /// answered. `false` where the query has moved on, which is the same
+    /// ordinary outcome as a search already judged.
+    pub async fn gap_event(&self, event_id: &str, query: &str) -> Result<bool> {
         Ok(sqlx::query(
             "UPDATE search_events
              SET judged_at = ?, verdict = ?, expect_id = NULL, judged_by = ?
-             WHERE id = ? AND judged_at IS NULL",
+             WHERE id = ? AND query = ? AND judged_at IS NULL",
         )
         .bind(now())
         .bind(Verdict::Gap.as_str())
         .bind(Labeller::Confirm.as_sql())
         .bind(event_id)
+        .bind(query)
         .execute(&self.pool)
         .await?
         .rows_affected()
@@ -767,14 +842,23 @@ impl Store {
     /// than no pair at all: it is scored against the ranker as truth. Clearing
     /// `expect_id` with the verdict matters — a stale answer left behind would
     /// keep counting towards recall for a judgement nobody stands behind.
-    pub async fn unjudge(&self, event_id: &str) -> Result<()> {
+    ///
+    /// Takes back only what this labeller gave: `judged_by IS ?`, which is the
+    /// deck's NULL or the bar's `confirm`. An undo is a second thought about
+    /// one's own answer, and unguarded it was a way to erase somebody else's —
+    /// press No on the bar (which leaves the search pending), let the deck deal
+    /// it and record a hit, then press undo in the tab still holding the bar,
+    /// and the confirmed pair was gone. The same failure `decline` is guarded
+    /// against, on the button beside it.
+    pub async fn unjudge(&self, event_id: &str, by: Labeller) -> Result<()> {
         Self::judged_one(
             sqlx::query(
                 "UPDATE search_events
                  SET judged_at = NULL, verdict = NULL, expect_id = NULL, judged_by = NULL
-                 WHERE id = ?",
+                 WHERE id = ? AND judged_by IS ?",
             )
             .bind(event_id)
+            .bind(by.as_sql())
             .execute(&self.pool)
             .await?,
         )
@@ -797,6 +881,17 @@ impl Store {
     /// Split out of `feedback_stats`, which runs half a dozen queries and two
     /// joins: this one is read on every page render to draw the nav, and the
     /// nav must not cost what the ops page costs.
+    ///
+    /// It is not the single indexed count it once was — the nav counts what the
+    /// deck will actually deal, or it reads "12 waiting" over an empty deck —
+    /// so `dealable!` is two correlated subqueries per row it looks at. Both
+    /// seek `search_candidates` by `event_id`, which leads the primary key and
+    /// `idx_candidates_similarity`, so each is an index seek rather than a
+    /// scan; what it costs is that pair of seeks per unjudged event. With
+    /// `retain_days = 0` — the default, where nothing is ever trimmed — that
+    /// set only grows, and the events this predicate holds back (a query under
+    /// three characters, a pool of nothing) stay in it forever. If the nav ever
+    /// becomes the slow part of a page, that is the thing to measure.
     pub async fn pending_count(&self, weak_below: f32) -> Result<i64> {
         Ok(sqlx::query_scalar(concat!(
             "SELECT count(*) FROM search_events WHERE ",
@@ -1174,6 +1269,7 @@ mod tests {
 
     fn scoped(query: &str, door: Door, scope: Option<&str>) -> NewEvent {
         NewEvent {
+            fold_onto: None,
             query: query.into(),
             door,
             scope: scope.map(str::to_string),
@@ -1187,6 +1283,15 @@ mod tests {
                 shown: true,
             }],
             answered: false,
+        }
+    }
+
+    /// The next keystroke from a page already holding `prev` — what the box
+    /// sends once an answer has named the event it was recorded under.
+    fn after(prev: &str, query: &str, door: Door) -> NewEvent {
+        NewEvent {
+            fold_onto: Some(prev.to_string()),
+            ..ev(query, door)
         }
     }
 
@@ -1208,14 +1313,15 @@ mod tests {
         // early keystroke of it, and B's search — and its whole pool — was
         // never recorded at all.
         let store = Store::memory().await.unwrap();
-        store
+        let alice = store
             .record_search(scoped("backup restore", Door::Ui, Some("alice")), 15)
             .await
             .unwrap();
-        store
-            .record_search(scoped("backup", Door::Ui, Some("bob")), 15)
-            .await
-            .unwrap();
+        // Bob's page naming Alice's event, which an id off a page is always
+        // free to do — it is not a capability. The scope is what refuses.
+        let mut bob = scoped("backup", Door::Ui, Some("bob"));
+        bob.fold_onto = Some(alice.clone());
+        store.record_search(bob, 15).await.unwrap();
 
         let mut got = queries(&store).await;
         got.sort();
@@ -1249,8 +1355,17 @@ mod tests {
     #[tokio::test]
     async fn a_typing_burst_collapses_to_its_final_wording() {
         let store = Store::memory().await.unwrap();
-        for q in ["daten", "datentr", "datenträger nicht erkannt"] {
-            store.record_search(ev(q, Door::Ui), 15).await.unwrap();
+        // The box carries the id forward from each answer, the way the page
+        // does: one chain of keystrokes, folding into its own event.
+        let mut id = store
+            .record_search(ev("daten", Door::Ui), 15)
+            .await
+            .unwrap();
+        for q in ["datentr", "datenträger nicht erkannt"] {
+            id = store
+                .record_search(after(&id, q, Door::Ui), 15)
+                .await
+                .unwrap();
         }
         assert_eq!(queries(&store).await, vec!["datenträger nicht erkannt"]);
     }
@@ -1282,12 +1397,12 @@ mod tests {
         // row of it, so an open was stamped and a verdict scored against a
         // search nobody was looking at. The record follows the box.
         let store = Store::memory().await.unwrap();
-        store
+        let id = store
             .record_search(ev("fat32 mount", Door::Ui), 15)
             .await
             .unwrap();
         store
-            .record_search(ev("fat32", Door::Ui), 15)
+            .record_search(after(&id, "fat32", Door::Ui), 15)
             .await
             .unwrap();
 
@@ -1307,12 +1422,16 @@ mod tests {
         // one connection, so it cannot reproduce the busy-snapshot failure the
         // capture mutex is there for; only the file-backed store can.
         let store = Store::memory().await.unwrap();
+        // Every one of them names the id the page was holding when it fired,
+        // which is the same id for a burst still in flight.
+        let first = store.record_search(ev("d", Door::Ui), 15).await.unwrap();
         let mut tasks = Vec::new();
-        for n in 1..="datenträger".chars().count() {
+        for n in 2..="datenträger".chars().count() {
             let store = store.clone();
+            let first = first.clone();
             let q: String = "datenträger".chars().take(n).collect();
             tasks.push(tokio::spawn(async move {
-                store.record_search(ev(&q, Door::Ui), 15).await
+                store.record_search(after(&first, &q, Door::Ui), 15).await
             }));
         }
         for t in tasks {
@@ -1332,9 +1451,13 @@ mod tests {
         // `--export-eval` emitted five identical pairs that weighted that one
         // query five times over in recall@10 and MRR.
         let store = Store::memory().await.unwrap();
-        for _ in 0..3 {
-            store
-                .record_search(ev("fat32", Door::Ui), 15)
+        let mut id = store
+            .record_search(ev("fat32", Door::Ui), 15)
+            .await
+            .unwrap();
+        for _ in 0..2 {
+            id = store
+                .record_search(after(&id, "fat32", Door::Ui), 15)
                 .await
                 .unwrap();
         }
@@ -1364,7 +1487,7 @@ mod tests {
             .await
             .unwrap();
         store
-            .record_search(ev("fat32", Door::Ui), 15)
+            .record_search(after(&first, "fat32", Door::Ui), 15)
             .await
             .unwrap();
 
@@ -1377,11 +1500,14 @@ mod tests {
         // ways. Folded only on prefix, each wording was its own card — three
         // questions about one thing, two of them about words nobody meant.
         let store = Store::memory().await.unwrap();
-        store
+        let id = store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
             .unwrap();
-        store.record_search(ev("ntfs", Door::Ui), 15).await.unwrap();
+        store
+            .record_search(after(&id, "ntfs", Door::Ui), 15)
+            .await
+            .unwrap();
         assert_eq!(queries(&store).await, vec!["ntfs"]);
     }
 
@@ -1423,7 +1549,7 @@ mod tests {
         // against a search the artifact was never in.
         let store = Store::memory().await.unwrap();
         let id = store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
-        let mut later = ev("fat32", Door::Ui);
+        let mut later = after(&id, "fat32", Door::Ui);
         later.candidates[0].artifact_id = "a2".into();
         assert_eq!(store.record_search(later, 15).await.unwrap(), id, "folded");
         assert!(
@@ -1432,6 +1558,136 @@ mod tests {
         );
         // The row the fold left behind is still openable on its own terms.
         assert!(store.open_event(&id, "a2").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn yes_cannot_overwrite_a_verdict_somebody_else_gave() {
+        // The other half of the same race, on the button beside "no": the deck
+        // calls the search a gap while the tab holding the bar is open, and Yes
+        // in that stale tab replaced the gap with a hit — a pair in
+        // `pairs.json` nobody meant to put there.
+        let store = Store::memory().await.unwrap();
+        let id = store.record_search(ev("ntfs", Door::Ui), 0).await.unwrap();
+        store
+            .judge(&id, Verdict::Gap, Labeller::Deck)
+            .await
+            .unwrap();
+        assert!(matches!(
+            store.judge_hit(&id, "a1", Labeller::Confirm).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        let s = store.feedback_stats(0.0).await.unwrap();
+        assert_eq!((s.gaps, s.hits), (1, 0), "the gap stood: {s:?}");
+    }
+
+    #[tokio::test]
+    async fn undo_takes_back_only_what_this_labeller_gave() {
+        // "No" leaves the search pending, so the deck can deal it and record a
+        // hit while the bar — now showing undo — is still on screen. Pressing
+        // it wiped the confirmed pair, which is what `decline` two tests up is
+        // guarded against; the undo beside it was not.
+        let store = Store::memory().await.unwrap();
+        let id = store.record_search(ev("ntfs", Door::Ui), 0).await.unwrap();
+        assert!(store.decline(&id).await.unwrap());
+        store.judge_hit(&id, "a1", Labeller::Deck).await.unwrap();
+
+        assert!(matches!(
+            store.unjudge(&id, Labeller::Confirm).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        assert_eq!(
+            store.feedback_stats(0.0).await.unwrap().hits,
+            1,
+            "the pair survived the stale tab"
+        );
+        // The deck's own undo still reaches the deck's own verdict.
+        store.unjudge(&id, Labeller::Deck).await.unwrap();
+        assert_eq!(store.feedback_stats(0.0).await.unwrap().hits, 0);
+    }
+
+    #[tokio::test]
+    async fn two_windows_of_one_searcher_do_not_fold_into_each_other() {
+        // Keyed on the searcher alone, a second window searching inside the
+        // window folded into the first one's event: it overwrote that query
+        // and its whole pool while the first window's rail went on naming the
+        // id on every row, so the open that followed was refused — or scored
+        // against words nobody in that window had typed. Each page names the
+        // event it is holding, and holds a different one.
+        let store = Store::memory().await.unwrap();
+        let tab_a = store
+            .record_search(scoped("fat32", Door::Ui, Some("me")), 15)
+            .await
+            .unwrap();
+        let tab_b = store
+            .record_search(scoped("ntfs", Door::Ui, Some("me")), 15)
+            .await
+            .unwrap();
+        assert_ne!(tab_a, tab_b, "the second window started its own search");
+
+        // Both go on typing, and each stays its own.
+        let mut b = scoped("ntfs mount", Door::Ui, Some("me"));
+        b.fold_onto = Some(tab_b.clone());
+        assert_eq!(store.record_search(b, 15).await.unwrap(), tab_b);
+        let mut got = queries(&store).await;
+        got.sort();
+        assert_eq!(got, vec!["fat32", "ntfs mount"]);
+        // And the first window's rail can still be answered.
+        assert!(store.open_event(&tab_a, "a1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn the_nav_count_reads_the_pool_through_an_index() {
+        // `pending_count` draws the nav on every page render, and `dealable!`
+        // asks two things of `search_candidates` for every unjudged event it
+        // looks at. Both have to be index reads: with `retain_days = 0` — the
+        // default, where nothing is trimmed — the set they run over only
+        // grows, and the events this predicate holds back stay in it forever.
+        let store = Store::memory().await.unwrap();
+        let plan: Vec<String> = sqlx::query(concat!(
+            "EXPLAIN QUERY PLAN SELECT count(*) FROM search_events WHERE ",
+            dealable!()
+        ))
+        .bind(0.3f32)
+        .fetch_all(&store.pool)
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.get::<String, _>("detail"))
+        .collect();
+        assert!(
+            plan.iter().all(|l| !l.contains("SCAN search_candidates")),
+            "the nav scans the pool table: {plan:#?}"
+        );
+        assert_eq!(
+            plan.iter()
+                .filter(|l| l.contains("idx_candidates_similarity"))
+                .count(),
+            2,
+            "both subqueries should be covered by the index: {plan:#?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_gap_is_refused_where_the_box_has_moved_on() {
+        // The rail is drawn, a trailing keystroke folds a later wording into
+        // the same row, and only then is "nothing here has it" pressed. The
+        // gap belongs to the words that were on the screen: recorded against
+        // the newer ones it reports a hole in the base over a search that
+        // answered. Same check `open_event` makes against the pool.
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .record_search(ev("fat32", Door::Ui), 15)
+            .await
+            .unwrap();
+        store
+            .record_search(after(&id, "fat32 mount", Door::Ui), 15)
+            .await
+            .unwrap();
+
+        assert!(!store.gap_event(&id, "fat32").await.unwrap());
+        assert_eq!(store.feedback_stats(0.0).await.unwrap().gaps, 0);
+        // The wording the row now holds is still answerable.
+        assert!(store.gap_event(&id, "fat32 mount").await.unwrap());
     }
 
     #[tokio::test]
@@ -1475,7 +1731,7 @@ mod tests {
         let id = store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
         assert!(store.open_event(&id, "a1").await.unwrap());
         store
-            .record_search(ev("fat32", Door::Ui), 15)
+            .record_search(after(&id, "fat32", Door::Ui), 15)
             .await
             .unwrap();
         assert_eq!(queries(&store).await, vec!["fat", "fat32"]);
@@ -1578,7 +1834,7 @@ mod tests {
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
         // Taking it back returns the search to the deck with nothing on it —
         // no verdict, no expectation, and no record of who once gave one.
-        store.unjudge(&id).await.unwrap();
+        store.unjudge(&id, Labeller::Confirm).await.unwrap();
         assert_eq!(judged_by(&store, &id).await, None);
         assert_eq!(
             store.next_pending(0.0).await.unwrap().map(|e| e.id),
@@ -1593,15 +1849,15 @@ mod tests {
             .record_search(scoped("xyz", Door::Ui, Some("me")), 15)
             .await
             .unwrap();
-        assert!(store.gap_event(&id).await.unwrap());
+        assert!(store.gap_event(&id, "xyz").await.unwrap());
         assert_eq!(store.feedback_stats(0.0).await.unwrap().gaps, 1);
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
         assert!(
-            !store.gap_event(&id).await.unwrap(),
+            !store.gap_event(&id, "xyz").await.unwrap(),
             "a second press finds nothing left to label"
         );
         assert!(
-            !store.gap_event("no-such-event").await.unwrap(),
+            !store.gap_event("no-such-event", "xyz").await.unwrap(),
             "and an event that is no longer there is not a gap either"
         );
     }
@@ -1634,8 +1890,8 @@ mod tests {
         // The candidates belong to the query that produced them. Keeping the
         // earlier ones would describe a result list that was never shown.
         let store = Store::memory().await.unwrap();
-        store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
-        let mut second = ev("fat32", Door::Ui);
+        let id = store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
+        let mut second = after(&id, "fat32", Door::Ui);
         second.candidates[0].artifact_id = "a2".into();
         store.record_search(second, 15).await.unwrap();
 
@@ -1663,7 +1919,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut filtered = ev("fat32", Door::Ui);
+        let mut filtered = after(&first, "fat32", Door::Ui);
         filtered.filters = r#"{"category":"recipes"}"#.into();
         filtered.candidates.clear();
         let second = store.record_search(filtered, 15).await.unwrap();
@@ -1683,11 +1939,11 @@ mod tests {
         // results is the documented case: one search, judged once, against the
         // narrowing that was actually meant.
         let store = Store::memory().await.unwrap();
-        store
+        let id = store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
             .unwrap();
-        let mut filtered = ev("fat32", Door::Ui);
+        let mut filtered = after(&id, "fat32", Door::Ui);
         filtered.filters = r#"{"category":"disks"}"#.into();
         filtered.candidates[0].artifact_id = "a2".into();
         store.record_search(filtered, 15).await.unwrap();
@@ -1714,7 +1970,7 @@ mod tests {
             .await
             .unwrap();
         store
-            .record_search(ev("fat32", Door::Ui), 15)
+            .record_search(after(&id, "fat32", Door::Ui), 15)
             .await
             .unwrap();
         assert_eq!(queries(&store).await, vec!["fat", "fat32"]);
@@ -1869,7 +2125,7 @@ mod tests {
         for res in [
             store.judge_hit(&id, "a", Labeller::Deck).await,
             store.judge(&id, Verdict::Gap, Labeller::Deck).await,
-            store.unjudge(&id).await,
+            store.unjudge(&id, Labeller::Deck).await,
             store.skip_event(&id).await,
         ] {
             assert!(

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -429,11 +429,21 @@ pub struct PendingEvent {
 }
 
 /// What the deck deals: see `Store::next_pending`. One bind, `weak_below`.
-/// `COALESCE` so an empty pool reads as the weakest search there is.
+///
+/// Two `COALESCE`s, for two different absences. The outer one: an empty pool
+/// reads as the weakest search there is, because a search that returned nothing
+/// is a hole rather than a card. The inner one: a candidate the vector half
+/// never scored reads as the *strongest*, because a similarity nobody measured
+/// is not evidence of a weak match. A hit found by the lexical half alone
+/// carries none — `search_inner` stores what the vector search returned, and
+/// with the embedder down or the query answered on keywords it returns nothing
+/// — and reading those as zero withheld every such search from the deck
+/// silently, when a keyword search that found something is exactly the card a
+/// person can answer.
 macro_rules! dealable {
     () => {
         "judged_at IS NULL AND length(query) >= 3
-         AND COALESCE((SELECT max(similarity) FROM search_candidates
+         AND COALESCE((SELECT max(COALESCE(similarity, 1.0)) FROM search_candidates
                         WHERE event_id = search_events.id), 0) >= ?"
     };
 }
@@ -441,6 +451,11 @@ macro_rules! dealable {
 #[derive(Debug, Clone, Default)]
 pub struct Stats {
     pub captured: i64,
+    /// Searches still waiting for a verdict *and* answerable — the same
+    /// `dealable!` set the deck deals and `pending_count` draws the nav from.
+    /// Every screen showing this says "waiting", and a number counting cards
+    /// nobody will ever be dealt is a queue that never empties: the pulse read
+    /// "12 waiting" over an empty deck while the nav beside it read nothing.
     pub pending: i64,
     pub judged: i64,
     pub hits: i64,
@@ -610,43 +625,32 @@ impl Store {
         )
     }
 
-    /// The search a result was opened from: the newest of this person's still
-    /// unjudged events, within `within_secs`, whose pool holds the artifact.
-    /// Stamped `opened_at`, which is what stops the next rewording folding
-    /// into it — see `record_search`.
+    /// The search a result was opened from, named by the page that listed it.
+    /// Stamped `opened_at`, which is what stops the next rewording folding into
+    /// it — see `record_search`.
     ///
-    /// The capture is written off the request path and its id is thrown away,
-    /// so the page cannot carry one. Asking the store at open time is the one
-    /// lookup that also survives the fold: whatever wording the burst ended on,
-    /// the pool the person is looking at is the one stored.
-    pub async fn open_event_for(
-        &self,
-        artifact_id: &str,
-        scope: Option<&str>,
-        within_secs: i64,
-    ) -> Result<Option<String>> {
-        let at = now();
-        let id: Option<String> = sqlx::query_scalar(
-            "SELECT id FROM search_events
-              WHERE scope IS ? AND (judged_at IS NULL OR judged_by = 'dwell')
-                AND created_at > ?
-                AND EXISTS (SELECT 1 FROM search_candidates
-                             WHERE event_id = search_events.id AND artifact_id = ?)
-              ORDER BY created_at DESC, id DESC LIMIT 1",
+    /// Named rather than guessed: the UI door waits for its own capture (see
+    /// `Core::search_inner`) so every rail row carries the id of the search
+    /// that produced it. What this replaced looked for the newest recent event
+    /// whose pool happened to hold the artifact, which had two ways to be
+    /// wrong — a click arriving before the background write found nothing, and
+    /// one arriving an hour later could be answered by a different search
+    /// entirely, then labelled by a read that had nothing to do with it.
+    ///
+    /// `false` where the event is gone — retention expires them, Ops purges
+    /// them — or where a person has already spoken for it. That is what
+    /// decides whether the bar under the artifact is drawn at all.
+    pub async fn open_event(&self, event_id: &str) -> Result<bool> {
+        Ok(sqlx::query(
+            "UPDATE search_events SET opened_at = ?
+              WHERE id = ? AND (judged_at IS NULL OR judged_by = 'dwell')",
         )
-        .bind(scope)
-        .bind(at - within_secs)
-        .bind(artifact_id)
-        .fetch_optional(&self.pool)
-        .await?;
-        if let Some(id) = &id {
-            sqlx::query("UPDATE search_events SET opened_at = ? WHERE id = ?")
-                .bind(at)
-                .bind(id)
-                .execute(&self.pool)
-                .await?;
-        }
-        Ok(id)
+        .bind(now())
+        .bind(event_id)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            == 1)
     }
 
     /// A read long enough to count, as a hit — only where no person has said
@@ -688,29 +692,27 @@ impl Store {
         )
     }
 
-    /// The rail's "nothing here has it": a gap against this person's newest
-    /// unjudged search for these words, within `within_secs`. The id it
-    /// labelled, or `None` where there was nothing left to label.
-    pub async fn gap_for_query(
-        &self,
-        query: &str,
-        scope: Option<&str>,
-        within_secs: i64,
-    ) -> Result<Option<String>> {
-        let id: Option<String> = sqlx::query_scalar(
-            "SELECT id FROM search_events
-              WHERE scope IS ? AND query = ? AND judged_at IS NULL AND created_at > ?
-              ORDER BY created_at DESC, id DESC LIMIT 1",
+    /// The rail's "nothing here has it": a gap against the search the rail was
+    /// filled by, named by the page as an open is. `false` where there was
+    /// nothing left to label — the event was purged, or already judged.
+    ///
+    /// Not `judge`, which would report a second click as an error and a purged
+    /// event as the same error: the button has two outcomes and both of them
+    /// are ordinary.
+    pub async fn gap_event(&self, event_id: &str) -> Result<bool> {
+        Ok(sqlx::query(
+            "UPDATE search_events
+             SET judged_at = ?, verdict = ?, expect_id = NULL, judged_by = ?
+             WHERE id = ? AND judged_at IS NULL",
         )
-        .bind(scope)
-        .bind(query)
-        .bind(now() - within_secs)
-        .fetch_optional(&self.pool)
-        .await?;
-        if let Some(id) = &id {
-            self.judge(id, Verdict::Gap, Labeller::Confirm).await?;
-        }
-        Ok(id)
+        .bind(now())
+        .bind(Verdict::Gap.as_str())
+        .bind(Labeller::Confirm.as_sql())
+        .bind(event_id)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            == 1)
     }
 
     /// Take a verdict back, returning the event to the pending queue.
@@ -763,16 +765,12 @@ impl Store {
     /// actually gave. No vector store and no embedding are involved, so the
     /// number can move on every single judgement — which is what makes it worth
     /// showing while judging rather than afterwards.
-    pub async fn feedback_stats(&self) -> Result<Stats> {
+    pub async fn feedback_stats(&self, weak_below: f32) -> Result<Stats> {
         let mut s = Stats {
             captured: sqlx::query_scalar("SELECT count(*) FROM search_events")
                 .fetch_one(&self.pool)
                 .await?,
-            pending: sqlx::query_scalar(
-                "SELECT count(*) FROM search_events WHERE judged_at IS NULL",
-            )
-            .fetch_one(&self.pool)
-            .await?,
+            pending: self.pending_count(weak_below).await?,
             ..Default::default()
         };
 
@@ -1344,35 +1342,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn opening_a_result_names_the_search_it_came_from() {
-        // The capture is written off the request path and its id thrown away,
-        // so nothing on the page knows which event an open belongs to. The
-        // store answers instead: the newest unjudged event of this person's
-        // whose pool holds the artifact.
+    async fn opening_a_result_stamps_the_search_the_page_named() {
+        // The UI door waits for its own capture, so the page carries the id and
+        // this is a stamp rather than a guess.
         let store = Store::memory().await.unwrap();
         let id = store
             .record_search(scoped("fat32", Door::Ui, Some("me")), 15)
             .await
             .unwrap();
-        assert_eq!(
-            store.open_event_for("a1", Some("me"), 600).await.unwrap(),
-            Some(id.clone())
+        assert!(store.open_event(&id).await.unwrap());
+        assert!(
+            !store.open_event("no-such-event").await.unwrap(),
+            "an event retention or a purge took away is nothing to open"
         );
-        assert_eq!(
-            store.open_event_for("a9", Some("me"), 600).await.unwrap(),
-            None,
-            "an artifact the search never offered is not an open of it"
-        );
-        assert_eq!(
-            store.open_event_for("a1", Some("you"), 600).await.unwrap(),
-            None,
-            "someone else's search is not mine to open"
-        );
-        assert_eq!(
-            store.open_event_for("a1", Some("me"), 0).await.unwrap(),
-            None,
-            "outside the window there is nothing to attach to"
-        );
+
+        // A person having answered closes it: the bar is not drawn again over
+        // a search that has been spoken for.
+        store.judge_hit(&id, "a1", Labeller::Confirm).await.unwrap();
+        assert!(!store.open_event(&id).await.unwrap());
     }
 
     #[tokio::test]
@@ -1381,12 +1368,8 @@ mod tests {
         // and the hit about to be recorded against it needs the rank it held.
         // A search after the open starts its own event.
         let store = Store::memory().await.unwrap();
-        store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
-        store
-            .open_event_for("a1", None, 600)
-            .await
-            .unwrap()
-            .unwrap();
+        let id = store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
+        assert!(store.open_event(&id).await.unwrap());
         store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
@@ -1402,7 +1385,7 @@ mod tests {
             .await
             .unwrap();
         assert!(store.implicit_hit(&id, "a1").await.unwrap());
-        let s = store.feedback_stats().await.unwrap();
+        let s = store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.judged, s.hits), (1, 1));
         assert_eq!(s.recall_at_10, 1.0);
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("dwell"));
@@ -1424,7 +1407,7 @@ mod tests {
             .await
             .unwrap();
         assert!(!store.implicit_hit(&id, "a1").await.unwrap());
-        assert_eq!(store.feedback_stats().await.unwrap().gaps, 1);
+        assert_eq!(store.feedback_stats(0.0).await.unwrap().gaps, 1);
 
         // "No" clears nothing into a verdict, but it is still a person having
         // spoken: the dwell that flushes when the pane is left must not put the
@@ -1433,7 +1416,7 @@ mod tests {
         store.implicit_hit(&id, "a1").await.unwrap();
         store.decline(&id).await.unwrap();
         assert!(!store.implicit_hit(&id, "a1").await.unwrap());
-        let s = store.feedback_stats().await.unwrap();
+        let s = store.feedback_stats(0.0).await.unwrap();
         assert_eq!(s.hits, 0, "the provisional hit was withdrawn");
         assert_eq!(
             store.next_pending(0.0).await.unwrap().map(|e| e.id),
@@ -1450,9 +1433,8 @@ mod tests {
         let store = Store::memory().await.unwrap();
         let id = seed(&store, "fat32", &["a1", "a2"]).await;
         assert!(store.implicit_hit(&id, "a1").await.unwrap());
-        assert_eq!(
-            store.open_event_for("a2", None, 600).await.unwrap(),
-            Some(id.clone()),
+        assert!(
+            store.open_event(&id).await.unwrap(),
             "a search labelled only by reading is still open to the next open"
         );
         assert!(store.implicit_hit(&id, "a2").await.unwrap());
@@ -1487,10 +1469,46 @@ mod tests {
         );
         assert_eq!(store.pending_count(0.3).await.unwrap(), 1);
 
+        // Every screen that says "waiting" counts the same set. The pulse used
+        // to read its number off a plain `judged_at IS NULL` and say "12
+        // waiting" over a deck that had nothing left to deal.
+        assert_eq!(
+            store.feedback_stats(0.3).await.unwrap().pending,
+            store.pending_count(0.3).await.unwrap()
+        );
+
         // And the card knows whether anything was opened from it.
         assert!(!store.next_pending(0.3).await.unwrap().unwrap().opened);
-        store.open_event_for("a1", None, 600).await.unwrap();
+        store.open_event(&id).await.unwrap();
         assert!(store.next_pending(0.3).await.unwrap().unwrap().opened);
+    }
+
+    #[tokio::test]
+    async fn a_search_the_vector_half_never_scored_is_still_dealt() {
+        // A hit found by the lexical half alone carries no similarity — the
+        // embedder is down, or the query was answered on keywords. Reading that
+        // absence as a zero withheld every such search from the deck and from
+        // the count, silently, when a keyword search that found something is
+        // exactly the card a person can answer. Only a measured similarity
+        // under the line, or a pool with nothing in it, is undealable.
+        let store = Store::memory().await.unwrap();
+        let mut lexical = ev("fat32", Door::Ui);
+        lexical.candidates[0].similarity = None;
+        let id = store.record_search(lexical, 0).await.unwrap();
+        assert_eq!(
+            store.next_pending(0.35).await.unwrap().map(|e| e.id),
+            Some(id)
+        );
+        assert_eq!(store.pending_count(0.35).await.unwrap(), 1);
+
+        let mut empty = ev("ntfs", Door::Ui);
+        empty.candidates.clear();
+        store.record_search(empty, 0).await.unwrap();
+        assert_eq!(
+            store.pending_count(0.35).await.unwrap(),
+            1,
+            "a search that returned nothing is a hole, not a card"
+        );
     }
 
     #[tokio::test]
@@ -1516,21 +1534,16 @@ mod tests {
             .record_search(scoped("xyz", Door::Ui, Some("me")), 15)
             .await
             .unwrap();
-        assert_eq!(
-            store.gap_for_query("xyz", Some("me"), 600).await.unwrap(),
-            Some(id.clone())
-        );
-        assert_eq!(store.feedback_stats().await.unwrap().gaps, 1);
+        assert!(store.gap_event(&id).await.unwrap());
+        assert_eq!(store.feedback_stats(0.0).await.unwrap().gaps, 1);
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
-        assert_eq!(
-            store.gap_for_query("xyz", Some("me"), 600).await.unwrap(),
-            None,
+        assert!(
+            !store.gap_event(&id).await.unwrap(),
             "a second press finds nothing left to label"
         );
-        assert_eq!(
-            store.gap_for_query("abc", Some("me"), 600).await.unwrap(),
-            None,
-            "a query nobody searched for is not a gap"
+        assert!(
+            !store.gap_event("no-such-event").await.unwrap(),
+            "and an event that is no longer there is not a gap either"
         );
     }
 
@@ -1817,7 +1830,7 @@ mod tests {
         let third = seed(&store, "third hit", &["x", "y", "z"]).await;
         store.judge_hit(&third, "z", Labeller::Deck).await.unwrap();
 
-        let s = store.feedback_stats().await.unwrap();
+        let s = store.feedback_stats(0.0).await.unwrap();
         assert_eq!(s.judged, 2);
         assert_eq!(s.hits, 2);
         assert!((s.recall_at_10 - 1.0).abs() < 1e-9);
@@ -1871,7 +1884,7 @@ mod tests {
             .await
             .unwrap();
 
-        let s = store.feedback_stats().await.unwrap();
+        let s = store.feedback_stats(0.0).await.unwrap();
         assert_eq!(s.finds, 1);
         assert_eq!(s.recall_at_10, 0.0);
         assert_eq!(s.mrr, 0.0);
@@ -1889,7 +1902,7 @@ mod tests {
             .await
             .unwrap();
 
-        let s = store.feedback_stats().await.unwrap();
+        let s = store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.gaps, s.discards, s.hits), (1, 1, 0));
         // Neither can score: one has no answer, the other was not a question.
         assert_eq!(s.mrr, 0.0);

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -193,10 +193,10 @@ impl Store {
     /// Capturing only deliberate searches would lose the most valuable case:
     /// `mark` is set on open, expand and submit, so a search where the operator
     /// found nothing useful and gave up would never be recorded. So everything
-    /// is captured, and an event whose query extends the previous one from the
-    /// same searcher — or repeats it verbatim — within `coalesce_secs` replaces
-    /// it. What survives is the final wording: the query that was actually
-    /// meant, asked once.
+    /// is captured, and any query from the same searcher within
+    /// `coalesce_secs` — longer, shorter or the same words again — replaces the
+    /// one before it. What survives is the final wording: the query that was
+    /// actually meant, asked once, holding the pool that answered it.
     ///
     /// Only text boxes fold, and only within one `scope`. That is the web UI's
     /// search field and the browser extension's panel, both of which search as
@@ -234,12 +234,24 @@ impl Store {
             _ => None,
         };
 
-        // Same burst, whatever the wording. A keystroke is one HTTP request
-        // among several in flight, so "fat" can land after "fat32", and a
-        // shorter prefix arriving late is dropped rather than folded forward.
-        // Anything else inside the window folds forward: a rewording is the
-        // same need said again, and a burst of three wordings ending in one
-        // open used to be three cards, two of them about words nobody meant.
+        // Same burst, whatever the wording. Everything inside the window folds
+        // forward: a rewording is the same need said again, and a burst of
+        // three wordings ending in one open used to be three cards, two of them
+        // about words nobody meant.
+        //
+        // A shorter query folds like any other, and used to not. The rule that
+        // dropped it read a shorter prefix as a keystroke arriving late — "fat"
+        // landing after "fat32" — and kept the longer stored wording as the one
+        // that was meant. Backspacing is indistinguishable from that at the
+        // point of the write and is not rare: the box searches as you type, so
+        // deleting a word is an ordinary edit. What the stale rule left behind
+        // was an event holding a *different* query and a *different* pool than
+        // the rail beside it was showing, named on every row of it — so an open
+        // was stamped, and a verdict later scored, against a search nobody was
+        // looking at. Folding forward keeps the stored event and what was
+        // rendered the same thing; the race it gave up on was already the rule
+        // everywhere else in this match, where the last write wins.
+        //
         // The one thing that stops a fold is an open — `opened_at` above —
         // because the pool that was read is the pool the hit is scored on.
         // The same query twice (the form fires on load, on submit and on every
@@ -248,13 +260,10 @@ impl Store {
         enum Fold {
             /// The stored event is an earlier wording of this one.
             Extends(String),
-            /// This is an earlier keystroke of the stored event, arriving late.
-            Superseded(String),
             New,
         }
         let fold = match prev.as_ref() {
             Some(r) => {
-                let prior: String = r.get("query");
                 let created: i64 = r.get("created_at");
                 // A window of zero means folding is off, not "fold within the
                 // same second" — which is what a plain `<=` gives, since both
@@ -272,11 +281,7 @@ impl Store {
                 // of it, so the empty search starts its own event instead.
                 let pool: i64 = r.get("pool");
                 let empties = ev.candidates.is_empty() && pool > 0;
-                if !fresh {
-                    Fold::New
-                } else if prior.len() > ev.query.len() && prior.starts_with(&ev.query) {
-                    Fold::Superseded(id)
-                } else if empties {
+                if !fresh || empties {
                     Fold::New
                 } else {
                     Fold::Extends(id)
@@ -285,11 +290,6 @@ impl Store {
             None => Fold::New,
         };
 
-        // Nothing to write: the final wording is already stored, and it was
-        // answered by a pool drawn for the query that was actually meant.
-        if let Fold::Superseded(id) = fold {
-            return Ok(id);
-        }
         let extends = match fold {
             Fold::Extends(id) => Some(id),
             _ => None,
@@ -394,9 +394,15 @@ pub enum Labeller {
     Deck,
     /// The bar under an opened result, or the gap button on the rail: at the
     /// moment, by the person who searched.
+    ///
+    /// The only other labeller there is. A read long enough used to count as a
+    /// hit on its own, and it is gone: what it measured was a page staying
+    /// open, which is a tab left behind as often as it is an answer, and it
+    /// arrived *after* the click it was overwriting — the beacon flushes when
+    /// the pane is left, so it landed on top of "not sure" and "undo" and put
+    /// a hit back that a person had just taken away. A verdict now comes from
+    /// somebody saying so.
     Confirm,
-    /// Reading a result long enough. Provisional: never overwrites the others.
-    Dwell,
 }
 
 impl Labeller {
@@ -404,7 +410,6 @@ impl Labeller {
         match self {
             Labeller::Deck => None,
             Labeller::Confirm => Some("confirm"),
-            Labeller::Dwell => Some("dwell"),
         }
     }
 }
@@ -432,7 +437,12 @@ pub struct PendingEvent {
 ///
 /// Two `COALESCE`s, for two different absences. The outer one: an empty pool
 /// reads as the weakest search there is, because a search that returned nothing
-/// is a hole rather than a card. The inner one: a candidate the vector half
+/// is a hole rather than a card — there is no list to point at, so the only
+/// answers left are gap and discard, and neither is worth spending a person's
+/// turn on. It is not thereby lost: `unmatched_gaps_from!` in `store::gaps`
+/// names the empty pool explicitly and the sweep raises it as a hole in the
+/// base, which is what it is. (It did not, once, and the search fell through
+/// the crack between the two.) The inner one: a candidate the vector half
 /// never scored reads as the *strongest*, because a similarity nobody measured
 /// is not evidence of a weak match. A hit found by the lexical half alone
 /// carries none — `search_inner` stores what the vector search returned, and
@@ -625,6 +635,30 @@ impl Store {
         )
     }
 
+    /// Whether this event was recorded by this searcher.
+    ///
+    /// Every route that labels a search takes the event id from the page — the
+    /// `?event=` on a rail link, the id in the verdict and gap posts — because
+    /// the page is what knows which search a row came from. An id is not a
+    /// capability, though: on an install with more than one person, anything
+    /// that acted on the id alone let one person stamp opens and verdicts onto
+    /// another's searches, and quietly break their coalescing besides, by
+    /// guessing at ids that are not secret. So the caller has to own the row.
+    ///
+    /// `scope = ?` and not `IS`: every search that can reach these routes came
+    /// through the UI door, and the UI door always names its subject (see
+    /// `Origin`). A row with no scope is not one of them.
+    pub async fn event_is_mine(&self, event_id: &str, scope: &str) -> Result<bool> {
+        Ok(
+            sqlx::query_scalar::<_, i64>("SELECT 1 FROM search_events WHERE id = ? AND scope = ?")
+                .bind(event_id)
+                .bind(scope)
+                .fetch_optional(&self.pool)
+                .await?
+                .is_some(),
+        )
+    }
+
     /// The search a result was opened from, named by the page that listed it.
     /// Stamped `opened_at`, which is what stops the next rewording folding into
     /// it — see `record_search`.
@@ -641,44 +675,21 @@ impl Store {
     /// them — or where a person has already spoken for it. That is what
     /// decides whether the bar under the artifact is drawn at all.
     pub async fn open_event(&self, event_id: &str) -> Result<bool> {
-        Ok(sqlx::query(
-            "UPDATE search_events SET opened_at = ?
-              WHERE id = ? AND (judged_at IS NULL OR judged_by = 'dwell')",
+        Ok(
+            sqlx::query(
+                "UPDATE search_events SET opened_at = ? WHERE id = ? AND judged_at IS NULL",
+            )
+            .bind(now())
+            .bind(event_id)
+            .execute(&self.pool)
+            .await?
+            .rows_affected()
+                == 1,
         )
-        .bind(now())
-        .bind(event_id)
-        .execute(&self.pool)
-        .await?
-        .rows_affected()
-            == 1)
     }
 
-    /// A read long enough to count, as a hit — only where no person has said
-    /// anything. Whether it was written. A later read replaces an earlier one:
-    /// skimming the first result and reading the second is the second being
-    /// the one.
-    ///
-    /// `judged_by IS NULL` beside `judged_at IS NULL`: a "no" from the bar
-    /// leaves the event pending but marks it spoken for, and the dwell that
-    /// flushes when the pane is left must not put the hit straight back.
-    pub async fn implicit_hit(&self, event_id: &str, artifact_id: &str) -> Result<bool> {
-        Ok(sqlx::query(
-            "UPDATE search_events
-             SET judged_at = ?, verdict = 'hit', expect_id = ?, judged_by = 'dwell'
-             WHERE id = ?
-               AND ((judged_at IS NULL AND judged_by IS NULL) OR judged_by = 'dwell')",
-        )
-        .bind(now())
-        .bind(artifact_id)
-        .bind(event_id)
-        .execute(&self.pool)
-        .await?
-        .rows_affected()
-            == 1)
-    }
-
-    /// "Not this one": whatever a read recorded is withdrawn, the search stays
-    /// a question for the deck, and no later read may answer it.
+    /// "Not this one": the search stays a question for the deck, and the column
+    /// records that the answer came from a person rather than the deck.
     pub async fn decline(&self, event_id: &str) -> Result<()> {
         Self::judged_one(
             sqlx::query(
@@ -1227,24 +1238,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_keystroke_that_arrives_late_folds_into_the_wording_it_preceded() {
-        // Each keystroke is its own request, so "fat" can be committed after
-        // "fat32". Testing only whether the query grew left the earlier
-        // keystroke standing as a second event, and the judging queue filled
-        // with half-typed prefixes — the thing coalescing exists to prevent.
+    async fn a_shorter_query_folds_forward_like_any_other() {
+        // Deleting a word is an ordinary edit — the box searches as you type —
+        // and it used to be read as a half-typed keystroke arriving late, so
+        // the longer wording stayed and the shorter one was thrown away. What
+        // that left was a stored event holding a different query and a
+        // different pool than the rail beside it was showing, named on every
+        // row of it, so an open was stamped and a verdict scored against a
+        // search nobody was looking at. The record follows the box.
         let store = Store::memory().await.unwrap();
+        store
+            .record_search(ev("fat32 mount", Door::Ui), 15)
+            .await
+            .unwrap();
         store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
             .unwrap();
-        store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
 
         assert_eq!(queries(&store).await, vec!["fat32"]);
         let candidates: i64 = sqlx::query_scalar("SELECT count(*) FROM search_candidates")
             .fetch_one(&store.pool)
             .await
             .unwrap();
-        assert_eq!(candidates, 1, "the surviving event lost its pool");
+        assert_eq!(candidates, 1, "and the pool that answered it");
     }
 
     #[tokio::test]
@@ -1378,73 +1395,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_read_records_a_provisional_hit_that_no_human_has_to_give() {
+    async fn saying_no_leaves_the_search_a_question_for_the_deck() {
+        // "No" clears nothing into a verdict — it is a person saying the thing
+        // in front of them was not it, which is not the same as saying the
+        // base has nothing. So the search goes back to the deck, marked as
+        // having been spoken for by a person rather than by the deck.
         let store = Store::memory().await.unwrap();
-        let id = store
-            .record_search(ev("fat32", Door::Ui), 15)
-            .await
-            .unwrap();
-        assert!(store.implicit_hit(&id, "a1").await.unwrap());
-        let s = store.feedback_stats(0.0).await.unwrap();
-        assert_eq!((s.judged, s.hits), (1, 1));
-        assert_eq!(s.recall_at_10, 1.0);
-        assert_eq!(judged_by(&store, &id).await.as_deref(), Some("dwell"));
-        assert!(
-            store.next_pending(0.0).await.unwrap().is_none(),
-            "a search already labelled by reading is not dealt to the deck"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_read_never_overrules_a_person() {
-        let store = Store::memory().await.unwrap();
-        let id = store
-            .record_search(ev("fat32", Door::Ui), 15)
-            .await
-            .unwrap();
-        store
-            .judge(&id, Verdict::Gap, Labeller::Confirm)
-            .await
-            .unwrap();
-        assert!(!store.implicit_hit(&id, "a1").await.unwrap());
-        assert_eq!(store.feedback_stats(0.0).await.unwrap().gaps, 1);
-
-        // "No" clears nothing into a verdict, but it is still a person having
-        // spoken: the dwell that flushes when the pane is left must not put the
-        // hit straight back.
         let id = store.record_search(ev("ntfs", Door::Ui), 0).await.unwrap();
-        store.implicit_hit(&id, "a1").await.unwrap();
         store.decline(&id).await.unwrap();
-        assert!(!store.implicit_hit(&id, "a1").await.unwrap());
         let s = store.feedback_stats(0.0).await.unwrap();
-        assert_eq!(s.hits, 0, "the provisional hit was withdrawn");
+        assert_eq!((s.judged, s.hits), (0, 0));
+        assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
         assert_eq!(
             store.next_pending(0.0).await.unwrap().map(|e| e.id),
             Some(id),
             "and the search goes to the deck, still a question"
         );
-    }
-
-    #[tokio::test]
-    async fn a_later_read_replaces_an_earlier_one() {
-        // Skimming the first result and then reading the second is the second
-        // being the one. A read is provisional against a person, and equally
-        // provisional against the next read.
-        let store = Store::memory().await.unwrap();
-        let id = seed(&store, "fat32", &["a1", "a2"]).await;
-        assert!(store.implicit_hit(&id, "a1").await.unwrap());
-        assert!(
-            store.open_event(&id).await.unwrap(),
-            "a search labelled only by reading is still open to the next open"
-        );
-        assert!(store.implicit_hit(&id, "a2").await.unwrap());
-        let expect: Option<String> =
-            sqlx::query_scalar("SELECT expect_id FROM search_events WHERE id = ?")
-                .bind(&id)
-                .fetch_one(&store.pool)
-                .await
-                .unwrap();
-        assert_eq!(expect.as_deref(), Some("a2"));
     }
 
     #[tokio::test]
@@ -1507,24 +1473,30 @@ mod tests {
         assert_eq!(
             store.pending_count(0.35).await.unwrap(),
             1,
-            "a search that returned nothing is a hole, not a card"
+            "a search that returned nothing is a hole, not a card: there is no
+             list to point at, so the deck has no question to ask. It is not
+             lost — `store::gaps` raises it as an unmatched gap, which is what
+             `a_search_that_returned_nothing_is_an_unmatched_gap` holds it to."
         );
     }
 
     #[tokio::test]
-    async fn saying_yes_after_a_read_makes_the_hit_a_persons() {
+    async fn a_verdict_records_who_gave_it_and_undo_forgets_it() {
         let store = Store::memory().await.unwrap();
         let id = store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
             .unwrap();
-        store.implicit_hit(&id, "a1").await.unwrap();
         store.judge_hit(&id, "a1", Labeller::Confirm).await.unwrap();
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
-        // Taking it back forgets who gave it, so a read can label it again.
+        // Taking it back returns the search to the deck with nothing on it —
+        // no verdict, no expectation, and no record of who once gave one.
         store.unjudge(&id).await.unwrap();
         assert_eq!(judged_by(&store, &id).await, None);
-        assert!(store.implicit_hit(&id, "a1").await.unwrap());
+        assert_eq!(
+            store.next_pending(0.0).await.unwrap().map(|e| e.id),
+            Some(id)
+        );
     }
 
     #[tokio::test]

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -698,11 +698,25 @@ impl Store {
         )
     }
 
+    /// The deck's gap and discard, and the same `AND judged_at IS NULL` the
+    /// other three writes carry — for the same race, read from the other side.
+    /// A card sits on screen while the searcher who made that search opens a
+    /// result from it and presses Yes in the workspace; unguarded, G on the
+    /// stale card turned their confirmed hit into a gap, dropped the pair from
+    /// `pairs.json`, and left `expect_id` naming an artifact on a `gap` row —
+    /// a state no other path can produce. `expect_id = NULL` beside it, as
+    /// `gap_event` writes it: with the guard an unjudged row never holds one,
+    /// and the two writes that mean the same thing should not differ.
+    ///
+    /// `NotFound` is what a refusal reads as here, which is what the deck
+    /// already does with `judge_hit`: the deck deals only unjudged events, so
+    /// for it the answer means what it always meant — that row is gone.
     pub async fn judge(&self, event_id: &str, verdict: Verdict, by: Labeller) -> Result<()> {
         Self::judged_one(
             sqlx::query(
-                "UPDATE search_events SET judged_at = ?, verdict = ?, judged_by = ?
-                 WHERE id = ?",
+                "UPDATE search_events
+                 SET judged_at = ?, verdict = ?, expect_id = NULL, judged_by = ?
+                 WHERE id = ? AND judged_at IS NULL",
             )
             .bind(now())
             .bind(verdict.as_str())
@@ -2110,6 +2124,25 @@ mod tests {
                 .is_empty(),
             "the profiles built from them survived"
         );
+    }
+
+    #[tokio::test]
+    async fn the_deck_does_not_write_over_what_the_searcher_confirmed() {
+        // The race the other three writes are guarded for, read from the deck's
+        // side: a card is dealt, and before the operator answers it the person
+        // who made that search opens a result and presses Yes. G on the stale
+        // card used to turn their hit into a gap — the pair gone from
+        // `pairs.json`, and `expect_id` left naming an artifact on a `gap` row.
+        let store = Store::memory().await.unwrap();
+        let id = seed(&store, "already answered", &["a"]).await;
+        store.judge_hit(&id, "a", Labeller::Confirm).await.unwrap();
+
+        assert!(matches!(
+            store.judge(&id, Verdict::Gap, Labeller::Deck).await,
+            Err(crate::error::Error::NotFound)
+        ));
+        let s = store.feedback_stats(0.0).await.unwrap();
+        assert_eq!((s.hits, s.gaps), (1, 0), "{s:?}");
     }
 
     #[tokio::test]

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -205,12 +205,18 @@ impl Store {
     /// agent narrowing one search into a longer one made two decisions worth
     /// judging separately.
     pub async fn record_search(&self, ev: NewEvent, coalesce_secs: i64) -> Result<String> {
-        // One capture at a time. Two of these overlapping would read the same
-        // previous event and both try to upgrade to a write, which fails
-        // outright rather than waiting — and a lost capture is a search nobody
-        // can judge.
-        let _serialised = self.capture.lock().await;
-        let mut tx = self.pool.begin().await?;
+        // A write transaction from the first statement. This reads the previous
+        // event and then writes over it, and a deferred transaction would take
+        // the read snapshot first and only upgrade at the `UPDATE` — which two
+        // overlapping captures answer with `SQLITE_BUSY_SNAPSHOT`, a failure no
+        // `busy_timeout` waits out, and a lost capture is a search nobody can
+        // judge. Taking the write lock up front makes the read and the write
+        // one atomic thing and leaves the queueing to SQLite's busy timeout,
+        // where a second writer waits instead of failing. It also means the UI
+        // door, which now awaits this on every keystroke, queues only behind
+        // another write to the same file rather than behind a lock held across
+        // every door at once.
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
         let at = now();
 
         // `scope IS ?` rather than `=`, so a UI event recorded without a
@@ -218,7 +224,7 @@ impl Store {
         let prev = match ev.door {
             Door::Ui | Door::Extension => {
                 sqlx::query(
-                    "SELECT id, query, created_at,
+                    "SELECT id, created_at,
                             (SELECT COUNT(*) FROM search_candidates
                               WHERE event_id = search_events.id) AS pool
                        FROM search_events
@@ -435,14 +441,20 @@ pub struct PendingEvent {
 
 /// What the deck deals: see `Store::next_pending`. One bind, `weak_below`.
 ///
-/// Two `COALESCE`s, for two different absences. The outer one: an empty pool
-/// reads as the weakest search there is, because a search that returned nothing
-/// is a hole rather than a card — there is no list to point at, so the only
-/// answers left are gap and discard, and neither is worth spending a person's
-/// turn on. It is not thereby lost: `unmatched_gaps_from!` in `store::gaps`
-/// names the empty pool explicitly and the sweep raises it as a hole in the
-/// base, which is what it is. (It did not, once, and the search fell through
-/// the crack between the two.) The inner one: a candidate the vector half
+/// An `EXISTS` and two `COALESCE`s, for three different absences. The `EXISTS`:
+/// an empty pool is not a card, because a search that returned nothing is a
+/// hole — there is no list to point at, so the only answers left are gap and
+/// discard, and neither is worth spending a person's turn on. It is not thereby
+/// lost: `unmatched_gaps_from!` in `store::gaps` names the empty pool
+/// explicitly and the sweep raises it as a hole in the base, which is what it
+/// is. (It did not, once, and the search fell through the crack between the
+/// two.) Said as an `EXISTS` and not left to the outer `COALESCE` below, which
+/// reads an empty pool as the weakest search there is: that holds the empty
+/// pool out at every threshold but the lowest one, and `weak_below = 0.0` is a
+/// supported setting — it turns the labelling off — where `0 >= 0` let exactly
+/// the unanswerable card through and raised the same search as a gap beside
+/// it. The outer one still stands, because it is what the threshold means. The
+/// inner one: a candidate the vector half
 /// never scored reads as the *strongest*, because a similarity nobody measured
 /// is not evidence of a weak match. A hit found by the lexical half alone
 /// carries none — `search_inner` stores what the vector search returned, and
@@ -453,6 +465,7 @@ pub struct PendingEvent {
 macro_rules! dealable {
     () => {
         "judged_at IS NULL AND length(query) >= 3
+         AND EXISTS (SELECT 1 FROM search_candidates WHERE event_id = search_events.id)
          AND COALESCE((SELECT max(COALESCE(similarity, 1.0)) FROM search_candidates
                         WHERE event_id = search_events.id), 0) >= ?"
     };
@@ -671,36 +684,58 @@ impl Store {
     /// one arriving an hour later could be answered by a different search
     /// entirely, then labelled by a read that had nothing to do with it.
     ///
+    /// The artifact is named as well as the event, and the pool is checked for
+    /// it: a search still in flight when the click lands takes this very row as
+    /// its predecessor — `opened_at` is still NULL at the moment it reads —
+    /// and folds forward over the query, the filters and the whole candidate
+    /// set before this statement runs. Stamping that row regardless drew the
+    /// bar against a search the artifact was never in, so a Yes recorded a hit
+    /// on a pool that never held it. The window is one type-ahead debounce
+    /// wide, and it is the same misattribution the named event exists to stop.
+    ///
     /// `false` where the event is gone — retention expires them, Ops purges
-    /// them — or where a person has already spoken for it. That is what
-    /// decides whether the bar under the artifact is drawn at all.
-    pub async fn open_event(&self, event_id: &str) -> Result<bool> {
-        Ok(
-            sqlx::query(
-                "UPDATE search_events SET opened_at = ? WHERE id = ? AND judged_at IS NULL",
-            )
-            .bind(now())
-            .bind(event_id)
-            .execute(&self.pool)
-            .await?
-            .rows_affected()
-                == 1,
+    /// them — or where a person has already spoken for it, or where the fold
+    /// above happened. That is what decides whether the bar under the artifact
+    /// is drawn at all.
+    pub async fn open_event(&self, event_id: &str, artifact_id: &str) -> Result<bool> {
+        Ok(sqlx::query(
+            "UPDATE search_events SET opened_at = ?
+              WHERE id = ? AND judged_at IS NULL
+                AND EXISTS (SELECT 1 FROM search_candidates
+                             WHERE event_id = ? AND artifact_id = ?)",
         )
+        .bind(now())
+        .bind(event_id)
+        .bind(event_id)
+        .bind(artifact_id)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            == 1)
     }
 
     /// "Not this one": the search stays a question for the deck, and the column
     /// records that the answer came from a person rather than the deck.
-    pub async fn decline(&self, event_id: &str) -> Result<()> {
-        Self::judged_one(
-            sqlx::query(
-                "UPDATE search_events
-                 SET judged_at = NULL, verdict = NULL, expect_id = NULL, judged_by = 'confirm'
-                 WHERE id = ?",
-            )
-            .bind(event_id)
-            .execute(&self.pool)
-            .await?,
+    ///
+    /// `AND judged_at IS NULL`, as `open_event` and `gap_event` both carry, and
+    /// for a sharper reason than either: this clears the verdict columns, so
+    /// without the guard it is the one answer on the bar that *destroys* a
+    /// label. The bar is drawn against an unjudged event, but the deck can
+    /// answer the same search in the time a tab is left open, and pressing No
+    /// in that tab used to silently delete a confirmed pair out of
+    /// `pairs.json`. `false` where that has happened — the same two ordinary
+    /// outcomes `gap_event` reports.
+    pub async fn decline(&self, event_id: &str) -> Result<bool> {
+        Ok(sqlx::query(
+            "UPDATE search_events
+             SET judged_at = NULL, verdict = NULL, expect_id = NULL, judged_by = 'confirm'
+             WHERE id = ? AND judged_at IS NULL",
         )
+        .bind(event_id)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            == 1)
     }
 
     /// The rail's "nothing here has it": a gap against the search the rail was
@@ -1367,16 +1402,68 @@ mod tests {
             .record_search(scoped("fat32", Door::Ui, Some("me")), 15)
             .await
             .unwrap();
-        assert!(store.open_event(&id).await.unwrap());
+        assert!(store.open_event(&id, "a1").await.unwrap());
         assert!(
-            !store.open_event("no-such-event").await.unwrap(),
+            !store.open_event("no-such-event", "a1").await.unwrap(),
             "an event retention or a purge took away is nothing to open"
         );
 
         // A person having answered closes it: the bar is not drawn again over
         // a search that has been spoken for.
         store.judge_hit(&id, "a1", Labeller::Confirm).await.unwrap();
-        assert!(!store.open_event(&id).await.unwrap());
+        assert!(!store.open_event(&id, "a1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_fold_that_took_the_artifact_out_of_the_pool_refuses_the_open() {
+        // The click and the next keystroke race: a search still in flight when
+        // the link is followed reads this very row as its predecessor —
+        // nothing has stamped `opened_at` yet — and folds forward over the
+        // query and the whole pool. Stamping it anyway drew the verdict bar
+        // against a search the artifact was never in.
+        let store = Store::memory().await.unwrap();
+        let id = store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
+        let mut later = ev("fat32", Door::Ui);
+        later.candidates[0].artifact_id = "a2".into();
+        assert_eq!(store.record_search(later, 15).await.unwrap(), id, "folded");
+        assert!(
+            !store.open_event(&id, "a1").await.unwrap(),
+            "the pool the rail was showing is gone, so there is nothing to open against"
+        );
+        // The row the fold left behind is still openable on its own terms.
+        assert!(store.open_event(&id, "a2").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn no_cannot_erase_a_verdict_somebody_else_gave() {
+        // The bar is drawn against an unjudged search, and the deck can answer
+        // the same search while the tab holding it is open. "No" clears the
+        // verdict columns, so without a guard it is the one answer on the bar
+        // that deletes a confirmed pair out of the eval set.
+        let store = Store::memory().await.unwrap();
+        let id = store.record_search(ev("ntfs", Door::Ui), 0).await.unwrap();
+        store.judge_hit(&id, "a1", Labeller::Deck).await.unwrap();
+        assert!(!store.decline(&id).await.unwrap());
+        assert_eq!(
+            store.feedback_stats(0.0).await.unwrap().hits,
+            1,
+            "the pair survived"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_search_that_returned_nothing_is_not_dealt_with_labelling_off() {
+        // `weak_below = 0.0` turns the labelling off, and at that setting the
+        // outer `COALESCE` in `dealable!` reads an empty pool as `0 >= 0` and
+        // lets it through — a card with no options, which is unanswerable
+        // except by skip, gap or discard, and which the sweep is raising as a
+        // hole in the base at the same time.
+        let store = Store::memory().await.unwrap();
+        let mut empty = ev("nothing here", Door::Ui);
+        empty.candidates.clear();
+        store.record_search(empty, 0).await.unwrap();
+        assert!(store.next_pending(0.0).await.unwrap().is_none());
+        assert_eq!(store.pending_count(0.0).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -1386,7 +1473,7 @@ mod tests {
         // A search after the open starts its own event.
         let store = Store::memory().await.unwrap();
         let id = store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
-        assert!(store.open_event(&id).await.unwrap());
+        assert!(store.open_event(&id, "a1").await.unwrap());
         store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
@@ -1402,7 +1489,7 @@ mod tests {
         // having been spoken for by a person rather than by the deck.
         let store = Store::memory().await.unwrap();
         let id = store.record_search(ev("ntfs", Door::Ui), 0).await.unwrap();
-        store.decline(&id).await.unwrap();
+        assert!(store.decline(&id).await.unwrap());
         let s = store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.judged, s.hits), (0, 0));
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
@@ -1445,7 +1532,7 @@ mod tests {
 
         // And the card knows whether anything was opened from it.
         assert!(!store.next_pending(0.3).await.unwrap().unwrap().opened);
-        store.open_event(&id).await.unwrap();
+        store.open_event(&id, "a1").await.unwrap();
         assert!(store.next_pending(0.3).await.unwrap().unwrap().opened);
     }
 

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -223,6 +223,7 @@ impl Store {
                               WHERE event_id = search_events.id) AS pool
                        FROM search_events
                       WHERE door = ? AND scope IS ? AND judged_at IS NULL
+                        AND opened_at IS NULL
                       ORDER BY created_at DESC, id DESC LIMIT 1",
                 )
                 .bind(ev.door.as_str())
@@ -233,18 +234,19 @@ impl Store {
             _ => None,
         };
 
-        // Same typing burst, in either direction. A keystroke is one HTTP
-        // request among several in flight, so "fat" can land after "fat32"; the
-        // test asks whether one query is a prefix of the other rather than
-        // whether this one grew, so the burst folds the same way regardless of
-        // the order the requests happened to arrive in. A prefix of equal
-        // length is the same query twice — the form fires on load, on submit
-        // and on every filter change, so one search reaches here several times
-        // over — and it folds forward like any other, taking the newer filters
-        // and pool with it. Left unfolded it would be a second thing to judge
-        // that says nothing new, and a second identical pair in the eval set.
+        // Same burst, whatever the wording. A keystroke is one HTTP request
+        // among several in flight, so "fat" can land after "fat32", and a
+        // shorter prefix arriving late is dropped rather than folded forward.
+        // Anything else inside the window folds forward: a rewording is the
+        // same need said again, and a burst of three wordings ending in one
+        // open used to be three cards, two of them about words nobody meant.
+        // The one thing that stops a fold is an open — `opened_at` above —
+        // because the pool that was read is the pool the hit is scored on.
+        // The same query twice (the form fires on load, on submit and on every
+        // filter change) folds forward like any other, taking the newer
+        // filters and pool with it.
         enum Fold {
-            /// The stored event is an earlier keystroke of this one.
+            /// The stored event is an earlier wording of this one.
             Extends(String),
             /// This is an earlier keystroke of the stored event, arriving late.
             Superseded(String),
@@ -272,13 +274,12 @@ impl Store {
                 let empties = ev.candidates.is_empty() && pool > 0;
                 if !fresh {
                     Fold::New
-                } else if ev.query.len() >= prior.len() && ev.query.starts_with(&prior) && !empties
-                {
-                    Fold::Extends(id)
                 } else if prior.len() > ev.query.len() && prior.starts_with(&ev.query) {
                     Fold::Superseded(id)
-                } else {
+                } else if empties {
                     Fold::New
+                } else {
+                    Fold::Extends(id)
                 }
             }
             None => Fold::New,
@@ -381,6 +382,29 @@ impl Verdict {
             Verdict::Hit => "hit",
             Verdict::Gap => "gap",
             Verdict::Discard => "discard",
+        }
+    }
+}
+
+/// Who gave a verdict. See `search_events.judged_by`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Labeller {
+    /// The judge deck, later and out of context. Stored as NULL, which is
+    /// what every verdict before the column existed was.
+    Deck,
+    /// The bar under an opened result, or the gap button on the rail: at the
+    /// moment, by the person who searched.
+    Confirm,
+    /// Reading a result long enough. Provisional: never overwrites the others.
+    Dwell,
+}
+
+impl Labeller {
+    fn as_sql(self) -> Option<&'static str> {
+        match self {
+            Labeller::Deck => None,
+            Labeller::Confirm => Some("confirm"),
+            Labeller::Dwell => Some("dwell"),
         }
     }
 }
@@ -532,29 +556,138 @@ impl Store {
         Ok(())
     }
 
-    pub async fn judge_hit(&self, event_id: &str, artifact_id: &str) -> Result<()> {
+    pub async fn judge_hit(&self, event_id: &str, artifact_id: &str, by: Labeller) -> Result<()> {
         Self::judged_one(
             sqlx::query(
-                "UPDATE search_events SET judged_at = ?, verdict = 'hit', expect_id = ?
+                "UPDATE search_events
+                 SET judged_at = ?, verdict = 'hit', expect_id = ?, judged_by = ?
                  WHERE id = ?",
             )
             .bind(now())
             .bind(artifact_id)
+            .bind(by.as_sql())
             .bind(event_id)
             .execute(&self.pool)
             .await?,
         )
     }
 
-    pub async fn judge(&self, event_id: &str, verdict: Verdict) -> Result<()> {
+    pub async fn judge(&self, event_id: &str, verdict: Verdict, by: Labeller) -> Result<()> {
         Self::judged_one(
-            sqlx::query("UPDATE search_events SET judged_at = ?, verdict = ? WHERE id = ?")
-                .bind(now())
-                .bind(verdict.as_str())
-                .bind(event_id)
-                .execute(&self.pool)
-                .await?,
+            sqlx::query(
+                "UPDATE search_events SET judged_at = ?, verdict = ?, judged_by = ?
+                 WHERE id = ?",
+            )
+            .bind(now())
+            .bind(verdict.as_str())
+            .bind(by.as_sql())
+            .bind(event_id)
+            .execute(&self.pool)
+            .await?,
         )
+    }
+
+    /// The search a result was opened from: the newest of this person's still
+    /// unjudged events, within `within_secs`, whose pool holds the artifact.
+    /// Stamped `opened_at`, which is what stops the next rewording folding
+    /// into it — see `record_search`.
+    ///
+    /// The capture is written off the request path and its id is thrown away,
+    /// so the page cannot carry one. Asking the store at open time is the one
+    /// lookup that also survives the fold: whatever wording the burst ended on,
+    /// the pool the person is looking at is the one stored.
+    pub async fn open_event_for(
+        &self,
+        artifact_id: &str,
+        scope: Option<&str>,
+        within_secs: i64,
+    ) -> Result<Option<String>> {
+        let at = now();
+        let id: Option<String> = sqlx::query_scalar(
+            "SELECT id FROM search_events
+              WHERE scope IS ? AND (judged_at IS NULL OR judged_by = 'dwell')
+                AND created_at > ?
+                AND EXISTS (SELECT 1 FROM search_candidates
+                             WHERE event_id = search_events.id AND artifact_id = ?)
+              ORDER BY created_at DESC, id DESC LIMIT 1",
+        )
+        .bind(scope)
+        .bind(at - within_secs)
+        .bind(artifact_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        if let Some(id) = &id {
+            sqlx::query("UPDATE search_events SET opened_at = ? WHERE id = ?")
+                .bind(at)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(id)
+    }
+
+    /// A read long enough to count, as a hit — only where no person has said
+    /// anything. Whether it was written. A later read replaces an earlier one:
+    /// skimming the first result and reading the second is the second being
+    /// the one.
+    ///
+    /// `judged_by IS NULL` beside `judged_at IS NULL`: a "no" from the bar
+    /// leaves the event pending but marks it spoken for, and the dwell that
+    /// flushes when the pane is left must not put the hit straight back.
+    pub async fn implicit_hit(&self, event_id: &str, artifact_id: &str) -> Result<bool> {
+        Ok(sqlx::query(
+            "UPDATE search_events
+             SET judged_at = ?, verdict = 'hit', expect_id = ?, judged_by = 'dwell'
+             WHERE id = ?
+               AND ((judged_at IS NULL AND judged_by IS NULL) OR judged_by = 'dwell')",
+        )
+        .bind(now())
+        .bind(artifact_id)
+        .bind(event_id)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            == 1)
+    }
+
+    /// "Not this one": whatever a read recorded is withdrawn, the search stays
+    /// a question for the deck, and no later read may answer it.
+    pub async fn decline(&self, event_id: &str) -> Result<()> {
+        Self::judged_one(
+            sqlx::query(
+                "UPDATE search_events
+                 SET judged_at = NULL, verdict = NULL, expect_id = NULL, judged_by = 'confirm'
+                 WHERE id = ?",
+            )
+            .bind(event_id)
+            .execute(&self.pool)
+            .await?,
+        )
+    }
+
+    /// The rail's "nothing here has it": a gap against this person's newest
+    /// unjudged search for these words, within `within_secs`. The id it
+    /// labelled, or `None` where there was nothing left to label.
+    pub async fn gap_for_query(
+        &self,
+        query: &str,
+        scope: Option<&str>,
+        within_secs: i64,
+    ) -> Result<Option<String>> {
+        let id: Option<String> = sqlx::query_scalar(
+            "SELECT id FROM search_events
+              WHERE scope IS ? AND query = ? AND judged_at IS NULL AND created_at > ?
+              ORDER BY created_at DESC, id DESC LIMIT 1",
+        )
+        .bind(scope)
+        .bind(query)
+        .bind(now() - within_secs)
+        .fetch_optional(&self.pool)
+        .await?;
+        if let Some(id) = &id {
+            self.judge(id, Verdict::Gap, Labeller::Confirm).await?;
+        }
+        Ok(id)
     }
 
     /// Take a verdict back, returning the event to the pending queue.
@@ -567,7 +700,7 @@ impl Store {
         Self::judged_one(
             sqlx::query(
                 "UPDATE search_events
-                 SET judged_at = NULL, verdict = NULL, expect_id = NULL
+                 SET judged_at = NULL, verdict = NULL, expect_id = NULL, judged_by = NULL
                  WHERE id = ?",
             )
             .bind(event_id)
@@ -1164,14 +1297,188 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_query_that_is_not_a_prefix_starts_its_own_event() {
+    async fn a_rewording_within_the_window_folds_into_one_event() {
+        // A burst of searches that ends in one open is one need, worded three
+        // ways. Folded only on prefix, each wording was its own card — three
+        // questions about one thing, two of them about words nobody meant.
         let store = Store::memory().await.unwrap();
         store
             .record_search(ev("fat32", Door::Ui), 15)
             .await
             .unwrap();
         store.record_search(ev("ntfs", Door::Ui), 15).await.unwrap();
-        assert_eq!(queries(&store).await, vec!["fat32", "ntfs"]);
+        assert_eq!(queries(&store).await, vec!["ntfs"]);
+    }
+
+    async fn judged_by(store: &Store, id: &str) -> Option<String> {
+        sqlx::query_scalar("SELECT judged_by FROM search_events WHERE id = ?")
+            .bind(id)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn opening_a_result_names_the_search_it_came_from() {
+        // The capture is written off the request path and its id thrown away,
+        // so nothing on the page knows which event an open belongs to. The
+        // store answers instead: the newest unjudged event of this person's
+        // whose pool holds the artifact.
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .record_search(scoped("fat32", Door::Ui, Some("me")), 15)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.open_event_for("a1", Some("me"), 600).await.unwrap(),
+            Some(id.clone())
+        );
+        assert_eq!(
+            store.open_event_for("a9", Some("me"), 600).await.unwrap(),
+            None,
+            "an artifact the search never offered is not an open of it"
+        );
+        assert_eq!(
+            store.open_event_for("a1", Some("you"), 600).await.unwrap(),
+            None,
+            "someone else's search is not mine to open"
+        );
+        assert_eq!(
+            store.open_event_for("a1", Some("me"), 0).await.unwrap(),
+            None,
+            "outside the window there is nothing to attach to"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_opened_event_is_never_folded_into() {
+        // Opening freezes the pool: it is the list the person actually read,
+        // and the hit about to be recorded against it needs the rank it held.
+        // A search after the open starts its own event.
+        let store = Store::memory().await.unwrap();
+        store.record_search(ev("fat", Door::Ui), 15).await.unwrap();
+        store
+            .open_event_for("a1", None, 600)
+            .await
+            .unwrap()
+            .unwrap();
+        store
+            .record_search(ev("fat32", Door::Ui), 15)
+            .await
+            .unwrap();
+        assert_eq!(queries(&store).await, vec!["fat", "fat32"]);
+    }
+
+    #[tokio::test]
+    async fn a_read_records_a_provisional_hit_that_no_human_has_to_give() {
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .record_search(ev("fat32", Door::Ui), 15)
+            .await
+            .unwrap();
+        assert!(store.implicit_hit(&id, "a1").await.unwrap());
+        let s = store.feedback_stats().await.unwrap();
+        assert_eq!((s.judged, s.hits), (1, 1));
+        assert_eq!(s.recall_at_10, 1.0);
+        assert_eq!(judged_by(&store, &id).await.as_deref(), Some("dwell"));
+        assert!(
+            store.next_pending().await.unwrap().is_none(),
+            "a search already labelled by reading is not dealt to the deck"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_read_never_overrules_a_person() {
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .record_search(ev("fat32", Door::Ui), 15)
+            .await
+            .unwrap();
+        store
+            .judge(&id, Verdict::Gap, Labeller::Confirm)
+            .await
+            .unwrap();
+        assert!(!store.implicit_hit(&id, "a1").await.unwrap());
+        assert_eq!(store.feedback_stats().await.unwrap().gaps, 1);
+
+        // "No" clears nothing into a verdict, but it is still a person having
+        // spoken: the dwell that flushes when the pane is left must not put the
+        // hit straight back.
+        let id = store.record_search(ev("ntfs", Door::Ui), 0).await.unwrap();
+        store.implicit_hit(&id, "a1").await.unwrap();
+        store.decline(&id).await.unwrap();
+        assert!(!store.implicit_hit(&id, "a1").await.unwrap());
+        let s = store.feedback_stats().await.unwrap();
+        assert_eq!(s.hits, 0, "the provisional hit was withdrawn");
+        assert_eq!(
+            store.next_pending().await.unwrap().map(|e| e.id),
+            Some(id),
+            "and the search goes to the deck, still a question"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_later_read_replaces_an_earlier_one() {
+        // Skimming the first result and then reading the second is the second
+        // being the one. A read is provisional against a person, and equally
+        // provisional against the next read.
+        let store = Store::memory().await.unwrap();
+        let id = seed(&store, "fat32", &["a1", "a2"]).await;
+        assert!(store.implicit_hit(&id, "a1").await.unwrap());
+        assert_eq!(
+            store.open_event_for("a2", None, 600).await.unwrap(),
+            Some(id.clone()),
+            "a search labelled only by reading is still open to the next open"
+        );
+        assert!(store.implicit_hit(&id, "a2").await.unwrap());
+        let expect: Option<String> =
+            sqlx::query_scalar("SELECT expect_id FROM search_events WHERE id = ?")
+                .bind(&id)
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert_eq!(expect.as_deref(), Some("a2"));
+    }
+
+    #[tokio::test]
+    async fn saying_yes_after_a_read_makes_the_hit_a_persons() {
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .record_search(ev("fat32", Door::Ui), 15)
+            .await
+            .unwrap();
+        store.implicit_hit(&id, "a1").await.unwrap();
+        store.judge_hit(&id, "a1", Labeller::Confirm).await.unwrap();
+        assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
+        // Taking it back forgets who gave it, so a read can label it again.
+        store.unjudge(&id).await.unwrap();
+        assert_eq!(judged_by(&store, &id).await, None);
+        assert!(store.implicit_hit(&id, "a1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn nothing_here_has_it_records_a_gap_against_the_search_just_made() {
+        let store = Store::memory().await.unwrap();
+        let id = store
+            .record_search(scoped("xyz", Door::Ui, Some("me")), 15)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.gap_for_query("xyz", Some("me"), 600).await.unwrap(),
+            Some(id.clone())
+        );
+        assert_eq!(store.feedback_stats().await.unwrap().gaps, 1);
+        assert_eq!(judged_by(&store, &id).await.as_deref(), Some("confirm"));
+        assert_eq!(
+            store.gap_for_query("xyz", Some("me"), 600).await.unwrap(),
+            None,
+            "a second press finds nothing left to label"
+        );
+        assert_eq!(
+            store.gap_for_query("abc", Some("me"), 600).await.unwrap(),
+            None,
+            "a query nobody searched for is not a gap"
+        );
     }
 
     #[tokio::test]
@@ -1338,7 +1645,7 @@ mod tests {
     async fn a_judged_event_does_not_come_back() {
         let store = Store::memory().await.unwrap();
         let id = seed(&store, "only one", &["a"]).await;
-        store.judge_hit(&id, "a").await.unwrap();
+        store.judge_hit(&id, "a", Labeller::Deck).await.unwrap();
         assert!(store.next_pending().await.unwrap().is_none());
     }
 
@@ -1429,8 +1736,8 @@ mod tests {
         store.purge_feedback().await.unwrap();
 
         for res in [
-            store.judge_hit(&id, "a").await,
-            store.judge(&id, Verdict::Gap).await,
+            store.judge_hit(&id, "a", Labeller::Deck).await,
+            store.judge(&id, Verdict::Gap, Labeller::Deck).await,
             store.unjudge(&id).await,
             store.skip_event(&id).await,
         ] {
@@ -1447,9 +1754,9 @@ mod tests {
         // when the search happened, so confirming one settles its rank too.
         let store = Store::memory().await.unwrap();
         let first = seed(&store, "top hit", &["a", "b", "c"]).await;
-        store.judge_hit(&first, "a").await.unwrap();
+        store.judge_hit(&first, "a", Labeller::Deck).await.unwrap();
         let third = seed(&store, "third hit", &["x", "y", "z"]).await;
-        store.judge_hit(&third, "z").await.unwrap();
+        store.judge_hit(&third, "z", Labeller::Deck).await.unwrap();
 
         let s = store.feedback_stats().await.unwrap();
         assert_eq!(s.judged, 2);
@@ -1466,11 +1773,17 @@ mod tests {
         // replayed as a pair, one would be a query the ranking can only fail.
         let store = Store::memory().await.unwrap();
         let hit = seed(&store, "the image will not mount", &["a", "b"]).await;
-        store.judge_hit(&hit, "a").await.unwrap();
+        store.judge_hit(&hit, "a", Labeller::Deck).await.unwrap();
         let gap = seed(&store, "nothing about this", &["c"]).await;
-        store.judge(&gap, Verdict::Gap).await.unwrap();
+        store
+            .judge(&gap, Verdict::Gap, Labeller::Deck)
+            .await
+            .unwrap();
         let junk = seed(&store, "asdf", &["d"]).await;
-        store.judge(&junk, Verdict::Discard).await.unwrap();
+        store
+            .judge(&junk, Verdict::Discard, Labeller::Deck)
+            .await
+            .unwrap();
         seed(&store, "still waiting", &["e"]).await;
 
         let pairs = store.judged_pairs().await.unwrap();
@@ -1494,7 +1807,10 @@ mod tests {
         // it drags recall down — which is the truth about that search.
         let store = Store::memory().await.unwrap();
         let id = seed(&store, "found nothing useful", &["a", "b"]).await;
-        store.judge_hit(&id, "something-else").await.unwrap();
+        store
+            .judge_hit(&id, "something-else", Labeller::Deck)
+            .await
+            .unwrap();
 
         let s = store.feedback_stats().await.unwrap();
         assert_eq!(s.finds, 1);
@@ -1507,9 +1823,12 @@ mod tests {
     async fn gaps_and_discards_are_counted_but_are_not_pairs() {
         let store = Store::memory().await.unwrap();
         let g = seed(&store, "nothing written about this", &[]).await;
-        store.judge(&g, Verdict::Gap).await.unwrap();
+        store.judge(&g, Verdict::Gap, Labeller::Deck).await.unwrap();
         let d = seed(&store, "asdf", &["a"]).await;
-        store.judge(&d, Verdict::Discard).await.unwrap();
+        store
+            .judge(&d, Verdict::Discard, Labeller::Deck)
+            .await
+            .unwrap();
 
         let s = store.feedback_stats().await.unwrap();
         assert_eq!((s.gaps, s.discards, s.hits), (1, 1, 0));
@@ -1562,7 +1881,7 @@ mod tests {
         let store = Store::memory().await.unwrap();
         let kept = seed(&store, "judged", &["a"]).await;
         let gone = seed(&store, "never looked at", &["a"]).await;
-        store.judge_hit(&kept, "a").await.unwrap();
+        store.judge_hit(&kept, "a", Labeller::Deck).await.unwrap();
         sqlx::query("UPDATE search_events SET created_at = ?")
             .bind(now() - 40 * 86_400)
             .execute(&store.pool)
@@ -1583,7 +1902,10 @@ mod tests {
         // typos forever is keeping exactly what the window exists to shed.
         let store = Store::memory().await.unwrap();
         let id = seed(&store, "asdf", &["a"]).await;
-        store.judge(&id, Verdict::Discard).await.unwrap();
+        store
+            .judge(&id, Verdict::Discard, Labeller::Deck)
+            .await
+            .unwrap();
         sqlx::query("UPDATE search_events SET created_at = ?")
             .bind(now() - 40 * 86_400)
             .execute(&store.pool)
@@ -1629,7 +1951,7 @@ mod tests {
         let mut e = ev("a question", Door::Ui);
         e.answered = true;
         let id = store.record_search(e, 0).await.unwrap();
-        store.judge_hit(&id, "a1").await.unwrap();
+        store.judge_hit(&id, "a1", Labeller::Deck).await.unwrap();
         let now = now();
         let got = store.events_between(0, now + 1).await.unwrap();
         assert_eq!(got.len(), 1);

--- a/src/store/feedback.rs
+++ b/src/store/feedback.rs
@@ -422,7 +422,20 @@ pub struct PendingEvent {
     pub query: String,
     pub door: String,
     pub created_at: i64,
+    /// Whether a result was ever opened from it. The card asks a different
+    /// question of a search nobody opened anything from.
+    pub opened: bool,
     pub candidates: Vec<Candidate>,
+}
+
+/// What the deck deals: see `Store::next_pending`. One bind, `weak_below`.
+/// `COALESCE` so an empty pool reads as the weakest search there is.
+macro_rules! dealable {
+    () => {
+        "judged_at IS NULL AND length(query) >= 3
+         AND COALESCE((SELECT max(similarity) FROM search_candidates
+                        WHERE event_id = search_events.id), 0) >= ?"
+    };
 }
 
 #[derive(Debug, Clone, Default)]
@@ -460,15 +473,22 @@ impl Store {
     /// Newest first because a judgement is worth something only while the
     /// situation is still in mind, and that memory is the most perishable part
     /// of the whole dataset.
-    pub async fn next_pending(&self) -> Result<Option<PendingEvent>> {
-        let row = sqlx::query(
+    ///
+    /// Not every unjudged search is dealt. A query under three characters and a
+    /// search whose best match fell under `weak_below` are the cards nobody can
+    /// answer — a typo, or a hole the distance already says is one and
+    /// `GapKind::Unmatched` already counts. They stay pending, for that sweep;
+    /// they are just never asked about.
+    pub async fn next_pending(&self, weak_below: f32) -> Result<Option<PendingEvent>> {
+        let row = sqlx::query(concat!(
             // `id DESC` breaks the tie: two searches within one second are
             // ordinary, and `created_at` alone would leave SQLite to pick.
             // Ids are uuid v7, so they sort by time down to the millisecond.
-            "SELECT id, query, door, created_at FROM search_events
-             WHERE judged_at IS NULL
-             ORDER BY skips ASC, created_at DESC, id DESC LIMIT 1",
-        )
+            "SELECT id, query, door, created_at, opened_at FROM search_events WHERE ",
+            dealable!(),
+            " ORDER BY skips ASC, created_at DESC, id DESC LIMIT 1"
+        ))
+        .bind(weak_below)
         .fetch_optional(&self.pool)
         .await?;
         let Some(row) = row else { return Ok(None) };
@@ -481,10 +501,12 @@ impl Store {
     /// the judging order now puts first, and the operator expects to land back
     /// on the card they were looking at rather than somewhere else.
     pub async fn pending_by_id(&self, event_id: &str) -> Result<Option<PendingEvent>> {
-        let row = sqlx::query("SELECT id, query, door, created_at FROM search_events WHERE id = ?")
-            .bind(event_id)
-            .fetch_optional(&self.pool)
-            .await?;
+        let row = sqlx::query(
+            "SELECT id, query, door, created_at, opened_at FROM search_events WHERE id = ?",
+        )
+        .bind(event_id)
+        .fetch_optional(&self.pool)
+        .await?;
         let Some(row) = row else { return Ok(None) };
         self.hydrate(row).await.map(Some)
     }
@@ -512,6 +534,7 @@ impl Store {
             query: row.get("query"),
             door: row.get("door"),
             created_at: row.get("created_at"),
+            opened: row.get::<Option<i64>, _>("opened_at").is_some(),
             candidates,
         })
     }
@@ -726,12 +749,14 @@ impl Store {
     /// Split out of `feedback_stats`, which runs half a dozen queries and two
     /// joins: this one is read on every page render to draw the nav, and the
     /// nav must not cost what the ops page costs.
-    pub async fn pending_count(&self) -> Result<i64> {
-        Ok(
-            sqlx::query_scalar("SELECT count(*) FROM search_events WHERE judged_at IS NULL")
-                .fetch_one(&self.pool)
-                .await?,
-        )
+    pub async fn pending_count(&self, weak_below: f32) -> Result<i64> {
+        Ok(sqlx::query_scalar(concat!(
+            "SELECT count(*) FROM search_events WHERE ",
+            dealable!()
+        ))
+        .bind(weak_below)
+        .fetch_one(&self.pool)
+        .await?)
     }
 
     /// The field value: recall@10 and MRR read from the ranks the searches
@@ -1382,7 +1407,7 @@ mod tests {
         assert_eq!(s.recall_at_10, 1.0);
         assert_eq!(judged_by(&store, &id).await.as_deref(), Some("dwell"));
         assert!(
-            store.next_pending().await.unwrap().is_none(),
+            store.next_pending(0.0).await.unwrap().is_none(),
             "a search already labelled by reading is not dealt to the deck"
         );
     }
@@ -1411,7 +1436,7 @@ mod tests {
         let s = store.feedback_stats().await.unwrap();
         assert_eq!(s.hits, 0, "the provisional hit was withdrawn");
         assert_eq!(
-            store.next_pending().await.unwrap().map(|e| e.id),
+            store.next_pending(0.0).await.unwrap().map(|e| e.id),
             Some(id),
             "and the search goes to the deck, still a question"
         );
@@ -1438,6 +1463,34 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(expect.as_deref(), Some("a2"));
+    }
+
+    #[tokio::test]
+    async fn a_search_too_short_or_too_loose_to_judge_is_never_dealt() {
+        // A two-letter query and a search whose best match was under the
+        // weak line are the cards nobody can answer: a typo, or a hole the
+        // distance already says is one (`GapKind::Unmatched`). They stay
+        // recorded and stay pending — the gap sweep reads them — but the deck
+        // does not deal them and the badge does not count them.
+        let store = Store::memory().await.unwrap();
+        seed(&store, "ab", &["a1"]).await;
+        let mut loose = ev("fat32", Door::Ui);
+        loose.candidates[0].similarity = Some(0.2);
+        store.record_search(loose, 0).await.unwrap();
+        assert!(store.next_pending(0.3).await.unwrap().is_none());
+        assert_eq!(store.pending_count(0.3).await.unwrap(), 0);
+
+        let id = seed(&store, "ntfs", &["a1"]).await;
+        assert_eq!(
+            store.next_pending(0.3).await.unwrap().map(|e| e.id),
+            Some(id.clone())
+        );
+        assert_eq!(store.pending_count(0.3).await.unwrap(), 1);
+
+        // And the card knows whether anything was opened from it.
+        assert!(!store.next_pending(0.3).await.unwrap().unwrap().opened);
+        store.open_event_for("a1", None, 600).await.unwrap();
+        assert!(store.next_pending(0.3).await.unwrap().unwrap().opened);
     }
 
     #[tokio::test]
@@ -1629,7 +1682,10 @@ mod tests {
         let store = Store::memory().await.unwrap();
         seed(&store, "older", &["a"]).await;
         seed(&store, "newer", &["b"]).await;
-        assert_eq!(store.next_pending().await.unwrap().unwrap().query, "newer");
+        assert_eq!(
+            store.next_pending(0.0).await.unwrap().unwrap().query,
+            "newer"
+        );
     }
 
     #[tokio::test]
@@ -1638,7 +1694,10 @@ mod tests {
         seed(&store, "older", &["a"]).await;
         let newer = seed(&store, "newer", &["b"]).await;
         store.skip_event(&newer).await.unwrap();
-        assert_eq!(store.next_pending().await.unwrap().unwrap().query, "older");
+        assert_eq!(
+            store.next_pending(0.0).await.unwrap().unwrap().query,
+            "older"
+        );
     }
 
     #[tokio::test]
@@ -1646,7 +1705,7 @@ mod tests {
         let store = Store::memory().await.unwrap();
         let id = seed(&store, "only one", &["a"]).await;
         store.judge_hit(&id, "a", Labeller::Deck).await.unwrap();
-        assert!(store.next_pending().await.unwrap().is_none());
+        assert!(store.next_pending(0.0).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1845,7 +1904,10 @@ mod tests {
         let older = seed(&store, "older", &["a"]).await;
         seed(&store, "newer", &["b"]).await;
 
-        assert_eq!(store.next_pending().await.unwrap().unwrap().query, "newer");
+        assert_eq!(
+            store.next_pending(0.0).await.unwrap().unwrap().query,
+            "newer"
+        );
         assert_eq!(
             store.event_query(&older).await.unwrap().as_deref(),
             Some("older")
@@ -1926,7 +1988,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(n, 0);
-        assert!(store.next_pending().await.unwrap().is_none());
+        assert!(store.next_pending(0.0).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -232,11 +232,24 @@ macro_rules! search_gaps_sql {
 /// A search nothing came close to answering.
 ///
 /// The similarity is not a column on `search_events` — it is on the candidate
-/// rows, one per result — so the test is an aggregate rather than a read.
-/// `MAX(...)` over no rows is `NULL`, and `NULL < ?` is not true, so a search
-/// that recorded no candidates is *not* a gap. That looks like an oversight and
-/// is not one: "nothing came close" is a claim about what was measured, and
-/// nothing was.
+/// rows, one per result — so the test is an aggregate rather than a read, and
+/// `MAX(...)` over no rows is `NULL`. Two different absences hide behind that
+/// one `NULL`, and only one of them is a gap.
+///
+/// A search that returned *nothing* is the plainest hole there is: the base was
+/// asked and had not one thing to offer. It is named here explicitly, because
+/// `NULL < ?` is not true and the aggregate alone would drop it — and nothing
+/// else picks it up. The deck will not deal it (see `dealable!`): a card with
+/// an empty list is unanswerable except by gap or discard, which is not a
+/// question worth a person's turn. So the sweep is where it lands.
+///
+/// Candidates that exist but were never *scored* are the other absence, and
+/// they are not a gap. That is the embedder down, or a query the lexical half
+/// answered on keywords alone — `search_inner` stores what the vector search
+/// returned, and it returned nothing. "Nothing came close" would be a claim
+/// about a measurement nobody took. `AND c.similarity IS NOT NULL` inside the
+/// aggregate keeps those out, the same reading `dealable!`'s inner `COALESCE`
+/// takes of them.
 ///
 /// A search that has been judged at all is left out. `gap` for the obvious
 /// reason — it would be two gaps, the same row said twice in two different
@@ -258,8 +271,9 @@ macro_rules! unmatched_gaps_from {
             AND e.verdict IS NULL
             AND NOT EXISTS (SELECT 1 FROM gap_coverage
                              WHERE kind = 'unmatched' AND gap_id = e.id)
-            AND (SELECT MAX(c.similarity) FROM search_candidates c
-                  WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?"
+            AND (NOT EXISTS (SELECT 1 FROM search_candidates c WHERE c.event_id = e.id)
+                 OR (SELECT MAX(c.similarity) FROM search_candidates c
+                      WHERE c.event_id = e.id AND c.similarity IS NOT NULL) < ?)"
     };
 }
 
@@ -1289,11 +1303,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_search_that_measured_nothing_is_not_a_gap() {
-        // `MAX(...)` over no candidate rows is NULL, and NULL is not under the
-        // line. "Nothing came close" is a claim about what was measured.
+    async fn a_search_that_returned_nothing_is_an_unmatched_gap() {
+        // The plainest hole there is: the base was asked and had nothing at
+        // all. `MAX(...)` over no candidate rows is NULL and NULL is not under
+        // the line, so the aggregate alone would drop it — and the deck will
+        // not deal it either, because a card with an empty list has no question
+        // on it. Named explicitly here, or it falls between the two.
         let store = Store::memory().await.unwrap();
-        search_with(&store, "mount an E01", &[]).await;
+        let empty = search_with(&store, "mount an E01", &[]).await;
+
+        let unmatched: Vec<String> = store
+            .open_gaps("fake", 0.35)
+            .await
+            .unwrap()
+            .gaps
+            .iter()
+            .filter(|g| g.gap.kind == GapKind::Unmatched)
+            .map(|g| g.gap.id.clone())
+            .collect();
+        assert_eq!(unmatched, vec![empty]);
+    }
+
+    #[tokio::test]
+    async fn a_search_whose_candidates_were_never_scored_is_not_a_gap() {
+        // The other absence behind the same NULL, and this one is not a hole.
+        // The embedder was down, or the query was answered on keywords alone:
+        // `search_inner` stores what the vector search returned, and it
+        // returned nothing. "Nothing came close" would be a claim about a
+        // measurement nobody took.
+        let store = Store::memory().await.unwrap();
+        store
+            .record_search(
+                NewEvent {
+                    query: "mount an E01".into(),
+                    door: Door::Api,
+                    scope: None,
+                    filters: "{}".into(),
+                    query_vec: vec![1.0, 0.0],
+                    embed_model: "fake".into(),
+                    candidates: vec![crate::store::feedback::NewCandidate {
+                        artifact_id: "a-0".into(),
+                        score: 0.9,
+                        similarity: None,
+                        shown: true,
+                    }],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
 
         assert!(
             store

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -1234,6 +1234,7 @@ mod tests {
         let id = store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: q.into(),
                     door: Door::Api,
                     scope: None,
@@ -1260,6 +1261,7 @@ mod tests {
         store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: q.into(),
                     door: Door::Api,
                     scope: None,
@@ -1335,6 +1337,7 @@ mod tests {
         store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: "mount an E01".into(),
                     door: Door::Api,
                     scope: None,

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -1233,7 +1233,10 @@ mod tests {
             )
             .await
             .unwrap();
-        store.judge(&id, Verdict::Gap).await.unwrap();
+        store
+            .judge(&id, Verdict::Gap, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
         id
     }
 
@@ -1308,7 +1311,10 @@ mod tests {
         // The same row, said twice, in two different words.
         let store = Store::memory().await.unwrap();
         let id = search_with(&store, "mount an E01", &[0.10]).await;
-        store.judge(&id, Verdict::Gap).await.unwrap();
+        store
+            .judge(&id, Verdict::Gap, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
 
         let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
         let mine: Vec<GapKind> = gaps
@@ -1330,9 +1336,23 @@ mod tests {
         // was there.
         let store = Store::memory().await.unwrap();
         let typo = search_with(&store, "mont an E01", &[0.10]).await;
-        store.judge(&typo, Verdict::Discard).await.unwrap();
+        store
+            .judge(
+                &typo,
+                Verdict::Discard,
+                crate::store::feedback::Labeller::Deck,
+            )
+            .await
+            .unwrap();
         let weak_hit = search_with(&store, "grep a pcap", &[0.12]).await;
-        store.judge(&weak_hit, Verdict::Hit).await.unwrap();
+        store
+            .judge(
+                &weak_hit,
+                Verdict::Hit,
+                crate::store::feedback::Labeller::Deck,
+            )
+            .await
+            .unwrap();
 
         let gaps = store.open_gaps("fake", 0.35).await.unwrap().gaps;
 
@@ -1451,7 +1471,10 @@ mod tests {
             .unwrap();
         assert!(store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty());
 
-        store.judge(&id, Verdict::Gap).await.unwrap();
+        store
+            .judge(&id, Verdict::Gap, crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
 
         assert!(
             store.open_gaps("fake", 0.35).await.unwrap().gaps.is_empty(),

--- a/src/store/gaps.rs
+++ b/src/store/gaps.rs
@@ -261,14 +261,20 @@ macro_rules! search_gaps_sql {
 /// whose candidates all scored weakly is a search someone answered; the
 /// scores say the ranking was poor, not that the knowledge is missing.
 ///
-/// The guard this needs already exists. A typing burst folds into one event by
-/// `feedback.coalesce_secs`, so what is measured is the finished query and not
-/// its first two letters.
+/// Two guards keep the half-typed out of this. A typing burst folds into one
+/// event by `feedback.coalesce_secs`, so what is measured is the finished query
+/// and not its first two letters; and `length(e.query) >= 3`, which is
+/// `dealable!`'s own lower bound, for the burst that was never finished. That
+/// bound makes the two predicates exact complements, which is what the escape
+/// hatch above depends on: `discard` is only reachable through the deck, so a
+/// hole the deck will never deal is a hole nobody can ever discard. Without it
+/// a `qq` typed and walked away from sat on the capture page as a gap in the
+/// base until somebody dismissed it by hand.
 macro_rules! unmatched_gaps_from {
     () => {
         " FROM search_events e
           WHERE e.dismissed_at IS NULL AND e.embed_model = ? AND e.vec_dim > 0
-            AND e.verdict IS NULL
+            AND e.verdict IS NULL AND length(e.query) >= 3
             AND NOT EXISTS (SELECT 1 FROM gap_coverage
                              WHERE kind = 'unmatched' AND gap_id = e.id)
             AND (NOT EXISTS (SELECT 1 FROM search_candidates c WHERE c.event_id = e.id)
@@ -1324,6 +1330,31 @@ mod tests {
             .map(|g| g.gap.id.clone())
             .collect();
         assert_eq!(unmatched, vec![empty]);
+    }
+
+    #[tokio::test]
+    async fn a_query_too_short_for_the_deck_is_not_a_gap_either() {
+        // `dealable!` holds back anything under three characters, and `discard`
+        // — the operator saying this was never a search — is only reachable
+        // from the deck. So a hole the deck will never deal is a hole nobody
+        // can ever discard: the box searches as you type, somebody taps `qq`
+        // and walks away, and that sat on the capture page as a gap in the base
+        // for good. Both branches of the predicate, because the pool being
+        // empty is not what makes it not a search.
+        let store = Store::memory().await.unwrap();
+        search_with(&store, "qq", &[]).await;
+        search_with(&store, "qq", &[0.01]).await;
+
+        let unmatched: Vec<String> = store
+            .open_gaps("fake", 0.35)
+            .await
+            .unwrap()
+            .gaps
+            .iter()
+            .filter(|g| g.gap.kind == GapKind::Unmatched)
+            .map(|g| g.gap.id.clone())
+            .collect();
+        assert!(unmatched.is_empty(), "{unmatched:?}");
     }
 
     #[tokio::test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -38,13 +38,6 @@ pub struct Store {
     /// appears anywhere below the web layer. The knowledge tables never see
     /// it: they are already alone in a file of their own.
     pub subject: String,
-    /// Held for the length of a capture write. `record_search` reads the
-    /// previous event and then writes over it, and the UI fires one of these per
-    /// keystroke: two overlapping transactions upgrade from read to write on the
-    /// same snapshot, which SQLite answers with `SQLITE_BUSY_SNAPSHOT` and no
-    /// `busy_timeout` can wait out. Shared by every clone, which is what makes
-    /// it a queue rather than eight of them.
-    capture: std::sync::Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Store {
@@ -72,7 +65,6 @@ impl Store {
             pool,
             control,
             subject: subject.to_string(),
-            capture: Default::default(),
         };
         store.migrate().await?;
         Ok(store)
@@ -239,7 +231,6 @@ impl Store {
             pool,
             control,
             subject: TEST_SUBJECT.to_string(),
-            capture: Default::default(),
         };
         store.migrate().await?;
         Ok(store)
@@ -330,7 +321,6 @@ mod tests {
             pool,
             control: control::Control::memory().await.unwrap(),
             subject: TEST_SUBJECT.to_string(),
-            capture: Default::default(),
         };
         // A base as it was before the column existed: the real schema, with
         // the column taken back off. Hand-writing a cut-down `artifacts` would
@@ -447,7 +437,6 @@ mod tests {
             pool,
             control: control::Control::memory().await.unwrap(),
             subject: TEST_SUBJECT.to_string(),
-            capture: Default::default(),
         };
 
         let err = store.migrate().await.unwrap_err().to_string();
@@ -572,7 +561,6 @@ mod tests {
             pool,
             control: control::Control::memory().await.unwrap(),
             subject: TEST_SUBJECT.to_string(),
-            capture: Default::default(),
         };
 
         let err = store.migrate().await.unwrap_err().to_string();

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -154,7 +154,7 @@ impl Store {
         // additive" would make this boot path guess, and the guess would be
         // wrong the first time a column's default is not what its old rows
         // should say. Everything not on this list still recreates.
-        const ADDITIVE: [(&str, &str, &str); 2] = [
+        const ADDITIVE: [(&str, &str, &str); 4] = [
             (
                 "artifacts",
                 "updated_at",
@@ -169,6 +169,19 @@ impl Store {
                 "artifact_pairs",
                 "decided_by",
                 "ALTER TABLE artifact_pairs ADD COLUMN decided_by TEXT",
+            ),
+            // Both nullable for the same reason: every verdict before these
+            // columns came from the deck, and no search before them was opened
+            // in a way anything recorded.
+            (
+                "search_events",
+                "judged_by",
+                "ALTER TABLE search_events ADD COLUMN judged_by TEXT",
+            ),
+            (
+                "search_events",
+                "opened_at",
+                "ALTER TABLE search_events ADD COLUMN opened_at INTEGER",
             ),
         ];
         for (table, column, ddl) in ADDITIVE {
@@ -345,6 +358,33 @@ mod tests {
         assert_eq!(stamp, 0, "a stamp nobody has set is not a claim about when");
         // And again, because migrate runs on every connect.
         store.migrate().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_base_judged_only_from_the_deck_gains_the_two_search_columns() {
+        // `judged_by` and `opened_at` are nullable and mean, on an old row,
+        // exactly what NULL says: the deck gave the verdict, and nobody recorded
+        // an open. A base full of deck verdicts must keep them.
+        let store = Store::memory().await.unwrap();
+        sqlx::raw_sql(
+            "INSERT INTO search_events (id, query, door, query_vec, vec_dim, embed_model,
+                                        created_at, judged_at, verdict)
+                  VALUES ('e', 'fat32', 'ui', x'00', 0, 'fake', 1, 2, 'gap');
+             ALTER TABLE search_events DROP COLUMN judged_by;
+             ALTER TABLE search_events DROP COLUMN opened_at;",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        store.migrate().await.unwrap();
+        let (verdict, by, opened): (String, Option<String>, Option<i64>) = sqlx::query_as(
+            "SELECT verdict, judged_by, opened_at FROM search_events WHERE id = 'e'",
+        )
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        assert_eq!((verdict.as_str(), by, opened), ("gap", None, None));
     }
 
     #[tokio::test]

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -287,6 +287,16 @@ CREATE TABLE IF NOT EXISTS search_events (
   judged_at   INTEGER,
   verdict     TEXT,
   expect_id   TEXT,
+  -- Who gave the verdict: `confirm` from the bar under an opened result,
+  -- `dwell` from reading one long enough, NULL from the judge deck. A read is
+  -- the weakest of the three and never overwrites the other two — and a
+  -- `confirm` with no verdict is a person having said "not this one", which
+  -- keeps the search pending and keeps the read from labelling it.
+  judged_by   TEXT,
+  -- When a result from this search was opened. Freezes the pool: a rewording
+  -- after an open starts its own event rather than folding into the list the
+  -- person actually read.
+  opened_at   INTEGER,
   skips       INTEGER NOT NULL DEFAULT 0,
   -- Set when the operator says a `gap` search has since been covered.
   dismissed_at INTEGER,

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -324,6 +324,14 @@ CREATE TABLE IF NOT EXISTS search_candidates (
   shown       INTEGER NOT NULL,
   PRIMARY KEY (event_id, rank)
 );
+-- `dealable!` asks two things of this table for every unjudged event, and the
+-- nav asks `dealable!` on every page render: whether the event has a pool at
+-- all, and the strongest similarity in it. The primary key answers the first
+-- one, and answered the second by seeking every row of the pool to read a
+-- column it does not carry. Holding `similarity` in the index makes that a
+-- covering read.
+CREATE INDEX IF NOT EXISTS idx_candidates_similarity
+  ON search_candidates(event_id, similarity);
 
 -- ── Tuning sweeps ────────────────────────────────────────────────────────────
 -- One row per background sweep over the judged pairs: what the running

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -287,11 +287,13 @@ CREATE TABLE IF NOT EXISTS search_events (
   judged_at   INTEGER,
   verdict     TEXT,
   expect_id   TEXT,
-  -- Who gave the verdict: `confirm` from the bar under an opened result,
-  -- `dwell` from reading one long enough, NULL from the judge deck. A read is
-  -- the weakest of the three and never overwrites the other two — and a
-  -- `confirm` with no verdict is a person having said "not this one", which
-  -- keeps the search pending and keeps the read from labelling it.
+  -- Who gave the verdict: `confirm` from the bar under an opened result or the
+  -- gap button on the rail, NULL from the judge deck. A `confirm` with no
+  -- verdict is a person having said "not this one" — the search stays pending
+  -- and the column records that the answer came from the moment rather than
+  -- from the deck. A third value, `dwell`, was written by a read long enough
+  -- to count as a hit on its own; that is gone, and rows still carrying it are
+  -- verdicts nobody gave out loud.
   judged_by   TEXT,
   -- When a result from this search was opened. Freezes the pool: a rewording
   -- after an open starts its own event rather than folding into the list the

--- a/src/web/insights.rs
+++ b/src/web/insights.rs
@@ -528,7 +528,11 @@ async fn page(tenant: Tenant) -> Result<Response> {
         // the honest answer is that there is nothing to say — not 0.00.
         retrieval: match tenant.core.learn.enabled {
             true => {
-                let f = tenant.core.store.feedback_stats().await?;
+                let f = tenant
+                    .core
+                    .store
+                    .feedback_stats(tenant.core.weak_below)
+                    .await?;
                 Some(Retrieval {
                     recall_at_10: format!("{:.2}", f.recall_at_10),
                     mrr: format!("{:.2}", f.mrr),

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -10,7 +10,7 @@
 //! failure leaves a record instead of passing as a shrug.
 
 use crate::error::Result;
-use crate::store::feedback::{PendingEvent, Stats, Verdict};
+use crate::store::feedback::{Labeller, PendingEvent, Stats, Verdict};
 use crate::tenants::Tenant;
 use crate::web::auth_routes::HtmlTemplate;
 use crate::web::state::AppState;
@@ -589,20 +589,28 @@ async fn hit(
     tenant
         .core
         .store
-        .judge_hit(&event_id, &f.artifact_id)
+        .judge_hit(&event_id, &f.artifact_id, Labeller::Deck)
         .await?;
     card_after(&tenant, before, rank, Verdict::Hit, &event_id).await
 }
 
 async fn gap(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Result<Response> {
     let before = tenant.core.store.feedback_stats().await?;
-    tenant.core.store.judge(&event_id, Verdict::Gap).await?;
+    tenant
+        .core
+        .store
+        .judge(&event_id, Verdict::Gap, Labeller::Deck)
+        .await?;
     card_after(&tenant, before, None, Verdict::Gap, &event_id).await
 }
 
 async fn discard(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Result<Response> {
     let before = tenant.core.store.feedback_stats().await?;
-    tenant.core.store.judge(&event_id, Verdict::Discard).await?;
+    tenant
+        .core
+        .store
+        .judge(&event_id, Verdict::Discard, Labeller::Deck)
+        .await?;
     card_after(&tenant, before, None, Verdict::Discard, &event_id).await
 }
 
@@ -2301,7 +2309,10 @@ mod tests {
             )
             .await
             .unwrap();
-        core.store.judge_hit(&id, &ids[0]).await.unwrap();
+        core.store
+            .judge_hit(&id, &ids[0], crate::store::feedback::Labeller::Deck)
+            .await
+            .unwrap();
 
         let body = get(&app, "/ui/judge", &cookie).await;
         assert!(body.contains("--to:10%"), "{body}");

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -1449,6 +1449,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_fold_over_the_rest_of_the_pool_is_styled() {
+        // Same oversight, one class along: the fold shipped with no rule and
+        // rendered as a native disclosure triangle and a line of body text
+        // between two lists that are neither, inside a pool that styles
+        // everything else on the card.
+        let (app, cookie, _core, _ids) = judge_app(13, &[]).await;
+        let body = get(&app, "/ui/judge", &cookie).await;
+        assert!(body.contains(r#"class="judge-more"#), "{body}");
+        let css = include_str!("../../assets/app.css");
+        assert!(css.contains(".judge-more"), "the fold has no rule");
+    }
+
+    #[tokio::test]
     async fn the_card_offers_the_whole_pool_not_only_what_was_shown() {
         // Offering only the ten that were displayed would make a buried hit
         // unconfirmable, and the ranking failure invisible.

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -1434,6 +1434,13 @@ mod tests {
         let body = get(&app, "/ui/judge", &cookie).await;
         assert!(body.contains("1 of 2 questions judged"), "{body}");
         assert!(body.contains("1 right"), "{body}");
+        // And the count the card is built around is sized. It was renamed out
+        // from under its rule when the XP bar came out, and rendered at body
+        // size with no margin while every assertion about it still passed on
+        // the text alone.
+        assert!(body.contains(r#"class="judge-count"#), "{body}");
+        let css = include_str!("../../assets/app.css");
+        assert!(css.contains(".judge-count"), "the count has no rule");
     }
 
     #[tokio::test]
@@ -1484,7 +1491,8 @@ mod tests {
         assert!(body.contains("opened nothing"), "{body}");
         assert!(body.contains("No, I was just looking"), "{body}");
         let event = core.store.next_pending(0.0).await.unwrap().unwrap();
-        assert!(core.store.open_event(&event.id).await.unwrap());
+        let opened = event.candidates[0].artifact_id.clone();
+        assert!(core.store.open_event(&event.id, &opened).await.unwrap());
         let body = get(&app, "/ui/judge/next", &cookie).await;
         assert!(!body.contains("opened nothing"), "{body}");
         assert!(body.contains("which of these was it"), "{body}");

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -1,9 +1,17 @@
 //! Turning captured searches into labelled pairs.
 //!
-//! The card shows the query as it was typed and the stored pool shuffled, with
-//! no ranks and no scores. Both omissions are deliberate: the ranker's opinion
-//! is the one thing that must not be visible while its work is being judged, or
-//! what gets measured is agreement rather than relevance.
+//! Most pairs are made at the moment of search now — a result read, a bar
+//! answered, a gap pressed on the rail — and the deck deals only what none of
+//! that labelled. See `web::ui::artifact_detail` and `Store::open_event_for`.
+//!
+//! The card shows the query as it was typed and the top five of the stored pool
+//! in the order the search gave them, titled, with the rest behind a fold. It
+//! used to shuffle the whole pool, so that the ranker's opinion could not be
+//! seen while its work was judged; that made a card of twenty unordered
+//! paragraphs, and the honest answer to it was "I don't know, I was looking".
+//! Five, in order, is a question a person can answer. The position bias that
+//! costs is small, and `docs/evaluation.md` says so beside the number. Scores
+//! are still withheld.
 //!
 //! The pool offered is wider than the answer the searcher saw, so an artifact
 //! the ranking buried can still be confirmed. That is the only way a ranking
@@ -40,18 +48,36 @@ pub struct Choice {
     /// `card_for` for why it is shown at all.
     pub usable: bool,
     /// The digit that presses this option, or `None` where no key reaches it:
-    /// past the ninth, or on something unusable. Assigned after the shuffle,
-    /// over the choosable options only, so the digits an operator can see are
-    /// the digits that work and they run without a gap.
+    /// behind the fold, or on something unusable. Over the choosable options
+    /// among the five dealt, so the digits an operator can see are the digits
+    /// that work and they run without a gap.
     pub key: Option<usize>,
 }
+
+/// How many of the pool the card deals openly. The rest are one click away.
+pub const DEALT: usize = 5;
 
 pub struct Card {
     pub id: String,
     pub query: String,
     pub door: String,
     pub when: String,
+    /// Whether anything was opened from this search. See `PendingEvent::opened`.
+    pub opened: bool,
+    /// In the order the search gave them.
     pub choices: Vec<Choice>,
+}
+
+impl Card {
+    /// Where the fold starts, for the template.
+    pub fn dealt(&self) -> usize {
+        DEALT
+    }
+
+    /// How many are behind it.
+    pub fn folded(&self) -> usize {
+        self.choices.len().saturating_sub(DEALT)
+    }
 }
 
 /// The header's live half: what is true right now, and what just moved.
@@ -61,18 +87,11 @@ pub struct Card {
 /// copies of the same dozen fields would drift.
 pub struct Pulse {
     pub judged: i64,
-    /// The judgement count the last sweep ran at, and so where this stretch of
-    /// the bar starts. Zero before the first one.
+    /// The judgement count the last sweep ran at. Zero before the first one,
+    /// which is when the page still explains what a sweep is.
     pub floor: i64,
     /// The judgement count the next sweep runs at.
     pub target: i64,
-    /// How far along the stretch between the two, not how far along the count.
-    pub pct: i64,
-    /// Where the bar stood before this verdict. A swapped element is a new
-    /// element with no previous width to transition away from, so the previous
-    /// width is sent and the fill is animated between the two. Equal to `pct`
-    /// wherever nothing moved, which is what makes the animation a no-op there.
-    pub pct_prev: i64,
     /// What that target buys, in the words for a first sweep or a later one.
     pub label: &'static str,
     pub recall: String,
@@ -210,21 +229,6 @@ fn snippet_of(text: &str) -> String {
     crate::web::markdown::snippet(text, 140)
 }
 
-/// Shuffle without pulling in a random-number crate: the event id is already a
-/// uuid v7, so hashing it together with each artifact id gives an order that is
-/// stable for one card, different for the next, and unrelated to rank.
-fn shuffled(event_id: &str, mut choices: Vec<Choice>) -> Vec<Choice> {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    choices.sort_by_key(|c| {
-        let mut h = DefaultHasher::new();
-        event_id.hash(&mut h);
-        c.artifact_id.hash(&mut h);
-        h.finish()
-    });
-    choices
-}
-
 /// Hydrate a pending event into something renderable, dropping candidates whose
 /// artifact has since been deleted and marking those the benchmark cannot hold.
 ///
@@ -294,11 +298,9 @@ async fn card_for(tenant: &Tenant, event: PendingEvent) -> Result<Card> {
             }
         }
     }
-    let mut choices = shuffled(&event.id, choices);
-    // After the shuffle, because the digits number the card as it is read. The
-    // range is the cap: the shortcut is one digit, so the tenth choosable
-    // option and everything after it keeps its column and loses the number.
-    for (key, c) in (1..=9).zip(choices.iter_mut().filter(|c| c.usable)) {
+    // Over the five dealt only: an option behind the fold answering to a key
+    // would be a key that presses something the operator cannot see.
+    for (key, c) in (1..=DEALT).zip(choices.iter_mut().take(DEALT).filter(|c| c.usable)) {
         c.key = Some(key);
     }
     Ok(Card {
@@ -307,11 +309,17 @@ async fn card_for(tenant: &Tenant, event: PendingEvent) -> Result<Card> {
         query: event.query,
         door: event.door,
         when: ago(event.created_at),
+        opened: event.opened,
     })
 }
 
 async fn next_pending_card(tenant: &Tenant) -> Result<Option<Card>> {
-    match tenant.core.store.next_pending().await? {
+    match tenant
+        .core
+        .store
+        .next_pending(tenant.core.weak_below)
+        .await?
+    {
         Some(event) => Ok(Some(card_for(tenant, event).await?)),
         None => Ok(None),
     }
@@ -323,7 +331,7 @@ async fn next_pending_card(tenant: &Tenant) -> Result<Option<Card>> {
 /// judgement buys is a measurement, and after the first one the distance is to
 /// the next re-sweep. Read from the last run rather than counted, so the two
 /// always agree about when it is due.
-async fn pulse_of(tenant: &Tenant, stats: &Stats, delta: String, prev: i64) -> Result<Pulse> {
+async fn pulse_of(tenant: &Tenant, stats: &Stats, delta: String) -> Result<Pulse> {
     let tune = &tenant.core.feedback.tune;
     let (floor, label) = match tenant.core.store.latest_eval_run().await? {
         None => (0, "until the first sweep"),
@@ -333,20 +341,11 @@ async fn pulse_of(tenant: &Tenant, stats: &Stats, delta: String, prev: i64) -> R
         0 => tune.min_judgements,
         n => n + tune.resweep_after,
     };
-    // A target already passed would draw a bar over 100% and a hint counting
-    // backwards; it happens whenever a sweep is queued but has not run yet.
+    // A target already passed would read as a count going backwards; it
+    // happens whenever a sweep is queued but has not run yet.
     let target = target.max(stats.judged).max(1);
-    // Against the last sweep rather than against zero. Measured from zero the
-    // bar reads the share of all judgements ever given that have been swept —
-    // which after the first sweep is always nearly all of them, so it stood at
-    // 95% and then 96%, and the one visual the header is built around stopped
-    // saying anything.
-    let span = (target - floor).max(1);
-    let along = |n: i64| ((n - floor).max(0) * 100 / span).min(100);
     Ok(Pulse {
         judged: stats.judged,
-        pct: along(stats.judged),
-        pct_prev: along(prev),
         floor,
         target,
         label,
@@ -377,7 +376,7 @@ async fn page(CanJudge(tenant): CanJudge) -> Result<Response> {
     Ok(HtmlTemplate(JudgeTemplate {
         // Read off the stats already in hand rather than counted again.
         judge_pending: tenant.core.learn.enabled.then_some(stats.pending),
-        pulse: Some(pulse_of(&tenant, &stats, String::new(), stats.judged).await?),
+        pulse: Some(pulse_of(&tenant, &stats, String::new()).await?),
         tune: Some(tune_view(&tenant, "").await?),
         tune_oob: false,
         misses,
@@ -399,7 +398,7 @@ async fn next_card(CanJudge(tenant): CanJudge) -> Result<Response> {
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(&tenant).await?,
         flash: None,
-        pulse: Some(pulse_of(&tenant, &stats, String::new(), stats.judged).await?),
+        pulse: Some(pulse_of(&tenant, &stats, String::new()).await?),
         tune: None,
         tune_oob: true,
     })
@@ -447,7 +446,7 @@ async fn card_after(
             delta: format!("MRR {:.2} → {after:.2}", before.mrr),
             undo: Some(judged.to_string()),
         }),
-        pulse: Some(pulse_of(tenant, &stats, delta, before.judged).await?),
+        pulse: Some(pulse_of(tenant, &stats, delta).await?),
         tune: Some(tune_view(tenant, "").await?),
         tune_oob: true,
     })
@@ -479,7 +478,7 @@ async fn card_again(tenant: &Tenant, event_id: &str, line: &str) -> Result<Respo
         }),
         // Nothing was recorded, so the figures are rendered where they stand and
         // `delta` is empty, which is what every animation on them keys on.
-        pulse: Some(pulse_of(tenant, &stats, String::new(), stats.judged).await?),
+        pulse: Some(pulse_of(tenant, &stats, String::new()).await?),
         tune: None,
         tune_oob: true,
     })
@@ -534,7 +533,7 @@ async fn undo(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Resul
         // at them while it happens. No delta, though: the tick and the bar's
         // travel are how the page acknowledges work, and taking a judgement
         // back is not some of it.
-        pulse: Some(pulse_of(&tenant, &stats, String::new(), stats.judged).await?),
+        pulse: Some(pulse_of(&tenant, &stats, String::new()).await?),
         tune: None,
         tune_oob: true,
     })
@@ -1417,23 +1416,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn only_the_options_a_key_can_reach_are_numbered() {
-        // The shortcut is a single digit and the pool is twenty deep by
-        // default, so past the ninth the badge advertised a key that does
-        // nothing — half the card looking operable and answering to nothing.
-        let (app, cookie, _core, _) = judge_app(13, &[]).await;
+    async fn the_card_deals_the_top_five_in_order_and_folds_the_rest() {
+        // Twenty unordered paragraphs forced a linear read of all twenty. The
+        // top five in the order the search gave them is a question a person
+        // can answer; the rest of the pool is still there — a buried hit can
+        // still be confirmed — behind one click, and carries no key.
+        let (app, cookie, _core, ids) = judge_app(13, &[]).await;
         let body = get(&app, "/ui/judge/next", &cookie).await;
-
-        assert!(body.contains(r#"<span class="judge-key">9</span>"#));
+        let fold = body.find("judge-more").expect("no fold for the rest");
+        let mut last = 0;
+        for id in &ids[..5] {
+            let at = body.find(id.as_str()).unwrap();
+            assert!(at < fold, "{id} is not among the five dealt: {body}");
+            assert!(at > last, "the five are not in the search's order: {body}");
+            last = at;
+        }
+        for id in &ids[5..] {
+            assert!(body.find(id.as_str()).unwrap() > fold, "{id} dealt openly");
+        }
+        assert!(body.contains("8 more"), "{body}");
+        assert!(body.contains(r#"<span class="judge-key">5</span>"#));
         assert!(
-            !body.contains(r#"<span class="judge-key">10</span>"#),
-            "the tenth option offers a key that cannot be pressed"
+            !body.contains(r#"<span class="judge-key">6</span>"#),
+            "a key points at an option behind the fold"
         );
-        assert_eq!(
-            body.matches(r#"<span class="judge-key"></span>"#).count(),
-            4,
-            "the options past the ninth must keep their column and lose the number"
-        );
+    }
+
+    #[tokio::test]
+    async fn the_card_says_whether_anything_was_opened() {
+        // A search nobody opened anything from is a different question — was
+        // there something you wanted at all? — from one where something was
+        // read and not confirmed.
+        let (app, cookie, core, ids) = judge_app(2, &[]).await;
+        let body = get(&app, "/ui/judge/next", &cookie).await;
+        assert!(body.contains("opened nothing"), "{body}");
+        assert!(body.contains("No, I was just looking"), "{body}");
+        core.store
+            .open_event_for(&ids[0], None, 600)
+            .await
+            .unwrap()
+            .expect("the seeded search holds this artifact");
+        let body = get(&app, "/ui/judge/next", &cookie).await;
+        assert!(!body.contains("opened nothing"), "{body}");
+        assert!(body.contains("which of these was it"), "{body}");
     }
 
     #[tokio::test]
@@ -1476,43 +1501,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_bar_carries_where_it_moved_from_as_well_as_where_it_is() {
-        // A swapped element is a new element: it has no previous width to
-        // transition away from, so a bar rendered by the server can only be
-        // animated between two values it was told. Without the first one it
-        // jumps, which is the thing it exists not to do.
+    async fn a_verdict_moves_the_count_and_there_is_no_bar() {
+        // The XP bar, the trail and the sheen made the page prettier and the
+        // question no easier. The count is what a verdict buys: the distance
+        // to the next sweep, said as a number.
         let (app, cookie, core, ids) = judge_app(2, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
-        let card = {
-            let res = app
-                .clone()
-                .oneshot(
-                    Request::builder()
-                        .uri(format!("/ui/judge/{}/hit", event.id))
-                        .method("POST")
-                        .header("cookie", &cookie)
-                        .header("content-type", "application/x-www-form-urlencoded")
-                        .body(Body::from(format!("artifact_id={}", ids[0])))
-                        .unwrap(),
-                )
-                .await
-                .unwrap();
-            body_of(res).await
-        };
-        assert!(card.contains("--from:"), "no starting position: {card}");
-        assert!(card.contains("--to:"), "no finishing position: {card}");
-        assert!(
-            card.contains("judge-xp-moved"),
-            "a verdict left the bar still: {card}"
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
+        assert_eq!(
+            post(
+                &app,
+                &format!("/ui/judge/{}/hit", event.id),
+                &cookie,
+                &format!("artifact_id={}", ids[0])
+            )
+            .await,
+            StatusCode::OK
         );
-
-        // And a plain fetch does not: an animation there is the page
-        // acknowledging its own load.
-        let plain = get(&app, "/ui/judge/next", &cookie).await;
-        assert!(
-            !plain.contains("judge-xp-moved"),
-            "the bar animates on a fetch that judged nothing: {plain}"
-        );
+        let card = get(&app, "/ui/judge/next", &cookie).await;
+        assert!(!card.contains("progressbar"), "the bar is back: {card}");
+        assert!(card.contains("<b>1</b> /"), "{card}");
+        assert!(card.contains("until the first sweep"), "{card}");
     }
 
     #[tokio::test]
@@ -1545,7 +1553,7 @@ mod tests {
     #[tokio::test]
     async fn confirming_a_candidate_records_the_hit_and_moves_on() {
         let (app, cookie, core, ids) = judge_app(2, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         let status = post(
             &app,
             &format!("/ui/judge/{}/hit", event.id),
@@ -1557,7 +1565,7 @@ mod tests {
 
         let s = core.store.feedback_stats().await.unwrap();
         assert_eq!(s.hits, 1);
-        assert!(core.store.next_pending().await.unwrap().is_none());
+        assert!(core.store.next_pending(0.0).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1571,7 +1579,7 @@ mod tests {
             .set_artifact_status(&ids[1], ArtifactStatus::Deprecated)
             .await
             .unwrap();
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
 
         let status = post(
             &app,
@@ -1584,7 +1592,7 @@ mod tests {
 
         assert_eq!(core.store.feedback_stats().await.unwrap().hits, 0);
         assert_eq!(
-            core.store.next_pending().await.unwrap().map(|e| e.id),
+            core.store.next_pending(0.0).await.unwrap().map(|e| e.id),
             Some(event.id),
             "the event must still be waiting for a verdict it can keep"
         );
@@ -1644,7 +1652,7 @@ mod tests {
             "the reading view is not the artifact: {full}"
         );
         // Reading must stay a read: the event is still waiting for a verdict.
-        assert!(core.store.next_pending().await.unwrap().is_some());
+        assert!(core.store.next_pending(0.0).await.unwrap().is_some());
     }
 
     #[tokio::test]
@@ -1667,7 +1675,7 @@ mod tests {
         // that is exactly what makes it misfire. A pair labelled by a slipped
         // key is scored as truth.
         let (app, cookie, core, ids) = judge_app(2, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         let flash = {
             let res = app
                 .clone()
@@ -1710,7 +1718,7 @@ mod tests {
 
         let s = core.store.feedback_stats().await.unwrap();
         assert_eq!((s.hits, s.judged), (0, 0), "the verdict outlived its undo");
-        let pending = core.store.next_pending().await.unwrap().unwrap();
+        let pending = core.store.next_pending(0.0).await.unwrap().unwrap();
         assert_eq!(pending.id, event.id, "a different event came back");
         assert!(
             back.contains(&event.id),
@@ -1738,10 +1746,10 @@ mod tests {
     #[tokio::test]
     async fn skipping_leaves_it_pending() {
         let (app, cookie, core, _) = judge_app(1, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         post(&app, &format!("/ui/judge/{}/skip", event.id), &cookie, "").await;
 
-        assert!(core.store.next_pending().await.unwrap().is_some());
+        assert!(core.store.next_pending(0.0).await.unwrap().is_some());
         assert_eq!(core.store.feedback_stats().await.unwrap().judged, 0);
     }
 
@@ -1761,7 +1769,7 @@ mod tests {
         // search would never have shown you this" — a find, and a permanent
         // dent in recall@10 for a ranking failure that never happened.
         let (app, cookie, core, _) = judge_app(1, &["gone-for-good"]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         let status = post(
             &app,
             &format!("/ui/judge/{}/hit", event.id),
@@ -1775,7 +1783,7 @@ mod tests {
         assert_eq!(s.finds, 0, "a phantom was counted as a find");
         assert_eq!(s.judged, 0);
         assert!(
-            core.store.next_pending().await.unwrap().is_some(),
+            core.store.next_pending(0.0).await.unwrap().is_some(),
             "the event was consumed by a verdict that was refused"
         );
     }
@@ -1785,7 +1793,7 @@ mod tests {
         // Retention or an Ops purge under an open judging screen. The flash
         // would otherwise show an MRR delta and an Undo for a row that is gone.
         let (app, cookie, core, ids) = judge_app(1, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         core.store.purge_feedback().await.unwrap();
 
         for (uri, body) in [
@@ -1884,7 +1892,7 @@ mod tests {
         for id in &ids {
             crate::jobs::embed::run(&core, id).await.unwrap();
         }
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         let body = get(
             &app,
             &format!("/ui/judge/{}/assign/results?q=mounting", event.id),
@@ -1908,7 +1916,7 @@ mod tests {
     #[tokio::test]
     async fn confirming_from_outside_the_pool_is_reported_as_a_find() {
         let (app, cookie, core, ids) = judge_app(1, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         // An artifact that exists but was never in this event's pool.
         let src = core
             .store
@@ -1957,7 +1965,7 @@ mod tests {
         // The loop the whole feature is: a verdict is what buys the next
         // measurement, so the check rides on the verdict rather than a timer.
         let (app, cookie, core, ids) = judge_app_tuned(2, &[], Some(1)).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         post(
             &app,
             &format!("/ui/judge/{}/hit", event.id),
@@ -1977,7 +1985,7 @@ mod tests {
         // Below it a sweep would recommend the quirks of a handful of queries
         // as confidently as a real improvement.
         let (app, cookie, core, ids) = judge_app_tuned(2, &[], Some(50)).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         post(
             &app,
             &format!("/ui/judge/{}/hit", event.id),
@@ -1997,7 +2005,7 @@ mod tests {
         // searches per verdict.
         let (app, cookie, core, ids) = judge_app_tuned(3, &[], Some(1)).await;
         for id in ids.iter().take(2) {
-            let event = core.store.next_pending().await.unwrap();
+            let event = core.store.next_pending(0.0).await.unwrap();
             let Some(event) = event else { break };
             post(
                 &app,
@@ -2185,7 +2193,7 @@ mod tests {
         // stood at whatever it read on arrival while the queue was worked
         // down — the one figure the work is measured by, frozen.
         let (app, cookie, core, ids) = judge_app(2, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         let res = app
             .clone()
             .oneshot(
@@ -2264,13 +2272,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_bar_counts_from_the_last_sweep_rather_than_from_zero() {
-        // Measured from zero it reads the share of every judgement ever given
-        // that has been swept — which after the first sweep is nearly all of
-        // them. It stood at 95%, then 96%, then 98%, and the one visual the
-        // header is built around stopped conveying anything.
+    async fn the_count_targets_the_next_sweep_rather_than_a_fixed_milestone() {
+        // What a judgement buys is a measurement, and after the first sweep
+        // the distance is to the next re-sweep, read from the last run rather
+        // than counted so the two always agree about when it is due.
         let (app, cookie, core, ids) = judge_app(2, &[]).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         post(
             &app,
             &format!("/ui/judge/{}/hit", event.id),
@@ -2282,40 +2289,14 @@ mod tests {
         record_run_at(&core, swept_at).await;
 
         let body = get(&app, "/ui/judge", &cookie).await;
+        let target = swept_at + core.feedback.tune.resweep_after;
         assert!(
-            body.contains("--to:0%"),
-            "the stretch to the next sweep has not started: {body}"
+            body.contains(&format!(
+                "<b>{swept_at}</b> / {target} until the next sweep"
+            )),
+            "the count does not run to the next sweep: {body}"
         );
-        assert!(
-            body.contains(&format!(r#"aria-valuemin="{swept_at}""#)),
-            "the bar starts where the last sweep did: {body}"
-        );
-
-        // One further verdict is one tenth of the ten the next sweep waits for.
-        let id = core
-            .store
-            .record_search(
-                NewEvent {
-                    query: "a second question entirely".into(),
-                    door: Door::Ui,
-                    scope: None,
-                    filters: "{}".into(),
-                    query_vec: vec![0.1, 0.2],
-                    embed_model: "fake".into(),
-                    candidates: vec![],
-                    answered: false,
-                },
-                0,
-            )
-            .await
-            .unwrap();
-        core.store
-            .judge_hit(&id, &ids[0], crate::store::feedback::Labeller::Deck)
-            .await
-            .unwrap();
-
-        let body = get(&app, "/ui/judge", &cookie).await;
-        assert!(body.contains("--to:10%"), "{body}");
+        assert!(!body.contains("progressbar"), "the bar is back: {body}");
     }
 
     /// A sweep in the store, recorded as having run at `judged`.
@@ -2403,7 +2384,7 @@ mod tests {
         // It runs off the request path, so the page that paid for it has
         // already been sent. The next verdict is the first chance to say so.
         let (app, cookie, core, ids) = judge_app_tuned(2, &[], Some(1)).await;
-        let event = core.store.next_pending().await.unwrap().unwrap();
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
         let res = app
             .clone()
             .oneshot(

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -2,7 +2,7 @@
 //!
 //! Most pairs are made at the moment of search now — a result read, a bar
 //! answered, a gap pressed on the rail — and the deck deals only what none of
-//! that labelled. See `web::ui::artifact_detail` and `Store::open_event_for`.
+//! that labelled. See `web::ui::artifact_detail` and `Store::open_event`.
 //!
 //! The card shows the query as it was typed and the top five of the stored pool
 //! in the order the search gave them, titled, with the rest behind a fold. It
@@ -367,7 +367,11 @@ async fn pulse_of(tenant: &Tenant, stats: &Stats, delta: String) -> Result<Pulse
 
 async fn page(CanJudge(tenant): CanJudge) -> Result<Response> {
     use axum::response::IntoResponse;
-    let stats = tenant.core.store.feedback_stats().await?;
+    let stats = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     let misses = if stats.judged >= MISS_LIST_AT {
         tenant.core.store.misses(20).await?
     } else {
@@ -394,7 +398,11 @@ async fn page(CanJudge(tenant): CanJudge) -> Result<Response> {
 /// movement: `delta` is empty, and every animation on this fragment keys on it.
 async fn next_card(CanJudge(tenant): CanJudge) -> Result<Response> {
     use axum::response::IntoResponse;
-    let stats = tenant.core.store.feedback_stats().await?;
+    let stats = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     Ok(HtmlTemplate(CardTemplate {
         card: next_pending_card(&tenant).await?,
         flash: None,
@@ -417,7 +425,11 @@ async fn card_after(
     judged: &str,
 ) -> Result<Response> {
     use axum::response::IntoResponse;
-    let stats = tenant.core.store.feedback_stats().await?;
+    let stats = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     let after = stats.mrr;
     // A verdict is what buys the next measurement. Off the request path: the
     // operator must not wait on a grid of searches, and a sweep that fails
@@ -465,7 +477,11 @@ async fn card_again(tenant: &Tenant, event_id: &str, line: &str) -> Result<Respo
         Some(event) => Some(card_for(tenant, event).await?),
         None => next_pending_card(tenant).await?,
     };
-    let stats = tenant.core.store.feedback_stats().await?;
+    let stats = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     Ok(HtmlTemplate(CardTemplate {
         card,
         flash: Some(Flash {
@@ -525,7 +541,11 @@ async fn undo(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Resul
         // is a better answer than an error page.
         None => next_pending_card(&tenant).await?,
     };
-    let stats = tenant.core.store.feedback_stats().await?;
+    let stats = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     Ok(HtmlTemplate(CardTemplate {
         card,
         flash: None,
@@ -584,7 +604,11 @@ async fn hit(
         .store
         .rank_in_event(&event_id, &f.artifact_id)
         .await?;
-    let before = tenant.core.store.feedback_stats().await?;
+    let before = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     tenant
         .core
         .store
@@ -594,7 +618,11 @@ async fn hit(
 }
 
 async fn gap(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Result<Response> {
-    let before = tenant.core.store.feedback_stats().await?;
+    let before = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     tenant
         .core
         .store
@@ -604,7 +632,11 @@ async fn gap(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Result
 }
 
 async fn discard(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Result<Response> {
-    let before = tenant.core.store.feedback_stats().await?;
+    let before = tenant
+        .core
+        .store
+        .feedback_stats(tenant.core.weak_below)
+        .await?;
     tenant
         .core
         .store
@@ -1447,15 +1479,12 @@ mod tests {
         // A search nobody opened anything from is a different question — was
         // there something you wanted at all? — from one where something was
         // read and not confirmed.
-        let (app, cookie, core, ids) = judge_app(2, &[]).await;
+        let (app, cookie, core, _) = judge_app(2, &[]).await;
         let body = get(&app, "/ui/judge/next", &cookie).await;
         assert!(body.contains("opened nothing"), "{body}");
         assert!(body.contains("No, I was just looking"), "{body}");
-        core.store
-            .open_event_for(&ids[0], None, 600)
-            .await
-            .unwrap()
-            .expect("the seeded search holds this artifact");
+        let event = core.store.next_pending(0.0).await.unwrap().unwrap();
+        assert!(core.store.open_event(&event.id).await.unwrap());
         let body = get(&app, "/ui/judge/next", &cookie).await;
         assert!(!body.contains("opened nothing"), "{body}");
         assert!(body.contains("which of these was it"), "{body}");
@@ -1563,7 +1592,7 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK);
 
-        let s = core.store.feedback_stats().await.unwrap();
+        let s = core.store.feedback_stats(0.0).await.unwrap();
         assert_eq!(s.hits, 1);
         assert!(core.store.next_pending(0.0).await.unwrap().is_none());
     }
@@ -1590,7 +1619,7 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK, "the operator gets the card back");
 
-        assert_eq!(core.store.feedback_stats().await.unwrap().hits, 0);
+        assert_eq!(core.store.feedback_stats(0.0).await.unwrap().hits, 0);
         assert_eq!(
             core.store.next_pending(0.0).await.unwrap().map(|e| e.id),
             Some(event.id),
@@ -1696,7 +1725,7 @@ mod tests {
             flash.contains(&format!("/ui/judge/{}/undo", event.id)),
             "the verdict was recorded with no way back: {flash}"
         );
-        assert_eq!(core.store.feedback_stats().await.unwrap().hits, 1);
+        assert_eq!(core.store.feedback_stats(0.0).await.unwrap().hits, 1);
 
         let back = {
             let res = app
@@ -1716,7 +1745,7 @@ mod tests {
             body_of(res).await
         };
 
-        let s = core.store.feedback_stats().await.unwrap();
+        let s = core.store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.hits, s.judged), (0, 0), "the verdict outlived its undo");
         let pending = core.store.next_pending(0.0).await.unwrap().unwrap();
         assert_eq!(pending.id, event.id, "a different event came back");
@@ -1750,7 +1779,7 @@ mod tests {
         post(&app, &format!("/ui/judge/{}/skip", event.id), &cookie, "").await;
 
         assert!(core.store.next_pending(0.0).await.unwrap().is_some());
-        assert_eq!(core.store.feedback_stats().await.unwrap().judged, 0);
+        assert_eq!(core.store.feedback_stats(0.0).await.unwrap().judged, 0);
     }
 
     #[tokio::test]
@@ -1779,7 +1808,7 @@ mod tests {
         .await;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
-        let s = core.store.feedback_stats().await.unwrap();
+        let s = core.store.feedback_stats(0.0).await.unwrap();
         assert_eq!(s.finds, 0, "a phantom was counted as a find");
         assert_eq!(s.judged, 0);
         assert!(
@@ -1860,7 +1889,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let before = core.store.feedback_stats().await.unwrap().captured;
+        let before = core.store.feedback_stats(0.0).await.unwrap().captured;
 
         get(
             &app,
@@ -1871,7 +1900,7 @@ mod tests {
         core.background.wait_idle().await;
 
         assert_eq!(
-            core.store.feedback_stats().await.unwrap().captured,
+            core.store.feedback_stats(0.0).await.unwrap().captured,
             before,
             "looking something up in order to label it must not become data"
         );
@@ -1957,7 +1986,7 @@ mod tests {
             .unwrap();
         let body = body_of(res).await;
         assert!(body.contains("a find"), "the flash did not name it a find");
-        assert_eq!(core.store.feedback_stats().await.unwrap().finds, 1);
+        assert_eq!(core.store.feedback_stats(0.0).await.unwrap().finds, 1);
     }
 
     #[tokio::test]
@@ -2285,7 +2314,7 @@ mod tests {
             &format!("artifact_id={}", ids[0]),
         )
         .await;
-        let swept_at = core.store.feedback_stats().await.unwrap().judged;
+        let swept_at = core.store.feedback_stats(0.0).await.unwrap().judged;
         record_run_at(&core, swept_at).await;
 
         let body = get(&app, "/ui/judge", &cookie).await;

--- a/src/web/judge.rs
+++ b/src/web/judge.rs
@@ -531,7 +531,10 @@ async fn undo(CanJudge(tenant): CanJudge, Path(event_id): Path<String>) -> Resul
     // The event may have expired between the verdict and the second thoughts.
     // The store says so now rather than reporting a write it did not make; here
     // that is not an error, for the reason below.
-    match tenant.core.store.unjudge(&event_id).await {
+    // `Labeller::Deck`: the deck takes back the deck's own verdicts. One given
+    // at the moment of search, from the bar, belongs to the person who was
+    // there — the store refuses, and the card comes back unchanged.
+    match tenant.core.store.unjudge(&event_id, Labeller::Deck).await {
         Ok(()) | Err(crate::error::Error::NotFound) => {}
         Err(e) => return Err(e),
     }
@@ -1282,6 +1285,7 @@ mod tests {
             core.store
                 .record_search(
                     NewEvent {
+                        fold_onto: None,
                         query: "the image will not mount".into(),
                         door: Door::Ui,
                         scope: None,
@@ -1374,6 +1378,7 @@ mod tests {
         core.store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: "sourdough".into(),
                     door: Door::Ui,
                     scope: None,
@@ -1496,6 +1501,16 @@ mod tests {
         let body = get(&app, "/ui/judge/next", &cookie).await;
         assert!(!body.contains("opened nothing"), "{body}");
         assert!(body.contains("which of these was it"), "{body}");
+        // And the discard follows the question. The action row is shared, so
+        // "I was just looking" stood under a card that said something *was*
+        // opened — a contradiction an operator answering it literally would
+        // spend a real labelled search on, since a discard leaves the deck for
+        // good and is the one verdict retention still purges.
+        assert!(
+            !body.contains("No, I was just looking"),
+            "the discard contradicts the question above it: {body}"
+        );
+        assert!(body.contains("Not a real search"), "{body}");
     }
 
     #[tokio::test]
@@ -1884,6 +1899,7 @@ mod tests {
             .store
             .record_search(
                 NewEvent {
+                    fold_onto: None,
                     query: "the one being judged".into(),
                     door: Door::Ui,
                     scope: None,

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -128,7 +128,7 @@ pub async fn judge_pending(t: &crate::tenants::Tenant) -> Option<i64> {
             return None;
         }
     }
-    match t.core.store.pending_count().await {
+    match t.core.store.pending_count(t.core.weak_below).await {
         Ok(n) => Some(n),
         Err(e) => {
             tracing::warn!(error = %e, "could not count searches waiting to be judged");

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -1,6 +1,4 @@
-{# `data-event` names the search this was opened from, where there is one, so
-   the dwell timer can report the read against it. #}
-<div data-terms="{{ d.terms }}" data-artifact="{{ d.id }}"{% if let Some(ev) = d.search_event %} data-event="{{ ev }}"{% endif %}>
+<div data-terms="{{ d.terms }}" data-artifact="{{ d.id }}">
   {# The way back to the list, for a narrow window where opening a result hides
      it. An installed app has no back button to fall back on. Hidden above
      60rem, where the rail is still on screen beside this — the same width that

--- a/src/web/templates/_artifact_detail.html
+++ b/src/web/templates/_artifact_detail.html
@@ -1,4 +1,6 @@
-<div data-terms="{{ d.terms }}" data-artifact="{{ d.id }}">
+{# `data-event` names the search this was opened from, where there is one, so
+   the dwell timer can report the read against it. #}
+<div data-terms="{{ d.terms }}" data-artifact="{{ d.id }}"{% if let Some(ev) = d.search_event %} data-event="{{ ev }}"{% endif %}>
   {# The way back to the list, for a narrow window where opening a result hides
      it. An installed app has no back button to fall back on. Hidden above
      60rem, where the rail is still on screen beside this — the same width that
@@ -174,6 +176,13 @@
                            f.querySelector('textarea').focus()">edit</button>
         </div>
         <div class="md clampable" data-copyable>{{ d.html|safe }}</div>
+        {# Under the text, once it has been read: was it the one? Only where
+           this was opened from the rail and the search was recorded. #}
+        {% if let Some(event_id) = d.search_event %}
+        {% let artifact_id = d.id %}
+        {% let state = "" %}
+        {% include "_search_verdict.html" %}
+        {% endif %}
         {# The passage stopped mid-sentence, so the window it was cut from did.
            The source column beside this already shows the rest of the line;
            this is the way to the artifact that carries it. #}

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -155,11 +155,17 @@
         Can't remember <kbd>S</kbd>
       </button>
       <span class="spacer"></span>
-      {# A discard: not a pair, not a gap, not a card again. #}
+      {# A discard: not a pair, not a gap, not a card again. The row is shared
+         by both questions above, and this one word of it cannot be: "I was
+         just looking" is an answer to "was there something you wanted?", and
+         over a search that demonstrably opened something it is a contradiction
+         — one an operator answering literally would spend a real labelled
+         search on, since a discard is dropped from the pairs, gone from the
+         deck for good and the one verdict retention still purges. #}
       <button class="btn btn-ghost btn-sm" data-key="x"
               hx-post="/ui/judge/{{ c.id }}/discard"
               hx-target="#card" hx-swap="innerHTML swap:220ms">
-        No, I was just looking <kbd>X</kbd>
+        {% if c.opened %}Not a real search{% else %}No, I was just looking{% endif %} <kbd>X</kbd>
       </button>
     </div>
   </article>

--- a/src/web/templates/_judge_card.html
+++ b/src/web/templates/_judge_card.html
@@ -43,22 +43,36 @@
       <p class="judge-meta mono muted">{{ c.when }} · {{ c.door }}</p>
       <h2 class="judge-query">{{ c.query }}</h2>
       {% include "_judge_pulse.html" %}
-      <p class="muted hint judge-ask">Which of these was the one you needed?
-        <span class="mono">— {{ c.choices.len() }} candidates, unordered</span></p>
+      {# Two questions, not one. A search nobody opened anything from may not
+         have been a need at all; one where something was read and not
+         confirmed was. #}
+      {% if c.opened %}
+      <p class="muted hint judge-ask">You searched this and opened something — which of these was it?</p>
+      {% else %}
+      <p class="muted hint judge-ask">You searched this and opened nothing — was there something you wanted?</p>
+      {% endif %}
     </div>
 
     {# The pool is the only thing on this card that scrolls, and it is bounded
        so the question and the three ways out of it are always both on screen.
        The whole pool is in it: shortening the list is what would make a verdict
-       mean something it doesn't, and a scroll inside a box is not a shortening.
+       mean something it doesn't, and a fold inside a box is not a shortening.
        This is what the sticky action bar used to work around — twenty-three
        cards' worth of page, with the way out at the bottom of it. #}
     <div class="judge-pool">
-      {# Numbered for the keyboard only. The order is a hash of the event id, so
-         it carries no information about how the search ranked them — seeing
-         that would turn judging into agreeing. #}
+      {# In the order the search gave them, the first five open and the rest
+         behind a fold. Ordered on purpose: twenty unordered paragraphs forced a
+         linear read of all twenty, and the shuffle that kept the ranker's
+         opinion out of sight made the card unanswerable. The order is visible
+         now; the scores still are not. #}
       <ol class="judge-options">
         {% for o in c.choices %}
+        {% if loop.index0 == c.dealt() %}
+      </ol>
+      <details class="judge-more">
+        <summary>{{ c.folded() }} more, further down the list</summary>
+      <ol class="judge-options">
+        {% endif %}
         {# Deprecated and superseded artifacts stay in the pool at full length so
            the operator sees what the search actually returned, but they are
            disabled: `hit` would refuse them, and a refusal arriving after the
@@ -71,11 +85,10 @@
                   hx-vals='{"artifact_id": "{{ o.artifact_id }}"}'
                   hx-target="#card" hx-swap="innerHTML swap:220ms"
                   {% else %}disabled{% endif %}>
-            {# Only the first nine choosable options carry a number. The shortcut
-               is a single digit and `feedback.candidates` is 20 by default, so a
-               badge on the tenth would advertise a key that does nothing; a badge
-               on a disabled one would advertise a key that refuses. The column
-               stays either way so the titles line up. #}
+            {# Only the choosable options among the five dealt carry a number:
+               a badge behind the fold would advertise a key that presses what
+               cannot be seen; a badge on a disabled one would advertise a key
+               that refuses. The column stays either way so the titles line up. #}
             <span class="judge-key">{% if let Some(k) = o.key %}{{ k }}{% endif %}</span>
             {# No heading where there is no name. A verbatim passage has no title
                by design, and a list of "Untitled" is a column of a word that says
@@ -120,6 +133,9 @@
         </li>
         {% endfor %}
       </ol>
+      {% if c.folded() > 0 %}
+      </details>
+      {% endif %}
     </div>
 
     {# `data-key` is what the shortcut binds to. By position it bound to whatever
@@ -131,7 +147,7 @@
       <button class="btn btn-ghost btn-sm" data-key="n"
               hx-get="/ui/judge/{{ c.id }}/assign"
               hx-target="#card" hx-swap="innerHTML">
-        None of these <kbd>N</kbd>
+        Yes, something else <kbd>N</kbd>
       </button>
       <button class="btn btn-ghost btn-sm" data-key="s"
               hx-post="/ui/judge/{{ c.id }}/skip"
@@ -139,10 +155,11 @@
         Can't remember <kbd>S</kbd>
       </button>
       <span class="spacer"></span>
+      {# A discard: not a pair, not a gap, not a card again. #}
       <button class="btn btn-ghost btn-sm" data-key="x"
               hx-post="/ui/judge/{{ c.id }}/discard"
               hx-target="#card" hx-swap="innerHTML swap:220ms">
-        Not a real search <kbd>X</kbd>
+        No, I was just looking <kbd>X</kbd>
       </button>
     </div>
   </article>

--- a/src/web/templates/_judge_pulse.html
+++ b/src/web/templates/_judge_pulse.html
@@ -7,31 +7,17 @@
    copy, swapped with everything else, and no `hx-swap-oob` left to keep in
    step.
 
-   Nothing here reacts to *which* verdict was given. What moves is progress
+   Nothing here reacts to *which* verdict was given. What moves is the count
    towards the next sweep — the work — never agreement with the ranker. The
    flash line above the card is where a judgement is spoken about, and its
-   loudness runs the other way on purpose. #}
+   loudness runs the other way on purpose.
+
+   A count, not a bar. There was an XP bar here, with a trail and a sheen; it
+   made the page prettier and the question no easier, and most of the distance
+   is covered by searching now rather than by this page. #}
 {% if let Some(p) = pulse %}
 <div id="judge-live" class="judge-live">
-  {# The bar is an object with a height, not the edge of one.
-
-     `--from` and `--to` are what let it move at all on a server-rendered swap:
-     the element that arrives is a new one, with no previous width to transition
-     away from, so the previous width is sent alongside the current one and the
-     fill is animated between the two. The pale trail goes straight to `--to`,
-     so for the length of the fill's delay the ground just won reads as area
-     rather than as a different endpoint. The notches are what make it a
-     distance instead of a percentage. #}
-  <div class="judge-xp{% if !p.delta.is_empty() %} judge-xp-moved{% endif %}"
-       style="--from:{{ p.pct_prev }}%;--to:{{ p.pct }}%"
-       role="progressbar" aria-valuenow="{{ p.judged }}"
-       aria-valuemin="{{ p.floor }}" aria-valuemax="{{ p.target }}">
-    <span class="judge-xp-trail"></span>
-    <span class="judge-xp-fill"></span>
-    <span class="judge-xp-notches"></span>
-    <span class="judge-xp-sheen"></span>
-  </div>
-  <p class="judge-xp-read mono">
+  <p class="judge-count mono">
     <b>{{ p.judged }}</b> / {{ p.target }} {{ p.label }}
   </p>
   {# Said in full only while it has never happened. After the first sweep the

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -59,10 +59,10 @@
     <a class="rail-item{% if r.past_cliff %} rail-past{% endif %}" role="option" aria-selected="false"
        href="/ui/artifacts/{{ r.artifact_id }}"
        {# The search that listed this row travels with the link. It is what the
-          bar under the artifact and the dwell timer report against, and naming
-          it here is what keeps an open attributed to the search it came from
-          rather than to whichever recent search happened to hold the same
-          artifact. Absent while searches are not being recorded. #}
+          bar under the artifact reports against, and naming it here is what
+          keeps an open attributed to the search it came from rather than to
+          whichever recent search happened to hold the same artifact. Absent
+          while searches are not being recorded. #}
        hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}{% if let Some(ev) = event_id %}&event={{ ev }}{% endif %}"
        hx-target="#pane-content" hx-swap="innerHTML transition:true" hx-push-url="true">
       <div class="rail-head">

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -1,7 +1,14 @@
+{# The id this rail was recorded under, handed straight back to the box: the
+   next keystroke sends it, and the fold is onto this event rather than onto
+   whatever this operator's other tab wrote last. Out of band because the form
+   is not inside the target this fragment fills, and empty where nothing was
+   recorded — the box then has nothing to name and starts a new event, which is
+   what it should do. See `Store::record_search`. #}
+<span hx-swap-oob="innerHTML:#fold-of">{% if let Some(ev) = event_id %}<input type="hidden" name="fold" value="{{ ev }}">{% endif %}</span>
 {% if results.is_empty() && associated.is_empty() %}
   <p class="muted">No matches.</p>
   {% if let Some(ev) = event_id %}
-  <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ ev }}/gap"
+  <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ ev }}/gap?q={{ q|urlencode }}"
              hx-target="this" hx-swap="outerHTML">Nothing here has it</button></p>
   {% endif %}
 {% else %}
@@ -33,7 +40,7 @@
          A verdict on the whole list, so it sits with the line about the whole
          list rather than under any one row. #}
       {% if let Some(ev) = event_id %}
-      <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ ev }}/gap"
+      <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ ev }}/gap?q={{ q|urlencode }}"
                  hx-target="this" hx-swap="outerHTML">Nothing here has it</button></p>
       {% endif %}
     </div>

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -1,5 +1,9 @@
 {% if results.is_empty() && associated.is_empty() %}
   <p class="muted">No matches.</p>
+  {% if let Some(q) = gap_q %}
+  <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/gap" hx-vals='{"q":"{{ q }}"}'
+             hx-target="this" hx-swap="outerHTML">Nothing here has it</button></p>
+  {% endif %}
 {% else %}
 <div data-terms="{{ terms }}">
   {# Counted off the list rather than passed in beside it, so the number and
@@ -25,6 +29,13 @@
       <div>These are the nearest artifacts, but none of them is a close match
         for what you typed. Check the spelling, or try describing the thing
         rather than naming it.</div>
+      {# The deck's "gap" key, moved to where the person is when they know.
+         A verdict on the whole list, so it sits with the line about the whole
+         list rather than under any one row. #}
+      {% if let Some(q) = gap_q %}
+      <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/gap" hx-vals='{"q":"{{ q }}"}'
+                 hx-target="this" hx-swap="outerHTML">Nothing here has it</button></p>
+      {% endif %}
     </div>
   </div>
   {% endif %}
@@ -47,7 +58,7 @@
   <div class="rail-row">
     <a class="rail-item{% if r.past_cliff %} rail-past{% endif %}" role="option" aria-selected="false"
        href="/ui/artifacts/{{ r.artifact_id }}"
-       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}"
+       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}&from=results"
        hx-target="#pane-content" hx-swap="innerHTML transition:true" hx-push-url="true">
       <div class="rail-head">
         {% if r.weak %}

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -57,12 +57,18 @@
      rule empties the animation either way. #}
   <div class="rail-row">
     <a class="rail-item{% if r.past_cliff %} rail-past{% endif %}" role="option" aria-selected="false"
-       href="/ui/artifacts/{{ r.artifact_id }}"
        {# The search that listed this row travels with the link. It is what the
           bar under the artifact reports against, and naming it here is what
           keeps an open attributed to the search it came from rather than to
           whichever recent search happened to hold the same artifact. Absent
-          while searches are not being recorded. #}
+          while searches are not being recorded.
+
+          On the `href` as well as the `hx-get`, and identical to it: a
+          middle-click, a ⌘-click and a load that reached the page without htmx
+          are all the same open, and a link that carried the search down one
+          path and not the other produced a label from one and silence from the
+          other for the same act. #}
+       href="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}{% if let Some(ev) = event_id %}&event={{ ev }}{% endif %}"
        hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}{% if let Some(ev) = event_id %}&event={{ ev }}{% endif %}"
        hx-target="#pane-content" hx-swap="innerHTML transition:true" hx-push-url="true">
       <div class="rail-head">

--- a/src/web/templates/_results.html
+++ b/src/web/templates/_results.html
@@ -1,7 +1,7 @@
 {% if results.is_empty() && associated.is_empty() %}
   <p class="muted">No matches.</p>
-  {% if let Some(q) = gap_q %}
-  <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/gap" hx-vals='{"q":"{{ q }}"}'
+  {% if let Some(ev) = event_id %}
+  <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ ev }}/gap"
              hx-target="this" hx-swap="outerHTML">Nothing here has it</button></p>
   {% endif %}
 {% else %}
@@ -32,8 +32,8 @@
       {# The deck's "gap" key, moved to where the person is when they know.
          A verdict on the whole list, so it sits with the line about the whole
          list rather than under any one row. #}
-      {% if let Some(q) = gap_q %}
-      <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/gap" hx-vals='{"q":"{{ q }}"}'
+      {% if let Some(ev) = event_id %}
+      <p><button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ ev }}/gap"
                  hx-target="this" hx-swap="outerHTML">Nothing here has it</button></p>
       {% endif %}
     </div>
@@ -58,7 +58,12 @@
   <div class="rail-row">
     <a class="rail-item{% if r.past_cliff %} rail-past{% endif %}" role="option" aria-selected="false"
        href="/ui/artifacts/{{ r.artifact_id }}"
-       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}&from=results"
+       {# The search that listed this row travels with the link. It is what the
+          bar under the artifact and the dwell timer report against, and naming
+          it here is what keeps an open attributed to the search it came from
+          rather than to whichever recent search happened to hold the same
+          artifact. Absent while searches are not being recorded. #}
+       hx-get="/ui/artifacts/{{ r.artifact_id }}?terms={{ terms|urlencode }}{% if let Some(ev) = event_id %}&event={{ ev }}{% endif %}"
        hx-target="#pane-content" hx-swap="innerHTML transition:true" hx-push-url="true">
       <div class="rail-head">
         {% if r.weak %}

--- a/src/web/templates/_search_verdict.html
+++ b/src/web/templates/_search_verdict.html
@@ -1,0 +1,21 @@
+{# The bar under a result opened from the rail: the judge deck's question,
+   asked where the answer is cheap — at the moment, by the person who searched,
+   with the result in front of them. `_ask_verdict.html` applied to search.
+
+   Three answers, and none of them is "gap": whether *nothing* has it is a
+   verdict on the whole list, and the rail asks that where the list is. #}
+<div id="search-verdict" class="row ask-verdict">
+  {% if state.is_empty() %}
+    <span class="muted">Was this what you were looking for?</span>
+    <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
+            hx-vals='{"verdict":"hit","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">Yes</button>
+    <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
+            hx-vals='{"verdict":"no","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">No</button>
+    <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
+            hx-vals='{"verdict":"discard","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">Not sure</button>
+  {% else %}
+    <span class="muted">{% if state == "hit" %}yes, this was it{% else if state == "no" %}not this one{% else %}not sure{% endif %}</span>
+    <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
+            hx-vals='{"verdict":"none","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">undo</button>
+  {% endif %}
+</div>

--- a/src/web/templates/_search_verdict.html
+++ b/src/web/templates/_search_verdict.html
@@ -3,7 +3,11 @@
    with the result in front of them. `_ask_verdict.html` applied to search.
 
    Three answers, and none of them is "gap": whether *nothing* has it is a
-   verdict on the whole list, and the rail asks that where the list is. #}
+   verdict on the whole list, and the rail asks that where the list is.
+
+   Nor is "Not sure" a verdict. It is the deck's skip: the search stays a
+   question and only sinks in the order. Recording it as a discard — which says
+   the search was never real — spent the search on somebody not remembering. #}
 <div id="search-verdict" class="row ask-verdict">
   {% if state.is_empty() %}
     <span class="muted">Was this what you were looking for?</span>
@@ -12,9 +16,13 @@
     <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
             hx-vals='{"verdict":"no","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">No</button>
     <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
-            hx-vals='{"verdict":"discard","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">Not sure</button>
+            hx-vals='{"verdict":"skip","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">Not sure</button>
+  {% else if state == "skip" %}
+    {# No undo: a skip is not a verdict, so there is nothing to take back. The
+       search is still pending, and the deck will ask again later. #}
+    <span class="muted">left for the deck</span>
   {% else %}
-    <span class="muted">{% if state == "hit" %}yes, this was it{% else if state == "no" %}not this one{% else %}not sure{% endif %}</span>
+    <span class="muted">{% if state == "hit" %}yes, this was it{% else %}not this one{% endif %}</span>
     <button class="btn btn-ghost btn-sm" hx-post="/ui/search/{{ event_id }}/verdict"
             hx-vals='{"verdict":"none","artifact_id":"{{ artifact_id }}"}' hx-target="#search-verdict" hx-swap="outerHTML">undo</button>
   {% endif %}

--- a/src/web/templates/judge.html
+++ b/src/web/templates/judge.html
@@ -2,14 +2,14 @@
 {% block title %}Judge — engram{% endblock %}
 {% block regions %}regions-judge{% endblock %}
 {% block content %}
-{# What the page is for, said once and standing. The card asks a genuine
-   cognitive task — twenty unordered candidates and a question — and never said
-   why it was worth answering. The answer is the one number on Insights that is
-   not a proxy: recall@10 and MRR are read off exactly these verdicts, which is
-   why an unlabelled, shuffled pool is the only honest way to ask. #}
-<p class="muted hint">These are your own searches, coming back unlabelled and
-  shuffled. Saying which result you actually wanted is what turns the retrieval
-  figure on Insights into a measurement rather than a guess.</p>
+{# What the page is for, said once and standing. Most searches are labelled
+   where they happen now — a result read, a bar answered — and what comes here
+   is the rest. The answer is still the one number on Insights that is not a
+   proxy: recall@10 and MRR are read off exactly these verdicts. #}
+<p class="muted hint">These are your own searches, coming back unlabelled — the
+  ones nothing was opened from, or confirmed under. Saying whether there was
+  something you wanted is what turns the retrieval figure on Insights into a
+  measurement rather than a guess.</p>
 
 {# Directly above the card: it is the one thing on this page that can be acted
    on, and it is what the bar inside the card is counting towards. #}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -77,7 +77,12 @@ reading, and search from a panel beside it.</p>
    beside the search box would be in view during every keystroke; this is the
    page for things that are true about the installation. #}
 <p class="muted">
-  Searches are being recorded — {{ f.captured }} captured, {{ f.pending }} unjudged.
+  {# "waiting" rather than "unjudged": the number is what the deck will deal,
+     which is not every search without a verdict — a typo and a search nothing
+     came close to are recorded and stay pending, and neither is a card anyone
+     can answer. A count the link cannot deliver on is a queue that never
+     empties. #}
+  Searches are being recorded — {{ f.captured }} captured, {{ f.pending }} waiting.
   {% if f.pending > 0 %}<a href="/ui/judge">Review them</a>{% endif %}
 </p>
 {# Counted here beside the searches because one purge takes both. The judged

--- a/src/web/templates/workspace.html
+++ b/src/web/templates/workspace.html
@@ -54,7 +54,7 @@
                   input[!event.isComposing] changed delay:120ms from:textarea[name=q],
                   submit{% if !q.is_empty() && open_with.is_empty() %},
                   load{% endif %}"
-      hx-params="q,category,rerank,explain"
+      hx-params="q,category,rerank,explain,fold"
       hx-indicator="#search-spinner"{% if search_reranks %} data-rerank="true"{% endif %}>
   {# `/ui?explain=1` and nothing else. `hx-params` above is an allowlist, so
      the name has to appear in both places or the fragment is asked without it
@@ -62,6 +62,13 @@
      field was missing. app.js's refining pass reads it here too, so the
      second, reranked answer carries the same question the first one did. #}
   {% if explain %}<input type="hidden" name="explain" value="1">{% endif %}
+  {# Empty until the first answer comes back, which fills it out of band with
+     the id that answer was recorded under. The box then names its own last
+     search on every keystroke, and a burst folds into that one event instead
+     of into whatever this operator's other window wrote most recently — which
+     used to overwrite that window's query and its whole pool while its rail
+     went on naming the id on every row. See `_results.html`. #}
+  <span id="fold-of"></span>
   {# A textarea from the first keystroke to the last. It grows to a ten-line
      cap and then scrolls inside itself; it never switches element type, and it
      never infers a verb from a length or a newline. What decides which of the

--- a/src/web/tenant.rs
+++ b/src/web/tenant.rs
@@ -53,6 +53,17 @@ impl FromRequestParts<AppState> for CanJudge {
         //
         // One indexed read on the control database, and only on this door. The
         // hot paths keep the snapshot, which is what the cache is for.
+        //
+        // What this gate covers, and what it does not: the judging deck, which
+        // labels anyone's searches out of context and is the only route in the
+        // tree that writes `config.toml`. It is deliberately not on the verdict
+        // bar or the rail's gap button in `workspace.rs` — those answer the
+        // caller's own search, at the moment of it, the way the ask bar does,
+        // and `event_is_mine` is what stands there instead. So `--revoke-judge`
+        // means "no deck and no tuning", not "cannot label a pair": a revoked
+        // user can still say yes, no or gap about a search they just ran, and
+        // those rows do reach `feedback_stats`, `--export-eval` and the sweep.
+        // Taking that away as well means taking the bar off their own results.
         let live = state
             .tenants
             .control()

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -1685,18 +1685,19 @@ async fn reread_uncovered_ui(
 struct DwellForm {
     #[serde(default)]
     secs: i64,
-    /// The search the artifact was opened from, where the pane knew one.
-    #[serde(default)]
-    event: Option<String>,
 }
-
-/// A read this long is taken as the search having found what it was for.
-/// Provisional — see `Store::implicit_hit` — but enough to give recall@10 a
-/// value from ordinary use, with nothing clicked.
-const DWELL_HIT_SECS: i64 = 20;
 
 /// The page saying how long an artifact was open, sent as the reader leaves
 /// it. `sendBeacon` lands here; nothing is rendered back.
+///
+/// A pursuit signal and nothing more. It used to also label the search: a read
+/// past twenty seconds was written as a hit, on the theory that recall could
+/// come from ordinary use with nothing clicked. It cannot. What the timer
+/// measures is a pane that stayed open, which is a tab abandoned as often as it
+/// is an answer — and because the beacon flushes as the pane is *left*, it
+/// arrived after the buttons it was overwriting and put a hit back on searches
+/// a person had just marked "not sure" or undone. The bar under the result is
+/// the whole of the answer now.
 async fn artifact_dwell(
     tenant: Tenant,
     Path(aid): Path<String>,
@@ -1705,17 +1706,6 @@ async fn artifact_dwell(
     tenant
         .core
         .record_dwell(&aid, f.secs, Some(&tenant.user.subject));
-    // Not for an artifact search will no longer return: `eval::export` drops
-    // the pair, so the hit would move the recall on the judging page and
-    // nothing in `pairs.json`. `judge::hit` and the verdict bar both refuse one
-    // for that reason, and a beacon is not the way around them. The pane omits
-    // `data-event` in that case, so this is the write agreeing with the page.
-    if let Some(event) = f.event.filter(|_| f.secs >= DWELL_HIT_SECS)
-        && tenant.core.learn.enabled
-        && tenant.core.store.get_artifact(&aid).await?.in_results()
-    {
-        tenant.core.store.implicit_hit(&event, &aid).await?;
-    }
     Ok(axum::http::StatusCode::NO_CONTENT.into_response())
 }
 
@@ -2961,14 +2951,20 @@ async fn artifact_detail(
     //
     // Not for an artifact search will no longer return. `eval::export` freezes
     // only active, un-superseded artifacts and drops any pair naming something
-    // else, so a hit recorded here — by the bar, or by the dwell timer that
-    // reads the same id off the pane — would raise the recall and MRR on the
+    // else, so a hit recorded here would raise the recall and MRR on the
     // judging page while contributing nothing to `pairs.json`. `judge::hit`
-    // refuses one for that reason; so does this. No bar and no `data-event`
-    // means neither path can fire.
+    // refuses one for that reason; so does this. Without `search_event` the bar
+    // is not drawn, which is the only way a verdict can be given at all.
+    // And only the searcher's own event: the id arrives on a link, so it is
+    // whatever the caller sent. See `Store::event_is_mine`.
     if tenant.core.learn.enabled
         && d.in_results()
         && let Some(event) = p.event.as_deref()
+        && tenant
+            .core
+            .store
+            .event_is_mine(event, &tenant.user.subject)
+            .await?
         && tenant.core.store.open_event(event).await?
     {
         d.search_event = Some(event.to_string());
@@ -11353,9 +11349,6 @@ mod tests {
             page.contains(&format!("/ui/search/{event}/verdict")),
             "the bar does not name the search: {page}"
         );
-        // Named on the root beside the artifact, so the dwell timer can report
-        // which search the read belongs to.
-        assert!(page.contains(&format!("data-event=\"{event}\"")), "{page}");
         // The rail's own links carry the search that listed them.
         let rail = include_str!("templates/_results.html");
         assert!(rail.contains("&event={{ ev }}"), "{rail}");
@@ -11430,34 +11423,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reading_a_result_long_enough_confirms_it_without_a_click() {
+    async fn a_long_read_is_a_pursuit_signal_and_never_a_verdict() {
+        // A read past some threshold used to be written as the search having
+        // found its answer. What that measured was a pane left open, which is
+        // an abandoned tab as often as it is an answer — and because the beacon
+        // flushes as the pane is *left*, it landed after the buttons under the
+        // result and put a hit back onto searches a person had just marked
+        // "not sure" or undone. The timer still feeds the pursuit sweep; it no
+        // longer labels anything.
         let (app, cookie, handle, a, event) = searched_app().await;
-        // A glance is not a read.
         let res = app
             .clone()
             .oneshot(form(
                 &format!("/ui/artifacts/{a}/dwell"),
                 &cookie,
-                &format!("secs=5&event={event}"),
-            ))
-            .await
-            .unwrap();
-        assert_eq!(res.status(), StatusCode::NO_CONTENT);
-        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().hits, 0);
-
-        let res = app
-            .clone()
-            .oneshot(form(
-                &format!("/ui/artifacts/{a}/dwell"),
-                &cookie,
-                &format!("secs=42&event={event}"),
+                "secs=42",
             ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NO_CONTENT);
         let s = handle.store.feedback_stats(0.0).await.unwrap();
-        assert_eq!((s.hits, s.pending), (1, 0), "{s:?}");
-        assert_eq!(s.recall_at_10, 1.0);
+        assert_eq!((s.hits, s.judged), (0, 0), "{s:?}");
+        assert_eq!(
+            handle.store.next_pending(0.0).await.unwrap().map(|e| e.id),
+            Some(event),
+            "the search is still a question for the deck"
+        );
     }
 
     #[tokio::test]
@@ -11574,12 +11565,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_search_somebody_else_made_cannot_be_opened_or_judged() {
+        // Every route that labels a search takes the event id from the page,
+        // because the page is what knows which search a row came from. An id
+        // is not a capability: guessing at one used to be enough to stamp an
+        // open onto another person's search, answer it, or call it a gap —
+        // and, by stamping `opened_at`, quietly stop their next keystroke
+        // folding as well.
+        let (app, cookie, handle, a, _) = searched_app().await;
+        let theirs = handle
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "image will not mount".into(),
+                    door: crate::store::feedback::Door::Ui,
+                    scope: Some("somebody-else".into()),
+                    filters: "{}".into(),
+                    query_vec: vec![0.1, 0.2],
+                    embed_model: "fake".into(),
+                    candidates: vec![crate::store::feedback::NewCandidate {
+                        artifact_id: a.clone(),
+                        score: 1.0,
+                        similarity: Some(0.5),
+                        shown: true,
+                    }],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?event={theirs}")).await;
+        assert!(
+            !page.contains("Was this what you were looking for?"),
+            "{page}"
+        );
+        let opened: Option<i64> =
+            sqlx::query_scalar("SELECT opened_at FROM search_events WHERE id = ?")
+                .bind(&theirs)
+                .fetch_one(&handle.store.pool)
+                .await
+                .unwrap();
+        assert_eq!(opened, None, "their next keystroke still folds");
+
+        for body in [
+            format!("verdict=hit&artifact_id={a}"),
+            format!("verdict=no&artifact_id={a}"),
+        ] {
+            let res = app
+                .clone()
+                .oneshot(form(
+                    &format!("/ui/search/{theirs}/verdict"),
+                    &cookie,
+                    &body,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        }
+        let res = app
+            .clone()
+            .oneshot(form(&format!("/ui/search/{theirs}/gap"), &cookie, ""))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+        let s = handle.store.feedback_stats(0.0).await.unwrap();
+        assert_eq!((s.judged, s.hits, s.gaps), (0, 0, 0), "{s:?}");
+    }
+
+    #[tokio::test]
     async fn a_deprecated_result_is_never_asked_about() {
         // `eval::export` drops any pair naming an artifact search will not
         // return, so a hit recorded against one raises the recall on the
         // judging page and contributes nothing to `pairs.json`. `judge::hit`
-        // refuses one; the bar under a result must not be a way around it, and
-        // neither must the dwell timer that reads the same id off the pane.
+        // refuses one, and the bar under a result must not be a way around it.
         let (app, cookie, handle, a, event) = searched_app().await;
         handle
             .store
@@ -11591,20 +11652,8 @@ mod tests {
             !page.contains("Was this what you were looking for?"),
             "{page}"
         );
-        assert!(
-            !page.contains("data-event="),
-            "the dwell timer would report a hit the benchmark cannot hold: {page}"
-        );
-        // And the writes refuse it too, not only the render: a beacon or a
-        // replayed form naming the pair is not the way around the guard.
-        app.clone()
-            .oneshot(form(
-                &format!("/ui/artifacts/{a}/dwell"),
-                &cookie,
-                &format!("secs=42&event={event}"),
-            ))
-            .await
-            .unwrap();
+        // And the write refuses it too, not only the render: a replayed form
+        // naming the pair is not the way around the guard.
         let res = app
             .clone()
             .oneshot(form(

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -518,6 +518,11 @@ struct ResultsTemplate {
     /// searches are not being recorded, and the button and the links go
     /// without.
     event_id: Option<String>,
+    /// The query this rail was drawn for, carried by the gap button alone: a
+    /// gap is a verdict about a wording, and a trailing keystroke can fold a
+    /// later one into the same row before the button is pressed. See
+    /// `Store::gap_event`.
+    q: String,
 }
 
 /// The rail before anything is asked: the base introducing itself.
@@ -1076,6 +1081,12 @@ pub(crate) struct UiSearchParams {
     /// the operator stops, whose answer reorders the rail it just painted.
     #[serde(default)]
     pub(crate) rerank: bool,
+    /// The search event this page is holding — the id the last answer handed
+    /// it, sent back so a typing burst folds into its own chain. A second tab
+    /// carries a different one, or none yet, and the two never collide. See
+    /// `Store::record_search`.
+    #[serde(default)]
+    pub(crate) fold: Option<String>,
     /// Ask the rail to say why a row is where it is. Off unless the link
     /// carries it: the line is for an operator looking into a ranking, not
     /// something every keystroke paints. `/ui?explain=1` puts it on the form
@@ -1155,6 +1166,9 @@ pub(crate) async fn search_results(
     // Function words are dropped: a query phrased as a situation is mostly
     // stopwords, and highlighting every "to" marks the whole card.
     let terms = highlightable_terms(p.q.trim());
+    // The wording this rail is about to be drawn for, kept because `p.q` is
+    // about to be moved into the search. Only the gap button reads it.
+    let q = p.q.trim().to_string();
     // What this sitting is working on. A typing burst folds into one entry
     // here as it does in the log, so what is carried is the query that was
     // meant rather than every prefix of it.
@@ -1198,7 +1212,11 @@ pub(crate) async fn search_results(
                 .by(tenant.user.subject)
                 // The live sitting, for priming. Off unless `sitting.prime` is
                 // on, and impossible at any door with no session.
-                .in_sitting(identity.session.clone()),
+                .in_sitting(identity.session.clone())
+                // The event this page is already holding, so a burst folds into
+                // its own chain and not into whatever this operator's other tab
+                // wrote last. Empty on the first search of a page.
+                .folding_onto(p.fold.filter(|f| !f.is_empty())),
         )
         .await?;
 
@@ -1257,6 +1275,7 @@ pub(crate) async fn search_results(
         // would assert a confirmation that never took place.
         reranked: outcome.timing.reranked,
         event_id: outcome.event,
+        q,
     })
     .into_response();
     // Measured as before, reported where a browser already knows to show it.
@@ -5664,6 +5683,7 @@ mod tests {
             core.store
                 .record_search(
                     crate::store::feedback::NewEvent {
+                        fold_onto: None,
                         query: format!("search number {i}"),
                         door: crate::store::feedback::Door::Ui,
                         scope: None,
@@ -6410,6 +6430,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         })
         .unwrap();
         assert!(html.contains("Nothing matches closely"), "{html}");
@@ -6514,6 +6535,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         })
         .unwrap();
 
@@ -6538,6 +6560,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         })
         .unwrap();
 
@@ -6645,6 +6668,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         })
         .unwrap();
         assert!(!html.contains("Untitled"), "{html}");
@@ -6695,6 +6719,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -6718,6 +6743,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -6738,6 +6764,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -6770,6 +6797,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         };
         let body = template.render().unwrap();
         assert!(body.contains("Recalled by association"), "{body}");
@@ -6787,6 +6815,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         };
         let body = judged.render().unwrap();
         assert!(body.contains("the tool and its errors"), "{body}");
@@ -6806,6 +6835,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: true,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -6818,6 +6848,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -6895,6 +6926,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         };
         let body = weak_with_association.render().unwrap();
         assert!(
@@ -6909,6 +6941,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         };
         let body = good_with_association.render().unwrap();
         assert!(
@@ -7148,6 +7181,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -7196,6 +7230,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -7216,6 +7251,7 @@ mod tests {
             event_id: None,
             terms: String::new(),
             reranked: false,
+            q: String::new(),
         }
         .render()
         .unwrap();
@@ -9312,6 +9348,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "how do I mount an E01".into(),
                     door: crate::store::feedback::Door::Api,
                     scope: None,
@@ -9501,6 +9538,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "judged one".into(),
                     door: crate::store::feedback::Door::Api,
                     scope: None,
@@ -9526,6 +9564,7 @@ mod tests {
         core.store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "nothing near one".into(),
                     door: crate::store::feedback::Door::Api,
                     scope: None,
@@ -9687,7 +9726,7 @@ mod tests {
         // `explain` for the same reason: a name missing here is a flag the
         // fragment is never asked with, however carefully the rest is wired.
         assert!(
-            page.contains(r#"hx-params="q,category,rerank,explain""#),
+            page.contains(r#"hx-params="q,category,rerank,explain,fold""#),
             "{page}"
         );
     }
@@ -11322,6 +11361,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "image will not mount".into(),
                     door: crate::store::feedback::Door::Ui,
                     scope: Some(crate::store::TEST_SUBJECT.into()),
@@ -11385,6 +11425,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "image mount".into(),
                     door: crate::store::feedback::Door::Ui,
                     scope: Some(crate::store::TEST_SUBJECT.into()),
@@ -11542,14 +11583,20 @@ mod tests {
         // nothing at all, silently.
         let event = newest_event(&handle).await;
         assert!(
-            rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap""#)),
+            rail.contains(&format!(
+                r#"hx-post="/ui/search/{event}/gap?q=nothing%20here""#
+            )),
             "{rail}"
         );
         assert!(!rail.contains("hx-vals='{\"q\""), "{rail}");
 
         let res = app
             .clone()
-            .oneshot(form(&format!("/ui/search/{event}/gap"), &cookie, ""))
+            .oneshot(form(
+                &format!("/ui/search/{event}/gap?q=nothing%20here"),
+                &cookie,
+                "",
+            ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
@@ -11558,6 +11605,45 @@ mod tests {
         assert!(
             body_of(res).await.contains("recorded as a gap"),
             "the button did not say what it did"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_rail_hands_the_box_the_search_it_should_fold_into() {
+        // The box types into one event by naming it, not by being the most
+        // recent thing this operator wrote — which is what a second window
+        // also is. The id goes back into the form out of band, and the next
+        // keystroke carries it.
+        let (app, cookie, handle) = app_session_and_core_with_feedback().await;
+        let rail = get_body(&app, &cookie, "/ui/search/results?q=fat32").await;
+        let first = newest_event(&handle).await;
+        assert!(
+            rail.contains(&format!(
+                r#"<span hx-swap-oob="innerHTML:#fold-of"><input type="hidden" name="fold" value="{first}">"#
+            )),
+            "{rail}"
+        );
+
+        // The next keystroke, naming it: one search, still.
+        get_body(
+            &app,
+            &cookie,
+            &format!("/ui/search/results?q=fat32+mount&fold={first}"),
+        )
+        .await;
+        assert_eq!(newest_event(&handle).await, first);
+        assert_eq!(
+            handle.store.feedback_stats(0.0).await.unwrap().captured,
+            1,
+            "the burst folded into the event the page was holding"
+        );
+
+        // A second window, holding nothing yet, does not fold into it.
+        get_body(&app, &cookie, "/ui/search/results?q=ntfs").await;
+        assert_eq!(
+            handle.store.feedback_stats(0.0).await.unwrap().captured,
+            2,
+            "the other window started its own search"
         );
     }
 
@@ -11574,13 +11660,16 @@ mod tests {
         )
         .await;
         let event = newest_event(&handle).await;
+        // The wording rides the URL, so a quote is percent-encoded rather than
+        // spliced into an HTML attribute or a JSON blob.
+        let q = "say%20%22hi%22%20%5Cnow";
         assert!(
-            rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap""#)),
+            rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap?q={q}""#)),
             "{rail}"
         );
         let res = app
             .clone()
-            .oneshot(form(&format!("/ui/search/{event}/gap"), &cookie, ""))
+            .oneshot(form(&format!("/ui/search/{event}/gap?q={q}"), &cookie, ""))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
@@ -11600,6 +11689,7 @@ mod tests {
             .store
             .record_search(
                 crate::store::feedback::NewEvent {
+                    fold_onto: None,
                     query: "image will not mount".into(),
                     door: crate::store::feedback::Door::Ui,
                     scope: Some("somebody-else".into()),
@@ -11649,7 +11739,11 @@ mod tests {
         }
         let res = app
             .clone()
-            .oneshot(form(&format!("/ui/search/{theirs}/gap"), &cookie, ""))
+            .oneshot(form(
+                &format!("/ui/search/{theirs}/gap?q=image%20will%20not%20mount"),
+                &cookie,
+                "",
+            ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -11688,5 +11782,41 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
         assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().hits, 0);
+    }
+
+    #[tokio::test]
+    async fn a_stale_bar_says_so_rather_than_writing_over_the_deck() {
+        // The bar is drawn against an unjudged search and the tab holding it
+        // can be left open for as long as anyone likes, so both of its writing
+        // answers can arrive after the deck has answered the same search.
+        // Neither replaces what is there; both come back saying why.
+        let (app, cookie, handle, a, event) = searched_app().await;
+        handle
+            .store
+            .judge(
+                &event,
+                crate::store::feedback::Verdict::Gap,
+                crate::store::feedback::Labeller::Deck,
+            )
+            .await
+            .unwrap();
+
+        for body in [
+            format!("verdict=hit&artifact_id={a}"),
+            format!("verdict=none&artifact_id={a}"),
+        ] {
+            let res = app
+                .clone()
+                .oneshot(form(&format!("/ui/search/{event}/verdict"), &cookie, &body))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+            assert!(
+                body_of(res).await.contains("already judged"),
+                "the bar wrote over the deck instead of saying it could not"
+            );
+        }
+        let s = handle.store.feedback_stats(0.0).await.unwrap();
+        assert_eq!((s.gaps, s.hits, s.judged), (1, 0, 1), "{s:?}");
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -191,6 +191,10 @@ pub struct ArtifactDetail {
     /// it is showing is the artifact's own text reflected back rather than the
     /// document it was drawn from.
     pub corpus_restored: bool,
+    /// The search this was opened from, when it was opened from the rail and
+    /// searches are being recorded. What the bar under the artifact and the
+    /// dwell timer both report against. See `Store::open_event_for`.
+    pub search_event: Option<String>,
     /// Link to the source, scrolled to and highlighting the exact lines this
     /// artifact was drawn from. Falls back to the plain source page for an
     /// artifact with no recorded span — a restored one, for instance.
@@ -499,6 +503,9 @@ struct ResultsTemplate {
     /// The tick beside the count is what makes the reordering legible as a
     /// refinement rather than a glitch.
     reranked: bool,
+    /// The query as typed, for the "nothing here has it" button — and only
+    /// while searches are being recorded, since a gap is a verdict on one.
+    gap_q: Option<String>,
 }
 
 /// The rail before anything is asked: the base introducing itself.
@@ -1136,6 +1143,9 @@ pub(crate) async fn search_results(
     // Function words are dropped: a query phrased as a situation is mostly
     // stopwords, and highlighting every "to" marks the whole card.
     let terms = highlightable_terms(p.q.trim());
+    // Trimmed, because that is the wording the capture stores and the gap
+    // button has to name the same event.
+    let gap_q = tenant.core.learn.enabled.then(|| p.q.trim().to_string());
     // What this sitting is working on. A typing burst folds into one entry
     // here as it does in the log, so what is carried is the query that was
     // meant rather than every prefix of it.
@@ -1237,6 +1247,7 @@ pub(crate) async fn search_results(
         // that failed or was skipped answered in vector order, and the tick
         // would assert a confirmation that never took place.
         reranked: outcome.timing.reranked,
+        gap_q,
     })
     .into_response();
     // Measured as before, reported where a browser already knows to show it.
@@ -1664,7 +1675,15 @@ async fn reread_uncovered_ui(
 struct DwellForm {
     #[serde(default)]
     secs: i64,
+    /// The search the artifact was opened from, where the pane knew one.
+    #[serde(default)]
+    event: Option<String>,
 }
+
+/// A read this long is taken as the search having found what it was for.
+/// Provisional — see `Store::implicit_hit` — but enough to give recall@10 a
+/// value from ordinary use, with nothing clicked.
+const DWELL_HIT_SECS: i64 = 20;
 
 /// The page saying how long an artifact was open, sent as the reader leaves
 /// it. `sendBeacon` lands here; nothing is rendered back.
@@ -1676,6 +1695,11 @@ async fn artifact_dwell(
     tenant
         .core
         .record_dwell(&aid, f.secs, Some(&tenant.user.subject));
+    if let Some(event) = f.event.filter(|_| f.secs >= DWELL_HIT_SECS)
+        && tenant.core.learn.enabled
+    {
+        tenant.core.store.implicit_hit(&event, &aid).await?;
+    }
     Ok(axum::http::StatusCode::NO_CONTENT.into_response())
 }
 
@@ -2868,8 +2892,14 @@ pub(crate) async fn build_artifact_detail(
         slice_label: slice.label,
         slice_lines: slice.lines,
         terms: terms.to_string(),
+        search_event: None,
     })
 }
+
+/// How long after a search an open from its rail still counts as an open of
+/// it. Generous: the rail stays on screen for as long as the tab does, and
+/// the lookup also asks that the pool hold the artifact.
+pub(crate) const OPEN_WITHIN_SECS: i64 = 3600;
 
 #[derive(serde::Deserialize)]
 struct ArtifactViewParams {
@@ -2890,6 +2920,10 @@ struct ArtifactViewParams {
     /// every click lands in one bucket on Ops.
     #[serde(default)]
     rung: Option<String>,
+    /// `results` when the link was a row on the search rail. Only then is
+    /// there a search this open can be the answer to.
+    #[serde(default)]
+    from: Option<String>,
 }
 
 /// One route, two shapes. An htmx swap wants the pane's body; a pasted link
@@ -2901,7 +2935,18 @@ async fn artifact_detail(
     Path(cid): Path<String>,
     Query(p): Query<ArtifactViewParams>,
 ) -> Result<Response> {
-    let d = build_artifact_detail(&tenant.core, &cid, &p.terms).await?;
+    let mut d = build_artifact_detail(&tenant.core, &cid, &p.terms).await?;
+    // Opened from the rail: the search it answers is asked of the store, since
+    // the capture was written off the request path and nothing on the page
+    // carries its id. On the request path, because the bar under the artifact
+    // needs the id before it can render.
+    if tenant.core.learn.enabled && p.from.as_deref() == Some("results") {
+        d.search_event = tenant
+            .core
+            .store
+            .open_event_for(&cid, Some(&tenant.user.subject), OPEN_WITHIN_SECS)
+            .await?;
+    }
     // Opening a chunk is the deliberate act that counts as remembering it.
     tenant.core.mark_artifact_seen(&cid);
     // And the act the pursuit sweep reads: opened, or pivoted through — unless
@@ -6331,6 +6376,7 @@ mod tests {
             results: vec![loose],
             associated: vec![],
             all_weak: true,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6434,6 +6480,7 @@ mod tests {
             results: vec![named, offered],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6457,6 +6504,7 @@ mod tests {
             results: vec![row("a", "#1")],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6563,6 +6611,7 @@ mod tests {
             results: vec![r],
             associated: vec![render_hit(0, hit(None, Some("a")), &titles, false)],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6612,6 +6661,7 @@ mod tests {
             results: vec![above.clone(), above.clone(), past, also_past],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6634,6 +6684,7 @@ mod tests {
             results: vec![above.clone(), above.clone(), above],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6653,6 +6704,7 @@ mod tests {
             results: vec![own, borrowed],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6684,6 +6736,7 @@ mod tests {
             results: vec![],
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         };
@@ -6700,6 +6753,7 @@ mod tests {
                 Some("the tool and its errors"),
             )],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         };
@@ -6718,6 +6772,7 @@ mod tests {
             results: vec![rendered(Some("Mounting E01 images"), None)],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: true,
         }
@@ -6729,6 +6784,7 @@ mod tests {
             results: vec![rendered(Some("Mounting E01 images"), None)],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6805,6 +6861,7 @@ mod tests {
             results: vec![ranked(true)],
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: true,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         };
@@ -6818,6 +6875,7 @@ mod tests {
             results: vec![ranked(false)],
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         };
@@ -7056,6 +7114,7 @@ mod tests {
             results: vec![r],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -7103,6 +7162,7 @@ mod tests {
             results: vec![ranked(false)],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -7122,6 +7182,7 @@ mod tests {
             results: vec![r],
             associated: vec![],
             all_weak: false,
+            gap_q: None,
             terms: String::new(),
             reranked: false,
         }
@@ -9234,7 +9295,11 @@ mod tests {
             .await
             .unwrap();
         core.store
-            .judge(&gap, crate::store::feedback::Verdict::Gap)
+            .judge(
+                &gap,
+                crate::store::feedback::Verdict::Gap,
+                crate::store::feedback::Labeller::Deck,
+            )
             .await
             .unwrap();
         core.store
@@ -9419,7 +9484,11 @@ mod tests {
             .await
             .unwrap();
         core.store
-            .judge(&judged, crate::store::feedback::Verdict::Gap)
+            .judge(
+                &judged,
+                crate::store::feedback::Verdict::Gap,
+                crate::store::feedback::Labeller::Deck,
+            )
             .await
             .unwrap();
         // Nothing came close.
@@ -11183,5 +11252,247 @@ mod tests {
         // The detail root names the artifact, which is what the page's timer reads.
         let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
         assert!(page.contains(&format!("data-artifact=\"{a}\"")), "{page}");
+    }
+
+    // ── Judging at the moment of search ──────────────────────────────────────
+
+    /// A recording session, one artifact, and one captured search of this
+    /// user's whose pool holds it.
+    async fn searched_app() -> (axum::Router, String, crate::core::Core, String, String) {
+        let mut core = crate::core::test_support::test_core().await;
+        core.learn.enabled = true;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        let src = handle
+            .store
+            .insert_corpus("raw", "web", None)
+            .await
+            .unwrap();
+        let a = handle
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "mounting the image".into(),
+                    corpus_span: None,
+                    title: Some("mount".into()),
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let event = handle
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "image will not mount".into(),
+                    door: crate::store::feedback::Door::Ui,
+                    scope: Some(crate::store::TEST_SUBJECT.into()),
+                    filters: "{}".into(),
+                    query_vec: vec![0.1, 0.2],
+                    embed_model: "fake".into(),
+                    candidates: vec![crate::store::feedback::NewCandidate {
+                        artifact_id: a.clone(),
+                        score: 1.0,
+                        similarity: Some(0.5),
+                        shown: true,
+                    }],
+                    answered: false,
+                },
+                0,
+            )
+            .await
+            .unwrap();
+        (app, cookie, handle, a, event)
+    }
+
+    #[tokio::test]
+    async fn a_result_opened_from_the_rail_asks_whether_it_was_the_one() {
+        // The judge deck asks hours later, out of context, and the honest
+        // answer then is "I don't know, I was looking". Under the result just
+        // opened the answer is cheap, so that is where it is asked.
+        let (app, cookie, handle, a, event) = searched_app().await;
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?from=results")).await;
+        assert!(
+            page.contains("Was this what you were looking for?"),
+            "{page}"
+        );
+        assert!(
+            page.contains(&format!("/ui/search/{event}/verdict")),
+            "the bar does not name the search: {page}"
+        );
+        // Named on the root beside the artifact, so the dwell timer can report
+        // which search the read belongs to.
+        assert!(page.contains(&format!("data-event=\"{event}\"")), "{page}");
+        // The rail's own links say they are the rail's.
+        let rail = include_str!("templates/_results.html");
+        assert!(rail.contains("&from=results\""), "{rail}");
+
+        // Reached any other way — a corpus page, a pasted link — there is no
+        // search to be the answer to.
+        let plain = get_body(&app, &cookie, &format!("/ui/artifacts/{a}")).await;
+        assert!(
+            !plain.contains("Was this what you were looking for?"),
+            "{plain}"
+        );
+        // And a bar was not the whole of the open: the rewording after it starts
+        // its own event because this one is now the list that was read.
+        handle
+            .store
+            .record_search(
+                crate::store::feedback::NewEvent {
+                    query: "image mount".into(),
+                    door: crate::store::feedback::Door::Ui,
+                    scope: Some(crate::store::TEST_SUBJECT.into()),
+                    filters: "{}".into(),
+                    query_vec: vec![0.1, 0.2],
+                    embed_model: "fake".into(),
+                    candidates: vec![],
+                    answered: false,
+                },
+                60,
+            )
+            .await
+            .unwrap();
+        assert_eq!(handle.store.feedback_stats().await.unwrap().captured, 2);
+    }
+
+    #[tokio::test]
+    async fn with_learning_off_a_result_is_just_a_result() {
+        let core = crate::core::test_support::test_core().await;
+        let handle = core.clone();
+        let (app, cookie) = app_with_cookie(core).await;
+        let src = handle
+            .store
+            .insert_corpus("raw", "web", None)
+            .await
+            .unwrap();
+        let a = handle
+            .store
+            .insert_artifacts(
+                &src.id,
+                &[crate::store::artifacts::NewArtifact {
+                    ordinal: 0,
+                    text: "a".into(),
+                    corpus_span: None,
+                    title: None,
+                    category: None,
+                    tags: vec![],
+                    segment_idx: None,
+                    caveats: vec![],
+                }],
+            )
+            .await
+            .unwrap()[0]
+            .id
+            .clone();
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?from=results")).await;
+        assert!(
+            !page.contains("Was this what you were looking for?"),
+            "{page}"
+        );
+        let rail = get_body(&app, &cookie, "/ui/search/results?q=nothing+here").await;
+        assert!(!rail.contains("Nothing here has it"), "{rail}");
+    }
+
+    #[tokio::test]
+    async fn reading_a_result_long_enough_confirms_it_without_a_click() {
+        let (app, cookie, handle, a, event) = searched_app().await;
+        // A glance is not a read.
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{a}/dwell"),
+                &cookie,
+                &format!("secs=5&event={event}"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        assert_eq!(handle.store.feedback_stats().await.unwrap().hits, 0);
+
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{a}/dwell"),
+                &cookie,
+                &format!("secs=42&event={event}"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        let s = handle.store.feedback_stats().await.unwrap();
+        assert_eq!((s.hits, s.pending), (1, 0), "{s:?}");
+        assert_eq!(s.recall_at_10, 1.0);
+    }
+
+    #[tokio::test]
+    async fn the_bar_takes_yes_no_and_not_sure_and_each_can_be_taken_back() {
+        let (app, cookie, handle, a, event) = searched_app().await;
+        let verdict = |v: &str| {
+            form(
+                &format!("/ui/search/{event}/verdict"),
+                &cookie,
+                &format!("verdict={v}&artifact_id={a}"),
+            )
+        };
+        let res = app.clone().oneshot(verdict("hit")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let bar = body_of(res).await;
+        assert!(bar.contains("undo"), "{bar}");
+        let s = handle.store.feedback_stats().await.unwrap();
+        assert_eq!((s.hits, s.pending), (1, 0), "{s:?}");
+
+        // Undo: a question again.
+        app.clone().oneshot(verdict("none")).await.unwrap();
+        assert_eq!(handle.store.feedback_stats().await.unwrap().pending, 1);
+
+        // No: still a question, for the deck — and one no read may answer.
+        app.clone().oneshot(verdict("no")).await.unwrap();
+        assert_eq!(handle.store.feedback_stats().await.unwrap().pending, 1);
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{a}/dwell"),
+                &cookie,
+                &format!("secs=42&event={event}"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(handle.store.feedback_stats().await.unwrap().hits, 0);
+
+        // Not sure: not a pair, and not a card either.
+        app.clone().oneshot(verdict("discard")).await.unwrap();
+        let s = handle.store.feedback_stats().await.unwrap();
+        assert_eq!((s.discards, s.pending), (1, 0), "{s:?}");
+    }
+
+    #[tokio::test]
+    async fn the_rail_offers_a_gap_where_nothing_matches() {
+        // The deck's `N` key, moved to where the person is when they know.
+        let (app, cookie, handle) = app_session_and_core_with_feedback().await;
+        let rail = get_body(&app, &cookie, "/ui/search/results?q=nothing+here").await;
+        assert!(rail.contains("No matches."), "{rail}");
+        assert!(rail.contains("Nothing here has it"), "{rail}");
+        assert!(rail.contains(r#"hx-post="/ui/search/gap""#), "{rail}");
+        handle.background.wait_idle().await;
+
+        let res = app
+            .clone()
+            .oneshot(form("/ui/search/gap", &cookie, "q=nothing+here"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let s = handle.store.feedback_stats().await.unwrap();
+        assert_eq!((s.gaps, s.pending), (1, 0), "{s:?}");
+        assert!(
+            body_of(res).await.contains("recorded as a gap"),
+            "the button did not say what it did"
+        );
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -224,11 +224,10 @@ pub struct ArtifactDetail {
 
 impl ArtifactDetail {
     /// `Chunk::in_results`, read off what the pane already holds rather than
-    /// fetched again. One spelling of the predicate, in one place, as that
-    /// method's own doc insists.
+    /// fetched again — and through that method's own predicate rather than a
+    /// second copy of it, so a third lifecycle state still changes one place.
     fn in_results(&self) -> bool {
-        self.status == crate::store::artifacts::ArtifactStatus::Active
-            && self.superseded_by.is_none()
+        crate::store::artifacts::in_results(self.status, self.superseded_by.as_deref())
     }
 }
 
@@ -2965,7 +2964,7 @@ async fn artifact_detail(
             .store
             .event_is_mine(event, &tenant.user.subject)
             .await?
-        && tenant.core.store.open_event(event).await?
+        && tenant.core.store.open_event(event, &cid).await?
     {
         d.search_event = Some(event.to_string());
     }
@@ -5671,7 +5670,17 @@ mod tests {
                         filters: "{}".into(),
                         query_vec: vec![0.1, 0.2],
                         embed_model: "fake".into(),
-                        candidates: vec![],
+                        // A pool, because a search that returned nothing is a
+                        // hole rather than a card and the deck does not deal
+                        // one — see `dealable!`. These stand for searches
+                        // waiting to be judged, so they have something to
+                        // judge.
+                        candidates: vec![crate::store::feedback::NewCandidate {
+                            artifact_id: format!("a{i}"),
+                            score: 0.9,
+                            similarity: Some(0.8),
+                            shown: true,
+                        }],
                         answered: false,
                     },
                     // No folding: these stand for separate searches, not one
@@ -11349,9 +11358,19 @@ mod tests {
             page.contains(&format!("/ui/search/{event}/verdict")),
             "the bar does not name the search: {page}"
         );
-        // The rail's own links carry the search that listed them.
+        // The rail's own links carry the search that listed them — on the
+        // `href` as well as on the `hx-get`. A middle-click, a ⌘-click and a
+        // load that reached the page without htmx are all the same open, and
+        // the plain `href` used to drop the event: the same act produced a
+        // label down one path and silence down the other.
         let rail = include_str!("templates/_results.html");
-        assert!(rail.contains("&event={{ ev }}"), "{rail}");
+        let carries = |attr: &str| {
+            rail.contains(&format!(
+                r#"{attr}="/ui/artifacts/{{{{ r.artifact_id }}}}?terms={{{{ terms|urlencode }}}}{{% if let Some(ev) = event_id %}}&event={{{{ ev }}}}{{% endif %}}""#
+            ))
+        };
+        assert!(carries("href"), "{rail}");
+        assert!(carries("hx-get"), "{rail}");
 
         // Reached any other way — a corpus page, a pasted link — there is no
         // search to be the answer to.
@@ -11500,6 +11519,16 @@ mod tests {
         assert_eq!((s.discards, s.judged, s.pending), (0, 0, 1), "{s:?}");
     }
 
+    /// The search just recorded, read off the table rather than off the deck.
+    /// A search that returned nothing is not a card the deck deals — see
+    /// `dealable!` — and the rail asks about one of those.
+    async fn newest_event(handle: &crate::core::Core) -> String {
+        sqlx::query_scalar("SELECT id FROM search_events ORDER BY created_at DESC, id DESC LIMIT 1")
+            .fetch_one(&handle.store.pool)
+            .await
+            .expect("the search the rail was filled by")
+    }
+
     #[tokio::test]
     async fn the_rail_offers_a_gap_where_nothing_matches() {
         // The deck's `N` key, moved to where the person is when they know.
@@ -11511,13 +11540,7 @@ mod tests {
         // reaches the client as data, so no wording can break the request: a
         // `"` in `hx-vals` JSON used to make htmx throw and the button do
         // nothing at all, silently.
-        let event = handle
-            .store
-            .next_pending(0.0)
-            .await
-            .unwrap()
-            .expect("the search the rail was filled by")
-            .id;
+        let event = newest_event(&handle).await;
         assert!(
             rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap""#)),
             "{rail}"
@@ -11550,7 +11573,7 @@ mod tests {
             "/ui/search/results?q=say%20%22hi%22%20%5Cnow",
         )
         .await;
-        let event = handle.store.next_pending(0.0).await.unwrap().unwrap().id;
+        let event = newest_event(&handle).await;
         assert!(
             rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap""#)),
             "{rail}"

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -193,7 +193,7 @@ pub struct ArtifactDetail {
     pub corpus_restored: bool,
     /// The search this was opened from, when it was opened from the rail and
     /// searches are being recorded. What the bar under the artifact and the
-    /// dwell timer both report against. See `Store::open_event_for`.
+    /// dwell timer both report against. See `Store::open_event`.
     pub search_event: Option<String>,
     /// Link to the source, scrolled to and highlighting the exact lines this
     /// artifact was drawn from. Falls back to the plain source page for an
@@ -220,6 +220,16 @@ pub struct ArtifactDetail {
     /// is what this resembles, the other is what it has been reached for
     /// together with, and they answer different questions.
     pub seen_together: Vec<SeenTogether>,
+}
+
+impl ArtifactDetail {
+    /// `Chunk::in_results`, read off what the pane already holds rather than
+    /// fetched again. One spelling of the predicate, in one place, as that
+    /// method's own doc insists.
+    fn in_results(&self) -> bool {
+        self.status == crate::store::artifacts::ArtifactStatus::Active
+            && self.superseded_by.is_none()
+    }
 }
 
 /// A neighbour, as one line in the pane.
@@ -503,9 +513,12 @@ struct ResultsTemplate {
     /// The tick beside the count is what makes the reordering legible as a
     /// refinement rather than a glitch.
     reranked: bool,
-    /// The query as typed, for the "nothing here has it" button — and only
-    /// while searches are being recorded, since a gap is a verdict on one.
-    gap_q: Option<String>,
+    /// The search that filled this rail, where it was recorded. Every row
+    /// carries it onward, so an open, a verdict and the "nothing here has it"
+    /// button all name the one search they are answers about. `None` while
+    /// searches are not being recorded, and the button and the links go
+    /// without.
+    event_id: Option<String>,
 }
 
 /// The rail before anything is asked: the base introducing itself.
@@ -1143,9 +1156,6 @@ pub(crate) async fn search_results(
     // Function words are dropped: a query phrased as a situation is mostly
     // stopwords, and highlighting every "to" marks the whole card.
     let terms = highlightable_terms(p.q.trim());
-    // Trimmed, because that is the wording the capture stores and the gap
-    // button has to name the same event.
-    let gap_q = tenant.core.learn.enabled.then(|| p.q.trim().to_string());
     // What this sitting is working on. A typing burst folds into one entry
     // here as it does in the log, so what is carried is the query that was
     // meant rather than every prefix of it.
@@ -1247,7 +1257,7 @@ pub(crate) async fn search_results(
         // that failed or was skipped answered in vector order, and the tick
         // would assert a confirmation that never took place.
         reranked: outcome.timing.reranked,
-        gap_q,
+        event_id: outcome.event,
     })
     .into_response();
     // Measured as before, reported where a browser already knows to show it.
@@ -1695,8 +1705,14 @@ async fn artifact_dwell(
     tenant
         .core
         .record_dwell(&aid, f.secs, Some(&tenant.user.subject));
+    // Not for an artifact search will no longer return: `eval::export` drops
+    // the pair, so the hit would move the recall on the judging page and
+    // nothing in `pairs.json`. `judge::hit` and the verdict bar both refuse one
+    // for that reason, and a beacon is not the way around them. The pane omits
+    // `data-event` in that case, so this is the write agreeing with the page.
     if let Some(event) = f.event.filter(|_| f.secs >= DWELL_HIT_SECS)
         && tenant.core.learn.enabled
+        && tenant.core.store.get_artifact(&aid).await?.in_results()
     {
         tenant.core.store.implicit_hit(&event, &aid).await?;
     }
@@ -2339,7 +2355,13 @@ async fn settings(tenant: Tenant) -> Result<Response> {
         judge_pending: crate::web::state::judge_pending(&tenant).await,
         tokens: token_rows(&tenant).await?,
         feedback: match tenant.core.learn.enabled {
-            true => Some(tenant.core.store.feedback_stats().await?),
+            true => Some(
+                tenant
+                    .core
+                    .store
+                    .feedback_stats(tenant.core.weak_below)
+                    .await?,
+            ),
             false => None,
         },
         asks: match tenant.core.learn.enabled {
@@ -2896,11 +2918,6 @@ pub(crate) async fn build_artifact_detail(
     })
 }
 
-/// How long after a search an open from its rail still counts as an open of
-/// it. Generous: the rail stays on screen for as long as the tab does, and
-/// the lookup also asks that the pool hold the artifact.
-pub(crate) const OPEN_WITHIN_SECS: i64 = 3600;
-
 #[derive(serde::Deserialize)]
 struct ArtifactViewParams {
     #[serde(default)]
@@ -2920,10 +2937,12 @@ struct ArtifactViewParams {
     /// every click lands in one bucket on Ops.
     #[serde(default)]
     rung: Option<String>,
-    /// `results` when the link was a row on the search rail. Only then is
-    /// there a search this open can be the answer to.
+    /// The search this row was listed by, carried on the link the rail drew.
+    /// Present only on a rail row, so it says both which search this open
+    /// answers and that it came from a list of answers at all.
+    /// See `SearchOutcome::event`.
     #[serde(default)]
-    from: Option<String>,
+    event: Option<String>,
 }
 
 /// One route, two shapes. An htmx swap wants the pane's body; a pasted link
@@ -2936,16 +2955,23 @@ async fn artifact_detail(
     Query(p): Query<ArtifactViewParams>,
 ) -> Result<Response> {
     let mut d = build_artifact_detail(&tenant.core, &cid, &p.terms).await?;
-    // Opened from the rail: the search it answers is asked of the store, since
-    // the capture was written off the request path and nothing on the page
-    // carries its id. On the request path, because the bar under the artifact
-    // needs the id before it can render.
-    if tenant.core.learn.enabled && p.from.as_deref() == Some("results") {
-        d.search_event = tenant
-            .core
-            .store
-            .open_event_for(&cid, Some(&tenant.user.subject), OPEN_WITHIN_SECS)
-            .await?;
+    // Opened from the rail, which named the search that listed it. Stamped
+    // here rather than looked up: the id is on the link, so this open is
+    // attributed to the search it came from and to no other.
+    //
+    // Not for an artifact search will no longer return. `eval::export` freezes
+    // only active, un-superseded artifacts and drops any pair naming something
+    // else, so a hit recorded here — by the bar, or by the dwell timer that
+    // reads the same id off the pane — would raise the recall and MRR on the
+    // judging page while contributing nothing to `pairs.json`. `judge::hit`
+    // refuses one for that reason; so does this. No bar and no `data-event`
+    // means neither path can fire.
+    if tenant.core.learn.enabled
+        && d.in_results()
+        && let Some(event) = p.event.as_deref()
+        && tenant.core.store.open_event(event).await?
+    {
+        d.search_event = Some(event.to_string());
     }
     // Opening a chunk is the deliberate act that counts as remembering it.
     tenant.core.mark_artifact_seen(&cid);
@@ -6376,7 +6402,7 @@ mod tests {
             results: vec![loose],
             associated: vec![],
             all_weak: true,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6480,7 +6506,7 @@ mod tests {
             results: vec![named, offered],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6504,7 +6530,7 @@ mod tests {
             results: vec![row("a", "#1")],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6611,7 +6637,7 @@ mod tests {
             results: vec![r],
             associated: vec![render_hit(0, hit(None, Some("a")), &titles, false)],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         })
@@ -6661,7 +6687,7 @@ mod tests {
             results: vec![above.clone(), above.clone(), past, also_past],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6684,7 +6710,7 @@ mod tests {
             results: vec![above.clone(), above.clone(), above],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6704,7 +6730,7 @@ mod tests {
             results: vec![own, borrowed],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6736,7 +6762,7 @@ mod tests {
             results: vec![],
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         };
@@ -6753,7 +6779,7 @@ mod tests {
                 Some("the tool and its errors"),
             )],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         };
@@ -6772,7 +6798,7 @@ mod tests {
             results: vec![rendered(Some("Mounting E01 images"), None)],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: true,
         }
@@ -6784,7 +6810,7 @@ mod tests {
             results: vec![rendered(Some("Mounting E01 images"), None)],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -6861,7 +6887,7 @@ mod tests {
             results: vec![ranked(true)],
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: true,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         };
@@ -6875,7 +6901,7 @@ mod tests {
             results: vec![ranked(false)],
             associated: vec![rendered(Some("Mounting E01 images"), None)],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         };
@@ -7114,7 +7140,7 @@ mod tests {
             results: vec![r],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -7162,7 +7188,7 @@ mod tests {
             results: vec![ranked(false)],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -7182,7 +7208,7 @@ mod tests {
             results: vec![r],
             associated: vec![],
             all_weak: false,
-            gap_q: None,
+            event_id: None,
             terms: String::new(),
             reranked: false,
         }
@@ -11318,7 +11344,7 @@ mod tests {
         // answer then is "I don't know, I was looking". Under the result just
         // opened the answer is cheap, so that is where it is asked.
         let (app, cookie, handle, a, event) = searched_app().await;
-        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?from=results")).await;
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?event={event}")).await;
         assert!(
             page.contains("Was this what you were looking for?"),
             "{page}"
@@ -11330,9 +11356,9 @@ mod tests {
         // Named on the root beside the artifact, so the dwell timer can report
         // which search the read belongs to.
         assert!(page.contains(&format!("data-event=\"{event}\"")), "{page}");
-        // The rail's own links say they are the rail's.
+        // The rail's own links carry the search that listed them.
         let rail = include_str!("templates/_results.html");
-        assert!(rail.contains("&from=results\""), "{rail}");
+        assert!(rail.contains("&event={{ ev }}"), "{rail}");
 
         // Reached any other way — a corpus page, a pasted link — there is no
         // search to be the answer to.
@@ -11360,7 +11386,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(handle.store.feedback_stats().await.unwrap().captured, 2);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().captured, 2);
     }
 
     #[tokio::test]
@@ -11392,7 +11418,9 @@ mod tests {
             .unwrap()[0]
             .id
             .clone();
-        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?from=results")).await;
+        // With learning off nothing is captured, so the rail draws no event on
+        // its links and there is nothing for the bar to be a verdict on.
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?event=whatever")).await;
         assert!(
             !page.contains("Was this what you were looking for?"),
             "{page}"
@@ -11415,7 +11443,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NO_CONTENT);
-        assert_eq!(handle.store.feedback_stats().await.unwrap().hits, 0);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().hits, 0);
 
         let res = app
             .clone()
@@ -11427,7 +11455,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NO_CONTENT);
-        let s = handle.store.feedback_stats().await.unwrap();
+        let s = handle.store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.hits, s.pending), (1, 0), "{s:?}");
         assert_eq!(s.recall_at_10, 1.0);
     }
@@ -11446,16 +11474,16 @@ mod tests {
         assert_eq!(res.status(), StatusCode::OK);
         let bar = body_of(res).await;
         assert!(bar.contains("undo"), "{bar}");
-        let s = handle.store.feedback_stats().await.unwrap();
+        let s = handle.store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.hits, s.pending), (1, 0), "{s:?}");
 
         // Undo: a question again.
         app.clone().oneshot(verdict("none")).await.unwrap();
-        assert_eq!(handle.store.feedback_stats().await.unwrap().pending, 1);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().pending, 1);
 
         // No: still a question, for the deck — and one no read may answer.
         app.clone().oneshot(verdict("no")).await.unwrap();
-        assert_eq!(handle.store.feedback_stats().await.unwrap().pending, 1);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().pending, 1);
         app.clone()
             .oneshot(form(
                 &format!("/ui/artifacts/{a}/dwell"),
@@ -11464,12 +11492,21 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(handle.store.feedback_stats().await.unwrap().hits, 0);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().hits, 0);
 
-        // Not sure: not a pair, and not a card either.
-        app.clone().oneshot(verdict("discard")).await.unwrap();
-        let s = handle.store.feedback_stats().await.unwrap();
-        assert_eq!((s.discards, s.pending), (1, 0), "{s:?}");
+        // Not sure: no verdict at all. The search stays a question for the deck
+        // — it is not a discard, which says the search was never real and would
+        // drop it from the pairs, from the deck and out of the purge's
+        // exemption on the strength of somebody not remembering.
+        let res = app.clone().oneshot(verdict("skip")).await.unwrap();
+        let bar = body_of(res).await;
+        assert!(bar.contains("left for the deck"), "{bar}");
+        assert!(
+            !bar.contains("undo"),
+            "a skip is not a verdict to take back"
+        );
+        let s = handle.store.feedback_stats(0.0).await.unwrap();
+        assert_eq!((s.discards, s.judged, s.pending), (0, 0, 1), "{s:?}");
     }
 
     #[tokio::test]
@@ -11479,20 +11516,105 @@ mod tests {
         let rail = get_body(&app, &cookie, "/ui/search/results?q=nothing+here").await;
         assert!(rail.contains("No matches."), "{rail}");
         assert!(rail.contains("Nothing here has it"), "{rail}");
-        assert!(rail.contains(r#"hx-post="/ui/search/gap""#), "{rail}");
-        handle.background.wait_idle().await;
+        // The button names the search it is a verdict on. The query never
+        // reaches the client as data, so no wording can break the request: a
+        // `"` in `hx-vals` JSON used to make htmx throw and the button do
+        // nothing at all, silently.
+        let event = handle
+            .store
+            .next_pending(0.0)
+            .await
+            .unwrap()
+            .expect("the search the rail was filled by")
+            .id;
+        assert!(
+            rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap""#)),
+            "{rail}"
+        );
+        assert!(!rail.contains("hx-vals='{\"q\""), "{rail}");
 
         let res = app
             .clone()
-            .oneshot(form("/ui/search/gap", &cookie, "q=nothing+here"))
+            .oneshot(form(&format!("/ui/search/{event}/gap"), &cookie, ""))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
-        let s = handle.store.feedback_stats().await.unwrap();
+        let s = handle.store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.gaps, s.pending), (1, 0), "{s:?}");
         assert!(
             body_of(res).await.contains("recorded as a gap"),
             "the button did not say what it did"
         );
+    }
+
+    #[tokio::test]
+    async fn a_quotation_mark_in_the_query_does_not_break_the_gap_button() {
+        // The capture is on the request path at this door, so the rail comes
+        // back naming its own search whatever was typed — and the button
+        // carries an id rather than the words.
+        let (app, cookie, handle) = app_session_and_core_with_feedback().await;
+        let rail = get_body(
+            &app,
+            &cookie,
+            "/ui/search/results?q=say%20%22hi%22%20%5Cnow",
+        )
+        .await;
+        let event = handle.store.next_pending(0.0).await.unwrap().unwrap().id;
+        assert!(
+            rail.contains(&format!(r#"hx-post="/ui/search/{event}/gap""#)),
+            "{rail}"
+        );
+        let res = app
+            .clone()
+            .oneshot(form(&format!("/ui/search/{event}/gap"), &cookie, ""))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().gaps, 1);
+    }
+
+    #[tokio::test]
+    async fn a_deprecated_result_is_never_asked_about() {
+        // `eval::export` drops any pair naming an artifact search will not
+        // return, so a hit recorded against one raises the recall on the
+        // judging page and contributes nothing to `pairs.json`. `judge::hit`
+        // refuses one; the bar under a result must not be a way around it, and
+        // neither must the dwell timer that reads the same id off the pane.
+        let (app, cookie, handle, a, event) = searched_app().await;
+        handle
+            .store
+            .set_artifact_status(&a, crate::store::artifacts::ArtifactStatus::Deprecated)
+            .await
+            .unwrap();
+        let page = get_body(&app, &cookie, &format!("/ui/artifacts/{a}?event={event}")).await;
+        assert!(
+            !page.contains("Was this what you were looking for?"),
+            "{page}"
+        );
+        assert!(
+            !page.contains("data-event="),
+            "the dwell timer would report a hit the benchmark cannot hold: {page}"
+        );
+        // And the writes refuse it too, not only the render: a beacon or a
+        // replayed form naming the pair is not the way around the guard.
+        app.clone()
+            .oneshot(form(
+                &format!("/ui/artifacts/{a}/dwell"),
+                &cookie,
+                &format!("secs=42&event={event}"),
+            ))
+            .await
+            .unwrap();
+        let res = app
+            .clone()
+            .oneshot(form(
+                &format!("/ui/search/{event}/verdict"),
+                &cookie,
+                &format!("verdict=hit&artifact_id={a}"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(handle.store.feedback_stats(0.0).await.unwrap().hits, 0);
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -11819,4 +11819,29 @@ mod tests {
         let s = handle.store.feedback_stats(0.0).await.unwrap();
         assert_eq!((s.gaps, s.hits, s.judged), (1, 0, 1), "{s:?}");
     }
+
+    #[tokio::test]
+    async fn a_purged_search_is_not_the_bar_owner_s_any_more() {
+        // Where the bar's writing guards do *not* come into it: the ownership
+        // check runs first and a row that is gone belongs to nobody, so all
+        // four answers stop there. Worth pinning, because the store guards
+        // below it read as the thing standing between a stale tab and a purged
+        // event, and they are not — this is.
+        let (app, cookie, handle, a, event) = searched_app().await;
+        handle.store.purge_feedback().await.unwrap();
+
+        for body in [
+            format!("verdict=hit&artifact_id={a}"),
+            format!("verdict=no&artifact_id={a}"),
+            format!("verdict=skip&artifact_id={a}"),
+            format!("verdict=none&artifact_id={a}"),
+        ] {
+            let res = app
+                .clone()
+                .oneshot(form(&format!("/ui/search/{event}/verdict"), &cookie, &body))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::NOT_FOUND, "{body}");
+        }
+    }
 }

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -54,7 +54,7 @@ pub fn routes() -> Router<AppState> {
         // bar — it is their own search — and unlike the deck, whose grant also
         // covers writing `config.toml`.
         .route("/ui/search/{id}/verdict", post(search_verdict))
-        .route("/ui/search/gap", post(search_gap))
+        .route("/ui/search/{id}/gap", post(search_gap))
         .route("/ui/ask/{id}/carried", post(ask_carried))
         .route("/ui/ask/{id}/keep", post(ask_keep))
 }
@@ -701,7 +701,7 @@ async fn ask_verdict(
 struct SearchVerdictTemplate {
     event_id: String,
     artifact_id: String,
-    /// `hit` / `no` / `discard` for display; empty shows the buttons.
+    /// `hit` / `no` / `skip` for display; empty shows the buttons.
     state: &'static str,
 }
 
@@ -721,10 +721,21 @@ async fn search_verdict(
     if !tenant.core.learn.enabled {
         return Err(Error::NotFound);
     }
-    use crate::store::feedback::{Labeller, Verdict};
+    use crate::store::feedback::Labeller;
     let store = &tenant.core.store;
     let state = match f.verdict.as_str() {
         "hit" => {
+            // The same guard `judge::hit` states in full: `eval::export` drops
+            // any pair naming an artifact search will not return, so recording
+            // one here would raise the recall on the judging page while
+            // contributing nothing to `pairs.json`. The bar is not drawn over
+            // such an artifact at all — see `ui::artifact_detail` — so this is
+            // the write refusing what the page already refuses to offer.
+            if !store.get_artifact(&f.artifact_id).await?.in_results() {
+                return Err(Error::Validation(
+                    "that one is deprecated or superseded, so the benchmark can't hold it".into(),
+                ));
+            }
             store
                 .judge_hit(&id, &f.artifact_id, Labeller::Confirm)
                 .await?;
@@ -734,11 +745,16 @@ async fn search_verdict(
             store.decline(&id).await?;
             "no"
         }
-        "discard" => {
-            store
-                .judge(&id, Verdict::Discard, Labeller::Confirm)
-                .await?;
-            "discard"
+        // Not `Verdict::Discard`, which the deck's own key means and which says
+        // something else entirely: that the search was never real. A discard is
+        // dropped from the eval pairs, gone from the deck for good, and — alone
+        // among the verdicts — not exempt from the retention purge. Somebody
+        // unsure whether the result in front of them was the one has not said
+        // any of that. The deck's skip is what the label promises: the search
+        // stays a question and only sinks in the judging order.
+        "skip" => {
+            store.skip_event(&id).await?;
+            "skip"
         }
         "none" => {
             store.unjudge(&id).await?;
@@ -754,29 +770,16 @@ async fn search_verdict(
     .into_response())
 }
 
-#[derive(serde::Deserialize)]
-struct SearchGapForm {
-    q: String,
-}
-
-/// The rail's "nothing here has it": a gap against the search just made.
-/// Answers with the line that replaces the button.
-async fn search_gap(tenant: Tenant, Form(f): Form<SearchGapForm>) -> Result<Response> {
+/// The rail's "nothing here has it": a gap against the search that filled the
+/// rail, named by the page the way an open is. Answers with the line that
+/// replaces the button.
+async fn search_gap(tenant: Tenant, Path(id): Path<String>) -> Result<Response> {
     if !tenant.core.learn.enabled {
         return Err(Error::NotFound);
     }
-    let line = match tenant
-        .core
-        .store
-        .gap_for_query(
-            f.q.trim(),
-            Some(&tenant.user.subject),
-            crate::web::ui::OPEN_WITHIN_SECS,
-        )
-        .await?
-    {
-        Some(_) => "recorded as a gap: your base doesn't know this yet.",
-        None => "nothing to record — that search was already judged.",
+    let line = match tenant.core.store.gap_event(&id).await? {
+        true => "recorded as a gap: your base doesn't know this yet.",
+        false => "nothing to record — that search was already judged.",
     };
     Ok(axum::response::Html(format!(r#"<span class="muted">{line}</span>"#)).into_response())
 }

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -711,6 +711,18 @@ struct SearchVerdictForm {
     artifact_id: String,
 }
 
+/// What the bar says when the write it was drawn for is refused. Every guard
+/// on this path — a verdict from the deck, a search that expired, a query the
+/// box has since moved on from — reaches the person as the same ordinary
+/// sentence, because from where they are sitting it is the same fact: the
+/// search they were looking at is no longer waiting for them.
+fn already_judged() -> Response {
+    axum::response::Html(
+        r#"<span class="muted">nothing to record — that search was already judged.</span>"#,
+    )
+    .into_response()
+}
+
 /// The bar under an opened result. `none` is the undo; `no` is "not this
 /// one", which leaves the search a question for the deck.
 async fn search_verdict(
@@ -741,10 +753,18 @@ async fn search_verdict(
                     "that one is deprecated or superseded, so the benchmark can't hold it".into(),
                 ));
             }
-            store
+            // `NotFound` here is the store's guard, not a missing route: the
+            // deck can answer this search while the tab holding the bar is
+            // open, and `judge_hit` refuses to write over a verdict rather
+            // than replace it. The same line "no" gets, for the same reason.
+            match store
                 .judge_hit(&id, &f.artifact_id, Labeller::Confirm)
-                .await?;
-            "hit"
+                .await
+            {
+                Ok(()) => "hit",
+                Err(Error::NotFound) => return Ok(already_judged()),
+                Err(e) => return Err(e),
+            }
         }
         "no" => {
             // The one answer that clears columns rather than filling them, so
@@ -753,10 +773,7 @@ async fn search_verdict(
             // rather than applied, and said in the same words the rail's gap
             // button uses for the same situation.
             if !store.decline(&id).await? {
-                return Ok(axum::response::Html(
-                    r#"<span class="muted">nothing to record — that search was already judged.</span>"#,
-                )
-                .into_response());
+                return Ok(already_judged());
             }
             "no"
         }
@@ -772,8 +789,16 @@ async fn search_verdict(
             "skip"
         }
         "none" => {
-            store.unjudge(&id).await?;
-            ""
+            // Only back over what this bar wrote — `Labeller::Confirm`. The
+            // undo appears after "no", which leaves the search pending, so the
+            // deck can deal it and record a hit while the tab is still open;
+            // unguarded, this button then erased a confirmed pair. The store
+            // says so by matching nothing.
+            match store.unjudge(&id, Labeller::Confirm).await {
+                Ok(()) => "",
+                Err(Error::NotFound) => return Ok(already_judged()),
+                Err(e) => return Err(e),
+            }
         }
         v => return Err(Error::Validation(format!("unknown verdict {v}"))),
     };
@@ -788,7 +813,21 @@ async fn search_verdict(
 /// The rail's "nothing here has it": a gap against the search that filled the
 /// rail, named by the page the way an open is. Answers with the line that
 /// replaces the button.
-async fn search_gap(tenant: Tenant, Path(id): Path<String>) -> Result<Response> {
+///
+/// The query travels with the id for the same reason the open path names an
+/// artifact: it is what the button was drawn over, and a trailing keystroke can
+/// fold a later wording into the row between the render and the press. See
+/// `Store::gap_event`.
+#[derive(serde::Deserialize)]
+struct GapParams {
+    q: String,
+}
+
+async fn search_gap(
+    tenant: Tenant,
+    Path(id): Path<String>,
+    axum::extract::Query(p): axum::extract::Query<GapParams>,
+) -> Result<Response> {
     if !tenant.core.learn.enabled {
         return Err(Error::NotFound);
     }
@@ -801,7 +840,7 @@ async fn search_gap(tenant: Tenant, Path(id): Path<String>) -> Result<Response> 
     {
         return Err(Error::NotFound);
     }
-    let line = match tenant.core.store.gap_event(&id).await? {
+    let line = match tenant.core.store.gap_event(&id, p.q.trim()).await? {
         true => "recorded as a gap: your base doesn't know this yet.",
         false => "nothing to record — that search was already judged.",
     };
@@ -1400,7 +1439,7 @@ mod tests {
             "a reranker serving search is what arms the refining pass"
         );
         assert!(
-            html.contains(r#"hx-params="q,category,rerank,explain""#),
+            html.contains(r#"hx-params="q,category,rerank,explain,fold""#),
             "hx-params is the allowlist for what rides a search GET; without \
              `rerank` on it the refining pass's own flag is filtered off the \
              wire and the server only ever runs the fast path — and `explain` \

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -785,8 +785,18 @@ async fn search_verdict(
         // any of that. The deck's skip is what the label promises: the search
         // stays a question and only sinks in the judging order.
         "skip" => {
-            store.skip_event(&id).await?;
-            "skip"
+            // Not a verdict, so nothing can have got here first, and a search
+            // already gone was refused by the ownership check above. What is
+            // left is the window between that check and this write, which
+            // retention and an Ops purge can both fall into. `judged_one` calls
+            // it `NotFound`, and a 404 is the one answer htmx will not swap —
+            // the button would do nothing at all, silently, where the other
+            // three say so in words.
+            match store.skip_event(&id).await {
+                Ok(()) => "skip",
+                Err(Error::NotFound) => return Ok(already_judged()),
+                Err(e) => return Err(e),
+            }
         }
         "none" => {
             // Only back over what this bar wrote — `Labeller::Confirm`. The

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -747,7 +747,17 @@ async fn search_verdict(
             "hit"
         }
         "no" => {
-            store.decline(&id).await?;
+            // The one answer that clears columns rather than filling them, so
+            // the one that can undo somebody else's work: the deck can judge
+            // this search while the tab holding the bar is open. Refused
+            // rather than applied, and said in the same words the rail's gap
+            // button uses for the same situation.
+            if !store.decline(&id).await? {
+                return Ok(axum::response::Html(
+                    r#"<span class="muted">nothing to record — that search was already judged.</span>"#,
+                )
+                .into_response());
+            }
             "no"
         }
         // Not `Verdict::Discard`, which the deck's own key means and which says

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -49,6 +49,12 @@ pub fn routes() -> Router<AppState> {
         .route("/ui/ask", get(ask_door).post(ask_submit))
         .route("/ui/ask/{id}/stream", get(ask_stream))
         .route("/ui/ask/{id}/verdict", post(ask_verdict))
+        // Judging at the moment of search: the bar under an opened result and
+        // the gap button on the rail. Open to whoever searched, like the ask
+        // bar — it is their own search — and unlike the deck, whose grant also
+        // covers writing `config.toml`.
+        .route("/ui/search/{id}/verdict", post(search_verdict))
+        .route("/ui/search/gap", post(search_gap))
         .route("/ui/ask/{id}/carried", post(ask_carried))
         .route("/ui/ask/{id}/keep", post(ask_keep))
 }
@@ -688,6 +694,91 @@ async fn ask_verdict(
         }
     }
     Ok(axum::response::Html(ask_verdict_bar(&tenant, &id, false).await?).into_response())
+}
+
+#[derive(Template)]
+#[template(path = "_search_verdict.html")]
+struct SearchVerdictTemplate {
+    event_id: String,
+    artifact_id: String,
+    /// `hit` / `no` / `discard` for display; empty shows the buttons.
+    state: &'static str,
+}
+
+#[derive(serde::Deserialize)]
+struct SearchVerdictForm {
+    verdict: String,
+    artifact_id: String,
+}
+
+/// The bar under an opened result. `none` is the undo; `no` is "not this
+/// one", which leaves the search a question for the deck.
+async fn search_verdict(
+    tenant: Tenant,
+    Path(id): Path<String>,
+    Form(f): Form<SearchVerdictForm>,
+) -> Result<Response> {
+    if !tenant.core.learn.enabled {
+        return Err(Error::NotFound);
+    }
+    use crate::store::feedback::{Labeller, Verdict};
+    let store = &tenant.core.store;
+    let state = match f.verdict.as_str() {
+        "hit" => {
+            store
+                .judge_hit(&id, &f.artifact_id, Labeller::Confirm)
+                .await?;
+            "hit"
+        }
+        "no" => {
+            store.decline(&id).await?;
+            "no"
+        }
+        "discard" => {
+            store
+                .judge(&id, Verdict::Discard, Labeller::Confirm)
+                .await?;
+            "discard"
+        }
+        "none" => {
+            store.unjudge(&id).await?;
+            ""
+        }
+        v => return Err(Error::Validation(format!("unknown verdict {v}"))),
+    };
+    Ok(HtmlTemplate(SearchVerdictTemplate {
+        event_id: id,
+        artifact_id: f.artifact_id,
+        state,
+    })
+    .into_response())
+}
+
+#[derive(serde::Deserialize)]
+struct SearchGapForm {
+    q: String,
+}
+
+/// The rail's "nothing here has it": a gap against the search just made.
+/// Answers with the line that replaces the button.
+async fn search_gap(tenant: Tenant, Form(f): Form<SearchGapForm>) -> Result<Response> {
+    if !tenant.core.learn.enabled {
+        return Err(Error::NotFound);
+    }
+    let line = match tenant
+        .core
+        .store
+        .gap_for_query(
+            f.q.trim(),
+            Some(&tenant.user.subject),
+            crate::web::ui::OPEN_WITHIN_SECS,
+        )
+        .await?
+    {
+        Some(_) => "recorded as a gap: your base doesn't know this yet.",
+        None => "nothing to record — that search was already judged.",
+    };
+    Ok(axum::response::Html(format!(r#"<span class="muted">{line}</span>"#)).into_response())
 }
 
 async fn ask_carried(

--- a/src/web/workspace.rs
+++ b/src/web/workspace.rs
@@ -723,6 +723,11 @@ async fn search_verdict(
     }
     use crate::store::feedback::Labeller;
     let store = &tenant.core.store;
+    // The id comes off the page, so it is whatever the caller sent. One check
+    // for all four answers below — see `Store::event_is_mine`.
+    if !store.event_is_mine(&id, &tenant.user.subject).await? {
+        return Err(Error::NotFound);
+    }
     let state = match f.verdict.as_str() {
         "hit" => {
             // The same guard `judge::hit` states in full: `eval::export` drops
@@ -775,6 +780,15 @@ async fn search_verdict(
 /// replaces the button.
 async fn search_gap(tenant: Tenant, Path(id): Path<String>) -> Result<Response> {
     if !tenant.core.learn.enabled {
+        return Err(Error::NotFound);
+    }
+    // Only against the caller's own search — see `Store::event_is_mine`.
+    if !tenant
+        .core
+        .store
+        .event_is_mine(&id, &tenant.user.subject)
+        .await?
+    {
         return Err(Error::NotFound);
     }
     let line = match tenant.core.store.gap_event(&id).await? {


### PR DESCRIPTION
Closes #67.

## Judge at the moment, not later

The deck asked *"which of these twenty was the one"* about a query typed hours earlier, and the honest answer was "I don't know, I was looking". The label is cheap where the person is, so that is where it is asked.

- **Opening a result from the rail** names the search it came from (`Store::open_event_for`, asked of the store because the capture is written off the request path and its id was thrown away). The open **freezes the event**: a rewording after it starts its own event instead of overwriting the pool that was read.
- **Implicit hit.** Reading a result for 20 s records a provisional hit (`judged_by = 'dwell'`). A later read replaces it; a person always overrules it; a "No" from the bar keeps the dwell that flushes afterwards from putting it back.
- **One-tap confirm** under the artifact — *Was this what you were looking for? Yes · No · Not sure* — the ask verdict bar applied to search (`POST /ui/search/{id}/verdict`).
- **Gap at the moment.** *Nothing here has it* on a rail that matched nothing or only loosely (`POST /ui/search/gap`).
- **Fold the exploratory.** Coalescing folds any rewording inside `coalesce_secs`, not only a prefix, so a burst that ends in one open is one event carrying the last query.

Both new routes are open to any signed-in user with learning on, like the ask bar; `CanJudge` stays on the deck and the config-writing tune route.

## The deck, for what that leaves

- Top five in the order the search gave them, titled, keys 1–5; the rest behind one fold, unkeyed. The position bias this costs is noted in `docs/evaluation.md` beside the number. Scores are still withheld.
- The question depends on whether anything was opened: *opened nothing — was there something you wanted?* vs *which of these was it?*, with *No, I was just looking* as the discard.
- Queries under three characters and searches whose best match was under `weak_below` are never dealt and not counted in the badge. They stay pending — `GapKind::Unmatched` still reads them.
- The XP bar is gone; the count to the next sweep stays.

## Schema

Two nullable columns on `search_events`, `judged_by` and `opened_at`, added through the `ADDITIVE` migration list; an old base full of deck verdicts keeps them (test included). `judge_hit`/`judge` take a `Labeller` (`Deck | Confirm | Dwell`).

## Verification

2160 lib tests (17 new), integration tests, clippy and fmt clean. Not exercised in a browser: the `sendBeacon` change in `app.js` is covered only by the route tests behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEmBMMBsaH2zBn2W3sLVxx
